### PR TITLE
curate: 30 new DE stations batch 2

### DIFF
--- a/data/stations.yaml
+++ b/data/stations.yaml
@@ -6590,6 +6590,476 @@
   country: DE
   status: stream-only
 
+# ─── DE — Radio Browser sweep batch 2 (2026-05-04) ───
+
+- id: de-maretimo-lounge
+  stationuuid: aedd2edd-c8f1-4f75-9667-9d84cd6d690c
+  changeuuid: 8b366a1f-be24-4e7a-89d6-ad6f643afabf
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: Maretimo Lounge
+  streamUrl: https://s35.derstream.net/lounge.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [lounge, germany]
+  favicon: https://d3kle7qwymxpcy.cloudfront.net/images/broadcasts/08/a3/107873/5/c175.png
+  homepage: http://www.maretimo-lounge-radio.com/
+  country: DE
+  status: stream-only
+
+- id: de-nightride-fm-chillsynth
+  stationuuid: 9067dc39-4bf4-4364-bd6b-8020cff3e15d
+  changeuuid: 36b89f53-0d32-4932-a0cc-717f7a4c16f9
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: Nightride FM - Chillsynth
+  streamUrl: https://stream.nightride.fm/chillsynth.mp3
+  bitrate: 320
+  codec: MP3
+  tags: [lounge, ambient, germany]
+  favicon: https://nightride.fm/thumbnail.png
+  homepage: https://nightride.fm/
+  country: DE
+  status: stream-only
+
+- id: de-antenne-bayern-coffeemusic
+  stationuuid: 52ba8d13-e5e7-11e8-a9cc-52543be04c81
+  changeuuid: 2a1d9403-ce4f-4aa1-a15a-e2ddaf24b3d2
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: Antenne Bayern - CoffeeMusic
+  streamUrl: https://mp3channels.webradio.de/coffee
+  bitrate: 128
+  codec: MP3
+  tags: [ambient, pop, germany]
+  homepage: https://www.webradio.de/antenne-bayern/coffeemusic
+  country: DE
+  status: stream-only
+
+- id: de-rock-antenne-hair-metal
+  stationuuid: 2ed4195c-73a1-46ab-b6cb-e1afe68ea82a
+  changeuuid: 8aace9a0-b9b4-403c-82f5-884a49ba5b4e
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: ROCK ANTENNE Hair Metal
+  streamUrl: https://stream.rockantenne.de/hair-metal/stream/aacp
+  codec: AAC
+  tags: [rock, germany]
+  homepage: https://www.rockantenne.de/
+  country: DE
+  status: stream-only
+
+- id: de-epic-rock-radio
+  stationuuid: ddf0a603-ed3a-4d52-8d1b-cc11357734f3
+  changeuuid: 8915ad8e-b213-4bb5-8835-ca627a8b0ff5
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: Epic Rock Radio
+  streamUrl: https://securestreams6.autopo.st:2222/stream
+  bitrate: 128
+  codec: MP3
+  tags: [rock, germany]
+  homepage: https://www.epicrockradio.com/
+  country: DE
+  status: stream-only
+
+- id: de-sex-by-rautemusik-rm-fm
+  stationuuid: c52f22bd-7bc4-4fd2-ab2b-c3c7f031a530
+  changeuuid: f605a241-0f32-4578-83e1-c27d0058de39
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: __SEX__ by rautemusik (rm.fm)
+  streamUrl: https://sex-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [pop, germany]
+  favicon: https://i.ibb.co/sQNvYtT/sex.jpg
+  homepage: https://www.rm.fm/sex
+  country: DE
+  status: stream-only
+
+- id: de-technolovers-drum-n-bass
+  stationuuid: cbcff885-49bb-4db1-8b78-7060e70ff06d
+  changeuuid: 771913f2-0478-4991-ada5-8a7cbdb30e69
+  reviewedAt: 2026-05-04
+  geo: [50.684, 7.910]
+  broadcaster: independent
+  name: Technolovers DRUM N BASS
+  streamUrl: https://stream.technolovers.fm/drummnbass?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [electronic, germany]
+  homepage: https://technolovers.fm/
+  country: DE
+  status: stream-only
+
+- id: de-chillout-piano-by-epic-piano
+  stationuuid: 5143bb9a-3c5e-4c53-a6ec-0108435caf5a
+  changeuuid: 27e1d142-fb95-4f31-afd8-70eff86bace2
+  reviewedAt: 2026-05-04
+  geo: [50.237, 7.910]
+  broadcaster: independent
+  name: CHILLOUT PIANO by Epic Piano
+  streamUrl: https://stream.epic-piano.com/chillout-piano?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [classical, lounge, germany]
+  homepage: https://epic-piano.com/
+  country: DE
+  status: stream-only
+
+- id: de-0-n-disco-on-radio
+  stationuuid: d6d00207-f360-11e8-a471-52543be04c81
+  changeuuid: 41b1da29-b9f4-4b51-88b5-9c46eb4cc8a0
+  reviewedAt: 2026-05-04
+  geo: [50.312, 11.923]
+  broadcaster: independent
+  name: "- 0 N - Disco on Radio"
+  streamUrl: https://0n-disco.radionetz.de/0n-disco.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [pop, oldies, electronic, soul, germany]
+  favicon: https://www.0nradio.com/logos/0n-disco_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+
+- id: de-rockantenne-alternative-mp3
+  stationuuid: d608bb74-0740-47e3-a1e2-c11edfeec91f
+  changeuuid: 81630f4e-094d-4bdc-a93e-11d24a174aa7
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: ROCKANTENNE Alternative (mp3)
+  streamUrl: https://stream.rockantenne.de/alternative/stream/mp3
+  bitrate: 128
+  codec: MP3
+  tags: [rock, germany]
+  favicon: https://www.rockantenne.de/logos/station-rock-antenne/apple-touch-icon.png
+  homepage: https://www.rockantenne.de/
+  country: DE
+  status: stream-only
+
+- id: de-epic-lounge-ibiza-chillout-lounge
+  stationuuid: bc0fc480-9229-4d6a-85b8-b91f38191f43
+  changeuuid: 03374158-4af2-44df-b1da-344ad236dbb6
+  reviewedAt: 2026-05-04
+  geo: [50.748, 8.555]
+  broadcaster: independent
+  name: Epic Lounge - IBIZA CHILLOUT LOUNGE
+  streamUrl: https://stream.epic-lounge.com/ibiza-chillout-lounge?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [ambient, lounge, germany]
+  homepage: https://epic-lounge.com/
+  country: DE
+  status: stream-only
+
+- id: de-rock-antenne-blues-rock
+  stationuuid: e54ee752-d84d-4a38-b35d-dc035fbded20
+  changeuuid: 1a9b2c82-f4ce-4b72-a219-25b728ea3457
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: ROCK ANTENNE Blues rock
+  streamUrl: https://stream.rockantenne.de/blues-rock/stream/mp3
+  bitrate: 128
+  codec: MP3
+  tags: [rock, germany]
+  favicon: https://www.rockantenne.de/logos/station-rock-antenne/apple-touch-icon.png
+  homepage: https://www.rockantenne.de/
+  country: DE
+  status: stream-only
+
+- id: de-schwany-5-oberkrain
+  stationuuid: 06f59caa-a243-4383-be08-2f6d3ceefdb2
+  changeuuid: 352dd93f-7a83-4e7c-95f6-005f1bf31d0c
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: Schwany 5 Oberkrain
+  streamUrl: https://schwany5oberkrain.hoamatwelle.de/
+  bitrate: 320
+  codec: MP3
+  tags: [classical, germany]
+  favicon: http://schwany.de/favicon.ico
+  homepage: http://schwany.de/
+  country: DE
+  status: stream-only
+
+- id: de-0-n-dance-on-radio
+  stationuuid: 8b596ce2-3a96-11e9-9b4e-52543be04c81
+  changeuuid: 3f0d2460-40b6-42cf-ac0d-9b6734b64eb2
+  reviewedAt: 2026-05-04
+  geo: [50.312, 11.923]
+  broadcaster: independent
+  name: "- 0 N - Dance on Radio"
+  streamUrl: https://0n-dance.radionetz.de/0n-dance.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [electronic, germany]
+  favicon: https://www.0nradio.com/logos/0n-dance_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+
+- id: de-technolovers-psytrance
+  stationuuid: 27d331f9-6685-47d4-a9e8-7fd16d91b66d
+  changeuuid: ca15902f-07e8-4484-878b-cfbe14d70f87
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: Technolovers - PSYTRANCE
+  streamUrl: https://stream.technolovers.fm/psytrance?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [electronic, germany]
+  homepage: https://technolovers.fm/
+  country: DE
+  status: stream-only
+
+- id: de-technolovers-minimal
+  stationuuid: 01fa3ef0-acf6-4e63-8777-f5bb4957b5ec
+  changeuuid: 20afe025-5741-4aaf-8970-cc1088a0d6eb
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: Technolovers - MINIMAL
+  streamUrl: https://stream.technolovers.fm/minimal?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [electronic, germany]
+  favicon: https://i.ibb.co/LncDTYz/MINIMAL-TL.jpg
+  homepage: https://technolovers.fm/
+  country: DE
+  status: stream-only
+
+- id: de-technolovers-techno
+  stationuuid: 2100610c-13c2-4536-879f-6a88ccb07dc8
+  changeuuid: aeff31c5-b850-49b9-8dae-a69499365049
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: Technolovers - TECHNO
+  streamUrl: https://stream.technolovers.fm/techno?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [electronic, germany]
+  favicon: https://i.ibb.co/ScwBQ49/TECHNO-TL.jpg
+  homepage: https://technolovers.fm/
+  country: DE
+  status: stream-only
+
+- id: de-0-n-smooth-jazz-on-radio
+  stationuuid: 4cd97318-3a95-11e9-9b4e-52543be04c81
+  changeuuid: 73356ac0-3fac-498e-b630-8787ad7c294e
+  reviewedAt: 2026-05-04
+  geo: [50.312, 11.923]
+  broadcaster: independent
+  name: "- 0 N - Smooth Jazz on Radio"
+  streamUrl: https://0n-smoothjazz.radionetz.de/0n-smoothjazz.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [jazz, germany]
+  favicon: https://www.0nradio.com/logos/0n-smooth-jazz_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+
+- id: de-90s-by-rautemusik-rm-fm
+  stationuuid: c87339e0-c556-4ed5-9ef2-4dd176cabbb0
+  changeuuid: dc882fea-12dc-4bb5-a1df-5990ba984f33
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: __90S__ by rautemusik (rm.fm)
+  streamUrl: https://90s-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [pop, electronic, hip-hop, oldies, germany]
+  favicon: https://www.rm.fm/favicon.ico
+  homepage: https://www.rm.fm/90s
+  country: DE
+  status: stream-only
+
+- id: de-hr2-kultur
+  stationuuid: 70614720-560e-4638-913d-0f682d3f9fa7
+  changeuuid: b744f84c-11c5-4ed2-96d8-76d99b97aef4
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: hr2-kultur
+  streamUrl: https://dispatcher.rndfnk.com/hr/hr2/live/mp3/high
+  bitrate: 128
+  codec: MP3
+  tags: [public radio, germany]
+  favicon: https://www.hr2.de/favicon.png?v=3.84.2
+  homepage: https://www.hr2.de/
+  country: DE
+  status: stream-only
+
+- id: de-0-n-country-on-radio
+  stationuuid: 5dd6437a-3a93-11e9-9b4e-52543be04c81
+  changeuuid: 3f8068ff-bda7-4c2f-bf28-470612c6309d
+  reviewedAt: 2026-05-04
+  geo: [50.312, 11.923]
+  broadcaster: independent
+  name: "- 0 N - Country on Radio"
+  streamUrl: https://0n-country.radionetz.de/0n-country.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [country, pop, rock, germany]
+  favicon: https://www.0nradio.com/logos/0n-country_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+
+- id: de-charivari-munchen-lounge-music
+  stationuuid: e0419c41-b016-11e9-acb2-52543be04c81
+  changeuuid: 27491595-01a0-46bc-8358-caab22968d43
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: Charivari München - Lounge Music
+  streamUrl: https://rs24.stream24.net/lounge.aac?ref=charivari.de&aw_0_1st.playerid=radioplayer.de
+  codec: AAC
+  tags: [lounge, germany]
+  favicon: https://www.charivari.de/apple-icon-120x120.png
+  homepage: https://www.charivari.de/
+  country: DE
+  status: stream-only
+
+- id: de-deutsche-welle-radio
+  stationuuid: bc2bbd05-59b2-4bff-86ef-a15a34e7d89e
+  changeuuid: c0aae25d-a313-4b35-ada9-5e0fbd74095a
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: Deutsche Welle Radio
+  streamUrl: https://dw.audiostream.io/dw/1027/mp3/64/dw08
+  bitrate: 64
+  codec: MP3
+  tags: [news, public radio, germany]
+  homepage: https://dw.com/
+  country: DE
+  status: stream-only
+
+- id: de-radio-seefunk
+  stationuuid: 213abeab-b8d2-4057-b570-5a6143607b2c
+  changeuuid: 1aba16e9-5aea-4da5-bf68-9fff51c116bd
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: Radio Seefunk
+  streamUrl: https://webradio.radio-seefunk.de/
+  bitrate: 128
+  codec: MP3
+  tags: [pop, electronic, germany]
+  homepage: https://www.dasneueradioseefunk.de/
+  country: DE
+  status: stream-only
+
+- id: de-0-n-70s-on-radio
+  stationuuid: b1a47819-f2c1-11e8-a471-52543be04c81
+  changeuuid: 7346d804-3534-4809-99a0-6b7ad96d2dd7
+  reviewedAt: 2026-05-04
+  geo: [50.312, 11.923]
+  broadcaster: independent
+  name: "- 0 N - 70s on Radio"
+  streamUrl: https://0n-70s.radionetz.de/0n-70s.aac
+  bitrate: 64
+  codec: AAC
+  tags: [pop, oldies, germany]
+  favicon: https://www.0nradio.com/logos/0n-70s_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+
+- id: de-deutschlandfunk-dokumente-und-debatten-dlf-aac-9
+  stationuuid: 9649888d-0601-11e8-ae97-52543be04c81
+  changeuuid: 58977477-0b33-4777-901c-5d7f17b1e5d5
+  reviewedAt: 2026-05-04
+  geo: [52.480, 13.335]
+  broadcaster: independent
+  name: "Deutschlandfunk Dokumente und Debatten | DLF | AAC 96k"
+  streamUrl: https://st04.sslstream.dlf.de/dlf/04/mid/aac/stream.aac?aggregator=web
+  bitrate: 128
+  codec: AAC
+  tags: [news, electronic, public radio, germany]
+  favicon: https://www.deutschlandradio.de/static/img/deutschlandradio/icons/apple-touch-icon-128x128.png
+  homepage: https://www.deutschlandradio.de/dokumente-und-debatten-102.html
+  country: DE
+  status: stream-only
+
+- id: de-lounge-by-rautemusik-rm-fm
+  stationuuid: 25ff1b4c-ffcb-4572-a561-9347e0e58c75
+  changeuuid: 6840f918-952b-43d1-bc03-f45f2a68c7c8
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: __LOUNGE__ by rautemusik (rm.fm)
+  streamUrl: https://lounge-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [ambient, lounge, germany]
+  favicon: https://www.rm.fm/favicon.ico
+  homepage: https://www.rm.fm/lounge
+  country: DE
+  status: stream-only
+
+- id: de-best-of-schlager-by-rautemusik-rm-fm
+  stationuuid: a3ac6250-7f5b-4246-a3ad-eb9721c29606
+  changeuuid: 99cfdf0c-4abf-4a45-95fc-9dbae19d5b38
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: __BEST OF SCHLAGER__ by rautemusik (rm.fm)
+  streamUrl: https://best-of-schlager-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [oldies, pop, schlager, germany]
+  favicon: https://www.rm.fm/favicon.ico
+  homepage: https://www.rm.fm/best-of-schlager
+  country: DE
+  status: stream-only
+
+- id: de-1-a-ndw-neue-deutsche-welle-von-1a-radio
+  stationuuid: 7f06cacb-f36f-11e8-a471-52543be04c81
+  changeuuid: 75862cdf-c875-4aa9-ba76-7f7a8d5912d7
+  reviewedAt: 2026-05-04
+  geo: [50.312, 11.923]
+  broadcaster: independent
+  name: "- 1 A - NDW (Neue Deutsche Welle) von 1A Radio"
+  streamUrl: https://1a-ndw.radionetz.de/1a-ndw.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [pop, public radio, germany]
+  favicon: https://www.1aradio.com/logos/1a-ndw_600x600.jpg
+  homepage: http://www.1aradio.com/
+  country: DE
+  status: stream-only
+
+- id: de-schlager-oldies-by-rautemusik-rm-fm
+  stationuuid: bd0b7f45-2ff6-4318-84b6-77a3490723f7
+  changeuuid: b50b78b2-bf77-4a9b-9a6b-2510188e7bd0
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: __SCHLAGER OLDIES__ by rautemusik (rm.fm)
+  streamUrl: https://schlager-oldies-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [pop, schlager, oldies, germany]
+  favicon: https://i.ibb.co/NNxSg2H/schlageroldies.jpg
+  homepage: https://www.rm.fm/schlager-oldies
+  country: DE
+  status: stream-only
 # ─── CA — CBC / Radio-Canada public broadcaster (2026-04-29) ───
 # CBC live streams are regional rather than national: every URL is
 # cbcradiolive.akamaized.net/hls/live/<liveId>/<channelCode>/master.m3u8

--- a/public/station-duplicates.json
+++ b/public/station-duplicates.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-05-04T13:56:23.914Z",
-  "totalScanned": 906,
+  "generatedAt": "2026-05-04T14:05:14.256Z",
+  "totalScanned": 936,
   "collisionCount": 0,
   "byKind": {
     "stationuuid": 0,

--- a/public/stations.json
+++ b/public/stations.json
@@ -8833,6 +8833,618 @@
       "status": "stream-only"
     },
     {
+      "id": "de-maretimo-lounge",
+      "name": "Maretimo Lounge",
+      "broadcaster": "independent",
+      "streamUrl": "https://s35.derstream.net/lounge.mp3",
+      "homepage": "http://www.maretimo-lounge-radio.com/",
+      "country": "DE",
+      "tags": [
+        "lounge",
+        "germany"
+      ],
+      "favicon": "https://d3kle7qwymxpcy.cloudfront.net/images/broadcasts/08/a3/107873/5/c175.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-nightride-fm-chillsynth",
+      "name": "Nightride FM - Chillsynth",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.nightride.fm/chillsynth.mp3",
+      "homepage": "https://nightride.fm/",
+      "country": "DE",
+      "tags": [
+        "lounge",
+        "ambient",
+        "germany"
+      ],
+      "favicon": "https://nightride.fm/thumbnail.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-antenne-bayern-coffeemusic",
+      "name": "Antenne Bayern - CoffeeMusic",
+      "broadcaster": "independent",
+      "streamUrl": "https://mp3channels.webradio.de/coffee",
+      "homepage": "https://www.webradio.de/antenne-bayern/coffeemusic",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "pop",
+        "germany"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-rock-antenne-hair-metal",
+      "name": "ROCK ANTENNE Hair Metal",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rockantenne.de/hair-metal/stream/aacp",
+      "homepage": "https://www.rockantenne.de/",
+      "country": "DE",
+      "tags": [
+        "rock",
+        "germany"
+      ],
+      "codec": "AAC",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-rock-radio",
+      "name": "Epic Rock Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://securestreams6.autopo.st:2222/stream",
+      "homepage": "https://www.epicrockradio.com/",
+      "country": "DE",
+      "tags": [
+        "rock",
+        "germany"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-sex-by-rautemusik-rm-fm",
+      "name": "__SEX__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://sex-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://www.rm.fm/sex",
+      "country": "DE",
+      "tags": [
+        "pop",
+        "germany"
+      ],
+      "favicon": "https://i.ibb.co/sQNvYtT/sex.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-technolovers-drum-n-bass",
+      "name": "Technolovers DRUM N BASS",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.technolovers.fm/drummnbass?ref=radiobrowser",
+      "homepage": "https://technolovers.fm/",
+      "country": "DE",
+      "tags": [
+        "electronic",
+        "germany"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.684,
+        7.91
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-chillout-piano-by-epic-piano",
+      "name": "CHILLOUT PIANO by Epic Piano",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-piano.com/chillout-piano?ref=radiobrowser",
+      "homepage": "https://epic-piano.com/",
+      "country": "DE",
+      "tags": [
+        "classical",
+        "lounge",
+        "germany"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.237,
+        7.91
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-disco-on-radio",
+      "name": "- 0 N - Disco on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-disco.radionetz.de/0n-disco.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "pop",
+        "oldies",
+        "electronic",
+        "soul",
+        "germany"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-disco_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.312,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-rockantenne-alternative-mp3",
+      "name": "ROCKANTENNE Alternative (mp3)",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rockantenne.de/alternative/stream/mp3",
+      "homepage": "https://www.rockantenne.de/",
+      "country": "DE",
+      "tags": [
+        "rock",
+        "germany"
+      ],
+      "favicon": "https://www.rockantenne.de/logos/station-rock-antenne/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-lounge-ibiza-chillout-lounge",
+      "name": "Epic Lounge - IBIZA CHILLOUT LOUNGE",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-lounge.com/ibiza-chillout-lounge?ref=radiobrowser",
+      "homepage": "https://epic-lounge.com/",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "lounge",
+        "germany"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.748,
+        8.555
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-rock-antenne-blues-rock",
+      "name": "ROCK ANTENNE Blues rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rockantenne.de/blues-rock/stream/mp3",
+      "homepage": "https://www.rockantenne.de/",
+      "country": "DE",
+      "tags": [
+        "rock",
+        "germany"
+      ],
+      "favicon": "https://www.rockantenne.de/logos/station-rock-antenne/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-schwany-5-oberkrain",
+      "name": "Schwany 5 Oberkrain",
+      "broadcaster": "independent",
+      "streamUrl": "https://schwany5oberkrain.hoamatwelle.de/",
+      "homepage": "http://schwany.de/",
+      "country": "DE",
+      "tags": [
+        "classical",
+        "germany"
+      ],
+      "favicon": "http://schwany.de/favicon.ico",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-dance-on-radio",
+      "name": "- 0 N - Dance on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-dance.radionetz.de/0n-dance.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "electronic",
+        "germany"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-dance_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.312,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-technolovers-psytrance",
+      "name": "Technolovers - PSYTRANCE",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.technolovers.fm/psytrance?ref=radiobrowser",
+      "homepage": "https://technolovers.fm/",
+      "country": "DE",
+      "tags": [
+        "electronic",
+        "germany"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-technolovers-minimal",
+      "name": "Technolovers - MINIMAL",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.technolovers.fm/minimal?ref=radiobrowser",
+      "homepage": "https://technolovers.fm/",
+      "country": "DE",
+      "tags": [
+        "electronic",
+        "germany"
+      ],
+      "favicon": "https://i.ibb.co/LncDTYz/MINIMAL-TL.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-technolovers-techno",
+      "name": "Technolovers - TECHNO",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.technolovers.fm/techno?ref=radiobrowser",
+      "homepage": "https://technolovers.fm/",
+      "country": "DE",
+      "tags": [
+        "electronic",
+        "germany"
+      ],
+      "favicon": "https://i.ibb.co/ScwBQ49/TECHNO-TL.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-smooth-jazz-on-radio",
+      "name": "- 0 N - Smooth Jazz on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-smoothjazz.radionetz.de/0n-smoothjazz.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "jazz",
+        "germany"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-smooth-jazz_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.312,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-90s-by-rautemusik-rm-fm",
+      "name": "__90S__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://90s-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://www.rm.fm/90s",
+      "country": "DE",
+      "tags": [
+        "pop",
+        "electronic",
+        "hip-hop",
+        "oldies",
+        "germany"
+      ],
+      "favicon": "https://www.rm.fm/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-hr2-kultur",
+      "name": "hr2-kultur",
+      "broadcaster": "independent",
+      "streamUrl": "https://dispatcher.rndfnk.com/hr/hr2/live/mp3/high",
+      "homepage": "https://www.hr2.de/",
+      "country": "DE",
+      "tags": [
+        "public radio",
+        "germany"
+      ],
+      "favicon": "https://www.hr2.de/favicon.png?v=3.84.2",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-country-on-radio",
+      "name": "- 0 N - Country on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-country.radionetz.de/0n-country.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "country",
+        "pop",
+        "rock",
+        "germany"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-country_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.312,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-charivari-munchen-lounge-music",
+      "name": "Charivari München - Lounge Music",
+      "broadcaster": "independent",
+      "streamUrl": "https://rs24.stream24.net/lounge.aac?ref=charivari.de&aw_0_1st.playerid=radioplayer.de",
+      "homepage": "https://www.charivari.de/",
+      "country": "DE",
+      "tags": [
+        "lounge",
+        "germany"
+      ],
+      "favicon": "https://www.charivari.de/apple-icon-120x120.png",
+      "codec": "AAC",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-deutsche-welle-radio",
+      "name": "Deutsche Welle Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://dw.audiostream.io/dw/1027/mp3/64/dw08",
+      "homepage": "https://dw.com/",
+      "country": "DE",
+      "tags": [
+        "news",
+        "public radio",
+        "germany"
+      ],
+      "bitrate": 64,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-seefunk",
+      "name": "Radio Seefunk",
+      "broadcaster": "independent",
+      "streamUrl": "https://webradio.radio-seefunk.de/",
+      "homepage": "https://www.dasneueradioseefunk.de/",
+      "country": "DE",
+      "tags": [
+        "pop",
+        "electronic",
+        "germany"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-70s-on-radio",
+      "name": "- 0 N - 70s on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-70s.radionetz.de/0n-70s.aac",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "pop",
+        "oldies",
+        "germany"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-70s_600x600.jpg",
+      "bitrate": 64,
+      "codec": "AAC",
+      "geo": [
+        50.312,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-deutschlandfunk-dokumente-und-debatten-dlf-aac-9",
+      "name": "Deutschlandfunk Dokumente und Debatten | DLF | AAC 96k",
+      "broadcaster": "independent",
+      "streamUrl": "https://st04.sslstream.dlf.de/dlf/04/mid/aac/stream.aac?aggregator=web",
+      "homepage": "https://www.deutschlandradio.de/dokumente-und-debatten-102.html",
+      "country": "DE",
+      "tags": [
+        "news",
+        "electronic",
+        "public radio",
+        "germany"
+      ],
+      "favicon": "https://www.deutschlandradio.de/static/img/deutschlandradio/icons/apple-touch-icon-128x128.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        52.48,
+        13.335
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-lounge-by-rautemusik-rm-fm",
+      "name": "__LOUNGE__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://lounge-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://www.rm.fm/lounge",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "lounge",
+        "germany"
+      ],
+      "favicon": "https://www.rm.fm/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-best-of-schlager-by-rautemusik-rm-fm",
+      "name": "__BEST OF SCHLAGER__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://best-of-schlager-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://www.rm.fm/best-of-schlager",
+      "country": "DE",
+      "tags": [
+        "oldies",
+        "pop",
+        "schlager",
+        "germany"
+      ],
+      "favicon": "https://www.rm.fm/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1-a-ndw-neue-deutsche-welle-von-1a-radio",
+      "name": "- 1 A - NDW (Neue Deutsche Welle) von 1A Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://1a-ndw.radionetz.de/1a-ndw.mp3",
+      "homepage": "http://www.1aradio.com/",
+      "country": "DE",
+      "tags": [
+        "pop",
+        "public radio",
+        "germany"
+      ],
+      "favicon": "https://www.1aradio.com/logos/1a-ndw_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.312,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-schlager-oldies-by-rautemusik-rm-fm",
+      "name": "__SCHLAGER OLDIES__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://schlager-oldies-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://www.rm.fm/schlager-oldies",
+      "country": "DE",
+      "tags": [
+        "pop",
+        "schlager",
+        "oldies",
+        "germany"
+      ],
+      "favicon": "https://i.ibb.co/NNxSg2H/schlageroldies.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
       "id": "builtin-cbc-radio-1-toronto",
       "name": "CBC Radio 1 Toronto",
       "broadcaster": "cbc",


### PR DESCRIPTION
## Germany — RB sweep batch 2 (2026-05-04)

Stacks on top of #106. Merge #106 first, then this.

Same source file: `rb-analysis-DE.json` (probed 2026-04-28, 5726 total DE stations, 2113 playable). These are positions 31–60 by RB vote count after deduplication.

### What was imported

| # | Name | Votes | Format |
|---|---|---|---|
| 1 | Maretimo Lounge | 1552 | MP3 128 |
| 2 | Nightride FM - Chillsynth | 1520 | MP3 320 |
| 3 | Antenne Bayern - CoffeeMusic | 1515 | MP3 128 |
| 4 | ROCK ANTENNE Hair Metal | 1501 | AAC |
| 5 | Epic Rock Radio | 1483 | MP3 128 |
| 6 | __SEX__ by rautemusik (rm.fm) | 1451 | MP3 192 |
| 7 | Technolovers DRUM N BASS | 1451 | MP3 192 |
| 8 | CHILLOUT PIANO by Epic Piano | 1406 | MP3 192 |
| 9 | - 0 N - Disco on Radio | 1402 | MP3 128 |
| 10 | ROCKANTENNE Alternative (mp3) | 1379 | MP3 128 |
| 11 | Epic Lounge - IBIZA CHILLOUT LOUNGE | 1372 | MP3 192 |
| 12 | ROCK ANTENNE Blues rock | 1361 | MP3 128 |
| 13 | Schwany 5 Oberkrain | 1336 | MP3 320 |
| 14 | - 0 N - Dance on Radio | 1319 | MP3 128 |
| 15 | Technolovers - PSYTRANCE | 1314 | MP3 192 |
| 16 | Technolovers - MINIMAL | 1307 | MP3 192 |
| 17 | Technolovers - TECHNO | 1286 | MP3 192 |
| 18 | - 0 N - Smooth Jazz on Radio | 1285 | MP3 128 |
| 19 | __90S__ by rautemusik (rm.fm) | 1198 | MP3 192 |
| 20 | hr2-kultur | 1197 | MP3 128 |
| 21 | - 0 N - Country on Radio | 1183 | MP3 128 |
| 22 | Charivari München - Lounge Music | 1183 | AAC |
| 23 | Deutsche Welle Radio | 1163 | MP3 64 |
| 24 | Radio Seefunk | 1160 | MP3 128 |
| 25 | - 0 N - 70s on Radio | 1106 | AAC 64 |
| 26 | Deutschlandfunk Dokumente und Debatten \| DLF \| AAC 96k | 1084 | AAC 128 |
| 27 | __LOUNGE__ by rautemusik (rm.fm) | 1049 | MP3 192 |
| 28 | __BEST OF SCHLAGER__ by rautemusik (rm.fm) | 1046 | MP3 192 |
| 29 | - 1 A - NDW (Neue Deutsche Welle) von 1A Radio | 1041 | AAC |
| 30 | __SCHLAGER OLDIES__ by rautemusik (rm.fm) | 1037 | MP3 192 |

### What was skipped

- **DLF AAC 96k + AAC 192k**: codec-only variants of existing `dlf-deutschlandfunk` (MP3 stream)
- ~1570 remaining candidates for future DE batches

### Verification

```
npm run catalog       → 936/936 stations published ✓
npm run check-catalog → 936 YAML stations match JSON ✓
npm run check-duplicates → 0 collisions ✓
npm test -- --run     → 281/281 tests passed ✓
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)