### PR TITLE
curate: import DE tier 2 (votes 20–99, ~509)

### DIFF
--- a/data/stations.yaml
+++ b/data/stations.yaml
@@ -6590,6 +6590,476 @@
   country: DE
   status: stream-only
 
+# ─── DE — Radio Browser sweep batch 2 (2026-05-04) ───
+
+- id: de-maretimo-lounge
+  stationuuid: aedd2edd-c8f1-4f75-9667-9d84cd6d690c
+  changeuuid: 8b366a1f-be24-4e7a-89d6-ad6f643afabf
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: Maretimo Lounge
+  streamUrl: https://s35.derstream.net/lounge.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [lounge, germany]
+  favicon: https://d3kle7qwymxpcy.cloudfront.net/images/broadcasts/08/a3/107873/5/c175.png
+  homepage: http://www.maretimo-lounge-radio.com/
+  country: DE
+  status: stream-only
+
+- id: de-nightride-fm-chillsynth
+  stationuuid: 9067dc39-4bf4-4364-bd6b-8020cff3e15d
+  changeuuid: 36b89f53-0d32-4932-a0cc-717f7a4c16f9
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: Nightride FM - Chillsynth
+  streamUrl: https://stream.nightride.fm/chillsynth.mp3
+  bitrate: 320
+  codec: MP3
+  tags: [lounge, ambient, germany]
+  favicon: https://nightride.fm/thumbnail.png
+  homepage: https://nightride.fm/
+  country: DE
+  status: stream-only
+
+- id: de-antenne-bayern-coffeemusic
+  stationuuid: 52ba8d13-e5e7-11e8-a9cc-52543be04c81
+  changeuuid: 2a1d9403-ce4f-4aa1-a15a-e2ddaf24b3d2
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: Antenne Bayern - CoffeeMusic
+  streamUrl: https://mp3channels.webradio.de/coffee
+  bitrate: 128
+  codec: MP3
+  tags: [ambient, pop, germany]
+  homepage: https://www.webradio.de/antenne-bayern/coffeemusic
+  country: DE
+  status: stream-only
+
+- id: de-rock-antenne-hair-metal
+  stationuuid: 2ed4195c-73a1-46ab-b6cb-e1afe68ea82a
+  changeuuid: 8aace9a0-b9b4-403c-82f5-884a49ba5b4e
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: ROCK ANTENNE Hair Metal
+  streamUrl: https://stream.rockantenne.de/hair-metal/stream/aacp
+  codec: AAC
+  tags: [rock, germany]
+  homepage: https://www.rockantenne.de/
+  country: DE
+  status: stream-only
+
+- id: de-epic-rock-radio
+  stationuuid: ddf0a603-ed3a-4d52-8d1b-cc11357734f3
+  changeuuid: 8915ad8e-b213-4bb5-8835-ca627a8b0ff5
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: Epic Rock Radio
+  streamUrl: https://securestreams6.autopo.st:2222/stream
+  bitrate: 128
+  codec: MP3
+  tags: [rock, germany]
+  homepage: https://www.epicrockradio.com/
+  country: DE
+  status: stream-only
+
+- id: de-sex-by-rautemusik-rm-fm
+  stationuuid: c52f22bd-7bc4-4fd2-ab2b-c3c7f031a530
+  changeuuid: f605a241-0f32-4578-83e1-c27d0058de39
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: __SEX__ by rautemusik (rm.fm)
+  streamUrl: https://sex-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [pop, germany]
+  favicon: https://i.ibb.co/sQNvYtT/sex.jpg
+  homepage: https://www.rm.fm/sex
+  country: DE
+  status: stream-only
+
+- id: de-technolovers-drum-n-bass
+  stationuuid: cbcff885-49bb-4db1-8b78-7060e70ff06d
+  changeuuid: 771913f2-0478-4991-ada5-8a7cbdb30e69
+  reviewedAt: 2026-05-04
+  geo: [50.684, 7.910]
+  broadcaster: independent
+  name: Technolovers DRUM N BASS
+  streamUrl: https://stream.technolovers.fm/drummnbass?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [electronic, germany]
+  homepage: https://technolovers.fm/
+  country: DE
+  status: stream-only
+
+- id: de-chillout-piano-by-epic-piano
+  stationuuid: 5143bb9a-3c5e-4c53-a6ec-0108435caf5a
+  changeuuid: 27e1d142-fb95-4f31-afd8-70eff86bace2
+  reviewedAt: 2026-05-04
+  geo: [50.237, 7.910]
+  broadcaster: independent
+  name: CHILLOUT PIANO by Epic Piano
+  streamUrl: https://stream.epic-piano.com/chillout-piano?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [classical, lounge, germany]
+  homepage: https://epic-piano.com/
+  country: DE
+  status: stream-only
+
+- id: de-0-n-disco-on-radio
+  stationuuid: d6d00207-f360-11e8-a471-52543be04c81
+  changeuuid: 41b1da29-b9f4-4b51-88b5-9c46eb4cc8a0
+  reviewedAt: 2026-05-04
+  geo: [50.312, 11.923]
+  broadcaster: independent
+  name: "- 0 N - Disco on Radio"
+  streamUrl: https://0n-disco.radionetz.de/0n-disco.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [pop, oldies, electronic, soul, germany]
+  favicon: https://www.0nradio.com/logos/0n-disco_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+
+- id: de-rockantenne-alternative-mp3
+  stationuuid: d608bb74-0740-47e3-a1e2-c11edfeec91f
+  changeuuid: 81630f4e-094d-4bdc-a93e-11d24a174aa7
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: ROCKANTENNE Alternative (mp3)
+  streamUrl: https://stream.rockantenne.de/alternative/stream/mp3
+  bitrate: 128
+  codec: MP3
+  tags: [rock, germany]
+  favicon: https://www.rockantenne.de/logos/station-rock-antenne/apple-touch-icon.png
+  homepage: https://www.rockantenne.de/
+  country: DE
+  status: stream-only
+
+- id: de-epic-lounge-ibiza-chillout-lounge
+  stationuuid: bc0fc480-9229-4d6a-85b8-b91f38191f43
+  changeuuid: 03374158-4af2-44df-b1da-344ad236dbb6
+  reviewedAt: 2026-05-04
+  geo: [50.748, 8.555]
+  broadcaster: independent
+  name: Epic Lounge - IBIZA CHILLOUT LOUNGE
+  streamUrl: https://stream.epic-lounge.com/ibiza-chillout-lounge?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [ambient, lounge, germany]
+  homepage: https://epic-lounge.com/
+  country: DE
+  status: stream-only
+
+- id: de-rock-antenne-blues-rock
+  stationuuid: e54ee752-d84d-4a38-b35d-dc035fbded20
+  changeuuid: 1a9b2c82-f4ce-4b72-a219-25b728ea3457
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: ROCK ANTENNE Blues rock
+  streamUrl: https://stream.rockantenne.de/blues-rock/stream/mp3
+  bitrate: 128
+  codec: MP3
+  tags: [rock, germany]
+  favicon: https://www.rockantenne.de/logos/station-rock-antenne/apple-touch-icon.png
+  homepage: https://www.rockantenne.de/
+  country: DE
+  status: stream-only
+
+- id: de-schwany-5-oberkrain
+  stationuuid: 06f59caa-a243-4383-be08-2f6d3ceefdb2
+  changeuuid: 352dd93f-7a83-4e7c-95f6-005f1bf31d0c
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: Schwany 5 Oberkrain
+  streamUrl: https://schwany5oberkrain.hoamatwelle.de/
+  bitrate: 320
+  codec: MP3
+  tags: [classical, germany]
+  favicon: http://schwany.de/favicon.ico
+  homepage: http://schwany.de/
+  country: DE
+  status: stream-only
+
+- id: de-0-n-dance-on-radio
+  stationuuid: 8b596ce2-3a96-11e9-9b4e-52543be04c81
+  changeuuid: 3f0d2460-40b6-42cf-ac0d-9b6734b64eb2
+  reviewedAt: 2026-05-04
+  geo: [50.312, 11.923]
+  broadcaster: independent
+  name: "- 0 N - Dance on Radio"
+  streamUrl: https://0n-dance.radionetz.de/0n-dance.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [electronic, germany]
+  favicon: https://www.0nradio.com/logos/0n-dance_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+
+- id: de-technolovers-psytrance
+  stationuuid: 27d331f9-6685-47d4-a9e8-7fd16d91b66d
+  changeuuid: ca15902f-07e8-4484-878b-cfbe14d70f87
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: Technolovers - PSYTRANCE
+  streamUrl: https://stream.technolovers.fm/psytrance?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [electronic, germany]
+  homepage: https://technolovers.fm/
+  country: DE
+  status: stream-only
+
+- id: de-technolovers-minimal
+  stationuuid: 01fa3ef0-acf6-4e63-8777-f5bb4957b5ec
+  changeuuid: 20afe025-5741-4aaf-8970-cc1088a0d6eb
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: Technolovers - MINIMAL
+  streamUrl: https://stream.technolovers.fm/minimal?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [electronic, germany]
+  favicon: https://i.ibb.co/LncDTYz/MINIMAL-TL.jpg
+  homepage: https://technolovers.fm/
+  country: DE
+  status: stream-only
+
+- id: de-technolovers-techno
+  stationuuid: 2100610c-13c2-4536-879f-6a88ccb07dc8
+  changeuuid: aeff31c5-b850-49b9-8dae-a69499365049
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: Technolovers - TECHNO
+  streamUrl: https://stream.technolovers.fm/techno?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [electronic, germany]
+  favicon: https://i.ibb.co/ScwBQ49/TECHNO-TL.jpg
+  homepage: https://technolovers.fm/
+  country: DE
+  status: stream-only
+
+- id: de-0-n-smooth-jazz-on-radio
+  stationuuid: 4cd97318-3a95-11e9-9b4e-52543be04c81
+  changeuuid: 73356ac0-3fac-498e-b630-8787ad7c294e
+  reviewedAt: 2026-05-04
+  geo: [50.312, 11.923]
+  broadcaster: independent
+  name: "- 0 N - Smooth Jazz on Radio"
+  streamUrl: https://0n-smoothjazz.radionetz.de/0n-smoothjazz.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [jazz, germany]
+  favicon: https://www.0nradio.com/logos/0n-smooth-jazz_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+
+- id: de-90s-by-rautemusik-rm-fm
+  stationuuid: c87339e0-c556-4ed5-9ef2-4dd176cabbb0
+  changeuuid: dc882fea-12dc-4bb5-a1df-5990ba984f33
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: __90S__ by rautemusik (rm.fm)
+  streamUrl: https://90s-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [pop, electronic, hip-hop, oldies, germany]
+  favicon: https://www.rm.fm/favicon.ico
+  homepage: https://www.rm.fm/90s
+  country: DE
+  status: stream-only
+
+- id: de-hr2-kultur
+  stationuuid: 70614720-560e-4638-913d-0f682d3f9fa7
+  changeuuid: b744f84c-11c5-4ed2-96d8-76d99b97aef4
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: hr2-kultur
+  streamUrl: https://dispatcher.rndfnk.com/hr/hr2/live/mp3/high
+  bitrate: 128
+  codec: MP3
+  tags: [public radio, germany]
+  favicon: https://www.hr2.de/favicon.png?v=3.84.2
+  homepage: https://www.hr2.de/
+  country: DE
+  status: stream-only
+
+- id: de-0-n-country-on-radio
+  stationuuid: 5dd6437a-3a93-11e9-9b4e-52543be04c81
+  changeuuid: 3f8068ff-bda7-4c2f-bf28-470612c6309d
+  reviewedAt: 2026-05-04
+  geo: [50.312, 11.923]
+  broadcaster: independent
+  name: "- 0 N - Country on Radio"
+  streamUrl: https://0n-country.radionetz.de/0n-country.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [country, pop, rock, germany]
+  favicon: https://www.0nradio.com/logos/0n-country_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+
+- id: de-charivari-munchen-lounge-music
+  stationuuid: e0419c41-b016-11e9-acb2-52543be04c81
+  changeuuid: 27491595-01a0-46bc-8358-caab22968d43
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: Charivari München - Lounge Music
+  streamUrl: https://rs24.stream24.net/lounge.aac?ref=charivari.de&aw_0_1st.playerid=radioplayer.de
+  codec: AAC
+  tags: [lounge, germany]
+  favicon: https://www.charivari.de/apple-icon-120x120.png
+  homepage: https://www.charivari.de/
+  country: DE
+  status: stream-only
+
+- id: de-deutsche-welle-radio
+  stationuuid: bc2bbd05-59b2-4bff-86ef-a15a34e7d89e
+  changeuuid: c0aae25d-a313-4b35-ada9-5e0fbd74095a
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: Deutsche Welle Radio
+  streamUrl: https://dw.audiostream.io/dw/1027/mp3/64/dw08
+  bitrate: 64
+  codec: MP3
+  tags: [news, public radio, germany]
+  homepage: https://dw.com/
+  country: DE
+  status: stream-only
+
+- id: de-radio-seefunk
+  stationuuid: 213abeab-b8d2-4057-b570-5a6143607b2c
+  changeuuid: 1aba16e9-5aea-4da5-bf68-9fff51c116bd
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: Radio Seefunk
+  streamUrl: https://webradio.radio-seefunk.de/
+  bitrate: 128
+  codec: MP3
+  tags: [pop, electronic, germany]
+  homepage: https://www.dasneueradioseefunk.de/
+  country: DE
+  status: stream-only
+
+- id: de-0-n-70s-on-radio
+  stationuuid: b1a47819-f2c1-11e8-a471-52543be04c81
+  changeuuid: 7346d804-3534-4809-99a0-6b7ad96d2dd7
+  reviewedAt: 2026-05-04
+  geo: [50.312, 11.923]
+  broadcaster: independent
+  name: "- 0 N - 70s on Radio"
+  streamUrl: https://0n-70s.radionetz.de/0n-70s.aac
+  bitrate: 64
+  codec: AAC
+  tags: [pop, oldies, germany]
+  favicon: https://www.0nradio.com/logos/0n-70s_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+
+- id: de-deutschlandfunk-dokumente-und-debatten-dlf-aac-9
+  stationuuid: 9649888d-0601-11e8-ae97-52543be04c81
+  changeuuid: 58977477-0b33-4777-901c-5d7f17b1e5d5
+  reviewedAt: 2026-05-04
+  geo: [52.480, 13.335]
+  broadcaster: independent
+  name: "Deutschlandfunk Dokumente und Debatten | DLF | AAC 96k"
+  streamUrl: https://st04.sslstream.dlf.de/dlf/04/mid/aac/stream.aac?aggregator=web
+  bitrate: 128
+  codec: AAC
+  tags: [news, electronic, public radio, germany]
+  favicon: https://www.deutschlandradio.de/static/img/deutschlandradio/icons/apple-touch-icon-128x128.png
+  homepage: https://www.deutschlandradio.de/dokumente-und-debatten-102.html
+  country: DE
+  status: stream-only
+
+- id: de-lounge-by-rautemusik-rm-fm
+  stationuuid: 25ff1b4c-ffcb-4572-a561-9347e0e58c75
+  changeuuid: 6840f918-952b-43d1-bc03-f45f2a68c7c8
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: __LOUNGE__ by rautemusik (rm.fm)
+  streamUrl: https://lounge-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [ambient, lounge, germany]
+  favicon: https://www.rm.fm/favicon.ico
+  homepage: https://www.rm.fm/lounge
+  country: DE
+  status: stream-only
+
+- id: de-best-of-schlager-by-rautemusik-rm-fm
+  stationuuid: a3ac6250-7f5b-4246-a3ad-eb9721c29606
+  changeuuid: 99cfdf0c-4abf-4a45-95fc-9dbae19d5b38
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: __BEST OF SCHLAGER__ by rautemusik (rm.fm)
+  streamUrl: https://best-of-schlager-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [oldies, pop, schlager, germany]
+  favicon: https://www.rm.fm/favicon.ico
+  homepage: https://www.rm.fm/best-of-schlager
+  country: DE
+  status: stream-only
+
+- id: de-1-a-ndw-neue-deutsche-welle-von-1a-radio
+  stationuuid: 7f06cacb-f36f-11e8-a471-52543be04c81
+  changeuuid: 75862cdf-c875-4aa9-ba76-7f7a8d5912d7
+  reviewedAt: 2026-05-04
+  geo: [50.312, 11.923]
+  broadcaster: independent
+  name: "- 1 A - NDW (Neue Deutsche Welle) von 1A Radio"
+  streamUrl: https://1a-ndw.radionetz.de/1a-ndw.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [pop, public radio, germany]
+  favicon: https://www.1aradio.com/logos/1a-ndw_600x600.jpg
+  homepage: http://www.1aradio.com/
+  country: DE
+  status: stream-only
+
+- id: de-schlager-oldies-by-rautemusik-rm-fm
+  stationuuid: bd0b7f45-2ff6-4318-84b6-77a3490723f7
+  changeuuid: b50b78b2-bf77-4a9b-9a6b-2510188e7bd0
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: __SCHLAGER OLDIES__ by rautemusik (rm.fm)
+  streamUrl: https://schlager-oldies-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [pop, schlager, oldies, germany]
+  favicon: https://i.ibb.co/NNxSg2H/schlageroldies.jpg
+  homepage: https://www.rm.fm/schlager-oldies
+  country: DE
+  status: stream-only
 # ─── CA — CBC / Radio-Canada public broadcaster (2026-04-29) ───
 # CBC live streams are regional rather than national: every URL is
 # cbcradiolive.akamaized.net/hls/live/<liveId>/<channelCode>/master.m3u8

--- a/data/stations.yaml
+++ b/data/stations.yaml
@@ -6111,6 +6111,485 @@
   country: DE
   status: working
 
+# ─── DE — Radio Browser sweep 2026-05-04 (top 30 of 1710 candidates) ───
+# Sorted by RB votes desc. 2113 playable of 5726 total DE stations.
+
+
+
+- id: de-technolovers-edm
+  stationuuid: 5ea0c406-cc3e-4a36-9a32-37ed4d5a180e
+  changeuuid: f542c307-b541-487e-b193-31ab8670196c
+  reviewedAt: 2026-05-04
+  geo: [50.906, 7.910]
+  broadcaster: independent
+  name: Technolovers EDM
+  streamUrl: https://stream.technolovers.fm/edm?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [electronic, germany]
+  favicon: https://i.ibb.co/TmRLJsp/EDM-TL.jpg
+  homepage: https://technolovers.fm/
+  country: DE
+  status: stream-only
+
+- id: de-technobase-fm
+  stationuuid: 6058ff93-ee55-407e-9221-c6ad07fd2531
+  changeuuid: 45853b0e-a825-48e6-a706-3b18b1f36c16
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: TechnoBase.FM
+  streamUrl: https://listener3.mp3.tb-group.fm/tb.mp3
+  bitrate: 192
+  codec: MP3
+  tags: [electronic, germany]
+  favicon: https://cdn.onlineradiobox.com/img/l/0/32040.v12.png
+  country: DE
+  status: stream-only
+
+
+
+- id: de-0-n-2000s-on-radio
+  stationuuid: 1a4914a2-f35f-11e8-a471-52543be04c81
+  changeuuid: 2a0541a1-4f2d-4330-83cb-e675113d0c23
+  reviewedAt: 2026-05-04
+  geo: [50.312, 11.923]
+  broadcaster: independent
+  name: "- 0 N - 2000s on Radio"
+  streamUrl: https://0n-2000s.radionetz.de/0n-2000s.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [electronic, pop, rock, oldies, germany]
+  favicon: https://www.0nradio.com/logos/0n-2000s_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+
+- id: de-1000-goldschlager
+  stationuuid: 5f154f50-472f-11e9-aa55-52543be04c81
+  changeuuid: 9342199d-503f-4df6-8371-445e2b40cbd9
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: 1000 Goldschlager
+  streamUrl: https://1000goldschlager.stream.laut.fm/1000goldschlager
+  bitrate: 128
+  codec: MP3
+  tags: [schlager, germany]
+  favicon: https://1000goldschlager.de/apple-icon-120x120.png
+  homepage: https://1000goldschlager.de/
+  country: DE
+  status: stream-only
+
+
+
+- id: de-0-n-chillout-on-radio
+  stationuuid: 8b3e9c54-f365-11e8-a471-52543be04c81
+  changeuuid: 82c34172-3a04-48d9-8e6d-3f0179a074e3
+  reviewedAt: 2026-05-04
+  geo: [50.312, 11.923]
+  broadcaster: independent
+  name: "- 0 N - Chillout on Radio"
+  streamUrl: https://0n-chillout.radionetz.de/0n-chillout.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [ambient, electronic, germany]
+  favicon: https://www.0nradio.com/logos/0n-chillout_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+
+- id: de-radio-bollerwagen
+  stationuuid: a3a695be-35ba-4a1a-b8e7-d90815f4b942
+  changeuuid: e6622abd-983e-4057-8e48-65464a359d3e
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: Radio Bollerwagen
+  streamUrl: https://ffn-stream19.radiohost.de/radiobollerwagen_mp3-192?ref=radioplayer&listenerid=31363233323633323031-323030333a64653a343731363a3730313a623731343a346664383a313761363a39386165-3537373636-4d6f7a696c6c612f352e3020285831313b205562
+  bitrate: 192
+  codec: MP3
+  tags: [germany]
+  favicon: https://www.radio.de/images/broadcasts/80/eb/100349/3/c300.png
+  homepage: https://player.ffn.de/radioplayer/radio-bollerwagen/
+  country: DE
+  status: stream-only
+
+- id: de-italo-disco
+  stationuuid: 4a9cd8e0-1b0d-4c87-91bf-d227e06b23eb
+  changeuuid: 0f7776b9-8a63-4674-881e-369b41a868f2
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: Italo Disco
+  streamUrl: https://italo-disco.stream.laut.fm/italo-disco
+  bitrate: 128
+  codec: MP3
+  tags: [electronic, oldies, germany]
+  favicon: https://cdn.onlineradiobox.com/img/l/1/44061.v2.png
+  country: DE
+  status: stream-only
+
+- id: de-technolovers-electro-house
+  stationuuid: 830a7eff-916d-456c-842a-d7786e475658
+  changeuuid: a0a12390-135f-461d-98d7-36df3af7398e
+  reviewedAt: 2026-05-04
+  geo: [51.235, 7.240]
+  broadcaster: independent
+  name: Technolovers ELECTRO HOUSE
+  streamUrl: https://stream.technolovers.fm/electro-house?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [electronic, germany]
+  favicon: https://i.ibb.co/B4R6kNj/Electrohouse-tl.jpg
+  homepage: https://technolovers.fm/
+  country: DE
+  status: stream-only
+
+- id: de-0-n-60s-on-radio
+  stationuuid: f9533da3-f2c1-11e8-a471-52543be04c81
+  changeuuid: 0d8dc6ce-198e-4c8e-bd90-5fd4d192b661
+  reviewedAt: 2026-05-04
+  geo: [50.312, 11.923]
+  broadcaster: independent
+  name: "- 0 N - 60s on Radio"
+  streamUrl: https://0n-60s.radionetz.de/0n-60s.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [pop, soul, oldies, germany]
+  favicon: https://www.0nradio.com/logos/0n-60s_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+
+- id: de-0nlineradio-remix
+  stationuuid: a8c1c86e-e1c0-4e86-ba15-74c258ac0af9
+  changeuuid: 6f1c9806-23d8-4c8b-8407-4c4865e5139b
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: 0nlineradio REMIX
+  streamUrl: https://stream.0nlineradio.com/remix?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [electronic, hip-hop, pop, latin, germany]
+  homepage: https://0nlineradio.com/
+  country: DE
+  status: stream-only
+
+- id: de-electro-swing-revolution
+  stationuuid: 0e8da368-6917-11e8-b15b-52543be04c81
+  changeuuid: 206327f7-1354-4a9a-94ae-9da53f78eb33
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: Electro Swing Revolution
+  streamUrl: https://streamer.radio.co/s2c3cc784b/listen
+  bitrate: 192
+  codec: MP3
+  tags: [electronic, swing, germany]
+  favicon: https://www.electroswing-radio.com/favicon.ico
+  homepage: https://www.electroswing-radio.com/
+  country: DE
+  status: stream-only
+
+
+
+- id: de-hr-info
+  stationuuid: 83b7ec82-15dd-4cfe-96b4-db0a27c6b979
+  changeuuid: 21c65a5b-4609-46d7-bc91-1f23d324d123
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: HR Info
+  streamUrl: https://dispatcher.rndfnk.com/hr/hrinfo/live/mp3/high
+  bitrate: 128
+  codec: MP3
+  tags: [news, public radio, germany]
+  homepage: https://www.hr-inforadio.de/index.html
+  country: DE
+  status: stream-only
+
+- id: de-i-love-radio-us-only-rap-hiphop-radio
+  stationuuid: 7997cf34-9131-11e9-a6c6-52543be04c81
+  changeuuid: eaf3ef0f-8736-4c89-9673-1953ce6f8f0b
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: "i love radio - US Only Rap&HipHop Radio"
+  streamUrl: https://ilm.stream35.radiohost.de/ilm_iloveusonlyrapradio_mp3-192?upd-meta&upd-scheme=https&_art=dD0xNzY4NDU1Mjg0JmQ9YjVlNGIxYTMwOGY3YTQxZjVlZGQ
+  bitrate: 192
+  codec: MP3
+  tags: [hip-hop, germany]
+  favicon: https://www.iloveradio.de/favicon.ico
+  homepage: https://www.iloveradio.de/iloveusonlyrapradio/
+  country: DE
+  status: stream-only
+
+- id: de-schlagerparadies
+  stationuuid: 9607be6f-0601-11e8-ae97-52543be04c81
+  changeuuid: b557c2e5-1b79-4ac3-bac5-3d555e5c4793
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: Schlagerparadies
+  streamUrl: https://webstream.schlagerparadies.de/schlager30842
+  bitrate: 192
+  codec: MP3
+  tags: [schlager, germany]
+  homepage: http://www.schlagerparadies.de/
+  country: DE
+  status: stream-only
+
+- id: de-epic-classical-classical-music-for-sleep
+  stationuuid: 1665ae4c-74dc-44f0-bd0a-7a0d0291aa8c
+  changeuuid: a905e808-e183-40dd-beb5-c7f8fd48b183
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: EPIC CLASSICAL - Classical Music For Sleep
+  streamUrl: https://stream.epic-classical.com/classical-music-for-sleep
+  bitrate: 192
+  codec: MP3
+  tags: [ambient, classical, lounge, germany]
+  homepage: https://epic-classical.com/
+  country: DE
+  status: stream-only
+
+- id: de-bayern-1-franken
+  stationuuid: 3a0985e9-788d-11e8-83fa-52543be04c81
+  changeuuid: 5542c7fb-b910-44dd-b689-b88f4bb5e3db
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: Bayern 1 Franken
+  streamUrl: https://dispatcher.rndfnk.com/br/br1/franken/mp3/mid
+  bitrate: 128
+  codec: MP3
+  tags: [pop, germany]
+  favicon: https://api.ardmediathek.de/image-service/images/urn:ard:image:b366004f6196d70c?w=512
+  homepage: https://www.br.de/radio/bayern1/index.html
+  country: DE
+  status: stream-only
+
+- id: de-absolut-bella
+  stationuuid: df1045ec-c8ef-410f-b800-9a81cdf0d252
+  changeuuid: 9b19924b-7fcb-4db8-97a4-31f154113a3f
+  reviewedAt: 2026-05-04
+  geo: [52.506, 13.400]
+  broadcaster: independent
+  name: Absolut bella
+  streamUrl: https://absolut-bella.live-sm.absolutradio.de/absolut-bella/stream/mp3
+  bitrate: 128
+  codec: MP3
+  tags: [germany]
+  favicon: https://absolutradio.de/apple-touch-icon.png
+  homepage: https://absolutradio.de/
+  country: DE
+  status: stream-only
+
+- id: de-hip-hop-forever
+  stationuuid: 563b5435-61d9-11e9-a622-52543be04c81
+  changeuuid: 5288a728-75c5-4142-863f-d347cd3d5ce8
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: Hip Hop Forever
+  streamUrl: https://stream.laut.fm/hiphop-forever
+  bitrate: 128
+  codec: MP3
+  tags: [hip-hop, germany]
+  country: DE
+  status: stream-only
+
+- id: de-nightride-fm-spacesynth
+  stationuuid: 9aea4f9e-4170-4d8f-ad8c-67f2bfeaa9e0
+  changeuuid: ccd5f826-19be-4923-b4fa-a564feabb7dd
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: Nightride FM - Spacesynth
+  streamUrl: https://stream.nightride.fm/spacesynth.mp3
+  bitrate: 320
+  codec: MP3
+  tags: [germany]
+  favicon: https://nightride.fm/thumbnail.png
+  homepage: https://nightride.fm/
+  country: DE
+  status: stream-only
+
+- id: de-0-n-electro-on-radio
+  stationuuid: f00f65b1-f36a-11e8-a471-52543be04c81
+  changeuuid: 9dab194d-28c8-4c96-ac5d-a732a3c582c5
+  reviewedAt: 2026-05-04
+  geo: [50.312, 11.923]
+  broadcaster: independent
+  name: "- 0 N - Electro on Radio"
+  streamUrl: https://0n-electro.radionetz.de/0n-electro.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [electronic, germany]
+  favicon: https://www.0nradio.com/logos/0n-electro_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+
+- id: de-deutschlandfunk-nova-dlf-mp3-128k
+  stationuuid: 0e1a47cb-f16d-4169-851a-5985c6133055
+  changeuuid: 14c92ee1-4bb6-4cc2-bca4-8f26579fd379
+  reviewedAt: 2026-05-04
+  geo: [52.480, 13.335]
+  broadcaster: independent
+  name: "Deutschlandfunk Nova | DLF | MP3 128k"
+  streamUrl: https://st03.sslstream.dlf.de/dlf/03/128/mp3/stream.mp3?aggregator=web
+  bitrate: 128
+  codec: MP3
+  tags: [news, public radio, germany]
+  favicon: https://www.deutschlandfunknova.de/apple-touch-icon.png
+  homepage: https://www.deutschlandfunknova.de/
+  country: DE
+  status: stream-only
+
+- id: de-epic-lounge-sleep-meditation
+  stationuuid: 4c0118e7-97d9-4657-9bb8-427758a4aa85
+  changeuuid: 88fcf0bd-c0be-45fc-99fc-9684a6870d1c
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: "Epic Lounge - SLEEP & MEDITATION"
+  streamUrl: https://stream.epic-lounge.com/sleep-meditation?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [ambient, lounge, germany]
+  homepage: https://epic-lounge.com/
+  country: DE
+  status: stream-only
+
+- id: de-0-n-greatest-hits-on-radio
+  stationuuid: b8e70464-2f37-45cb-8069-512206b6d7f7
+  changeuuid: f434af7f-e655-43fd-be85-c3891ab96a4b
+  reviewedAt: 2026-05-04
+  geo: [50.312, 11.923]
+  broadcaster: independent
+  name: "- 0 N - Greatest Hits on Radio"
+  streamUrl: https://0n-greatesthits.radionetz.de/0n-greatesthits.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [pop, electronic, hip-hop, rock, germany]
+  favicon: https://www.0nradio.com/logos/0n-greatest-hits_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+
+- id: de-club-by-rautemusik-rm-fm
+  stationuuid: 5f7cdd03-86fc-4d13-89c1-2f9a0b92fc23
+  changeuuid: f1113c9d-96a2-4f45-ab1e-f01f48824f6f
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: __CLUB__ by rautemusik (rm.fm)
+  streamUrl: https://club-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [electronic, pop, germany]
+  favicon: https://www.rm.fm/favicon.ico
+  homepage: https://www.rm.fm/club
+  country: DE
+  status: stream-only
+
+- id: de-0-n-classic-rock-on-radio
+  stationuuid: fd13051d-40ec-11e9-aa55-52543be04c81
+  changeuuid: 08b238a7-3ea4-4851-bf65-7f2ca2e0487e
+  reviewedAt: 2026-05-04
+  geo: [50.312, 11.923]
+  broadcaster: independent
+  name: "- 0 N - Classic Rock on Radio"
+  streamUrl: https://0n-classicrock.radionetz.de/0n-classicrock.aac
+  bitrate: 64
+  codec: AAC
+  tags: [pop, rock, germany]
+  favicon: https://www.0nradio.com/logos/0n-classic-rock_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+
+- id: de-technolovers-eurodance
+  stationuuid: ee6043f7-124d-4f20-b020-c1a77ca8383e
+  changeuuid: f78ac9b5-89aa-4a0d-b6c8-0775cc86b288
+  reviewedAt: 2026-05-04
+  geo: [50.674, 9.609]
+  broadcaster: independent
+  name: Technolovers EURODANCE
+  streamUrl: https://stream.technolovers.fm/eurodance?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [pop, electronic, germany]
+  homepage: https://technolovers.fm/
+  country: DE
+  status: stream-only
+
+- id: de-technolovers-funky-house
+  stationuuid: 57df1d35-5943-46e6-a76c-f9ef35ea73e7
+  changeuuid: 15c870e5-7312-4e2a-a8f2-fb5f0886bb8f
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: Technolovers - FUNKY HOUSE
+  streamUrl: https://stream.technolovers.fm/funky-house?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [electronic, germany]
+  homepage: https://technolovers.fm/
+  country: DE
+  status: stream-only
+
+- id: de-0nlineradio-bach
+  stationuuid: 5dc97c2f-566f-47df-8236-021db5906dde
+  changeuuid: d8a77fa8-5d27-40f7-84c1-12aebf6d7672
+  reviewedAt: 2026-05-04
+  geo: [51.128, 8.965]
+  broadcaster: independent
+  name: 0nlineradio BACH
+  streamUrl: https://stream.0nlineradio.com/bach?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [classical, germany]
+  favicon: https://i.ibb.co/n1CQpDf/BACH-NEW.jpg
+  homepage: https://0nlineradio.com/
+  country: DE
+  status: stream-only
+
+- id: de-technolovers-vocal-trance
+  stationuuid: 00c4c0c7-bf13-4a8b-b14f-05f9e5a4a116
+  changeuuid: 4514d297-7508-4f27-87bb-e06e042c4edf
+  reviewedAt: 2026-05-04
+  geo: [51.117, 8.906]
+  broadcaster: independent
+  name: Technolovers VOCAL TRANCE
+  streamUrl: https://stream.technolovers.fm/vocal-trance?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [electronic, germany]
+  homepage: https://technolovers.fm/
+  country: DE
+  status: stream-only
+
+- id: de-deutschrap-charts-by-rautemusik-rm-fm
+  stationuuid: 92602eb8-2cc7-4839-a739-b9132aeed6a5
+  changeuuid: ec586cd4-662b-4b1b-866c-4b3a16266825
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: __DEUTSCHRAP CHARTS__ by rautemusik (rm.fm)
+  streamUrl: https://deutschrap-charts-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [hip-hop, pop, germany]
+  favicon: https://www.rm.fm/favicon.ico
+  homepage: https://www.rm.fm/deutschrap-charts
+  country: DE
+  status: stream-only
+
 # ─── CA — CBC / Radio-Canada public broadcaster (2026-04-29) ───
 # CBC live streams are regional rather than national: every URL is
 # cbcradiolive.akamaized.net/hls/live/<liveId>/<channelCode>/master.m3u8

--- a/data/stations.yaml
+++ b/data/stations.yaml
@@ -14122,3 +14122,6426 @@
   homepage: https://rusongs.ru/
   country: RU
   status: stream-only
+
+- id: de-top-100-club-charts-dance-dj-mix-radio-24-hours-
+  broadcaster: independent
+  name: "# TOP 100 CLUB CHARTS - DANCE & DJ MIX RADIO - 24 HOURS NON-STOP MUSIC @ TikTok Hits, Ibiza House, Sunset Lounge, Melodic Music, EDM, Deep House, Dance Music, Techno & Hypertechno, Rave Charts, Top 40 Charts, Latin, Reggaeton Music, Moombahton, Urban Hits, HipHop, Party & Clubbing Radio, Trending Chartmusic, R&B, Urban, Mixtape - & LIVE DJ SET "
+  streamUrl: https://breakz-2012-high.rautemusik.fm/?ref=radiobrowser-top100-clubcharts
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/T1gH75m/rb-top100clubcharts.png
+  homepage: https://rm.fm/breakz/team
+  country: DE
+  status: stream-only
+  stationuuid: dd98c499-a0c4-4019-a35e-99caa6940407
+  changeuuid: 9933c662-e5d0-463d-801c-3eba20d31fd5
+  reviewedAt: "2026-05-04"
+
+- id: de-top-100-dj-charts-dj-remix-charts-radio-tiktok-c
+  broadcaster: independent
+  name: "# TOP 100 DJ CHARTS - DJ REMIX & CHARTS RADIO @ TikTok Charts, Electronic Music, EDM, House, Deep House, Dance Music, Techno & Hypertechno, Top40, Latin Charts, Reggaeton, Urban, HipHop, Club & Party Radio - & LIVE DJ SETS "
+  streamUrl: https://breakz-high.rautemusik.fm/?ref=radiobrowser-top100-djcharts
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/jMmvLjz/TOP100-DJ-CHARTS-RADIO.png
+  homepage: https://rm.fm/breakz
+  country: DE
+  status: stream-only
+  stationuuid: 5bc44bcd-7481-40e1-b503-bb92b936f4cf
+  changeuuid: 720ecea3-3ba1-41ca-8a3f-23ac524be365
+  reviewedAt: "2026-05-04"
+
+- id: de-deutschlandfunk-dlf-opus-24k
+  broadcaster: independent
+  name: "Deutschlandfunk | DLF | OPUS 24k"
+  streamUrl: https://st01.sslstream.dlf.de/dlf/01/low/opus/stream.opus?aggregator=web
+  bitrate: 24
+  codec: OGG
+  favicon: https://www.deutschlandfunk.de/static/img/deutschlandfunk/icons/apple-touch-icon-128x128.png
+  homepage: https://www.deutschlandfunk.de/
+  country: DE
+  status: stream-only
+  stationuuid: 5a6946a2-f02f-4fd1-a16b-558c90150041
+  changeuuid: f5b6b60f-4a48-47dc-9569-c34ac89fc339
+  reviewedAt: "2026-05-04"
+
+- id: de-deutschlandfunk-dlf-aac-48k
+  broadcaster: independent
+  name: "Deutschlandfunk | DLF | AAC 48k"
+  streamUrl: https://st01.sslstream.dlf.de/dlf/01/low/aac/stream.aac?aggregator=web
+  bitrate: 48
+  codec: AAC
+  favicon: https://www.deutschlandfunk.de/static/img/deutschlandfunk/icons/apple-touch-icon-128x128.png
+  homepage: https://www.deutschlandfunk.de/
+  country: DE
+  status: stream-only
+  stationuuid: 97730dcf-857f-4b0a-9f33-c18af303c14b
+  changeuuid: 98e9f2f9-467b-4e85-9d6f-eed36bca2a02
+  reviewedAt: "2026-05-04"
+
+- id: de-deutschlandfunk-dlf-aac-96k
+  broadcaster: independent
+  name: "Deutschlandfunk | DLF | AAC 96k"
+  streamUrl: https://st01.sslstream.dlf.de/dlf/01/mid/aac/stream.aac?aggregator=web
+  bitrate: 96
+  codec: AAC
+  favicon: https://www.deutschlandfunk.de/static/img/deutschlandfunk/icons/apple-touch-icon-128x128.png
+  homepage: https://www.deutschlandfunk.de/
+  country: DE
+  status: stream-only
+  stationuuid: 01683d91-4e1e-4152-b1bc-30f2f1360b98
+  changeuuid: a2c5ea1e-6741-4b5b-b06e-19688804633b
+  reviewedAt: "2026-05-04"
+
+- id: de-remix-partybreaks-your-house-edm-hiphop-rnb-tech
+  broadcaster: independent
+  name: "# REMIX & PARTYBREAKS - Your House - EDM - HipHop - RnB - Techno - TechHouse - Top 40 Charts - Latin - DJ Mixtape RADIO"
+  streamUrl: https://stream.breakz.fm/?ref=radiobrowser-remix-partybreaks-radio
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/1bdF482/REMIX-PARTYNBREAKS-LOGO-1.png
+  homepage: https://rm.fm/breakz
+  country: DE
+  status: stream-only
+  stationuuid: b591d01a-e72b-4030-a640-a8da10ed73f6
+  changeuuid: 0e8346de-d4a1-473e-99f5-05598679127f
+  reviewedAt: "2026-05-04"
+
+- id: de-deutschlandfunk-dlf-aac-192k
+  broadcaster: independent
+  name: "Deutschlandfunk | DLF | AAC 192k"
+  streamUrl: https://st01.sslstream.dlf.de/dlf/01/high/aac/stream.aac?aggregator=web
+  bitrate: 256
+  codec: AAC
+  favicon: https://www.deutschlandfunk.de/static/img/deutschlandfunk/icons/apple-touch-icon-128x128.png
+  homepage: https://www.deutschlandfunk.de/
+  country: DE
+  status: stream-only
+  stationuuid: 717e3749-b9e8-4497-bd6a-61ccec935922
+  changeuuid: 49443b21-518d-448b-8495-218e8084b83c
+  reviewedAt: "2026-05-04"
+
+- id: de-trap-by-rautemusik-rm-fm
+  broadcaster: independent
+  name: __TRAP__ by rautemusik (rm.fm)
+  streamUrl: https://trap-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.rm.fm/favicon.ico
+  homepage: https://www.rm.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 5378792b-2ad9-4fae-b00f-e431766771c0
+  changeuuid: 9deee749-208f-4b27-9354-6b4cc404c3a1
+  reviewedAt: "2026-05-04"
+
+- id: de-br-klassik
+  broadcaster: independent
+  name: BR-Klassik
+  streamUrl: https://dispatcher.rndfnk.com/br/brklassik/live/mp3/high
+  bitrate: 128
+  codec: MP3
+  favicon: https://api.ardmediathek.de/image-service/images/urn:ard:image:476e47d76c4bbf78?w=512
+  homepage: https://www.br-klassik.de/index.html
+  country: DE
+  status: stream-only
+  stationuuid: 29010f42-faef-4a9e-b15c-3ad1613b45cb
+  changeuuid: 188ec6eb-225a-4846-848b-0fb42dacc13a
+  reviewedAt: "2026-05-04"
+
+- id: de-1-a-oldies-von-1a-radio
+  broadcaster: independent
+  name: "- 1 A - Oldies von 1A Radio"
+  streamUrl: https://1a-oldies.radionetz.de/1a-oldies.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.1aradio.com/logos/1a-oldies_600x600.jpg
+  homepage: http://www.1aradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 05a9eb02-33b0-11e9-8f31-52543be04c81
+  changeuuid: 973c6a32-2ac0-49ec-bd33-b4abce43d508
+  reviewedAt: "2026-05-04"
+
+- id: de-technolovers-bass-house
+  broadcaster: independent
+  name: Technolovers - BASS HOUSE
+  streamUrl: https://stream.technolovers.fm/bass-house?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://technolovers.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 22423370-efbf-4bf2-a301-5bd918cd8ad5
+  changeuuid: 10e48db0-dcc4-4cc6-911a-f6cb5d05433a
+  reviewedAt: "2026-05-04"
+
+- id: de-0-n-gothic-on-radio
+  broadcaster: independent
+  name: "- 0 N - Gothic on Radio"
+  streamUrl: https://0n-gothic.radionetz.de/0n-gothic.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.0nradio.com/logos/0n-gothic_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: c2f56cc5-f369-11e8-a471-52543be04c81
+  changeuuid: bd581412-cb4a-4fb6-87ce-aeb161b3762c
+  reviewedAt: "2026-05-04"
+
+- id: de-swr2
+  broadcaster: independent
+  name: SWR2
+  streamUrl: https://f111.rndfnk.com/ard/swr/swr2/live/mp3/256/stream.mp3?aggregator=web&sid=28ew6Usq6cch83eglcsXwLlNRS3&token=Ip5bwQ_T81Lq_mqKc3HUjnxrk94ek2bDcfNyNHuqRGk&tvf=XFsRgyq06xZmMTExLnJuZGZuay5jb20
+  bitrate: 256
+  codec: MP3
+  favicon: https://www.swr.de/assets/swr/swrkultur/apple-touch-icon.png
+  homepage: https://www.swr.de/swr2/index.html
+  country: DE
+  status: stream-only
+  stationuuid: 5444eb2d-f989-4c1c-a482-ecb8d8f389b2
+  changeuuid: 050019ee-1035-427f-b8c4-de4a7ec24cbf
+  reviewedAt: "2026-05-04"
+
+- id: de-0-n-pop-on-radio
+  broadcaster: independent
+  name: "- 0 N - Pop on Radio"
+  streamUrl: https://0n-pop.radionetz.de/0n-pop.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.0nradio.com/logos/0n-pop_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 28444f06-3a91-11e9-9b4e-52543be04c81
+  changeuuid: ea10fd3f-a662-4f3e-a3f8-1d67a668d5b3
+  reviewedAt: "2026-05-04"
+
+- id: de-bass-by-rautemusik-rm-fm
+  broadcaster: independent
+  name: __BASS__ by rautemusik (rm.fm)
+  streamUrl: https://bass-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.rm.fm/favicon.ico
+  homepage: https://www.rm.fm/bass
+  country: DE
+  status: stream-only
+  stationuuid: 6b36f91e-0a61-459c-bd84-853df27c49ed
+  changeuuid: b693e692-c2ff-4e08-9101-1fd73312aee1
+  reviewedAt: "2026-05-04"
+
+- id: de-house-by-rautemusik-rm-fm
+  broadcaster: independent
+  name: __HOUSE__ by rautemusik (rm.fm)
+  streamUrl: https://house-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.rm.fm/favicon.ico
+  homepage: https://www.rm.fm/house
+  country: DE
+  status: stream-only
+  stationuuid: 6d83b863-e60e-4f50-9916-597f23ebf1ce
+  changeuuid: 96402322-427f-49e4-bcc2-625b12738704
+  reviewedAt: "2026-05-04"
+
+- id: de-technolovers-handsup
+  broadcaster: independent
+  name: Technolovers HANDSUP
+  streamUrl: https://stream.technolovers.fm/handsup?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://technolovers.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 0beeb085-5116-4f2a-a543-cdcb837f8116
+  changeuuid: 719e21f5-07fd-42dd-ac3f-2dfd3d8e030b
+  reviewedAt: "2026-05-04"
+
+- id: de-goldies-by-rautemusik-rm-fm
+  broadcaster: independent
+  name: __GOLDIES__ by rautemusik (rm.fm)
+  streamUrl: https://goldies-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.rm.fm/favicon.ico
+  homepage: https://www.rm.fm/goldies
+  country: DE
+  status: stream-only
+  stationuuid: e73254fa-6601-4cef-8b62-4aec024634bb
+  changeuuid: 4f93bfb4-9649-4898-8e04-8d94ab819237
+  reviewedAt: "2026-05-04"
+
+- id: de-0-n-oldies-on-radio
+  broadcaster: independent
+  name: "- 0 N - Oldies on Radio"
+  streamUrl: https://0n-oldies.radionetz.de/0n-oldies.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.0nradio.com/logos/0n-oldies_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: dad8c8b3-f2c2-11e8-a471-52543be04c81
+  changeuuid: 77ab7d53-7b13-4688-93e4-65e46abab06c
+  reviewedAt: "2026-05-04"
+
+- id: de-romantic-piano-by-epic-piano
+  broadcaster: independent
+  name: ROMANTIC PIANO by Epic Piano
+  streamUrl: https://stream.epic-piano.com/romantic-piano?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://epic-piano.com/
+  country: DE
+  status: stream-only
+  stationuuid: b78fd386-08ec-4246-8372-d5f97c56a8ee
+  changeuuid: b05d8380-80f8-4b27-b859-b28bc092f3bd
+  reviewedAt: "2026-05-04"
+
+- id: de-technolovers-ibiza-house
+  broadcaster: independent
+  name: Technolovers - IBIZA HOUSE
+  streamUrl: https://stream.technolovers.fm/ibiza-house?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://technolovers.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 41d830a3-c80c-4745-954d-f6b2fc3f6622
+  changeuuid: 48ac8268-ec34-4535-a390-14988d82a987
+  reviewedAt: "2026-05-04"
+
+- id: de-nightride-fm-darksynth
+  broadcaster: independent
+  name: Nightride FM - Darksynth
+  streamUrl: https://stream.nightride.fm/darksynth.mp3
+  bitrate: 320
+  codec: MP3
+  favicon: https://nightride.fm/thumbnail.png
+  homepage: https://nightride.fm/
+  country: DE
+  status: stream-only
+  stationuuid: edccbfd1-9f20-4f96-adee-b00c6b65dd3c
+  changeuuid: 69f52a47-87bd-4ff6-b1dc-2ac2ba8b3a08
+  reviewedAt: "2026-05-04"
+
+- id: de-epic-lounge-chillout-lounge
+  broadcaster: independent
+  name: Epic Lounge - CHILLOUT LOUNGE
+  streamUrl: https://stream.epic-lounge.com/chillout-lounge?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://epic-lounge.com/
+  country: DE
+  status: stream-only
+  stationuuid: 1e8ba89b-7dcd-4d62-a20d-073739df672d
+  changeuuid: 963f9241-c9fc-4c10-a0c3-25fada1d6395
+  reviewedAt: "2026-05-04"
+
+- id: de-0-n-80s-on-radio
+  broadcaster: independent
+  name: "- 0 N - 80s on Radio"
+  streamUrl: https://0n-80s.radionetz.de/0n-80s.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://www.0nradio.com/logos/0n-80s_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: f3842846-f2c0-11e8-a471-52543be04c81
+  changeuuid: a0455942-2fe3-4845-902f-3d9ab6275d15
+  reviewedAt: "2026-05-04"
+
+- id: de-you-fm-mp3-high
+  broadcaster: independent
+  name: YOU FM (mp3/high)
+  streamUrl: https://dispatcher.rndfnk.com/hr/youfm/live/mp3/high
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.you-fm.de/favicon.png?v=3.85.2
+  homepage: https://www.you-fm.de/
+  country: DE
+  status: stream-only
+  stationuuid: 26b0e463-5912-4758-86f7-d93749ea93b1
+  changeuuid: 4ac85070-91c4-4363-b8b7-b07e3c61d35e
+  reviewedAt: "2026-05-04"
+
+- id: de-technolovers-uplifting-trance
+  broadcaster: independent
+  name: Technolovers - UPLIFTING TRANCE
+  streamUrl: https://stream.technolovers.fm/uplifting-trance?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://technolovers.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 0901602c-18c9-4790-9d0f-04e10d1fa7f8
+  changeuuid: 4bbd9b2f-cb02-494b-946f-0bd012379a1f
+  reviewedAt: "2026-05-04"
+
+- id: de-schwarzwaldradio
+  broadcaster: independent
+  name: Schwarzwaldradio
+  streamUrl: https://edge80.streamonkey.net/fho-schwarzwaldradiolive/stream/mp3?aggregator=smk-m3u-mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://schwarzwaldradio.com/apple-touch-icon.png
+  homepage: https://schwarzwaldradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 65f5549e-a554-4386-9249-7f9651fd40f6
+  changeuuid: 97fc1cf7-0ef3-4c71-a5d2-b1a3ede2b6fb
+  reviewedAt: "2026-05-04"
+
+- id: de-countryhits-fm-by-rautemusik-rm-fm
+  broadcaster: independent
+  name: __COUNTRYHITS.FM__ by rautemusik (rm.fm)
+  streamUrl: https://country-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://countryhits.fm/
+  country: DE
+  status: stream-only
+  stationuuid: a4a3c3c4-d499-48e0-bec1-226868d22968
+  changeuuid: d18b5088-ff78-41b2-a721-9eefca81fcd4
+  reviewedAt: "2026-05-04"
+
+- id: de-melodic-house-techno-technolovers-fm-chillout-be
+  broadcaster: independent
+  name: "Melodic House & Techno @ Technolovers.FM (Chillout, Beach, Festival, Sundowner, Relax, Ibiza, Sea, Ocean Music, Beachclub, Cocktailbar, 2024, 2025, 2026 Future Rave 126, 128, 124 Beats per Minute , BPM)"
+  streamUrl: https://stream.technolovers.fm/melodic-house-techno?ref=radiobrowser-2
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/mFjn8LB/TL-Melodic-House-Techno-png.jpg
+  homepage: https://technolovers.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 1aa5a707-c24c-4c5d-abcc-6f9b7a8f2f2e
+  changeuuid: d45c1568-6c05-40ea-8fb6-e68d22b242a4
+  reviewedAt: "2026-05-04"
+
+- id: de-rock-antenne-80er-rock-aac
+  broadcaster: independent
+  name: ROCK ANTENNE 80er Rock (AAC)
+  streamUrl: https://stream.rockantenne.de/80er-rock/stream/aacp
+  codec: AAC
+  favicon: https://www.rockantenne.de/logos/rock-antenne/apple-touch-icon.png
+  homepage: https://www.rockantenne.de/
+  country: DE
+  status: stream-only
+  stationuuid: b8927613-63dd-47e9-9be7-8225af2aa0d6
+  changeuuid: 989a7157-eb39-418b-93a5-8105a1155973
+  reviewedAt: "2026-05-04"
+
+- id: de-ostseewelle
+  broadcaster: independent
+  name: "Ostseewelle "
+  streamUrl: https://addrad.io/4454pjf
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.ostseewelle.de/assets/icons/apple-touch-icon.png
+  homepage: https://www.ostseewelle.de/
+  country: DE
+  status: stream-only
+  stationuuid: 9188d3aa-9dbe-419d-9f0e-994914f67d90
+  changeuuid: 75de8370-9123-4c5e-8275-1a8150c6c87b
+  reviewedAt: "2026-05-04"
+
+- id: de-dw-tv
+  broadcaster: independent
+  name: DW TV
+  streamUrl: https://dwamdstream104.akamaized.net/hls/live/2015530/dwstream104/index.m3u8
+  bitrate: 1060
+  codec: AAC
+  favicon: https://www.dw.com/images/icons/favicon-120x120.png
+  homepage: https://www.dw.com/es/tv-en-vivo/s-100837
+  country: DE
+  status: stream-only
+  stationuuid: 8b792693-b3a1-4ce2-8c89-03e82640a753
+  changeuuid: fdd0a6ed-c8f5-42fb-8ade-3fa895cd4c69
+  reviewedAt: "2026-05-04"
+
+- id: de-lounge-radio-ibiza
+  broadcaster: independent
+  name: Lounge Radio Ibiza
+  streamUrl: https://stream.laut.fm/lounge-radio-ibiza
+  bitrate: 128
+  codec: MP3
+  favicon: https://lounge-radio-ibiza.com/favicon.ico
+  homepage: https://lounge-radio-ibiza.com/
+  country: DE
+  status: stream-only
+  stationuuid: 92aef6af-edb6-4fae-b212-c990deb76efc
+  changeuuid: bc83def4-84bc-44ab-9fac-c27bf9c0ffda
+  reviewedAt: "2026-05-04"
+
+- id: de-epic-classical-classical-pan-flute
+  broadcaster: independent
+  name: EPIC CLASSICAL - Classical Pan Flute
+  streamUrl: https://stream.epic-classical.com/classical-pan-flute?ref=liveradio
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/R2FqgKq/Pan-Flute.jpg
+  homepage: https://epic-classical.com/
+  country: DE
+  status: stream-only
+  stationuuid: e764ca37-9692-47d9-bd39-17842b9db3e6
+  changeuuid: c85becc9-9523-4eb3-a1e7-4849ee42e8cb
+  reviewedAt: "2026-05-04"
+
+- id: de-0-n-top-40-on-radio
+  broadcaster: independent
+  name: "- 0 N - Top 40 on Radio"
+  streamUrl: https://0n-top40.radionetz.de/0n-top40.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.0nradio.com/logos/0n-top-40_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 3d3fc522-0a50-11ea-a87e-52543be04c81
+  changeuuid: 9595f6c9-9e1c-49e5-9dba-0de025c20f9e
+  reviewedAt: "2026-05-04"
+
+- id: de-partyhits-dein-musikmix-aus-ballermann-apres-ski
+  broadcaster: independent
+  name: "# PartyHits - Dein Musikmix aus Ballermann, Apres Ski, Wiesn, Karneval, Silvesterparty, TOP 100 Party, Malle, Nonstop, DJ LIVE, Abriss, Feier, Bass, Feiermusik, Partymusik, Apres ski Party, Fussball Hits"
+  streamUrl: https://partyhits-high.rautemusik.fm/?ref=radio-browser-ph2
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/GFBh5tm/rautemusik-partyhits.jpg
+  homepage: https://rm.fm/partyhits
+  country: DE
+  status: stream-only
+  stationuuid: d382abcc-961a-4458-9eba-fee99e94c6bc
+  changeuuid: b7452b6f-69ea-4b13-ace8-8bfa5ee92cab
+  reviewedAt: "2026-05-04"
+
+- id: de-absolute-relax
+  broadcaster: independent
+  name: absolute relax
+  streamUrl: https://absolut-relax.live-sm.absolutradio.de/absolut-relax/stream/mp3
+  bitrate: 128
+  codec: MP3
+  country: DE
+  status: stream-only
+  stationuuid: 2121eef0-8347-4e12-a0e5-cd6476f2d803
+  changeuuid: 25e7230a-d588-44b2-8690-69f01ceb1a91
+  reviewedAt: "2026-05-04"
+
+- id: de-dw-english-hd
+  broadcaster: independent
+  name: DW English HD
+  streamUrl: https://dwamdstream102.akamaized.net/hls/live/2015525/dwstream102/index.m3u8
+  bitrate: 1060
+  codec: AAC
+  homepage: https://www.dw.com/en/live-tv/channel-english
+  country: DE
+  status: stream-only
+  stationuuid: efd7c468-11a2-4bae-b7ae-3d93271e0e95
+  changeuuid: 8587d404-2118-40d9-a552-405bd0365603
+  reviewedAt: "2026-05-04"
+
+- id: de-swr3-96k-aac
+  broadcaster: independent
+  name: SWR3 - 96K AAC
+  streamUrl: https://liveradio.swr.de/sw331ch/swr3/play.aac
+  bitrate: 128
+  codec: AAC
+  favicon: https://www.swr3.de/assets/swr3/icons/favicon.ico
+  homepage: http://swr3.de/
+  country: DE
+  status: stream-only
+  stationuuid: 54e7f42e-7c5f-4124-aed8-ca9266022c20
+  changeuuid: 64f5d8a0-7ff0-4939-b409-1548592523ec
+  reviewedAt: "2026-05-04"
+
+- id: de-top-200-dj-charts-just-music-dj-remix-charts-rad
+  broadcaster: independent
+  name: "#TOP 200 DJ CHARTS - JUST MUSIC - DJ REMIX & CHARTS RADIO @ TikTok Charts, Electronic Music, EDM, House, Deep House, Dance Music, Techno & Hypertechno, Top40, Latin Charts, Reggaeton, Urban, HipHop, Club & Party Radio - & LIVE DJ SETS @ Festival Melodic House, Melodic Techno. Best 100 Lounge, Mixed Radio Station @ PartyHits / Schlager Remix Top 50"
+  streamUrl: https://breakz-high.rautemusik.fm/stream.mp3?ref=DJCHARTSRB
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/Gc5TMjP/Top-200-Dj-Charts-breakz-logo.jpg
+  homepage: https://www.breakz.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 02734cfa-5c5b-46f2-85c6-a5a654be7a24
+  changeuuid: a878c81c-5ef0-4aae-b8d4-33f42f6b22f3
+  reviewedAt: "2026-05-04"
+
+- id: de-double-bass-fm-viel-mehr-als-nur-mainstream
+  broadcaster: independent
+  name: "Double Bass FM – Viel mehr als nur Mainstream!"
+  streamUrl: https://double-bass-fm.stream.laut.fm/double-bass-fm
+  bitrate: 128
+  codec: MP3
+  homepage: https://doublebass.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 91e5f068-8011-4103-a28a-f1028c7e0aed
+  changeuuid: fd0a94c1-bcad-42a8-9a0e-6eb6d46c9a15
+  reviewedAt: "2026-05-04"
+
+- id: de-absolut-germany
+  broadcaster: independent
+  name: Absolut Germany
+  streamUrl: https://absolut-germany.live-sm.absolutradio.de/absolut-germany/stream/mp3?aggregator
+  bitrate: 128
+  codec: MP3
+  favicon: https://absolutradio.de/apple-touch-icon.png
+  homepage: https://absolutradio.de/germany
+  country: DE
+  status: stream-only
+  stationuuid: 0c93b8e2-bde5-49cd-9c64-5d006be06aa9
+  changeuuid: 51d371e5-d1a2-4c83-b952-853398a23433
+  reviewedAt: "2026-05-04"
+
+- id: de-chopin-by-epic-piano
+  broadcaster: independent
+  name: CHOPIN by Epic Piano
+  streamUrl: https://stream.epic-piano.com/chopin?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://epic-piano.com/
+  country: DE
+  status: stream-only
+  stationuuid: 6816e8cd-8b06-4d68-b61f-4d9f54015f95
+  changeuuid: 9080e6d6-a988-4609-af48-7e8255b20b62
+  reviewedAt: "2026-05-04"
+
+- id: de-punkrockers-radio
+  broadcaster: independent
+  name: punkrockers-radio
+  streamUrl: https://stream.punkrockers-radio.de:8443/prr.flac
+  codec: OGG
+  favicon: https://www.punkrockers-radio.de/img/punkrockers-radio_play-button.png
+  homepage: http://punkrockers-radio.de/
+  country: DE
+  status: stream-only
+  stationuuid: 960cccb6-0601-11e8-ae97-52543be04c81
+  changeuuid: af26c384-85df-4aa8-95ef-880bd8609cf3
+  reviewedAt: "2026-05-04"
+
+- id: de-charthits-fm-by-rautemusik-rm-fm
+  broadcaster: independent
+  name: __CHARTHITS.FM__ by rautemusik (rm.fm)
+  streamUrl: https://charthits-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.charthits.fm/favicon.ico
+  homepage: https://www.charthits.fm/
+  country: DE
+  status: stream-only
+  stationuuid: aae7a2f0-b8b3-41be-95f6-4448ebd44e2e
+  changeuuid: 19e16c66-6c19-435c-9311-bf796d4ebc35
+  reviewedAt: "2026-05-04"
+
+- id: de-0-n-rock-on-radio
+  broadcaster: independent
+  name: "- 0 N - Rock on Radio"
+  streamUrl: https://0n-rock.radionetz.de/0n-rock.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.0nradio.com/logos/0n-rock_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 1bf09691-f362-11e8-a471-52543be04c81
+  changeuuid: 4b59ddb1-2188-4811-ace8-207f509a50db
+  reviewedAt: "2026-05-04"
+
+- id: de-i-love-radio-hip-hop
+  broadcaster: independent
+  name: I love Radio Hip Hop
+  streamUrl: https://ilm.stream18.radiohost.de/ilm_ilovehiphop_mp3-192?upd-meta&upd-scheme=https&_art=dD0xNzY4NDY1NTU0JmQ9MGE3MmM0MmIxN2YzNDljYmY1Zjc
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.ilovemusic.de/favicon.ico
+  homepage: https://www.ilovemusic.de/ilovehiphop.m3u
+  country: DE
+  status: stream-only
+  stationuuid: 1623de65-2466-434c-ba04-ec075557f339
+  changeuuid: 3aa40bf9-15ae-4cf4-a4a3-612806431b11
+  reviewedAt: "2026-05-04"
+
+- id: de-i-love-hardstyle
+  broadcaster: independent
+  name: I love Hardstyle
+  streamUrl: https://ilm.stream35.radiohost.de/ilm_ilovehardstyle_mp3-192?upd-meta&upd-scheme=https&_art=dD0xNzY4NDYxNzc3JmQ9MjgxZDVmMTU4NTg2ODU1MTE3NjQ
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.ilovemusic.de/favicon.ico
+  homepage: https://www.ilovemusic.de/ilovehardstyle.m3u
+  country: DE
+  status: stream-only
+  stationuuid: 61fc1add-0637-491a-8dfc-2b1afd549a2a
+  changeuuid: b805d0e2-31f0-4805-848e-8ceceeb52805
+  reviewedAt: "2026-05-04"
+
+- id: de-0-n-new-wave-on-radio
+  broadcaster: independent
+  name: "- 0 N - New Wave on Radio"
+  streamUrl: https://0n-newwave.radionetz.de/0n-newwave.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.0nradio.com/logos/0n-newwave_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 8f00a42a-c4e3-4138-8f21-551896a29065
+  changeuuid: 0564e9d4-6653-4895-9bd2-d97443a41253
+  reviewedAt: "2026-05-04"
+
+- id: de-0-n-jazz-on-radio
+  broadcaster: independent
+  name: "- 0 N - Jazz on Radio"
+  streamUrl: https://0n-jazz.radionetz.de/0n-jazz.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.0nradio.com/logos/0n-jazz_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: d7339299-f364-11e8-a471-52543be04c81
+  changeuuid: c6a8b483-7043-47b0-bd33-115bc7cf0073
+  reviewedAt: "2026-05-04"
+
+- id: de-0-n-90s-on-radio
+  broadcaster: independent
+  name: "- 0 N - 90s on Radio"
+  streamUrl: https://0n-90s.radionetz.de/0n-90s.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://www.0nradio.com/logos/0n-90s_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 9241b3f7-f2c2-11e8-a471-52543be04c81
+  changeuuid: a7f0002a-4c02-4bf0-8546-43ebc5401969
+  reviewedAt: "2026-05-04"
+
+- id: de-deutschlandfunk-kultur-dlf-aac-96k
+  broadcaster: independent
+  name: "Deutschlandfunk Kultur | DLF | AAC 96k"
+  streamUrl: https://st02.sslstream.dlf.de/dlf/02/mid/aac/stream.aac?aggregator=web
+  bitrate: 96
+  codec: AAC
+  favicon: https://www.deutschlandfunkkultur.de/static/img/deutschlandfunk_kultur/icons/apple-touch-icon-128x128.png
+  homepage: https://www.deutschlandfunkkultur.de/
+  country: DE
+  status: stream-only
+  stationuuid: 447b5296-56b1-45a7-9eab-f078daf0fd25
+  changeuuid: e5ab8377-add7-423a-85e5-779039d86bca
+  reviewedAt: "2026-05-04"
+
+- id: de-technolovers-future-house
+  broadcaster: independent
+  name: Technolovers FUTURE HOUSE
+  streamUrl: https://stream.technolovers.fm/future-house?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://technolovers.fm/
+  country: DE
+  status: stream-only
+  stationuuid: d3a18908-6077-4f34-96a8-7d72938c1015
+  changeuuid: 38265008-b7a1-41d4-9f62-07c6162ec239
+  reviewedAt: "2026-05-04"
+
+- id: de-ballermann-radio-club-style
+  broadcaster: independent
+  name: Ballermann Radio Club Style
+  streamUrl: https://stream.bmr-radio.de/bmr-clubstyle.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.ballermann-radio.de/wp-content/uploads/2024/02/stream-ballermann-radio-clubstyle-750x750.png
+  homepage: https://www.ballermann-radio.de/stream/ballermannradio-clubstyle/
+  country: DE
+  status: stream-only
+  stationuuid: d4aff3d1-61b9-453a-bb5b-24be59d5b343
+  changeuuid: 45801c78-ed40-42e2-a5d5-5a657592c7a7
+  reviewedAt: "2026-05-04"
+
+- id: de-juka-radio-kpop
+  broadcaster: independent
+  name: juka radio kpop
+  streamUrl: https://juka-kpop.stream.laut.fm/juka-kpop?t302=2021-04-01_09-03-35&uuid=6aa06ca0-9a01-407d-91af-155d24c5c405
+  bitrate: 128
+  codec: MP3
+  homepage: https://juka-radio.de/
+  country: DE
+  status: stream-only
+  stationuuid: 2973ff08-fb80-4281-8b7a-33bd213b06d4
+  changeuuid: cd913d11-94ad-4b5d-89fd-53a3da49b57d
+  reviewedAt: "2026-05-04"
+
+- id: de-ballermann-radio-ab-18
+  broadcaster: independent
+  name: Ballermann Radio Ab 18
+  streamUrl: https://stream.bmr-radio.de/bmr-ab18.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.ballermann-radio.de/wp-content/uploads/2024/02/stream-ballermann-radio-ab-18-750x750.png
+  homepage: https://www.ballermann-radio.de/stream/ballermannradio-ab18/
+  country: DE
+  status: stream-only
+  stationuuid: 85954f7d-387f-4857-861f-4c6d464a16cb
+  changeuuid: 3cddcbe8-ddab-4b3c-a9b6-0043c7c47fd1
+  reviewedAt: "2026-05-04"
+
+- id: de-0-n-soft-rock-on-radio
+  broadcaster: independent
+  name: "- 0 N - Soft Rock on Radio"
+  streamUrl: https://0n-softrock.radionetz.de/0n-softrock.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.0nradio.com/logos/0n-soft-rock_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: ed4fb1c0-74a9-462c-85a7-5a6bc49f275f
+  changeuuid: 998e007f-a075-4bb1-8559-ab5b69222380
+  reviewedAt: "2026-05-04"
+
+- id: de-the-christmas-channel-by-rautemusik-rm-fm
+  broadcaster: independent
+  name: __THE CHRISTMAS CHANNEL__ by rautemusik (rm.fm)
+  streamUrl: https://christmas-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  favicon: https://christmas-channel.com/wp-content/themes/christmaschannel2020/img/favicon.png
+  homepage: https://christmas-channel.com/
+  country: DE
+  status: stream-only
+  stationuuid: f3eee02f-2d60-4805-8b95-dcf065aab67a
+  changeuuid: 3a90da9b-abfb-4149-98b2-d78058fb3dc9
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-80000
+  broadcaster: independent
+  name: Radio 80000
+  streamUrl: https://radio80k.out.airtime.pro:8000/radio80k_a
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.radio80k.de/app/uploads/2022/10/cropped-favicon-8000-192x192.gif
+  homepage: https://www.radio80k.de/
+  country: DE
+  status: stream-only
+  stationuuid: 6b4c2748-07ee-11e8-ae97-52543be04c81
+  changeuuid: a88ae81f-1492-4543-b2fd-dccfc997ccee
+  reviewedAt: "2026-05-04"
+
+- id: de-0nlineradio-vivaldi
+  broadcaster: independent
+  name: 0nlineradio VIVALDI
+  streamUrl: https://stream.0nlineradio.com/vivaldi?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/HKNTfSQ/VIVALDI-NEW.jpg
+  homepage: https://0nlineradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 0c7c0c0c-5981-440f-bc8a-98530962c191
+  changeuuid: 1ddaac46-7cbb-496f-b50b-e2c6a1bd962a
+  reviewedAt: "2026-05-04"
+
+- id: de-day-dee-eurodance
+  broadcaster: independent
+  name: Day Dee Eurodance
+  streamUrl: https://daydeeeurodance.stream.laut.fm/daydeeeurodance
+  bitrate: 128
+  codec: MP3
+  homepage: http://eurodance.ga/
+  country: DE
+  status: stream-only
+  stationuuid: 5d7eaf84-c541-11e9-8502-52543be04c81
+  changeuuid: c6ca9cd7-95b3-49d7-8f96-2f8426d7078b
+  reviewedAt: "2026-05-04"
+
+- id: de-technolovers-hardcore
+  broadcaster: independent
+  name: Technolovers HARDCORE
+  streamUrl: https://stream.technolovers.fm/hardcore?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://technolovers.fm/
+  country: DE
+  status: stream-only
+  stationuuid: c6de7ff5-8c25-4e3a-987d-3e0c7ecb9db9
+  changeuuid: 715b3bc2-2862-420f-84fd-95afe2aaa896
+  reviewedAt: "2026-05-04"
+
+- id: de-swr-2
+  broadcaster: independent
+  name: SWR 2
+  streamUrl: https://liveradio.swr.de/sw331ch/swr2/play.aac
+  bitrate: 128
+  codec: AAC
+  country: DE
+  status: stream-only
+  stationuuid: ad6f4746-32d1-4301-98ee-6bd3d6fb4902
+  changeuuid: 3682fabb-4428-4e92-8338-14a74d0a1eed
+  reviewedAt: "2026-05-04"
+
+- id: de-0nlineradio-country
+  broadcaster: independent
+  name: 0nlineradio COUNTRY
+  streamUrl: https://stream.0nlineradio.com/country?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/qmK33Rk/country.jpg
+  homepage: https://0nlineradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 753eb884-6e6a-464e-b283-dbc6f6808e69
+  changeuuid: 032e0b9b-d5f1-4245-9fb2-65ed3cdb75dc
+  reviewedAt: "2026-05-04"
+
+- id: de-0-n-k-pop-on-radio
+  broadcaster: independent
+  name: "- 0 N - K-Pop on Radio"
+  streamUrl: https://0n-kpop.radionetz.de/0n-kpop.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://www.0nradio.com/logos/0n-k-pop_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 0ea480ed-bd7a-469e-b050-00c258b65772
+  changeuuid: 8b9d8130-2ee1-4fb3-83c2-4523a562a2af
+  reviewedAt: "2026-05-04"
+
+- id: de-epic-lounge-piano-jazz-bar
+  broadcaster: independent
+  name: "Epic Lounge - PIANO & JAZZ BAR"
+  streamUrl: https://stream.epic-lounge.com/piano-jazz-bar?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://epic-lounge.com/
+  country: DE
+  status: stream-only
+  stationuuid: eb987d1a-ef9c-47dd-a70f-f35a34b11313
+  changeuuid: 9ba4c7e4-2811-4844-aec1-ab34495c1e5f
+  reviewedAt: "2026-05-04"
+
+- id: de-rock-antenne-gothic
+  broadcaster: independent
+  name: Rock Antenne Gothic
+  streamUrl: https://s6-webradio.rockantenne.de/gothic/stream/mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.rockantenne.de/logos/station-rock-antenne/apple-touch-icon.png
+  homepage: https://www.rockantenne.de/webradio/gothic
+  country: DE
+  status: stream-only
+  stationuuid: 72e2c8e3-3d74-41e3-855c-d44812d5023e
+  changeuuid: f3f2568a-3f8d-4240-8ffc-5d2bd0c28692
+  reviewedAt: "2026-05-04"
+
+- id: de-oriental-by-rautemusik-rm-fm
+  broadcaster: independent
+  name: __ORIENTAL__ by rautemusik (rm.fm)
+  streamUrl: https://oriental-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.rm.fm/favicon.ico
+  homepage: https://www.rm.fm/oriental
+  country: DE
+  status: stream-only
+  stationuuid: fc9b8946-0044-4ed6-ab99-80082e0fa33b
+  changeuuid: 12247908-57b7-4856-b7b7-9074e4d15dd1
+  reviewedAt: "2026-05-04"
+
+- id: de-ballermann-radio-top-40
+  broadcaster: independent
+  name: Ballermann Radio Top 40
+  streamUrl: https://stream.bmr-radio.de/bmr-top30.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.ballermann-radio.de/stream/ballermannradio-top30/
+  country: DE
+  status: stream-only
+  stationuuid: 461cee3c-75f8-4357-ae9c-0f1754c6a410
+  changeuuid: 293ce10a-6513-4c3a-bd64-896bc26cceed
+  reviewedAt: "2026-05-04"
+
+- id: de-eurodance
+  broadcaster: independent
+  name: Eurodance
+  streamUrl: https://eurodance.stream.laut.fm/eurodance
+  bitrate: 128
+  codec: MP3
+  country: DE
+  status: stream-only
+  stationuuid: 7313a2ed-3c96-4e00-ab2b-73aedd1b6772
+  changeuuid: d8ce1bda-3c52-4267-8304-d011b15668d7
+  reviewedAt: "2026-05-04"
+
+- id: de-0-n-relax-on-radio
+  broadcaster: independent
+  name: "- 0 N - Relax on Radio"
+  streamUrl: https://0n-relax.radionetz.de/0n-relax.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.0nradio.com/logos/0n-relax_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 50ab7eb7-40ed-11e9-aa55-52543be04c81
+  changeuuid: b080b760-43f4-4f29-9d7e-186630ed3f8c
+  reviewedAt: "2026-05-04"
+
+- id: de-epic-classical-classical-piano
+  broadcaster: independent
+  name: EPIC CLASSICAL - Classical Piano
+  streamUrl: https://stream.epic-classical.com/classical-piano
+  bitrate: 192
+  codec: MP3
+  homepage: https://epic-classical.com/
+  country: DE
+  status: stream-only
+  stationuuid: 750cbe31-150e-4cd2-8ec5-a6a8a9a7c8b2
+  changeuuid: 08b7af94-931d-458d-9ac9-79dd1cc90ec9
+  reviewedAt: "2026-05-04"
+
+- id: de-deutschlandfunk-dlf-opus-64k
+  broadcaster: independent
+  name: "Deutschlandfunk | DLF | OPUS 64k"
+  streamUrl: https://st01.sslstream.dlf.de/dlf/01/high/opus/stream.opus?aggregator=web
+  bitrate: 64
+  codec: OGG
+  favicon: https://www.deutschlandfunk.de/static/img/deutschlandfunk/icons/apple-touch-icon-128x128.png
+  homepage: https://www.deutschlandfunk.de/
+  country: DE
+  status: stream-only
+  stationuuid: 3cd11a2a-4a42-44d7-b349-a652af7573dd
+  changeuuid: ba289164-9d97-4e46-8303-5af3e38570e9
+  reviewedAt: "2026-05-04"
+
+- id: de-ffn
+  broadcaster: independent
+  name: ffn
+  streamUrl: https://ffn-de-hz-fal-stream04-cluster01.radiohost.de/ffn_mp3-192
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.ffn.de/
+  country: DE
+  status: stream-only
+  stationuuid: 8d5e1ce1-0625-469f-920e-8fee0f3da72e
+  changeuuid: 1b662590-ddaf-4a30-9c87-bfcbbb299be8
+  reviewedAt: "2026-05-04"
+
+- id: de-filmradio
+  broadcaster: independent
+  name: Filmradio
+  streamUrl: https://filmradio.stream.laut.fm/filmradio?t302=2018-03-10_04-44-05&uuid=59ca68e0-84a4-492d-9b0b-36c45690cd59
+  bitrate: 128
+  codec: MP3
+  homepage: https://laut.fm/filmradio
+  country: DE
+  status: stream-only
+  stationuuid: 4f043737-2416-11e8-91bf-52543be04c81
+  changeuuid: 6dfe6c56-8704-43d7-b676-f7477c58508d
+  reviewedAt: "2026-05-04"
+
+- id: de-technolovers-electro
+  broadcaster: independent
+  name: Technolovers  ELECTRO
+  streamUrl: https://stream.technolovers.fm/electro?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://technolovers.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 31854302-9f36-4697-a4e8-ffd66d4e1487
+  changeuuid: 735fb39d-b8aa-4eea-a8dc-6d2d727203d3
+  reviewedAt: "2026-05-04"
+
+- id: de-progressive-trance-mix
+  broadcaster: independent
+  name: Progressive Trance Mix
+  streamUrl: https://stream.laut.fm/progressive-trance-mix
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.laut.fm/progressive-trance-mix
+  country: DE
+  status: stream-only
+  stationuuid: 9ef2da84-5133-4446-989c-0b02b0f565ab
+  changeuuid: 6cbb3199-3b87-4953-943f-df9aa1612434
+  reviewedAt: "2026-05-04"
+
+- id: de-1-a-70er-von-1a-radio
+  broadcaster: independent
+  name: "- 1 A - 70er von 1A Radio"
+  streamUrl: https://1a-70er.radionetz.de/1a-70er.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.1aradio.com/logos/1a-70er_600x600.jpg
+  homepage: http://www.1aradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: eb1930be-f372-11e8-a471-52543be04c81
+  changeuuid: a58ac7f1-8316-4b1b-bfda-5b850cefe63c
+  reviewedAt: "2026-05-04"
+
+- id: de-technolovers-hardstyle
+  broadcaster: independent
+  name: Technolovers HARDSTYLE
+  streamUrl: https://stream.technolovers.fm/hardstyle?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://technolovers.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 6a74e9a2-e5ac-40d5-9d2d-f956f15b7058
+  changeuuid: 72a825c2-12ab-4122-be84-287bfb168d70
+  reviewedAt: "2026-05-04"
+
+- id: de-epic-classical-classical-coffee-bar
+  broadcaster: independent
+  name: EPIC CLASSICAL - Classical Coffee Bar
+  streamUrl: https://stream.epic-classical.com/classical-coffee-bar
+  bitrate: 192
+  codec: MP3
+  homepage: https://epic-classical.com/
+  country: DE
+  status: stream-only
+  stationuuid: d3639208-37c3-418e-b71b-ffbd0ec512c1
+  changeuuid: 7dc6d7e3-7f07-4ae9-8d0e-84d5286eb21e
+  reviewedAt: "2026-05-04"
+
+- id: de-ndr-info-schleswig-holstein
+  broadcaster: independent
+  name: NDR Info Schleswig-Holstein
+  streamUrl: https://icecast.ndr.de/ndr/ndrinfo/schleswigholstein/mp3/128/stream.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://static-media.streema.com/media/cache/9d/b3/9db365c0d939c0980e7eb7383156ec78.jpg
+  country: DE
+  status: stream-only
+  stationuuid: d6874c84-5e44-4cfd-ae7c-a42232a5fc0e
+  changeuuid: 0d98b617-9ce3-4652-b3d0-1109b41da3d4
+  reviewedAt: "2026-05-04"
+
+- id: de-0-n-50s-on-radio
+  broadcaster: independent
+  name: "- 0 N - 50s on Radio"
+  streamUrl: https://0n-50s.radionetz.de/0n-50s.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.0nradio.com/logos/0n-50s_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: d4c545ef-a4e5-412a-b141-852c2fe50707
+  changeuuid: 02aee472-4176-499c-a7ec-575b4198188b
+  reviewedAt: "2026-05-04"
+
+- id: de-epic-classical-classical-meditation
+  broadcaster: independent
+  name: EPIC CLASSICAL - Classical Meditation
+  streamUrl: https://stream.epic-classical.com/classical-meditation
+  bitrate: 128
+  codec: MP3
+  homepage: https://epic-classical.com/
+  country: DE
+  status: stream-only
+  stationuuid: b26c3de7-c2ca-4595-95b7-af9f42db3f75
+  changeuuid: cfce2086-40c8-4e8b-abca-b8668da5870b
+  reviewedAt: "2026-05-04"
+
+- id: de-technolovers-afro-house
+  broadcaster: independent
+  name: Technolovers - AFRO HOUSE
+  streamUrl: https://stream.technolovers.fm/afro-house?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://technolovers.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 11bb3621-4e62-4143-a275-2303e1ae5ce6
+  changeuuid: d3014f73-9b48-4dda-8972-3c630cb2e1ec
+  reviewedAt: "2026-05-04"
+
+- id: de-0-n-heavy-metal-on-radio
+  broadcaster: independent
+  name: "- 0 N - Heavy Metal on Radio"
+  streamUrl: https://0n-heavymetal.radionetz.de/0n-heavymetal.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.0nradio.com/logos/0n-heavymetal_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: daa600d2-3d8d-4e7b-9974-90b5be49b40e
+  changeuuid: 3d344e4f-3e0e-4073-b067-e9a4f7783cef
+  reviewedAt: "2026-05-04"
+
+- id: de-laut-fm-chillharmonie
+  broadcaster: independent
+  name: Laut.FM Chillharmonie
+  streamUrl: https://chillharmonie.stream.laut.fm/chillharmonie
+  bitrate: 128
+  codec: MP3
+  favicon: https://lh3.ggpht.com/a4M_Oyz2Jek1bkcRe8I7v3A8clEOoOI8Y-NiYuuICuw0wOHwaZgMUit4rRgC18mGZMo_=w300
+  homepage: http://laut.fm/chillharmonie
+  country: DE
+  status: stream-only
+  stationuuid: 9609e140-0601-11e8-ae97-52543be04c81
+  changeuuid: 8eae1bec-69c2-4c0f-9526-980f1536dc26
+  reviewedAt: "2026-05-04"
+
+- id: de-epic-lounge-nature-sounds
+  broadcaster: independent
+  name: Epic Lounge - NATURE SOUNDS
+  streamUrl: https://stream.epic-lounge.com/nature-sounds?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://epic-lounge.com/
+  country: DE
+  status: stream-only
+  stationuuid: 23cbcb6f-64cb-4589-a462-9aceaeab8e52
+  changeuuid: 3355398f-ddc6-4c71-9c6e-307718fd0bc2
+  reviewedAt: "2026-05-04"
+
+- id: de-wackenradio-by-rautemusik-rm-fm
+  broadcaster: independent
+  name: __WACKENRADIO__ by rautemusik (rm.fm)
+  streamUrl: https://wackenradio-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/rGpB2Bx/wackenradio.jpg
+  homepage: https://www.rm.fm/wacken
+  country: DE
+  status: stream-only
+  stationuuid: 17028094-01a5-49f0-b35a-d792b6ea7da9
+  changeuuid: ca5abedf-d3fc-4803-9795-a9f281c930d7
+  reviewedAt: "2026-05-04"
+
+- id: de-1-a-schlager-gold-von-1a-radio
+  broadcaster: independent
+  name: "- 1 A - Schlager Gold von 1A Radio"
+  streamUrl: https://1a-schlagergold.radionetz.de/1a-schlagergold.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.1aradio.com/logos/1a-schlager-gold_600x600.jpg
+  homepage: http://www.1aradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: b7835e9e-f36c-11e8-a471-52543be04c81
+  changeuuid: 8bb5fcfa-18c2-41a7-b78d-dee47e006609
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-91-2-dortmund
+  broadcaster: independent
+  name: Radio 91.2 Dortmund
+  streamUrl: https://radio912--di--nacs-ais-lgc--0c--cdn.cast.addradio.de/radio912/live/mp3/high
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.radio912.de/assets/images/favicons/radio912/favicon_x96.png
+  homepage: https://www.radio912.de/
+  country: DE
+  status: stream-only
+  stationuuid: d8cb2336-9d7e-4f57-8f6c-a41d3b8bad09
+  changeuuid: 7ded0fe8-9e6a-4531-9b00-9d04c506284f
+  reviewedAt: "2026-05-04"
+
+- id: de-house-vs-hip-hop-rap-deutschrap-r-b-trap-techno-
+  broadcaster: independent
+  name: "House vs. Hip-Hop, Rap, Deutschrap, R&B, Trap, Techno, House, EDM, Deep House, Hardstyle, Trance, Drum & Bass, Lo-Fi, Chillout, Festival, Club, Party, Afterhour, Beats, Underground, Hype, Techno, TechHouse - Top 40 Charts - DJ Mixtape RADIO"
+  streamUrl: https://breakz-office.rautemusik.fm/?ref=rb-festival
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/DgmQsmPW/festival-vibes.png
+  homepage: https://www.breakz.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 5a6ecb07-e6ba-418f-9f4e-43dd40fe3a95
+  changeuuid: 6271a1bf-7ea3-4501-9ffc-78f3643f9e20
+  reviewedAt: "2026-05-04"
+
+- id: de-epic-classical-classical-guitar
+  broadcaster: independent
+  name: EPIC CLASSICAL - Classical Guitar
+  streamUrl: https://stream.epic-classical.com/classical-guitar
+  bitrate: 192
+  codec: MP3
+  homepage: https://epic-classical.com/
+  country: DE
+  status: stream-only
+  stationuuid: e26602e7-e8e5-4910-8d05-3b760cd9b52c
+  changeuuid: 36ec73be-bac3-48fd-ad61-df9b10bec9f5
+  reviewedAt: "2026-05-04"
+
+- id: de-0nlineradio-80s-rock
+  broadcaster: independent
+  name: 0nlineradio 80s ROCK
+  streamUrl: https://stream.0nlineradio.com/80s-rock?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://0nlineradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 99a0a3ef-d6b6-42f8-bad8-63132543c363
+  changeuuid: fec7db21-955d-4313-bd72-44c6335527cd
+  reviewedAt: "2026-05-04"
+
+- id: de-0nlineradio-handel
+  broadcaster: independent
+  name: 0nlineradio HÄNDEL
+  streamUrl: https://stream.0nlineradio.com/haendel?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/y8Pcv7T/HA-NDEL-NEW.jpg
+  homepage: https://0nlineradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 07e6c4b7-b1b5-430b-a7a8-166260a775ee
+  changeuuid: 1addf0e2-41c0-486d-bee1-920edc45a722
+  reviewedAt: "2026-05-04"
+
+- id: de-ballermann-radio
+  broadcaster: independent
+  name: Ballermann Radio
+  streamUrl: https://stream.bmr-radio.de/ballermann-radio.mp3
+  codec: MP3
+  favicon: https://www.ballermann-radio.de/wp-content/uploads/2024/02/stream-ballermann-radio-750x750.png
+  homepage: https://www.ballermann-radio.de/stream/ballermannradio/
+  country: DE
+  status: stream-only
+  stationuuid: 2f3d991d-f1d3-400b-897e-17f5c5986686
+  changeuuid: 2b22ee00-c1c4-4a91-80dc-00079ccfdc44
+  reviewedAt: "2026-05-04"
+
+- id: de-technolovers-techhouse
+  broadcaster: independent
+  name: Technolovers - TECHHOUSE
+  streamUrl: https://stream.technolovers.fm/techhouse?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://technolovers.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 514118f5-7fc0-451f-9fac-dfb877376721
+  changeuuid: ad87dbc6-d430-46b3-8b35-cb2dda2bdc1b
+  reviewedAt: "2026-05-04"
+
+- id: de-wdr-2-ruhrgebiet
+  broadcaster: independent
+  name: WDR 2 Ruhrgebiet
+  streamUrl: https://wdr-wdr2-ruhrgebiet.icecastssl.wdr.de/wdr/wdr2/ruhrgebiet/mp3/128/stream.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www1.wdr.de/resources-v5.139.1/img/favicon/apple-touch-icon.png
+  homepage: https://www1.wdr.de/radio/wdr2/wdrzwei-startseite-102.html
+  country: DE
+  status: stream-only
+  stationuuid: b61115e1-d005-4bcf-b64d-540b40f504a8
+  changeuuid: 2cbd0fd4-cec3-42ab-ab27-33fb89c9f031
+  reviewedAt: "2026-05-04"
+
+- id: de-happy-hardcore-by-rautemusik-rm-fm
+  broadcaster: independent
+  name: __HAPPY HARDCORE__ by rautemusik (rm.fm)
+  streamUrl: https://happyhardcore-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.rm.fm/favicon.ico
+  homepage: https://www.rm.fm/happyhardcore
+  country: DE
+  status: stream-only
+  stationuuid: b9fad3b3-f66e-4ede-84e5-0d4641aabb66
+  changeuuid: bd709eb2-8c40-47c5-a4a1-d0e2000f8e86
+  reviewedAt: "2026-05-04"
+
+- id: de-nightride-fm-ebsm
+  broadcaster: independent
+  name: Nightride FM - EBSM
+  streamUrl: https://stream.nightride.fm/ebsm.mp3
+  bitrate: 320
+  codec: MP3
+  favicon: https://nightride.fm/thumbnail.png
+  homepage: https://nightride.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 6d6cce52-c2e6-4615-8251-27f5ce62e788
+  changeuuid: 2c6bb9c5-ff7d-4f88-9403-443914adbcc9
+  reviewedAt: "2026-05-04"
+
+- id: de-br24live
+  broadcaster: independent
+  name: BR24live
+  streamUrl: https://dispatcher.rndfnk.com/br/br24live/live/mp3/mid
+  bitrate: 128
+  codec: MP3
+  favicon: https://api.ardmediathek.de/image-service/images/urn:ard:image:c3ab9296f3b282bf?w=512
+  homepage: https://www.br.de/radio/br24/index.html
+  country: DE
+  status: stream-only
+  stationuuid: 65e1287a-6e7b-11ea-b1cf-52543be04c81
+  changeuuid: 3aa6ccd3-ea0c-485d-bfea-48e19eb89e20
+  reviewedAt: "2026-05-04"
+
+- id: de-deutschlandfunk-kultur-dlf-aac-192k
+  broadcaster: independent
+  name: "Deutschlandfunk Kultur | DLF | AAC 192k"
+  streamUrl: https://st02.sslstream.dlf.de/dlf/02/high/aac/stream.aac?aggregator=web
+  bitrate: 192
+  codec: AAC
+  favicon: https://www.deutschlandfunkkultur.de/static/img/deutschlandfunk_kultur/icons/apple-touch-icon-128x128.png
+  homepage: https://www.deutschlandfunkkultur.de/
+  country: DE
+  status: stream-only
+  stationuuid: 0b6cc5a0-f5a0-4a62-b128-e48153fd864c
+  changeuuid: 519cfe84-df2a-457b-ac74-9e097b2d3aeb
+  reviewedAt: "2026-05-04"
+
+- id: de-epic-classical-classical-violin
+  broadcaster: independent
+  name: EPIC CLASSICAL - Classical Violin
+  streamUrl: https://stream.epic-classical.com/classical-violin
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/DkDPhcZ/Violin.jpg
+  homepage: https://epic-classical.com/
+  country: DE
+  status: stream-only
+  stationuuid: 9f3d4c02-c3f0-4f00-bebe-509ff81b4d54
+  changeuuid: e7d06dbc-88a0-414e-bb79-f02f178cce63
+  reviewedAt: "2026-05-04"
+
+- id: de-metal-only-http-www-metal-only-de-metal-only-htt
+  broadcaster: independent
+  name: "METAL ONLY - http://www.metal-only.de,METAL ONLY - http://www.metal-only.de - 24h Black Death Heavy Metal Rock und mehr!"
+  streamUrl: https://metal-only.sp.radio.fm/stream
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.metal-only.de/fileadmin/tpl//fav.ico
+  country: DE
+  status: stream-only
+  stationuuid: 259e410c-b516-11e8-afe1-52543be04c81
+  changeuuid: 991aa07d-84a3-4b42-be4e-cd7666c994b1
+  reviewedAt: "2026-05-04"
+
+- id: de-1-a-chillout-von-1a-radio
+  broadcaster: independent
+  name: "- 1 A - Chillout von 1A Radio"
+  streamUrl: https://1a-chillout.radionetz.de/1a-chillout.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.1aradio.com/logos/1a-chillout_600x600.jpg
+  homepage: http://www.1aradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 98c90ccb-3a90-11e9-9b4e-52543be04c81
+  changeuuid: 10523ee0-61b5-4b5a-8ab3-bf58a4130a10
+  reviewedAt: "2026-05-04"
+
+- id: de-deutschrap-classic-by-rautemusik-rm-fm
+  broadcaster: independent
+  name: __DEUTSCHRAP CLASSIC__ by rautemusik (rm.fm)
+  streamUrl: https://deutschrap-classic-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.rm.fm/favicon.ico
+  homepage: https://www.rm.fm/deutschrap-classic
+  country: DE
+  status: stream-only
+  stationuuid: 8a9b05bf-02ed-45f3-9805-4ae42b1da7a9
+  changeuuid: 3c459a98-30b3-46d6-96f4-75f02da931f7
+  reviewedAt: "2026-05-04"
+
+- id: de-1-a-2000er-von-1a-radio
+  broadcaster: independent
+  name: "- 1 A - 2000er von 1A Radio"
+  streamUrl: https://1a-2000er.radionetz.de/1a-2000er.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.1aradio.com/logos/1a-2000er_600x600.jpg
+  homepage: http://www.1aradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 1defd57a-bf9c-11e9-8502-52543be04c81
+  changeuuid: add0829a-9792-4df1-b65e-ca94bef46b87
+  reviewedAt: "2026-05-04"
+
+- id: de-nightride-fm
+  broadcaster: independent
+  name: Nightride FM
+  streamUrl: https://stream.nightride.fm/nightride.mp3
+  bitrate: 320
+  codec: MP3
+  favicon: https://nightride.fm/thumbnail.png
+  homepage: https://nightride.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 12e458f2-cf9b-426a-8d18-7cb07c75b07c
+  changeuuid: 1ba22b1b-538e-4431-9de7-eb6419292993
+  reviewedAt: "2026-05-04"
+
+- id: de-ffh-eurodance-2
+  broadcaster: independent
+  name: FFH Eurodance
+  streamUrl: https://mp3.ffh.de/ffhchannels/hqeurodance.aac
+  bitrate: 128
+  codec: AAC+
+  country: DE
+  status: stream-only
+  stationuuid: 4d00b27c-ee39-4b00-b4b2-8ae6c7ae23ab
+  changeuuid: 8130deb0-2725-457b-9189-bf073d07df61
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-paloma-100-deutscher-schlager
+  broadcaster: independent
+  name: "Radio Paloma - 100% Deutscher Schlager!"
+  streamUrl: https://stream.silvacast.com/RPLive/mp3-128/RadioPaloma_Homepage
+  bitrate: 128
+  codec: MP3
+  favicon: https://schlager.radio/wp-content/uploads/2020/11/cropped-radio-paloma-fav-180x180.png
+  homepage: https://schlager.radio/
+  country: DE
+  status: stream-only
+  stationuuid: c86eed65-a2e3-45fa-a67f-62d98bd91e3a
+  changeuuid: 5fe23b0d-58ce-4a0f-a9c9-04b82883f32d
+  reviewedAt: "2026-05-04"
+
+- id: de-ebm
+  broadcaster: independent
+  name: EBM
+  streamUrl: https://stream.laut.fm/ebm
+  bitrate: 128
+  codec: MP3
+  favicon: https://i0.wp.com/flatlinesradio.de/storage/2021/11/244611397_1194785584320990_6265045071816304131_n-1.jpg?fit=180%2c180&#038;ssl=1
+  homepage: https://flatlinesradio.de/
+  country: DE
+  status: stream-only
+  stationuuid: 80bdfdeb-66bb-11e9-af37-52543be04c81
+  changeuuid: 8d693f29-2d24-44be-8dd9-ce7bf8c11cc1
+  reviewedAt: "2026-05-04"
+
+- id: de-techhouse-by-rautemusik-rm-fm
+  broadcaster: independent
+  name: __TECHHOUSE__ by rautemusik (rm.fm)
+  streamUrl: https://techhouse-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.rm.fm/favicon.ico
+  homepage: https://www.rm.fm/techhouse
+  country: DE
+  status: stream-only
+  stationuuid: 0457c8f9-bae5-4f83-9f8d-9b440ea3b887
+  changeuuid: 9bcc32bc-0cc3-49e8-9682-9ca1191542af
+  reviewedAt: "2026-05-04"
+
+- id: de-epic-lounge-soft-house-lounge
+  broadcaster: independent
+  name: Epic Lounge - SOFT HOUSE LOUNGE
+  streamUrl: https://stream.epic-lounge.com/soft-house-lounge?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://epic-lounge.com/
+  country: DE
+  status: stream-only
+  stationuuid: 52adc4eb-92c9-4214-ba8c-dff98d386b83
+  changeuuid: 35c46db4-f1c3-40bf-88ac-e3e14c7598a5
+  reviewedAt: "2026-05-04"
+
+- id: de-0-n-hits-on-radio
+  broadcaster: independent
+  name: "- 0 N - Hits on Radio"
+  streamUrl: https://0n-hits.radionetz.de/0n-hits.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.0nradio.com/logos/0n-hits_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 6e6bb4a4-f2c3-11e8-a471-52543be04c81
+  changeuuid: c3b061eb-421d-4603-b192-19ee8fa21e36
+  reviewedAt: "2026-05-04"
+
+- id: de-0nlineradio-mozart
+  broadcaster: independent
+  name: 0nlineradio MOZART
+  streamUrl: https://stream.0nlineradio.com/mozart?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://0nlineradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 2929b616-4cad-40fd-9d9e-42e5cd1d9bc8
+  changeuuid: 9b763916-ae72-4ce5-a7ee-cfa0e692d750
+  reviewedAt: "2026-05-04"
+
+- id: de-technolovers-gabber
+  broadcaster: independent
+  name: Technolovers - GABBER
+  streamUrl: https://stream.technolovers.fm/gabber?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://technolovers.fm/
+  country: DE
+  status: stream-only
+  stationuuid: ed1d2979-fb9a-47b0-9483-d61aa4c42016
+  changeuuid: 60ca136c-cdd3-4a0e-9c5a-2e126c32fccb
+  reviewedAt: "2026-05-04"
+
+- id: de-laut-fm-freestyle
+  broadcaster: independent
+  name: laut.fm freestyle
+  streamUrl: https://stream.laut.fm/freestyle
+  bitrate: 128
+  codec: MP3
+  homepage: https://laut.fm/freestyle
+  country: DE
+  status: stream-only
+  stationuuid: 9645787a-0601-11e8-ae97-52543be04c81
+  changeuuid: d4967d5a-a258-4ec2-9f37-77e2a536c0da
+  reviewedAt: "2026-05-04"
+
+- id: de-1-a-60er-von-1a-radio
+  broadcaster: independent
+  name: "- 1 A - 60er von 1A Radio"
+  streamUrl: https://1a-60er.radionetz.de/1a-60er.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.1aradio.com/logos/1a-60er_600x600.jpg
+  homepage: http://www.1aradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 45a1da91-33af-11e9-8f31-52543be04c81
+  changeuuid: 9293a094-27df-41d2-a82c-34f3aa5535ae
+  reviewedAt: "2026-05-04"
+
+- id: de-1-a-classic-rock-von-1a-radio
+  broadcaster: independent
+  name: "- 1 A - Classic Rock von 1A Radio"
+  streamUrl: https://1a-classicrock.radionetz.de/1a-classicrock.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.1aradio.com/logos/1a-classic-rock_600x600.jpg
+  homepage: http://www.1aradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 864f2e75-bf9c-11e9-8502-52543be04c81
+  changeuuid: 912bdf66-609c-46f2-9433-7eed5a31dcd5
+  reviewedAt: "2026-05-04"
+
+- id: de-deutschrap-by-rautemusik-rm-fm
+  broadcaster: independent
+  name: __DEUTSCHRAP__ by rautemusik (rm.fm)
+  streamUrl: https://deutschrap-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/jMH358Y/deutschrap.jpg
+  homepage: https://www.rm.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 75d2c7f0-5499-4555-b738-50fc65d064a4
+  changeuuid: 5fb01bf3-48af-4fe9-97aa-08dc3c33845c
+  reviewedAt: "2026-05-04"
+
+- id: de-1-a-90er-von-1a-radio
+  broadcaster: independent
+  name: "- 1 A - 90er von 1A Radio"
+  streamUrl: https://1a-90er.radionetz.de/1a-90er.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://www.1aradio.com/logos/1a-90er_600x600.jpg
+  homepage: http://www.1aradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: befda847-f373-11e8-a471-52543be04c81
+  changeuuid: d06fba33-0466-4c28-8e1a-235c564a36ab
+  reviewedAt: "2026-05-04"
+
+- id: de-rautemusik-club-aac-48-kbps
+  broadcaster: independent
+  name: "RauteMusik Club | AAC 48 kbps"
+  streamUrl: https://club-aacp.rautemusik.fm/
+  bitrate: 48
+  codec: AAC+
+  favicon: https://www.rm.fm/favicon.ico
+  homepage: https://www.rautemusik.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 156eb4a1-48ad-40d2-b7c5-8d702f57819c
+  changeuuid: a2c0c95e-984a-4518-8a6b-ab5bb8fd46df
+  reviewedAt: "2026-05-04"
+
+- id: de-reyfm-kpop
+  broadcaster: independent
+  name: "REYFM - #kpop"
+  streamUrl: https://listen.reyfm.de/kpop_320kbps.mp3
+  bitrate: 320
+  codec: MP3
+  favicon: https://www.reyfm.de/_nuxt/icons/icon_64x64.88ab9f.png
+  homepage: https://www.reyfm.de/
+  country: DE
+  status: stream-only
+  stationuuid: 7ad3b3f3-802d-4ae4-bc62-dc82881c3a43
+  changeuuid: af9f636d-3811-4dee-bc68-bb1bd024e1a7
+  reviewedAt: "2026-05-04"
+
+- id: de-top40-by-rautemusik-rm-fm
+  broadcaster: independent
+  name: __TOP40__ by rautemusik (rm.fm)
+  streamUrl: https://top40-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.rm.fm/favicon.ico
+  homepage: https://www.rm.fm/top40
+  country: DE
+  status: stream-only
+  stationuuid: bd7135e8-5d0d-4e74-922c-0deb8f315587
+  changeuuid: 23843461-bb68-4e69-b68a-4a07b42170f6
+  reviewedAt: "2026-05-04"
+
+- id: de-swr-4-bw-stuttgart-128k
+  broadcaster: independent
+  name: SWR 4 BW Stuttgart (128k)
+  streamUrl: https://liveradio.swr.de/sw282p3/swr4bw/play.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://liveradio.swr.de/favicon.ico
+  homepage: https://liveradio.swr.de/sw282p3/swr4bw
+  country: DE
+  status: stream-only
+  stationuuid: 702481e2-4cbb-459b-9b00-f5a6e926ac1b
+  changeuuid: 81c8112e-3704-4c86-a2b1-3c794d2d6246
+  reviewedAt: "2026-05-04"
+
+- id: de-berliner-rundfunk-non-stop-musik
+  broadcaster: independent
+  name: Berliner Rundfunk - Non-Stop Musik
+  streamUrl: https://topradio-de-hz-fal-stream10-cluster01.radiohost.de/brf-pure_mp3-128
+  bitrate: 128
+  codec: MP3
+  favicon: https://upload.berliner-rundfunk.de/production/static/1659973942875/icons/icon_64.a80y02808w0.png
+  homepage: https://www.berliner-rundfunk.de/
+  country: DE
+  status: stream-only
+  stationuuid: df11e97c-5a7e-4077-a581-b4144d0e61e6
+  changeuuid: 33f1151f-1e11-4f22-8239-44e7b8bb7ac6
+  reviewedAt: "2026-05-04"
+
+- id: de-schlager-radio-b2-berlin-brandenburg
+  broadcaster: independent
+  name: schlager radio B2 - Berlin Brandenburg
+  streamUrl: https://addrad.io/4454rnz
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.schlagerradio.de/
+  country: DE
+  status: stream-only
+  stationuuid: 8929a686-3467-43f1-9e22-612bfa1207be
+  changeuuid: c6d92654-81a2-4e8b-ad7b-0f468c0e20e2
+  reviewedAt: "2026-05-04"
+
+- id: de-0nlineradio-50s
+  broadcaster: independent
+  name: 0nlineradio 50s
+  streamUrl: https://stream.0nlineradio.com/50s?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://0nlineradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 0725d662-7f7b-4363-8c8f-2b35c6916d84
+  changeuuid: 8869f9de-3f8b-413e-bfc5-003c96e56166
+  reviewedAt: "2026-05-04"
+
+- id: de-90s90s-rock-hls
+  broadcaster: independent
+  name: 90s90s Rock (HLS)
+  streamUrl: https://streams.90s90s.de/rock/mp3-192/streams.90s90s.de/play.m3u8
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.radio.de/images/broadcasts/8d/ce/185038/1/c300.png
+  homepage: http://www.90s90s.de/
+  country: DE
+  status: stream-only
+  stationuuid: 9f1ecafe-856d-4610-92fe-4f006af9dfc7
+  changeuuid: 006c01c2-a26c-4b0e-939f-83950944f4e8
+  reviewedAt: "2026-05-04"
+
+- id: de-alpin-fm
+  broadcaster: independent
+  name: Alpin FM
+  streamUrl: https://s16.myradiostream.com/:6390/stream/3/listen.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://alpin.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 02226ea8-b869-4b12-823c-f06bf2ac4866
+  changeuuid: cb1a6783-b461-4c2f-a4b6-d62ea6a2e850
+  reviewedAt: "2026-05-04"
+
+- id: de-wdr-5-nachrichten
+  broadcaster: independent
+  name: WDR 5 Nachrichten
+  streamUrl: https://www.wdr.de/realaudio/radio/nachrichten/nachrichten_wdr5.mp3
+  codec: MP3
+  favicon: https://www1.wdr.de/resources-v5.134.2/img/favicon/favicon.ico
+  homepage: https://www1.wdr.de/radio/wdr5/index.html
+  country: DE
+  status: stream-only
+  stationuuid: 5910a89e-ccf4-48b0-92aa-9dc0c3fe220e
+  changeuuid: f49e316a-f77b-40d4-8f01-12bf1dab365a
+  reviewedAt: "2026-05-04"
+
+- id: de-schwany-souvenir-2
+  broadcaster: independent
+  name: Schwany  Souvenir 2
+  streamUrl: https://souvenir2.spcast.eu:443/stream?time=1768459221
+  bitrate: 320
+  codec: MP3
+  favicon: http://schwany.de/favicon.ico
+  homepage: http://schwany.de/
+  country: DE
+  status: stream-only
+  stationuuid: 2484d8fb-eb64-410a-8fe6-6c2d2d00faf2
+  changeuuid: c1ff06e0-0a56-4f9e-b9ba-66b5e99d7d99
+  reviewedAt: "2026-05-04"
+
+- id: de-0-n-2010s-on-radio
+  broadcaster: independent
+  name: "- 0 N - 2010s on Radio"
+  streamUrl: https://0n-2010s.radionetz.de/0n-2010s.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.0nradio.com/logos/0n-2010s_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 17508989-6b85-4327-806f-fbb65492b369
+  changeuuid: fdf867a7-6bb3-4d18-b723-0160dbaefdc9
+  reviewedAt: "2026-05-04"
+
+- id: de-solo-piano-by-epic-piano
+  broadcaster: independent
+  name: SOLO PIANO by Epic Piano
+  streamUrl: https://stream.epic-piano.com/solo-piano?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://epic-piano.com/
+  country: DE
+  status: stream-only
+  stationuuid: 26bcf620-4738-4778-acec-e64d19b4335f
+  changeuuid: 1c3783ee-0c2b-44d0-9b7e-e4963bb97111
+  reviewedAt: "2026-05-04"
+
+- id: de-1-a-schlager-kult-von-1a-radio
+  broadcaster: independent
+  name: "- 1 A - Schlager Kult von 1A Radio"
+  streamUrl: https://1a-schlagerkult.radionetz.de/1a-schlagerkult.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.1aradio.com/logos/1a-schlager-kult_600x600.jpg
+  homepage: http://www.1aradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 5061f15e-f36c-11e8-a471-52543be04c81
+  changeuuid: 15e40be1-0335-41a0-849d-47f92925cc49
+  reviewedAt: "2026-05-04"
+
+- id: de-ndr-1-niedersachsen-ol
+  broadcaster: independent
+  name: NDR 1 Niedersachsen (OL)
+  streamUrl: https://icecast.ndr.de/ndr/ndr1niedersachsen/oldenburg/mp3/128/stream.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.phonostar.de/images/auto_created/NDR1_Niedersachsen2184x184.png
+  homepage: https://www.ndr.de/ndr1niedersachsen/index.html
+  country: DE
+  status: stream-only
+  stationuuid: decf0c5d-aec6-11e9-88f4-52543be04c81
+  changeuuid: 71e9c936-45db-4b23-a2e6-bde2b14b2dd5
+  reviewedAt: "2026-05-04"
+
+- id: de-reyfm-dance
+  broadcaster: independent
+  name: "REYFM - #Dance"
+  streamUrl: https://listen.reyfm.de/reyfm-dance/
+  bitrate: 320
+  codec: MP3
+  favicon: https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png
+  homepage: https://rey.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 0ba65779-de06-4adf-83d0-1de3da5ff5ad
+  changeuuid: e456dbc1-e81c-4088-ad35-7489da734603
+  reviewedAt: "2026-05-04"
+
+- id: de-deutschlandfunk-kultur-dlf-opus-24k
+  broadcaster: independent
+  name: "Deutschlandfunk Kultur | DLF | OPUS 24k"
+  streamUrl: https://st02.sslstream.dlf.de/dlf/02/low/opus/stream.opus?aggregator=web
+  bitrate: 24
+  codec: OGG
+  favicon: https://www.deutschlandfunkkultur.de/static/img/deutschlandfunk_kultur/icons/apple-touch-icon-128x128.png
+  homepage: https://www.deutschlandfunkkultur.de/
+  country: DE
+  status: stream-only
+  stationuuid: 9f3b3ed9-7106-11ea-b1cf-52543be04c81
+  changeuuid: d0edd31d-ab70-432d-b942-2332a9970d76
+  reviewedAt: "2026-05-04"
+
+- id: de-reyfm-lofi
+  broadcaster: independent
+  name: "REYFM -#LOFI"
+  streamUrl: https://listen.reyfm.de/lofi_320kbps.mp3
+  bitrate: 320
+  codec: MP3
+  favicon: http://reyfm.de/_nuxt/icons/icon_64x64.88ab9f.png
+  homepage: http://reyfm.de/
+  country: DE
+  status: stream-only
+  stationuuid: 4e681355-3ebb-4b6c-a79a-d7cc81a0afd5
+  changeuuid: b0d09c3f-86ef-40fc-8ff0-a4fec12e6df9
+  reviewedAt: "2026-05-04"
+
+- id: de-0nlineradio-60s
+  broadcaster: independent
+  name: 0nlineradio 60s
+  streamUrl: https://stream.0nlineradio.com/60s?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://0nlineradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 7bc651fa-ce87-4b0e-86cb-1f20e9b4b6ee
+  changeuuid: c76d01a4-d284-43a2-89ee-e396aebac89b
+  reviewedAt: "2026-05-04"
+
+- id: de-swr3-48k-aac
+  broadcaster: independent
+  name: "SWR3 | 48k aac"
+  streamUrl: https://liveradio.swr.de/sw890cl/swr3/
+  bitrate: 96
+  codec: AAC
+  favicon: https://www.swr3.de/assets/swr3/icons/apple-touch-icon.png
+  homepage: https://www.swr3.de/
+  country: DE
+  status: stream-only
+  stationuuid: 312a4b18-1edb-4ef7-9a19-15ceba809118
+  changeuuid: 89de7762-ca8a-4cd5-8a1d-d0afcf548137
+  reviewedAt: "2026-05-04"
+
+- id: de-salsa-by-rautemusik-rm-fm
+  broadcaster: independent
+  name: __SALSA__ by rautemusik (rm.fm)
+  streamUrl: https://salsa-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.rm.fm/favicon.ico
+  homepage: https://www.rm.fm/salsa
+  country: DE
+  status: stream-only
+  stationuuid: a33fe6ce-4f02-4b43-9c50-6db6a3ad693a
+  changeuuid: 4ee8fe65-3ea6-4b7b-a593-c0e1d1dff521
+  reviewedAt: "2026-05-04"
+
+- id: de-bigcitybeats-fm-by-rautemusik-rm-fm
+  broadcaster: independent
+  name: __BIGCITYBEATS.FM__ by rautemusik (rm.fm)
+  streamUrl: https://stream.bigcitybeats.de/bcb-radio/mp3-192/radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://bigcitybeats.de/
+  country: DE
+  status: stream-only
+  stationuuid: 847ab878-67d8-49c1-9587-4098f3da3515
+  changeuuid: 68009fca-ccd0-4a68-9920-9746ed360149
+  reviewedAt: "2026-05-04"
+
+- id: de-swr1-rheinland-pfalz-48k-aac
+  broadcaster: independent
+  name: "SWR1 – Rheinland-Pfalz | 48k aac"
+  streamUrl: https://liveradio.swr.de/sw890cl/swr1rp/
+  bitrate: 96
+  codec: AAC
+  favicon: https://www.swr.de/assets/swr/swr1/apple-touch-icon-180x180.png
+  homepage: https://www.swr.de/swr1/rp/index.html
+  country: DE
+  status: stream-only
+  stationuuid: 68560eba-85ea-4cab-8935-28cfd99209e8
+  changeuuid: 7824f14e-6ffc-459c-816e-adb6370edb7e
+  reviewedAt: "2026-05-04"
+
+- id: de-0-n-house-on-radio
+  broadcaster: independent
+  name: "- 0 N - House on Radio"
+  streamUrl: https://0n-house.radionetz.de/0n-house.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.0nradio.com/logos/0n-house_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: bc2fdecc-fcf3-47b4-b751-1a8d34a20577
+  changeuuid: 05557371-f8c6-4592-a90d-6b9748159ba8
+  reviewedAt: "2026-05-04"
+
+- id: de-rautemusik-k-pop
+  broadcaster: independent
+  name: RauteMusik K-POP
+  streamUrl: https://streams.rautemusik.fm/k-pop/mp3-192?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/Kbvr4xf/k-pop-400x400.jpg
+  homepage: https://rm.fm/k-pop
+  country: DE
+  status: stream-only
+  stationuuid: 4548080b-3497-46dc-a72b-55c136b16f06
+  changeuuid: 19c7b62b-c195-4ed9-baad-3b11ee70aadf
+  reviewedAt: "2026-05-04"
+
+- id: de-0nlineradio-70s
+  broadcaster: independent
+  name: 0nlineradio 70s
+  streamUrl: https://stream.0nlineradio.com/70s?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://0nlineradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 7b9e38ae-51b5-4cc7-a646-c774976c4dd0
+  changeuuid: e78c3dfa-c3a0-4f49-b53d-e195aa196124
+  reviewedAt: "2026-05-04"
+
+- id: de-wdr-cosmo-afrobeats
+  broadcaster: independent
+  name: WDR COSMO - Afrobeats
+  streamUrl: https://wdr-cosmo-afrobeat.icecastssl.wdr.de/wdr/cosmo/afrobeat/mp3/128/stream.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www1.wdr.de/radio/cosmo/resources-v5.128.1/img/favicon/favicon-32x32.png
+  homepage: https://www1.wdr.de/radio/cosmo/channels/afrobeats-channel-106.html
+  country: DE
+  status: stream-only
+  stationuuid: e5f1cdc8-e711-46ab-9739-f3e711549c5c
+  changeuuid: 6aea559f-cc11-4c84-acc3-7e1b03174340
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-bonn-rhein-sieg
+  broadcaster: independent
+  name: Radio Bonn / Rhein-Sieg
+  streamUrl: https://rbrs-live.cast.addradio.de/rbrs/live/mp3/high
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.radiobonn.de/assets/images/senderlogos/radio_brs_webradio.png
+  homepage: https://www.radiobonn.de/
+  country: DE
+  status: stream-only
+  stationuuid: 334bac11-d245-11e9-a861-52543be04c81
+  changeuuid: db5d7ed8-65ff-4a55-803f-6bbf82c973ff
+  reviewedAt: "2026-05-04"
+
+- id: de-workout-by-rautemusik-rm-fm
+  broadcaster: independent
+  name: __WORKOUT__ by rautemusik (rm.fm)
+  streamUrl: https://workout-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.rm.fm/workout
+  country: DE
+  status: stream-only
+  stationuuid: 877fb292-0e44-46a1-9673-5cac9ce60152
+  changeuuid: fec8e61e-0a87-4310-afe6-1129a0e30290
+  reviewedAt: "2026-05-04"
+
+- id: de-0-n-schlager-on-radio
+  broadcaster: independent
+  name: "- 0 N - Schlager on Radio"
+  streamUrl: https://0n-schlager.radionetz.de/0n-schlager.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.0nradio.com/logos/0n-schlager_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: b09bd12d-f35e-11e8-a471-52543be04c81
+  changeuuid: 8dfbb3ba-f1ed-45a0-bfdb-0c46eda92e26
+  reviewedAt: "2026-05-04"
+
+- id: de-1-a-schlager-von-1a-radio
+  broadcaster: independent
+  name: "- 1 A - Schlager von 1A Radio"
+  streamUrl: https://1a-schlager.radionetz.de/1a-schlager.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.1aradio.com/logos/1a-schlager_600x600.jpg
+  homepage: http://www.1aradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 228c6a6a-f376-11e8-a471-52543be04c81
+  changeuuid: 2e8eb084-d11a-4e53-9776-27b2168f6036
+  reviewedAt: "2026-05-04"
+
+- id: de-christmas-schlager-by-rautemusik-rm-fm
+  broadcaster: independent
+  name: __CHRISTMAS SCHLAGER__ by rautemusik (rm.fm)
+  streamUrl: https://christmas-schlager-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.rm.fm/favicon.ico
+  homepage: https://www.rm.fm/christmas-schlager
+  country: DE
+  status: stream-only
+  stationuuid: d9045149-7240-4f82-8d23-6b7857fc5b09
+  changeuuid: 73a36450-e56a-4f0d-9278-c14cd5cad309
+  reviewedAt: "2026-05-04"
+
+- id: de-0nlineradio-metal
+  broadcaster: independent
+  name: 0nlineradio METAL
+  streamUrl: https://stream.0nlineradio.com/metal?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://0nlineradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 716d0d91-4c12-4bd6-bf7e-e5173ef40d39
+  changeuuid: e4472734-def8-41d1-bc45-3d77d10e65d5
+  reviewedAt: "2026-05-04"
+
+- id: de-technolovers-tropical-house
+  broadcaster: independent
+  name: Technolovers TROPICAL HOUSE
+  streamUrl: https://stream.technolovers.fm/tropical-house?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://technolovers.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 752939c0-c0e4-483c-a4bb-eb62a4870935
+  changeuuid: 8c306648-0f8e-4190-bd09-91bda301dc9a
+  reviewedAt: "2026-05-04"
+
+- id: de-epic-lounge-coffee-bar-lounge
+  broadcaster: independent
+  name: Epic Lounge - COFFEE BAR LOUNGE
+  streamUrl: https://stream.epic-lounge.com/coffee-bar-lounge?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://epic-lounge.com/
+  country: DE
+  status: stream-only
+  stationuuid: fe7fb48e-b603-4003-8b95-68a21654feea
+  changeuuid: f7597b64-d18a-4538-8547-e482aff0b24a
+  reviewedAt: "2026-05-04"
+
+- id: de-hirschmilch-radio
+  broadcaster: independent
+  name: Hirschmilch Radio
+  streamUrl: https://hirschmilch.de:7001/chillout.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://hirschmilch.de:7001/chillout.mp3
+  country: DE
+  status: stream-only
+  stationuuid: fa8b58ac-6503-4f55-b7ea-a70879c871c5
+  changeuuid: e5f47b69-3f09-4a37-bfe5-b37b7042d307
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-emergency
+  broadcaster: independent
+  name: Radio Emergency
+  streamUrl: https://www.radioemergency.de/radioemergency.mp3
+  bitrate: 320
+  codec: MP3
+  homepage: https://www.radioemergency.de/
+  country: DE
+  status: stream-only
+  stationuuid: 21f58c07-ecd9-491f-a5d0-74eef1b8c71d
+  changeuuid: 19c1a796-a98e-4ff0-9b6e-4bac4ad19d32
+  reviewedAt: "2026-05-04"
+
+- id: de-0nlineradio-greatest-hits
+  broadcaster: independent
+  name: 0nlineradio GREATEST HITS
+  streamUrl: https://stream.0nlineradio.com/greatest-hits?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://0nlineradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 82579116-af7c-49a6-8a97-7bdd4ddca608
+  changeuuid: 020c0e61-7759-4b20-91db-85107f0e3506
+  reviewedAt: "2026-05-04"
+
+- id: de-epic-classical-classical-relax
+  broadcaster: independent
+  name: EPIC CLASSICAL - Classical Relax
+  streamUrl: https://stream.epic-classical.com/classical-relax
+  bitrate: 192
+  codec: MP3
+  homepage: https://epic-classical.com/
+  country: DE
+  status: stream-only
+  stationuuid: 9da44a77-ac72-4908-8576-b53e2d0e5d14
+  changeuuid: 38589764-cbf9-4e41-9098-604365250212
+  reviewedAt: "2026-05-04"
+
+- id: de-study-by-rautemusik-rm-fm
+  broadcaster: independent
+  name: __STUDY__ by rautemusik (rm.fm)
+  streamUrl: https://study-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.rm.fm/favicon.ico
+  homepage: https://www.rm.fm/study
+  country: DE
+  status: stream-only
+  stationuuid: 0ea5c74b-3d4c-4d4d-aea9-d63e4a7019ee
+  changeuuid: 4b458c32-2932-48a2-bd54-95d28297dd3f
+  reviewedAt: "2026-05-04"
+
+- id: de-1-reggae-joint
+  broadcaster: independent
+  name: 1 reggae joint
+  streamUrl: https://jointil.com/stream-reggae
+  bitrate: 320
+  codec: MP3
+  favicon: https://www.jointil.com/broadcast/images/joint.radio330X330.png
+  homepage: https://www.jointil.com/radio/
+  country: DE
+  status: stream-only
+  stationuuid: bb904f3c-d4c8-4012-8432-70be72c81186
+  changeuuid: 2fc6c531-10a5-406a-81f3-abb439b894b1
+  reviewedAt: "2026-05-04"
+
+- id: de-aida-radio-flac
+  broadcaster: independent
+  name: AIDa radio Flac
+  streamUrl: https://cdn05.radio.cloud:8128/AIDA-OMNIA-GAI
+  bitrate: 2000
+  codec: OGG
+  homepage: https://aidaradio.de/
+  country: DE
+  status: stream-only
+  stationuuid: fa7390a8-97f2-4fb9-bcc3-11ffda584a8e
+  changeuuid: e1addb34-f7ff-4bf9-bbb0-8040c496a7b6
+  reviewedAt: "2026-05-04"
+
+- id: de-0-n-christmas-on-radio
+  broadcaster: independent
+  name: "- 0 N - Christmas on Radio"
+  streamUrl: https://0n-christmas.radionetz.de/0n-christmas.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.0nradio.com/logos/0n-christmas_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 171a0ff8-f186-11e8-a471-52543be04c81
+  changeuuid: c39dffda-e117-4dc4-b54a-9d75ad2c54b3
+  reviewedAt: "2026-05-04"
+
+- id: de-schlagerradio-fm-by-rautemusik-rm-fm
+  broadcaster: independent
+  name: __SCHLAGERRADIO.FM__ by rautemusik (rm.fm)
+  streamUrl: https://schlager-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.rm.fm/favicon.ico
+  homepage: https://www.rm.fm/schlager
+  country: DE
+  status: stream-only
+  stationuuid: af118154-fe5f-4911-a614-25617db23492
+  changeuuid: f6a67d9a-4c10-4bae-89a4-d0556cc8b367
+  reviewedAt: "2026-05-04"
+
+- id: de-0-n-lounge-on-radio
+  broadcaster: independent
+  name: "- 0 N - Lounge on Radio"
+  streamUrl: https://0n-lounge.radionetz.de/0n-lounge.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.0nradio.com/logos/0n-lounge_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: a1736a09-6b1e-4f1c-89bc-644033121167
+  changeuuid: a9e54f72-b58d-4bc6-b21e-e8bab243c6a2
+  reviewedAt: "2026-05-04"
+
+- id: de-12punks-fm-by-rautemusik-rm-fm
+  broadcaster: independent
+  name: __12PUNKS.FM__ by rautemusik (rm.fm)
+  streamUrl: https://12punks-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.rm.fm/favicon.ico
+  homepage: https://www.rm.fm/12punks
+  country: DE
+  status: stream-only
+  stationuuid: 3446b04f-839f-4367-b119-b85842787b97
+  changeuuid: 343f0f39-e438-4045-b675-48f11f73ed8b
+  reviewedAt: "2026-05-04"
+
+- id: de-refuge-worldwide
+  broadcaster: independent
+  name: Refuge Worldwide
+  streamUrl: https://streaming.radio.co/s3699c5e49/listen
+  bitrate: 192
+  codec: MP3
+  favicon: https://refugeworldwide.com/apple-touch-icon.png
+  homepage: https://refugeworldwide.com/
+  country: DE
+  status: stream-only
+  stationuuid: edb81cbf-0645-4944-a376-554b8299ff27
+  changeuuid: b63a5b6b-564f-4504-8b31-46cc5fee7e81
+  reviewedAt: "2026-05-04"
+
+- id: de-0-n-black-on-radio
+  broadcaster: independent
+  name: "- 0 N - Black on Radio"
+  streamUrl: https://0n-black.radionetz.de/0n-black.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.0nradio.com/logos/0n-black_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 47d26813-f361-11e8-a471-52543be04c81
+  changeuuid: 3ee51e94-eff5-4c45-ad79-8d12bcf6fb69
+  reviewedAt: "2026-05-04"
+
+- id: de-0-n-schlager-gold-on-radio
+  broadcaster: independent
+  name: "- 0 N - Schlager Gold on Radio"
+  streamUrl: https://0n-schlagergold.radionetz.de/0n-schlagergold.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://www.0nradio.com/logos/0n-schlager-gold_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: d218a93a-bf9d-11e9-8502-52543be04c81
+  changeuuid: e7edc41c-5942-47fa-ae3e-a35d8e49a21d
+  reviewedAt: "2026-05-04"
+
+- id: de-0-n-soft-pop-on-radio
+  broadcaster: independent
+  name: "- 0 N - Soft Pop on Radio"
+  streamUrl: https://0n-softpop.radionetz.de/0n-softpop.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.0nradio.com/logos/0n-soft-pop_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: b20789de-29dc-46ac-8341-61991053cde8
+  changeuuid: b99f6203-1718-44cd-9d2a-bed84b6f9498
+  reviewedAt: "2026-05-04"
+
+- id: de-1-a-relax-von-1a-radio
+  broadcaster: independent
+  name: "- 1 A - Relax von 1A Radio"
+  streamUrl: https://1a-relax.radionetz.de/1a-relax.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.1aradio.com/logos/1a-relax_600x600.jpg
+  homepage: http://www.1aradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: f1771246-bf9c-11e9-8502-52543be04c81
+  changeuuid: 6ddd6b99-24eb-44fe-9e75-1fce074dcf04
+  reviewedAt: "2026-05-04"
+
+- id: de-laut-fm-madonna
+  broadcaster: independent
+  name: Laut FM Madonna
+  streamUrl: https://extraradioweb-radio.stream.laut.fm/extraradio_web-radio?t302
+  bitrate: 128
+  codec: MP3
+  favicon: https://laut.fm/assets/touch-icons/apple-touch-icon.png?9e172e15
+  homepage: https://laut.fm/
+  country: DE
+  status: stream-only
+  stationuuid: e7c5988c-3496-47c0-afd0-17221ea2c932
+  changeuuid: 64fad7e2-f5d9-4830-83ae-a0b0e3ed2bb4
+  reviewedAt: "2026-05-04"
+
+- id: de-techno-by-rautemusik-fm
+  broadcaster: independent
+  name: __TECHNO__ by rautemusik.fm
+  streamUrl: https://streams.rautemusik.fm/techno/mp3-192/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  favicon: https://rm.fm/favicon.ico
+  homepage: https://rm.fm/techno
+  country: DE
+  status: stream-only
+  stationuuid: 18ab1514-a53b-4f44-936e-f8583a68b5aa
+  changeuuid: 5a37ac65-2478-4f20-8ac6-51c10e7c6122
+  reviewedAt: "2026-05-04"
+
+- id: de-0nlineradio-90s
+  broadcaster: independent
+  name: 0nlineradio 90s
+  streamUrl: https://stream.0nlineradio.com/90s?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://0nlineradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: ddcddcef-8564-4462-8919-4c3938a10182
+  changeuuid: 783618d2-7d0d-4963-ad6c-01a07aad870a
+  reviewedAt: "2026-05-04"
+
+- id: de-i-love-music-i-love-chillhop
+  broadcaster: independent
+  name: I Love Music - I Love Chillhop
+  streamUrl: https://ilm.stream35.radiohost.de/ilm_ilovechillhop_mp3-192?upd-meta&upd-scheme=https&_art=dD0xNzY4NDUwMTU1JmQ9MzQxNTMxNDFhODdjYmQ4MjA5NjE
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.ilovemusic.de/favicon.ico
+  homepage: https://www.ilovemusic.de/ilovechillhop/
+  country: DE
+  status: stream-only
+  stationuuid: c1484aa5-b758-47a1-b098-69db58d6fb78
+  changeuuid: 427887d5-d13b-479e-8ef7-810a80120176
+  reviewedAt: "2026-05-04"
+
+- id: de-0nlineradio-80s
+  broadcaster: independent
+  name: 0nlineradio 80s
+  streamUrl: https://stream.0nlineradio.com/80s?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://0nlineradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: c87c50c6-4068-4270-a83a-80b91d43212d
+  changeuuid: 46b6dcea-2bd9-457e-a24d-a3b21eb13789
+  reviewedAt: "2026-05-04"
+
+- id: de-0nlineradio-beethoven
+  broadcaster: independent
+  name: 0nlineradio BEETHOVEN
+  streamUrl: https://stream.0nlineradio.com/beethoven?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://0nlineradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 7dc0ac6d-a91f-4e96-8621-fc411514ea77
+  changeuuid: 5a0b60bf-48ff-4445-baaf-d767be047693
+  reviewedAt: "2026-05-04"
+
+- id: de-epic-lounge-french-cafe-lounge
+  broadcaster: independent
+  name: Epic Lounge - FRENCH CAFÉ LOUNGE
+  streamUrl: https://0nlineradio.stream42.radiohost.de/lounge-french-cafe-lounge?ref=radiobrowser&upd-meta&upd-scheme=https&_art=dD0xNzY4NDQ1MTE3JmQ9ODA5N2Q3ZjM4NTY5ZGM3NzdlNTM
+  bitrate: 192
+  codec: MP3
+  homepage: https://epic-lounge.com/
+  country: DE
+  status: stream-only
+  stationuuid: 67658fa0-4d4a-401b-a2b6-27bb060fb3bf
+  changeuuid: 75548806-60d8-4793-bca0-c98682ad9b77
+  reviewedAt: "2026-05-04"
+
+- id: de-maretimo-chill-radio
+  broadcaster: independent
+  name: Maretimo Chill Radio
+  streamUrl: https://s35.derstream.net/chillradio.mp3?
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.maretimo-records.com/wp-content/uploads/2022/09/favicon.png
+  homepage: https://www.maretimo-records.com/
+  country: DE
+  status: stream-only
+  stationuuid: 7c57e87b-a5e2-410b-9055-922d9df50a20
+  changeuuid: 976ed03a-a7aa-4a7e-ac33-be38a81c5ff9
+  reviewedAt: "2026-05-04"
+
+- id: de-harder-by-rautemusik-rm-fm
+  broadcaster: independent
+  name: __HARDER__ by rautemusik (rm.fm)
+  streamUrl: https://harder-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.rm.fm/favicon.ico
+  homepage: https://www.rm.fm/harder
+  country: DE
+  status: stream-only
+  stationuuid: 810c8f16-fc17-4eab-a8ef-908f280eb26a
+  changeuuid: 0fad9011-3b74-4cff-8fb7-5c722866c974
+  reviewedAt: "2026-05-04"
+
+- id: de-epic-classical-classical-background-music
+  broadcaster: independent
+  name: EPIC CLASSICAL - Classical Background Music
+  streamUrl: https://stream.epic-classical.com/classical-background-music
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/251sfzx/Background-Music.jpg
+  homepage: https://epic-classical.com/
+  country: DE
+  status: stream-only
+  stationuuid: 034a6f29-f448-40d9-917e-0d981bdfb5d2
+  changeuuid: b8c8b865-9e9c-4d24-9787-23dd5601ed7a
+  reviewedAt: "2026-05-04"
+
+- id: de-0-n-movies-on-radio
+  broadcaster: independent
+  name: "- 0 N - Movies on Radio"
+  streamUrl: https://0n-movies.radionetz.de/0n-movies.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://www.0nradio.com/logos/0n-movies_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 1bca288e-3a95-11e9-9b4e-52543be04c81
+  changeuuid: ca1b9c5a-25c2-4473-8b58-af36cf62ad67
+  reviewedAt: "2026-05-04"
+
+- id: de-antenne-bayern-happy-hits
+  broadcaster: independent
+  name: Antenne Bayern Happy Hits
+  streamUrl: https://stream.antenne.de/happy-hits/stream/mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://antenne.de/logos/station-antenne-bayern/apple-touch-icon.png
+  homepage: https://antenne.de/
+  country: DE
+  status: stream-only
+  stationuuid: f383c447-16bf-4e4b-869c-30259dfb0ff5
+  changeuuid: 017d6c28-c8ee-4f22-b9b6-ea4dbe98c4b2
+  reviewedAt: "2026-05-04"
+
+- id: de-1000-techno
+  broadcaster: independent
+  name: 1000 Techno
+  streamUrl: https://1000techno.stream.laut.fm/1000techno?pl=m3u&t302=2026-01-15_05-44-54&uuid=6755f28b-3f75-4762-916c-484df706ef7d
+  bitrate: 128
+  codec: MP3
+  homepage: http://rsn.li/
+  country: DE
+  status: stream-only
+  stationuuid: 6fa5c74b-1f5c-11ea-a955-52543be04c81
+  changeuuid: f08f86be-941c-4b50-b851-d027aad05bc8
+  reviewedAt: "2026-05-04"
+
+- id: de-technolovers-melbourne-bounce
+  broadcaster: independent
+  name: Technolovers MELBOURNE BOUNCE
+  streamUrl: https://stream.technolovers.fm/melbourne-bounce?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://technolovers.fm/
+  country: DE
+  status: stream-only
+  stationuuid: d6efe91b-b16a-488b-8b0c-1b689e8dd815
+  changeuuid: 08f79b9e-a922-4af6-894d-2f789a791357
+  reviewedAt: "2026-05-04"
+
+- id: de-flower-power-radio
+  broadcaster: independent
+  name: Flower Power Radio
+  streamUrl: https://nl1.streamingpulse.com/ssl/flowerpowerradio
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.flowerpowerradio.com/favicon.ico
+  homepage: https://www.flowerpowerradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: b421583d-b66d-49da-8980-f912448af8a7
+  changeuuid: 1c4b20b7-453a-4047-8f91-edcd777d5e96
+  reviewedAt: "2026-05-04"
+
+- id: de-0nlineradio-house
+  broadcaster: independent
+  name: 0nlineradio HOUSE
+  streamUrl: https://stream.0nlineradio.com/house?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://0nlineradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 9817bc6e-49dc-468a-8c14-b91841b7047e
+  changeuuid: ce3ef314-3dd1-42c4-822c-e836ee401141
+  reviewedAt: "2026-05-04"
+
+- id: de-technolovers-frenchcore
+  broadcaster: independent
+  name: Technolovers - FRENCHCORE
+  streamUrl: https://stream.technolovers.fm/frenchcore?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://technolovers.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 6f74701a-d559-4c46-ae23-c3e3b4d6be5a
+  changeuuid: 0bb28aa9-2325-4c13-bce1-674dfa262d28
+  reviewedAt: "2026-05-04"
+
+- id: de-nightride-fm-horrorsynth
+  broadcaster: independent
+  name: Nightride FM - Horrorsynth
+  streamUrl: https://stream.nightride.fm/horrorsynth.mp3
+  bitrate: 320
+  codec: MP3
+  favicon: https://nightride.fm/thumbnail.png
+  homepage: https://nightride.fm/
+  country: DE
+  status: stream-only
+  stationuuid: fc8a1eed-b1e9-42d4-b618-dd18bd65e5b2
+  changeuuid: cf7c2938-b55b-4453-95e6-e5f07ae8a9a2
+  reviewedAt: "2026-05-04"
+
+- id: de-1-a-rock-von-1a-radio
+  broadcaster: independent
+  name: "- 1 A - Rock von 1A Radio"
+  streamUrl: https://1a-rock.radionetz.de/1a-rock.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.1aradio.com/logos/1a-rock_600x600.jpg
+  homepage: http://www.1aradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: d5831ac6-f375-11e8-a471-52543be04c81
+  changeuuid: d9f53f10-6949-46de-9652-4df837b8dd6c
+  reviewedAt: "2026-05-04"
+
+- id: de-technolovers-house
+  broadcaster: independent
+  name: Technolovers HOUSE
+  streamUrl: https://stream.technolovers.fm/house?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://technolovers.fm/
+  country: DE
+  status: stream-only
+  stationuuid: c79c1017-de96-4a8d-ad63-443e2eb1656c
+  changeuuid: 3895db35-816f-4547-a23a-82eeb563a5df
+  reviewedAt: "2026-05-04"
+
+- id: de-solopiano-by-rautemusik-rm-fm
+  broadcaster: independent
+  name: __SOLOPIANO__ by rautemusik (rm.fm)
+  streamUrl: https://solopiano-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.rm.fm/favicon.ico
+  homepage: https://www.rm.fm/solopiano
+  country: DE
+  status: stream-only
+  stationuuid: 66bda19f-02fe-4462-a6c1-dbdcbf9feebe
+  changeuuid: 3a425865-5094-4639-804d-cf478a9b7c04
+  reviewedAt: "2026-05-04"
+
+- id: de-rbb-24-inforadio
+  broadcaster: independent
+  name: RBB 24 Inforadio
+  streamUrl: https://f121.rndfnk.com/ard/rbb/inforadio/live/mp3/128/stream.mp3?cid=01FC1WYDPN76K6HSCD8QCR9D3S&sid=2QcLzffN32wHfW1lVCzlxHze7qi&token=pGWtFx8DdsdTygJQfppoygwrmQAJ9neXn-Oapylzh_E&tvf=RIPifb2zZBdmMTIxLnJuZGZuay5jb20
+  bitrate: 128
+  codec: MP3
+  homepage: http://inforadio.de/
+  country: DE
+  status: stream-only
+  stationuuid: 051a1bf5-646b-421c-975e-4022c4be3e09
+  changeuuid: 9dbd0b80-760b-486d-8c34-b08321e05055
+  reviewedAt: "2026-05-04"
+
+- id: de-epic-classical-classical-chillout
+  broadcaster: independent
+  name: EPIC CLASSICAL - Classical Chillout
+  streamUrl: https://stream.epic-classical.com/classical-chillout?ref=liveradio
+  bitrate: 192
+  codec: MP3
+  homepage: https://epic-classical.com/
+  country: DE
+  status: stream-only
+  stationuuid: 69bc2427-259f-44d3-8593-6bae1e3fbc16
+  changeuuid: f94ac118-d058-47c8-bdb2-d9e80f99306a
+  reviewedAt: "2026-05-04"
+
+- id: de-russia-today-germany
+  broadcaster: independent
+  name: Russia Today Germany
+  streamUrl: https://rt-ger.rttv.com/dvr/rtdeutsch/playlist.m3u8
+  bitrate: 4664
+  codec: AAC,H.264
+  favicon: https://th.bing.com/th/id/OIP.fFhTxl0dHi7zOZGQEOor6wAAAA
+  homepage: https://de.rt.com/
+  country: DE
+  status: stream-only
+  stationuuid: f3c8ee2d-64ca-4988-98f9-147a224d12b3
+  changeuuid: 8ac3fa6f-6e67-41f7-86c3-8ab223762e7a
+  reviewedAt: "2026-05-04"
+
+- id: de-1-a-80er-von-1a-radio
+  broadcaster: independent
+  name: "- 1 A - 80er von 1A Radio"
+  streamUrl: https://1a-80er.radionetz.de/1a-80er.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.1aradio.com/logos/1a-80er_600x600.jpg
+  homepage: http://www.1aradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 3ad4ddf1-f373-11e8-a471-52543be04c81
+  changeuuid: 56e873bc-95d4-4cd8-8643-17f3d64031fb
+  reviewedAt: "2026-05-04"
+
+- id: de-rock-antenne-live-rock
+  broadcaster: independent
+  name: ROCK ANTENNE Live Rock
+  streamUrl: https://stream.rockantenne.de/live-rock/stream/aacp
+  codec: AAC
+  favicon: https://www.rockantenne.de/logos/station-rock-antenne/apple-touch-icon.png
+  homepage: https://www.rockantenne.de/
+  country: DE
+  status: stream-only
+  stationuuid: 8807f4d7-a515-41ac-9e87-21125a4290a5
+  changeuuid: 8a06b33a-8583-417d-af79-f2420dc7b939
+  reviewedAt: "2026-05-04"
+
+- id: de-70-s-80-s-90-s-riw-vintage-channel
+  broadcaster: independent
+  name: "70's 80's 90's Riw Vintage Channel"
+  streamUrl: https://stream.laut.fm/70s-80s-90s-riw-vintage-channel
+  bitrate: 128
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/f361b3_3b8537296cb04e049fdfe55af2a45900~mv2.jpg
+  homepage: https://laut.fm/70s-80s-90s-riw-vintage-channel
+  country: DE
+  status: stream-only
+  stationuuid: 7481adce-989e-4692-bfcf-07774ed1ced9
+  changeuuid: 75501883-945f-4de0-9c4f-506744088d23
+  reviewedAt: "2026-05-04"
+
+- id: de-rock-by-rautemusik-rm-fm
+  broadcaster: independent
+  name: __ROCK__ by rautemusik (rm.fm)
+  streamUrl: https://rock-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.rm.fm/favicon.ico
+  homepage: https://www.rm.fm/rock
+  country: DE
+  status: stream-only
+  stationuuid: c1cf2a48-9720-4728-bf6d-bae391f5bccd
+  changeuuid: 4c32e997-4df2-48f0-b98c-b3f0fc83a12b
+  reviewedAt: "2026-05-04"
+
+- id: de-piano-coverhits-by-epic-piano
+  broadcaster: independent
+  name: PIANO COVERHITS by Epic Piano
+  streamUrl: https://stream.epic-piano.com/piano-coverhits?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://epic-piano.com/
+  country: DE
+  status: stream-only
+  stationuuid: ba3ca13b-147a-4591-b3c0-89c84cdd45ff
+  changeuuid: 0cd0dbb6-ef08-41f2-9ab6-9cc4a92cf408
+  reviewedAt: "2026-05-04"
+
+- id: de-swr2-48k-aac
+  broadcaster: independent
+  name: "SWR2 | 48k aac"
+  streamUrl: https://liveradio.swr.de/sw890cl/swr2/
+  bitrate: 96
+  codec: AAC
+  favicon: https://www.swr.de/assets/swr/swr2/apple-touch-icon.png
+  homepage: https://www.swr.de/swr2/index.html
+  country: DE
+  status: stream-only
+  stationuuid: b815d3b4-d0e6-43d6-81e4-e205c328fe44
+  changeuuid: e5d598f7-4017-4e86-b77c-8611626c8793
+  reviewedAt: "2026-05-04"
+
+- id: de-technolovers-trance
+  broadcaster: independent
+  name: Technolovers TRANCE
+  streamUrl: https://stream.technolovers.fm/trance?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://technolovers.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 57a27605-e80a-499c-b1a2-aca15a4ce92e
+  changeuuid: 7e5e4be7-3a62-491c-bbbc-5d492b05870e
+  reviewedAt: "2026-05-04"
+
+- id: de-0nlineradio-2000er
+  broadcaster: independent
+  name: 0nlineradio 2000er
+  streamUrl: https://stream.0nlineradio.com/2000er?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://0nlineradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: f8186a9f-7df1-4787-9d1f-ba32229814be
+  changeuuid: 15dd1820-a1b0-4113-b8e0-610f833d74eb
+  reviewedAt: "2026-05-04"
+
+- id: de-neofolk
+  broadcaster: independent
+  name: NEOFOLK
+  streamUrl: https://stream.laut.fm/neofolk
+  bitrate: 128
+  codec: MP3
+  favicon: https://i0.wp.com/flatlinesradio.de/storage/2021/11/244611397_1194785584320990_6265045071816304131_n-1.jpg?fit=180%2c180&#038;ssl=1
+  homepage: https://flatlinesradio.de/
+  country: DE
+  status: stream-only
+  stationuuid: 3a6e96c5-66bb-11e9-af37-52543be04c81
+  changeuuid: 4d3cc84c-16f4-4283-b7a2-6d56e678b87f
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-dark-pulse
+  broadcaster: independent
+  name: Radio Dark Pulse
+  streamUrl: https://radiodarkpulse.stream.laut.fm/radiodarkpulse
+  bitrate: 128
+  codec: MP3
+  favicon: https://cdn.onlineradiobox.com/img/l/1/35171.v1.png
+  country: DE
+  status: stream-only
+  stationuuid: 6a207472-4d14-4f03-aaa7-f6286b081d6f
+  changeuuid: 704493be-9bbf-40b9-bd44-df978d94f6e8
+  reviewedAt: "2026-05-04"
+
+- id: de-christmas-chor-by-rautemusik-rm-fm
+  broadcaster: independent
+  name: __CHRISTMAS CHOR__ by rautemusik (rm.fm)
+  streamUrl: https://christmas-chor-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.rm.fm/favicon.ico
+  homepage: https://www.rm.fm/christmas-chor
+  country: DE
+  status: stream-only
+  stationuuid: 09522918-f835-41ae-94ff-9dab9dd073ac
+  changeuuid: 878019b3-68b6-4507-8114-28b83691ed5b
+  reviewedAt: "2026-05-04"
+
+- id: de-98-2-radio-paradiso
+  broadcaster: independent
+  name: 98.2 Radio Paradiso
+  streamUrl: https://streams.paradiso.de/Berlin/mp3-128/Web/?pkey=web-radioparadiso-de&tcstring=CPXGs4APXGs4AAFADBDECKCgAAAAAAAAAAYgAAAAAAAA.YAAAAAAAAAAA
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.paradiso.de/assets/favicons/apple-icon-120x120.png
+  homepage: https://www.paradiso.de/
+  country: DE
+  status: stream-only
+  stationuuid: 64512383-0fd7-44b3-8c77-63035da01938
+  changeuuid: 918e5d57-3737-4227-a6cb-4449a19209ee
+  reviewedAt: "2026-05-04"
+
+- id: de-deutschlandfunk-nova-dlf-opus-64k
+  broadcaster: independent
+  name: "Deutschlandfunk Nova | DLF | OPUS 64k"
+  streamUrl: https://st03.sslstream.dlf.de/dlf/03/high/opus/stream.opus?aggregator=web
+  bitrate: 64
+  codec: OGG
+  favicon: https://www.deutschlandfunknova.de/apple-touch-icon.png
+  homepage: https://www.deutschlandfunknova.de/
+  country: DE
+  status: stream-only
+  stationuuid: bfc67b48-6800-4dd3-8347-cabc7fd5d37d
+  changeuuid: cf3f8db6-d84c-4185-91e5-52623faf316d
+  reviewedAt: "2026-05-04"
+
+- id: de-epic-classical-classical-romance
+  broadcaster: independent
+  name: EPIC CLASSICAL - Classical Romance
+  streamUrl: https://stream.epic-classical.com/classical-romance
+  bitrate: 192
+  codec: MP3
+  homepage: https://epic-classical.com/
+  country: DE
+  status: stream-only
+  stationuuid: 8b2da670-18bc-4bde-ae60-ebfef8985161
+  changeuuid: 0b4d402b-07a9-4759-a73e-7e28b8b0db21
+  reviewedAt: "2026-05-04"
+
+- id: de-rock-antenne-symphonic-rock
+  broadcaster: independent
+  name: Rock Antenne Symphonic Rock
+  streamUrl: https://s2-webradio.rockantenne.de/symphonic-rock/stream
+  bitrate: 128
+  codec: MP3
+  country: DE
+  status: stream-only
+  stationuuid: f8759b95-915b-40ba-982a-4b51a5b4465c
+  changeuuid: fd2ff4f0-56b0-4920-81f1-6f622f646380
+  reviewedAt: "2026-05-04"
+
+- id: de-0-n-gold-on-radio
+  broadcaster: independent
+  name: "- 0 N - Gold on Radio"
+  streamUrl: https://0n-gold.radionetz.de/0n-gold.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.0nradio.com/logos/0n-gold_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: f36b67a6-b7aa-4511-a2fa-53feed51abe2
+  changeuuid: 1e573ee6-e83c-410f-aeee-2d8020ea5ad3
+  reviewedAt: "2026-05-04"
+
+- id: de-top-100-dj-charts-remix-deejay-radio-club-radio-
+  broadcaster: independent
+  name: "- TOP 100 - DJ Charts - / - REMIX DEEJAY RADIO - CLUB RADIO - HOUSE - EDM - TECHHOUSE - TECHNO - DANCE - TOP100 - TOP40 - RNB - BLACKMUSIC - HIPHOP - URBAN - REGGEATON - MIXTAPE RADIO - RAVE MUSIC -  LIVE DEEJAY RADIO - LIVE EVENTS"
+  streamUrl: https://radio2.breakz.fm/?ref=rb-gpt-t100
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/b7gfKT6/TOP-100-DJ-CHARTS-GPT.jpg
+  homepage: https://www.breakz.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 29717342-f376-48a3-93a6-3dae781e6c92
+  changeuuid: fbfdc04e-76d6-4aa0-b2d2-b07518561f17
+  reviewedAt: "2026-05-04"
+
+- id: de-christmas-piano-by-epic-piano
+  broadcaster: independent
+  name: CHRISTMAS PIANO by Epic Piano
+  streamUrl: https://stream.epic-piano.com/christmas-piano?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://epic-piano.com/
+  country: DE
+  status: stream-only
+  stationuuid: 8459559c-4623-465e-9c2d-def8e55cbba9
+  changeuuid: 0c782b45-5957-4b3b-b3d0-6470b01e3137
+  reviewedAt: "2026-05-04"
+
+- id: de-80s-by-rautemusik-rm-fm
+  broadcaster: independent
+  name: __80S__ by rautemusik (rm.fm)
+  streamUrl: https://80s-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.rm.fm/favicon.ico
+  homepage: https://www.rm.fm/80s
+  country: DE
+  status: stream-only
+  stationuuid: 0507b8b1-4a4d-42cd-872f-fd6f6c64712f
+  changeuuid: 6aa4e67c-7060-45a4-a796-da9ec3aa8078
+  reviewedAt: "2026-05-04"
+
+- id: de-1-splash-70s
+  broadcaster: independent
+  name: "#1 Splash 70s"
+  streamUrl: https://c4.auracast.net/radio/8040/radio.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.splashradio.eu/
+  country: DE
+  status: stream-only
+  stationuuid: 8b2d98fd-f448-4149-9b41-59ffea2b2a1e
+  changeuuid: 5ea2928e-7293-47c0-b170-1b76de1f1f68
+  reviewedAt: "2026-05-04"
+
+- id: de-epic-lounge-new-york-lounge
+  broadcaster: independent
+  name: Epic Lounge - NEW YORK LOUNGE
+  streamUrl: https://stream.epic-lounge.com/new-york-lounge
+  bitrate: 192
+  codec: MP3
+  homepage: https://epic-lounge.com/
+  country: DE
+  status: stream-only
+  stationuuid: 793bb20d-e596-45c4-831b-9b552bc2f846
+  changeuuid: 1ead6a4e-f423-453d-b5f7-684c7b1db9a0
+  reviewedAt: "2026-05-04"
+
+- id: de-technolovers-trap
+  broadcaster: independent
+  name: Technolovers TRAP
+  streamUrl: https://stream.technolovers.fm/trap?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://technolovers.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 3511172e-a0f1-4568-9d34-87c3ef0fa608
+  changeuuid: c08c3fbd-1194-45e9-841b-89258c1735b0
+  reviewedAt: "2026-05-04"
+
+- id: de-epic-classical-classical-study
+  broadcaster: independent
+  name: EPIC CLASSICAL - Classical Study
+  streamUrl: https://stream.epic-classical.com/classical-study
+  bitrate: 192
+  codec: MP3
+  homepage: https://epic-classical.com/
+  country: DE
+  status: stream-only
+  stationuuid: d5fdc0d9-8aac-4a19-9c3c-3e10692d74f6
+  changeuuid: 94ae34c4-f35a-4c19-b76f-b2691c6cdbb4
+  reviewedAt: "2026-05-04"
+
+- id: de-swr-4-rp-mainz-128k
+  broadcaster: independent
+  name: SWR 4 RP Mainz (128k)
+  streamUrl: https://liveradio.swr.de/sw282p3/swr4rp/play.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://liveradio.swr.de/favicon.ico
+  homepage: https://liveradio.swr.de/sw282p3/swr4rp
+  country: DE
+  status: stream-only
+  stationuuid: 6b7e1995-d91f-44b2-a547-adec22cc7e5d
+  changeuuid: a881ce29-ecba-43ec-afb4-f3ef3520fd0b
+  reviewedAt: "2026-05-04"
+
+- id: de-technolovers-dirty-house
+  broadcaster: independent
+  name: Technolovers DIRTY HOUSE
+  streamUrl: https://stream.technolovers.fm/dirty-house?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://technolovers.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 88f2d271-efe3-4d79-96fc-eba05786807d
+  changeuuid: 048bf974-d8bf-4da7-9174-35f884bf8de2
+  reviewedAt: "2026-05-04"
+
+- id: de-deutschlandfunk-nova-dlf-aac-48k
+  broadcaster: independent
+  name: "Deutschlandfunk Nova | DLF | AAC 48k"
+  streamUrl: https://st03.sslstream.dlf.de/dlf/03/low/aac/stream.aac?aggregator=web
+  bitrate: 48
+  codec: AAC
+  favicon: https://www.deutschlandfunknova.de/apple-touch-icon.png
+  homepage: https://www.deutschlandfunknova.de/
+  country: DE
+  status: stream-only
+  stationuuid: 9d560a7f-3d37-45b0-bf17-a7cc19a3b1c6
+  changeuuid: 71daba46-15bc-407d-9592-b3faf660d0fd
+  reviewedAt: "2026-05-04"
+
+- id: de-fu-ball-bundesliga-konferenz
+  broadcaster: independent
+  name: "Fußball-Bundesliga: Konferenz"
+  streamUrl: https://wdr-sportschau-liga1konferenz.icecastssl.wdr.de/wdr/sportschau/liga1konferenz/mp3/high
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.sportschau.de/resources/assets/image/favicon/apple-icon-120x120.png
+  homepage: https://livecenter.sportschau.de/
+  country: DE
+  status: stream-only
+  stationuuid: 1e2d02c2-99bf-4e5c-a383-47be01bb68a1
+  changeuuid: bf1640e2-700f-44f6-91eb-242fa46bca38
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-munchen-256kb
+  broadcaster: independent
+  name: Radio München 256kb
+  streamUrl: https://stream.radiomuenchen.net/rm256.mp3
+  bitrate: 256
+  codec: MP3
+  homepage: https://radiomuenchen.net/
+  country: DE
+  status: stream-only
+  stationuuid: 958c9cb5-2e74-42cd-8b91-bba4fe31acf8
+  changeuuid: 65e12e0d-32e2-4929-99fb-331d857680fb
+  reviewedAt: "2026-05-04"
+
+- id: de-antenne-nrw
+  broadcaster: independent
+  name: Antenne NRW
+  streamUrl: https://stream.antenne.de/antenne-nrw/stream/aacp
+  bitrate: 47
+  codec: AAC+
+  country: DE
+  status: stream-only
+  stationuuid: 6ab145af-21d1-43ff-b144-c6331a4c6c5d
+  changeuuid: 043ad121-059e-43eb-b352-7a3d3db2c6b1
+  reviewedAt: "2026-05-04"
+
+- id: de-0-n-gay-on-radio
+  broadcaster: independent
+  name: "- 0 N - Gay on Radio"
+  streamUrl: https://0n-gay.radionetz.de/0n-gay.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.0nradio.com/logos/0n-gay_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 016123a1-f367-11e8-a471-52543be04c81
+  changeuuid: 7821bc34-d392-4726-b30e-41cad11bc65c
+  reviewedAt: "2026-05-04"
+
+- id: de-erf-plus
+  broadcaster: independent
+  name: ERF plus
+  streamUrl: https://stream.erfplus.de/erf-1a64/aac-64?ar-distributor=ffa5
+  bitrate: 64
+  codec: AAC+
+  favicon: https://erf.de/apple-touch-icon.png?v=pbzut9eb
+  homepage: https://erf.de/
+  country: DE
+  status: stream-only
+  stationuuid: 9866bdc3-ee77-4a0f-a98d-88eed5468ec7
+  changeuuid: a31a0dbc-ad20-4226-b2e4-b67a9b13d0b8
+  reviewedAt: "2026-05-04"
+
+- id: de-swr-aktuell-48k-aac
+  broadcaster: independent
+  name: "SWR Aktuell | 48k aac"
+  streamUrl: https://liveradio.swr.de/sw890cl/swraktuell/
+  bitrate: 128
+  codec: AAC
+  homepage: https://www.swr.de/swraktuell/index.html
+  country: DE
+  status: stream-only
+  stationuuid: 31385346-c6d1-45c0-a628-5ea6188e2ffb
+  changeuuid: 2dc35d82-d3df-4642-9e40-cba52b0127e5
+  reviewedAt: "2026-05-04"
+
+- id: de-deutschlandfunk-dokumente-und-debatten-dlf-mp3-1
+  broadcaster: independent
+  name: "Deutschlandfunk Dokumente und Debatten | DLF | MP3 128k"
+  streamUrl: https://st04.sslstream.dlf.de/dlf/04/128/mp3/stream.mp3?aggregator=web
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.deutschlandradio.de/static/img/deutschlandradio/icons/apple-touch-icon-128x128.png
+  homepage: https://www.deutschlandradio.de/dokumente-und-debatten-102.html
+  country: DE
+  status: stream-only
+  stationuuid: 8bd4c5c5-7d73-11ea-8a3b-52543be04c81
+  changeuuid: ec94ee83-c4c9-4161-8876-8032ded02123
+  reviewedAt: "2026-05-04"
+
+- id: de-showagenten-radio
+  broadcaster: independent
+  name: ShowAgenten Radio
+  streamUrl: https://listen.radioking.com/radio/395746/stream/449383
+  bitrate: 320
+  codec: MP3
+  favicon: https://www.radioking.com/wp-content/uploads/2023/06/cropped-faviconrk-180x180.webp
+  homepage: https://de.radioking.com/radio/showagenten
+  country: DE
+  status: stream-only
+  stationuuid: 47d3dc84-05a2-4b45-a6b5-a3359b5f3d5a
+  changeuuid: 47a047d3-4713-46fa-879c-fa44c44adc91
+  reviewedAt: "2026-05-04"
+
+- id: de-laut-fm-shoegaze
+  broadcaster: independent
+  name: Laut.FM Shoegaze
+  streamUrl: https://shoegaze.stream.laut.fm/shoegaze
+  bitrate: 128
+  codec: MP3
+  homepage: https://laut.fm/shoegaze
+  country: DE
+  status: stream-only
+  stationuuid: b14e3c20-6343-11e8-b15b-52543be04c81
+  changeuuid: ddbb67ab-cd4a-4850-ba96-79854a3a6a0d
+  reviewedAt: "2026-05-04"
+
+- id: de-1000-weihnachten
+  broadcaster: independent
+  name: 1000 Weihnachten
+  streamUrl: https://stream.laut.fm/1000weihnachten
+  bitrate: 128
+  codec: MP3
+  favicon: http://radiosummernight.ch/favicon.ico
+  homepage: http://radiosummernight.ch/
+  country: DE
+  status: stream-only
+  stationuuid: fe6cadad-0b05-11ea-a87e-52543be04c81
+  changeuuid: 1c27f1f2-325a-49e9-8243-167b6712d8ba
+  reviewedAt: "2026-05-04"
+
+- id: de-epic-classical-classical-orchestral
+  broadcaster: independent
+  name: EPIC CLASSICAL - Classical Orchestral
+  streamUrl: https://stream.epic-classical.com/classical-orchestral?ref=liveradio
+  bitrate: 192
+  codec: MP3
+  homepage: https://epic-classical.com/
+  country: DE
+  status: stream-only
+  stationuuid: 329dd2cc-2574-445f-a32e-759e39ba9e71
+  changeuuid: 2cf3e2d1-195a-4397-a802-35f7d3b43bc0
+  reviewedAt: "2026-05-04"
+
+- id: de-0nlineradio-gospel
+  broadcaster: independent
+  name: 0nlineradio GOSPEL
+  streamUrl: https://stream.0nlineradio.com/gospel?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://0nlineradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 62252aa8-78e3-4450-ba6e-e6ccaff21cf3
+  changeuuid: a024a580-8a9e-46a8-a433-13fbb738fefd
+  reviewedAt: "2026-05-04"
+
+- id: de-epic-lounge-beach-club-lounge
+  broadcaster: independent
+  name: Epic Lounge - BEACH CLUB LOUNGE
+  streamUrl: https://stream.epic-lounge.com/beach-club-lounge?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://epic-lounge.com/
+  country: DE
+  status: stream-only
+  stationuuid: a988450c-b109-4be5-93d4-323cb6a3f324
+  changeuuid: 9b700ca5-8417-45a6-8d60-3d22feeb9570
+  reviewedAt: "2026-05-04"
+
+- id: de-epic-lounge-spa-lounge
+  broadcaster: independent
+  name: Epic Lounge - SPA LOUNGE
+  streamUrl: https://stream.epic-lounge.com/spa-lounge?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://epic-lounge.com/
+  country: DE
+  status: stream-only
+  stationuuid: 157b699e-8895-4154-a764-59877eef735d
+  changeuuid: 4f1afa32-c5e0-4ff6-ad6d-fdaa683f4b87
+  reviewedAt: "2026-05-04"
+
+- id: de-i-love-hip-hop
+  broadcaster: independent
+  name: I love Hip Hop
+  streamUrl: https://ilm.stream12.radiohost.de/ilm_ilovehiphop_mp3-192?upd-meta&upd-scheme=https&_art=dD0xNzY4NDQyMzAyJmQ9YjViMzFhNzk1ZjkxNTJhMmMwZTM
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.ilovemusic.de/favicon.ico
+  homepage: https://www.ilovemusic.de/
+  country: DE
+  status: stream-only
+  stationuuid: 5060c98c-e853-434d-a096-f4b8e9bdc52e
+  changeuuid: fd6da2b4-b6fc-44ac-b032-3b8fce84ee7d
+  reviewedAt: "2026-05-04"
+
+- id: de-lagerfeuermetal
+  broadcaster: independent
+  name: LAGERFEUERMETAL
+  streamUrl: https://lagerfeuermetal.stream.laut.fm/lagerfeuermetal?pl=m3u&t302=2026-01-14_23-49-48&uuid=021d8a2b-c686-453c-9525-49713d9cebab
+  bitrate: 128
+  codec: MP3
+  homepage: https://laut.fm/lagerfeuermetal
+  country: DE
+  status: stream-only
+  stationuuid: 4723a254-2bc1-442d-9ddd-7debc003370f
+  changeuuid: 421eb7f8-c484-4395-8bc0-72005258c36c
+  reviewedAt: "2026-05-04"
+
+- id: de-antenne-bayern-2010er-hits
+  broadcaster: independent
+  name: Antenne Bayern - 2010er Hits
+  streamUrl: https://s8-webradio.antenne.de/2010er-hits/stream/mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.antenne.de/logos/station-antenne-bayern/apple-touch-icon.png
+  homepage: https://www.antenne.de/
+  country: DE
+  status: stream-only
+  stationuuid: 44e251b6-5457-444a-a501-c2c1f2f2366e
+  changeuuid: 0a8c1e0e-7254-4741-b1d7-0f87b1dcf531
+  reviewedAt: "2026-05-04"
+
+- id: de-1-a-hits-von-1a-radio
+  broadcaster: independent
+  name: "- 1 A - Hits von 1A Radio"
+  streamUrl: https://1a-hits.radionetz.de/1a-hits.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.1aradio.com/logos/1a-hits_600x600.jpg
+  homepage: http://www.1aradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 5a2b36a0-f374-11e8-a471-52543be04c81
+  changeuuid: 5afa3213-da45-4a26-b871-5869e8af771a
+  reviewedAt: "2026-05-04"
+
+- id: de-0-n-indie-on-radio
+  broadcaster: independent
+  name: "- 0 N - Indie on Radio"
+  streamUrl: https://0n-indie.radionetz.de/0n-indie.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://www.0nradio.com/logos/0n-indie_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 86fa975a-f369-11e8-a471-52543be04c81
+  changeuuid: 5d9fdab2-bbcc-4dbe-8462-7c138567056a
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-lippe
+  broadcaster: independent
+  name: Radio Lippe
+  streamUrl: https://radiolippe-live.cast.addradio.de/radiolippe/live/mp3/high
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.radiolippe.de/icons/apple-icon-120.png
+  homepage: https://www.radiolippe.de/home.html
+  country: DE
+  status: stream-only
+  stationuuid: cdfaa2da-b883-4e74-82bb-b37cdcae3376
+  changeuuid: c4e50d4c-a29d-48e8-8578-754f30262b7b
+  reviewedAt: "2026-05-04"
+
+- id: de-1-a-weihnachten-von-1a-radio
+  broadcaster: independent
+  name: "- 1 A - Weihnachten von 1A Radio"
+  streamUrl: https://1a-weihnachten.radionetz.de/1a-weihnachten.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.1aradio.com/logos/1a-weihnachten_600x600.jpg
+  homepage: http://www.1aradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 2d63a059-f188-11e8-a471-52543be04c81
+  changeuuid: dcbc6e2a-cb9e-47d3-ac93-d577b92404e8
+  reviewedAt: "2026-05-04"
+
+- id: de-0-n-charts-on-radio
+  broadcaster: independent
+  name: "- 0 N - Charts on Radio"
+  streamUrl: https://0n-charts.radionetz.de/0n-charts.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.0nradio.com/logos/0n-charts_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: e0e0c40c-f2c3-11e8-a471-52543be04c81
+  changeuuid: a26f9e86-171e-42e7-b949-9642ad2ed0fc
+  reviewedAt: "2026-05-04"
+
+- id: de-berliner-rundfunk-60er-70er
+  broadcaster: independent
+  name: "Berliner Rundfunk 60er & 70er"
+  streamUrl: https://topradio-stream19.radiohost.de/brf-60er-70er_mp3-128
+  bitrate: 128
+  codec: MP3
+  favicon: https://upload.berliner-rundfunk.de/production/static/1713539285366/icons/icon_64.a80y02808w0.png
+  homepage: https://www.berliner-rundfunk.de/clone-of-60er-70er-love-peace-rock-n-roll
+  country: DE
+  status: stream-only
+  stationuuid: 3ede5a77-225c-49f1-945c-5fae3b48b4c5
+  changeuuid: f688cf39-9534-44fc-b291-86473b1b1bfe
+  reviewedAt: "2026-05-04"
+
+- id: de-1-splash-60s
+  broadcaster: independent
+  name: "#1 Splash 60s"
+  streamUrl: https://c4.auracast.net/radio/8020/radio.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.splashradio.eu/
+  country: DE
+  status: stream-only
+  stationuuid: 7c6d140a-0af1-4d2a-be01-c06e878f6238
+  changeuuid: 12b18902-3ece-4c6c-9c2e-d9f01d60580b
+  reviewedAt: "2026-05-04"
+
+- id: de-music-of-china
+  broadcaster: independent
+  name: Music of China 中国音乐
+  streamUrl: https://vip.wongsong.cn/proxy/wongsong/stream-mp3-WongSong
+  bitrate: 128
+  codec: MP3
+  favicon: https://wongsong.cn/img/fav.ico
+  homepage: https://wongsong.cn/
+  country: DE
+  status: stream-only
+  stationuuid: 65a4ed77-3097-4d46-9d10-5257bedf7d7a
+  changeuuid: 25235554-c48a-494e-a7e4-4e1a0353c3c6
+  reviewedAt: "2026-05-04"
+
+- id: de-1live-top-hits
+  broadcaster: independent
+  name: 1LIVE Top Hits
+  streamUrl: https://wdr-1live-tophits.icecast.wdr.de/wdr/1live/tophits/mp3/128/stream.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www1.wdr.de/radio/1live/app/loopstream-cover-1live-top-hits-100~_v-TeaserAufmacher.jpg
+  homepage: https://www1.wdr.de/radio/1live/musik/1live-streams/loopstream-1live-top-hits-100.html
+  country: DE
+  status: stream-only
+  stationuuid: 44a79452-4f3c-42da-a0a3-17e73d3b1154
+  changeuuid: 9ff467b3-041e-4010-800d-0d3df0fe6726
+  reviewedAt: "2026-05-04"
+
+- id: de-80s-90s
+  broadcaster: independent
+  name: 80s-90s
+  streamUrl: https://stream.laut.fm/80s-90s
+  bitrate: 128
+  codec: MP3
+  homepage: https://stream.laut.fm/80s-90s
+  country: DE
+  status: stream-only
+  stationuuid: 2fc851df-715c-11e9-af37-52543be04c81
+  changeuuid: 2fc851eb-715c-11e9-af37-52543be04c81
+  reviewedAt: "2026-05-04"
+
+- id: de-nightride-fm-datawave
+  broadcaster: independent
+  name: Nightride FM - Datawave
+  streamUrl: https://stream.nightride.fm/datawave.mp3
+  bitrate: 320
+  codec: MP3
+  favicon: https://nightride.fm/thumbnail.png
+  homepage: https://nightride.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 65479d00-dd6e-494e-93b0-a8607b846d12
+  changeuuid: 4a076232-f0ae-45a0-9be0-4baf1ebb9116
+  reviewedAt: "2026-05-04"
+
+- id: de-rockantenne-hamburg-64-kbps-aac
+  broadcaster: independent
+  name: ROCKANTENNE Hamburg (64 kbps AAC)
+  streamUrl: https://mp3channels.rockantenne.hamburg/rockantenne-hamburg.aac
+  codec: AAC
+  homepage: https://www.rockantenne.de/
+  country: DE
+  status: stream-only
+  stationuuid: f84ab96c-b68f-11e9-acb2-52543be04c81
+  changeuuid: a4a29fa6-22a6-4c49-bb97-aed976e298e2
+  reviewedAt: "2026-05-04"
+
+- id: de-epic-lounge-sax-house-lounge
+  broadcaster: independent
+  name: Epic Lounge - SAX HOUSE LOUNGE
+  streamUrl: https://stream.epic-lounge.com/sax-house-lounge?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/LJByzTs/sax-house-lounge.jpg
+  homepage: https://epic-lounge.com/
+  country: DE
+  status: stream-only
+  stationuuid: 09c04067-681d-471f-92dc-f7b172664e02
+  changeuuid: 3e0f7396-b77b-47ad-a5f5-4696a4287be3
+  reviewedAt: "2026-05-04"
+
+- id: de-berliner-rundfunk-91-4-ostrock-pop
+  broadcaster: independent
+  name: "Berliner Rundfunk 91.4 - Ostrock & Pop "
+  streamUrl: https://topradio-de-hz-fal-stream08-cluster01.radiohost.de/brf-oldies_mp3-128?ref=homepage&amsparams=homepage&listenerid=31363231303734323636-37372e32322e36382e3830-3439333932-4d6f7a696c6c612f352e30202857696e646f7773
+  bitrate: 128
+  codec: MP3
+  favicon: https://upload.berliner-rundfunk.de/production/static/1659973942875/icons/icon_64.a80y02808w0.png
+  homepage: https://www.berliner-rundfunk.de/
+  country: DE
+  status: stream-only
+  stationuuid: 40e63764-adec-4e81-978b-f7bda48795c0
+  changeuuid: bd7b88ea-bcab-4c4a-a901-568ea8452460
+  reviewedAt: "2026-05-04"
+
+- id: de-blasmusikradio-mit-bernd
+  broadcaster: independent
+  name: "\tBlasmusikradio mit Bernd"
+  streamUrl: https://stream.laut.fm/blasmusikradio_mit_bernd
+  bitrate: 128
+  codec: MP3
+  favicon: https://assets.laut.fm/b22749b7fdb382b8912269e3d8054380?t=_120x120
+  homepage: https://laut.fm/blasmusikradio_mit_bernd
+  country: DE
+  status: stream-only
+  stationuuid: ffc0d701-f43b-4232-8be6-f7ff72add8ef
+  changeuuid: 4af32abe-0c71-4ccf-94a8-62387cad17b2
+  reviewedAt: "2026-05-04"
+
+- id: de-schwany-souvenir-1
+  broadcaster: independent
+  name: Schwany  Souvenir 1
+  streamUrl: https://souvenir.spcast.eu:443/stream?time=1768465529
+  bitrate: 320
+  codec: MP3
+  favicon: http://schwany.de/favicon.ico
+  homepage: http://schwany.de/
+  country: DE
+  status: stream-only
+  stationuuid: c5bd581f-8188-4e61-9ee7-aa56fe6e0761
+  changeuuid: bedce316-cbe0-4fb0-ae92-159807f239af
+  reviewedAt: "2026-05-04"
+
+- id: de-1000-dance
+  broadcaster: independent
+  name: 1000 Dance
+  streamUrl: https://1000dance.stream.laut.fm/1000dance?pl=m3u&t302=2026-01-15_07-29-36&uuid=997342b3-8538-4ed6-b66f-15bb7009d340
+  bitrate: 128
+  codec: MP3
+  homepage: http://radiosummernight.ch/
+  country: DE
+  status: stream-only
+  stationuuid: 256b7931-1f5c-11ea-a955-52543be04c81
+  changeuuid: 8c28cca1-5bba-41e8-8234-05b266d9902a
+  reviewedAt: "2026-05-04"
+
+- id: de-0nlineradio-neue-deutsche-welle
+  broadcaster: independent
+  name: 0nlineradio NEUE DEUTSCHE WELLE
+  streamUrl: https://stream.0nlineradio.com/neuedeutschewelle?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://0nlineradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: a491d74d-e2d9-4a9a-91cc-e934220ac02d
+  changeuuid: acb1f72d-03b7-4655-9949-2168305eb554
+  reviewedAt: "2026-05-04"
+
+- id: de-deutschlandfunk-kultur-dlf-aac-48k
+  broadcaster: independent
+  name: "Deutschlandfunk Kultur | DLF | AAC 48k"
+  streamUrl: https://st02.sslstream.dlf.de/dlf/02/low/aac/stream.aac?aggregator=web
+  bitrate: 48
+  codec: AAC
+  favicon: https://www.deutschlandfunkkultur.de/static/img/deutschlandfunk_kultur/icons/apple-touch-icon-128x128.png
+  homepage: https://www.deutschlandfunkkultur.de/
+  country: DE
+  status: stream-only
+  stationuuid: d15b3add-7106-11ea-b1cf-52543be04c81
+  changeuuid: f396cd18-04d0-438b-834d-9872c30e70fd
+  reviewedAt: "2026-05-04"
+
+- id: de-1-a-party-von-1a-radio
+  broadcaster: independent
+  name: "- 1 A - Party von 1A Radio"
+  streamUrl: https://1a-party.radionetz.de/1a-party.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.1aradio.com/logos/1a-party_600x600.jpg
+  homepage: http://www.1aradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: edb75f23-f36f-11e8-a471-52543be04c81
+  changeuuid: 603d8449-bd0b-41d6-a0ed-8d5b810747f8
+  reviewedAt: "2026-05-04"
+
+- id: de-epic-lounge-lounge-covers
+  broadcaster: independent
+  name: Epic Lounge - LOUNGE COVERS
+  streamUrl: https://stream.epic-lounge.com/lounge-covers?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://epic-lounge.com/
+  country: DE
+  status: stream-only
+  stationuuid: c556e56c-8577-4910-a215-7acbba07be9c
+  changeuuid: 377e52a4-a8e9-4ec9-9bbc-84da38fc16dd
+  reviewedAt: "2026-05-04"
+
+- id: de-great-piano-concerts-by-epic-piano
+  broadcaster: independent
+  name: GREAT PIANO CONCERTS by Epic Piano
+  streamUrl: https://stream.epic-piano.com/great-piano-concerts?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://epic-piano.com/
+  country: DE
+  status: stream-only
+  stationuuid: 3ed7d046-0a6a-47f4-a470-147b3dee79ff
+  changeuuid: 153c8258-a126-490a-8994-cd528f1913f7
+  reviewedAt: "2026-05-04"
+
+- id: de-happy-by-rautemusik-rm-fm
+  broadcaster: independent
+  name: __HAPPY__ by rautemusik (rm.fm)
+  streamUrl: https://happy-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.rm.fm/favicon.ico
+  homepage: https://www.rm.fm/happy
+  country: DE
+  status: stream-only
+  stationuuid: 2ada7660-dff4-478a-ad03-7937ac002ed8
+  changeuuid: f30a3f88-4e11-48b9-86da-d5e0d02112bd
+  reviewedAt: "2026-05-04"
+
+- id: de-0-n-reggae-on-radio
+  broadcaster: independent
+  name: "- 0 N - Reggae on Radio"
+  streamUrl: https://0n-reggae.radionetz.de/0n-reggae.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.0nradio.com/logos/0n-reggae_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 188577fe-af05-4d1d-b02e-ce992005372c
+  changeuuid: 467fc322-993c-4afb-bd76-af691ebcad80
+  reviewedAt: "2026-05-04"
+
+- id: de-dance-family-radio
+  broadcaster: independent
+  name: Dance Family Radio
+  streamUrl: https://dance-family-radio.stream.laut.fm/dance-family-radio
+  bitrate: 128
+  codec: MP3
+  favicon: https://cdn.onlineradiobox.com/img/l/1/52351.v3.png
+  country: DE
+  status: stream-only
+  stationuuid: 31de526e-9d6c-463e-97f9-9188b1b14a17
+  changeuuid: 95c6e859-b984-448d-9ad3-7d6909b8f659
+  reviewedAt: "2026-05-04"
+
+- id: de-deutschlandfunk-nova-dlf-opus-24k
+  broadcaster: independent
+  name: "Deutschlandfunk Nova | DLF | OPUS 24k"
+  streamUrl: https://st03.sslstream.dlf.de/dlf/03/low/opus/stream.opus?aggregator=web
+  bitrate: 24
+  codec: OGG
+  favicon: https://www.deutschlandfunknova.de/apple-touch-icon.png
+  homepage: https://www.deutschlandfunknova.de/
+  country: DE
+  status: stream-only
+  stationuuid: 436caf9b-8194-461b-92b3-728db19bb0aa
+  changeuuid: 30366fb9-cb09-4bd3-aaed-ca4cf1a4b243
+  reviewedAt: "2026-05-04"
+
+- id: de-epic-lounge-jazzhop
+  broadcaster: independent
+  name: Epic Lounge - JAZZHOP
+  streamUrl: https://stream.epic-lounge.com/jazzhop-lounge?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/9Hc5TxR/Jazz-Hop-Lounge.jpg
+  homepage: https://epic-lounge.com/
+  country: DE
+  status: stream-only
+  stationuuid: c72d442a-d73b-40f1-b741-e143b620eecf
+  changeuuid: 1ffc517c-6ec2-4405-b3eb-7aa61aebe7eb
+  reviewedAt: "2026-05-04"
+
+- id: de-0nlineradio-schlager
+  broadcaster: independent
+  name: 0nlineradio SCHLAGER
+  streamUrl: https://stream.0nlineradio.com/schlager?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://0nlineradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: bb09bafd-17b6-4dc1-8b41-8668da2b13fd
+  changeuuid: a679f348-1810-4829-9002-41020c724dd4
+  reviewedAt: "2026-05-04"
+
+- id: de-0-n-weihnachten-on-radio
+  broadcaster: independent
+  name: "- 0 N - Weihnachten on Radio"
+  streamUrl: https://0n-weihnachten.radionetz.de/0n-weihnachten.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.0nradio.com/logos/0n-weihnachten_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 0ba45fad-0a4a-11ea-a87e-52543be04c81
+  changeuuid: 04a12202-1773-4fc8-b029-9c23176da4e6
+  reviewedAt: "2026-05-04"
+
+- id: de-schwany-heimatwelle
+  broadcaster: independent
+  name: Schwany Heimatwelle
+  streamUrl: https://hoamatwelle.schwany.de/
+  bitrate: 320
+  codec: MP3
+  favicon: http://schwany.de/favicon.ico
+  homepage: http://schwany.de/
+  country: DE
+  status: stream-only
+  stationuuid: fc7a2004-c921-4599-82f3-7ab5ac80b73a
+  changeuuid: 9aecdca6-af83-42d5-a799-436c18bf7df3
+  reviewedAt: "2026-05-04"
+
+- id: de-die-sendung-mit-der-maus-zum-horen
+  broadcaster: independent
+  name: Die Sendung mit der Maus zum Hören
+  streamUrl: https://wdrhf.akamaized.net/hls/live/2028167/diemaus/master.m3u8
+  bitrate: 102
+  codec: AAC
+  favicon: https://www.wdrmaus.de/icon/apple-icon-120x120.png
+  homepage: https://www.wdrmaus.de/hoeren/
+  country: DE
+  status: stream-only
+  stationuuid: 3d20f066-8ac3-47e9-b854-939189129e09
+  changeuuid: d002903a-d84d-4361-b9a6-dd767c8e9456
+  reviewedAt: "2026-05-04"
+
+- id: de-plattenkiste-von-oldies-aus-den-50er-n-bis-zu-hi
+  broadcaster: independent
+  name: "Plattenkiste - von Oldies aus den 50er'n bis zu Hits von morgen"
+  streamUrl: https://stream.laut.fm/plattenkiste
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.laut.fm/plattenkiste
+  country: DE
+  status: stream-only
+  stationuuid: adf698b1-40ef-11ea-a9fa-52543be04c81
+  changeuuid: d3b12958-b3ca-4ca4-ba3e-f5da5deeef8d
+  reviewedAt: "2026-05-04"
+
+- id: de-malle-fm
+  broadcaster: independent
+  name: Malle FM
+  streamUrl: https://stream.laut.fm/malle-fm?ref=web-app&start_time=1687953524529
+  bitrate: 128
+  codec: MP3
+  homepage: https://laut.fm/malle-fm
+  country: DE
+  status: stream-only
+  stationuuid: 85781bc6-dec2-473c-8d04-24ff5342cce2
+  changeuuid: 39fafefa-8c4a-4293-b9d6-6989ff3f6641
+  reviewedAt: "2026-05-04"
+
+- id: de-ndr-2-hamburg
+  broadcaster: independent
+  name: NDR 2 Hamburg
+  streamUrl: https://icecast.ndr.de/ndr/ndr2/hamburg/mp3/128/stream.mp3?1728423809880&aggregator=web
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.phonostar.de/images/auto_created/NDR22184x184.png
+  homepage: https://www.ndr.de/ndr2/
+  country: DE
+  status: stream-only
+  stationuuid: 9e535cb5-1bfd-4f83-9c3f-13571d01a487
+  changeuuid: 039bc304-9954-4b15-b81e-aad7e531ca6b
+  reviewedAt: "2026-05-04"
+
+- id: de-volksmusik-fm-by-rautemusik-rm-fm
+  broadcaster: independent
+  name: __VOLKSMUSIK.FM__ by rautemusik (rm.fm)
+  streamUrl: https://volksmusik-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.volksmusik.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 2b57f96f-4dd6-4c74-bf5a-da654f028cc9
+  changeuuid: 06349ce0-b275-46bc-8272-3ba9b0d12c23
+  reviewedAt: "2026-05-04"
+
+- id: de-0nlineradio-schlager-evergreens
+  broadcaster: independent
+  name: 0nlineradio SCHLAGER EVERGREENS
+  streamUrl: https://stream.0nlineradio.com/schlager-evergreens?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://0nlineradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 9146aa9a-1021-499d-ae12-010e17eb6873
+  changeuuid: c16aeb63-749c-4f54-9025-2112aacef775
+  reviewedAt: "2026-05-04"
+
+- id: de-epic-lounge-dinner-lounge
+  broadcaster: independent
+  name: Epic Lounge - DINNER LOUNGE
+  streamUrl: https://stream.epic-lounge.com/dinner-lounge
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/MhFMB2k/Dinner-Lounge.jpg
+  homepage: https://epic-lounge.com/
+  country: DE
+  status: stream-only
+  stationuuid: 4cbec6b2-e81a-48c7-bd59-b2b4f4c78ffb
+  changeuuid: b09c26b6-27e4-44a8-883d-47d6b9d54831
+  reviewedAt: "2026-05-04"
+
+- id: de-hellweg-radio
+  broadcaster: independent
+  name: Hellweg Radio
+  streamUrl: https://stream.lokalradio.nrw/4453zcj
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.hellwegradio.de/assets/images/favicons/hellwegradio/favicon_x96.png
+  homepage: https://www.hellwegradio.de/
+  country: DE
+  status: stream-only
+  stationuuid: 96853554-2a23-49f9-a1dd-57765e63503b
+  changeuuid: 992cc3da-8e53-4df6-9b37-408ac863e2b6
+  reviewedAt: "2026-05-04"
+
+- id: de-ndw
+  broadcaster: independent
+  name: NDW
+  streamUrl: https://stream.laut.fm/ndw
+  bitrate: 128
+  codec: MP3
+  favicon: https://assets.laut.fm/d17d1513505a2c0740d7013a4a68f5a0?t=_120x120
+  homepage: https://laut.fm/ndw
+  country: DE
+  status: stream-only
+  stationuuid: 56e9e4e3-4128-48a0-bcba-445c6f77e29b
+  changeuuid: ee740717-2668-413a-8439-39df3b0c26fb
+  reviewedAt: "2026-05-04"
+
+- id: de-0-n-love-on-radio
+  broadcaster: independent
+  name: "- 0 N - Love on Radio"
+  streamUrl: https://0n-love.radionetz.de/0n-love.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.0nradio.com/logos/0n-love_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 7370f167-508f-473e-99aa-2b3170cbfc0e
+  changeuuid: 1a44c5a6-b9af-42a6-a0aa-6b9cda501682
+  reviewedAt: "2026-05-04"
+
+- id: de-deutsche-hits-by-rautemusik-rm-fm
+  broadcaster: independent
+  name: __DEUTSCHE HITS__ by rautemusik (rm.fm)
+  streamUrl: https://deutsche-hits-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.rm.fm/favicon.ico
+  homepage: https://www.rm.fm/deutsche-hits
+  country: DE
+  status: stream-only
+  stationuuid: a6d675b8-1ce5-42c6-97e2-4440d233c58d
+  changeuuid: 95e22c4f-e13b-422c-97b0-5c498628b0d3
+  reviewedAt: "2026-05-04"
+
+- id: de-epic-classical-classical-hotel-lounge
+  broadcaster: independent
+  name: EPIC CLASSICAL - Classical Hotel Lounge
+  streamUrl: https://stream.epic-classical.com/classical-hotel-lounge
+  bitrate: 192
+  codec: MP3
+  homepage: https://epic-classical.com/
+  country: DE
+  status: stream-only
+  stationuuid: a555dcd5-f15e-41e2-b5f5-9d44baffc752
+  changeuuid: 8c33e9c9-b116-4c80-9138-e58e69f21fa4
+  reviewedAt: "2026-05-04"
+
+- id: de-modern-talking-pc
+  broadcaster: independent
+  name: Modern Talking PC
+  streamUrl: https://stream05.pcradio.ru/Modern_Talking-med
+  codec: AAC
+  country: DE
+  status: stream-only
+  stationuuid: 9be8d81d-67f7-4b3d-a905-ef2a78d3fd9b
+  changeuuid: a684820e-93d4-4e9f-8593-3f2d4827797b
+  reviewedAt: "2026-05-04"
+
+- id: de-tagesschau24
+  broadcaster: independent
+  name: tagesschau24
+  streamUrl: https://icecast.tagesschau.de/ndr/tagesschau24/live/mp3/128/stream.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://tagesschau.de/resources/assets/image/favicon/apple-icon-120x120.png
+  homepage: https://tagesschau.de/
+  country: DE
+  status: stream-only
+  stationuuid: 354f5aa8-88ef-4c9e-8d69-8c6bf0eb8057
+  changeuuid: 7d59a926-6755-4a7a-bb55-6e748c8b5b43
+  reviewedAt: "2026-05-04"
+
+- id: de-0-n-jukebox-on-radio
+  broadcaster: independent
+  name: "- 0 N - Jukebox on Radio"
+  streamUrl: https://0n-jukebox.radionetz.de/0n-jukebox.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.0nradio.com/logos/0n-jukebox_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 07832b85-0a4d-11ea-a87e-52543be04c81
+  changeuuid: e9f49e23-a9d1-4f69-bde5-55c120ba6651
+  reviewedAt: "2026-05-04"
+
+- id: de-0nlineradio-schubert
+  broadcaster: independent
+  name: 0nlineradio SCHUBERT
+  streamUrl: https://stream.0nlineradio.com/schubert?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://0nlineradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: a5cc0522-9dcb-45c2-acd9-fce370d20698
+  changeuuid: b0ed6dbd-453a-44b6-bb8d-f041207e4530
+  reviewedAt: "2026-05-04"
+
+- id: de-i-love-dance-first
+  broadcaster: independent
+  name: "I Love - Dance first!"
+  streamUrl: https://ilm.stream35.radiohost.de/ilm_ilovedancefirst_mp3-192?upd-meta&upd-scheme=https&_art=dD0xNzY4NDU2NzE2JmQ9OGJiYTc3MmNmYjNjMWZkMjkxZGY
+  bitrate: 192
+  codec: MP3
+  homepage: https://streams.ilovemusic.de/
+  country: DE
+  status: stream-only
+  stationuuid: 8ea5c537-31d7-4af8-93dd-030ce3cb38d8
+  changeuuid: 843cedb3-958d-493a-9805-a2a8ee1d5a3e
+  reviewedAt: "2026-05-04"
+
+- id: de-antenne-bayern-oldies-but-goldies
+  broadcaster: independent
+  name: Antenne Bayern - Oldies but Goldies
+  streamUrl: https://stream.oldie-antenne.de/oldie-antenne/stream/mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://antenne.de/logos/station-antenne-bayern/apple-touch-icon.png
+  homepage: https://antenne.de/
+  country: DE
+  status: stream-only
+  stationuuid: eb8148fe-9402-4c69-8bc6-1f07157106eb
+  changeuuid: 1237e725-1186-4691-a2d6-2b45bab3a036
+  reviewedAt: "2026-05-04"
+
+- id: de-bdj-eurodance-90s
+  broadcaster: independent
+  name: BDJ Eurodance 90s
+  streamUrl: https://stream-90s.bdjradio.com/
+  bitrate: 128
+  codec: MP3
+  favicon: https://bdjradio.com/media/images/bdj-eurodance-90s-456214.png
+  homepage: https://bdjradio.com/90s/index.html
+  country: DE
+  status: stream-only
+  stationuuid: 4ef9334f-e341-4d49-9d3b-ff0d972d7214
+  changeuuid: 045f968c-aba7-4d37-a8b8-88d44b70c7e3
+  reviewedAt: "2026-05-04"
+
+- id: de-1000-70er-laut-fm
+  broadcaster: independent
+  name: 1000 70er - laut.fm
+  streamUrl: https://100070er.stream.laut.fm/100070er
+  bitrate: 128
+  codec: MP3
+  homepage: https://laut.fm/100070er
+  country: DE
+  status: stream-only
+  stationuuid: 5328e3f0-cd69-11e9-8502-52543be04c81
+  changeuuid: fa75234b-e452-4dbb-8335-5bbe7be48193
+  reviewedAt: "2026-05-04"
+
+- id: de-0nlineradio-schlager-oldies
+  broadcaster: independent
+  name: 0nlineradio SCHLAGER OLDIES
+  streamUrl: https://stream.0nlineradio.com/schlager-oldies?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://0nlineradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 81b052b5-af4c-456b-81c3-dc1c6b8f0e19
+  changeuuid: 6ce68ff0-3c71-4ed1-856f-d79ec8582e82
+  reviewedAt: "2026-05-04"
+
+- id: de-0-n-techno-on-radio
+  broadcaster: independent
+  name: "- 0 N - Techno on Radio"
+  streamUrl: https://0n-techno.radionetz.de/0n-techno.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.0nradio.com/logos/0n-techno_600x600.jpg
+  homepage: https://www.0nradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 3a4f48a2-4cf4-4fd1-819d-358e49aa4dcc
+  changeuuid: ccb4e08e-076c-475a-a7aa-0a3725af6326
+  reviewedAt: "2026-05-04"
+
+- id: de-wdr3-256
+  broadcaster: independent
+  name: wdr3 256
+  streamUrl: https://wdr-wdr3-live.icecastssl.wdr.de/wdr/wdr3/live/mp3/256/stream.mp3
+  bitrate: 256
+  codec: MP3
+  homepage: https://wdr-wdr3-live.icecastssl.wdr.de/wdr/wdr3/live/mp3/256/stream.mp3
+  country: DE
+  status: stream-only
+  stationuuid: fa5dee28-159d-4c26-937f-7c07e14147c2
+  changeuuid: 271ed0aa-e9a5-4a15-9f24-09892f2a5661
+  reviewedAt: "2026-05-04"
+
+- id: de-klassik-by-rautemusik-rm-fm
+  broadcaster: independent
+  name: __KLASSIK__ by rautemusik (rm.fm)
+  streamUrl: https://klassik-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.rm.fm/favicon.ico
+  homepage: https://www.rm.fm/klassik
+  country: DE
+  status: stream-only
+  stationuuid: 4dd2e9f8-4463-4f38-940b-a6b8923f5978
+  changeuuid: e44d1cf5-51f6-40e6-8e0f-6693113de7b3
+  reviewedAt: "2026-05-04"
+
+- id: de-rock-antenne-70er-rock-mp3
+  broadcaster: independent
+  name: ROCK ANTENNE 70er Rock (MP3)
+  streamUrl: https://s2-webradio.rockantenne.de/70er-rock/stream/mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.rockantenne.de/logos/station-rock-antenne/apple-touch-icon.png
+  homepage: https://www.rockantenne.de/
+  country: DE
+  status: stream-only
+  stationuuid: 826ae57b-5483-4219-bd29-cf95dcca6ebf
+  changeuuid: 8755642b-e2db-4dc5-82c7-a536e671a381
+  reviewedAt: "2026-05-04"
+
+- id: de-schwany-weihnacht
+  broadcaster: independent
+  name: Schwany Weihnacht
+  streamUrl: https://schwany.streampanel.cloud/14-weihnacht
+  bitrate: 320
+  codec: MP3
+  favicon: http://schwany.de/images/Radio-Schwany-Weihnacht-Logo-600-x-600-px-mit-www.jpg
+  homepage: http://schwany.de/
+  country: DE
+  status: stream-only
+  stationuuid: 45144dda-03de-4826-869a-6463b0ff359a
+  changeuuid: 0673d56c-5398-40e4-99f0-816028abde94
+  reviewedAt: "2026-05-04"
+
+- id: de-1-a-entspannt-von-1a-radio
+  broadcaster: independent
+  name: "- 1 A - Entspannt von 1A Radio"
+  streamUrl: https://1a-entspannt.radionetz.de/1a-entspannt.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.1aradio.com/logos/1a-entspannt_600x600.jpg
+  homepage: http://www.1aradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 79232bcc-f372-11e8-a471-52543be04c81
+  changeuuid: 4e37e551-3a1c-4bd0-81eb-7340b403c518
+  reviewedAt: "2026-05-04"
+
+- id: de-1-a-deutsch-rap-von-1a-radio
+  broadcaster: independent
+  name: "- 1 A - Deutsch Rap von 1A Radio"
+  streamUrl: https://1a-deutschrap.radionetz.de/1a-deutschrap.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.1aradio.com/logos/1a-deutsch-rap_600x600.jpg
+  homepage: http://www.1aradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: c839ca40-f36e-11e8-a471-52543be04c81
+  changeuuid: 51a275ed-8b1e-4fe3-b18c-202a15bf9ae1
+  reviewedAt: "2026-05-04"
+
+- id: de-swr1
+  broadcaster: independent
+  name: SWR1
+  streamUrl: https://f121.rndfnk.com/ard/swr/swr1/bw/mp3/128/stream.mp3?cid=01FC1X3K2Z71SMDKMEC68DM7MW&sid=38Gm6dGXmN9qJODTt2jxHj3IW9Q&token=BzI6w0PSAZ9vG7xsgGi3EnRu1ppRlMe7KsArb4c9qK0&tvf=fAp2mhjRihhmMTIxLnJuZGZuay5jb20
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.swr.de/assets/swr/swr1/apple-touch-icon.png
+  homepage: https://www.swr.de/swr1/index.html
+  country: DE
+  status: stream-only
+  stationuuid: 287e1c64-b9d5-49b3-b47e-cf9f9e2503ac
+  changeuuid: bed3a392-bb56-4bc0-aa65-8753a84a447d
+  reviewedAt: "2026-05-04"
+
+- id: de-80er-revival
+  broadcaster: independent
+  name: 80er-Revival
+  streamUrl: https://stream.laut.fm/80er-revival
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.80er-revival.de/favicon.ico
+  homepage: https://www.80er-revival.de/
+  country: DE
+  status: stream-only
+  stationuuid: 6502d4ae-0e78-11e9-a80b-52543be04c81
+  changeuuid: 70fbb713-885c-4610-87f8-3ed37eba4691
+  reviewedAt: "2026-05-04"
+
+- id: de-antenne-bayern-bayerische-weihnacht
+  broadcaster: independent
+  name: Antenne Bayern - Bayerische Weihnacht
+  streamUrl: https://stream.antenne.de/bayerische-weihnacht/stream/mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.antenne.de/logos/station-antenne-bayern/apple-touch-icon.png
+  homepage: https://www.antenne.de/webradio/bayerische-weihnacht
+  country: DE
+  status: stream-only
+  stationuuid: 6aad0396-110e-453d-8e59-0574ff0231f6
+  changeuuid: 76d2393d-dfe9-4aea-a968-cdc586e15745
+  reviewedAt: "2026-05-04"
+
+- id: de-ne-ws-89-4
+  broadcaster: independent
+  name: NE-WS 89.4
+  streamUrl: https://news894--di--nacs-ais-lgc--0a--cdn.cast.addradio.de/news894/live/mp3/high
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.news894.de/assets/images/favicons/news894/favicon_x96.png
+  homepage: https://www.news894.de/
+  country: DE
+  status: stream-only
+  stationuuid: 29998da4-8dc4-499d-83fc-d06ea5ae3d1e
+  changeuuid: 83a7ffee-4739-456a-bf91-7ecedaeb37cf
+  reviewedAt: "2026-05-04"
+
+- id: de-0nlineradio-cinema-hits
+  broadcaster: independent
+  name: 0nlineradio CINEMA HITS
+  streamUrl: https://stream.0nlineradio.com/cinema-hits?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/NysqyMR/cinema-hits.jpg
+  homepage: https://0nlineradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 6746402d-62bf-485a-8769-f2ebed3e10b4
+  changeuuid: 483725de-a579-46cd-8488-a9a114a49ee2
+  reviewedAt: "2026-05-04"
+
+- id: de-antenne-bayern-2000er-hits
+  broadcaster: independent
+  name: Antenne Bayern - 2000er Hits
+  streamUrl: https://s2-webradio.antenne.de/2000er-hits
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.antenne.de/logos/station-antenne-bayern/apple-touch-icon.png
+  homepage: https://www.antenne.de/
+  country: DE
+  status: stream-only
+  stationuuid: 1f0ae82b-b259-4ce6-a6c0-0a4bfea85ea6
+  changeuuid: 21e32838-7159-4a9b-af48-cb415ecfd38c
+  reviewedAt: "2026-05-04"
+
+- id: de-kuschelrock
+  broadcaster: independent
+  name: Kuschelrock
+  streamUrl: https://stream.laut.fm/kuschelrock
+  bitrate: 128
+  codec: MP3
+  favicon: https://softrock.ch/wp-content/uploads/2020/12/cropped-cropped-4aba99803d183f31ddfb950ca799e9c6-150x150-1-180x180.png
+  homepage: https://softrock.ch/
+  country: DE
+  status: stream-only
+  stationuuid: acaff2c9-0e1e-11e9-a80b-52543be04c81
+  changeuuid: 00849686-5f3b-424b-8f29-dd58eccaf242
+  reviewedAt: "2026-05-04"
+
+- id: de-rock-antenne-80er-rock-mp3
+  broadcaster: independent
+  name: ROCK ANTENNE 80er Rock (MP3)
+  streamUrl: https://stream.rockantenne.de/80er-rock/stream/mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.rockantenne.de/logos/station-rock-antenne/apple-touch-icon.png
+  homepage: https://www.rockantenne.de/
+  country: DE
+  status: stream-only
+  stationuuid: a3d713bf-d742-4b24-8aae-4d865820dcd5
+  changeuuid: 3b06f42f-f798-4a0a-b210-ac6ea31f5226
+  reviewedAt: "2026-05-04"
+
+- id: de-karneval-by-rautemusik-rm-fm
+  broadcaster: independent
+  name: __KARNEVAL__ by rautemusik (rm.fm)
+  streamUrl: https://karneval-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/GHPKzgV/karneval.jpg
+  homepage: https://www.rm.fm/karneval
+  country: DE
+  status: stream-only
+  stationuuid: f0d285db-c07e-42d5-bf5e-f54e6c73ef44
+  changeuuid: 418aa314-0b85-43d8-bb59-9f0f8270477b
+  reviewedAt: "2026-05-04"
+
+- id: de-0-n-evergreens-on-radio
+  broadcaster: independent
+  name: "- 0 N - Evergreens on Radio"
+  streamUrl: https://0n-evergreens.radionetz.de/0n-evergreens.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.0nradio.com/logos/0n-evergreens_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 8da2a5ec-04bd-4085-865e-cf587bb67614
+  changeuuid: e4098883-32ee-468e-b265-46bcae20475c
+  reviewedAt: "2026-05-04"
+
+- id: de-juka-radio-tophits
+  broadcaster: independent
+  name: juka radio tophits
+  streamUrl: https://juka-radio.stream.laut.fm/juka-radio?t302=2021-04-01_09-08-21&uuid=ecbcab5b-a799-4581-bc34-b292c056efbd
+  bitrate: 128
+  codec: MP3
+  homepage: https://juka-radio.de/
+  country: DE
+  status: stream-only
+  stationuuid: 2ab8b370-bdf4-4944-9875-8e923f3d9c05
+  changeuuid: 68c65030-d0ef-457b-9114-9688731fe3b3
+  reviewedAt: "2026-05-04"
+
+- id: de-0nlineradio-classic-rock
+  broadcaster: independent
+  name: 0nlineradio CLASSIC ROCK
+  streamUrl: https://stream.0nlineradio.com/classic-rock?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://0nlineradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 96e2b3e5-21a0-45ee-8da9-f4870bfa5378
+  changeuuid: 27b6fa1c-0162-4dfb-aef9-63cfdc363df4
+  reviewedAt: "2026-05-04"
+
+- id: de-0-n-party-on-radio
+  broadcaster: independent
+  name: "- 0 N - Party on Radio"
+  streamUrl: https://0n-party.radionetz.de/0n-party.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.0nradio.com/logos/0n-party_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: a2dacd48-33b2-11e9-8f31-52543be04c81
+  changeuuid: 1d13e0ee-e185-4684-8be3-f2e4b3b243f3
+  reviewedAt: "2026-05-04"
+
+- id: de-dish-fm
+  broadcaster: independent
+  name: Dish FM
+  streamUrl: https://server27166.streamplus.de/stream.mp3?shoutcast
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.dishfm.de/images/logo.png
+  homepage: https://www.dishfm.de/
+  country: DE
+  status: stream-only
+  stationuuid: e3ef12fd-4e96-4a5c-9602-bfb79c2d3681
+  changeuuid: 7f582bec-fdfc-49f7-b51a-9965e2b507aa
+  reviewedAt: "2026-05-04"
+
+- id: de-1-a-volksmusik-von-1a-radio
+  broadcaster: independent
+  name: "- 1 A - Volksmusik von 1A Radio"
+  streamUrl: https://1a-volksmusik.radionetz.de/1a-volksmusik.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.1aradio.com/logos/1a-volksmusik_600x600.jpg
+  homepage: http://www.1aradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: cd31f31f-f36b-11e8-a471-52543be04c81
+  changeuuid: c10c62a1-97c2-4344-aa57-af135d7139ca
+  reviewedAt: "2026-05-04"
+
+- id: de-sr2-kulturradio
+  broadcaster: independent
+  name: SR2 Kulturradio
+  streamUrl: https://f131.rndfnk.com/ard/sr/sr2/mp3/128/stream.mp3?aggregator=web&sid=2AcIChGD4UajakncGfrTM4Luw2m&token=22MZpE9iYFWN_F5-aAwNzTTXesRGdOZS5XLWXw1bDT8&tvf=pXLt81Xk-BZmMTMxLnJuZGZuay5jb20
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.sr.de/sr/static/images/favicon.ico
+  homepage: https://www.sr.de/sr/sr2/index.html
+  country: DE
+  status: stream-only
+  stationuuid: 8ef7aba5-4c62-442a-876f-265ffd7e8a2f
+  changeuuid: fb9e3a22-da9d-437a-8589-035379b756f9
+  reviewedAt: "2026-05-04"
+
+- id: de-1live-rnb-hip-hop
+  broadcaster: independent
+  name: "1LIVE RnB & Hip Hop"
+  streamUrl: https://wdr-1live-hiphoprnb.icecast.wdr.de/wdr/1live/hiphoprnb/mp3/128/stream.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www1.wdr.de/radio/1live/app/loopstream-1live-rnb-hip-hop-100~_v-TeaserAufmacher.jpg
+  homepage: https://www1.wdr.de/radio/1live/musik/1live-streams/loopstream-1live-rnb-hiphop-100.html
+  country: DE
+  status: stream-only
+  stationuuid: 723f72f5-de5e-42bf-af0f-bd2740cdcd33
+  changeuuid: fd5dd67c-cf8b-439d-b71e-2bdb2adf0dee
+  reviewedAt: "2026-05-04"
+
+- id: de-epic-lounge-hotel-lounge
+  broadcaster: independent
+  name: Epic Lounge - HOTEL LOUNGE
+  streamUrl: https://stream.epic-lounge.com/hotel-lounge?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://epic-lounge.com/
+  country: DE
+  status: stream-only
+  stationuuid: cc9030c8-bd33-40e5-8613-5f1d4d26e4a8
+  changeuuid: c0a6dc11-d00b-4603-9760-5d14290d4488
+  reviewedAt: "2026-05-04"
+
+- id: de-0-n-klassik-on-radio
+  broadcaster: independent
+  name: "- 0 N - Klassik on Radio"
+  streamUrl: https://0n-klassik.radionetz.de/0n-klassik.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.0nradio.com/logos/0n-klassik_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: f397bb44-3a93-11e9-9b4e-52543be04c81
+  changeuuid: 43e6d68d-b93e-4fc2-ba30-060e713e9968
+  reviewedAt: "2026-05-04"
+
+- id: de-bayern-1-schwaben
+  broadcaster: independent
+  name: Bayern 1 Schwaben
+  streamUrl: https://dispatcher.rndfnk.com/br/br1/schwaben/mp3/mid
+  bitrate: 128
+  codec: MP3
+  favicon: https://api.ardmediathek.de/image-service/images/urn:ard:image:b366004f6196d70c?w=512
+  homepage: https://www.br.de/radio/bayern1/index.html
+  country: DE
+  status: stream-only
+  stationuuid: 1e2095c0-4845-45c3-bc61-d2c7fc1ee52a
+  changeuuid: 6f5686fd-702b-4c7c-926d-00e3330e1f6b
+  reviewedAt: "2026-05-04"
+
+- id: de-epic-lounge-restaurant-lounge
+  broadcaster: independent
+  name: Epic Lounge - RESTAURANT LOUNGE
+  streamUrl: https://stream.epic-lounge.com/restaurant-lounge?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://epic-lounge.com/
+  country: DE
+  status: stream-only
+  stationuuid: c98622f7-4955-4a1f-911a-68bfe226bc9a
+  changeuuid: 6d22afb2-0b8e-45fc-a838-63c386be992e
+  reviewedAt: "2026-05-04"
+
+- id: de-radiomonster-fm-evergreens
+  broadcaster: independent
+  name: Radiomonster.FM - Evergreens
+  streamUrl: https://ic.radiomonster.fm/evergreens.ultra
+  bitrate: 320
+  codec: MP3
+  homepage: http://www.radiomonster.fm/
+  country: DE
+  status: stream-only
+  stationuuid: eb5a1ea9-60fb-11e8-b15b-52543be04c81
+  changeuuid: 926d2f1b-8c24-44ba-a49f-d94ade2f2c51
+  reviewedAt: "2026-05-04"
+
+- id: de-ultra-dark-radio
+  broadcaster: independent
+  name: Ultra Dark Radio
+  streamUrl: https://ultradarkradio.stream.laut.fm/ultradarkradio
+  bitrate: 128
+  codec: MP3
+  favicon: https://cdn.onlineradiobox.com/img/l/2/34162.v1.png
+  country: DE
+  status: stream-only
+  stationuuid: 7f2a4fbf-c9c4-415a-abab-c41d2cc40d3a
+  changeuuid: 8952a418-2620-4bc4-b921-077c07da4388
+  reviewedAt: "2026-05-04"
+
+- id: de-1-a-christmas-on-radio
+  broadcaster: independent
+  name: "- 1 A - Christmas on Radio"
+  streamUrl: https://1a-christmas.radionetz.de/1a-christmas.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.1aradio.com/logos/1a-christmas_600x600.jpg
+  homepage: http://www.1aradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 0ff4271b-0a4b-11ea-a87e-52543be04c81
+  changeuuid: af3c577a-5c3c-4f00-ac54-9fa7f0320e1f
+  reviewedAt: "2026-05-04"
+
+- id: de-swr4-ulm
+  broadcaster: independent
+  name: SWR4 Ulm
+  streamUrl: https://liveradio.swr.de/sw282p3/swr4ul/
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.swr.de/assets/swr/swraktuell/apple-touch-icon-120x120.png
+  homepage: https://www.swr.de/swraktuell/baden-wuerttemberg/ulm/index.html
+  country: DE
+  status: stream-only
+  stationuuid: d722b005-cc22-4062-85b8-19021a86419b
+  changeuuid: ec815505-8357-4d17-9159-68feaa89a91c
+  reviewedAt: "2026-05-04"
+
+- id: de-100-5-das-hitradio-alemannia-livestream
+  broadcaster: independent
+  name: 100,5 DAS HITRADIO Alemannia-Livestream
+  streamUrl: https://stream.dashitradio.de/alemannia/mp3-128/stream.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://stream.dashitradio.de/alemannia/mp3-128/stream.mp3
+  country: DE
+  status: stream-only
+  stationuuid: 8dd04644-7938-49b4-b855-44fd1e6055db
+  changeuuid: 1af1405a-2c07-4cd2-a741-911d222dc138
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-gold
+  broadcaster: independent
+  name: radio Gold
+  streamUrl: https://radiogold-live.cast.addradio.de/radiogold/live/mp3/high/stream.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.radiogold.de/favicon.ico
+  homepage: https://www.radiogold.de/
+  country: DE
+  status: stream-only
+  stationuuid: f1634c46-bdd0-410b-a16c-89f7f5226e57
+  changeuuid: 9b672572-143d-4c7e-93c8-ad449f967d11
+  reviewedAt: "2026-05-04"
+
+- id: de-berliner-rundfunk
+  broadcaster: independent
+  name: Berliner Rundfunk
+  streamUrl: https://stream.berliner-rundfunk.de/brf/mp3-128/?ref=radioplayer&=&&___cb=339744594540955
+  bitrate: 128
+  codec: MP3
+  favicon: https://upload.berliner-rundfunk.de/production/static/1688453791035/icons/icon_512.a80y02808w0.png
+  homepage: https://www.berliner-rundfunk.de/
+  country: DE
+  status: stream-only
+  stationuuid: 468cd6a3-6028-446b-b4e2-1b9bf4231374
+  changeuuid: a0ff3e79-600c-402a-b23f-961d49696818
+  reviewedAt: "2026-05-04"
+
+- id: de-synthwave-neon-city-laut-fm
+  broadcaster: independent
+  name: Synthwave Neon City laut.fm
+  streamUrl: https://stream.laut.fm/synthwave
+  bitrate: 128
+  codec: MP3
+  homepage: https://laut.fm/synthwave
+  country: DE
+  status: stream-only
+  stationuuid: 5af08b5b-20ab-4c17-a774-916fbdcd06bd
+  changeuuid: d6b22f75-0312-4ed3-a54b-3b2eada8728b
+  reviewedAt: "2026-05-04"
+
+- id: de-egofm-soundtrack
+  broadcaster: independent
+  name: egoFM Soundtrack
+  streamUrl: https://cast.egofm.de/egofmsoundtrack.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.egofm.de/
+  country: DE
+  status: stream-only
+  stationuuid: 1cdf5903-ba29-4575-acdc-28fa6fc1395b
+  changeuuid: a42d72f8-6764-4e3c-9cc5-4844dc0d9b24
+  reviewedAt: "2026-05-04"
+
+- id: de-0-n-deutsch-pop-on-radio
+  broadcaster: independent
+  name: "- 0 N - Deutsch Pop on Radio"
+  streamUrl: https://0n-deutschpop.radionetz.de/0n-deutschpop.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.0nradio.com/logos/0n-deutsch-pop_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 1725ca0b-bf9f-11e9-8502-52543be04c81
+  changeuuid: 0650354d-298e-4951-a4fe-73a2b5ed3e08
+  reviewedAt: "2026-05-04"
+
+- id: de-berliner-rundfunk-100-deutsch
+  broadcaster: independent
+  name: "Berliner Rundfunk - 100% deutsch"
+  streamUrl: https://stream.berliner-rundfunk.de/brf-100prozent-deutsch/mp3-128/?ref=radiode
+  bitrate: 128
+  codec: MP3
+  favicon: https://upload.berliner-rundfunk.de/production/static/1693298496587/icons/icon_64.a80y02808w0.png
+  homepage: https://www.berliner-rundfunk.de/
+  country: DE
+  status: stream-only
+  stationuuid: 0ee62f57-3ac2-464a-8c0e-932c2c9d73d3
+  changeuuid: 81223dfb-8d37-4d01-8685-915303dd9e3c
+  reviewedAt: "2026-05-04"
+
+- id: de-epic-classical-classical-love-music
+  broadcaster: independent
+  name: EPIC CLASSICAL - Classical Love Music
+  streamUrl: https://stream.epic-classical.com/classical-love-music
+  bitrate: 192
+  codec: MP3
+  homepage: https://epic-classical.com/
+  country: DE
+  status: stream-only
+  stationuuid: 75339d4e-caf5-4ebf-808a-c3fbad7fab5c
+  changeuuid: dfd04a25-f7cb-44e8-a1e4-2eb0bb7854d7
+  reviewedAt: "2026-05-04"
+
+- id: de-swr1-baden-wurttemberg
+  broadcaster: independent
+  name: "SWR1 Baden Württemberg "
+  streamUrl: https://liveradio.swr.de/sw890cl/swr1bw/
+  bitrate: 128
+  codec: AAC
+  favicon: https://swr1.de/favicon.ico
+  homepage: https://swr1.de/
+  country: DE
+  status: stream-only
+  stationuuid: 466d5283-c5fc-425e-9699-3b1850ffde64
+  changeuuid: b4b2a96a-fc95-4799-a2f7-282cc8d471fc
+  reviewedAt: "2026-05-04"
+
+- id: de-liszt-by-epic-piano
+  broadcaster: independent
+  name: LISZT by Epic Piano
+  streamUrl: https://stream.epic-piano.com/liszt?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://epic-piano.com/
+  country: DE
+  status: stream-only
+  stationuuid: f8ba223e-a674-4c7a-ac99-787dfe36ca02
+  changeuuid: 7fe7faa3-0453-494a-8d64-79b087c181e8
+  reviewedAt: "2026-05-04"
+
+- id: de-mdr-jump-im-osten-zu-hause-und-immer-deine-liebl
+  broadcaster: independent
+  name: "MDR JUMP - Im Osten zu Hause und immer deine Lieblingshits!"
+  streamUrl: https://mdr-radio-hls.akamaized.net/hls/live/2112904/mdr-284320-0-hls/index.m3u8
+  bitrate: 102
+  codec: AAC
+  favicon: https://www.mdrjump.de/resources/jump/img/favicons/favicon-512x512.png
+  homepage: https://www.mdrjump.de/radio/index.html
+  country: DE
+  status: stream-only
+  stationuuid: 045bc079-453b-454c-be0e-8cf2217b0630
+  changeuuid: 266259c6-b186-4fd7-b664-490a9307ff1a
+  reviewedAt: "2026-05-04"
+
+- id: de-die-neue-107-7-oldies
+  broadcaster: independent
+  name: Die Neue 107.7 - OLDIES
+  streamUrl: https://dieneue1077.cast.addradio.de/dieneue1077/oldie/high/stream.mp3?ar-purpose=web&ar-distributor=f0b7
+  bitrate: 192
+  codec: MP3
+  favicon: https://upload.dieneue1077.de/production/static/1713539298713/icons/icon_64.ax1w460g800.png
+  homepage: https://dieneue1077.de/radioplayer/oldies/
+  country: DE
+  status: stream-only
+  stationuuid: 00035e3d-9730-11e8-a767-52543be04c81
+  changeuuid: d490a67f-f18a-4faa-b0d0-4262eeecd3f8
+  reviewedAt: "2026-05-04"
+
+- id: de-vinyl-maxi-fm
+  broadcaster: independent
+  name: Vinyl Maxi FM
+  streamUrl: https://vinyl-maxi-fm.stream.laut.fm/vinyl-maxi-fm?t302=2026-01-15_00-13-00&uuid=1d247b88-8cbe-462c-be39-bc2af72ca582
+  bitrate: 128
+  codec: MP3
+  homepage: https://laut.fm/vinyl-maxi-fm
+  country: DE
+  status: stream-only
+  stationuuid: d444d17e-c372-445d-b1f3-8cd9532b00c0
+  changeuuid: 4b2ef067-0360-4ad7-96a6-b1b5b465b18e
+  reviewedAt: "2026-05-04"
+
+- id: de-krasse-weihnachten-by-rautemusik-rm-fm
+  broadcaster: independent
+  name: __KRASSE WEIHNACHTEN__ by rautemusik (rm.fm)
+  streamUrl: https://weihnachten-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.rm.fm/favicon.ico
+  homepage: https://www.rm.fm/weihnachten
+  country: DE
+  status: stream-only
+  stationuuid: de53974f-4251-458b-953b-a232e25f2542
+  changeuuid: b73dcb77-9a56-4123-b2ca-534fd1bb257b
+  reviewedAt: "2026-05-04"
+
+- id: de-0-n-hot-on-radio
+  broadcaster: independent
+  name: "- 0 N - Hot on Radio"
+  streamUrl: https://0n-hot.radionetz.de/0n-hot.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://www.0nradio.com/logos/0n-hot_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 8be60a79-5d30-4e22-8a2e-aa6fb2a7e03d
+  changeuuid: 723ad4d3-3c64-40be-aabb-82fd05cde18c
+  reviewedAt: "2026-05-04"
+
+- id: de-1000-goldies
+  broadcaster: independent
+  name: 1000 GOLDIES
+  streamUrl: https://1000goldies.stream.laut.fm/1000goldies?t302=2026-01-15_05-47-39&uuid=3ab95a19-1c96-4c55-8e81-bef2637010de
+  bitrate: 128
+  codec: MP3
+  homepage: https://laut.fm/1000goldies
+  country: DE
+  status: stream-only
+  stationuuid: 5e8f177e-1bcf-479a-891f-d207070ec237
+  changeuuid: 46314b3a-fca1-4ea8-9262-7023946b928a
+  reviewedAt: "2026-05-04"
+
+- id: de-tschaikowski-by-epic-piano
+  broadcaster: independent
+  name: TSCHAIKOWSKI by Epic Piano
+  streamUrl: https://stream.epic-piano.com/tschaikowski?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/hLKJJQS/Tschaikovski-PIANO.jpg
+  homepage: https://epic-piano.com/
+  country: DE
+  status: stream-only
+  stationuuid: fefcd817-c686-40d1-8027-0ee2fdc74d84
+  changeuuid: bb637545-aaa4-4316-9902-c914e7fd2616
+  reviewedAt: "2026-05-04"
+
+- id: de-deutschlandfunk-nova-dlf-aac-96k
+  broadcaster: independent
+  name: "Deutschlandfunk Nova | DLF | AAC 96k"
+  streamUrl: https://st03.sslstream.dlf.de/dlf/03/mid/aac/stream.aac?aggregator=web
+  bitrate: 128
+  codec: AAC
+  favicon: https://www.deutschlandfunknova.de/apple-touch-icon.png
+  homepage: https://www.deutschlandfunknova.de/
+  country: DE
+  status: stream-only
+  stationuuid: 495237c6-9daf-49ba-8071-7441a90191e3
+  changeuuid: cecabf66-574b-48d6-95d9-9d17020c0ddb
+  reviewedAt: "2026-05-04"
+
+- id: de-lovehits-by-rautemusik-rm-fm
+  broadcaster: independent
+  name: __LOVEHITS__ by rautemusik (rm.fm)
+  streamUrl: https://lovehits-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/thKTGN3/lovehits.jpg
+  homepage: https://www.rm.fm/lovehits
+  country: DE
+  status: stream-only
+  stationuuid: 53e51681-3220-451b-a88b-529977a8d2e7
+  changeuuid: 5dc81097-f00b-4dd4-905f-234418cbbdd3
+  reviewedAt: "2026-05-04"
+
+- id: de-deutschlandfunk-dokumente-und-debatten-dlf-aac-4
+  broadcaster: independent
+  name: "Deutschlandfunk Dokumente und Debatten | DLF | AAC 48k"
+  streamUrl: https://st04.sslstream.dlf.de/dlf/04/low/aac/stream.aac?aggregator=web
+  bitrate: 48
+  codec: AAC
+  favicon: https://www.deutschlandradio.de/static/img/deutschlandradio/icons/apple-touch-icon-128x128.png
+  homepage: https://www.deutschlandradio.de/dokumente-und-debatten-102.html
+  country: DE
+  status: stream-only
+  stationuuid: 1b0ed303-3c26-4e47-8b16-71ec3141d6d0
+  changeuuid: e2d06604-cb84-492f-9fa9-5799f2fa3134
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-westfalica
+  broadcaster: independent
+  name: Radio Westfalica
+  streamUrl: https://addrad.io/444zbcj
+  bitrate: 192
+  codec: MP3
+  country: DE
+  status: stream-only
+  stationuuid: 2fec97b6-2e37-4e3d-ab9a-9bc79c54019f
+  changeuuid: 2d4c883b-d076-444a-a3b5-885d44ce0485
+  reviewedAt: "2026-05-04"
+
+- id: de-technolovers-latin-house
+  broadcaster: independent
+  name: Technolovers LATIN HOUSE
+  streamUrl: https://stream.technolovers.fm/latinhouse?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://technolovers.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 2ba9b9d9-cbd0-4ddd-a437-af8617b90198
+  changeuuid: aa5f19f0-4847-4e53-9b01-f353308f5e18
+  reviewedAt: "2026-05-04"
+
+- id: de-rock-antenne-modern-metal
+  broadcaster: independent
+  name: Rock Antenne Modern Metal
+  streamUrl: https://stream.rockantenne.de/modern-metal/stream/mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.rockantenne.de/logos/station-rock-antenne/apple-touch-icon.png
+  homepage: https://www.rockantenne.de/
+  country: DE
+  status: stream-only
+  stationuuid: ae6c1e45-2ec6-43de-99e3-75fc1e77465d
+  changeuuid: 337ef1e2-0645-4af8-9d6e-6e23327ca258
+  reviewedAt: "2026-05-04"
+
+- id: de-deutsche-welle-tv
+  broadcaster: independent
+  name: Deutsche Welle TV
+  streamUrl: https://dwamdstream102.akamaized.net/hls/live/2015525/dwstream102/stream05/streamPlaylist.m3u8
+  codec: UNKNOWN
+  homepage: https://www.dw.com/de/live-tv/channel-english
+  country: DE
+  status: stream-only
+  stationuuid: bb84ec03-fb49-459b-aac0-7bdee6700fe6
+  changeuuid: a0e4a3f7-1d78-446a-ab65-15962ecd75b0
+  reviewedAt: "2026-05-04"
+
+- id: de-world-club-dome-radio-das-offizielle-radio-des-w
+  broadcaster: independent
+  name: WORLD CLUB DOME Radio - Das offizielle Radio des WORLD CLUB DOME Festivals mit den besten DJ-Sets und dem Livestream vom größten Club der Welt - Dance, Electro, EDM, Techno, DJ Live Sets
+  streamUrl: https://radio.worldclubdome.com/wcd-radio/mp3-192?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/xtxNVZnG/Logo-WORLD-CLUB-DOME-Radio-2500x2500.jpg
+  homepage: https://www.worldclubdome.com/radio
+  country: DE
+  status: stream-only
+  stationuuid: bfd55baa-e4dc-4726-ba51-956756821b20
+  changeuuid: 65fb0126-216a-4c6a-90fe-250643564335
+  reviewedAt: "2026-05-04"
+
+- id: de-bayern-1-niederbayern-oberpfalz
+  broadcaster: independent
+  name: Bayern 1 Niederbayern / Oberpfalz
+  streamUrl: https://dispatcher.rndfnk.com/br/br1/nbopf/mp3/mid
+  bitrate: 128
+  codec: MP3
+  favicon: https://api.ardmediathek.de/image-service/images/urn:ard:image:b366004f6196d70c?w=512
+  homepage: https://www.br.de/radio/bayern1/index.html
+  country: DE
+  status: stream-only
+  stationuuid: 3d7eb0bd-1cfb-44c0-8424-2d6e3ad86a56
+  changeuuid: 09bebe20-b0af-49c9-80cf-07b0abf0b964
+  reviewedAt: "2026-05-04"
+
+- id: de-i-love-the-beach
+  broadcaster: independent
+  name: I love the beach
+  streamUrl: https://ilm.stream35.radiohost.de/ilm_ilovethebeach_mp3-192?upd-meta&upd-scheme=https&_art=dD0xNzY4NDUwODI4JmQ9YWVjYzRkNzE5MzNhN2E2Nzk0NWI
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.ilovemusic.de/favicon.ico
+  homepage: https://www.ilovemusic.de/ilovethebeach/
+  country: DE
+  status: stream-only
+  stationuuid: c8900e24-77c4-11ea-b1cf-52543be04c81
+  changeuuid: e025772c-eee6-4476-88ee-5a019d20d86c
+  reviewedAt: "2026-05-04"
+
+- id: de-ibiza-chillout-lounge-ambient-deep-house-baleari
+  broadcaster: independent
+  name: IBIZA CHILLOUT LOUNGE - Ambient, Deep House, Balearic, Smooth Jazz, Acoustic, Chill House, Lo-Fi, Chillwave, Dream Pop, Electro, Tropical House, Sunset Chill, Café del Mar, Soft Electronica, Slow House, Ambient, Relax, Easy Listening, Beach Vibes, Summer
+  streamUrl: https://0nlineradio.radioho.st/lounge-ibiza-chillout-lounge?ref=rb26
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/jPkfdprq/rb-Ibiza.png
+  homepage: https://0nlineradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: d271b4e8-a298-4862-9f4b-025c110cedd9
+  changeuuid: 2abb4408-2108-4dc6-ac9f-a0e96d299f19
+  reviewedAt: "2026-05-04"
+
+- id: de-swr4-koblenz
+  broadcaster: independent
+  name: swr4 koblenz
+  streamUrl: https://liveradio.swr.de/sw282p3/swr4ko/
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.swr.de/assets/swr/apple-touch-icon.png
+  homepage: https://www.swr.de/
+  country: DE
+  status: stream-only
+  stationuuid: 8287f5c1-1da9-4ca9-bd6f-cf0a7f4aef44
+  changeuuid: eea70cf5-cb8b-4abd-9972-c131b2536054
+  reviewedAt: "2026-05-04"
+
+- id: de-epic-classical-classical-restaurant-music
+  broadcaster: independent
+  name: EPIC CLASSICAL - Classical Restaurant Music
+  streamUrl: https://stream.epic-classical.com/classical-restaurant-music
+  bitrate: 192
+  codec: MP3
+  homepage: https://epic-classical.com/
+  country: DE
+  status: stream-only
+  stationuuid: 956ab97c-bba8-4959-b164-4a5657a1951b
+  changeuuid: 7c71ffd3-b59b-4e1b-9d68-f2d4f07c846a
+  reviewedAt: "2026-05-04"
+
+- id: de-epic-classical-modern-classical
+  broadcaster: independent
+  name: "EPIC CLASSICAL - Modern Classical "
+  streamUrl: https://stream.epic-classical.com/modern-classical
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/375rVWt/Modern.jpg
+  homepage: https://epic-classical.com/
+  country: DE
+  status: stream-only
+  stationuuid: e36bb843-4886-407a-a967-24bb45718cff
+  changeuuid: 9a66331d-88bf-40c4-ac6e-26894185a36c
+  reviewedAt: "2026-05-04"
+
+- id: de-i-love-music-mainstage-madness
+  broadcaster: independent
+  name: I Love Music - Mainstage Madness
+  streamUrl: https://ilm.stream18.radiohost.de/ilm_ilovemainstagemadness_mp3-192?upd-meta&upd-scheme=https&_art=dD0xNzY4NDM5NjA5JmQ9OTFlNjYyYTM4Zjk3MjY1ZDg2NmM
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.ilovemusic.de/favicon.ico
+  homepage: https://www.ilovemusic.de/
+  country: DE
+  status: stream-only
+  stationuuid: 54200f03-dfe9-4e31-8b03-457dd6c28a04
+  changeuuid: a9238f3f-d55a-49b9-8b46-f02ac2792168
+  reviewedAt: "2026-05-04"
+
+- id: de-epic-classical-classical-lounge
+  broadcaster: independent
+  name: EPIC CLASSICAL - Classical Lounge
+  streamUrl: https://stream.epic-classical.com/classical-lounge
+  bitrate: 192
+  codec: MP3
+  homepage: https://epic-classical.com/
+  country: DE
+  status: stream-only
+  stationuuid: a93c69b5-3384-41b6-98ee-a18a4ed5211a
+  changeuuid: ef02408b-1baa-40b7-927c-67d5d1bf8418
+  reviewedAt: "2026-05-04"
+
+- id: de-reyfm-hits2k
+  broadcaster: independent
+  name: "REYFM - #Hits2K"
+  streamUrl: https://listen.reyfm.de/reyfm-hits2k/
+  bitrate: 320
+  codec: MP3
+  favicon: https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png
+  homepage: https://rey.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 09252779-6543-487e-84ae-45cede8e2e15
+  changeuuid: d9886db5-50a4-4c58-967c-2609f5fe040d
+  reviewedAt: "2026-05-04"
+
+- id: de-1live-chillout
+  broadcaster: independent
+  name: 1LIVE Chillout
+  streamUrl: https://wdr-1live-chillout.icecast.wdr.de/wdr/1live/chillout/mp3/128/stream.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www1.wdr.de/radio/1live/resources-v5.143.2/img/favicon/apple-touch-icon.png
+  homepage: https://www1.wdr.de/radio/1live/musik/1live-streams/loopstream-1live-chillout-100.html
+  country: DE
+  status: stream-only
+  stationuuid: 365742be-75c8-4316-b165-3099cf494dac
+  changeuuid: 94c105e8-b9f1-4a09-a6ef-69a2d6899742
+  reviewedAt: "2026-05-04"
+
+- id: de-netlabel-org-germany
+  broadcaster: independent
+  name: Netlabel.org (Germany)
+  streamUrl: https://netlabelorg.stream.laut.fm/netlabel_org
+  bitrate: 128
+  codec: MP3
+  favicon: https://netlabel.org/favicon.ico
+  homepage: https://netlabel.org/
+  country: DE
+  status: stream-only
+  stationuuid: 6837d816-ac8a-44b4-835f-8d63a4111bfd
+  changeuuid: d32d9186-da2b-4eb6-9fcb-f4ec7cca0f26
+  reviewedAt: "2026-05-04"
+
+- id: de-just-90s
+  broadcaster: independent
+  name: Just 90s
+  streamUrl: https://just90s.stream.laut.fm/just90s
+  bitrate: 128
+  codec: MP3
+  favicon: https://cdn.onlineradiobox.com/img/l/0/54170.v8.png
+  country: DE
+  status: stream-only
+  stationuuid: 24595b28-374f-40e4-b98f-a3671f908a34
+  changeuuid: 02fc0559-4915-47da-8241-ff489fa6feac
+  reviewedAt: "2026-05-04"
+
+- id: de-deutschlandfunk-kultur-dlf-opus-64k
+  broadcaster: independent
+  name: "Deutschlandfunk Kultur | DLF | OPUS 64k"
+  streamUrl: https://st02.sslstream.dlf.de/dlf/02/high/opus/stream.opus?aggregator=web
+  bitrate: 64
+  codec: OGG
+  favicon: https://www.deutschlandfunkkultur.de/static/img/deutschlandfunk_kultur/icons/apple-touch-icon-128x128.png
+  homepage: https://www.deutschlandfunkkultur.de/
+  country: DE
+  status: stream-only
+  stationuuid: ea846b58-8d16-4e51-aa1d-879454967517
+  changeuuid: 7634a34a-b339-45bd-a0fd-da0c8906977b
+  reviewedAt: "2026-05-04"
+
+- id: de-i-love-bass-by-hbz
+  broadcaster: independent
+  name: I Love Bass by HBz
+  streamUrl: https://ilm.stream35.radiohost.de/ilm_ilovebass_mp3-192?upd-meta&upd-scheme=https&_art=dD0xNzY4NDMzMDg5JmQ9MjI5MmNkY2FhZWZjZDg0OThjMGY
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.ilovemusic.de/favicon.ico
+  homepage: https://www.ilovemusic.de/ilovebass/
+  country: DE
+  status: stream-only
+  stationuuid: bff54c56-1798-4f2e-83bc-ec3c90c732a6
+  changeuuid: 56a823d0-9c73-4eff-afe4-85eb3e917897
+  reviewedAt: "2026-05-04"
+
+- id: de-trigger-fm
+  broadcaster: independent
+  name: Trigger.FM
+  streamUrl: https://takeoff.jetstre.am/?account=bbm&file=trigger128SD&type=live&service=icecast&protocol=https&port=8000&output=pls
+  codec: MP3
+  favicon: https://triggerfm.com/wp-content/uploads/2023/09/512x512-trigger-logo.png
+  homepage: http://www.trigger.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 42e1768d-50ad-4cf2-bae3-add8a5c4df7f
+  changeuuid: 1bc2d87a-02c1-4635-a6a9-57b5de524b4c
+  reviewedAt: "2026-05-04"
+
+- id: de-gamernetfm
+  broadcaster: independent
+  name: GamerNETfm
+  streamUrl: https://gamernetfm.stream.laut.fm/gamernetfm
+  bitrate: 128
+  codec: MP3
+  homepage: https://gamernet.eu/Radio
+  country: DE
+  status: stream-only
+  stationuuid: 6d643fd7-0bde-11ea-a87e-52543be04c81
+  changeuuid: 0dc1ec45-73a8-4cf7-b04a-47757b87e09f
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-sunrise
+  broadcaster: independent
+  name: Radio Sunrise
+  streamUrl: https://radio-sunrise.stream.laut.fm/radio-sunrise
+  bitrate: 128
+  codec: MP3
+  favicon: https://cdn.onlineradiobox.com/img/l/8/60498.v4.png
+  country: DE
+  status: stream-only
+  stationuuid: f71534c9-19dd-4b16-9a69-5e74ff9a8924
+  changeuuid: afeb7da2-d9a5-4769-9e73-c41efb19d027
+  reviewedAt: "2026-05-04"
+
+- id: de-0nlineradio-2010er
+  broadcaster: independent
+  name: 0nlineradio 2010er
+  streamUrl: https://stream.0nlineradio.com/2010er?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://0nlineradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 895d1ea6-4abf-44cd-94bd-64f3f7c69a40
+  changeuuid: 3940a2b3-b395-41a1-ae13-8bd8d8a17a1d
+  reviewedAt: "2026-05-04"
+
+- id: de-epic-lounge-summer-lounge
+  broadcaster: independent
+  name: Epic Lounge - SUMMER LOUNGE
+  streamUrl: https://stream.epic-lounge.com/summer-lounge
+  bitrate: 192
+  codec: MP3
+  homepage: https://epic-lounge.com/
+  country: DE
+  status: stream-only
+  stationuuid: 91db298e-659b-4a4d-94a2-e5b1068d0919
+  changeuuid: cda6116b-5b9d-42e3-b154-8f7ea3ebdd1f
+  reviewedAt: "2026-05-04"
+
+- id: de-rock-antenne-modern-rock
+  broadcaster: independent
+  name: Rock Antenne Modern Rock
+  streamUrl: https://s4-webradio.rockantenne.de/modern-rock/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://cdn.onlineradiobox.com/img/l/0/102910.v1.png
+  country: DE
+  status: stream-only
+  stationuuid: 312b6581-c25e-40a6-8b64-e52aebf3f61c
+  changeuuid: 9cb2125c-9530-4e3b-8adc-08734b7122da
+  reviewedAt: "2026-05-04"
+
+- id: de-epic-lounge-soul-lounge
+  broadcaster: independent
+  name: Epic Lounge - SOUL LOUNGE
+  streamUrl: https://stream.epic-lounge.com/soul-lounge?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://epic-lounge.com/
+  country: DE
+  status: stream-only
+  stationuuid: a88ea71e-5303-4049-aa74-ae831cfb6ab2
+  changeuuid: db0c101f-bd02-42d2-9164-848a8dafb255
+  reviewedAt: "2026-05-04"
+
+- id: de-sportschau-live-1-bundesliga-spiel-7
+  broadcaster: independent
+  name: "Sportschau live: 1.Bundesliga / Spiel 7"
+  streamUrl: https://wdr-sportschau-liga1spiel7.icecastssl.wdr.de/wdr/sportschau/liga1spiel7/mp3/high?file=.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.sportschau.de/resources/assets/image/favicon/apple-icon-152x152.png
+  homepage: https://www.sportschau.de/sportimradio/audiostream-netcast-uebersicht-100.html
+  country: DE
+  status: stream-only
+  stationuuid: 4aac39a7-83d2-413a-913b-f6fb25114590
+  changeuuid: 6daf39f1-1f89-4b19-9e2b-d2c7405e7763
+  reviewedAt: "2026-05-04"
+
+- id: de-alpenweihnacht
+  broadcaster: independent
+  name: Alpenweihnacht
+  streamUrl: https://stream.laut.fm/alpenweihnacht
+  bitrate: 128
+  codec: MP3
+  homepage: https://alpenweihnacht.de/
+  country: DE
+  status: stream-only
+  stationuuid: 5ca8c118-7a3b-420f-bead-d8ecdc50e2d3
+  changeuuid: 756709c2-4561-48f7-8601-0ff6d12b2751
+  reviewedAt: "2026-05-04"
+
+- id: de-deutschlandfunk-dokumente-und-debatten-dlf-aac-1
+  broadcaster: independent
+  name: "Deutschlandfunk Dokumente und Debatten | DLF | AAC 192k"
+  streamUrl: https://st04.sslstream.dlf.de/dlf/04/high/aac/stream.aac?aggregator=web
+  bitrate: 192
+  codec: AAC
+  favicon: https://www.deutschlandradio.de/static/img/deutschlandradio/icons/apple-touch-icon-128x128.png
+  homepage: https://www.deutschlandradio.de/dokumente-und-debatten-102.html
+  country: DE
+  status: stream-only
+  stationuuid: d798b54a-1449-4741-b5ca-7a98ff67128d
+  changeuuid: 6a7c842a-87c5-43a1-bbd0-7b5c1e2d5754
+  reviewedAt: "2026-05-04"
+
+- id: de-pop-lounge-cafe
+  broadcaster: independent
+  name: "POP LOUNGE CAFE "
+  streamUrl: https://stream.laut.fm/poploungecafe
+  bitrate: 128
+  codec: MP3
+  homepage: https://poploungecafe.com/
+  country: DE
+  status: stream-only
+  stationuuid: d565778b-f29a-42c7-8a2d-5b45019cb3e2
+  changeuuid: 83bc3f93-da2a-4373-b501-7c5caad7d584
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-ffn-80er
+  broadcaster: independent
+  name: Radio FFN - 80er
+  streamUrl: https://stream.ffn.de/ffn-80er/?ref=radio-browser
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.ffn.de/
+  country: DE
+  status: stream-only
+  stationuuid: 849dea02-183e-4a88-b6b7-f517af0b24f4
+  changeuuid: 52715380-4c1a-439e-bac3-ce14c1344bc6
+  reviewedAt: "2026-05-04"
+
+- id: de-0-n-volksmusik-on-radio
+  broadcaster: independent
+  name: "- 0 N - Volksmusik on Radio"
+  streamUrl: https://0n-volksmusik.radionetz.de/0n-volksmusik.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://www.0nradio.com/logos/0n-volksmusik_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: ef973b3f-bf9e-11e9-8502-52543be04c81
+  changeuuid: 9e692197-af77-47ef-8e9c-ff862360086d
+  reviewedAt: "2026-05-04"
+
+- id: de-80s-mix-radio
+  broadcaster: independent
+  name: 80s Mix Radio
+  streamUrl: https://80s-mix-radio.stream.laut.fm/80s-mix-radio
+  bitrate: 128
+  codec: MP3
+  favicon: https://cdn.onlineradiobox.com/img/l/7/82797.v7.png
+  country: DE
+  status: stream-only
+  stationuuid: 1dbbb303-76be-4bed-bf46-fd6db8026594
+  changeuuid: d1ffb3fa-d373-4d8e-912d-c64daad80fa0
+  reviewedAt: "2026-05-04"
+
+- id: de-0nlineradio-deutschrock
+  broadcaster: independent
+  name: 0nlineradio DEUTSCHROCK
+  streamUrl: https://stream.0nlineradio.com/deutschrock?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://0nlineradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 6657e1a5-40a0-47e8-aabc-5c7debeaeff0
+  changeuuid: 783e9fec-3929-44ec-8ef8-59a55aa0e84a
+  reviewedAt: "2026-05-04"
+
+- id: de-japanradio-de
+  broadcaster: independent
+  name: Japanradio.de
+  streamUrl: https://stream.japanradio.de/live
+  bitrate: 192
+  codec: MP3
+  favicon: https://japanradio.de/wp-content/uploads/2020/05/japanradiodeR01.png
+  homepage: https://www.japanradio.de/
+  country: DE
+  status: stream-only
+  stationuuid: 4579447c-baff-4d5b-84ee-26c8acdf8498
+  changeuuid: 13013d13-9c50-4692-b7dc-624d6d9d3e27
+  reviewedAt: "2026-05-04"
+
+- id: de-epic-lounge-cocktail-lounge
+  broadcaster: independent
+  name: Epic Lounge - COCKTAIL LOUNGE
+  streamUrl: https://stream.epic-lounge.com/cocktail-lounge?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://epic-lounge.com/
+  country: DE
+  status: stream-only
+  stationuuid: b3426eb5-e6c3-43cd-90fe-ceb36c308238
+  changeuuid: f904e772-592e-4a33-8a83-93e8fba73ae2
+  reviewedAt: "2026-05-04"
+
+- id: de-grieg-by-epic-piano
+  broadcaster: independent
+  name: GRIEG by Epic Piano
+  streamUrl: https://stream.epic-piano.com/grieg?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://epic-piano.com/
+  country: DE
+  status: stream-only
+  stationuuid: 61d21e9e-5fd7-42fa-9cac-739ab515aa8c
+  changeuuid: 35f626f3-b410-45f6-b206-e2cb9e556173
+  reviewedAt: "2026-05-04"
+
+- id: de-ndr-kultur-aac-192
+  broadcaster: independent
+  name: NDR Kultur (AAC 192)
+  streamUrl: https://f131.rndfnk.com/ard/ndr/ndrkultur/live/aac/192/stream.aac?aggregator=web&cid=01FBQ2EJ6T7QK3WENQ5KT9S2FB&sid=2aWrl15TtQvWg6RQ9hvrVfdh99E&token=cgylLQKukz6c0ajNCSHCboafG1Q474A1QN0WA3_K3Hg&tvf=4vGFz6J7pxdmMTMxLnJuZGZuay5jb20
+  bitrate: 256
+  codec: AAC
+  favicon: https://www.ndr.de/kultur/radio/audiothekndrkultur100_v-podcast.jpg
+  homepage: https://www.ndr.de/kultur/live/stationndrkultur102-radioplayer_livestream-livestream1112.html
+  country: DE
+  status: stream-only
+  stationuuid: 59886778-a85d-4cbe-81e8-a0d0911d3ed6
+  changeuuid: bc5a125d-fe12-4e60-bb06-9e3b3002879e
+  reviewedAt: "2026-05-04"
+
+- id: de-epic-lounge-massage-lounge
+  broadcaster: independent
+  name: Epic Lounge - Massage Lounge
+  streamUrl: https://stream.epic-lounge.com/massage-lounge
+  bitrate: 192
+  codec: MP3
+  homepage: https://epic-lounge.com/
+  country: DE
+  status: stream-only
+  stationuuid: 8b160a9d-5d96-4106-a26e-503b35aaf007
+  changeuuid: 1462e0a3-857d-460d-a5ef-183e7a3c7bb3
+  reviewedAt: "2026-05-04"
+
+- id: de-epic-classical-classical-oldies
+  broadcaster: independent
+  name: EPIC CLASSICAL - Classical Oldies
+  streamUrl: https://stream.epic-classical.com/classical-oldies
+  bitrate: 192
+  codec: MP3
+  homepage: https://epic-classical.com/
+  country: DE
+  status: stream-only
+  stationuuid: 43f5dd99-a727-42d3-8164-19618a5957de
+  changeuuid: 057709aa-1c3e-4a3b-82ae-943edbcae8c7
+  reviewedAt: "2026-05-04"
+
+- id: de-laut-fm-80er-pop
+  broadcaster: independent
+  name: Laut.FM 80er, Pop
+  streamUrl: https://stream.laut.fm/80er
+  bitrate: 128
+  codec: MP3
+  homepage: https://laut.fm/80er
+  country: DE
+  status: stream-only
+  stationuuid: 101f7045-8c64-11e8-aa66-52543be04c81
+  changeuuid: c17e3391-7de9-467b-a6f3-30b5bf56b914
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-zusa
+  broadcaster: independent
+  name: Radio Zusa
+  streamUrl: https://funkturm.radio-zusa.net:8443/opus
+  codec: OGG
+  favicon: http://zusa.de/images/favicon.ico
+  homepage: http://zusa.de/
+  country: DE
+  status: stream-only
+  stationuuid: 961861ac-0601-11e8-ae97-52543be04c81
+  changeuuid: aa7462bc-c917-42e2-8288-73da039eacba
+  reviewedAt: "2026-05-04"
+
+- id: de-0nlineradio-volksmusik
+  broadcaster: independent
+  name: 0nlineradio VOLKSMUSIK
+  streamUrl: https://stream.0nlineradio.com/volksmusik?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://0nlineradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 02a1d3f7-8ef6-48b1-8c63-58e9743cea5c
+  changeuuid: 1a220cca-217e-41c0-999a-5d6a93a927c3
+  reviewedAt: "2026-05-04"
+
+- id: de-epic-classical-classical-christmas
+  broadcaster: independent
+  name: EPIC CLASSICAL - Classical Christmas
+  streamUrl: https://stream.epic-classical.com/classical-christmas
+  bitrate: 192
+  codec: MP3
+  homepage: https://epic-classical.com/
+  country: DE
+  status: stream-only
+  stationuuid: 82322c46-f07f-482b-8cac-342acc72180a
+  changeuuid: e27e545b-ebb3-4985-a8e4-5b671356e76d
+  reviewedAt: "2026-05-04"
+
+- id: de-technolovers-lounge
+  broadcaster: independent
+  name: Technolovers - LOUNGE
+  streamUrl: https://stream.technolovers.fm/lounge?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://technolovers.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 43ed2356-eba8-4943-b777-ed60691331c0
+  changeuuid: a435f994-014d-496f-ab57-5365c8357c7a
+  reviewedAt: "2026-05-04"
+
+- id: de-0-n-blues-on-radio
+  broadcaster: independent
+  name: "- 0 N - Blues on Radio"
+  streamUrl: https://0n-blues.radionetz.de/0n-blues.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://www.0nradio.com/logos/0n-blues_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: d46f2dcb-d9cf-4dd9-acbb-bd155e6b9058
+  changeuuid: 3982a160-c42e-4966-824c-6295b227da05
+  reviewedAt: "2026-05-04"
+
+- id: de-best-of-80s
+  broadcaster: independent
+  name: Best of 80s
+  streamUrl: https://bestof80s.stream.laut.fm/best_of_80s
+  bitrate: 128
+  codec: MP3
+  favicon: https://cdn.onlineradiobox.com/img/l/0/42610.v1.png
+  country: DE
+  status: stream-only
+  stationuuid: bbed731d-edb0-4a3a-aadd-3c2334c44406
+  changeuuid: 08aa862b-30b0-4459-a006-400b32536e3f
+  reviewedAt: "2026-05-04"
+
+- id: de-maretimo-house-radio
+  broadcaster: independent
+  name: Maretimo House Radio
+  streamUrl: https://s35.derstream.net/house.mp3
+  bitrate: 128
+  codec: MP3
+  country: DE
+  status: stream-only
+  stationuuid: afdf77fc-9dcc-417e-b5dd-ac5ab3df56a6
+  changeuuid: 5df097c3-e51c-450b-ba7c-2369e690a364
+  reviewedAt: "2026-05-04"
+
+- id: de-0nlineradio-party
+  broadcaster: independent
+  name: 0nlineradio PARTY
+  streamUrl: https://stream.0nlineradio.com/party?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://0nlineradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 3b8c57e6-5314-4240-9a50-9af47abc21cf
+  changeuuid: a2e4f3bf-8d20-4e2a-a632-68be1d936052
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-ffn-gold
+  broadcaster: independent
+  name: Radio FFN - Gold
+  streamUrl: https://stream.ffn.de/ffn-gold/mp3-192?ref=radio-browser
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.ffn.de/
+  country: DE
+  status: stream-only
+  stationuuid: 6cfe64e5-5314-462e-b336-98250ab0c6cf
+  changeuuid: 984bc904-f2a4-4d35-957c-48a4afb47d32
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-ffn-hits
+  broadcaster: independent
+  name: "Radio FFN - Hits*"
+  streamUrl: https://stream.ffn.de/ffn-hits/mp3-192?ref=radio-browser
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/h28n6TR/Logo-ffn-Hits.png
+  homepage: https://www.ffn.de/
+  country: DE
+  status: stream-only
+  stationuuid: 874a4e29-43e0-4975-b606-50fe5965c69c
+  changeuuid: b2a62171-f8c2-4ec0-8a87-c94768986afb
+  reviewedAt: "2026-05-04"
+
+- id: de-rock-antenne-gothic-2
+  broadcaster: independent
+  name: Rock Antenne - Gothic
+  streamUrl: https://s3-webradio.rockantenne.de/gothic
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.rockantenne.de/logos/station-rock-antenne/apple-touch-icon.png
+  homepage: https://www.rockantenne.de/webradio/gothic
+  country: DE
+  status: stream-only
+  stationuuid: f5f6ae79-b919-497b-a10f-720ea7cdc7bc
+  changeuuid: 1896d544-ba1d-4345-a72d-04b7e73af7c4
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-ostfriesland-burgerradio
+  broadcaster: independent
+  name: Radio Ostfriesland Bürgerradio
+  streamUrl: https://live.radio-ostfriesland.de/ostfriesland.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://ww2.radio-ostfriesland.de/wp-content/uploads/2020/05/favicon.png
+  homepage: https://ww2.radio-ostfriesland.de/
+  country: DE
+  status: stream-only
+  stationuuid: a60ead8d-4c40-4c15-85af-45e1bcc41f40
+  changeuuid: 587f8c51-2f34-47f2-9a3e-d5c68ad74ee9
+  reviewedAt: "2026-05-04"
+
+- id: de-rock-antenne-biker-rock
+  broadcaster: independent
+  name: Rock Antenne Biker Rock
+  streamUrl: https://stream.rockantenne.de/biker-rock/stream/
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.rockantenne.de/logos/station-rock-antenne/apple-touch-icon.png
+  homepage: https://www.rockantenne.de/
+  country: DE
+  status: stream-only
+  stationuuid: 76814b66-a613-4af7-9207-2a415b981296
+  changeuuid: 25bc555e-5d93-4858-9102-c2e92f89b5b4
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-mk
+  broadcaster: independent
+  name: Radio MK
+  streamUrl: https://stream.lokalradio.nrw/44542bb
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.radiomk.de/assets/images/senderlogos/radio_mk.png
+  homepage: https://www.radiomk.de/
+  country: DE
+  status: stream-only
+  stationuuid: d280c2ad-1156-4e6d-b76d-109ccd26dc0c
+  changeuuid: a4da7f3b-027a-461b-b889-b9ba9ef759b5
+  reviewedAt: "2026-05-04"
+
+- id: de-oldie-antenne-80er-hits
+  broadcaster: independent
+  name: Oldie Antenne - 80er Hits
+  streamUrl: https://s7-webradio.oldie-antenne.de/oldie-antenne-80er-hits/stream/mp3?aw_0_1st.playerid=OldieAntenneWebPlayer&aw_0_1st.skey=1706378427399&aw_0_req.userConsentV2=CP5CssAP5CssAAFADBDEAlEgAAAAAAAAAAYgAAAAAAEhIAMAAQL2DQAYAAgXsIgAwABAvYVABgACBewyADAAEC9h0AGAAIF7EIAMAAQL2JQAYAAgXsUgAwABAvYA.YAAAAAAAAAAA&companionAds=false&companion_zone_alias=41%2C42%2C40%2C731%2C752%2C756%2C768
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.oldie-antenne.de/media/cache/3/version/37897/oldie_80er_hits_2000x2000-v1.png/7e89fb3888c0cba3f06e0881fc336952.webp
+  homepage: https://www.oldie-antenne.de/mediathek/webradio/80er-hits
+  country: DE
+  status: stream-only
+  stationuuid: 41842595-f15b-4e04-a102-8bb35917e9db
+  changeuuid: 9ac315a5-63ac-4020-80ec-2474773f0d7c
+  reviewedAt: "2026-05-04"
+
+- id: de-pto-piratenteam-ostfriesland
+  broadcaster: independent
+  name: PTO - Piratenteam Ostfriesland
+  streamUrl: https://c01.lexycast.de:4200/listen1
+  bitrate: 192
+  codec: MP3
+  homepage: https://piratenteam-ostfriesland.de/
+  country: DE
+  status: stream-only
+  stationuuid: a85c571d-01b7-40e7-a0cf-d07d98b4f817
+  changeuuid: aac80d98-176a-402b-bf6b-1c12f71aac0d
+  reviewedAt: "2026-05-04"
+
+- id: de-antenne-unna
+  broadcaster: independent
+  name: Antenne Unna
+  streamUrl: https://antenneunna--di--nacs-ais-lgc--07--cdn.cast.addradio.de/antenneunna/live/mp3/high
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.antenneunna.de/assets/images/senderlogos/antenne_unna.png
+  homepage: https://www.antenneunna.de/
+  country: DE
+  status: stream-only
+  stationuuid: a0ce38a3-cca2-4e74-b9e6-d5688d0b04b1
+  changeuuid: 842a38fe-5dcf-49f0-a19b-9d52542f11c2
+  reviewedAt: "2026-05-04"
+
+- id: de-rautemusik-caribbean-wave
+  broadcaster: independent
+  name: RauteMusik Caribbean Wave
+  streamUrl: https://streams.rautemusik.fm/caribbean-wave/mp3-192/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/nL15LGH/cw.jpg
+  homepage: https://www.rm.fm/caribbean-wave
+  country: DE
+  status: stream-only
+  stationuuid: 208e60b9-2075-435a-9506-9787ef30928c
+  changeuuid: 41c1cd06-b69f-4c91-99c0-2c182b164d45
+  reviewedAt: "2026-05-04"
+
+- id: de-0-n-schlager-kult-on-radio
+  broadcaster: independent
+  name: "- 0 N - Schlager Kult on Radio"
+  streamUrl: https://0n-schlagerkult.radionetz.de/0n-schlagerkult.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.0nradio.com/logos/0n-schlager-kult_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 23495167-bf9e-11e9-8502-52543be04c81
+  changeuuid: 090b11b3-9333-4459-a9a8-cc2d2a253717
+  reviewedAt: "2026-05-04"
+
+- id: de-0nlineradio-brazil
+  broadcaster: independent
+  name: 0nlineradio BRAZIL
+  streamUrl: https://stream.0nlineradio.com/brazil?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/s90pDjm/brazil.jpg
+  homepage: https://0nlineradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 65dadf2c-37a5-4609-b4ee-03d45ef98e48
+  changeuuid: c749591b-4862-4b85-9303-5f8a3c564da9
+  reviewedAt: "2026-05-04"
+
+- id: de-0nlineradio-karneval
+  broadcaster: independent
+  name: 0nlineradio KARNEVAL
+  streamUrl: https://stream.0nlineradio.com/karneval?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/CJkTX9Q/karneval.jpg
+  homepage: https://0nlineradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 6e532e28-601d-4a19-aefc-763e731f6198
+  changeuuid: 5733c566-f4f5-4379-b118-7d6935646e73
+  reviewedAt: "2026-05-04"
+
+- id: de-deutscher-soldatensender-von-1970
+  broadcaster: independent
+  name: Deutscher Soldatensender von 1970
+  streamUrl: https://deutschersoldatensendervon1970.stream.laut.fm/deutscher_soldatensender_von_1970?t302=2026-01-15_07-15-24&uuid=12738ea1-febe-467d-8212-2b73cbf6c5a0
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.youtube.com/watch?v=DQ_sGpvSe0w
+  homepage: http://laut.fm/Deutscher_Soldatensender_von_1970
+  country: DE
+  status: stream-only
+  stationuuid: 063763e1-e1e9-4861-b3be-255a88b95c82
+  changeuuid: 109620e2-5995-4cc4-9efa-4c05f8b2877e
+  reviewedAt: "2026-05-04"
+
+- id: de-epic-lounge-workday-lounge
+  broadcaster: independent
+  name: Epic Lounge - WORKDAY LOUNGE
+  streamUrl: https://stream.epic-lounge.com/workday-lounge?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://epic-lounge.com/
+  country: DE
+  status: stream-only
+  stationuuid: 22b4735f-78fe-41db-bb98-800333352815
+  changeuuid: e64a67d2-f5f5-45a9-87b7-da4be875e30d
+  reviewedAt: "2026-05-04"
+
+- id: de-rock-antenne-hard-rock
+  broadcaster: independent
+  name: Rock Antenne - Hard Rock
+  streamUrl: https://stream.rockantenne.de/rock-antenne-hard-rock/stream/mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png
+  country: DE
+  status: stream-only
+  stationuuid: ab55d4aa-01db-46c6-9934-288828374ea1
+  changeuuid: 8b31dcfc-c078-448f-b1c7-da2bb208e141
+  reviewedAt: "2026-05-04"
+
+- id: de-showagenten-radio-alles-deutsch
+  broadcaster: independent
+  name: SHOWAGENTEN RADIO - ALLES DEUTSCH
+  streamUrl: https://www.radioking.com/play/alles-deutsch/599126
+  codec: MP3
+  favicon: https://www.radioking.com/api/track/cover/bb2b5cc2-106a-419e-9b6e-b688c2040a45?width=160&height=160
+  homepage: https://www.showagenten-radio.de/
+  country: DE
+  status: stream-only
+  stationuuid: 85f4e4e3-713b-4587-a1e0-7917eccf02f1
+  changeuuid: 1064a5e2-5a72-4823-b24b-2d95cbfada04
+  reviewedAt: "2026-05-04"
+
+- id: de-str-space-travel-radio
+  broadcaster: independent
+  name: STR - Space Travel Radio
+  streamUrl: https://spacetravelradio.de:2893/stream/2/
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.spacetravelradio.de/
+  country: DE
+  status: stream-only
+  stationuuid: 5e4da3b2-2e75-4bf8-b3a4-f5b04f3bc1c1
+  changeuuid: 8933d3d0-d674-4896-82b5-f70c38c2413d
+  reviewedAt: "2026-05-04"
+
+- id: de-wdr-cosmo-vintage
+  broadcaster: independent
+  name: WDR Cosmo Vintage
+  streamUrl: https://wdr-cosmo-special.icecastssl.wdr.de/wdr/cosmo/special/mp3/128/stream.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www1.wdr.de/radio/cosmo/musik/webradio-108.html
+  country: DE
+  status: stream-only
+  stationuuid: 60f02819-9721-4d9a-b763-c01c097cb15b
+  changeuuid: 2f1ac585-66c1-4f3d-855d-a835abb5ed4a
+  reviewedAt: "2026-05-04"
+
+- id: de-flux-electronic-chillout
+  broadcaster: independent
+  name: Flux Electronic Chillout
+  streamUrl: https://sfn.edge-ovh-gra5.streams.radiosphere.io/557b7263-9216-46b5-a813-a156ffbc9acb/channels/aa1a53ce-7743-444d-a0b9-115ba01c7321/stream.aac?quality=4&quality=4&source=fluxmusic.api.radiosphere.io&companionAds=true&aw_0_req.userConsentV2=CQLQfCgQLQfCgAfLoBDEBYFsAP_AAEPAAAigF7QFQACAAVAAuAB4AEEAJwAoABkADQAI4AXwAwgBuAGrAO4A7wB-gF1AOAAfsBFQC3gF7AH7AJAAqABcADwAIAAZAA0ACPAO4A7wB-gAAA
+  codec: AAC
+  favicon: https://fluxmusic.cdn.radiosphere.io/images/5d37d59f-ee04-41ef-b0ca-9b5b16810197_1705489427.webp.90
+  homepage: https://www.fluxfm.de/
+  country: DE
+  status: stream-only
+  stationuuid: b539eaaf-3dca-4071-aa8c-b2c7cb52f2ab
+  changeuuid: 9acae437-8d34-486c-bde6-9b48c430aace
+  reviewedAt: "2026-05-04"
+
+- id: de-trigger-fm-max
+  broadcaster: independent
+  name: Trigger.FM MAX
+  streamUrl: https://max-hd-radio.triggerfm.de/
+  bitrate: 256
+  codec: MP3
+  favicon: https://triggerfm.com/wp-content/uploads/2023/10/triggerMAX-512x512-1.png
+  homepage: https://triggerfm.com/radiochannel/trigger-fm-max-80er-90er-mix/
+  country: DE
+  status: stream-only
+  stationuuid: 1d03c07b-60c0-423d-8350-34a879330e1a
+  changeuuid: e2282e8b-8145-4c65-b468-70566386c372
+  reviewedAt: "2026-05-04"
+
+- id: de-ffh-soundtrack
+  broadcaster: independent
+  name: FFH SOUNDTRACK
+  streamUrl: https://mp3.ffh.de/ffhchannels/hqsoundtrack.aac
+  bitrate: 128
+  codec: AAC+
+  country: DE
+  status: stream-only
+  stationuuid: 2fd00b8f-3f84-4175-918a-622b114a2fac
+  changeuuid: 5efca328-7d55-4307-90fa-d9638172db8b
+  reviewedAt: "2026-05-04"
+
+- id: de-ffn-607080
+  broadcaster: independent
+  name: ffn 607080
+  streamUrl: https://ffn-de-hz-fal-stream03-cluster01.radiohost.de/ffn-607080radio_mp3-192
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.ffn.de/fileadmin/ffn.de/musik/streams/607080radio.png
+  homepage: https://player.ffn.de/ffn
+  country: DE
+  status: stream-only
+  stationuuid: 7b226f6d-a9ca-49cb-a8db-7d6288d28771
+  changeuuid: 58444288-4aeb-44be-ba82-d71f3b7108a0
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-cafe-zimmermann
+  broadcaster: independent
+  name: Radio Cafe Zimmermann
+  streamUrl: https://stream.radio-cafezimmermann.de/klassik/mp3-192/
+  bitrate: 192
+  codec: MP3
+  homepage: http://www.radio-cafezimmermann.de/
+  country: DE
+  status: stream-only
+  stationuuid: 41f0e2ba-a27c-48e0-83ce-0a3cf499a81b
+  changeuuid: 436d049f-2947-493c-90f0-573a3c9466dd
+  reviewedAt: "2026-05-04"
+
+- id: de-techno-paradize
+  broadcaster: independent
+  name: techno paradize
+  streamUrl: https://techno-paradize.stream.laut.fm/techno-paradize?t302=2021-12-12_09-00-32&uuid=8fb20a49-0aa6-427a-b0ff-2f65e43898b4
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.facebook.com/favicon.ico
+  homepage: https://www.facebook.com/TechnoParadize
+  country: DE
+  status: stream-only
+  stationuuid: 520b4124-922d-4bc5-83d9-5c86a354e12a
+  changeuuid: c444a79e-4d49-4329-82e9-87c089e7316d
+  reviewedAt: "2026-05-04"
+
+- id: de-reyfm-original
+  broadcaster: independent
+  name: ReyFM - Original
+  streamUrl: https://listen.reyfm.de/original_192kbps.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.reyfm.de/_nuxt/icons/icon_64x64.88ab9f.png
+  homepage: https://www.reyfm.de/
+  country: DE
+  status: stream-only
+  stationuuid: e5589411-82e8-46b2-b90d-e95b159afcf3
+  changeuuid: 670c1db8-96a4-42d6-a8a9-b245299cf550
+  reviewedAt: "2026-05-04"
+
+- id: de-1000-80er-laut-fm
+  broadcaster: independent
+  name: 1000 80er - laut.fm
+  streamUrl: https://100080er.stream.laut.fm/100080er
+  bitrate: 128
+  codec: MP3
+  homepage: https://laut.fm/100080er
+  country: DE
+  status: stream-only
+  stationuuid: d839fc2c-cd69-11e9-8502-52543be04c81
+  changeuuid: 54db27ad-1a13-4aff-8699-3c77680b3ec6
+  reviewedAt: "2026-05-04"
+
+- id: de-harmony-70er
+  broadcaster: independent
+  name: harmony +70er
+  streamUrl: https://mp3.harmonyfm.de/hrmplus/hq70er.aac?context=fHA6LTE=&amsparams=playerid:harmonyPopup;skey:1631618108&rtffh=ef12279c-76fc-410a-9bd8-4e7cafc7308f&listenerid=ef12279c-76fc-410a-9bd8-4e7cafc7308f
+  bitrate: 128
+  codec: AAC+
+  homepage: https://webradio.harmonyfm.de/harmonyplus70er
+  country: DE
+  status: stream-only
+  stationuuid: d7889964-7386-4950-b04f-6fb6312bbc2f
+  changeuuid: efc42467-9bb7-4a8d-b218-883f9c655b0d
+  reviewedAt: "2026-05-04"
+
+- id: de-die-neue-welle
+  broadcaster: independent
+  name: Die Neue Welle
+  streamUrl: https://dieneuewelle-90er.cast.addradio.de/dieneuewelle/90er/mp3/high
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.die-neue-welle.de/storage/thumbs/192x192/r:1694597173/483228.png
+  homepage: https://www.die-neue-welle.de/
+  country: DE
+  status: stream-only
+  stationuuid: c73c63c4-1c84-41f4-bd03-1eb025fb7afe
+  changeuuid: 92183d4b-33a0-4a63-aaee-279155998202
+  reviewedAt: "2026-05-04"
+
+- id: de-egofm-chillout
+  broadcaster: independent
+  name: egofm Chillout
+  streamUrl: https://cast.egofm.de/egofmchillout.mp3?ar-distributor=ffa0&aw_0_req.gdpr=true
+  bitrate: 128
+  codec: MP3
+  homepage: http://www.egofm.de/
+  country: DE
+  status: stream-only
+  stationuuid: 5c9bdd27-dc89-41f3-9ce0-1b775e489394
+  changeuuid: 53a99cfb-6953-4797-994f-08688ab1ef16
+  reviewedAt: "2026-05-04"
+
+- id: de-epic-lounge-shisha-lounge
+  broadcaster: independent
+  name: Epic Lounge - SHISHA LOUNGE
+  streamUrl: https://stream.epic-lounge.com/shisha-lounge?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://epic-lounge.com/
+  country: DE
+  status: stream-only
+  stationuuid: 55742ee4-6eea-4236-8814-1b279b4f8998
+  changeuuid: 70e5e15e-0ed8-4993-a09e-9a0798acf7d2
+  reviewedAt: "2026-05-04"
+
+- id: de-bayern-1-mainfranken
+  broadcaster: independent
+  name: Bayern 1 Mainfranken
+  streamUrl: https://dispatcher.rndfnk.com/br/br1/mainfranken/mp3/mid
+  bitrate: 128
+  codec: MP3
+  favicon: https://api.ardmediathek.de/image-service/images/urn:ard:image:b366004f6196d70c?w=512
+  homepage: https://www.br.de/radio/bayern1/index.html
+  country: DE
+  status: stream-only
+  stationuuid: 8ea86272-d529-4c44-b169-dd6920de647c
+  changeuuid: 621c5f50-2155-463f-af85-02095d41bbeb
+  reviewedAt: "2026-05-04"
+
+- id: de-swr-4-bw-karlsruhe-128k
+  broadcaster: independent
+  name: SWR 4 BW Karlsruhe (128K)
+  streamUrl: https://liveradio.swr.de/sw282p3/swr4ka/play.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://liveradio.swr.de/favicon.ico
+  homepage: https://liveradio.swr.de/sw282p3/swr4ka
+  country: DE
+  status: stream-only
+  stationuuid: 07e9d319-a6b4-42a3-ad2d-77d1f14597ad
+  changeuuid: 66fde359-0226-457e-a64f-2c32a713b970
+  reviewedAt: "2026-05-04"
+
+- id: de-1-a-charts-von-1a-radio
+  broadcaster: independent
+  name: "- 1 A - Charts von 1A Radio"
+  streamUrl: https://1a-charts.radionetz.de/1a-charts.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.1aradio.com/logos/1a-charts_600x600.jpg
+  homepage: http://www.1aradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: f7f9167b-f373-11e8-a471-52543be04c81
+  changeuuid: f4672ce8-16fa-4cdb-9faf-0abf3b43e91a
+  reviewedAt: "2026-05-04"
+
+- id: de-0-100-80er-90er-laut-fm
+  broadcaster: independent
+  name: 0-100 80er/90er - laut.fm
+  streamUrl: https://0-100-80er-90er.stream.laut.fm/0-100-80er-90er
+  bitrate: 128
+  codec: MP3
+  homepage: https://laut.fm/0-100-80er-90er
+  country: DE
+  status: stream-only
+  stationuuid: 8123cbc1-cd66-11e9-8502-52543be04c81
+  changeuuid: 464a9a20-a269-4665-ac88-6529f12d8a8d
+  reviewedAt: "2026-05-04"
+
+- id: de-epic-classical-classical-pop
+  broadcaster: independent
+  name: EPIC CLASSICAL - Classical Pop
+  streamUrl: https://stream.epic-classical.com/classical-pop
+  bitrate: 192
+  codec: MP3
+  homepage: https://epic-classical.com/
+  country: DE
+  status: stream-only
+  stationuuid: 0332d3fd-7ea1-460a-8eb1-ded9c1a4b008
+  changeuuid: c8ac7137-1935-4f0f-81be-bb4c28eb07e9
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-schwany-3-echte-volksmusik
+  broadcaster: independent
+  name: Radio Schwany 3 - Echte Volksmusik
+  streamUrl: https://schwany.streampanel.cloud/3-dieechte
+  bitrate: 320
+  codec: MP3
+  favicon: https://static.mytuner.mobi/media/radios-150px/Lw8GVPVZuA.jpg
+  homepage: https://www.schwany.de/index.html
+  country: DE
+  status: stream-only
+  stationuuid: 900abad0-7dd3-4f2c-ac3b-8d6b8bc6045d
+  changeuuid: 92b99f7d-6a3d-42ce-a7a4-dca3dc2e29a8
+  reviewedAt: "2026-05-04"
+
+- id: de-rock-antenne-coversongs
+  broadcaster: independent
+  name: ROCK ANTENNE Coversongs
+  streamUrl: https://stream.rockantenne.de/coversongs/stream/aacp
+  codec: AAC
+  favicon: https://www.rockantenne.de/logos/station-rock-antenne/apple-touch-icon.png
+  homepage: https://www.rockantenne.de/
+  country: DE
+  status: stream-only
+  stationuuid: 5bb30485-3760-4071-9f63-7fb791b2e395
+  changeuuid: a7095f19-791c-46f4-837d-2b41aaaa0d84
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-ffn-bollerwagen
+  broadcaster: independent
+  name: Radio FFN - Bollerwagen
+  streamUrl: https://stream.ffn.de/radiobollerwagen/mp3-192?ref=radio-browser
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.ffn.de/
+  country: DE
+  status: stream-only
+  stationuuid: 3731fe85-fde9-45f5-9def-2b7e4b0616d6
+  changeuuid: 180cbdbc-e448-4ff3-afae-971682fa8dcb
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-hsf
+  broadcaster: independent
+  name: Radio HSF
+  streamUrl: https://stream.radio-hsf.de/hsf.mp3
+  codec: MP3
+  favicon: https://radio-hsf.de/favicon.ico
+  homepage: https://radio-hsf.de/
+  country: DE
+  status: stream-only
+  stationuuid: c844afdd-bde7-4b12-9e62-a6b3db9cf2ed
+  changeuuid: 1f36b6bd-0fb5-4aaf-8241-4529593d5c4d
+  reviewedAt: "2026-05-04"
+
+- id: de-0nlineradio-latin
+  broadcaster: independent
+  name: 0nlineradio LATIN
+  streamUrl: https://stream.0nlineradio.com/latin?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://0nlineradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: dcb88753-7da0-4edf-bc4f-032a9f9d4972
+  changeuuid: ba7a4f25-5eeb-43d9-89f7-d56ae314da90
+  reviewedAt: "2026-05-04"
+
+- id: de-epic-lounge-poolside-lounge
+  broadcaster: independent
+  name: Epic Lounge - POOLSIDE LOUNGE
+  streamUrl: https://stream.epic-lounge.com/poolside-lounge?ref=streema
+  bitrate: 192
+  codec: MP3
+  homepage: https://epic-lounge.com/
+  country: DE
+  status: stream-only
+  stationuuid: 28c692bf-3113-401d-896e-e25480d0f93d
+  changeuuid: b332c1ca-e879-4e99-acca-e87454942860
+  reviewedAt: "2026-05-04"
+
+- id: de-ffh-hit-radio-aac-128-kbps
+  broadcaster: independent
+  name: FFH Hit Radio. AAC 128 kbps
+  streamUrl: https://mp3.ffh.de/radioffh/hqlivestream.aac
+  bitrate: 128
+  codec: AAC+
+  homepage: https://www.ffh.de/
+  country: DE
+  status: stream-only
+  stationuuid: 93f7c878-c404-469d-ae87-378d64fb909c
+  changeuuid: ed90d30d-91a0-40a8-8e55-8bd3962a9f49
+  reviewedAt: "2026-05-04"
+
+- id: de-flatlines-radio
+  broadcaster: independent
+  name: Flatlines Radio
+  streamUrl: https://stream.laut.fm/flatlines
+  bitrate: 128
+  codec: MP3
+  favicon: https://i0.wp.com/flatlinesradio.de/storage/2021/11/244611397_1194785584320990_6265045071816304131_n-1.jpg?fit=180%2c180&#038;ssl=1
+  homepage: https://www.flatlinesradio.de/
+  country: DE
+  status: stream-only
+  stationuuid: ddde7b16-66ba-11e9-af37-52543be04c81
+  changeuuid: 6ec4ba9b-bf46-4805-8cf8-4ffdc557bc2d
+  reviewedAt: "2026-05-04"
+
+- id: de-fu-ball-bundesliga-2-konferenz
+  broadcaster: independent
+  name: "Fußball-Bundesliga 2: Konferenz"
+  streamUrl: https://wdr-sportschau-liga2konferenz.icecastssl.wdr.de/wdr/sportschau/liga2konferenz/mp3/high
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.sportschau.de/resources/assets/image/favicon/apple-icon-120x120.png
+  homepage: https://livecenter.sportschau.de/
+  country: DE
+  status: stream-only
+  stationuuid: ce2ec4f2-9b0e-4794-a0d2-2c5e1d545240
+  changeuuid: 2a173255-5f55-44be-b503-6da551839a2b
+  reviewedAt: "2026-05-04"
+
+- id: de-hr3-rhein-main
+  broadcaster: independent
+  name: hr3 Rhein-Main
+  streamUrl: https://hlshr3.akamaized.net/hls/live/2016536/hr3rheinmain/master.m3u8
+  bitrate: 200
+  codec: AAC
+  favicon: https://www.hr3.de/favicon.ico?v=4.3.2
+  homepage: https://www.hr3.de/
+  country: DE
+  status: stream-only
+  stationuuid: ca08591c-4be0-4324-a049-ac22285d0ef8
+  changeuuid: 7a373c53-6d9d-4262-8439-d147f3fe5903
+  reviewedAt: "2026-05-04"
+
+- id: de-swr4-freiburg
+  broadcaster: independent
+  name: SWR4 Freiburg
+  streamUrl: https://liveradio.swr.de/sw282p3/swr4fr/
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.swr.de/assets/swr/swr4/favicon.ico
+  homepage: https://www.swr.de/swr4/nachrichten/suedbaden/index.html
+  country: DE
+  status: stream-only
+  stationuuid: e97341be-0a0b-4d24-8cb0-df11f2717a8a
+  changeuuid: 308b722f-8baa-4aeb-a1df-f18a142d0e53
+  reviewedAt: "2026-05-04"
+
+- id: de-1live-dance-hits
+  broadcaster: independent
+  name: 1LIVE Dance Hits
+  streamUrl: https://wdr-1live-dancehits.icecast.wdr.de/wdr/1live/dancehits/mp3/128/stream.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www1.wdr.de/radio/1live/resources-v5.145.2/img/favicon/apple-touch-icon.png
+  homepage: https://www1.wdr.de/radio/1live/musik/1live-streams/loopstream-1live-dance-hits-100.html
+  country: DE
+  status: stream-only
+  stationuuid: 7b9815b9-a510-44b1-b20a-41d0fa96badd
+  changeuuid: 0f114c38-f877-48d0-9fe6-cdbb152c767f
+  reviewedAt: "2026-05-04"
+
+- id: de-epic-classical-classical-sunrise
+  broadcaster: independent
+  name: EPIC CLASSICAL - Classical Sunrise
+  streamUrl: https://stream.epic-classical.com/classical-sunrise
+  bitrate: 192
+  codec: MP3
+  homepage: https://epic-classical.com/
+  country: DE
+  status: stream-only
+  stationuuid: fb600b96-e0b5-4787-a4de-8209c5b683d1
+  changeuuid: 387d2cd5-cb27-4b51-b05b-29b38fb1a244
+  reviewedAt: "2026-05-04"
+
+- id: de-schwany-radio-blass
+  broadcaster: independent
+  name: Schwany Radio Bläss
+  streamUrl: https://radio-blaess.spcast.eu:443/stream?time=1768462942
+  bitrate: 320
+  codec: MP3
+  favicon: http://schwany.de/favicon.ico
+  homepage: http://schwany.de/
+  country: DE
+  status: stream-only
+  stationuuid: 62f5181a-eb87-469f-a180-abede83918b9
+  changeuuid: 942c3813-ea15-4bb8-bbc9-4c1458c6afe5
+  reviewedAt: "2026-05-04"
+
+- id: de-0nlineradio-american-christmas
+  broadcaster: independent
+  name: 0nlineradio AMERICAN CHRISTMAS
+  streamUrl: https://stream.0nlineradio.com/us-christmas?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://0nlineradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: d825374d-d9e4-427b-a6a5-c20e37296147
+  changeuuid: 12be7dcd-f55a-4fc2-84f6-afe6a1e9e5e6
+  reviewedAt: "2026-05-04"
+
+- id: de-1000-90er-laut-fm
+  broadcaster: independent
+  name: 1000 90er - laut.fm
+  streamUrl: https://100090er.stream.laut.fm/100090er
+  bitrate: 128
+  codec: MP3
+  homepage: https://laut.fm/100090er
+  country: DE
+  status: stream-only
+  stationuuid: 48e6d6c0-cd6a-11e9-8502-52543be04c81
+  changeuuid: 6aff0b85-09a1-46b9-9a14-7e5b76e380b1
+  reviewedAt: "2026-05-04"
+
+- id: de-laut-fm-deutschrock-station
+  broadcaster: independent
+  name: Laut.FM DeutschRock Station
+  streamUrl: https://stream.laut.fm/deutschrock-station
+  bitrate: 128
+  codec: MP3
+  homepage: http://laut.fm/deutschrock-station
+  country: DE
+  status: stream-only
+  stationuuid: 9639fc4c-0601-11e8-ae97-52543be04c81
+  changeuuid: 0dd26dc7-1c93-40ef-a50a-284520d7db21
+  reviewedAt: "2026-05-04"
+
+- id: de-metal-only-https-www-metal-only-de-metal-only-ht
+  broadcaster: independent
+  name: "METAL ONLY - https://www.metal-only.de,METAL ONLY - http://www.metal-only.de - 24h Black Death Heavy Metal Rock und mehr!"
+  streamUrl: https://metalonly.sp.radio.fm/stream
+  bitrate: 192
+  codec: MP3
+  country: DE
+  status: stream-only
+  stationuuid: cbccd4ff-fbbf-4136-9c64-c01dcee69b2e
+  changeuuid: e879ea74-78a7-4601-a67f-33ac6e08c4e6
+  reviewedAt: "2026-05-04"
+
+- id: de-0r-piano-jazz-lounge-jazz-piano-lounge-smooth-ch
+  broadcaster: independent
+  name: "0R - PIANO JAZZ LOUNGE || Jazz, Piano, Lounge, Smooth, Chill, Relax, Soft, Acoustic, Instrumental, Evening, Romantic, Background, Coffee, Mellow, Elegant"
+  streamUrl: https://0nlineradio.radioho.st/lounge-piano-jazz-bar?ref=radio-browser26
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/MkhwYrRM/Piano-Jazz-Lounge.png
+  homepage: https://plus.rm.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 4f30d107-82f3-4e4e-99e4-44e05adcb2e9
+  changeuuid: fcec714e-832c-4507-a9f8-afcdbb9ccfdf
+  reviewedAt: "2026-05-04"
+
+- id: de-main-by-rautemusik-rm-fm
+  broadcaster: independent
+  name: __MAIN__ by rautemusik (rm.fm)
+  streamUrl: https://main-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.rm.fm/favicon.ico
+  homepage: https://www.rm.fm/main
+  country: DE
+  status: stream-only
+  stationuuid: aa96c45d-3e1f-4048-90ae-c93f316a0b13
+  changeuuid: 4096907b-f624-44f6-81e8-fd23115f281b
+  reviewedAt: "2026-05-04"
+
+- id: de-0r-coffee-lounge-background-music-jazz-lounge-ch
+  broadcaster: independent
+  name: "0R - COFFEE LOUNGE || Background Music, Jazz, Lounge, Chill, Smooth, Acoustic, Soft Pop, Easy Listening, Relax, Cafe, Background, Mellow, Evening, Instrumental, Romantic, Soft Jazz"
+  streamUrl: https://0nlineradio.radioho.st/lounge-coffee-bar-lounge?ref=radio-browser26
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/LDb4Ctnb/COFFEE-LOUNGE.png
+  homepage: https://plus.rm.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 70094073-a1a6-4c73-b871-6b25dddee813
+  changeuuid: 4e7010e0-452d-45af-9446-5843eda06684
+  reviewedAt: "2026-05-04"
+
+- id: de-1001-trumpet-song
+  broadcaster: independent
+  name: "1001 TRUMPET SONG "
+  streamUrl: https://stream.laut.fm/1001-trumpet-song
+  bitrate: 128
+  codec: MP3
+  favicon: https://d1ujqdpfgkvqfi.cloudfront.net/favicon-generator/htdocs/favicons/2023-05-29/6c4c8493efb0625e9df12380c53b3826.ico.png
+  homepage: https://laut.fm/1001-trumpet-song
+  country: DE
+  status: stream-only
+  stationuuid: 1954aa47-a7a1-4c62-b205-293cedb0c639
+  changeuuid: 4f10bdfc-9858-4d95-a143-44a61b37e5c6
+  reviewedAt: "2026-05-04"
+
+- id: de-epic-classical-classical-nighttime
+  broadcaster: independent
+  name: EPIC CLASSICAL - Classical Nighttime
+  streamUrl: https://stream.epic-classical.com/classical-nighttime
+  bitrate: 192
+  codec: MP3
+  homepage: https://epic-classical.com/
+  country: DE
+  status: stream-only
+  stationuuid: 13e9376c-9330-467e-9b13-cbd48f64cf1e
+  changeuuid: 73338412-c659-4c6d-9c50-30e86164be63
+  reviewedAt: "2026-05-04"
+
+- id: de-take-a-dj-radio
+  broadcaster: independent
+  name: TAKE A DJ - RADIO
+  streamUrl: https://takeadj-radio.stream.laut.fm/takeadj-radio
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.takeadj.com/radio-stream/
+  country: DE
+  status: stream-only
+  stationuuid: a4fd68f8-d932-11e9-a861-52543be04c81
+  changeuuid: 14f1dfb3-5376-4bf1-b20d-b8d339d1f52c
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-schwany-1-volksmusik
+  broadcaster: independent
+  name: Radio Schwany 1 - Volksmusik
+  streamUrl: https://volkstuemlich.spcast.eu:443/stream?time=1768458052
+  bitrate: 320
+  codec: MP3
+  homepage: https://www.schwany.de/index.html
+  country: DE
+  status: stream-only
+  stationuuid: 02f63d4e-74d8-4341-a1c0-084b101036c1
+  changeuuid: c42b088c-0b6b-4f3e-9b2a-17789cb32bc9
+  reviewedAt: "2026-05-04"
+
+- id: de-schwany-herzklang
+  broadcaster: independent
+  name: Schwany Herzklang
+  streamUrl: https://herzklang.spcast.eu:443/stream?time=1768441193
+  bitrate: 320
+  codec: MP3
+  favicon: http://schwany.de/favicon.ico
+  homepage: http://schwany.de/
+  country: DE
+  status: stream-only
+  stationuuid: 1843e14b-c27f-483f-897e-bdbae625b647
+  changeuuid: 55ffec21-9e51-45a7-8995-a7408eb8ca09
+  reviewedAt: "2026-05-04"
+
+- id: de-0-n-deutsch-rock-on-radio
+  broadcaster: independent
+  name: "- 0 N - Deutsch Rock on Radio"
+  streamUrl: https://0n-deutschrock.radionetz.de/0n-deutschrock.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.0nradio.com/logos/0n-deutsch-rock_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 0cf0aa9e-3def-49bd-838a-de40f2e647c4
+  changeuuid: 571cbbe3-2a2f-4d0f-bd4c-75ea317582a5
+  reviewedAt: "2026-05-04"
+
+- id: de-chillout-ibiza-fm
+  broadcaster: independent
+  name: Chillout Ibiza FM
+  streamUrl: https://edge3.peta.live365.net/b05055_128mp3
+  bitrate: 128
+  codec: MP3
+  favicon: null
+  homepage: https://edge3.peta.live365.net/
+  country: DE
+  status: stream-only
+  stationuuid: 18b295c0-0fb1-4cd6-a5a9-d9222a4e9a34
+  changeuuid: a8a3079b-2c29-40a1-924c-bb04bf1b7628
+  reviewedAt: "2026-05-04"
+
+- id: de-epic-classical-classical-dinner
+  broadcaster: independent
+  name: EPIC CLASSICAL - Classical Dinner
+  streamUrl: https://stream.epic-classical.com/classical-dinner
+  bitrate: 192
+  codec: MP3
+  homepage: https://epic-classical.com/
+  country: DE
+  status: stream-only
+  stationuuid: 3d0aad11-97ec-469c-835b-64f12c38dd0e
+  changeuuid: 446526a9-1874-402c-af5e-2b50be639c4e
+  reviewedAt: "2026-05-04"
+
+- id: de-ffh-rock
+  broadcaster: independent
+  name: FFH Rock
+  streamUrl: https://mp3.ffh.de/ffhchannels/hqrock.aac
+  bitrate: 128
+  codec: AAC+
+  country: DE
+  status: stream-only
+  stationuuid: ba618119-142f-4254-a8d3-a62ea8dfc4e3
+  changeuuid: 9f7c2289-7a39-4e77-a4be-558fbdfa004e
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-gutersloh
+  broadcaster: independent
+  name: Radio Gütersloh
+  streamUrl: https://ams.stream43.radiohost.de/ams-radioguetersloh_mp3-192?addradio&upd-meta&upd-scheme=https&_art=dD0xNzY4NDQ5Njg5JmQ9ZDg4NDYwMWI2ZjhmNDUzYmI2YjI
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.radioguetersloh.de/
+  country: DE
+  status: stream-only
+  stationuuid: 61955898-c641-45a0-9bb6-98751a2e9c8c
+  changeuuid: 4c8bdd98-ac28-486d-96d8-3600c2d77a18
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-neandertal
+  broadcaster: independent
+  name: Radio Neandertal
+  streamUrl: https://neandertal-live.cast.addradio.de/neandertal/live/mp3/high?ar-distributor=ffa3
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.radioneandertal.de/assets/images/favicons/radioneandertal/favicon_x96.png
+  homepage: https://www.radioneandertal.de/
+  country: DE
+  status: stream-only
+  stationuuid: 3c8e0796-3ac8-11ea-8dd7-52543be04c81
+  changeuuid: 606a85fd-7ea2-4c6f-835c-2b4de26841ad
+  reviewedAt: "2026-05-04"
+
+- id: de-wdr-cosmo-chill
+  broadcaster: independent
+  name: WDR Cosmo - Chill
+  streamUrl: https://wdr-cosmo-chillout.icecastssl.wdr.de/wdr/cosmo/chillout/mp3/128/stream.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www1.wdr.de/radio/cosmo/resources-v5.128.1/img/favicon/favicon-32x32.png
+  homepage: https://www1.wdr.de/radio/cosmo/channels/chill-out-channel-100.html
+  country: DE
+  status: stream-only
+  stationuuid: 4349bf4f-d6ff-4d0a-a667-c30160cc293f
+  changeuuid: c8a851d6-f8b4-4534-ae34-03d0b3e8e216
+  reviewedAt: "2026-05-04"
+
+- id: de-rautemusik-cofee-music
+  broadcaster: independent
+  name: RauteMusik COFEE-MUSIC
+  streamUrl: https://streams.rautemusik.fm/coffee-music/mp3-192/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  favicon: https://rm.fm/favicon.ico
+  homepage: https://rm.fm/coffee-music
+  country: DE
+  status: stream-only
+  stationuuid: 58e692de-42e0-4fd7-b658-9cf40c61d575
+  changeuuid: f6f6091e-78c7-4b4e-b041-04e04dcac440
+  reviewedAt: "2026-05-04"
+
+- id: de-rock-antenne-xmas-rock
+  broadcaster: independent
+  name: ROCK ANTENNE Xmas Rock
+  streamUrl: https://stream.rockantenne.de/xmas-rock/stream/aacp
+  codec: AAC
+  homepage: https://www.rockantenne.de/
+  country: DE
+  status: stream-only
+  stationuuid: 04a7d616-e800-43b3-acdc-493f694c73cf
+  changeuuid: 2ebb756a-40d6-4f3c-bdff-faf9267c6588
+  reviewedAt: "2026-05-04"
+
+- id: de-meditation-1000
+  broadcaster: independent
+  name: Meditation 1000
+  streamUrl: https://stream.laut.fm/meditation
+  bitrate: 128
+  codec: MP3
+  homepage: https://laut.fm/meditation
+  country: DE
+  status: stream-only
+  stationuuid: 6fe2127d-afad-40d0-abab-3c07034a6572
+  changeuuid: 9989a32a-bdd3-4c5a-972a-090002c58036
+  reviewedAt: "2026-05-04"
+
+- id: de-0-n-deutsch-rap-on-radio
+  broadcaster: independent
+  name: "- 0 N - Deutsch Rap on Radio"
+  streamUrl: https://0n-deutschrap.radionetz.de/0n-deutschrap.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.0nradio.com/logos/0n-deutsch-rap_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 62bed4a2-bf9f-11e9-8502-52543be04c81
+  changeuuid: 2e4dbbe2-bbe2-4a89-aba6-31f084b58a6c
+  reviewedAt: "2026-05-04"
+
+- id: de-dasding-48k-aac
+  broadcaster: independent
+  name: "DASDING | 48k aac"
+  streamUrl: https://liveradio.swr.de/sw890cl/dasding/
+  bitrate: 96
+  codec: AAC
+  favicon: https://www.dasding.de/assets/dasding/apple-touch-icon-152x152.png
+  homepage: https://www.dasding.de/
+  country: DE
+  status: stream-only
+  stationuuid: 27f909d9-a8f3-4209-bd16-66c50ba53049
+  changeuuid: f08a360e-2d0e-4137-b156-2ebebea4ad82
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-schwany-volksmusik-instrumental
+  broadcaster: independent
+  name: Radio Schwany - Volksmusik instrumental
+  streamUrl: https://instrumental-volksmusik.spcast.eu:443/stream?time=1768446385
+  bitrate: 320
+  codec: MP3
+  favicon: https://static.mytuner.mobi/media/radios-150px/a6cncjqwaf6x.png
+  homepage: https://www.schwany.de/index.html
+  country: DE
+  status: stream-only
+  stationuuid: 39bc256d-d78f-41ca-98bf-a7d510579464
+  changeuuid: 5c4b96c0-05dd-4d40-8522-17f0a2b27b9c
+  reviewedAt: "2026-05-04"
+
+- id: de-classic-videogames-radio
+  broadcaster: independent
+  name: Classic Videogames RADIO
+  streamUrl: https://lead-server.de:1551/stream/2/
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radio.classic-videogames.de/
+  country: DE
+  status: stream-only
+  stationuuid: e4b6d036-8184-484c-94c6-84b11a88d15b
+  changeuuid: acc76c01-d0b0-4f14-8dcc-796211071bd1
+  reviewedAt: "2026-05-04"
+
+- id: de-deutschlandfunk-nachrichten
+  broadcaster: independent
+  name: DeutschlandFunk Nachrichten
+  streamUrl: https://ondemand-mp3.dradio.de/file/dradio/nachrichten/nachrichten.mp3
+  codec: MP3
+  homepage: https://deutschlandfunk.de/
+  country: DE
+  status: stream-only
+  stationuuid: fbf9ceb6-4a94-42bd-89da-44f49c9a3e0d
+  changeuuid: e8da4357-0f6e-4d5e-8f83-829a512dd1fc
+  reviewedAt: "2026-05-04"
+
+- id: de-radio2day
+  broadcaster: independent
+  name: Radio2day
+  streamUrl: https://radio2day.ip-streaming.net/radio2day
+  bitrate: 128
+  codec: MP3
+  homepage: https://radio2day.de/
+  country: DE
+  status: stream-only
+  stationuuid: 9a4ab799-0363-11e9-a1be-52543be04c81
+  changeuuid: 6426d118-10fe-4c33-a43e-bc0bd9a02708
+  reviewedAt: "2026-05-04"
+
+- id: de-mdr-klassik-mp3-256
+  broadcaster: independent
+  name: MDR Klassik MP3 256
+  streamUrl: https://mdr-284350-0.sslcast.mdr.de/mdr/284350/0/mp3/max/stream.mp3
+  bitrate: 256
+  codec: MP3
+  favicon: https://www.mdr.de/resources/global/img/mdrde/favicons/android-icon-192x192.png
+  homepage: https://www.mdr.de/klassik/index.html
+  country: DE
+  status: stream-only
+  stationuuid: ff9e962e-d971-43d2-8465-93a00092b936
+  changeuuid: 91820a41-d88e-49d3-aa46-7cb0580b6377
+  reviewedAt: "2026-05-04"
+
+- id: de-0nlineradio-lo-fi
+  broadcaster: independent
+  name: 0nlineradio LO-FI
+  streamUrl: https://stream.0nlineradio.com/lo-fi?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://0nlineradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 22ed63fd-57bf-469a-9c71-4524834b74d0
+  changeuuid: 934f69e4-318c-4061-a7de-6f0d01e4eb17
+  reviewedAt: "2026-05-04"
+
+- id: de-antenne-wiesbaden
+  broadcaster: independent
+  name: antenne WIESBADEN
+  streamUrl: https://stream.antenne-wiesbaden.de/antennewiesbaden-live/mp3-192?ref=radio-browser
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/LDxCj60L/logo-up-2200.jpg
+  homepage: https://antenne-wiesbaden.de/
+  country: DE
+  status: stream-only
+  stationuuid: 00705334-8462-4b81-8372-07af848cd32b
+  changeuuid: 9f8cc539-947d-4fda-b7ea-350fb9500e31
+  reviewedAt: "2026-05-04"
+
+- id: de-bremen-eins-beat-club
+  broadcaster: independent
+  name: Bremen Eins Beat-Club
+  streamUrl: https://icecast.radiobremen.de/rb/webchannel6/mp3/128/stream.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.bremeneins.de/static/img/favicons/apple-touch-icon-180.png?v=4
+  homepage: https://www.bremeneins.de/
+  country: DE
+  status: stream-only
+  stationuuid: 35136214-f54e-48c8-a430-74b104dcbc11
+  changeuuid: 8b70b099-27ad-4015-b2e2-3b6aaf834811
+  reviewedAt: "2026-05-04"
+
+- id: de-epic-classical-classical-fairy-tales
+  broadcaster: independent
+  name: EPIC CLASSICAL - Classical Fairy Tales
+  streamUrl: https://stream.epic-classical.com/classical-fairy-tales
+  bitrate: 192
+  codec: MP3
+  homepage: https://epic-classical.com/
+  country: DE
+  status: stream-only
+  stationuuid: a99b24ae-ba07-4e69-b3af-988011cfa295
+  changeuuid: 7a4b2ceb-3b59-4fb4-b7bc-7d6f1f2abdff
+  reviewedAt: "2026-05-04"
+
+- id: de-oldiefans-das-original
+  broadcaster: independent
+  name: Oldiefans - Das Original
+  streamUrl: https://server7.streamserver24.com:8080/proxy/stekonig?mp=/stream
+  bitrate: 256
+  codec: MP3
+  homepage: https://oldiefans.com/
+  country: DE
+  status: stream-only
+  stationuuid: 1e640e9c-81ad-429e-9d0e-61c73216bd98
+  changeuuid: 774f3609-31d0-4652-9597-a7535a74d576
+  reviewedAt: "2026-05-04"

--- a/data/stations.yaml
+++ b/data/stations.yaml
@@ -20545,3 +20545,6348 @@
   stationuuid: 1e640e9c-81ad-429e-9d0e-61c73216bd98
   changeuuid: 774f3609-31d0-4652-9597-a7535a74d576
   reviewedAt: "2026-05-04"
+
+- id: de-bayernwelle-sudost
+  broadcaster: independent
+  name: Bayernwelle SüdOst
+  streamUrl: https://bayernwelle-live.cast.addradio.de/bayernwelle/live/mp3/high?ar-distributor=f0b7
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.bayernwelle.de/
+  country: DE
+  status: stream-only
+  stationuuid: 905a74a5-2a2e-4c14-84c8-2f3517d43fe6
+  changeuuid: 225121aa-3da3-4fdf-ae08-8fd51dc51865
+  reviewedAt: "2026-05-04"
+
+- id: de-schlager-radio-hor-auf-dein-herz
+  broadcaster: independent
+  name: Schlager Radio- Hör auf dein herz
+  streamUrl: https://addrad.io/4454r93
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.schlagerradio.de/wp-content/uploads/2021/10/cropped-Favicon_SchlagerRadio_Herzen_wei%C3%9Faufrot_rund-32x32.png
+  homepage: https://www.schlagerradio.de/
+  country: DE
+  status: stream-only
+  stationuuid: 140e1878-b9ac-4d69-87f5-ac8479960f26
+  changeuuid: 5eab5be4-454f-4a6c-bfc8-b2a88d554daf
+  reviewedAt: "2026-05-04"
+
+- id: de-0nlineradio-urban
+  broadcaster: independent
+  name: 0nlineradio URBAN
+  streamUrl: https://stream.0nlineradio.com/urban?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://0nlineradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: f4bbd589-443f-4ccd-b5f4-934856985066
+  changeuuid: b35e0094-7390-4922-ad9c-d31d9b3bfa87
+  reviewedAt: "2026-05-04"
+
+- id: de-lounge-plus
+  broadcaster: independent
+  name: lounge plus
+  streamUrl: https://addrad.io/4455g42
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.loungeplus.de/wp-content/uploads/2024/01/cropped-favicon-32x32-1-180x180.png
+  homepage: http://www.loungeplus.de/
+  country: DE
+  status: stream-only
+  stationuuid: 5647116d-cacf-499f-a716-dfd40f31e063
+  changeuuid: 7e549a47-7243-4ec8-bab1-2736a23ff25e
+  reviewedAt: "2026-05-04"
+
+- id: de-antenne-bayern-munich-city-nights
+  broadcaster: independent
+  name: Antenne Bayern Munich City Nights
+  streamUrl: https://stream.rockantenne.de/munich-city-nights/stream/mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.rockantenne.de/logos/station-rock-antenne/apple-touch-icon.png
+  homepage: https://www.rockantenne.de/
+  country: DE
+  status: stream-only
+  stationuuid: 65a790ce-3e4d-4f36-a4c7-7a4b8ebb75a3
+  changeuuid: 19f5e4f2-b08c-4428-8270-af0d3563f0d6
+  reviewedAt: "2026-05-04"
+
+- id: de-coco-und-jambo
+  broadcaster: independent
+  name: Coco und Jambo
+  streamUrl: https://stream.laut.fm/cocoundjambo
+  bitrate: 128
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/33fb6a_25e82fc9f2e44a41a93b29ecefadc02d~mv2.png/v1/fill/w_820,h_312,al_c/33fb6a_25e82fc9f2e44a41a93b29ecefadc02d~mv2.png
+  homepage: https://www.cocoundjambo.de/
+  country: DE
+  status: stream-only
+  stationuuid: fea2cd8e-7242-11ea-b1cf-52543be04c81
+  changeuuid: 3a9d2c41-75ad-4030-afaa-07cf9418150f
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-erft
+  broadcaster: independent
+  name: Radio Erft
+  streamUrl: https://radioerft--di--nacs-ais-lgc--04--cdn.cast.addradio.de/radioerft/live/mp3/high
+  bitrate: 128
+  codec: MP3
+  favicon: https://upload.wikimedia.org/wikipedia/commons/thumb/6/66/Radio_Erft_Logo.svg/800px-Radio_Erft_Logo.svg.png
+  homepage: https://www.radioerft.de/
+  country: DE
+  status: stream-only
+  stationuuid: dcd50deb-e41c-481b-9656-8ea90a11ccfb
+  changeuuid: 3093bb34-71f5-461e-915d-6b23bdc348b2
+  reviewedAt: "2026-05-04"
+
+- id: de-rock-antenne-70er-rock-2
+  broadcaster: independent
+  name: Rock Antenne - 70er Rock
+  streamUrl: https://stream.rockantenne.de/70er-rock/stream/mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://super-radio-mobile.devhub.top/logo/70e4d4.webp
+  homepage: https://www.rockantenne.de/rockhoeren/streams/70er-rock
+  country: DE
+  status: stream-only
+  stationuuid: bf42d0ff-2e56-4186-a2e3-b0e0d826ddce
+  changeuuid: 14240282-b1a0-4144-9dc4-2c460bdd8416
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-fratz
+  broadcaster: independent
+  name: Radio Fratz
+  streamUrl: https://stream.radio-fratz.de/stream_high.mp3
+  bitrate: 320
+  codec: MP3
+  homepage: https://www.radio-fratz.de/
+  country: DE
+  status: stream-only
+  stationuuid: b97c3b7a-64f9-44d4-905b-239a2ef67b3c
+  changeuuid: 72454673-b28a-4c87-83e5-09a3b8bc6040
+  reviewedAt: "2026-05-04"
+
+- id: de-0nlineradio-chillout
+  broadcaster: independent
+  name: 0nlineradio CHILLOUT
+  streamUrl: https://stream.0nlineradio.com/chillout?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://0nlineradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 47588e4a-a2d5-4b68-8bb3-1c60234ff404
+  changeuuid: be072069-fe30-4774-b2de-effab3e10627
+  reviewedAt: "2026-05-04"
+
+- id: de-rock-antenne-deutsch-rock
+  broadcaster: independent
+  name: Rock Antenne - Deutsch Rock
+  streamUrl: https://s1-webradio.rockantenne.de/deutschrock/stream/aacp
+  codec: AAC
+  homepage: https://www.rockantenne.de/
+  country: DE
+  status: stream-only
+  stationuuid: 13101aba-b1fd-4567-a438-c6a2d469a535
+  changeuuid: cf4b3289-b1cc-4159-8ae5-179598040ab8
+  reviewedAt: "2026-05-04"
+
+- id: de-schwany-3
+  broadcaster: independent
+  name: Schwany 3
+  streamUrl: https://schwany3volksmusik.hoamatwelle.de/
+  bitrate: 320
+  codec: MP3
+  favicon: http://schwany.de/favicon.ico
+  homepage: http://schwany.de/
+  country: DE
+  status: stream-only
+  stationuuid: 45a1bdba-c071-4337-8498-7bb3cab79556
+  changeuuid: cc07150b-e156-4b66-ab5d-94485d5f3dd1
+  reviewedAt: "2026-05-04"
+
+- id: de-wdr-2-rheinland-mp3-128-kbit-s
+  broadcaster: independent
+  name: "WDR 2 – Rheinland | mp3, 128 kBit/s"
+  streamUrl: https://wdr-wdr2-rheinland.icecastssl.wdr.de/wdr/wdr2/rheinland/mp3/128/stream.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www1.wdr.de/resources-v5.124.1/img/favicon/apple-touch-icon.png
+  homepage: https://www1.wdr.de/radio/wdr2/index.html
+  country: DE
+  status: stream-only
+  stationuuid: 5dc81cad-251e-4d59-b3e2-6c87c376820a
+  changeuuid: 56cc5938-6c8a-40c7-b180-f727348ea571
+  reviewedAt: "2026-05-04"
+
+- id: de-1-a-deutsch-pop-von-1a-radio
+  broadcaster: independent
+  name: "- 1 A - Deutsch Pop von 1A Radio"
+  streamUrl: https://1a-deutschpop.radionetz.de/1a-deutschpop.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.1aradio.com/logos/1a-deutsch-pop_600x600.jpg
+  homepage: http://www.1aradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 6246c7bd-f36e-11e8-a471-52543be04c81
+  changeuuid: 99badb0d-44c7-4435-978a-9cf3142cbd87
+  reviewedAt: "2026-05-04"
+
+- id: de-1-splash-classical
+  broadcaster: independent
+  name: "#1 Splash Classical"
+  streamUrl: https://ais-sa2.cdnstream1.com/2208_128.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.splashradio.eu/
+  country: DE
+  status: stream-only
+  stationuuid: 188930c7-cda9-4d8b-8262-a695f107c19a
+  changeuuid: 075c82f8-c907-4fd8-a41f-dac4447c9cbb
+  reviewedAt: "2026-05-04"
+
+- id: de-absolut-lovesongs
+  broadcaster: independent
+  name: Absolut Lovesongs
+  streamUrl: https://n06.radiojar.com/5bdyvqa9bm8uv
+  codec: MP3
+  favicon: https://absolutradio.de/apple-touch-icon.png
+  homepage: https://absolutradio.de/
+  country: DE
+  status: stream-only
+  stationuuid: 7727db26-f0ad-4081-8c7a-b96d04d39cb4
+  changeuuid: 4a1bb955-1a17-4cbd-9ae3-664b52f749cd
+  reviewedAt: "2026-05-04"
+
+- id: de-egofm-bayern
+  broadcaster: independent
+  name: egoFM Bayern
+  streamUrl: https://cast.egofm.de/egofm.mp3?ar-distributor=radio-browser
+  bitrate: 128
+  codec: MP3
+  favicon: https://streams.egofm.de/img/alexa/egoFM%20Simulcast-256x256.png
+  homepage: https://egofm.de/
+  country: DE
+  status: stream-only
+  stationuuid: 43d17c5a-1fd0-4f64-9f14-9d9fafa77823
+  changeuuid: 3234ef1d-f59d-4c86-b573-e86e25d872d5
+  reviewedAt: "2026-05-04"
+
+- id: de-ndr2-mv
+  broadcaster: independent
+  name: NDR2 MV
+  streamUrl: https://icecast.ndr.de/ndr/ndr2/mecklenburgvorpommern/mp3/128/stream.mp3?1681641486761&aggregator=web
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.ndr.de/favicon.ico
+  homepage: https://www.ndr.de/ndr2/epg/stationndrzwei102-radioplayer_livestream-livestream605.html
+  country: DE
+  status: stream-only
+  stationuuid: 29bb5edf-90da-46ce-b001-f89e3b0af8fd
+  changeuuid: f5be21dc-55ec-42cb-9cee-bc0f8ec4806c
+  reviewedAt: "2026-05-04"
+
+- id: de-0nlineradio-schumann
+  broadcaster: independent
+  name: 0nlineradio SCHUMANN
+  streamUrl: https://stream.0nlineradio.com/schumann?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://0nlineradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: bc853492-82b9-4a8d-ac0c-1f8fe5696ebe
+  changeuuid: e29af51c-7140-4efd-be31-9dd6ed8873ad
+  reviewedAt: "2026-05-04"
+
+- id: de-krautrockworld
+  broadcaster: independent
+  name: Krautrockworld
+  streamUrl: https://krautrockworld.stream.laut.fm/krautrockworld
+  bitrate: 128
+  codec: MP3
+  favicon: http://img.sedoparking.com/templates/logos/sedo_logo.png
+  homepage: http://www.krautrock-world.com/
+  country: DE
+  status: stream-only
+  stationuuid: dbb28050-c9f4-4f1a-a450-9410dac95ced
+  changeuuid: 21df0db3-91a7-4249-aa8a-713a56b499f6
+  reviewedAt: "2026-05-04"
+
+- id: de-epic-lounge-christmas-lounge
+  broadcaster: independent
+  name: Epic Lounge - CHRISTMAS LOUNGE
+  streamUrl: https://stream.epic-lounge.com/christmas-lounge?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://epic-lounge.com/
+  country: DE
+  status: stream-only
+  stationuuid: d63e7625-44e3-47f7-ab44-f8b15c3ee6bf
+  changeuuid: e5508ad6-dac4-4f5f-96c4-1b7fd8554137
+  reviewedAt: "2026-05-04"
+
+- id: de-horspielprojekt-bielefeld
+  broadcaster: independent
+  name: Hörspielprojekt Bielefeld
+  streamUrl: https://hoerspiel.stream.laut.fm/hoerspiel?pl=m3u&t302=2026-01-15_05-53-38&uuid=486935e5-a7e5-4f5f-9c23-f986524e38e3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.hoerspielprojekt.de/wp-content/uploads/2018/12/cropped-headphone-96x96.png
+  homepage: https://www.hoerspielprojekt.de/
+  country: DE
+  status: stream-only
+  stationuuid: 236cfaaa-fa1c-4b30-b597-01bbdcb2e0d1
+  changeuuid: 3e5c4d74-5a74-4bd7-a6b8-059408a01d4e
+  reviewedAt: "2026-05-04"
+
+- id: de-absolut-top-club-night
+  broadcaster: independent
+  name: Absolut TOP club night
+  streamUrl: https://n0c.radiojar.com/s1gwvam92hhvv?___cb=248720992580709
+  codec: MP3
+  favicon: https://absolutradio.de/images/stations/2924_handheld_default_square_image600.png
+  country: DE
+  status: stream-only
+  stationuuid: 694632be-5038-4bff-9674-6ffd8cd51d36
+  changeuuid: 2dd454cc-2a8b-497e-812c-5db79c566922
+  reviewedAt: "2026-05-04"
+
+- id: de-discosound-radio
+  broadcaster: independent
+  name: Discosound-Radio
+  streamUrl: https://stream.laut.fm/discosound-radio
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.discosound-radio.de/
+  country: DE
+  status: stream-only
+  stationuuid: d0e249c5-acee-4e85-a52e-a779303df77c
+  changeuuid: 858620bf-d540-41ee-9965-936a06d3c1a0
+  reviewedAt: "2026-05-04"
+
+- id: de-i-love-bass-by-ilovemusic-de
+  broadcaster: independent
+  name: I Love Bass by ilovemusic.de
+  streamUrl: https://ilm.stream18.radiohost.de/ilm_ilovebass_mp3-192?upd-meta&upd-scheme=https&_art=dD0xNzY4NDU5MjExJmQ9Zjk2M2M3Y2Y0MmRkZGViYTVlMmQ
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.ilovemusic.de/favicon.ico
+  homepage: https://www.ilovemusic.de/
+  country: DE
+  status: stream-only
+  stationuuid: d8ed1aeb-6d2e-4e60-bb69-ec62bfbeaf96
+  changeuuid: a30398f3-ef03-4041-9746-d86a646d2cae
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-schwany-4-blasmusik
+  broadcaster: independent
+  name: Radio Schwany 4 - Blasmusik
+  streamUrl: https://blasmusik.spcast.eu:443/stream?time=1768433624
+  bitrate: 320
+  codec: MP3
+  favicon: https://static.mytuner.mobi/media/radios-150px/MKV7TT95v9.jpg
+  homepage: https://www.schwany.de/index.html
+  country: DE
+  status: stream-only
+  stationuuid: 104f495e-9a37-44d9-bf9b-cd45996cdd3b
+  changeuuid: 0895d6d5-860e-416e-9bc5-2d873355a2f1
+  reviewedAt: "2026-05-04"
+
+- id: de-wdr-cosmo-https
+  broadcaster: independent
+  name: WDR COSMO -- (https)
+  streamUrl: https://wdr-cosmo-live.icecastssl.wdr.de/wdr/cosmo/live/mp3/128/stream.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www1.wdr.de/radio/cosmo/resources-v5.142.2/img/favicon/apple-touch-icon.png
+  homepage: https://www1.wdr.de/radio/cosmo/index.html
+  country: DE
+  status: stream-only
+  stationuuid: 11ca14a9-f6a2-49cf-befb-2d0cc84c730a
+  changeuuid: 93cdf565-97e2-4902-af5c-7711af9a4d88
+  reviewedAt: "2026-05-04"
+
+- id: de-0r-music-for-sleep-sleep-relax-calm-meditation-n
+  broadcaster: independent
+  name: "0R - MUSIC FOR SLEEP || Sleep, Relax, Calm, Meditation, Nature, Ambient, Soft Music, Piano, Deep Sleep, Peaceful, Chill, Background, Slow, Gentle, Instrumental"
+  streamUrl: https://0nlineradio.radioho.st/classical-classical-music-for-sleep?ref=radio-browser26
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/whsdTsct/MUSIC-FOR-SLEEP.png
+  homepage: https://plus.rm.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 3f4be720-c996-439f-be3b-cce594ea2852
+  changeuuid: d6279716-c4bb-444d-95f4-498c212db8cd
+  reviewedAt: "2026-05-04"
+
+- id: de-fu-ball-bundesliga-spiel-1
+  broadcaster: independent
+  name: "Fußball-Bundesliga: Spiel 1"
+  streamUrl: https://wdr-sportschau-liga1spiel1.icecastssl.wdr.de/wdr/sportschau/liga1spiel1/mp3/high
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.sportschau.de/resources/assets/image/favicon/apple-icon-120x120.png
+  homepage: https://livecenter.sportschau.de/
+  country: DE
+  status: stream-only
+  stationuuid: 8f9c7b73-0726-44b6-93e2-d32cd90e875a
+  changeuuid: 024d3030-378d-4a89-ad96-045cdad07500
+  reviewedAt: "2026-05-04"
+
+- id: de-0-n-radio-on-radio
+  broadcaster: independent
+  name: "- 0 N - Radio on Radio"
+  streamUrl: https://0n-radio.radionetz.de/0n-radio.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.0nradio.com/logos/0n-radio_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: d06a1fb8-ffb4-4b69-836d-df044ab66d95
+  changeuuid: 9a2b380c-ea1f-42e0-a90f-c7f30aff6373
+  reviewedAt: "2026-05-04"
+
+- id: de-0r-nature-relax-nature-sounds-sleep-relax-calm-f
+  broadcaster: independent
+  name: "0R - NATURE RELAX || Nature Sounds, Sleep, Relax, Calm, Forest, Ocean, Rain, Ambient, Meditation, Peaceful, Spa, Yoga, Gentle, Soothing, Background, Sleep"
+  streamUrl: https://0nlineradio.radioho.st/lounge-nature-sounds?ref=radio-browser26
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/NgtLbFs6/Nature-Relax-Sound.png
+  homepage: https://plus.rm.fm/
+  country: DE
+  status: stream-only
+  stationuuid: b828a184-3488-48f2-ab60-38a5e435a9fe
+  changeuuid: ff6fd164-031c-4ccb-a2bc-6bdcf3b2f3cc
+  reviewedAt: "2026-05-04"
+
+- id: de-kolncampus
+  broadcaster: independent
+  name: Kölncampus
+  streamUrl: https://live.koelncampus.com/live
+  bitrate: 128
+  codec: MP3
+  favicon: https://static.koelncampus.com/apple-touch-icon-precomposed.png
+  homepage: https://www.koelncampus.com/
+  country: DE
+  status: stream-only
+  stationuuid: a6fce20a-a1fb-4e83-9159-5b05801700b9
+  changeuuid: 6b5d4011-dcd0-4af8-ad74-64a61aa53744
+  reviewedAt: "2026-05-04"
+
+- id: de-oldie-welle-ingolstadt
+  broadcaster: independent
+  name: oldie-welle-Ingolstadt
+  streamUrl: https://funkhaus-ingolstadt.stream24.net/oldie-welle-ingolstadt.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.funkhaus-ingolstadt.de/
+  country: DE
+  status: stream-only
+  stationuuid: d52cac9f-2ccf-4aa3-b28b-6a9efbb46479
+  changeuuid: d02f5e88-3463-4918-a0ba-5cdde2aeec75
+  reviewedAt: "2026-05-04"
+
+- id: de-100-radio-zoom-de
+  broadcaster: independent
+  name: "100% Radio-Zoom.de"
+  streamUrl: https://office.radio-zoom.de/webplayer
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.radio-zoom.de/fileadmin/template_2022/image/favicon.png
+  homepage: http://www.radio-zoom.de/
+  country: DE
+  status: stream-only
+  stationuuid: 963eb072-0601-11e8-ae97-52543be04c81
+  changeuuid: 4172abe5-adf3-4141-acbf-b7bcd926654e
+  reviewedAt: "2026-05-04"
+
+- id: de-antenne-bayern-ndw
+  broadcaster: independent
+  name: Antenne Bayern NDW
+  streamUrl: https://s5-webradio.antenne.de/antenne-bayern-ndw/stream/mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.antenne.de/logos/station-antenne-bayern/apple-touch-icon.png
+  homepage: https://www.antenne.de/webradio/ndw
+  country: DE
+  status: stream-only
+  stationuuid: b4198bb3-fc7e-4dc5-9a5b-2f0ad8b7e67a
+  changeuuid: b5b48ecb-03fc-4613-92c6-73f13f14279b
+  reviewedAt: "2026-05-04"
+
+- id: de-laut-fm-after-hours
+  broadcaster: independent
+  name: Laut.fm - After Hours
+  streamUrl: https://after-hours.stream.laut.fm/after-hours?t302=2019-09-27_06-07-17&uuid=64f3acda-820a-4912-9df6-fe85b9cd99a2
+  bitrate: 128
+  codec: MP3
+  favicon: https://laut.fm/assets/touch-icons/apple-touch-icon.png?9e172e15
+  homepage: https://laut.fm/
+  country: DE
+  status: stream-only
+  stationuuid: b24966a5-e16c-11e9-a8ba-52543be04c81
+  changeuuid: 28263cb8-d306-4645-b6e3-39bc7d76a79b
+  reviewedAt: "2026-05-04"
+
+- id: de-1-a-jazz-von-1a-radio
+  broadcaster: independent
+  name: "- 1 A - Jazz von 1A Radio"
+  streamUrl: https://1a-jazz.radionetz.de/1a-jazz.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.1aradio.com/logos/1a-jazz_600x600.jpg
+  homepage: http://www.1aradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: e9ca7d9d-6e24-406a-898d-d6d1d5b0f3fe
+  changeuuid: 695ce50c-321c-48a9-98c7-a2f0eb943d15
+  reviewedAt: "2026-05-04"
+
+- id: de-jam-by-rautemusik-rm-fm
+  broadcaster: independent
+  name: __JAM__ by rautemusik (rm.fm)
+  streamUrl: https://jam-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.rm.fm/favicon.ico
+  homepage: https://www.rm.fm/jam
+  country: DE
+  status: stream-only
+  stationuuid: aeb0cbb6-fc1b-4f9c-b50d-51f70d3ade8a
+  changeuuid: f381211a-5e5b-491e-9f53-eb1f0debe136
+  reviewedAt: "2026-05-04"
+
+- id: de-0nlineradio-lovehits
+  broadcaster: independent
+  name: 0nlineradio LOVEHITS
+  streamUrl: https://stream.0nlineradio.com/lovehits?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://0nlineradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: b274ebb5-3be6-418b-b8b8-b50eb96fbae9
+  changeuuid: 31c24043-8080-4bc6-8e3a-f1db17a38e84
+  reviewedAt: "2026-05-04"
+
+- id: de-bremen-vier-rockt
+  broadcaster: independent
+  name: Bremen Vier Rockt
+  streamUrl: https://icecast.radiobremen.de/rb/webchannel8/mp3/128/stream.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.bremenvier.de/static/img/favicons/apple-touch-icon-180.png?v=3
+  homepage: https://www.bremenvier.de/
+  country: DE
+  status: stream-only
+  stationuuid: ed1d90b3-6b4c-455c-871b-935047dddd62
+  changeuuid: b9456aa0-1091-4fd2-813b-1762d16038b9
+  reviewedAt: "2026-05-04"
+
+- id: de-chillout-archiv
+  broadcaster: independent
+  name: Chillout Archiv
+  streamUrl: https://stream.laut.fm/chillout-archiv
+  bitrate: 128
+  codec: MP3
+  favicon: https://laut.fm/assets/touch-icons/apple-touch-icon.png?9e172e15
+  homepage: https://laut.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 9f09975a-3a9f-43ca-afd6-e7360285b19f
+  changeuuid: 2a2924cd-3a36-44a8-8ebe-8d72e121b24d
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-herford
+  broadcaster: independent
+  name: Radio Herford
+  streamUrl: https://addrad.io/444z8vj
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.radioherford.de/icons-hf/apple-icon-120.png
+  homepage: https://www.radioherford.de/
+  country: DE
+  status: stream-only
+  stationuuid: 554bdd21-257f-11e9-a80b-52543be04c81
+  changeuuid: b6ac092d-9804-47a1-af8a-92e0f5d825c2
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-potsdam
+  broadcaster: independent
+  name: Radio Potsdam
+  streamUrl: https://stream.radiogroup.de/radio-potsdam/mp3-192/?ref=website
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.radio-potsdam.de/favicon.ico
+  homepage: https://www.radio-potsdam.de/
+  country: DE
+  status: stream-only
+  stationuuid: 95bc8ead-c109-4e7c-9f91-8490c28b6ef8
+  changeuuid: bfc2691a-1397-4278-9759-f982ecf5c416
+  reviewedAt: "2026-05-04"
+
+- id: de-rock-antenne-rockabilly
+  broadcaster: independent
+  name: "Rock Antenne - Rockabilly "
+  streamUrl: https://stream.rockantenne.de/rockabilly/stream/aacp
+  codec: AAC
+  homepage: http://www.rockantenne.de/
+  country: DE
+  status: stream-only
+  stationuuid: 6fe38d95-866b-49ea-ae05-307a1316b5c4
+  changeuuid: 42688732-ead5-4b9e-b777-96a251bc3637
+  reviewedAt: "2026-05-04"
+
+- id: de-swr3-visual-radio
+  broadcaster: independent
+  name: SWR3 Visual Radio
+  streamUrl: https://swrswr3vr-hls.akamaized.net/hls/live/2018683/swr3vr/master.m3u8
+  bitrate: 2147
+  codec: AAC
+  homepage: https://www.swr3.de/
+  country: DE
+  status: stream-only
+  stationuuid: 7ec201c0-4dc5-4640-bc40-807eb3087b39
+  changeuuid: c57a85bf-6599-4233-a4ca-63b0bd43a675
+  reviewedAt: "2026-05-04"
+
+- id: de-ffn-comedy
+  broadcaster: independent
+  name: FFN Comedy
+  streamUrl: https://ffn.stream36.radiohost.de/ffn-comedy_mp3-192
+  bitrate: 192
+  codec: MP3
+  favicon: https://player.ffn.de/assets/channels/ffn-fruehstyxradio.png
+  homepage: https://player.ffn.de/ffnfruehstyxradio
+  country: DE
+  status: stream-only
+  stationuuid: 6e3b295f-54be-4c3c-8300-798150ddd940
+  changeuuid: 98a0dd1b-e81f-4679-b887-4e7752c5c695
+  reviewedAt: "2026-05-04"
+
+- id: de-ilovemusic-ilovegreatesthits
+  broadcaster: independent
+  name: "ilovemusic: ilovegreatesthits"
+  streamUrl: https://ilm.stream12.radiohost.de/ilm_ilovegreatesthits_mp3-192?upd-meta&upd-scheme=https&_art=dD0xNzY4NDU3MzY3JmQ9YTQyMTExMTdmZTI3ZWM5MzUyZGE
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.ilovemusic.de/favicon.ico
+  homepage: https://www.ilovemusic.de/
+  country: DE
+  status: stream-only
+  stationuuid: b4f99332-68ef-47d6-bbe2-66a5eb8a3b2b
+  changeuuid: 36b03406-a114-41f0-a9f5-360167abbad9
+  reviewedAt: "2026-05-04"
+
+- id: de-1live-rock-hits
+  broadcaster: independent
+  name: 1LIVE Rock Hits
+  streamUrl: https://wdr-1live-rockhits.icecast.wdr.de/wdr/1live/rockhits/mp3/128/stream.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www1.wdr.de/radio/1live/app/loopstream-cover-1live-rock-hits-100~_v-TeaserAufmacher.jpg
+  homepage: https://www1.wdr.de/radio/1live/musik/1live-streams/loopstreams-1live-rock-hits-100.html
+  country: DE
+  status: stream-only
+  stationuuid: cc975e01-600a-4e68-af73-02866b774934
+  changeuuid: ac2adaf8-8ea3-430a-9f96-9e28a08a7b36
+  reviewedAt: "2026-05-04"
+
+- id: de-boney-m
+  broadcaster: independent
+  name: Boney M
+  streamUrl: https://stream.pcradio.ru/BoneyM-hi
+  codec: AAC
+  favicon: null
+  homepage: https://pcradio.ru/
+  country: DE
+  status: stream-only
+  stationuuid: 0f30fb1f-b3a9-4fdb-86d9-418f0c658b7d
+  changeuuid: b70abc9d-f80e-4975-adf4-0388be84cd7b
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-ffn-peppermint
+  broadcaster: independent
+  name: Radio FFN - Peppermint
+  streamUrl: https://stream.ffn.de/peppermintfm/mp3-192/
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.ffn.de/
+  country: DE
+  status: stream-only
+  stationuuid: fb44022f-a950-42bd-8f80-add353ee75f6
+  changeuuid: dd40ca54-0a96-4165-bc41-866e0bbcef65
+  reviewedAt: "2026-05-04"
+
+- id: de-yourtime-fm
+  broadcaster: independent
+  name: YourTime-FM
+  streamUrl: https://stream.laut.fm/yourtime-fm
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.yourtimefm.de/
+  country: DE
+  status: stream-only
+  stationuuid: 1b73d269-1e00-48c3-a84c-bbffeded9de0
+  changeuuid: 842fc0ca-01a5-4a8d-baad-47c7fed879b7
+  reviewedAt: "2026-05-04"
+
+- id: de-0nlineradio
+  broadcaster: independent
+  name: 0nlineradio
+  streamUrl: https://stream.0nlineradio.com/jazz?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://0nlineradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: c1255365-8232-4d3f-be33-64f136ee99d6
+  changeuuid: d88f651d-a7be-472f-a90e-4dddf7a93f3b
+  reviewedAt: "2026-05-04"
+
+- id: de-dwg-pur
+  broadcaster: independent
+  name: DWG Pur
+  streamUrl: https://server25531.streamplus.de/stream.mp3
+  bitrate: 64
+  codec: MP3
+  homepage: https://radio.dwgradio.net/de/radio-pur-lyra/
+  country: DE
+  status: stream-only
+  stationuuid: a5a5c91f-9a77-497f-8be9-dbc6f21373b1
+  changeuuid: dff28021-6979-4689-b26c-0734804147fb
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-frankisch-spoken
+  broadcaster: independent
+  name: Radio Fränkisch Spoken
+  streamUrl: https://fraenkisch-spoken.stream.laut.fm/fraenkisch-spoken?t302=2026-01-15_02-52-07&uuid=c85f8f39-a411-48cf-9c1c-fbb11e26c345
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.zachmeier.de/blog/radio/
+  country: DE
+  status: stream-only
+  stationuuid: 57f91dff-0d23-4406-9a58-5f86456edaeb
+  changeuuid: 0bcdf921-e5a4-4f99-92cc-bb1d4da4198a
+  reviewedAt: "2026-05-04"
+
+- id: de-0nlineradio-trending-charts
+  broadcaster: independent
+  name: 0nlineradio - TRENDING CHARTS
+  streamUrl: https://stream.0nlineradio.com/trending-charts
+  bitrate: 192
+  codec: MP3
+  homepage: https://0nlineradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: a9f324c0-0181-4d41-be9e-aedcf9e6921c
+  changeuuid: ca673d3a-9cf9-45d1-bc37-34875ad57ea8
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-endstation
+  broadcaster: independent
+  name: Radio Endstation
+  streamUrl: https://funkturm.radio-endstation.de/hls/radio-endstation/live.m3u8
+  bitrate: 52
+  codec: AAC
+  homepage: https://radio-enderation.de/
+  country: DE
+  status: stream-only
+  stationuuid: 6208aaaa-7aea-4300-ac6b-b99b1cf6bd19
+  changeuuid: bd783751-f4f8-4b58-b89d-556534cd7884
+  reviewedAt: "2026-05-04"
+
+- id: de-reyfm-lofi-2
+  broadcaster: independent
+  name: "REYFM - #lofi"
+  streamUrl: https://listen.reyfm.de/lofi_64kbps.mp3
+  bitrate: 63
+  codec: AAC+
+  favicon: https://www.reyfm.de/_nuxt/icons/icon_64x64.88ab9f.png
+  homepage: https://www.reyfm.de/
+  country: DE
+  status: stream-only
+  stationuuid: 56b9be45-1211-4286-815d-56c3fec0ad8d
+  changeuuid: f7653f75-c2ac-4075-886c-febcb522614e
+  reviewedAt: "2026-05-04"
+
+- id: de-wdr4a
+  broadcaster: independent
+  name: WDR4a
+  streamUrl: https://wdrhf.akamaized.net/hls/live/2027995/wdr4/master.m3u8
+  bitrate: 102
+  codec: AAC
+  favicon: https://www1.wdr.de/radio/wdr4/wdrvier_logo~_v-ARDAustauschformat.jpg
+  homepage: https://www.wdr4.de/
+  country: DE
+  status: stream-only
+  stationuuid: dbcdfcaa-04da-43da-895e-69e9468a6670
+  changeuuid: 4ffc436b-ca26-4d1c-95ce-3c11a2011465
+  reviewedAt: "2026-05-04"
+
+- id: de-50s-60s-radio
+  broadcaster: independent
+  name: 50s 60s Radio
+  streamUrl: https://50s60s-radio.stream.laut.fm/50s60s-radio?
+  bitrate: 128
+  codec: MP3
+  homepage: https://50s60s-radio.stream.laut.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 035c4860-9392-4701-8c14-073093d846c4
+  changeuuid: d0f9ea05-ab78-43c4-b969-40daccf99b64
+  reviewedAt: "2026-05-04"
+
+- id: de-antenne-bayern-bayern-sound
+  broadcaster: independent
+  name: Antenne Bayern - Bayern Sound
+  streamUrl: https://stream.antenne.de/bayern-sound/stream/mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://cdn-profiles.tunein.com/s309706/images/logod.jpg?t=637538489160000000
+  homepage: https://www.antenne.de/webradio/bayern-sound
+  country: DE
+  status: stream-only
+  stationuuid: 2446bc54-bfbb-41b4-afac-4a1c0fb4b141
+  changeuuid: 13b97499-91d6-4825-b30d-27d2e644df46
+  reviewedAt: "2026-05-04"
+
+- id: de-landeswelle-deutsch
+  broadcaster: independent
+  name: LandesWelle Deutsch
+  streamUrl: https://edge19.streamonkey.net/landeswelle-deutsch?aggregator=rewrite/mp3-192/rin/
+  codec: AAC
+  favicon: http://www.landeswelle.de/images/landeswelle/favicons/touch-icon120.png
+  homepage: http://www.landeswelle.de/
+  country: DE
+  status: stream-only
+  stationuuid: 964449aa-0601-11e8-ae97-52543be04c81
+  changeuuid: 02fa833a-3472-4af3-81b1-384e8a64ba5c
+  reviewedAt: "2026-05-04"
+
+- id: de-gay-fm
+  broadcaster: independent
+  name: Gay FM
+  streamUrl: https://icepool.silvacast.com/GAYFM.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.gayfm.de/images/logos/logo.png
+  homepage: https://www.gayfm.de/
+  country: DE
+  status: stream-only
+  stationuuid: d3186605-c6e6-4d6d-9762-bc10614809a7
+  changeuuid: 72e3bc1c-c0bf-409f-9818-8bb730ac174c
+  reviewedAt: "2026-05-04"
+
+- id: de-hr4-mittelhessen
+  broadcaster: independent
+  name: hr4 Mittelhessen
+  streamUrl: https://dispatcher.rndfnk.com/hr/hr4/mittelhessen/high
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.hr4.de/favicon.png?v=3.84.2
+  homepage: https://www.hr4.de/
+  country: DE
+  status: stream-only
+  stationuuid: 6edf9450-d2b0-4221-8b0d-d7e84de8e098
+  changeuuid: 7d180bca-2731-403a-9ff1-c603e5d541f7
+  reviewedAt: "2026-05-04"
+
+- id: de-antenne-thuringen-fm-mitte-mp3-192k
+  broadcaster: independent
+  name: Antenne Thüringen (fm) (Mitte) (mp3 192k)
+  streamUrl: https://edge24.streamonkey.net/antthue-mitte?aggregator=rewrite/
+  codec: AAC
+  favicon: https://www.antennethueringen.de/assets/favicons/apple-icon-120x120.png
+  homepage: https://www.antennethueringen.de/
+  country: DE
+  status: stream-only
+  stationuuid: d9ec16b3-b828-11e9-acb2-52543be04c81
+  changeuuid: 0123d328-6d40-4fd9-8b84-8245eae14559
+  reviewedAt: "2026-05-04"
+
+- id: de-enigma
+  broadcaster: independent
+  name: Enigma
+  streamUrl: https://stream.pcradio.ru/Enigma-hi
+  codec: AAC
+  favicon: null
+  homepage: https://pcradio.ru/
+  country: DE
+  status: stream-only
+  stationuuid: 12507494-6205-425d-bf68-d6676a55abdc
+  changeuuid: 6cffdb26-42da-47e3-b5f8-2310bd37d76f
+  reviewedAt: "2026-05-04"
+
+- id: de-hr3-nordhessen
+  broadcaster: independent
+  name: hr3 Nordhessen
+  streamUrl: https://dispatcher.rndfnk.com/hr/hr3/nordhessen/high
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.hr3.de/favicon.png?v=3.84.2
+  homepage: https://www.hr3.de/
+  country: DE
+  status: stream-only
+  stationuuid: 3b48fe80-1dc7-43f6-8dd0-79c59aca3a45
+  changeuuid: 686b90de-4e37-43c8-87de-01115561b910
+  reviewedAt: "2026-05-04"
+
+- id: de-superfly-hiphop
+  broadcaster: independent
+  name: Superfly HipHop
+  streamUrl: https://web.stream.superfly.fm/superfly-hiphop
+  codec: AAC
+  favicon: https://superfly.fm/player/img/s_logo.png?cb=V3000008
+  homepage: https://superfly.fm/player/index.php?stream=darko_hiphop_app_playlist
+  country: DE
+  status: stream-only
+  stationuuid: 3be73d3d-4ef8-4769-9958-5f154355f0dd
+  changeuuid: 183d77c6-b25c-438f-b96b-9bd78a27a455
+  reviewedAt: "2026-05-04"
+
+- id: de-techno-bunker
+  broadcaster: independent
+  name: techno bunker
+  streamUrl: https://stream.laut.fm/technobunkerfm
+  bitrate: 128
+  codec: MP3
+  homepage: https://laut.fm/technobunkerfm
+  country: DE
+  status: stream-only
+  stationuuid: 58bfb205-fea8-4a9b-aae5-b9737115605e
+  changeuuid: 2731aa23-44ed-4540-8518-4b58ad6829c0
+  reviewedAt: "2026-05-04"
+
+- id: de-wdr-3-adaptive-bitrate
+  broadcaster: independent
+  name: WDR 3 (adaptive bitrate)
+  streamUrl: https://wdrhf.akamaized.net/hls/live/2027994/wdr3/master.m3u8
+  bitrate: 102
+  codec: AAC
+  favicon: https://www1.wdr.de/resources/img/favicon/apple-touch-icon.png
+  homepage: https://www1.wdr.de/radio/wdr3/index.html
+  country: DE
+  status: stream-only
+  stationuuid: 09460ae1-c00f-46e1-9fc6-7318c5a429e5
+  changeuuid: fbb9212a-a24d-4fe8-b5da-91c1340a112a
+  reviewedAt: "2026-05-04"
+
+- id: de-0nlineradio-christmas
+  broadcaster: independent
+  name: 0nlineradio CHRISTMAS
+  streamUrl: https://stream.0nlineradio.com/christmas?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://0nlineradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: eeace05c-2a63-4a00-8d03-89114c34584b
+  changeuuid: df07b631-5083-4fb2-bd90-533b8e4d5c14
+  reviewedAt: "2026-05-04"
+
+- id: de-ambient-radio
+  broadcaster: independent
+  name: Ambient Radio
+  streamUrl: https://stream.laut.fm/ambient
+  bitrate: 128
+  codec: MP3
+  homepage: https://laut.fm/ambient
+  country: DE
+  status: stream-only
+  stationuuid: fdf22946-65b2-4807-81ed-1f79a9588ff5
+  changeuuid: 4ce3a72a-e22f-46ab-9ade-41aa41acee99
+  reviewedAt: "2026-05-04"
+
+- id: de-leas-s-fox-schlager
+  broadcaster: independent
+  name: LEAS´s FOX SCHLAGER
+  streamUrl: https://radio2.myhitmusic.de/Fresh-Hit.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: http://myhitmusic.de/wp-content/uploads/2016/06/Leas-Fox-HD.jpg
+  homepage: https://myhitmusic.de/schlager-radio/
+  country: DE
+  status: stream-only
+  stationuuid: 2fc8bf37-a289-4405-bc5d-f8638891e648
+  changeuuid: 57a01d50-79f9-42e5-8b0a-55d500e5344d
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-primavera
+  broadcaster: independent
+  name: Radio Primavera
+  streamUrl: https://live.stream.primavera24.de/primavera24-radioprimavera/stream/mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.blm.de/files/png2/primavera_neu_gr.png
+  homepage: https://www.primavera24.de/
+  country: DE
+  status: stream-only
+  stationuuid: a119272e-e678-40fd-a50d-2af85fb1c1fe
+  changeuuid: 3513dfaa-f882-4fa3-9d79-bc58090e2424
+  reviewedAt: "2026-05-04"
+
+- id: de-swr1-die-80er
+  broadcaster: independent
+  name: SWR1 Die 80er
+  streamUrl: https://d121.rndfnk.com/ard/swr/swr/raka16/aac/96/stream.aac?aggregator=web&cid=01FCZAZ2K8SF1QJ7BNCNNGRXJJ&sid=2JDHAZvGoxO64wmxiXn4rAmZmqH&token=g5ndVaCdxQRbT8tS0Xb2n2rXMu3QrDWyRkyg-2rFK58&tvf=Voz6vhLQMhdkMTIxLnJuZGZuay5jb20
+  bitrate: 128
+  codec: AAC
+  favicon: https://www.swr.de/unternehmen/kommunikation/1653432715862%2Clogos-swr1-116~_v-16x9@2dM_-ad6791ade5eb8b5c935dd377130b903c4b5781d8.jpg
+  homepage: https://www.swr.de/swr1/swr1-webradio-kanal-die80er-100.html
+  country: DE
+  status: stream-only
+  stationuuid: f4479920-9bdc-4279-8f21-efad19afc4fd
+  changeuuid: e7194e19-cd1c-4cac-b16e-f755927e216d
+  reviewedAt: "2026-05-04"
+
+- id: de-0r-hotel-lounge-chill-jazz-smooth-relax-soft-mus
+  broadcaster: independent
+  name: "0R - HOTEL LOUNGE || Chill, Jazz, Smooth, Relax, Soft Music, Acoustic, Background, Dinner, Romantic, Evening, Calm, Cafe, Instrumental, Soft Pop"
+  streamUrl: https://0nlineradio.radioho.st/lounge-hotel-lounge?ref=radio-browser26
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/GLkKPMc/Hotel-Lounge.png
+  homepage: https://plus.rm.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 8f14d1fa-31f6-4fd7-9dcb-8ed0e3bf3d18
+  changeuuid: 52147c40-d03d-4ede-8e7a-896e10255b4d
+  reviewedAt: "2026-05-04"
+
+- id: de-antenne-mainz
+  broadcaster: independent
+  name: Antenne Mainz
+  streamUrl: https://antennemainz-live.cast.addradio.de/antennemainz/live/mp3/high
+  bitrate: 192
+  codec: MP3
+  favicon: https://antenne-mainz.de/wp-content/uploads/2024/07/cropped-favicon-180x180.png
+  homepage: https://www.antenne-mainz.de/
+  country: DE
+  status: stream-only
+  stationuuid: 86b4e063-502a-11ea-b877-52543be04c81
+  changeuuid: cdc2af4f-28c2-47e0-9169-e06f78bc857e
+  reviewedAt: "2026-05-04"
+
+- id: de-antenne-niederrhein
+  broadcaster: independent
+  name: Antenne Niederrhein
+  streamUrl: https://antennenr--di--nacs-ais-lgc--05--cdn.cast.addradio.de/antennenr/live/mp3/high
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.antenneniederrhein.de/
+  country: DE
+  status: stream-only
+  stationuuid: fed6f93c-d0f6-4961-8fe5-5da4fab9bc01
+  changeuuid: 4875566b-2d4b-494f-92a0-fe095a4e40fb
+  reviewedAt: "2026-05-04"
+
+- id: de-darkclub-radio
+  broadcaster: independent
+  name: DARKCLUB-RADIO
+  streamUrl: https://darkclubradio.stream.laut.fm/darkclubradio?pl=m3u&t302=2026-01-15_01-25-24&uuid=071b4561-c61e-4f53-bb60-527b9528ba2d
+  bitrate: 128
+  codec: MP3
+  homepage: https://laut.fm/darkclubradio
+  country: DE
+  status: stream-only
+  stationuuid: 046cb924-4b2d-4aeb-85e4-3b5d0365238f
+  changeuuid: 1fbaa043-27b9-48bb-a054-0cb811a24e61
+  reviewedAt: "2026-05-04"
+
+- id: de-hr1-mittelhessen
+  broadcaster: independent
+  name: hr1 Mittelhessen
+  streamUrl: https://dispatcher.rndfnk.com/hr/hr1/mittelhessen/high
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.hr1.de/favicon.png?v=3.84.2
+  homepage: https://www.hr1.de/
+  country: DE
+  status: stream-only
+  stationuuid: 7b569f9d-ec68-4772-b324-675a4f6ca77e
+  changeuuid: 737d5915-5d19-451d-83a6-b2483a818592
+  reviewedAt: "2026-05-04"
+
+- id: de-melodic-radio
+  broadcaster: independent
+  name: Melodic Radio
+  streamUrl: https://www.tunefm.de:2000/stream/melodicradio
+  bitrate: 192
+  codec: MP3
+  favicon: https://melodicradio.eu/wp-content/uploads/2023/08/mr_logo_130x130.png
+  homepage: https://melodicradio.eu/
+  country: DE
+  status: stream-only
+  stationuuid: 8f22f67e-479e-429a-8ebc-767c40eb022d
+  changeuuid: 69ab59a8-8959-4f49-840d-2a7feeddafe9
+  reviewedAt: "2026-05-04"
+
+- id: de-radiofunandmore-radiofunandmore
+  broadcaster: independent
+  name: RadioFunAndMore,RadioFunAndMore
+  streamUrl: https://radiofunandmore.sp.radio.fm/stream
+  bitrate: 320
+  codec: MP3
+  favicon: https://radiofunandmore.de/images/bilder/radiologo.png
+  country: DE
+  status: stream-only
+  stationuuid: fef86ea2-effc-4655-8de1-40a8d8942cb4
+  changeuuid: 4f0d7bde-b79e-47bf-8471-0bdcf51104ad
+  reviewedAt: "2026-05-04"
+
+- id: de-traurig-by-rautemusik-rm-fm
+  broadcaster: independent
+  name: __TRAURIG__ by rautemusik (rm.fm)
+  streamUrl: https://traurig-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.rm.fm/favicon.ico
+  homepage: https://www.rm.fm/traurig
+  country: DE
+  status: stream-only
+  stationuuid: 95fa43c9-7ecb-40e8-9b16-3b2406a1e8ab
+  changeuuid: bd8850cd-f28f-4671-ba8a-76c641ded4b9
+  reviewedAt: "2026-05-04"
+
+- id: de-charivari-munchen-live-hits
+  broadcaster: independent
+  name: Charivari München - Live Hits
+  streamUrl: https://rs24.stream24.net/live-hits?ref=charivari.de&aw_0_1st.playerid=radioplayer.de
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.charivari.de/apple-icon-120x120.png
+  homepage: https://www.charivari.de/
+  country: DE
+  status: stream-only
+  stationuuid: 6de1ef49-b016-11e9-acb2-52543be04c81
+  changeuuid: eb82c0cc-438b-4eac-98a3-9ba6bfca2de2
+  reviewedAt: "2026-05-04"
+
+- id: de-cosmo-dance
+  broadcaster: independent
+  name: Cosmo Dance
+  streamUrl: https://wdr-cosmo-dance.icecastssl.wdr.de/wdr/cosmo/dance/mp3/128/stream.mp3
+  bitrate: 128
+  codec: MP3
+  country: DE
+  status: stream-only
+  stationuuid: 9f3fdce8-9f75-4a9f-b778-8048790841c4
+  changeuuid: fe9007c7-cff0-4b9e-bb00-9482a38f4b73
+  reviewedAt: "2026-05-04"
+
+- id: de-oldie-antenne-60er-hits
+  broadcaster: independent
+  name: Oldie Antenne - 60er Hits
+  streamUrl: https://stream.oldie-antenne.de/oldie-antenne-60er-hits/stream/mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.oldie-antenne.de/
+  country: DE
+  status: stream-only
+  stationuuid: 04669a4c-ce24-424d-a54c-f8edbf8008d3
+  changeuuid: 60a296bd-7763-45f1-9fa6-c43c9e1bba0e
+  reviewedAt: "2026-05-04"
+
+- id: de-rock
+  broadcaster: independent
+  name: rock
+  streamUrl: https://stream.rockantenne.de/rockantenne/stream/mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.rockantenne.de/
+  country: DE
+  status: stream-only
+  stationuuid: 9f88b38b-4673-4ed3-a450-0ebb49cae695
+  changeuuid: 05e95e28-9ec8-4b97-be61-0a5264d8eb0a
+  reviewedAt: "2026-05-04"
+
+- id: de-rt1-classic-rock
+  broadcaster: independent
+  name: RT1 Classic Rock
+  streamUrl: https://frontend.streamonkey.net/rt1-ch01/stream/mp3?aggregator=rt1_web&aw_0_1st.playerid=rt1_web&aw_0_1st.source=imsuden_web
+  bitrate: 128
+  codec: MP3
+  favicon: https://rt1.imsueden.de/storage/thumbs/192x192/r:1678126825/1618.png
+  homepage: https://rt1.imsueden.de/rt1-classic-rock
+  country: DE
+  status: stream-only
+  stationuuid: 37efd306-ab35-4f49-87b8-926f5e1effe5
+  changeuuid: 4449bee0-8f59-4c4e-a3db-a242271014f0
+  reviewedAt: "2026-05-04"
+
+- id: de-skyline-efm-hard-trance
+  broadcaster: independent
+  name: Skyline EFM Hard Trance
+  streamUrl: https://hard-trance.stream.laut.fm/hard-trance?pl=m3u
+  bitrate: 128
+  codec: MP3
+  favicon: https://assets.laut.fm/b7de7a0f8a75ec5698a6b97e25de99da?t=_120x120
+  homepage: https://laut.fm/hard-trance
+  country: DE
+  status: stream-only
+  stationuuid: 653ea243-f587-4671-9066-5dae325656e4
+  changeuuid: 1f32a752-709a-4270-b6e2-c2e15e4445ea
+  reviewedAt: "2026-05-04"
+
+- id: de-90er-revival
+  broadcaster: independent
+  name: 90er-Revival
+  streamUrl: https://stream.laut.fm/90er-revival
+  bitrate: 128
+  codec: MP3
+  homepage: https://http//laut.fm/90er-revival
+  country: DE
+  status: stream-only
+  stationuuid: eaef888e-0e78-11e9-a80b-52543be04c81
+  changeuuid: 06b060cb-9ab2-4a07-86ff-98b93e8be236
+  reviewedAt: "2026-05-04"
+
+- id: de-absolut-wave
+  broadcaster: independent
+  name: Absolut Wave
+  streamUrl: https://absolut-wave.live.absolutradio.de/
+  codec: MP3
+  favicon: https://assets.radioplayer.org/276/2762711/600/600/kyaf2ebi.png
+  homepage: https://absolutradio.de/wave/player
+  country: DE
+  status: stream-only
+  stationuuid: 42bfcd8a-7209-4a54-8b71-3b5b7c2b04eb
+  changeuuid: adbfa020-63e0-462e-9ecb-7968f999e9a2
+  reviewedAt: "2026-05-04"
+
+- id: de-club-fm-mp3-192-kbit-s
+  broadcaster: independent
+  name: Club FM MP3 192 kbit/s
+  streamUrl: https://rs7.stream24.net/clubfm.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.clubfm.de/storage/thumbs/192x192/r:1695642276/zdiljpqk3fvaz.png
+  homepage: https://clubfm.de/empfang/
+  country: DE
+  status: stream-only
+  stationuuid: d4161d25-c12d-4297-aa63-fce935dd5da6
+  changeuuid: f1730ee9-4603-4c56-b99d-9918006fe8ce
+  reviewedAt: "2026-05-04"
+
+- id: de-deutschrock
+  broadcaster: independent
+  name: Deutschrock
+  streamUrl: https://stream.laut.fm/deutschrock
+  bitrate: 128
+  codec: MP3
+  homepage: https://deutschrock.eu/
+  country: DE
+  status: stream-only
+  stationuuid: 3675f086-7046-4a71-8653-001974344a44
+  changeuuid: 2126ee64-6ad4-4dbc-927d-e49e76f93259
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-ankerherz
+  broadcaster: independent
+  name: "Radio Ankerherz "
+  streamUrl: https://fra-pioneer08.dedicateware.com:3035/stream
+  bitrate: 192
+  codec: MP3
+  country: DE
+  status: stream-only
+  stationuuid: 9ba35a46-fbfd-4a42-8ae9-fefd7d094e0f
+  changeuuid: 10086166-8a11-4eaf-a01e-a25f5dbded86
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-victoria-100-4
+  broadcaster: independent
+  name: Radio Victoria 100,4
+  streamUrl: https://a8.asurahosting.com:6700/radio.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://radio-victoria.com/wp-content/uploads/2025/03/logo-sq-noframe.png
+  homepage: https://radio-victoria.com/
+  country: DE
+  status: stream-only
+  stationuuid: c61fccff-e147-4993-9eb1-b5b38c0352ba
+  changeuuid: b6dc1ccf-8a8c-48f4-bd4b-4a168bade561
+  reviewedAt: "2026-05-04"
+
+- id: de-rammstein
+  broadcaster: independent
+  name: Rammstein Радио
+  streamUrl: https://stream.pcradio.ru/Rammstein-hi
+  codec: AAC
+  favicon: null
+  homepage: https://pcradio.ru/
+  country: DE
+  status: stream-only
+  stationuuid: e9f52309-eb95-4294-9196-b3a95480861b
+  changeuuid: afa77d88-2c9c-4772-ba3c-57a06bafdcfe
+  reviewedAt: "2026-05-04"
+
+- id: de-swr1-bw
+  broadcaster: independent
+  name: SWR1 BW
+  streamUrl: https://liveradio.swr.de/sw331ch/swr1bw/
+  bitrate: 128
+  codec: AAC
+  favicon: https://api.ardmediathek.de/image-service/images/urn:ard:image:fcd6835b90ee9466?w=512
+  country: DE
+  status: stream-only
+  stationuuid: 486d5290-cf76-43e1-9cb9-d50f96eea034
+  changeuuid: 15e585d3-f95d-4890-9bb2-023e240a3215
+  reviewedAt: "2026-05-04"
+
+- id: de-tango-berlin
+  broadcaster: independent
+  name: Tango Berlin
+  streamUrl: https://tango.stream.laut.fm/tango?pl=m3u&t302=2026-01-14_23-52-14&uuid=c524b053-f88b-4e37-a732-f6248baa637f
+  bitrate: 128
+  codec: MP3
+  favicon: https://assets.laut.fm/0b99c828b64a9160d9a51463ffc09e1a?t=_120x120
+  homepage: https://tango-radio-berlin.de/
+  country: DE
+  status: stream-only
+  stationuuid: d85fd402-37b8-4776-8c2b-d0cdbebb9672
+  changeuuid: b2b12140-b032-4403-8b97-03da25d1da7d
+  reviewedAt: "2026-05-04"
+
+- id: de-htd-radio-hit-the-dark
+  broadcaster: independent
+  name: HTD Radio - Hit the Dark
+  streamUrl: https://htd-radio.stream.laut.fm/htd-radio?pl=pls&t302=2026-01-15_07-45-57&uuid=f054998e-93c0-400a-911a-92895c0501f8
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.htd-radio.de/
+  country: DE
+  status: stream-only
+  stationuuid: 9d1c6172-13d1-407a-98b0-e7b2c19ff161
+  changeuuid: edf2bb09-0a57-47c7-a4b7-283964f90fe2
+  reviewedAt: "2026-05-04"
+
+- id: de-modern-talking
+  broadcaster: independent
+  name: Modern Talking
+  streamUrl: https://stream.pcradio.ru/Modern_Talking-hi
+  codec: AAC
+  favicon: null
+  homepage: https://pcradio.ru/
+  country: DE
+  status: stream-only
+  stationuuid: 5eb5fb65-a154-4a58-b885-4a9743463025
+  changeuuid: bc1e346f-bf9e-4c1e-83e7-236bfcf4f423
+  reviewedAt: "2026-05-04"
+
+- id: de-rock-antenne-hamburg
+  broadcaster: independent
+  name: Rock Antenne Hamburg
+  streamUrl: https://stream.rockantenne.hamburg/rockantenne-hamburg/stream/mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.rockantenne.hamburg/
+  country: DE
+  status: stream-only
+  stationuuid: 83ad0b74-a709-4fa4-98fd-aca1774324c5
+  changeuuid: 4650a1e8-8bba-49e4-9bb2-2c16533f4a77
+  reviewedAt: "2026-05-04"
+
+- id: de-0nlineradio-rock
+  broadcaster: independent
+  name: 0nlineradio ROCK
+  streamUrl: https://stream.0nlineradio.com/rock?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://0nlineradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 8860e388-d794-4d93-abdd-7c5f84bd01b6
+  changeuuid: ae1f54c1-80cc-453d-a3ee-089bc9cef630
+  reviewedAt: "2026-05-04"
+
+- id: de-accept
+  broadcaster: independent
+  name: Accept
+  streamUrl: https://stream.pcradio.ru/accept-hi
+  codec: AAC
+  favicon: null
+  homepage: https://pcradio.ru/
+  country: DE
+  status: stream-only
+  stationuuid: e49a29ac-c6be-4959-99b1-820f7a272902
+  changeuuid: e02b64e3-a96f-4a99-950d-3037642a8053
+  reviewedAt: "2026-05-04"
+
+- id: de-karneval-radio-de
+  broadcaster: independent
+  name: karneval-radio.de
+  streamUrl: https://karneval-radio.stream.laut.fm/karneval-radio?t302=2026-01-15_06-55-01&uuid=bf3abab4-e369-4895-9f3d-7098920eb398
+  bitrate: 128
+  codec: MP3
+  homepage: https://karneval-radio.de/
+  country: DE
+  status: stream-only
+  stationuuid: aed92dbf-0c34-11e9-a80b-52543be04c81
+  changeuuid: d3903fa5-0c59-454b-be2d-7d5cf93d1a62
+  reviewedAt: "2026-05-04"
+
+- id: de-laut-fm-cinemaitaliano
+  broadcaster: independent
+  name: laut.fm Cinemaitaliano
+  streamUrl: https://stream.laut.fm/cinemaitaliano
+  bitrate: 128
+  codec: MP3
+  homepage: https://laut.fm/cinemaitaliano
+  country: DE
+  status: stream-only
+  stationuuid: 82b27836-421d-11e9-aa55-52543be04c81
+  changeuuid: 82b27841-421d-11e9-aa55-52543be04c81
+  reviewedAt: "2026-05-04"
+
+- id: de-megaradiomix
+  broadcaster: independent
+  name: MEGARADIOmix
+  streamUrl: https://play.megaradiomix.de/megaradiomix-berlin/mp3-192/
+  bitrate: 192
+  codec: MP3
+  favicon: https://megaradiomix.de/wp-content/uploads/2022/03/Radiologo600_600.png
+  homepage: https://megaradiomix.de/
+  country: DE
+  status: stream-only
+  stationuuid: 1b51bf1f-a6bf-4dd6-890f-5514bc370f17
+  changeuuid: ca0af5ca-5e40-4940-8c30-79188581534e
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-schlagerparadies
+  broadcaster: independent
+  name: Radio Schlagerparadies
+  streamUrl: https://webstream.schlagerparadies.de/schlagerparadies128.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://schlagerparadies.de/images/rsp_setup/apple-icon-180x180.png
+  homepage: https://schlagerparadies.de/player/webplayer
+  country: DE
+  status: stream-only
+  stationuuid: f65fa9c0-d36a-414e-917f-2532bdc144ab
+  changeuuid: 092edfc3-8345-4e81-92c4-c4b3d695f2b6
+  reviewedAt: "2026-05-04"
+
+- id: de-rock-antenne-country-antenne
+  broadcaster: independent
+  name: Rock Antenne - Country Antenne
+  streamUrl: https://stream.rockantenne.de/country-antenne/stream/mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png
+  homepage: https://www.rockantenne.de/rockhoeren/streams/country-antenne
+  country: DE
+  status: stream-only
+  stationuuid: adfd7f18-6c49-48be-a0be-0083eaa23d87
+  changeuuid: d93a0bb3-5be8-4292-b549-747d00ff44cc
+  reviewedAt: "2026-05-04"
+
+- id: de-swr2-archivradio
+  broadcaster: independent
+  name: "SWR2 Archivradio "
+  streamUrl: https://liveradio.swr.de/sw331ch/raka02/
+  bitrate: 128
+  codec: AAC
+  favicon: https://www.swr.de/assets/swr/swr2/apple-touch-icon-120x120.png
+  homepage: https://www.swr.de/swr2/wissen/archivradio/swr2-archivradio-ueber-uns-100.html
+  country: DE
+  status: stream-only
+  stationuuid: 97eb5100-26b3-4653-865e-4e2aee033a85
+  changeuuid: 735f48b6-e377-44b1-b905-4d45f2ad6455
+  reviewedAt: "2026-05-04"
+
+- id: de-swr4-kaiserslautern
+  broadcaster: independent
+  name: swr4 kaiserslautern
+  streamUrl: https://liveradio.swr.de/sw282p3/swr4kl/
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.swr.de/assets/swr/apple-touch-icon.png
+  homepage: https://www.swr.de/
+  country: DE
+  status: stream-only
+  stationuuid: 20fca869-6014-4cd2-a85f-ab0fd24fe4cf
+  changeuuid: 358cb57e-8304-4113-8bbb-6b4eafad99a2
+  reviewedAt: "2026-05-04"
+
+- id: de-0r-80s-80s-pop-80s-hits-synthpop-new-wave-dance-
+  broadcaster: independent
+  name: "0R - 80s || 80s Pop, 80s Hits, Synthpop, New Wave, Dance, Disco, Pop Classics, Retro, Teen Pop, Funk, Pop Rock, Chart Hits, 80s Dance, Nostalgic, Hit Songs"
+  streamUrl: https://0nlineradio.radioho.st/0r-80s?ref=radio-browser26
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/Xxj9zX6w/80s.png
+  homepage: https://plus.rm.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 2f6269a1-dee4-4c13-994a-2b10803d5eec
+  changeuuid: 3699f5ee-e5e7-4c29-9e5b-380c2503f897
+  reviewedAt: "2026-05-04"
+
+- id: de-ballermann-radio-classic
+  broadcaster: independent
+  name: Ballermann Radio Classic
+  streamUrl: https://audio.bmr-radio.de/classics/mp3-192/Webplayer
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.ballermann-radio.de/wp-content/uploads/2024/02/stream-ballermann-radio-classics-750x750.png
+  homepage: https://www.ballermann-radio.de/stream/ballermannradio-classics/
+  country: DE
+  status: stream-only
+  stationuuid: 898eeb38-85e4-48f7-b12b-2838d299c8cb
+  changeuuid: 96a3ad48-0151-4f08-8537-f37f213ef702
+  reviewedAt: "2026-05-04"
+
+- id: de-hr4-sudhessen
+  broadcaster: independent
+  name: hr4 Südhessen
+  streamUrl: https://dispatcher.rndfnk.com/hr/hr4/suedhessen/high
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.hr4.de/favicon.png?v=3.84.2
+  homepage: https://www.hr4.de/
+  country: DE
+  status: stream-only
+  stationuuid: 76a4d33f-cf89-4db5-973f-dce2bcc51276
+  changeuuid: e4c7372d-4d75-44e0-99a5-af4348651854
+  reviewedAt: "2026-05-04"
+
+- id: de-m-era-luna-fm
+  broadcaster: independent
+  name: "M'era Luna FM"
+  streamUrl: https://meralunafm.radionetz.de:8001/meralunafm.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://meraluna.de/en/
+  country: DE
+  status: stream-only
+  stationuuid: af18706b-c64c-4a97-a7ad-1c40d369d7df
+  changeuuid: 50d6d9b9-764c-48a6-9cab-b2e96b927a17
+  reviewedAt: "2026-05-04"
+
+- id: de-ostrock-und-ostpop
+  broadcaster: independent
+  name: Ostrock und Ostpop
+  streamUrl: https://topradio-de-hz-fal-stream07-cluster01.radiohost.de/brf-ostrock-pop_mp3-128
+  bitrate: 128
+  codec: MP3
+  favicon: https://upload.berliner-rundfunk.de/production/static/1713539285366/icons/icon_64.a80y02808w0.png
+  homepage: https://www.berliner-rundfunk.de/musik/streams/ostrock-und-ostpop
+  country: DE
+  status: stream-only
+  stationuuid: 9a1deffa-49a6-4940-b9ef-9385ef9f9500
+  changeuuid: 4c91f920-bb53-45d6-a1f4-45a4cc85a682
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-flora
+  broadcaster: independent
+  name: radio flora
+  streamUrl: https://radioflora.de:8443/stream/live192.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://radioflora.de/wp-content/uploads/2018/07/flora-logo-3.png
+  homepage: https://radioflora.de/
+  country: DE
+  status: stream-only
+  stationuuid: 5c4b6346-6397-4852-bcb4-c3f1be286873
+  changeuuid: f4781320-a709-4204-a412-2a40ae40c21e
+  reviewedAt: "2026-05-04"
+
+- id: de-you-fm
+  broadcaster: independent
+  name: you-fm
+  streamUrl: https://hlsyoufm.akamaized.net/hls/live/2016538/youfm/master.m3u8
+  bitrate: 200
+  codec: AAC
+  favicon: https://www.you-fm.de/favicon.png?v=3.84.2
+  homepage: https://www.you-fm.de/index.html
+  country: DE
+  status: stream-only
+  stationuuid: 0715ba1d-88a0-4e6f-a679-c2fc5da66ed5
+  changeuuid: e6304eac-cf66-4459-ae9c-784452b68837
+  reviewedAt: "2026-05-04"
+
+- id: de-blues-rock-cafe
+  broadcaster: independent
+  name: Blues Rock Cafe
+  streamUrl: https://bluesrockcafe.stream.laut.fm/bluesrockcafe?pl=m3u&t302=2026-01-15_01-42-17&uuid=93a25a07-e5e9-4200-b906-3ba3dac32e96
+  bitrate: 128
+  codec: MP3
+  homepage: https://laut.fm/bluesrockcafe
+  country: DE
+  status: stream-only
+  stationuuid: 8bbc6294-973f-47e5-84b0-7ac9c9f79bb3
+  changeuuid: 4cdcab0d-8917-4ef4-b2f1-bdcc5a83496e
+  reviewedAt: "2026-05-04"
+
+- id: de-ddreins
+  broadcaster: independent
+  name: ddreins
+  streamUrl: https://ddreins.stream.laut.fm/ddr_eins?t302=2021-04-10_23-03-54&uuid=43c8d3cf-54c4-4ee1-b109-b667d8878cc4
+  bitrate: 128
+  codec: MP3
+  favicon: https://duckduckgo.com/?q=ddreins&iax=images&ia=images&iai=https%3A%2F%2Fradio-marabu.de%2Fwordpress%2Fwp-content%2Fuploads%2F2020%2F11%2Fddreins...logo_large-1024x311.png
+  homepage: https://www.ddreins.de/
+  country: DE
+  status: stream-only
+  stationuuid: a052582e-4937-40e9-a08f-0f5eda92d0d2
+  changeuuid: b4899ac2-e74a-4e36-93ee-626a9b63ffc2
+  reviewedAt: "2026-05-04"
+
+- id: de-0nlineradio-deutschrap
+  broadcaster: independent
+  name: 0nlineradio DEUTSCHRAP
+  streamUrl: https://stream.0nlineradio.com/deutschrap?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://0nlineradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 9ddc74b4-00ac-4105-bb5b-4e98c167d3d7
+  changeuuid: 60902070-aa91-43fc-9a4f-1970444f8229
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-psr-80er
+  broadcaster: independent
+  name: RADIO PSR 80er
+  streamUrl: https://streams.radiopsr.de/psr-80er/mp3-192/www.radio-browser.info/play.m3u8
+  bitrate: 192
+  codec: MP3
+  favicon: https://upload.radiopsr.de/production/static/1693298881101/icons/icon_64.cawac0w0200.png
+  homepage: https://www.radiopsr.de/
+  country: DE
+  status: stream-only
+  stationuuid: 1e969d26-c3db-464e-864d-6da02f5d79dc
+  changeuuid: cabfa163-f91b-4d54-bc0c-e84832ca6d1f
+  reviewedAt: "2026-05-04"
+
+- id: de-0r-80s-rock-classic-rock-hard-rock-pop-rock-rock
+  broadcaster: independent
+  name: "0R - 80s ROCK || Classic Rock, Hard Rock, Pop Rock, Rock Hits, Guitar, Ballads, Hair Metal, Rock Anthems, Retro, Vintage, Arena Rock, Party Rock, Rock Classics, Melodic Rock"
+  streamUrl: https://0nlineradio.radioho.st/0r-80s-rock?ref=radio-browser26
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/hFC0q0h8/80s-Rock.png
+  homepage: https://0nlineradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 652a2fa1-d3fe-4724-a3eb-3d6b7fb1e687
+  changeuuid: d3acd9c0-9d6c-4e33-ab31-8c911bb45778
+  reviewedAt: "2026-05-04"
+
+- id: de-ostseewelle-hamburg-schleswig-holstein
+  broadcaster: independent
+  name: "Ostseewelle Hamburg & Schleswig-Holstein"
+  streamUrl: https://addrad.io/4459gsm
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.ostseewelle.de/assets/icons/apple-touch-icon.png
+  homepage: https://www.ostseewelle.de/
+  country: DE
+  status: stream-only
+  stationuuid: 0c892559-5302-4b9f-bdfa-5daabfa3ff77
+  changeuuid: 9b3b9d75-c95e-4e0b-bf6c-a3c51a07451c
+  reviewedAt: "2026-05-04"
+
+- id: de-prysm-radio-nu-disco
+  broadcaster: independent
+  name: Prysm Radio Nu Disco
+  streamUrl: https://streamingv2.shoutcast.com/prysm-nu-disco
+  bitrate: 128
+  codec: MP3
+  favicon: https://secure.gravatar.com/avatar/3d417d46e874e8c99e0283550d4a429e?s=36&#038;d=mm&#038;r=g
+  homepage: https://www.prysmradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 88862e2c-35bf-4161-bd91-e58f35d31dad
+  changeuuid: 22d25e41-24a6-4569-89b8-78fd8314aef5
+  reviewedAt: "2026-05-04"
+
+- id: de-laut-fm-freakquency
+  broadcaster: independent
+  name: "[laut.fm] Freakquency"
+  streamUrl: https://freakquency.stream.laut.fm/freakquency?pl=pls&t302=2026-01-15_07-18-13&uuid=5162a938-aa72-4ea6-9bca-c737541068ff
+  bitrate: 128
+  codec: MP3
+  homepage: https://laut.fm/freakquency
+  country: DE
+  status: stream-only
+  stationuuid: e9b4e2c8-1ff7-4da9-9480-0a88e0991d42
+  changeuuid: 9d33de98-7f36-4087-b1d1-c1f2b8e83d4d
+  reviewedAt: "2026-05-04"
+
+- id: de-0r-deep-house-chillout-ambient-house-chill-loung
+  broadcaster: independent
+  name: "0R - DEEP HOUSE || Chillout, Ambient House, Chill, Lounge, Electronic, Dance, Smooth, Vocal, Club, Night, Party, Groove, Melodic, Summer, Beat"
+  streamUrl: https://0nlineradio.radioho.st/technolovers-deep-house?ref=radio-browser26
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/Y7PzyGxb/Deep-House-TL.png
+  homepage: https://plus.rm.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 8cda8d0d-6166-4881-b9e3-db0994ce23be
+  changeuuid: 917b8d00-49e2-4d4b-a3f2-618d245c8d2a
+  reviewedAt: "2026-05-04"
+
+- id: de-0r-restaurant-lounge-lounge-jazz-chill-soft-musi
+  broadcaster: independent
+  name: "0R - RESTAURANT LOUNGE || Lounge, Jazz, Chill, Soft Music, Background, Acoustic, Easy Listening, Dinner, Relax, Romantic, Smooth, Cafe, Evening, Instrumental, Calm"
+  streamUrl: https://0nlineradio.radioho.st/lounge-restaurant-lounge?ref=radio-browser26
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/xKZ5J8jt/Restaurant-Lounge.png
+  homepage: https://plus.rm.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 1c807b13-e1e3-4425-96bf-00472bf23223
+  changeuuid: eb828d19-8df6-4cf4-8988-997688adf204
+  reviewedAt: "2026-05-04"
+
+- id: de-ffh-itunes-top-40-aac-128-kbps
+  broadcaster: independent
+  name: FFH iTunes Top 40. AAC 128 kbps
+  streamUrl: https://mp3.ffh.de/ffhchannels/hqtop40.aac
+  bitrate: 128
+  codec: AAC+
+  homepage: https://www.ffh.de/
+  country: DE
+  status: stream-only
+  stationuuid: 2f7c09e4-06e0-4ce0-90f6-f44e8fbcc8f0
+  changeuuid: d0647bc3-37ba-42fb-a2c6-434fa1b4f188
+  reviewedAt: "2026-05-04"
+
+- id: de-moviedance
+  broadcaster: independent
+  name: Moviedance
+  streamUrl: https://stream.laut.fm/moviedance
+  bitrate: 128
+  codec: MP3
+  favicon: https://assets.laut.fm/924196b9b3a8abfb760a4d145b12ee06
+  homepage: https://laut.fm/moviedance
+  country: DE
+  status: stream-only
+  stationuuid: 9008a8e4-78a3-4f58-8683-2d1014f70fd5
+  changeuuid: 1cf7a7d9-0ff2-485a-b7d9-c5826ceb8bc3
+  reviewedAt: "2026-05-04"
+
+- id: de-schlagerheilo
+  broadcaster: independent
+  name: Schlagerheilo
+  streamUrl: https://www.tunefm.de:2000/stream/schlagerheilo
+  bitrate: 320
+  codec: MP3
+  favicon: https://www.phonostar.de//images/auto_created/radio_schlagerheilo54x54.png
+  homepage: https://phonostar.de/radio/schlagerheilo
+  country: DE
+  status: stream-only
+  stationuuid: 04d00647-3b18-4d57-a22b-14e378e60761
+  changeuuid: eb9a3cc7-36bf-4f0e-bdd8-5e5951ddb20c
+  reviewedAt: "2026-05-04"
+
+- id: de-swr-2-aac-96k
+  broadcaster: independent
+  name: "SWR 2  [AAC 96k]"
+  streamUrl: https://liveradio.swr.de/sw331ch/swr2/
+  bitrate: 96
+  codec: AAC
+  favicon: https://www.swr.de/assets/swr/swr2/apple-touch-icon-120x120.png
+  homepage: https://www.swr.de/swr2/index.html
+  country: DE
+  status: stream-only
+  stationuuid: f4b3cf99-adf4-4dc8-8d8a-93916bf23460
+  changeuuid: 9561888b-15df-4de7-8f95-3a5954fa432a
+  reviewedAt: "2026-05-04"
+
+- id: de-0r-romantic-piano-piano-romantic-soft-classical-
+  broadcaster: independent
+  name: "0R - ROMANTIC PIANO || Piano, Romantic, Soft, Classical, Ballads, Love, Calm, Relaxing, Slow, Instrumental, Evening, Peaceful, Background, Melodic, Gentle"
+  streamUrl: https://0nlineradio.radioho.st/piano-romantic-piano?ref=radio-browser26
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/1tW9hJhd/Romantic-Piano.png
+  homepage: https://plus.rm.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 43d3984d-fd02-454e-b7a3-4d7ea82cea11
+  changeuuid: 98c86828-3eac-4251-a2da-5ddbf0ed7881
+  reviewedAt: "2026-05-04"
+
+- id: de-iloveradio
+  broadcaster: independent
+  name: ILoveRadio
+  streamUrl: https://play.ilovemusic.de/ilm_iloveradio/
+  bitrate: 192
+  codec: MP3
+  favicon: http://iloveradio.de/favicon.ico
+  homepage: http://iloveradio.de/
+  country: DE
+  status: stream-only
+  stationuuid: 96183602-0601-11e8-ae97-52543be04c81
+  changeuuid: a94908d6-ea03-43e5-8239-cee8e5ad9770
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-legende
+  broadcaster: independent
+  name: Radio Legende
+  streamUrl: https://einfach-webradio.de:10443/radio/8050/radio.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.radio-legende.de/favicon.ico
+  homepage: https://www.radio-legende.de/
+  country: DE
+  status: stream-only
+  stationuuid: a5c3b4fd-5c6f-47b6-a2e6-8cfdc63ce52b
+  changeuuid: aa879288-3428-4146-ac2e-ac703ab02edd
+  reviewedAt: "2026-05-04"
+
+- id: de-wdr-cosmo-italia
+  broadcaster: independent
+  name: WDR COSMO - Italia
+  streamUrl: https://dispatcher.rndfnk.com/wdr/cosmo/italia/mp3/128/stream.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www1.wdr.de/radio/cosmo/resources-v5.128.1/img/favicon/favicon-32x32.png
+  homepage: https://www1.wdr.de/radio/cosmo/channels/italia-channel-100.html
+  country: DE
+  status: stream-only
+  stationuuid: 77520c23-67e1-43f1-a008-b7ae287a30e2
+  changeuuid: 20c51323-7ea3-491e-89a9-4f4427d9dd80
+  reviewedAt: "2026-05-04"
+
+- id: de-laut-fm-lofi
+  broadcaster: independent
+  name: "[laut.fm] lofi"
+  streamUrl: https://stream.laut.fm/lofi
+  bitrate: 128
+  codec: MP3
+  homepage: https://laut.fm/
+  country: DE
+  status: stream-only
+  stationuuid: ef52b56c-6830-4346-b4d3-e42e5ae5d928
+  changeuuid: 148c3ccb-623f-4a5a-ae36-50f6cbf2d2e9
+  reviewedAt: "2026-05-04"
+
+- id: de-0nlineradio-top40
+  broadcaster: independent
+  name: 0nlineradio TOP40
+  streamUrl: https://stream.0nlineradio.com/top40?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://0nlineradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 468fcdc3-cd2a-4e4b-800c-e3d4164514e8
+  changeuuid: c849a2bb-9de2-4b5c-865f-9515d17e6940
+  reviewedAt: "2026-05-04"
+
+- id: de-epic-lounge-gaming-lounge
+  broadcaster: independent
+  name: Epic Lounge - GAMING LOUNGE
+  streamUrl: https://stream.epic-lounge.com/gaming-lounge?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://epic-lounge.com/
+  country: DE
+  status: stream-only
+  stationuuid: 801d9492-418a-42c4-92a6-cb332a0e178e
+  changeuuid: 2c35facb-c80c-437e-a683-7ba8b0225703
+  reviewedAt: "2026-05-04"
+
+- id: de-flashbass-fm
+  broadcaster: independent
+  name: Flashbass.fm
+  streamUrl: https://flashbass-fm.stream.laut.fm/flashbass-fm
+  bitrate: 128
+  codec: MP3
+  favicon: https://flashbass.fm/favicon.ico
+  homepage: https://flashbass.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 2ab50118-6c8a-4576-bc05-bfb74d065031
+  changeuuid: 467d57a8-2895-47c6-a77d-f930c360f082
+  reviewedAt: "2026-05-04"
+
+- id: de-laut-fm-post-rock
+  broadcaster: independent
+  name: Laut.fm Post-Rock
+  streamUrl: https://post-rock.stream.laut.fm/post-rock?pl=m3u&t302=2026-01-14_23-35-11&uuid=93c98b91-e6ff-4ab5-9657-597cdbf44605
+  bitrate: 128
+  codec: MP3
+  homepage: https://laut.fm/post-rock
+  country: DE
+  status: stream-only
+  stationuuid: 61b572b0-b512-4374-b6c5-ed26655a0706
+  changeuuid: 252f6289-eb7d-4e12-9b27-bab57a549848
+  reviewedAt: "2026-05-04"
+
+- id: de-soundsindie
+  broadcaster: independent
+  name: Soundsindie
+  streamUrl: https://soundsindie.stream.laut.fm/soundsindie?t302=2026-01-15_00-39-17&uuid=b964e14b-acde-48cc-9208-0a783f2e7667
+  bitrate: 128
+  codec: MP3
+  homepage: https://stream.laut.fm/soundsindie
+  country: DE
+  status: stream-only
+  stationuuid: 883f9074-fc3b-4dc2-9bc3-66259df8836f
+  changeuuid: 097fff39-0f2b-4789-af6d-0a56f5a4ad9a
+  reviewedAt: "2026-05-04"
+
+- id: de-startrek
+  broadcaster: independent
+  name: startrek
+  streamUrl: https://stream.laut.fm/startrek
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radio.net/s/lautfm-startrek
+  country: DE
+  status: stream-only
+  stationuuid: 3df37179-faed-4476-b803-5b5f110fe61b
+  changeuuid: cd2127c9-8b6a-4909-8276-32f5f82c3f42
+  reviewedAt: "2026-05-04"
+
+- id: de-1-splash-80s
+  broadcaster: independent
+  name: "#1 Splash 80s"
+  streamUrl: https://makri.cdnstream.com/1898_128
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.splashradio.eu/
+  country: DE
+  status: stream-only
+  stationuuid: 7d707724-958f-46c2-8600-afec9568e870
+  changeuuid: 3b314b81-eaca-47af-8f4b-c19098423dad
+  reviewedAt: "2026-05-04"
+
+- id: de-1000-2000er-laut-fm
+  broadcaster: independent
+  name: 1000 2000er - laut.fm
+  streamUrl: https://10002000er.stream.laut.fm/10002000er
+  bitrate: 128
+  codec: MP3
+  homepage: https://laut.fm/10002000er
+  country: DE
+  status: stream-only
+  stationuuid: ad72cd66-cd6a-11e9-8502-52543be04c81
+  changeuuid: b4928921-d31e-422c-8b93-0170ae0cf4da
+  reviewedAt: "2026-05-04"
+
+- id: de-laut-fm-radio-weihnacht
+  broadcaster: independent
+  name: laut.fm Radio-Weihnacht
+  streamUrl: https://radio-weihnacht.stream.laut.fm/radio-weihnacht?t302=2018-12-13_20-18-51&uuid=eb287bfb-fed0-4200-8702-c70ca537756b
+  bitrate: 128
+  codec: MP3
+  homepage: https://laut.fm/radio-weihnacht
+  country: DE
+  status: stream-only
+  stationuuid: b11834ce-ff0d-11e8-a1be-52543be04c81
+  changeuuid: 9aa98b0c-8bf5-42d2-a9a0-dfb59c81132a
+  reviewedAt: "2026-05-04"
+
+- id: de-nordpolradio
+  broadcaster: independent
+  name: Nordpolradio
+  streamUrl: https://stream.laut.fm/nordpolradio
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.nordpolradio.de/
+  country: DE
+  status: stream-only
+  stationuuid: f2a3997b-8901-455f-b003-dce8fba62ab6
+  changeuuid: 15e6dc2c-dd64-4781-bdd8-26212ca65d3f
+  reviewedAt: "2026-05-04"
+
+- id: de-planet-more-music-radio
+  broadcaster: independent
+  name: planet more music radio
+  streamUrl: https://mp3.planetradio.de/planetradio/hqlivestream.aac
+  bitrate: 128
+  codec: AAC+
+  favicon: https://static.planetradio.de/fileadmin/_processed_/7/0/csm_planet_simulcast_1x1_6362baa9c1.jpg
+  homepage: https://www.planetradio.de/musik/webradio/29-planet-radio.html
+  country: DE
+  status: stream-only
+  stationuuid: 3b4df336-a08d-4d5c-a059-51253617db72
+  changeuuid: 62666530-9c18-4785-b089-b30429587087
+  reviewedAt: "2026-05-04"
+
+- id: de-punktum-hd-regionalfernsehen-mansfeld-sudharz
+  broadcaster: independent
+  name: PUNKTum HD - Regionalfernsehen Mansfeld-Südharz
+  streamUrl: https://h056.video-stream-hosting.de/medienasa-live/_definst_/mp4:punktum_high/playlist.m3u8
+  bitrate: 2512
+  codec: AAC
+  homepage: https://www.punktum-fernsehen.de/
+  country: DE
+  status: stream-only
+  stationuuid: 5f0f005d-7bac-4e5b-a08b-dfe1a958fd93
+  changeuuid: 59344c75-774d-43f1-a35c-433f0220f1da
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-schwany-5-oberkrainer-musik
+  broadcaster: independent
+  name: Radio Schwany 5 - Oberkrainer Musik
+  streamUrl: https://schwany.streampanel.cloud/5-oberkrain
+  bitrate: 320
+  codec: MP3
+  favicon: https://static.mytuner.mobi/media/radios-150px/vndDV9QKFr.jpg
+  homepage: https://www.schwany.de/index.html
+  country: DE
+  status: stream-only
+  stationuuid: 540952da-77c9-4d45-9273-fbc52d16afe6
+  changeuuid: 890f74bd-9325-466f-9819-3fd33114f4ed
+  reviewedAt: "2026-05-04"
+
+- id: de-rpi-radio-peissnitz-international-world-music-ra
+  broadcaster: independent
+  name: RPI Radio Peissnitz International – World Music Radio
+  streamUrl: https://rpi-world-music-radio.stream.laut.fm/rpi-world-music-radio
+  bitrate: 128
+  codec: MP3
+  favicon: https://u.jimcdn.com/cms/o/s3920b80322ec5d13/img/favicon.png?t=1438726612
+  homepage: https://www.rpiworld.com/
+  country: DE
+  status: stream-only
+  stationuuid: d58ca7fa-74cc-11ea-b1cf-52543be04c81
+  changeuuid: 4f4ee7e5-321c-4d75-9818-5bd0dd636215
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-8-ansbach-de
+  broadcaster: independent
+  name: Radio 8 - Ansbach DE
+  streamUrl: https://live.radio8.de:8003/liver8
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.radio8.de/storage/thumbs/270x270/f:png/r:1518431307/27773.png
+  homepage: https://www.radio8.de/
+  country: DE
+  status: stream-only
+  stationuuid: 2bb4e180-e23d-43fc-a8a1-ffb0a21ea799
+  changeuuid: cc76985f-c3b9-4dcf-b5af-6028625378c0
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-fips-89-0-fm
+  broadcaster: independent
+  name: Radio Fips 89.0 FM
+  streamUrl: https://streams.radiofips.de/fipsmp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.radiofips.de/wp-content/uploads/2019/01/cropped-radiofips-f-transparent-8-180x180.png
+  homepage: https://www.radiofips.de/
+  country: DE
+  status: stream-only
+  stationuuid: 5a792307-6cad-4d44-9ff1-1ff12c5cce09
+  changeuuid: 9d2ab0ae-8ce1-486b-835d-95aa41ffd822
+  reviewedAt: "2026-05-04"
+
+- id: de-techno
+  broadcaster: independent
+  name: TECHNO
+  streamUrl: https://stream.laut.fm/techno
+  bitrate: 128
+  codec: MP3
+  favicon: https://assets.laut.fm/e837bb137d5e31a048d55632f3f84394?t=_120x120
+  homepage: https://laut.fm/techno
+  country: DE
+  status: stream-only
+  stationuuid: db581a1b-127b-4e3b-949e-fbb01ae14efb
+  changeuuid: 10faadb6-d89a-465e-a997-65a2c7337c45
+  reviewedAt: "2026-05-04"
+
+- id: de-wdr-3-klassik
+  broadcaster: independent
+  name: WDR 3 Klassik
+  streamUrl: https://wdr-wdr3-klassik.icecast.wdr.de/wdr/wdr3/klassik/mp3/128/stream.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www1.wdr.de/resources/img/wdr/logo/epgmodule/wdr3_logo.svg
+  homepage: https://www1.wdr.de/radio/player/radioplayer106~_layout-popupVersion.html
+  country: DE
+  status: stream-only
+  stationuuid: 828d9a66-2923-45cb-9f5e-138aee96d60a
+  changeuuid: 47b3e31c-873e-458b-9e89-3dd95af6b579
+  reviewedAt: "2026-05-04"
+
+- id: de-wdr-cosmo-dem-power
+  broadcaster: independent
+  name: "WDR COSMO dem:power"
+  streamUrl: https://f111.rndfnk.com/ard/wdr/cosmo/trap/mp3/128/stream.mp3?sid=250K8iAHEo0RuhvRIk3RiKsyUlJ&token=Vrq7nq_P_2K14sZf6TFoipEdEtiCqH2SZUkgrdpfywg&tvf=f7SxSsAT0xZmMTExLnJuZGZuay5jb20
+  bitrate: 128
+  codec: MP3
+  favicon: https://www1.wdr.de/radio/cosmo/resources-v5.142.2/img/favicon/apple-touch-icon.png
+  homepage: https://www1.wdr.de/radio/cosmo/channels/fempower-channel-100.html
+  country: DE
+  status: stream-only
+  stationuuid: e7db47c7-1901-48ec-90d8-d8ba67b9c49d
+  changeuuid: 6d9e926e-fc47-4ca4-ad5a-0368ad0818fa
+  reviewedAt: "2026-05-04"
+
+- id: de-wohltat-radio
+  broadcaster: independent
+  name: Wohltat Radio
+  streamUrl: https://soundvis.eu/stream/wohltat
+  bitrate: 128
+  codec: AAC
+  favicon: https://radio.wir-schaffen.de/wp-content/uploads/2023/11/cropped-wohltatradio.png
+  homepage: https://radio.wir-schaffen.de/
+  country: DE
+  status: stream-only
+  stationuuid: 9a28e188-0f58-4e2c-aa59-cd908844a51d
+  changeuuid: 6282af27-f2d4-4b98-853a-a8c71dd852d2
+  reviewedAt: "2026-05-04"
+
+- id: de-1-a-pop-von-1a-radio
+  broadcaster: independent
+  name: "- 1 A - Pop von 1A Radio"
+  streamUrl: https://1a-pop.radionetz.de/1a-pop.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.1aradio.com/logos/1a-pop_600x600.jpg
+  homepage: http://www.1aradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: a94d996a-33c7-49b2-ac19-f475f8cdc75d
+  changeuuid: 8db82500-3907-42d6-8394-7a5df79fce88
+  reviewedAt: "2026-05-04"
+
+- id: de-1st-house
+  broadcaster: independent
+  name: 1st-House
+  streamUrl: https://stream.laut.fm/1st-house
+  bitrate: 128
+  codec: MP3
+  homepage: https://laut.fm/1st-house
+  country: DE
+  status: stream-only
+  stationuuid: 0f894e67-7d53-4d60-9aa8-f3b6e208bf1b
+  changeuuid: a4e85e1c-d932-4234-8bbd-ce6ff4ee39bc
+  reviewedAt: "2026-05-04"
+
+- id: de-club-radio
+  broadcaster: independent
+  name: club radio
+  streamUrl: https://icecast.multhielemedia.de/radio/8010/clubradio.mp3
+  bitrate: 160
+  codec: MP3
+  homepage: https://www.club.radio/
+  country: DE
+  status: stream-only
+  stationuuid: e80012c8-e2a1-423f-8c98-29354fa738b1
+  changeuuid: d985c44c-9a59-48e2-841c-2f90e4f511d3
+  reviewedAt: "2026-05-04"
+
+- id: de-fu-ball-bundesliga-2-spiel-1
+  broadcaster: independent
+  name: "Fußball-Bundesliga 2: Spiel 1"
+  streamUrl: https://wdr-sportschau-liga2spiel1.icecastssl.wdr.de/wdr/sportschau/liga2spiel1/mp3/high
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.sportschau.de/resources/assets/image/favicon/apple-icon-120x120.png
+  homepage: https://livecenter.sportschau.de/
+  country: DE
+  status: stream-only
+  stationuuid: 41af93c0-e948-4e82-a1b9-d6d9cbf99419
+  changeuuid: b743aba4-886a-4c9a-a843-5e05d7b49fe1
+  reviewedAt: "2026-05-04"
+
+- id: de-kika-hd-kinderkanal-von-ard-und-zdf
+  broadcaster: independent
+  name: KiKA HD - Kinderkanal von ARD und ZDF
+  streamUrl: https://kikageohls.akamaized.net/hls/live/2022693/livetvkika_de/master.m3u8
+  bitrate: 1672
+  codec: AAC
+  homepage: https://www.kika.de/
+  country: DE
+  status: stream-only
+  stationuuid: a6d8ac49-3dbc-4de1-92da-2ec6affc1d35
+  changeuuid: 503b511b-c0a5-4b59-8ae7-d9457f4b4fae
+  reviewedAt: "2026-05-04"
+
+- id: de-musical-radio
+  broadcaster: independent
+  name: Musical Radio
+  streamUrl: https://radiostreamserver.de/musicalradio.mp3
+  bitrate: 320
+  codec: MP3
+  favicon: https://musicalradio.de/images/seitenelemente/favicon180.png
+  homepage: https://musicalradio.de/index.php
+  country: DE
+  status: stream-only
+  stationuuid: c3d8394a-6647-46e9-ac6e-96394ed154d8
+  changeuuid: 2f185635-bd5a-44c5-8a4e-985684286435
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-galaxy-ingolstadt
+  broadcaster: independent
+  name: Radio Galaxy Ingolstadt
+  streamUrl: https://funkhaus-ingolstadt.stream24.net/galaxy-ingolstadt.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.galaxy-ingolstadt.de/storage/thumbs/192x192/r:1670490964/463.png
+  homepage: https://www.galaxy-ingolstadt.de/
+  country: DE
+  status: stream-only
+  stationuuid: eefd6429-c022-4415-b631-58f914f36110
+  changeuuid: 549611d0-db8a-4b0c-9a28-13c84e1aaa79
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-waf
+  broadcaster: independent
+  name: Radio WAF
+  streamUrl: https://radiowaf--di--nacs-ais-lgc--05--cdn.cast.addradio.de/radiowaf/live/mp3/high
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radiowaf.de/home.html
+  country: DE
+  status: stream-only
+  stationuuid: dcf7a801-10b3-4b03-8ee1-e81743f73e6a
+  changeuuid: 966ac448-186d-4723-95d7-8ec6c49606e6
+  reviewedAt: "2026-05-04"
+
+- id: de-radiomonster-fm-2000s
+  broadcaster: independent
+  name: Radiomonster.FM - 2000s
+  streamUrl: https://ic.radiomonster.fm/2000s.ultra
+  bitrate: 320
+  codec: MP3
+  favicon: https://www.radiomonster.fm/wp-content/uploads/2020/06/cropped-radiomonster_logo_compact_transparent_2000px-180x180.png
+  homepage: http://www.radiomonster.fm/
+  country: DE
+  status: stream-only
+  stationuuid: d58c61eb-f28c-461e-aab1-ae75681512e2
+  changeuuid: a4a2dc64-c2ef-46a8-acae-466569ac5b50
+  reviewedAt: "2026-05-04"
+
+- id: de-0r-bach-classical-classical-baroque-orchestra-pi
+  broadcaster: independent
+  name: "0R - BACH - CLASSICAL || Classical, Baroque, Orchestra, Piano, Strings, Chamber Music, Solo Instrument, Sacred, Symphonies, Concertos, Melodic, Calm, Relaxing, Instrumental, Elegant"
+  streamUrl: https://0nlineradio.radioho.st/0r-bach?ref=radio-browser26
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/FbmVd1LG/Bach-KL.png
+  homepage: https://plus.rm.fm/
+  country: DE
+  status: stream-only
+  stationuuid: dd514cb7-fca6-427a-add8-bcf5892b6c3d
+  changeuuid: 5f55c980-48fc-4a01-8215-64f074ba3fe2
+  reviewedAt: "2026-05-04"
+
+- id: de-0r-mozart-classical-orchestra-piano-strings-cham
+  broadcaster: independent
+  name: "0R - MOZART - CLASSICAL || Orchestra, Piano, Strings, Chamber, Symphony, Solo Instrument, Elegant, Melodic, Calm, Relaxing, Timeless, Instrumental, Soft, Meditative"
+  streamUrl: https://0nlineradio.radioho.st/0r-mozart?ref=radio-browser26
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/Z67qTCXr/Mozart-KL.png
+  homepage: https://plus.rm.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 8e0f1ea7-495d-495e-9f49-1a320e2bc5d1
+  changeuuid: 8694996a-6da4-42d0-ae29-460408c3676f
+  reviewedAt: "2026-05-04"
+
+- id: de-ella-radio-coffee-jazz
+  broadcaster: independent
+  name: Ella Radio - Coffee Jazz
+  streamUrl: https://stream.ella-radio.de/ella-coffee-jazz/mp3-192/?ref=radio-browser
+  bitrate: 192
+  codec: MP3
+  favicon: https://ella-radio.de/uplink/Ella_Coffee-Jazz.jpg
+  homepage: https://www.ella-radio.de/
+  country: DE
+  status: stream-only
+  stationuuid: 62227b60-4bac-4f52-9d71-2e78844a0294
+  changeuuid: 930ba767-a082-4f85-b85c-499de42e63e3
+  reviewedAt: "2026-05-04"
+
+- id: de-m1-fm-90s
+  broadcaster: independent
+  name: M1.FM 90s
+  streamUrl: https://tuner.m1.fm/90er.aac
+  bitrate: 48
+  codec: AAC+
+  favicon: http://m1.fm/favicon.ico
+  homepage: http://m1.fm/90er.php
+  country: DE
+  status: stream-only
+  stationuuid: cd49f500-187b-4487-861a-32de5d592a46
+  changeuuid: 577c0ea6-f421-4308-8508-db19a9506ca3
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-aktiv-hameln
+  broadcaster: independent
+  name: radio aktiv Hameln
+  streamUrl: https://live.radio-aktiv.de/r-aktiv.mp3
+  bitrate: 256
+  codec: MP3
+  homepage: https://www.radio-aktiv.de/
+  country: DE
+  status: stream-only
+  stationuuid: 5efabc5c-79fa-4837-9abb-b2959ed582b9
+  changeuuid: bcb49799-168a-4d1a-aac3-87cff3bea98e
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-cafe-zimmermann-aac-48
+  broadcaster: independent
+  name: Radio Cafe Zimmermann (AAC 48)
+  streamUrl: https://stream.radio-cafezimmermann.de/klassik/aac-48/
+  bitrate: 48
+  codec: AAC+
+  favicon: https://www.phonostar.de/images/auto_created/Radio_Cafe_Zimmermann184x184.png
+  homepage: http://www.radio-cafezimmermann.de/
+  country: DE
+  status: stream-only
+  stationuuid: 4c9fe040-ea2b-44c0-88ab-775b675df485
+  changeuuid: d6b95974-923f-4ff9-aa33-3f61f17bc5f4
+  reviewedAt: "2026-05-04"
+
+- id: de-saarmaxxi-vinyls
+  broadcaster: independent
+  name: SaarMaxxi Vinyls
+  streamUrl: https://maxxi-fm.stream.laut.fm/maxxi-fm?t302=2025-03-03_21-07-02&uuid=11487338-935e-4c70-9579-e3772de51ac2
+  bitrate: 128
+  codec: MP3
+  homepage: http://www.saarlandsender.de/Startseite/
+  country: DE
+  status: stream-only
+  stationuuid: 10dc8cea-0481-43da-b985-24211512df14
+  changeuuid: 7811f4cd-1c8b-4498-be3d-f86f84175ddf
+  reviewedAt: "2026-05-04"
+
+- id: de-technothorium
+  broadcaster: independent
+  name: TECHNOTHORIUM
+  streamUrl: https://stream.laut.fm/technothorium
+  bitrate: 128
+  codec: MP3
+  favicon: https://assets.laut.fm/9658828545e209b495a0f7594937e470?t=_120x120
+  homepage: https://laut.fm/technothorium
+  country: DE
+  status: stream-only
+  stationuuid: 83ff5a8e-8fd4-4b66-9e8e-9b4cfdee54a9
+  changeuuid: 886b030a-bcf5-4fae-875a-a1fd06871c02
+  reviewedAt: "2026-05-04"
+
+- id: de-shredded-by-rautemusik-rm-fm
+  broadcaster: independent
+  name: __SHREDDED__ by RauteMusik (rm.fm)
+  streamUrl: https://streams.rautemusik.fm/shredded/mp3-192/stream.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.rm.fm/shredded/
+  country: DE
+  status: stream-only
+  stationuuid: 2ce54668-bb2c-4361-ab49-c54a6672d30e
+  changeuuid: 25367034-93a0-48cc-a22b-56d048b2434c
+  reviewedAt: "2026-05-04"
+
+- id: de-dwg-lyra
+  broadcaster: independent
+  name: DWG Lyra
+  streamUrl: https://server34599.streamplus.de/stream.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://radio.dwgradio.net/de/radio-pur-lyra/
+  country: DE
+  status: stream-only
+  stationuuid: f58e0576-d502-403c-93c3-5fc2225b58ec
+  changeuuid: 6a29e040-8ae9-4a88-8f61-419c222d7066
+  reviewedAt: "2026-05-04"
+
+- id: de-music-fm
+  broadcaster: independent
+  name: MUSIC FM
+  streamUrl: https://music-fm.stream.laut.fm/music-fm-
+  bitrate: 128
+  codec: MP3
+  favicon: https://music-fm.de/wp-content/uploads/2024/10/cropped-mfm_web_icon-180x180.png
+  homepage: https://music-fm.de/
+  country: DE
+  status: stream-only
+  stationuuid: e8e9db52-4018-4d94-a5cc-5bacdb402fbe
+  changeuuid: 6e305897-6fc5-495c-93e1-b1c6a2a55a40
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-italo-germanysaar
+  broadcaster: independent
+  name: Radio Italo GermanySaar
+  streamUrl: https://radio-italo.stream.laut.fm/radio-italo?t302=2025-03-03_21-43-43&uuid=27547de2-b116-4ee7-ad1b-44b79baac89d
+  bitrate: 128
+  codec: MP3
+  homepage: http://www.saarlandsender.de/Startseite/
+  country: DE
+  status: stream-only
+  stationuuid: a5d697b4-1ff3-4c67-b52f-9c2b4f1cb250
+  changeuuid: eb3175fd-e1b0-4bce-ad6b-a4f4244ad443
+  reviewedAt: "2026-05-04"
+
+- id: de-blk-tv-hd-regionalfernsehen-burgenlandkreis
+  broadcaster: independent
+  name: BLK TV HD - Regionalfernsehen Burgenlandkreis
+  streamUrl: https://h056.video-stream-hosting.de/medienasa-live/_definst_/mp4:BLKonline_high/playlist.m3u8
+  bitrate: 2447
+  codec: AAC
+  homepage: https://www.blkregional.de/
+  country: DE
+  status: stream-only
+  stationuuid: 45dcd1fa-dd58-4078-83fa-5801be04b39d
+  changeuuid: 90b955e6-eabe-41ab-8664-52522c2889db
+  reviewedAt: "2026-05-04"
+
+- id: de-castlefm
+  broadcaster: independent
+  name: CastleFM
+  streamUrl: https://stream.laut.fm/castlefm
+  bitrate: 128
+  codec: MP3
+  homepage: https://castlefm.de/
+  country: DE
+  status: stream-only
+  stationuuid: f1502385-312b-41c0-bfda-abe97732518a
+  changeuuid: 990372b4-5ff4-47c7-8a9e-f5805edc4cf9
+  reviewedAt: "2026-05-04"
+
+- id: de-hr1-nordhessen
+  broadcaster: independent
+  name: hr1 Nordhessen
+  streamUrl: https://dispatcher.rndfnk.com/hr/hr1/nordhessen/high
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.hr1.de/favicon.png?v=3.84.2
+  homepage: https://www.hr1.de/
+  country: DE
+  status: stream-only
+  stationuuid: 4d35d32a-90bf-42cb-b29b-8bd2b3662ef7
+  changeuuid: e43cb076-193f-46b3-94df-d594abe46bc4
+  reviewedAt: "2026-05-04"
+
+- id: de-reyfm-summer
+  broadcaster: independent
+  name: "REYFM - #Summer"
+  streamUrl: https://listen.reyfm.de/reyfm-summer/
+  bitrate: 320
+  codec: MP3
+  favicon: https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png
+  homepage: https://rey.fm/
+  country: DE
+  status: stream-only
+  stationuuid: e3f98b65-7657-42e1-b284-d8b25077ba8b
+  changeuuid: e48ee870-3e90-43e0-93ac-ded208795b7e
+  reviewedAt: "2026-05-04"
+
+- id: de-rock-antenne-party-rock
+  broadcaster: independent
+  name: Rock Antenne - Party Rock
+  streamUrl: https://stream.rockantenne.de/rock-antenne-party-rock/stream/mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png
+  homepage: https://www.rockantenne.de/rockhoeren/streams/party-rock
+  country: DE
+  status: stream-only
+  stationuuid: 31c35ae6-9da2-493f-a61c-cd45107244ba
+  changeuuid: c68e0b01-9f9a-4cdf-81c5-56c2fb8c0e20
+  reviewedAt: "2026-05-04"
+
+- id: de-burnfm-musik-intensiv
+  broadcaster: independent
+  name: "BurnFM - musik intensiv!"
+  streamUrl: https://burnfm.radionetz.de/burn-fm.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.1aradio.com/logos/burnfm.jpg
+  homepage: http://www.burn-fm.de/
+  country: DE
+  status: stream-only
+  stationuuid: 9a2fc4f3-f41c-11e9-a96c-52543be04c81
+  changeuuid: e036da8a-f013-4cda-9ad4-324a3bb60618
+  reviewedAt: "2026-05-04"
+
+- id: de-hertz-87-9-campusradio-fur-bielefeld-mp3-hq
+  broadcaster: independent
+  name: "Hertz 87.9 - Campusradio für Bielefeld | MP3 HQ"
+  streamUrl: https://stream.radiohertz.de/hertz-hq.mp3
+  codec: MP3
+  favicon: https://www.hertz879.de/wp-content/themes/wp-hertz/assets/img/favicon.ico
+  homepage: https://www.hertz879.de/
+  country: DE
+  status: stream-only
+  stationuuid: 0e30b79d-3977-4bb0-9e83-a1914cd757d0
+  changeuuid: a1e022fa-1f35-41ce-b426-fb8fe49285cd
+  reviewedAt: "2026-05-04"
+
+- id: de-laut-fm-punk-and-disorderly-the-80s
+  broadcaster: independent
+  name: Laut.FM - Punk and Disorderly The 80s
+  streamUrl: https://stream.laut.fm/punkanddisorderly-the80s
+  bitrate: 128
+  codec: MP3
+  homepage: https://laut.fm/punkanddisorderly-the80s
+  country: DE
+  status: stream-only
+  stationuuid: eb3041cd-69bc-41bd-b1e0-daf2a88fe190
+  changeuuid: 8cf81992-4577-4788-89df-5848f1c48ede
+  reviewedAt: "2026-05-04"
+
+- id: de-laut-fm-elektroradio
+  broadcaster: independent
+  name: "Laut.fm | Elektroradio"
+  streamUrl: https://stream.laut.fm/elektroradio
+  bitrate: 128
+  codec: MP3
+  favicon: https://assets.laut.fm/e837bb137d5e31a048d55632f3f84394?t=_120x120
+  homepage: https://laut.fm/elektroradio
+  country: DE
+  status: stream-only
+  stationuuid: b04387a2-ae49-447c-bd87-0b2971578043
+  changeuuid: abea00ef-6d38-4071-b8c9-a052a2769a39
+  reviewedAt: "2026-05-04"
+
+- id: de-britpop-laut-fm
+  broadcaster: independent
+  name: Britpop (Laut.FM)
+  streamUrl: https://stream.laut.fm/britpop
+  bitrate: 128
+  codec: MP3
+  homepage: https://laut.fm/britpop
+  country: DE
+  status: stream-only
+  stationuuid: 3ed63b06-0ffc-4759-b3a1-1ea7abd4d9f2
+  changeuuid: 7ceddf85-9b41-4f54-b4f8-cad11958d519
+  reviewedAt: "2026-05-04"
+
+- id: de-ella-radio-smooth-bossa-nova
+  broadcaster: independent
+  name: Ella Radio - Smooth Bossa Nova
+  streamUrl: https://stream.ella-radio.de/ella-smooth-bossa-nova/mp3-192/?ref=radio-browser
+  bitrate: 192
+  codec: MP3
+  favicon: https://ella-radio.de/uplink/Ella_Smooth-Bossa-Nova.jpg
+  homepage: https://www.ella-radio.de/
+  country: DE
+  status: stream-only
+  stationuuid: 32fed2d8-f1b5-42b4-a560-6e746c699b11
+  changeuuid: dc55ad14-5eef-4971-89d6-a323cda2c8be
+  reviewedAt: "2026-05-04"
+
+- id: de-gohappy-laut-fm
+  broadcaster: independent
+  name: Gohappy-Laut FM
+  streamUrl: https://gohappy-fm.stream.laut.fm/gohappy-fm?t302=2026-01-15_08-02-25&uuid=6a77bf8e-869c-4448-962c-2271e90ce762
+  bitrate: 128
+  codec: MP3
+  homepage: https://laut.fm/gohappy-fm
+  country: DE
+  status: stream-only
+  stationuuid: 03820286-7eda-4807-8f0f-b022b1f4e7c2
+  changeuuid: 25d8d04c-3036-4972-a135-1fae19553c28
+  reviewedAt: "2026-05-04"
+
+- id: de-kulturalkanal-laut-fm
+  broadcaster: independent
+  name: Kulturalkanal-Laut.fm
+  streamUrl: https://kulturkanal.stream.laut.fm/kulturkanal?t302=2026-01-15_05-22-09&uuid=89312619-bb03-4568-b161-630a21ee3098
+  bitrate: 128
+  codec: MP3
+  favicon: https://laut.fm/assets/touch-icons/apple-touch-icon.png
+  homepage: https://laut.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 9c0feecc-aec3-4ce8-8265-c8b3ee4fac8f
+  changeuuid: 6e59995c-8d27-48cc-a973-fc7020c5ce00
+  reviewedAt: "2026-05-04"
+
+- id: de-0r-spa-lounge-relax-spa-calm-meditation-nature-a
+  broadcaster: independent
+  name: "0R - SPA LOUNGE || Relax, Spa, Calm, Meditation, Nature, Ambient, Soft, Yoga, Peaceful, Instrumental, Chill, Wellness, Background, Gentle, Healing"
+  streamUrl: https://0nlineradio.radioho.st/lounge-spa-lounge?ref=radio-browser26
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/nMy1KKtY/SPA-LOUNGE.png
+  homepage: https://plus.rm.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 03f081d4-4b70-46b2-b353-b47b502495b2
+  changeuuid: f32482a6-71bb-4e42-9049-08f7588c0c3a
+  reviewedAt: "2026-05-04"
+
+- id: de-dnbradio
+  broadcaster: independent
+  name: DNBRadio
+  streamUrl: https://azura.drmnbss.org:8000/radio.mp3
+  bitrate: 320
+  codec: MP3
+  favicon: https://azura.drmnbss.org/static/uploads/dnbradio/album_art.1720523017.png
+  homepage: https://dnbradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 0a895c8d-4b0d-4b64-a06c-005bb5f4fde0
+  changeuuid: e697a09b-c20f-4882-af21-f8c7931ae41f
+  reviewedAt: "2026-05-04"
+
+- id: de-rock-antenne-bayern
+  broadcaster: independent
+  name: Rock Antenne Bayern
+  streamUrl: https://stream.rockantenne.bayern/rockantenne-bayern/stream/mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.rockantenne.bayern/logos/station-rock-antenne-bayern/station.svg
+  homepage: https://www.rockantenne.bayern/
+  country: DE
+  status: stream-only
+  stationuuid: f8b20bea-61d6-4c96-bf9d-d6287a5ec69b
+  changeuuid: 9ddc3485-d878-42fb-ba3a-f08fcc47db14
+  reviewedAt: "2026-05-04"
+
+- id: de-schwany-6-mundart
+  broadcaster: independent
+  name: Schwany 6 Mundart
+  streamUrl: https://oldie.spcast.eu:443/stream?time=1768443493
+  bitrate: 320
+  codec: MP3
+  favicon: http://schwany.de/favicon.ico
+  homepage: http://schwany.de/
+  country: DE
+  status: stream-only
+  stationuuid: c91cb2a4-866a-434e-b05a-deb49b9635cf
+  changeuuid: 2a150205-c2ad-4199-a11d-40399df01b9d
+  reviewedAt: "2026-05-04"
+
+- id: de-antenne-bayern-80-er-party
+  broadcaster: independent
+  name: Antenne Bayern 80-er party
+  streamUrl: https://stream.antenne.de/antenne-bayern-80er-party/stream/aacp
+  codec: AAC
+  favicon: https://www.antenne.de/webradio/80er-party
+  country: DE
+  status: stream-only
+  stationuuid: 0d417b4a-ac1e-40e3-afc3-1a33277cf9d2
+  changeuuid: d5f45442-7c68-440b-ac2d-b79b425172c5
+  reviewedAt: "2026-05-04"
+
+- id: de-bremen-zwei-sounds
+  broadcaster: independent
+  name: Bremen Zwei Sounds
+  streamUrl: https://icecast.radiobremen.de/rb/webchannel7/mp3/128/stream.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.bremenzwei.de/static/img/favicons/favicon-32.png?v=4
+  homepage: https://www.bremenzwei.de/
+  country: DE
+  status: stream-only
+  stationuuid: f48ccd2e-2d3a-4412-a8f3-9312d851fac6
+  changeuuid: 758cac42-4dd3-4696-9e93-9b8e82c880c1
+  reviewedAt: "2026-05-04"
+
+- id: de-fu-ball-bundesliga-spiel-4
+  broadcaster: independent
+  name: "Fußball-Bundesliga: Spiel 4"
+  streamUrl: https://wdr-sportschau-liga1spiel4.icecastssl.wdr.de/wdr/sportschau/liga1spiel4/mp3/high
+  bitrate: 128
+  codec: MP3
+  favicon: https://www1.wdr.de/sport/fussball/logo-dfl-fussball-bundesliga-zweitausendachtzehn-100~_v-ARDKleinerTeaser.jpg
+  homepage: https://livecenter.sportschau.de/
+  country: DE
+  status: stream-only
+  stationuuid: 5e9bdf98-972f-4cc5-a205-20467e971778
+  changeuuid: feb5f53c-4dcb-4d32-ab2e-afdd591c49ac
+  reviewedAt: "2026-05-04"
+
+- id: de-mdf1-hd-regionalfernsehen-magdeburg
+  broadcaster: independent
+  name: MDF1 HD - Regionalfernsehen Magdeburg
+  streamUrl: https://h056.video-stream-hosting.de/medienasa-live/_definst_/mp4:mdf1_high/playlist.m3u8
+  bitrate: 2468
+  codec: AAC
+  homepage: http://www.mdf1.de/
+  country: DE
+  status: stream-only
+  stationuuid: 7118260e-fde6-4288-97e4-7f714ff5a86b
+  changeuuid: 5504a6bf-dd61-4d7f-a9da-fb362738e6d3
+  reviewedAt: "2026-05-04"
+
+- id: de-ohrfunk-de
+  broadcaster: independent
+  name: Ohrfunk.de
+  streamUrl: https://icecast.multhielemedia.de/radio/8000/ohrfunk
+  bitrate: 192
+  codec: MP3
+  homepage: https://ohrfunk.de/
+  country: DE
+  status: stream-only
+  stationuuid: eca834ef-b983-496d-bc74-760b8c6fb26f
+  changeuuid: 5069954e-b8bb-44b1-9a8d-109cf534acf2
+  reviewedAt: "2026-05-04"
+
+- id: de-wdr-cosmo-concerts
+  broadcaster: independent
+  name: WDR Cosmo - Concerts
+  streamUrl: https://wdr-cosmo-coslive.icecastssl.wdr.de/wdr/cosmo/coslive/mp3/128/stream.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www1.wdr.de/radio/cosmo/resources-v5.128.1/img/favicon/favicon-32x32.png
+  homepage: https://www1.wdr.de/radio/cosmo/programm/sendungen/live/cosmo-konzerte-120.html
+  country: DE
+  status: stream-only
+  stationuuid: bbfa598e-e382-46db-8c38-70b8138eab03
+  changeuuid: 19c9cc05-a597-4e81-b6af-4391401a7954
+  reviewedAt: "2026-05-04"
+
+- id: de-egornb-hq
+  broadcaster: independent
+  name: "egoRNB [HQ]"
+  streamUrl: https://cast.egofm.de/egofmrnb.mp3?ar-distributor=ffa0&aw_0_req.gdpr=true
+  bitrate: 128
+  codec: MP3
+  favicon: https://streams.egofm.de/img/alexa/egoFM%20RNB-256x256.png
+  homepage: https://www.egofm.de/streams/egofmrnb
+  country: DE
+  status: stream-only
+  stationuuid: c509f463-0b09-4b39-9ecc-96b6a77e3a71
+  changeuuid: 96a0ea8c-ed9a-4db5-afb1-a44e2ba83ed8
+  reviewedAt: "2026-05-04"
+
+- id: de-hr1-sudhessen
+  broadcaster: independent
+  name: hr1 Südhessen
+  streamUrl: https://dispatcher.rndfnk.com/hr/hr1/suedhessen/high
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.hr1.de/favicon.png?v=3.84.2
+  homepage: https://www.hr1.de/
+  country: DE
+  status: stream-only
+  stationuuid: aa4ff657-8c47-4c45-aa8e-f6ece6d4001c
+  changeuuid: 48bca56b-4d58-42c6-9200-ade29468dd5e
+  reviewedAt: "2026-05-04"
+
+- id: de-mabu-beatz-radio-minimal
+  broadcaster: independent
+  name: MABU Beatz Radio - Minimal
+  streamUrl: https://audio.mabu-beatz-radio.com:8003/minimal
+  bitrate: 128
+  codec: MP3
+  favicon: https://i.postimg.cc/vHDM8brn/OIP.jpg
+  homepage: https://mabu-beatz-radio.com/streams/minimal/
+  country: DE
+  status: stream-only
+  stationuuid: 99349530-87ed-48a0-9c92-5ce42ccff0de
+  changeuuid: e6891cd0-93e0-44f5-9862-367dddc9df8a
+  reviewedAt: "2026-05-04"
+
+- id: de-nightride-fm-rektory
+  broadcaster: independent
+  name: Nightride FM - Rektory
+  streamUrl: https://stream.nightride.fm/rektory.mp3
+  bitrate: 320
+  codec: MP3
+  homepage: https://stream.nightride.fm/rektory.mp3
+  country: DE
+  status: stream-only
+  stationuuid: 2c4a0985-1355-4fcc-a9fc-ca38661008c7
+  changeuuid: 479b3379-c1b9-4a61-955d-7a31388f0d21
+  reviewedAt: "2026-05-04"
+
+- id: de-onkelz-radio
+  broadcaster: independent
+  name: Onkelz Radio
+  streamUrl: https://stream.laut.fm/b_o
+  bitrate: 128
+  codec: MP3
+  favicon: null
+  homepage: https://laut.fm/
+  country: DE
+  status: stream-only
+  stationuuid: b5c95537-c0bc-45cc-b1f2-132aa43916d0
+  changeuuid: 38561ed7-d599-46e3-8b53-3b18cee15d3a
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-ginseng
+  broadcaster: independent
+  name: Radio Ginseng
+  streamUrl: https://stream1.datenkollektiv.net/ginseng.mp3?_=1
+  bitrate: 256
+  codec: MP3
+  favicon: https://radioginseng.de/favicon.ico
+  homepage: https://radioginseng.de/
+  country: DE
+  status: stream-only
+  stationuuid: b5ab2fa7-fb13-48cb-a6ba-0d27a3a5b149
+  changeuuid: fa0c1682-527a-412d-b9b0-07119233a042
+  reviewedAt: "2026-05-04"
+
+- id: de-reyfm-xmas
+  broadcaster: independent
+  name: "REYFM - #xmas"
+  streamUrl: https://listen.reyfm.de/xmas_320kbps.mp3
+  bitrate: 320
+  codec: MP3
+  favicon: https://www.reyfm.de/_nuxt/icons/icon_64x64.88ab9f.png
+  homepage: https://www.reyfm.de/
+  country: DE
+  status: stream-only
+  stationuuid: 5246aa1b-5760-4bdd-b1fc-a857c3332837
+  changeuuid: 771f81e8-33ad-4305-9810-92e6864f9f9b
+  reviewedAt: "2026-05-04"
+
+- id: de-suedstadt-techno
+  broadcaster: independent
+  name: SUEDSTADT TECHNO
+  streamUrl: https://stream.laut.fm/suedstadt-techno
+  bitrate: 128
+  codec: MP3
+  favicon: https://assets.laut.fm/bd951c3cd672db98f8c3240bd4b8a8b9?t=_120x120
+  homepage: https://laut.fm/suedstadt-techno
+  country: DE
+  status: stream-only
+  stationuuid: 301bcba8-fcdf-404a-9af0-d6465c178fc2
+  changeuuid: beccd3bb-3577-494b-9185-e19278f67d9a
+  reviewedAt: "2026-05-04"
+
+- id: de-0nlineradio-queer
+  broadcaster: independent
+  name: 0nlineradio QUEER
+  streamUrl: https://stream.0nlineradio.com/queer?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://0nlineradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 13c6bdb4-3476-494c-91a2-877d70b5d3d2
+  changeuuid: 1ae12853-db7f-48f5-966a-250b584e87a6
+  reviewedAt: "2026-05-04"
+
+- id: de-christmas-radio
+  broadcaster: independent
+  name: Christmas Radio
+  streamUrl: https://lebkuchen-radio.stream.laut.fm/lebkuchen-radio
+  bitrate: 128
+  codec: MP3
+  favicon: https://lebkuchen-radio.de/favicon.ico
+  homepage: https://lebkuchen-radio.de/
+  country: DE
+  status: stream-only
+  stationuuid: 13aeec22-24bf-4a0c-9545-ffe67f29e959
+  changeuuid: 9de31b6f-e673-4d56-a3f4-d1c2187ad786
+  reviewedAt: "2026-05-04"
+
+- id: de-egofm-snow
+  broadcaster: independent
+  name: egoFM Snow
+  streamUrl: https://cast.egofm.de/egosnow.mp3?ar-distributor=ffa0&aw_0_req.gdpr=true
+  bitrate: 128
+  codec: MP3
+  homepage: https://player.egofm.de/radioplayer/?stream=egosnow
+  country: DE
+  status: stream-only
+  stationuuid: d3e8d14a-038a-11e9-a1be-52543be04c81
+  changeuuid: bab66745-47b3-4d1f-a390-fe459b84e3ee
+  reviewedAt: "2026-05-04"
+
+- id: de-hr3-sudhessen
+  broadcaster: independent
+  name: hr3 Südhessen
+  streamUrl: https://dispatcher.rndfnk.com/hr/hr3/suedhessen/high
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.hr3.de/favicon.png?v=3.84.2
+  homepage: https://www.hr3.de/
+  country: DE
+  status: stream-only
+  stationuuid: 7337fd46-737f-4050-8e6d-05fb151f2fcc
+  changeuuid: 036115bd-0f13-4d8d-a1cc-fd04f798bc94
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-isw
+  broadcaster: independent
+  name: Radio ISW
+  streamUrl: https://radioisw.icecaststream.de/stream/radioisw
+  bitrate: 192
+  codec: MP3
+  country: DE
+  status: stream-only
+  stationuuid: b11d5dd8-889d-431f-9e09-da3f827ee37a
+  changeuuid: 8b20b88e-137f-46c0-99b6-cfdce466c6da
+  reviewedAt: "2026-05-04"
+
+- id: de-reyfm-chillout
+  broadcaster: independent
+  name: "REYFM - #chillout"
+  streamUrl: https://listen.reyfm.de/chillout_64kbps.mp3
+  bitrate: 64
+  codec: AAC+
+  favicon: https://www.reyfm.de/favicon.png
+  homepage: https://www.reyfm.de/
+  country: DE
+  status: stream-only
+  stationuuid: 07da5c1b-14cb-45ba-ae39-e8372f896809
+  changeuuid: a1452226-c0bf-4d76-9037-bf2596166bcb
+  reviewedAt: "2026-05-04"
+
+- id: de-club-charts-top-100-immer-aktuell-dj-charts-hous
+  broadcaster: independent
+  name: "#CLUB CHARTS -> TOP 100 || IMMER AKTUELL || DJ CHARTS || HOUSE, EDM, DEEP HOUSE - TECH HOUSE - TECHNO - MELODIC TECHNO - EDM - ELECTRONIC DANCE MUSIC - CLUB - DJ - DJ MIX - REMIX - FESTIVAL - FESTIVAL RADIO - IBIZA - IBIZA HOUSE - SUMMER HOUSE - BEACH CLUB - CHILLOUT - LOUNGE - RAVE - PARTY MUSIC - NIGHTLIFE - URBAN - HIP HOP - RNB - AFRO HOUSE - LATIN HOUSE - TRANCE - HARDSTYLE - HARDCORE"
+  streamUrl: https://radio.breakz.fm/?ref=club2-71
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/m5jrHLWC/DJ-CLUB-CHARTS.png
+  homepage: https://breakz.fm/trackliste/
+  country: DE
+  status: stream-only
+  stationuuid: 215ea027-4fe8-4a4c-9f29-71ab4a659630
+  changeuuid: 221277ff-f454-4488-9a4d-93cdac717522
+  reviewedAt: "2026-05-04"
+
+- id: de-0r-dinner-lounge-lounge-chill-jazz-soft-music-ac
+  broadcaster: independent
+  name: "0R - DINNER LOUNGE || Lounge, Chill, Jazz, Soft Music, Acoustic, Easy Listening, Background, Romantic, Dinner, Smooth, Instrumental, Evening, Relax, Calm, Cafe"
+  streamUrl: https://0nlineradio.radioho.st/lounge-dinner-lounge?ref=radio-browser26
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/JjYRX77z/Dinner-Lounge.png
+  homepage: https://plus.rm.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 9fd6e036-c08b-49d3-a8b7-c8b282892ffe
+  changeuuid: 920ad0cf-1925-4d00-82bf-7c9404de786c
+  reviewedAt: "2026-05-04"
+
+- id: de-fu-ball-bundesliga-spiel-3
+  broadcaster: independent
+  name: "Fußball-Bundesliga: Spiel 3"
+  streamUrl: https://wdr-sportschau-liga1spiel3.icecastssl.wdr.de/wdr/sportschau/liga1spiel3/mp3/high
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.sportschau.de/resources/assets/image/favicon/apple-icon-120x120.png
+  homepage: https://livecenter.sportschau.de/
+  country: DE
+  status: stream-only
+  stationuuid: 5723ed9d-6838-46e1-bafa-a1dc745be92d
+  changeuuid: 72771d3f-9750-4700-a506-6050746e1d2e
+  reviewedAt: "2026-05-04"
+
+- id: de-fu-ball-bundesliga-spiel-8
+  broadcaster: independent
+  name: "Fußball-Bundesliga: Spiel 8"
+  streamUrl: https://wdr-sportschau-liga1spiel8.icecastssl.wdr.de/wdr/sportschau/liga1spiel8/mp3/high
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.sportschau.de/resources/assets/image/favicon/apple-icon-120x120.png
+  homepage: https://livecenter.sportschau.de/
+  country: DE
+  status: stream-only
+  stationuuid: 350b3bb8-619f-4ad3-b379-b38e8d16bf3a
+  changeuuid: 717c5c61-9032-426f-8ac9-5f95aa6e324e
+  reviewedAt: "2026-05-04"
+
+- id: de-hr2-kultur-128kb-mp3
+  broadcaster: independent
+  name: hr2-kultur 128kb mp3
+  streamUrl: https://dispatcher.rndfnk.com/hr/hr2/live/medium
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.hr2.de/favicon.png?v=3.89.1
+  homepage: https://www.hr2.de/
+  country: DE
+  status: stream-only
+  stationuuid: fca7524f-7baa-432e-8f61-670b5115d387
+  changeuuid: a98c4ff8-547c-4b4a-bc41-cdbee2988b1e
+  reviewedAt: "2026-05-04"
+
+- id: de-i-love-radio-chillout-beats
+  broadcaster: independent
+  name: I Love Radio - Chillout Beats
+  streamUrl: https://ilm.stream35.radiohost.de/ilm-ichillout_beats_mp3-192?upd-meta&upd-scheme=https&_art=dD0xNzY4NDUxNDA3JmQ9ZmUyMzQ0YmFjMjg5MTE2YTM3OGY
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.iloveradio.de/
+  country: DE
+  status: stream-only
+  stationuuid: ede84df6-808d-4735-bbb6-3d225c330952
+  changeuuid: cbb49a5e-efa0-4894-ab2e-ab59eea15113
+  reviewedAt: "2026-05-04"
+
+- id: de-m1-fm-kuschelschlager
+  broadcaster: independent
+  name: M1.FM - Kuschelschlager
+  streamUrl: https://tuner.m1.fm/kuschelschlager.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://m1.fm/kuschelschlager.php
+  country: DE
+  status: stream-only
+  stationuuid: 06302873-0041-4759-92b7-415ac79535f8
+  changeuuid: c7055bff-0b55-4041-ae21-07b163839ebf
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-101-madonna
+  broadcaster: independent
+  name: Radio 101 Madonna
+  streamUrl: https://pub0202.101.ru:8443/stream/pro/aac/64/128
+  bitrate: 64
+  codec: AAC+
+  homepage: https://101.ru/
+  country: DE
+  status: stream-only
+  stationuuid: 98c35027-03aa-4bcd-b517-0528be782947
+  changeuuid: c7562f9a-5301-4c05-9cef-b4c137e84307
+  reviewedAt: "2026-05-04"
+
+- id: de-sr1
+  broadcaster: independent
+  name: SR1
+  streamUrl: https://liveradio.sr.de/sr/sr1/mp3/128/stream.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.sr.de/sr/static/images/favicon.ico
+  homepage: https://www.sr.de/sr/livestream/sr1/index.html
+  country: DE
+  status: stream-only
+  stationuuid: d1edcf5b-d7e5-4ea7-9b3b-5913c2ecf9f6
+  changeuuid: aec45c2f-ab4e-4518-85d9-ae80ccdbaa16
+  reviewedAt: "2026-05-04"
+
+- id: de-0r-soft-rock-rock-pop-rock-ballads-classic-rock-
+  broadcaster: independent
+  name: "0R - SOFT ROCK || Rock, Pop Rock, Ballads, Classic Rock, Soft, Guitar, Melodic, 70s, 80s, 90s, Easy Listening, Romantic, Hits, Mellow, Nostalgic"
+  streamUrl: https://0nlineradio.radioho.st/0r-soft-rock?ref=radio-browser26
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/ZpnRsBPM/Soft-Rock.png
+  homepage: https://www.ella-radio.de/
+  country: DE
+  status: stream-only
+  stationuuid: f9c08c41-c711-410c-9152-82d5cddc17ed
+  changeuuid: 2d14fe79-ed25-4408-9c87-86effcdf345c
+  reviewedAt: "2026-05-04"
+
+- id: de-deutschfm
+  broadcaster: independent
+  name: deutschFM
+  streamUrl: https://server14768.streamplus.de/stream.mp3
+  bitrate: 64
+  codec: MP3
+  homepage: http://www.deutschfmonair.de/
+  country: DE
+  status: stream-only
+  stationuuid: 80ce151a-6e04-11ea-b1cf-52543be04c81
+  changeuuid: 00d1dd49-be8d-4564-bacd-d16a1a6b240e
+  reviewedAt: "2026-05-04"
+
+- id: de-dwg-radio-cesky
+  broadcaster: independent
+  name: DWG Radio Český
+  streamUrl: https://server25530.streamplus.de/;stream.mp3
+  bitrate: 64
+  codec: MP3
+  homepage: https://radio.dwgradio.net/cz/
+  country: DE
+  status: stream-only
+  stationuuid: 9d8b1d7b-c1ac-11e8-aaf2-52543be04c81
+  changeuuid: 895b0bcd-ef0d-4f3c-bd61-c794100d4379
+  reviewedAt: "2026-05-04"
+
+- id: de-fu-ball-bundesliga-spiel-9
+  broadcaster: independent
+  name: "Fußball-Bundesliga: Spiel 9"
+  streamUrl: https://wdr-sportschau-liga1spiel9.icecastssl.wdr.de/wdr/sportschau/liga1spiel9/mp3/high
+  bitrate: 128
+  codec: MP3
+  favicon: https://www1.wdr.de/sport/fussball/logo-dfl-fussball-bundesliga-zweitausendachtzehn-100~_v-ARDKleinerTeaser.jpg
+  homepage: https://livecenter.sportschau.de/
+  country: DE
+  status: stream-only
+  stationuuid: 730eb7a5-8c92-43a2-8bfc-bebb5645dca7
+  changeuuid: 639104c7-3401-4034-8226-eed4c0967a74
+  reviewedAt: "2026-05-04"
+
+- id: de-ohrka-radio-gute-musik-und-horspiele-von-ohrka-d
+  broadcaster: independent
+  name: Ohrka Radio - Gute Musik und Hörspiele von Ohrka.de
+  streamUrl: https://ohrka.stream.laut.fm/ohrka?t302=2026-01-15_03-39-54&uuid=1b4d685c-7bdc-4eec-a744-dbf3bb2dadd5
+  bitrate: 128
+  codec: MP3
+  favicon: https://assets.laut.fm/f0131b4118a6fa5af3d175ec4f30651f?t=_120x120
+  homepage: https://www.ohrka.de/
+  country: DE
+  status: stream-only
+  stationuuid: 4b7a54c2-e4a2-4a2e-9e58-8d31fd1f3e70
+  changeuuid: 998a5dd1-add1-427d-ab3b-e673f43e23ed
+  reviewedAt: "2026-05-04"
+
+- id: de-rock-antenne-rock-n-roll
+  broadcaster: independent
+  name: "Rock Antenne - Rock 'n' Roll"
+  streamUrl: https://stream.rockantenne.de/rockandroll/stream/mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png
+  homepage: https://www.rockantenne.de/rockhoeren/streams/rock-n-roll
+  country: DE
+  status: stream-only
+  stationuuid: cb76d033-6269-4261-a360-0ef183eca7fd
+  changeuuid: 57be3612-80dc-46ba-b197-3779fa7ca604
+  reviewedAt: "2026-05-04"
+
+- id: de-blackspot
+  broadcaster: independent
+  name: Blackspot
+  streamUrl: https://blackspot.stream.laut.fm/blackspot
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.blackspot.me/
+  country: DE
+  status: stream-only
+  stationuuid: 2d588fa4-a7f2-11e9-88f4-52543be04c81
+  changeuuid: 2d9ba329-a564-4697-bc35-8f014142dee3
+  reviewedAt: "2026-05-04"
+
+- id: de-egofm-kavka-hq
+  broadcaster: independent
+  name: "egoFM Kavka [HQ]"
+  streamUrl: https://cast.egofm.de/egofmkavka.mp3?ar-distributor=ffa0&aw_0_req.gdpr=true
+  bitrate: 128
+  codec: MP3
+  favicon: https://streams.egofm.de/img/alexa/egoFM%20Kavka-256x256.png
+  homepage: https://www.egofm.de/streams/egofmkavka
+  country: DE
+  status: stream-only
+  stationuuid: 60ddb20c-ab4f-4951-9875-68583853e8e0
+  changeuuid: 1f2e16c7-04c0-4fd7-afb2-275017635c5f
+  reviewedAt: "2026-05-04"
+
+- id: de-sr-2-kulturradio-mp3-256
+  broadcaster: independent
+  name: SR 2 KulturRadio MP3 256
+  streamUrl: https://liveradio.sr.de/sr/sr2/mp3/256/stream.mp3
+  bitrate: 256
+  codec: MP3
+  favicon: https://assets.radioplayer.org/276/276367/600/600/kzh8gidn.png
+  homepage: https://www.sr.de/sr/sr2/index.html
+  country: DE
+  status: stream-only
+  stationuuid: e6b44d50-d053-4855-80f5-85b454940c11
+  changeuuid: f5df0fe8-9a12-4764-8006-bd06967ed027
+  reviewedAt: "2026-05-04"
+
+- id: de-1-splash-love
+  broadcaster: independent
+  name: "#1 Splash Love"
+  streamUrl: https://ais-sa2.cdnstream1.com/2210_128.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.splashradio.eu/
+  country: DE
+  status: stream-only
+  stationuuid: 2006f6cb-65c3-4e31-8626-22922f22b3d4
+  changeuuid: d9aed4ac-99f3-4b17-8164-ebbaebfbf303
+  reviewedAt: "2026-05-04"
+
+- id: de-0r-soft-house-chill-lounge-dance-deep-house-smoo
+  broadcaster: independent
+  name: "0R - SOFT HOUSE || Chill, Lounge, Dance, Deep House, Smooth, Vocal, Party, Electronic, Club, Night, Beat, Melodic, Summer, Relax"
+  streamUrl: https://0nlineradio.radioho.st/lounge-soft-house-lounge?ref=radio-browser26
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/S7ZpK6VV/Soft-House.png
+  homepage: https://plus.rm.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 359d6083-ad87-45b6-bfd8-d9bbf1dae021
+  changeuuid: 638c701b-69fc-4465-8c1f-e26130cd7ab9
+  reviewedAt: "2026-05-04"
+
+- id: de-arcano-mundo
+  broadcaster: independent
+  name: Arcano Mundo
+  streamUrl: https://stream.laut.fm/arcano-mundo
+  bitrate: 128
+  codec: MP3
+  homepage: https://laut.fm/arcano-mundo
+  country: DE
+  status: stream-only
+  stationuuid: 8b59d8e8-9e65-11e8-a767-52543be04c81
+  changeuuid: 9afcf9a9-59f1-40c7-b264-dab71eb8399a
+  reviewedAt: "2026-05-04"
+
+- id: de-bremen-eins-spezial
+  broadcaster: independent
+  name: Bremen Eins Spezial
+  streamUrl: https://icecast.radiobremen.de/rb/webchannel5/mp3/128/stream.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.bremeneins.de/static/img/favicons/apple-touch-icon-180.png?v=4
+  homepage: https://www.bremeneins.de/
+  country: DE
+  status: stream-only
+  stationuuid: c6a2f638-0f06-4fff-83c6-f5d6df9080dd
+  changeuuid: deddac8c-6147-42f5-a15f-7f925992dd11
+  reviewedAt: "2026-05-04"
+
+- id: de-club-fm
+  broadcaster: independent
+  name: Club FM
+  streamUrl: https://rs7.stream24.net/clubfm.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://www.clubfm.de/storage/thumbs/192x192/r:1695642276/zdiljpqk3fvaz.png
+  homepage: https://clubfm.de/empfang/
+  country: DE
+  status: stream-only
+  stationuuid: 2657318f-2fb3-42cf-bbdb-01696ccfec4c
+  changeuuid: 1e3fc338-3d00-4ccb-be52-d243de036e01
+  reviewedAt: "2026-05-04"
+
+- id: de-fu-ball-bundesliga-spiel-2
+  broadcaster: independent
+  name: "Fußball-Bundesliga: Spiel 2"
+  streamUrl: https://wdr-sportschau-liga1spiel2.icecastssl.wdr.de/wdr/sportschau/liga1spiel2/mp3/high
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.sportschau.de/resources/assets/image/favicon/apple-icon-120x120.png
+  homepage: https://livecenter.sportschau.de/
+  country: DE
+  status: stream-only
+  stationuuid: 53076bec-f938-4c91-845a-d98657023cfa
+  changeuuid: 3af89486-1006-4350-8a75-a7cbe0a1587d
+  reviewedAt: "2026-05-04"
+
+- id: de-gartenheim-radio-gartenheim-radio
+  broadcaster: independent
+  name: Gartenheim-Radio,Gartenheim-Radio
+  streamUrl: https://gartenheimradio.sp.radio.fm/stream
+  bitrate: 320
+  codec: MP3
+  favicon: https://gartenheim-radio.de/bilder/logo-radio-Gartenheim-fav.png
+  country: DE
+  status: stream-only
+  stationuuid: 52fb820a-cea5-486d-b4c4-20deb6412b5b
+  changeuuid: cb14c1b5-a4f1-483f-aff5-70978caec528
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-bielefeld-80er
+  broadcaster: independent
+  name: Radio Bielefeld 80er
+  streamUrl: https://addrad.io/4455rqg
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radio-bielefeld.de/
+  country: DE
+  status: stream-only
+  stationuuid: cc4747a9-0f9d-4058-9989-3600684dfaf5
+  changeuuid: f2cdc89c-4568-43d7-a899-9774fdcdaf81
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-neue-hoffnung-aac-96-kbps
+  broadcaster: independent
+  name: Radio Neue Hoffnung (AAC 96 kbps)
+  streamUrl: https://stream.mnr.ch/rnh
+  bitrate: 96
+  codec: AAC+
+  favicon: https://www.mnr.ch/favicon.ico
+  homepage: https://www.mnr.ch/radio/
+  country: DE
+  status: stream-only
+  stationuuid: 27ff36ee-eee2-11e8-a471-52543be04c81
+  changeuuid: edc453a0-1cfe-45de-ab35-f20c155b734c
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-psr-90er
+  broadcaster: independent
+  name: Radio PSR 90er
+  streamUrl: https://streams.radiopsr.de/psr-90er/mp3-192/www.radio-browser.info/play.m3u8
+  bitrate: 192
+  codec: MP3
+  favicon: https://upload.radiopsr.de/production/static/1693298881101/icons/icon_64.cawac0w0200.png
+  homepage: https://www.radiopsr.de/
+  country: DE
+  status: stream-only
+  stationuuid: 59490420-28ba-432a-ad45-1c1b39835b6f
+  changeuuid: 326ac12b-fe57-46a9-82d4-2bd7762d702f
+  reviewedAt: "2026-05-04"
+
+- id: de-rattlesnake-radio
+  broadcaster: independent
+  name: "Rattlesnake Radio "
+  streamUrl: https://server3755.streamplus.de/stream.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: http://www.rattlesnake-radio.de/Rattlesnake_Radio/Willkommen.html
+  country: DE
+  status: stream-only
+  stationuuid: e6e3f601-2a85-4e03-8c48-7b883e7b3b29
+  changeuuid: daa92b2a-0aa6-4804-9eed-0fcaa089db1d
+  reviewedAt: "2026-05-04"
+
+- id: de-wdr-5-aac
+  broadcaster: independent
+  name: "WDR 5 [aac]"
+  streamUrl: https://wdrhf.akamaized.net/hls/live/2027996-b/wdr5/192/seglist.m3u8
+  codec: UNKNOWN
+  homepage: https://www1.wdr.de/radio/wdr5/index.html
+  country: DE
+  status: stream-only
+  stationuuid: 8c4042c9-84dc-4529-85b6-efe63ae25e3c
+  changeuuid: a8cd259f-d2fc-4050-a292-136174801aab
+  reviewedAt: "2026-05-04"
+
+- id: de-dancefox-radio
+  broadcaster: independent
+  name: Dancefox Radio
+  streamUrl: https://s35.derstream.net/dancefox-radio.mp3
+  codec: MP3
+  favicon: https://dancefox-radio.de/dancefox-radio.png
+  homepage: https://dancefox-radio.de/
+  country: DE
+  status: stream-only
+  stationuuid: 62ac4171-08de-4542-ae5d-20fd81f8d086
+  changeuuid: eadcc7c2-d607-4acd-ad9b-607ff204bdbf
+  reviewedAt: "2026-05-04"
+
+- id: de-egofm-bw-hq
+  broadcaster: independent
+  name: "egoFM BW [HQ]"
+  streamUrl: https://cast.egofm.de/egofmbw.mp3?ar-distributor=ffa0&aw_0_req.gdpr=true
+  bitrate: 128
+  codec: MP3
+  favicon: https://streams.egofm.de/img/alexa/egoFM%20BW-256x256.png
+  homepage: https://www.egofm.de/
+  country: DE
+  status: stream-only
+  stationuuid: e12fc796-dfc6-467e-8af3-30af755b507d
+  changeuuid: 39de6bb5-6ece-4983-9191-d879e8f02b98
+  reviewedAt: "2026-05-04"
+
+- id: de-egofm-jazz
+  broadcaster: independent
+  name: egoFM Jazz
+  streamUrl: https://cast.egofm.de/egofmjazz.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.egofm.de/
+  country: DE
+  status: stream-only
+  stationuuid: f445170a-f4a5-480a-bc0b-753fcec13ae5
+  changeuuid: 7ead9273-3ec3-4e7b-a4ce-e42990f10ef6
+  reviewedAt: "2026-05-04"
+
+- id: de-electrozombies
+  broadcaster: independent
+  name: Electrozombies
+  streamUrl: https://electrozombies.stream.laut.fm/electrozombies
+  bitrate: 128
+  codec: MP3
+  favicon: https://cdn.onlineradiobox.com/img/l/1/43221.v1.png
+  country: DE
+  status: stream-only
+  stationuuid: b48754a3-598c-44a5-ab26-55432a298392
+  changeuuid: ff339b72-e1dc-48cf-a3e5-7ebd764df238
+  reviewedAt: "2026-05-04"
+
+- id: de-kiepenkerl-songwriter
+  broadcaster: independent
+  name: Kiepenkerl Songwriter
+  streamUrl: https://stream.lokalradio.nrw/44565q3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.radiokiepenkerl.de/assets/images/favicons/radiokiepenkerl/favicon_x96.png
+  homepage: https://www.radiokiepenkerl.de/
+  country: DE
+  status: stream-only
+  stationuuid: c8027dd3-36e5-4fb6-8a6f-1e7076ba3e00
+  changeuuid: 66bd4a10-f2da-41f9-8b3d-19bc82b6e75f
+  reviewedAt: "2026-05-04"
+
+- id: de-ndr-fernsehen-hamburg
+  broadcaster: independent
+  name: NDR Fernsehen Hamburg
+  streamUrl: https://mcdn.ndr.de/ndr/hls/ndr_fs/ndr_hh/master.m3u8
+  bitrate: 1672
+  codec: AAC
+  homepage: https://www.ndr.de/fernsehen/index.html
+  country: DE
+  status: stream-only
+  stationuuid: 09f7e455-2587-4b2d-99d6-74e49cb0f113
+  changeuuid: 9cb5a97f-17ff-4fad-b70c-5e04bb11dc2f
+  reviewedAt: "2026-05-04"
+
+- id: de-rfh-hd-regionalfernsehen-harz
+  broadcaster: independent
+  name: RFH HD - Regionalfernsehen Harz
+  streamUrl: https://h056.video-stream-hosting.de/medienasa-live/_definst_/mp4:RFH_high/playlist.m3u8
+  bitrate: 2613
+  codec: AAC
+  homepage: https://www.rfh-tv.de/
+  country: DE
+  status: stream-only
+  stationuuid: 42bb1251-30f3-4aa7-81b3-c40623e386b6
+  changeuuid: b4eb50f9-7ffc-4418-b72e-0d730287bcec
+  reviewedAt: "2026-05-04"
+
+- id: de-swr-1
+  broadcaster: independent
+  name: SWR 1
+  streamUrl: https://liveradio.swr.de/sw282p3/swr1bw/
+  bitrate: 128
+  codec: MP3
+  country: DE
+  status: stream-only
+  stationuuid: 1402b3f2-0179-4866-a729-42f8e020006c
+  changeuuid: 4350b287-fc7f-45d4-993e-7b75ca2b44d7
+  reviewedAt: "2026-05-04"
+
+- id: de-zappa-stream-radio
+  broadcaster: independent
+  name: Zappa Stream Radio
+  streamUrl: https://streams.norbert.de/zappa.ogg
+  bitrate: 128
+  codec: OGG
+  favicon: https://www.norbert.de/typo3conf/ext/start/Resources/Public/Images/favicon.ico
+  homepage: https://www.norbert.de/index.php?id=10
+  country: DE
+  status: stream-only
+  stationuuid: ab37615b-5d85-46ba-8057-da90452a4a88
+  changeuuid: 2eda7c0d-5b1e-4ae5-bb7e-cbcd9bf780a5
+  reviewedAt: "2026-05-04"
+
+- id: de-berliner-rundfunk-91-4
+  broadcaster: independent
+  name: Berliner Rundfunk 91.4
+  streamUrl: https://topradio-de-hz-fal-stream10-cluster01.radiohost.de/brf_mp3-128
+  bitrate: 128
+  codec: MP3
+  favicon: https://upload.berliner-rundfunk.de/production/static/1693298496587/icons/icon_64.a80y02808w0.png
+  homepage: https://berliner-rundfunk.de/
+  country: DE
+  status: stream-only
+  stationuuid: 61046d79-1090-4e21-8739-229c07e366b8
+  changeuuid: b11d3992-f304-45dd-b4c7-8b01a09c8d62
+  reviewedAt: "2026-05-04"
+
+- id: de-christliches-radio-munchen
+  broadcaster: independent
+  name: Christliches Radio München
+  streamUrl: https://crm924.stream.laut.fm/crm924
+  bitrate: 128
+  codec: MP3
+  favicon: https://christlichesradio.de/storage/thumbs/192x192/r:1729866404/791lo3107c01q.png
+  homepage: https://christlichesradio.de/
+  country: DE
+  status: stream-only
+  stationuuid: fdcc91c5-2a51-471d-a055-7084c124f713
+  changeuuid: 82c1e4c4-76ee-47e4-b93c-bc04521f5a78
+  reviewedAt: "2026-05-04"
+
+- id: de-ella-radio-swing-big-band
+  broadcaster: independent
+  name: "Ella Radio - Swing & Big Band"
+  streamUrl: https://stream.ella-radio.de/ella-swing-and-bigband/mp3-192/?ref=radio-browser
+  bitrate: 192
+  codec: MP3
+  favicon: https://ella-radio.de/uplink/Ella_Swing-Big-Band.jpg
+  homepage: https://www.ella-radio.de/
+  country: DE
+  status: stream-only
+  stationuuid: ef57ef88-3b9f-484d-bdc5-8063e201b6df
+  changeuuid: 32318842-f080-429e-abe8-8931434f2c92
+  reviewedAt: "2026-05-04"
+
+- id: de-hr-info-2
+  broadcaster: independent
+  name: hr-info
+  streamUrl: https://dispatcher.rndfnk.com/hr/hrinfo-sued/mp3/high
+  bitrate: 128
+  codec: MP3
+  favicon: https://upload.wikimedia.org/wikipedia/commons/thumb/4/49/HR-Info_Logo_2023.svg/1024px-HR-Info_Logo_2023.svg.png
+  homepage: https://www.hr-inforadio.de/
+  country: DE
+  status: stream-only
+  stationuuid: 60035159-1931-4de9-a270-15958b071bbb
+  changeuuid: 1866dad3-2ada-40c4-a089-2bc67f6b5185
+  reviewedAt: "2026-05-04"
+
+- id: de-hr4-nordhessen
+  broadcaster: independent
+  name: hr4 Nordhessen
+  streamUrl: https://dispatcher.rndfnk.com/hr/hr4/nordhessen/high
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.hr4.de/favicon.png?v=3.84.2
+  homepage: https://www.hr4.de/
+  country: DE
+  status: stream-only
+  stationuuid: e791177f-c9b9-40a2-83cd-9e2ae6a39141
+  changeuuid: 05c10a9e-425a-40fe-9ff8-76d78aed2059
+  reviewedAt: "2026-05-04"
+
+- id: de-munchen-tv
+  broadcaster: independent
+  name: münchen.tv
+  streamUrl: https://muenchentv.iptv-playoutcenter.de/muenchentv/muenchentv.stream_1/playlist.m3u8
+  bitrate: 3199
+  codec: AAC,H.264
+  favicon: https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/tv/muenchentv.png
+  homepage: https://www.muenchen.tv/
+  country: DE
+  status: stream-only
+  stationuuid: 875acb57-a9b5-414b-8eb7-b8d4848cdc3f
+  changeuuid: 3f8a81ff-2e06-4cdb-808a-092458349754
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-b2
+  broadcaster: independent
+  name: radio b2
+  streamUrl: https://radiob2-national.cast.addradio.de/radiob2/national/mp3/high/stream.mp3?ar-distributor=f0b7&token=c3RhcnRUaW1lPTIwMTkwMjA2MTE0ODAxJmVuZFRpbWU9MjAxOTAyMDYxMzQ4MDEmaXB2ND0xODEuMjI2LjE1OS43MS8yNCZkaWdlc3Q9N2U1MmQxYTAwY2EzMGMwZDBhNzczZTg2OTVlZTBhZGU
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.radiob2.de/favicon.ico
+  homepage: https://www.radiob2.de/
+  country: DE
+  status: stream-only
+  stationuuid: b2090ebe-2a0d-11e9-96d1-52543be04c81
+  changeuuid: 11ad20f3-00c1-4125-b8fe-f13c9b9deb25
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-berg
+  broadcaster: independent
+  name: Radio Berg
+  streamUrl: https://radioberg--di--nacs-ais-lgc--0b--cdn.cast.addradio.de/radioberg/live/mp3/high?ar-distributor=ffa0&_art=dj0yJmlwPTIxMi4xODcuMjQ0LjgmaWQ9aWNzY3hsLWlxaGZhc2ltYiZ0PTE3MTA5NDMyNzQmcz03ODY2ZjI5YyNiODQwNGVlMjlkMDhmMGM4MDMzYTM0ZjM1YWZlZTFjOA
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.radioberg.de/assets/images/senderlogos/radio_berg_webradio.png
+  homepage: https://www.radioberg.de/
+  country: DE
+  status: stream-only
+  stationuuid: ce7a854e-ffc9-4f1e-9079-4be68c760061
+  changeuuid: 624d19a3-a59a-475e-9dab-66cd72a0b8d6
+  reviewedAt: "2026-05-04"
+
+- id: de-rbw-hd-regionalfernsehen-bitterfeld-wolfen
+  broadcaster: independent
+  name: RBW HD - Regionalfernsehen Bitterfeld-Wolfen
+  streamUrl: https://h056.video-stream-hosting.de/medienasa-live/_definst_/mp4:rbw_high/playlist.m3u8
+  bitrate: 2574
+  codec: AAC
+  homepage: https://www.rbwonline.de/
+  country: DE
+  status: stream-only
+  stationuuid: 7ed1f9a2-ac35-4abd-82a4-72ff9fe49d20
+  changeuuid: 7ded84db-05ae-4c0b-a051-512ce591db45
+  reviewedAt: "2026-05-04"
+
+- id: de-reyfm-deutschrap-gold
+  broadcaster: independent
+  name: "REYFM - #Deutschrap Gold"
+  streamUrl: https://listen.reyfm.de/reyfm-deutschrap_gold/
+  bitrate: 320
+  codec: MP3
+  favicon: https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png
+  country: DE
+  status: stream-only
+  stationuuid: 7792a295-2e47-4daa-a77f-c54555e1ca9c
+  changeuuid: 2141d18a-8afc-4a9e-950c-cbaf585389e2
+  reviewedAt: "2026-05-04"
+
+- id: de-southern-rock-radio
+  broadcaster: independent
+  name: Southern Rock Radio
+  streamUrl: https://stream.laut.fm/southern-rock_radio
+  bitrate: 128
+  codec: MP3
+  favicon: https://assets.laut.fm/ac123050ec59b3718d98712e0435746
+  homepage: https://laut.fm/southern
+  country: DE
+  status: stream-only
+  stationuuid: 47f68050-851a-46a8-a9b7-0726389ee1c3
+  changeuuid: 45e9e9ef-2ff8-466f-ad6a-d12f84ca7c4e
+  reviewedAt: "2026-05-04"
+
+- id: de-wdr-2-bewrgisch-land
+  broadcaster: independent
+  name: WDR-2 Bewrgisch Land
+  streamUrl: https://wdr-wdr2-bergischesland.icecastssl.wdr.de/wdr/wdr2/bergischesland/mp3/128/stream.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www1.wdr.de/radio/startseite/symbolbilder/dummy-logo108~_v-gseagaleriexl.jpg
+  homepage: https://www1.wdr.de/radio/wdr2
+  country: DE
+  status: stream-only
+  stationuuid: 29292a02-bdac-11e9-acb2-52543be04c81
+  changeuuid: 7a7a550d-930a-4805-a3a6-bf2759ecca76
+  reviewedAt: "2026-05-04"
+
+- id: de-70s-oldies-70er-disco-funk-soul-classic-pop-retr
+  broadcaster: independent
+  name: "* 70s || Oldies, 70er, Disco, Funk, Soul, Classic Pop, Retro, Kultsongs, Evergreens, Vinyl Vibes, Groovy, Feel Good, Nostalgie, Zeitlos, Charts"
+  streamUrl: https://0nlineradio.radioho.st/0r-70s?ref=rb26
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/B2YbXkQG/70s.png
+  homepage: https://plus.rm.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 7213ce93-3ded-4b0e-ab89-ef789d066e23
+  changeuuid: 71c055a8-09b2-4937-98dd-fb91987e1810
+  reviewedAt: "2026-05-04"
+
+- id: de-0r-beethoven-classical-classical-orchestra-symph
+  broadcaster: independent
+  name: "0R - BEETHOVEN - CLASSICAL || Classical, Orchestra, Symphony, Piano, Strings, Chamber Music, Concertos, Solo Instrument, Elegant, Relaxing, Timeless, Melodic, Instrumental, Calm, Meditative"
+  streamUrl: https://0nlineradio.radioho.st/0r-beethoven?ref=radio-browser26
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/6JrNQTzQ/BEETHOVEN-KL.png
+  homepage: https://plus.rm.fm/
+  country: DE
+  status: stream-only
+  stationuuid: c52e6b55-85d2-4fe8-bcbf-68ed86a56138
+  changeuuid: 9c817cd6-4a91-4014-b2c3-ed2f9a94244f
+  reviewedAt: "2026-05-04"
+
+- id: de-0r-piano-classical-klassik-solopiano-elegant-rel
+  broadcaster: independent
+  name: "0R - PIANO CLASSICAL || Klassik, Solopiano, Elegant, Relax, Calm, Instrumental, Melodic, Soft, Meditation, Romantic, Strings, Timeless, Background, Peaceful"
+  streamUrl: https://0nlineradio.radioho.st/classical-classical-piano?ref=radio-browser26
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/Tq7d6MMp/PIANO-only.png
+  homepage: https://plus.rm.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 79839c1c-bfb8-40a4-aed7-f31191cbd015
+  changeuuid: 4b723d17-5c0d-45ac-9fa7-229e79a6fada
+  reviewedAt: "2026-05-04"
+
+- id: de-deeredradio-red-zone
+  broadcaster: independent
+  name: DEEREDRADIO RED ZONE
+  streamUrl: https://webcast.deeredradio.com:8420/stream_aac_128
+  bitrate: 128
+  codec: AAC
+  favicon: https://sub60.tobit.com/l/64380-03776?size=128&f=none
+  homepage: https://www.deeredradio.com/webcastred
+  country: DE
+  status: stream-only
+  stationuuid: 37547bfd-0b87-4e74-9e00-1922aeb6ceb2
+  changeuuid: 4ff09300-9c46-48f3-9fb5-45f8d3ef6a16
+  reviewedAt: "2026-05-04"
+
+- id: de-deeredrdradio-black-zone
+  broadcaster: independent
+  name: DEEREDRDRADIO BLACK ZONE
+  streamUrl: https://webcast.deeredradio.com:8410/stream_aac_128
+  bitrate: 128
+  codec: AAC
+  homepage: https://www.deeredradio.com/webcastblack
+  country: DE
+  status: stream-only
+  stationuuid: 75b8ef43-d6ae-4965-92ab-73b3ce323db5
+  changeuuid: 46380f86-5516-4437-9df1-386f9cad918d
+  reviewedAt: "2026-05-04"
+
+- id: de-ella-radio-modern-vocal-jazz
+  broadcaster: independent
+  name: Ella Radio - Modern Vocal Jazz
+  streamUrl: https://stream.ella-radio.de/ella-modern-vocal-jazz/mp3-192/?ref=radio-browser
+  bitrate: 192
+  codec: MP3
+  favicon: https://ella-radio.de/uplink/Ella_Vocal-Jazz.jpg
+  homepage: https://www.ella-radio.de/
+  country: DE
+  status: stream-only
+  stationuuid: d51f98b9-d0da-4c3a-922b-056a180b9098
+  changeuuid: f320c235-cbaa-4bea-8443-5b7b01bb04dc
+  reviewedAt: "2026-05-04"
+
+- id: de-hr-fernsehen-hd
+  broadcaster: independent
+  name: hr-fernsehen HD
+  streamUrl: https://hrhlsde.akamaized.net/hls/live/2024526/hrhlsde/index.m3u8
+  codec: UNKNOWN
+  homepage: https://www.hr-fernsehen.de/
+  country: DE
+  status: stream-only
+  stationuuid: 04054a99-b749-41d8-b8a3-635ac8fef779
+  changeuuid: bfe5b1c9-040f-45e0-9fd5-0a6ad208fde6
+  reviewedAt: "2026-05-04"
+
+- id: de-lovebeats-laut-fm
+  broadcaster: independent
+  name: LoveBeats - laut.fm
+  streamUrl: https://lovebeats.stream.laut.fm/lovebeats
+  bitrate: 128
+  codec: MP3
+  homepage: https://laut.fm/lovebeats
+  country: DE
+  status: stream-only
+  stationuuid: 33fbbc41-cda4-11e9-8502-52543be04c81
+  changeuuid: 7b38e722-e743-42cb-af72-36ff502b9836
+  reviewedAt: "2026-05-04"
+
+- id: de-soul-rnb-lovers-radio
+  broadcaster: independent
+  name: Soul RnB Lovers Radio
+  streamUrl: https://s10.streamingcloud.online/stream/13580
+  bitrate: 320
+  codec: MP3
+  favicon: https://scontent-mty2-1.xx.fbcdn.net/v/t39.30808-6/403857353_122093636606138816_321048698194500544_n.jpg?_nc_cat=106&ccb=1-7&_nc_sid=6ee11a&_nc_ohc=iOMPoUwq6v0Q7kNvgGkTTjE&_nc_oc=AdhZmOyIG_v355RPmYzldtz_BNfKq0-DOnGkVSDv_DTJBSoOJDItw3ri6lkvjdwT1Ec&_nc_zt=23&_nc_ht=scontent-mty2-1.xx&_nc_gid=AQFx4ruh-kP6Wan4LKiIoje&oh=00_AYBq9HWSMCevYYNRfCKbqKasU1spgCr8wrX5THlg7KCoNg&oe=67B1B0B1
+  homepage: https://www.soulrnbloversradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: f4c1d760-825d-424c-bce0-64f6ab3576a1
+  changeuuid: a98c0149-291f-4756-8624-4ae644da25bf
+  reviewedAt: "2026-05-04"
+
+- id: de-swr3-rock
+  broadcaster: independent
+  name: SWR3 Rock
+  streamUrl: https://liveradio.swr.de/sw331ch/raka05/
+  bitrate: 128
+  codec: AAC
+  homepage: https://www.swr.de/
+  country: DE
+  status: stream-only
+  stationuuid: 2bc55905-b128-4c00-a520-959b90e8fea2
+  changeuuid: 7babd3f8-752a-47b4-8cfe-cf95a0e9a003
+  reviewedAt: "2026-05-04"
+
+- id: de-wdr-cosmo-neu-in-cosmo
+  broadcaster: independent
+  name: WDR COSMO - Neu in Cosmo
+  streamUrl: https://wdr-cosmo-neuincosmo.icecastssl.wdr.de/wdr/cosmo/neuincosmo/mp3/128/stream.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www1.wdr.de/radio/cosmo/resources-v5.128.1/img/favicon/favicon-32x32.png
+  homepage: https://www1.wdr.de/radio/cosmo/channels/neu-in-cosmo-channel-102.html
+  country: DE
+  status: stream-only
+  stationuuid: 33eb812d-cc84-427e-8d25-ff73db533da8
+  changeuuid: 2be2cc52-59d9-40cc-8054-a9f9196fd051
+  reviewedAt: "2026-05-04"
+
+- id: de-welt-tv-1080p
+  broadcaster: independent
+  name: WELT TV 1080p
+  streamUrl: https://welt.personalstream.tv/v1/master.m3u8
+  bitrate: 1128
+  codec: UNKNOWN
+  homepage: https://www.welt.de/mediathek/
+  country: DE
+  status: stream-only
+  stationuuid: 466eaec5-1d76-4fa0-8a6e-506dabc30c9e
+  changeuuid: 8915157e-383f-46f0-8a0b-7eec2ff37b92
+  reviewedAt: "2026-05-04"
+
+- id: de-ahoy
+  broadcaster: independent
+  name: ahoy
+  streamUrl: https://s37.derstream.net/ahoy-radio.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.ahoyradio.de/
+  country: DE
+  status: stream-only
+  stationuuid: 6e1cd2f0-6106-4d7d-a826-7cdca7dd4f44
+  changeuuid: 00b46be2-16df-4dcb-942f-580201626361
+  reviewedAt: "2026-05-04"
+
+- id: de-antenne-bayern-weihnachtslounge
+  broadcaster: independent
+  name: Antenne Bayern - Weihnachtslounge
+  streamUrl: https://stream.antenne.de/lounge/stream/mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.antenne.de/logos/station-antenne-bayern/apple-touch-icon.png
+  homepage: https://www.antenne.de/webradio/lounge
+  country: DE
+  status: stream-only
+  stationuuid: 9ccdea07-5b25-493b-bf28-d13954ec3874
+  changeuuid: 89db95e1-04ea-475f-ac8b-280960592b80
+  reviewedAt: "2026-05-04"
+
+- id: de-denge-cudi
+  broadcaster: independent
+  name: Denge Cudi
+  streamUrl: https://denge-cudi.stream.laut.fm/denge-cudi
+  bitrate: 128
+  codec: MP3
+  favicon: https://i1.sndcdn.com/avatars-000206444760-te747f-t500x500.jpg
+  homepage: https://laut.fm/denge-cudi
+  country: DE
+  status: stream-only
+  stationuuid: 09d04815-b82d-400c-a71c-2d3fdc56b604
+  changeuuid: 313ec4a6-eb28-417a-8074-5b7a0de78bda
+  reviewedAt: "2026-05-04"
+
+- id: de-ella-radio-blues-rock
+  broadcaster: independent
+  name: Ella Radio - Blues Rock
+  streamUrl: https://stream.ella-radio.de/ella-blues-rock/mp3-192/?ref=radio-browser
+  bitrate: 192
+  codec: MP3
+  favicon: https://ella-radio.de/uplink/Ella_Blues-Rock.jpg
+  homepage: https://www.ella-radio.de/
+  country: DE
+  status: stream-only
+  stationuuid: ac24bfd7-518e-4f27-a17a-034d36286efb
+  changeuuid: 19d439b0-3e9a-4e5d-83d3-4f4b7fa0e306
+  reviewedAt: "2026-05-04"
+
+- id: de-fun80sfm
+  broadcaster: independent
+  name: Fun80sFM
+  streamUrl: https://fun80sfm.stream.laut.fm/fun80sfm
+  bitrate: 128
+  codec: MP3
+  country: DE
+  status: stream-only
+  stationuuid: f5895a36-beb3-4500-9489-5e04ebc7c86a
+  changeuuid: 87a6a417-deb0-4b19-a2d8-471df3f7aa67
+  reviewedAt: "2026-05-04"
+
+- id: de-sr-fernsehen-hd
+  broadcaster: independent
+  name: SR Fernsehen HD
+  streamUrl: https://srfs.akamaized.net/hls/live/689649/srfsgeo/index.m3u8
+  bitrate: 1672
+  codec: AAC
+  homepage: https://www.sr.de/sr/fernsehen/index.html
+  country: DE
+  status: stream-only
+  stationuuid: 7f054d6c-ab70-4487-ab7d-90721d8fd577
+  changeuuid: b8010873-a006-4497-9452-f7732aea51c6
+  reviewedAt: "2026-05-04"
+
+- id: de-techliveradio
+  broadcaster: independent
+  name: TechLiveRadio
+  streamUrl: https://stream.laut.fm/techliveradio
+  bitrate: 128
+  codec: MP3
+  favicon: https://hitradiod1.de/wp-content/uploads/2023/06/192.png
+  homepage: https://techliveradio.de/
+  country: DE
+  status: stream-only
+  stationuuid: 07824f96-0c33-11e9-a80b-52543be04c81
+  changeuuid: bbb1050d-18b3-4414-90c9-0923a54bd1f6
+  reviewedAt: "2026-05-04"
+
+- id: de-1000-hamburg
+  broadcaster: independent
+  name: 1000 Hamburg
+  streamUrl: https://stream.laut.fm/1000hamburg
+  bitrate: 128
+  codec: MP3
+  homepage: https://1000.hamburg/
+  country: DE
+  status: stream-only
+  stationuuid: e44a124c-34ec-45fb-8954-8f447e8e9735
+  changeuuid: 5bb0cf8f-552c-403b-aa12-fb87e70b8c13
+  reviewedAt: "2026-05-04"
+
+- id: de-dancefloor-fm
+  broadcaster: independent
+  name: Dancefloor FM
+  streamUrl: https://dancefloor-fm.stream.laut.fm/dancefloor-fm?t302=2025-03-03_21-41-17&uuid=ebadfaf0-8781-4c90-bb05-6652467979a2
+  bitrate: 128
+  codec: MP3
+  homepage: http://www.saarlandsender.de/Startseite/
+  country: DE
+  status: stream-only
+  stationuuid: e4314c14-24dc-4f1e-863f-7075c7f4a036
+  changeuuid: fb634ea7-13b7-4807-bcc5-c4e01669e4da
+  reviewedAt: "2026-05-04"
+
+- id: de-ndr-fernsehen-niedersachsen
+  broadcaster: independent
+  name: NDR Fernsehen Niedersachsen
+  streamUrl: https://mcdn.ndr.de/ndr/hls/ndr_fs/ndr_nds/master.m3u8
+  bitrate: 1672
+  codec: AAC
+  homepage: https://www.ndr.de/fernsehen/index.html
+  country: DE
+  status: stream-only
+  stationuuid: 60f07a65-9dd0-4aaf-a4e1-0360312877a4
+  changeuuid: d28cf389-1175-453c-9eaa-876287f37796
+  reviewedAt: "2026-05-04"
+
+- id: de-ran1-hd-regionalfernsehen-dessau-ro-lau
+  broadcaster: independent
+  name: RAN1 HD - Regionalfernsehen Dessau-Roßlau
+  streamUrl: https://h056.video-stream-hosting.de/medienasa-live/_definst_/mp4:ran1_high/playlist.m3u8
+  bitrate: 2575
+  codec: AAC
+  homepage: https://www.ran1.de/
+  country: DE
+  status: stream-only
+  stationuuid: 23ca7f84-bbd9-433e-9fc0-124fdbd1a0e6
+  changeuuid: b50749e7-6f80-4cea-98f5-1b3bc881169d
+  reviewedAt: "2026-05-04"
+
+- id: de-scorpions
+  broadcaster: independent
+  name: Scorpions
+  streamUrl: https://stream.pcradio.ru/Scorpions-hi
+  codec: AAC
+  favicon: null
+  homepage: https://pcradio.ru/
+  country: DE
+  status: stream-only
+  stationuuid: 49d87bbb-9523-42a4-be99-36fe42db21a2
+  changeuuid: c73f9bed-2a5c-46c5-904a-6be36e08dbcb
+  reviewedAt: "2026-05-04"
+
+- id: de-studentenfunk-universitat-regensburg
+  broadcaster: independent
+  name: Studentenfunk (Universität Regensburg)
+  streamUrl: https://studentenfunk.out.airtime.pro/studentenfunk_a#
+  bitrate: 128
+  codec: MP3
+  favicon: https://studentenfunk-regensburg.de/wp-content/themes/studentenfunk/images/apple-touch-icon.png
+  homepage: https://studentenfunk-regensburg.de/
+  country: DE
+  status: stream-only
+  stationuuid: 0e7d5d00-f495-49af-bc5a-5ea78f8a1425
+  changeuuid: c60f1b0b-7ce9-4611-b0e2-1b5b64a65fb3
+  reviewedAt: "2026-05-04"
+
+- id: de-country-country-pop-country-rock-nashville-ameri
+  broadcaster: independent
+  name: "* COUNTRY || Country Pop, Country Rock, Nashville, Americana, Folk, Southern Rock, Roadtrip, Storytelling, Acoustic, Feel Good, Heartland, Modern Country, Classic Country, Chill, Roots"
+  streamUrl: https://0nlineradio.radioho.st/0r-country?ref=rb26
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/GyTyFSC/Country.png
+  homepage: https://plus.rm.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 6f4b6359-24af-411b-add3-402761ec7557
+  changeuuid: f3531f76-8bc5-4207-bd3f-a50389e29216
+  reviewedAt: "2026-05-04"
+
+- id: de-0r-lo-fi-lofi-chill-study-hip-hop-relax-backgrou
+  broadcaster: independent
+  name: "0R - LO-FI || LoFi, Chill, Study, Hip Hop, Relax, Background, Calm, Instrumental, Smooth, Beats, Coffee, Work, Focus, Soft, Chillhop"
+  streamUrl: https://0nlineradio.radioho.st/0r-lo-fi?ref=radio-browser26
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/v6hT16qV/LOFI.png
+  homepage: https://plus.rm.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 49902d2d-672d-4130-b42a-90592d0460c5
+  changeuuid: 1d49a18e-fc64-4a23-a177-409b0d6cca52
+  reviewedAt: "2026-05-04"
+
+- id: de-deep-house-sounds
+  broadcaster: independent
+  name: Deep House Sounds
+  streamUrl: https://deep-house-sounds.stream.laut.fm/deep-house-sounds
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.radio.net/300/lautfm-deep-house-sounds.jpeg
+  homepage: https://laut.fm/deep-house-sounds
+  country: DE
+  status: stream-only
+  stationuuid: 1ecb70fa-43b0-4eca-9462-31e94f7ace1d
+  changeuuid: f673f9d5-44b0-4f4e-83e2-462580840836
+  reviewedAt: "2026-05-04"
+
+- id: de-fu-fball-bundesliga-2-spiel-2
+  broadcaster: independent
+  name: "Fußfball-Bundesliga 2: Spiel 2"
+  streamUrl: https://wdr-sportschau-liga2spiel2.icecastssl.wdr.de/wdr/sportschau/liga2spiel2/mp3/high
+  bitrate: 128
+  codec: MP3
+  favicon: https://www1.wdr.de/sport/fussball/logo-dfl-fussball-zweite-liga-zweitausendachtzehn-100~_v-ARDKleinerTeaser.jpg
+  homepage: https://livecenter.sportschau.de/
+  country: DE
+  status: stream-only
+  stationuuid: e2f58a3c-d015-48d7-975b-71a288224c89
+  changeuuid: d9a3f40e-aa3d-4458-a9b0-66a70fbf70e7
+  reviewedAt: "2026-05-04"
+
+- id: de-i-love-workout
+  broadcaster: independent
+  name: I Love Workout
+  streamUrl: https://ilm.stream12.radiohost.de/ilm_iloveworkout_mp3-192?upd-meta&upd-scheme=https&_art=dD0xNzY4NDMyNzY0JmQ9YTIxNjc2ZmE5ZWYzZWI3ZGI0ZmM
+  bitrate: 192
+  codec: MP3
+  favicon: https://ilovemusic.de/fileadmin/user_upload/ilm2024_iloveworkout1x1_05_440x440.jpg
+  homepage: https://ilovemusic.de/iloveworkout/
+  country: DE
+  status: stream-only
+  stationuuid: e293653f-705e-4b6c-aebf-8bd6f2fd885d
+  changeuuid: b22100b4-0e58-4f19-ad40-cb2d86ccb60e
+  reviewedAt: "2026-05-04"
+
+- id: de-ndr-fernsehen-mv
+  broadcaster: independent
+  name: NDR Fernsehen MV
+  streamUrl: https://mcdn.ndr.de/ndr/hls/ndr_fs/ndr_mv/master.m3u8
+  bitrate: 1672
+  codec: AAC
+  homepage: https://www.ndr.de/fernsehen/index.html
+  country: DE
+  status: stream-only
+  stationuuid: 1f368f0e-c4bf-4e4a-9872-67151291a68a
+  changeuuid: 3e261745-5a6a-40db-869c-cbfaeb55f08d
+  reviewedAt: "2026-05-04"
+
+- id: de-novoe-radio
+  broadcaster: independent
+  name: Novoe Radio
+  streamUrl: https://emgspb.hostingradio.ru:80/novoespb64.mp3
+  bitrate: 64
+  codec: MP3
+  homepage: https://emgspb.hostingradio.ru:80/novoespb64.mp3
+  country: DE
+  status: stream-only
+  stationuuid: 03ef404e-43ec-4008-98f8-60e1f4f9b54b
+  changeuuid: bb97b870-25ea-4658-8c8a-9df5b566fec8
+  reviewedAt: "2026-05-04"
+
+- id: de-reyfm-hip-hop-gold
+  broadcaster: independent
+  name: "REYFM - #Hip-Hop Gold"
+  streamUrl: https://listen.reyfm.de/reyfm-hip-hop_gold/
+  bitrate: 320
+  codec: MP3
+  favicon: https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png
+  homepage: https://rey.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 283e8da3-bfe1-4e9f-9f2c-f6887db6443c
+  changeuuid: 2d1d5ecc-ed1f-42a4-8715-30da85ad91e1
+  reviewedAt: "2026-05-04"
+
+- id: de-reyfm-original-64kbps
+  broadcaster: independent
+  name: "REYFM - #original (64kbps)"
+  streamUrl: https://listen.reyfm.de/original_64kbps.mp3
+  bitrate: 64
+  codec: AAC+
+  favicon: https://www.reyfm.de/favicon.png
+  homepage: https://www.reyfm.de/
+  country: DE
+  status: stream-only
+  stationuuid: dce3238f-e9d3-4e0f-8c13-501e584e60fb
+  changeuuid: 40235f64-a0ba-4fa5-9b22-ae178cf5bb9b
+  reviewedAt: "2026-05-04"
+
+- id: de-weihnachten-mit-antenne-bayern
+  broadcaster: independent
+  name: Weihnachten mit ANTENNE BAYERN
+  streamUrl: https://stream.antenne.de/weihnachts-hits/stream/aacp
+  codec: AAC
+  country: DE
+  status: stream-only
+  stationuuid: f3e3a199-879d-41fe-b3c8-a7f31996d9c3
+  changeuuid: 6ff36d21-02dd-4509-8e94-a9e3128b2e23
+  reviewedAt: "2026-05-04"
+
+- id: de-wiphopbeatz
+  broadcaster: independent
+  name: wiphopbeatz
+  streamUrl: https://stream.laut.fm/wiphopbeatz
+  bitrate: 128
+  codec: MP3
+  homepage: https://laut.fm/wiphopbeatz
+  country: DE
+  status: stream-only
+  stationuuid: ec13eabe-7e71-4fa8-a141-1e009f3bb774
+  changeuuid: e304c356-6074-46dc-bef9-bd5b41a941e2
+  reviewedAt: "2026-05-04"
+
+- id: de-wunschradio-fm
+  broadcaster: independent
+  name: WunschRadio FM
+  streamUrl: https://radiostreamserver.de/wunschradio.mp3
+  bitrate: 320
+  codec: MP3
+  favicon: https://wunschradio.de/images/seitenelemente/favicon180.png
+  homepage: https://wunschradio.de/
+  country: DE
+  status: stream-only
+  stationuuid: a2522945-450a-11ea-a860-52543be04c81
+  changeuuid: f50a7c52-1c5f-4d8f-88fa-0dd17648be27
+  reviewedAt: "2026-05-04"
+
+- id: de-fu-ball-bundesliga-2-spiel-4
+  broadcaster: independent
+  name: "Fußball-Bundesliga 2: Spiel 4"
+  streamUrl: https://wdr-sportschau-liga2spiel4.icecastssl.wdr.de/wdr/sportschau/liga2spiel4/mp3/high
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.sportschau.de/resources/assets/image/favicon/apple-icon-120x120.png
+  homepage: https://livecenter.sportschau.de/
+  country: DE
+  status: stream-only
+  stationuuid: aa14763f-e528-4df2-886c-75b1e7b2b142
+  changeuuid: 5b272aee-8298-4af0-a019-64b1db7748d6
+  reviewedAt: "2026-05-04"
+
+- id: de-fu-ball-bundesliga-spiel-5
+  broadcaster: independent
+  name: "Fußball-Bundesliga: Spiel 5"
+  streamUrl: https://wdr-sportschau-liga1spiel5.icecastssl.wdr.de/wdr/sportschau/liga1spiel5/mp3/high
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.sportschau.de/resources/assets/image/favicon/apple-icon-120x120.png
+  homepage: https://livecenter.sportschau.de/
+  country: DE
+  status: stream-only
+  stationuuid: 8b400dc6-5113-432b-9600-14b1ed7b6349
+  changeuuid: 4864e53f-ab03-4cd1-b9ff-03163cb14e16
+  reviewedAt: "2026-05-04"
+
+- id: de-lazerradio
+  broadcaster: independent
+  name: LazerRadio
+  streamUrl: https://lazerradio.stream.laut.fm/lazerradio
+  bitrate: 128
+  codec: MP3
+  homepage: https://laut.fm/lazerradio
+  country: DE
+  status: stream-only
+  stationuuid: e535da32-cd75-471f-8402-56b98532c82f
+  changeuuid: f38168e4-b693-493d-bed5-07f7d6f5a8bc
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-landau
+  broadcaster: independent
+  name: Radio Landau
+  streamUrl: https://radiolandau.stream.laut.fm/radiolandau?autoplay=1&t302=2026-01-15_04-32-23&uuid=e7434870-47a3-40c8-b36b-28961178b681
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radiolandau.com/
+  country: DE
+  status: stream-only
+  stationuuid: 90241d36-ca8a-47b8-9be2-8431da8ce331
+  changeuuid: 9ff5d530-3cf0-4231-bca8-af5fc3a153a5
+  reviewedAt: "2026-05-04"
+
+- id: de-antenne-bayern-top-100u
+  broadcaster: independent
+  name: Antenne Bayern Top 100ü
+  streamUrl: https://stream.antenne.de/top-1000/stream/mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.antenne.de/media/cache/3/version/7347/streamlogo_top_1000_aby-v1.jpg/4274d87abb43dc80855d5b4f13c77b47.webp
+  homepage: https://www.antenne.de/
+  country: DE
+  status: stream-only
+  stationuuid: af14148d-4690-4f36-8c41-a5d618899354
+  changeuuid: 11033294-7e05-4efe-bccd-711d83e5cbee
+  reviewedAt: "2026-05-04"
+
+- id: de-bdj-radio-80s-90s
+  broadcaster: independent
+  name: "BDJ Radio - 80s & 90s"
+  streamUrl: https://stream-bdj80s90s.bdjradio.com/
+  bitrate: 128
+  codec: MP3
+  favicon: https://bdjradio.com/media/images/bdj-80s90s-456214.png
+  homepage: https://bdjradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 55eba47a-7b9f-4843-907e-f9ea2c0f6ba7
+  changeuuid: 3659a518-6e9e-4945-8865-65caf4474826
+  reviewedAt: "2026-05-04"
+
+- id: de-bibel-tv-impuls
+  broadcaster: independent
+  name: Bibel TV Impuls
+  streamUrl: https://bibeltv02.iptv-playoutcenter.de/bibeltv02/bibeltv02.stream_1/playlist.m3u8
+  bitrate: 3358
+  codec: AAC,H.264
+  favicon: https://www.bibeltv.de/assets/images/btv_logo.svg
+  homepage: https://www.bibeltv.de/livestreams/impuls/
+  country: DE
+  status: stream-only
+  stationuuid: 2553f2df-1770-4320-aaaa-8c0af242dd66
+  changeuuid: d52d0973-9840-4c33-800b-4ffc198dc71f
+  reviewedAt: "2026-05-04"
+
+- id: de-bibel-tv-musik
+  broadcaster: independent
+  name: Bibel TV Musik
+  streamUrl: https://bibeltv03.iptv-playoutcenter.de/bibeltv03/bibeltv03.stream_all/bibeltv03/bibeltv03.stream_1/chunks.m3u8
+  codec: UNKNOWN
+  favicon: https://beta.bibeltv.de/livestreams/favicon.ico
+  homepage: https://beta.bibeltv.de/livestreams/musik/
+  country: DE
+  status: stream-only
+  stationuuid: 4f9d0131-c19a-4db4-89e0-2e8a1cc6c7b0
+  changeuuid: e2dfb6a8-e784-4601-b755-5d02be2c87e2
+  reviewedAt: "2026-05-04"
+
+- id: de-fu-ball-bundesliga-2-spiel-3
+  broadcaster: independent
+  name: "Fußball-Bundesliga 2: Spiel 3"
+  streamUrl: https://wdr-sportschau-liga2spiel3.icecastssl.wdr.de/wdr/sportschau/liga2spiel3/mp3/high
+  bitrate: 128
+  codec: MP3
+  favicon: https://www1.wdr.de/sport/fussball/logo-dfl-fussball-zweite-liga-zweitausendachtzehn-100~_v-ARDKleinerTeaser.jpg
+  homepage: https://livecenter.sportschau.de/
+  country: DE
+  status: stream-only
+  stationuuid: 9e5ef7b7-46a3-4aab-b516-f0f190db34e2
+  changeuuid: a2f08052-6794-4d72-adb6-69e218dc5528
+  reviewedAt: "2026-05-04"
+
+- id: de-fu-ball-bundesliga-2-spiel-8
+  broadcaster: independent
+  name: "Fußball-Bundesliga 2: Spiel 8"
+  streamUrl: https://wdr-sportschau-liga2spiel8.icecastssl.wdr.de/wdr/sportschau/liga2spiel8/mp3/high
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.sportschau.de/resources/assets/image/favicon/apple-icon-120x120.png
+  homepage: https://livecenter.sportschau.de/
+  country: DE
+  status: stream-only
+  stationuuid: 8fae7b14-9307-4969-9e3d-650ee5acc900
+  changeuuid: b1a335d4-35e3-49fe-b003-915e894c1589
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-corax
+  broadcaster: independent
+  name: Radio CORAX
+  streamUrl: https://streaming.fueralle.org/corax_192.mp3
+  codec: MP3
+  favicon: https://radiocorax.de/favicon.ico
+  homepage: https://radiocorax.de/
+  country: DE
+  status: stream-only
+  stationuuid: 4fec5f7d-51ae-49af-b36f-b4a025119ea6
+  changeuuid: 7bb72403-d381-403b-97fc-b97de4a1ce9b
+  reviewedAt: "2026-05-04"
+
+- id: de-reyfm-hip-hop
+  broadcaster: independent
+  name: "REYFM - #Hip-Hop"
+  streamUrl: https://listen.reyfm.de/reyfm-hip-hop/
+  bitrate: 320
+  codec: MP3
+  favicon: https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png
+  homepage: https://rey.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 1be86a54-d998-4a41-abd1-946c95692870
+  changeuuid: d481cab5-3aed-47cc-b57a-2652a7f4841f
+  reviewedAt: "2026-05-04"
+
+- id: de-techno-classics
+  broadcaster: independent
+  name: Techno Classics
+  streamUrl: https://stream.laut.fm/techno_classics
+  bitrate: 128
+  codec: MP3
+  homepage: https://laut.fm/techno_classics
+  country: DE
+  status: stream-only
+  stationuuid: 7a767417-5335-4ff8-afde-da514a09981c
+  changeuuid: 327c9512-8fd3-4d58-a60f-eee56dcbcf25
+  reviewedAt: "2026-05-04"
+
+- id: de-afro-house-afro-tech-deep-house-organic-house-tr
+  broadcaster: independent
+  name: "* AFRO HOUSE || Afro Tech, Deep House, Organic House, Tribal House, Melodic House, Tropical House, Ethnic House, Latin House, Percussion House, Beach Vibes, Summer Vibes, Sunset Grooves, Ibiza Vibes, Warm Up Grooves"
+  streamUrl: https://0nlineradio.radioho.st/technolovers-afro-house?ref=radio-browser26
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/gbM5ns1q/Afro-House.png
+  homepage: https://plus.rm.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 991dd9d5-2a83-47ff-a8bb-99e1e948ffe6
+  changeuuid: 9e2208c4-f69c-4499-a953-548de81f52e0
+  reviewedAt: "2026-05-04"
+
+- id: de-0r-euro-dance-eurodance-90s-dance-pop-dance-club
+  broadcaster: independent
+  name: "0R - EURO DANCE || Eurodance, 90s Dance, Pop, Dance, Club, Party, Trance, Techno, Electronic, Vocal, Hits, Energetic, Beat, Night, Dancefloor"
+  streamUrl: https://0nlineradio.radioho.st/technolovers-eurodance?ref=radio-browser26
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/7dJcRxVv/EURODANCE.png
+  homepage: https://plus.rm.fm/
+  country: DE
+  status: stream-only
+  stationuuid: e7516606-f5e4-4f5a-9b4c-c1f0a5a6462e
+  changeuuid: f97418a8-5989-44c2-a308-470e983985ae
+  reviewedAt: "2026-05-04"
+
+- id: de-bn-radio
+  broadcaster: independent
+  name: BN-Radio
+  streamUrl: https://stream.radio-unicc.de:8000/bn-radio.aacp
+  bitrate: 64
+  codec: AAC+
+  favicon: https://stream.radio-unicc.de/images/Logo-Radio_UNiCC.png
+  homepage: http://www.bn-radio.de/
+  country: DE
+  status: stream-only
+  stationuuid: c968aaa6-9157-46d4-b120-11ff088ad8ac
+  changeuuid: 7d191fd9-eeb6-4fe9-99dc-6026e715bce0
+  reviewedAt: "2026-05-04"
+
+- id: de-egofm-fame
+  broadcaster: independent
+  name: egoFM Fame
+  streamUrl: https://cast.egofm.de/egofmhalloffame.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.egofm.de/
+  country: DE
+  status: stream-only
+  stationuuid: 85557442-cf21-40ed-acb3-cfb9ee56625c
+  changeuuid: 348edf7f-9197-4a27-943e-fc5e3e622feb
+  reviewedAt: "2026-05-04"
+
+- id: de-ilovemusic-ilove2dance
+  broadcaster: independent
+  name: "ilovemusic: ilove2dance"
+  streamUrl: https://ilm.stream35.radiohost.de/ilm_ilove2dance_mp3-192?upd-meta&upd-scheme=https&_art=dD0xNzY4NDYzODAxJmQ9N2RlNDJmYjRiNDI1YjcxZjVjOTc
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.ilovemusic.de/favicon.ico
+  homepage: https://www.ilovemusic.de/
+  country: DE
+  status: stream-only
+  stationuuid: ae59f18b-83ce-4682-b49a-1f1d4edcced4
+  changeuuid: 7583de93-b528-4ab7-9b73-0f7507cf35a7
+  reviewedAt: "2026-05-04"
+
+- id: de-onedrop
+  broadcaster: independent
+  name: Onedrop
+  streamUrl: https://stream.laut.fm/onedrop
+  bitrate: 128
+  codec: MP3
+  homepage: https://laut.fm/onedrop
+  country: DE
+  status: stream-only
+  stationuuid: 55b13453-f641-4467-918e-21ece6b87d21
+  changeuuid: 9b4689fc-86dc-4e17-8d9c-c27203bfdd75
+  reviewedAt: "2026-05-04"
+
+- id: de-rock-antenne-young-stars
+  broadcaster: independent
+  name: ROCK ANTENNE Young Stars
+  streamUrl: https://stream.rockantenne.de/young-stars/stream/aacp
+  codec: AAC
+  favicon: https://www.rockantenne.de/logos/station-rock-antenne/apple-touch-icon.png
+  homepage: https://www.rockantenne.de/
+  country: DE
+  status: stream-only
+  stationuuid: c3e19107-591e-4b35-a1fc-90045eafc3a7
+  changeuuid: 3927f576-63c7-459e-ada2-43ab0401fcda
+  reviewedAt: "2026-05-04"
+
+- id: de-unifm-88-4
+  broadcaster: independent
+  name: UniFM 88,4
+  streamUrl: https://unifm-streams.uni-freiburg.de/unifm.mp3
+  codec: MP3
+  favicon: https://www.unicross.uni-freiburg.de/favicon.ico
+  homepage: https://www.unicross.uni-freiburg.de/
+  country: DE
+  status: stream-only
+  stationuuid: a8d8ae76-c58c-46fb-8c56-5dca86f5b228
+  changeuuid: 0d17bb29-8f84-4ca8-be93-7fc31bc61a69
+  reviewedAt: "2026-05-04"
+
+- id: de-hypertechno-techno-hard-techno-hands-up-industri
+  broadcaster: independent
+  name: "* HYPERTECHNO || Techno, Hard Techno, Hands Up, Industrial Techno, Rave, Acid Techno, Peak Time, Warehouse, Underground, Driving Beats, High Energy, Dark, Fast BPM, Club, Festival, Night"
+  streamUrl: https://0nlineradio.radioho.st/technolovers-hypertechno?ref=radio-browser26
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/JRb5Cj0K/Hypertechno.png
+  homepage: https://plus.rm.fm/
+  country: DE
+  status: stream-only
+  stationuuid: d0f00451-eeb0-4fff-a23b-29aa68144fdf
+  changeuuid: 6708735d-8dbe-4137-9d39-78496bd04069
+  reviewedAt: "2026-05-04"
+
+- id: de-0nlineradio-gran-prix
+  broadcaster: independent
+  name: 0nlineradio GRAN PRIX
+  streamUrl: https://stream.0nlineradio.com/grandprix?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://0nlineradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: ea08555f-590e-445d-87dc-022f9db61d6b
+  changeuuid: 7d79ea61-e466-4f2b-b7ea-a68369ab6758
+  reviewedAt: "2026-05-04"
+
+- id: de-0r-beach-club-lounge-lounge-chill-deep-house-bal
+  broadcaster: independent
+  name: "0R - BEACH CLUB LOUNGE || Lounge, Chill, Deep House, Balearic, Summer, Relax, Tropical, Beach, Cafe, Cocktails, Smooth, Sunset, Downtempo, Background, Vibes"
+  streamUrl: https://0nlineradio.radioho.st/lounge-beach-club-lounge?ref=radio-browser26
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/j9rLGNvn/Beach-club-lounge.png
+  homepage: https://plus.rm.fm/
+  country: DE
+  status: stream-only
+  stationuuid: ef0f4fda-76d2-4fc1-88f0-8e150b0509bd
+  changeuuid: 3262e496-0d2e-4488-9f1d-78885e408f24
+  reviewedAt: "2026-05-04"
+
+- id: de-a-tv-augsburg
+  broadcaster: independent
+  name: a.tv Augsburg
+  streamUrl: https://augsburgtv.iptv-playoutcenter.de/augsburgtv/augsburgtv.stream_1/playlist.m3u8
+  bitrate: 3205
+  codec: AAC,H.264
+  favicon: https://www.augsburg.tv/storage/thumbs/192x192/r:1610477804/118847.png
+  homepage: https://www.augsburg.tv/
+  country: DE
+  status: stream-only
+  stationuuid: 1472814b-55f6-4124-9db7-a6fb59ea3a17
+  changeuuid: 7bf516ff-7704-4c5d-a1b1-57dfff6ececb
+  reviewedAt: "2026-05-04"
+
+- id: de-callshop-radio
+  broadcaster: independent
+  name: Callshop Radio
+  streamUrl: https://icecast.callshopradio.com/callshopradio
+  bitrate: 128
+  codec: MP3
+  homepage: https://callshopradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 3d31c7c7-9530-4e60-bd62-0b4398e94b65
+  changeuuid: 4d45b754-9316-4fb4-bdac-92ada20e2851
+  reviewedAt: "2026-05-04"
+
+- id: de-defjay
+  broadcaster: independent
+  name: DefJay
+  streamUrl: https://icepool.silvacast.com/DEFJAY.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://fility.com/wp-content/uploads/2020/07/defjay.png
+  homepage: http://defjay.com/
+  country: DE
+  status: stream-only
+  stationuuid: ff2ba961-4c95-4530-bf7f-cee7001d98e3
+  changeuuid: d473089f-aa3a-4497-8e42-d13e4c959b86
+  reviewedAt: "2026-05-04"
+
+- id: de-fu-ball-bundesliga-2-spiel-6
+  broadcaster: independent
+  name: "Fußball-Bundesliga 2: Spiel 6"
+  streamUrl: https://wdr-sportschau-liga2spiel6.icecastssl.wdr.de/wdr/sportschau/liga2spiel6/mp3/high
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.sportschau.de/resources/assets/image/favicon/apple-icon-120x120.png
+  homepage: https://livecenter.sportschau.de/
+  country: DE
+  status: stream-only
+  stationuuid: 7f09121a-2227-443e-87d7-286fb42aeef9
+  changeuuid: 6ab6711c-f197-4137-99af-edd089e6f279
+  reviewedAt: "2026-05-04"
+
+- id: de-jesus-deine-hoffnung-radio
+  broadcaster: independent
+  name: jesus-deine-hoffnung-radio
+  streamUrl: https://jesus-deine-hoffnung-radio.stream.laut.fm/jesus-deine-hoffnung-radio
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.jesus-deine-hoffnung.org/
+  country: DE
+  status: stream-only
+  stationuuid: ac9d99a2-e141-4b54-b69e-d2f7b8883ed9
+  changeuuid: 032cbc2f-a429-4167-b4d4-f80c430311dd
+  reviewedAt: "2026-05-04"
+
+- id: de-mother-earth-jazz
+  broadcaster: independent
+  name: Mother Earth Jazz
+  streamUrl: https://stream.motherearthradio.de/listen/motherearth_jazz/motherearth.jazz.mp4
+  bitrate: 320
+  codec: AAC
+  favicon: https://motherearthradio.de/wp-content/uploads/2024/03/mergoldcube512.png
+  homepage: https://motherearthradio.de/
+  country: DE
+  status: stream-only
+  stationuuid: a63ee551-5157-4dc1-b7ea-800356efc306
+  changeuuid: b311108a-fefb-487e-9a40-0b29b71dc351
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-galaxy-mittelfranken
+  broadcaster: independent
+  name: Radio Galaxy Mittelfranken
+  streamUrl: https://live.galaxy-mittelfranken.de/galaxy-mittelfranken.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://assets.radioplayer.de/stationimages/389_programme_image.png
+  homepage: https://www.galaxy-mittelfranken.de/
+  country: DE
+  status: stream-only
+  stationuuid: 6f6c83f9-73d7-4650-9c16-15c36ae054c4
+  changeuuid: a4b447c6-49ff-44b3-b3a3-c477d55cc5e5
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-reeperbahn-weihnachten
+  broadcaster: independent
+  name: RADIO Reeperbahn Weihnachten
+  streamUrl: https://s35.derstream.net/reeperbahn-ch3.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.radio-reeperbahn.de/wp-content/uploads/Logo-RR-Weihnachten-2200x2200-1.png
+  homepage: https://radio-reeperbahn.de/
+  country: DE
+  status: stream-only
+  stationuuid: b11bb7e0-2cc4-47dd-850c-81f7d65042a9
+  changeuuid: d4180108-3f2c-4800-b9eb-ea03bc3f1029
+  reviewedAt: "2026-05-04"
+
+- id: de-antenne-munster-deutsch-pop
+  broadcaster: independent
+  name: Antenne Münster Deutsch Pop
+  streamUrl: https://stream.lokalradio.nrw/4457nc9
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.antennemuenster.de/
+  country: DE
+  status: stream-only
+  stationuuid: 56ab86b0-29cf-47ba-9926-0826b0cd7de2
+  changeuuid: 3280f0ce-d5cd-45e4-a63e-aef7f3c70fdd
+  reviewedAt: "2026-05-04"
+
+- id: de-dengeqamishlo
+  broadcaster: independent
+  name: dengeqamishlo
+  streamUrl: https://dengeqamishlo.stream.laut.fm/dengeqamishlo
+  bitrate: 128
+  codec: MP3
+  favicon: https://cdn.onlineradiobox.com/img/apple-touch-icon-120x120.png
+  homepage: https://onlineradiobox.com/de/dengeqamishlo/?lang=tr
+  country: DE
+  status: stream-only
+  stationuuid: 56c4a36d-e895-483a-b856-07934c01b8d7
+  changeuuid: 319c0408-a877-4f0c-9f7b-807ab2f5c6b6
+  reviewedAt: "2026-05-04"
+
+- id: de-dublab-de
+  broadcaster: independent
+  name: dublab DE
+  streamUrl: https://dublabde.out.airtime.pro/dublabde_a
+  bitrate: 128
+  codec: MP3
+  favicon: https://pbs.twimg.com/profile_images/882223798275231745/rEbH-Yry_400x400.jpg
+  homepage: https://dublab.de/
+  country: DE
+  status: stream-only
+  stationuuid: 652e1061-5de4-442f-8b7e-cd0dfbd37048
+  changeuuid: 32d87188-f1a3-4ba3-86fe-6d2ed16f005e
+  reviewedAt: "2026-05-04"
+
+- id: de-ice-radio-waldkraiburg-3-dolce-vita-mit-italieni
+  broadcaster: independent
+  name: ICE RADIO WALDKRAIBURG 3 Dolce Vita mit Italienischen Hits
+  streamUrl: https://irw.tunefm.de:8050/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://irwradio.de/apple-icon-120x120.png
+  homepage: https://irwradio.de/
+  country: DE
+  status: stream-only
+  stationuuid: bfde674a-43ec-4b87-a8e0-fa69e7722705
+  changeuuid: 50279ed5-2894-4b25-bdee-83bf121f2716
+  reviewedAt: "2026-05-04"
+
+- id: de-ndr-fernsehen-sh
+  broadcaster: independent
+  name: NDR Fernsehen SH
+  streamUrl: https://mcdn.ndr.de/ndr/hls/ndr_fs/ndr_sh/master.m3u8
+  bitrate: 1672
+  codec: AAC
+  homepage: https://www.ndr.de/fernsehen/index.html
+  country: DE
+  status: stream-only
+  stationuuid: c5532b82-3437-4a8f-943d-7f753913c07e
+  changeuuid: d5fbf018-d5e7-4b0c-9997-eec3723a584b
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-altstastwelle
+  broadcaster: independent
+  name: Radio Altstastwelle
+  streamUrl: https://icecast.multhielemedia.de/radio/8040/rheinradio.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: https://altstadtwelle.de/
+  country: DE
+  status: stream-only
+  stationuuid: 863d235d-4273-4b10-ae0b-aade95352fcd
+  changeuuid: 640be245-291b-4517-9aee-81a0e1a4f4c3
+  reviewedAt: "2026-05-04"
+
+- id: de-fred-film-radio-deutsch
+  broadcaster: independent
+  name: Fred Film Radio(Deutsch)
+  streamUrl: https://s10.webradio-hosting.com/proxy/fredradioge/stream
+  bitrate: 128
+  codec: MP3
+  homepage: http://www.fred.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 2114450d-e723-437d-b18b-52cb9312b362
+  changeuuid: d7bb66dd-8285-4963-9ae5-e6e38ba7d87d
+  reviewedAt: "2026-05-04"
+
+- id: de-freies-sender-kombinat-hamburg
+  broadcaster: independent
+  name: Freies Sender Kombinat Hamburg
+  streamUrl: https://streaming.fueralle.org/fsk.ogg
+  bitrate: 320
+  codec: OGG
+  favicon: https://www.fsk-hh.org/favicon.ico
+  homepage: https://www.fsk-hh.org/
+  country: DE
+  status: stream-only
+  stationuuid: fd3d0da7-1832-45fd-a51f-8f95d6d91ee7
+  changeuuid: 6b951c96-8040-485c-89e8-00f905cdc459
+  reviewedAt: "2026-05-04"
+
+- id: de-fu-ball-bundesliga-2-spiel-7
+  broadcaster: independent
+  name: "Fußball-Bundesliga 2: Spiel 7"
+  streamUrl: https://wdr-sportschau-liga2spiel7.icecastssl.wdr.de/wdr/sportschau/liga2spiel7/mp3/high
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.sportschau.de/resources/assets/image/favicon/apple-icon-120x120.png
+  homepage: https://livecenter.sportschau.de/
+  country: DE
+  status: stream-only
+  stationuuid: 906c9429-b068-432b-8c23-2e2e783b25d9
+  changeuuid: b24ab5b2-839c-44bc-b567-7bb5dc809b8b
+  reviewedAt: "2026-05-04"
+
+- id: de-i-love-x-mas
+  broadcaster: independent
+  name: i love x-mas
+  streamUrl: https://ilm.stream18.radiohost.de/ilm_ilovexmas_mp3-192?upd-meta&upd-scheme=https&_art=dD0xNzY4NDU4MzE2JmQ9ZmJlN2QyNDY5YWUzODc0OWFlNGY
+  bitrate: 192
+  codec: MP3
+  favicon: http://www.iloveradio.de/favicon.ico
+  homepage: http://www.iloveradio.de/
+  country: DE
+  status: stream-only
+  stationuuid: 964bd54c-0601-11e8-ae97-52543be04c81
+  changeuuid: 0cbb0f18-390a-4adc-92ad-1dbf75ada445
+  reviewedAt: "2026-05-04"
+
+- id: de-primal-fm-dresden
+  broadcaster: independent
+  name: PRIMAL.FM DRESDEN
+  streamUrl: https://main.stream.primal.fm/dresden
+  bitrate: 320
+  codec: MP3
+  homepage: https://primal.fm/
+  country: DE
+  status: stream-only
+  stationuuid: e8e57947-b7ce-42f4-9e17-b1565017ccb2
+  changeuuid: c18f3a06-c8bf-455a-8f78-97d8ffe008ef
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-frankfurt
+  broadcaster: independent
+  name: Radio Frankfurt
+  streamUrl: https://radiogroup-stream32.radiohost.de/radio-frankfurt_mp3-192
+  bitrate: 192
+  codec: MP3
+  homepage: https://radiofrankfurt.de/
+  country: DE
+  status: stream-only
+  stationuuid: c1450051-84bf-44eb-9585-795dc31fb225
+  changeuuid: 8d335b60-886b-4ce4-a715-c575adad3949
+  reviewedAt: "2026-05-04"
+
+- id: de-radioselection
+  broadcaster: independent
+  name: RadioSelection
+  streamUrl: https://live.radio-selection.de/onair
+  bitrate: 128
+  codec: AAC
+  favicon: https://www.radioselection.de/favicon.ico
+  homepage: https://www.radioselection.de/
+  country: DE
+  status: stream-only
+  stationuuid: ec3c6921-6654-46f6-a5df-103e5bab8efb
+  changeuuid: e0978783-e89e-4ece-9352-5f52e97c8f04
+  reviewedAt: "2026-05-04"
+
+- id: de-retrowelle
+  broadcaster: independent
+  name: Retrowelle
+  streamUrl: https://stream.laut.fm/retrowelle
+  bitrate: 128
+  codec: MP3
+  homepage: https://laut.fm/retrowelle
+  country: DE
+  status: stream-only
+  stationuuid: bd3f379c-5bb5-4be1-9be5-e06aff0ccc31
+  changeuuid: 003928f4-dc55-4fbd-88b5-5df82c5fba30
+  reviewedAt: "2026-05-04"
+
+- id: de-0r-90s-90s-pop-90s-hits-eurodance-hip-hop-r-b-gr
+  broadcaster: independent
+  name: "0R - 90s || 90s Pop, 90s Hits, Eurodance, Hip Hop, R&B, Grunge, Alternative, Techno, Trance, Dance, Chill, Boyband, Girlband, Pop Rock, Nostalgic"
+  streamUrl: https://0nlineradio.radioho.st/0r-90s?ref=radio-browser26
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/S4y9mSR9/90s.png
+  homepage: https://plus.rm.fm/
+  country: DE
+  status: stream-only
+  stationuuid: ce3e9d01-3614-45f2-ae25-93f944005eaa
+  changeuuid: 43614a98-f12c-47e0-8c0f-96efdb587f72
+  reviewedAt: "2026-05-04"
+
+- id: de-brexit-laut-fm
+  broadcaster: independent
+  name: Brexit - Laut.FM
+  streamUrl: https://brexit.stream.laut.fm/brexit?ref=web-app&start_time=1702103555811&t302=2023-12-09_07-32-35&uuid=4db366ed-fe79-45d1-a858-be3945ba5b7f
+  bitrate: 128
+  codec: MP3
+  favicon: https://upload.wikimedia.org/wikipedia/commons/d/d4/BREXIT.jpg
+  homepage: https://laut.fm/brexit
+  country: DE
+  status: stream-only
+  stationuuid: 20581fd5-57fb-4670-9921-b37b178c08b9
+  changeuuid: 984c5169-17a5-4c50-aeb2-f0c1c309f35e
+  reviewedAt: "2026-05-04"
+
+- id: de-ella-radio-classic-jazz
+  broadcaster: independent
+  name: Ella Radio - Classic Jazz
+  streamUrl: https://stream.ella-radio.de/ella-classic-jazz/mp3-192/?ref=radio-browser
+  bitrate: 192
+  codec: MP3
+  favicon: https://ella-radio.de/uplink/Ella_Classic-Jazz.jpg
+  homepage: https://www.ella-radio.de/
+  country: DE
+  status: stream-only
+  stationuuid: 822383b9-7f85-44c6-b089-e069760f9106
+  changeuuid: 93ef9523-1441-415d-8190-e37e3987441b
+  reviewedAt: "2026-05-04"
+
+- id: de-freefm
+  broadcaster: independent
+  name: Freefm
+  streamUrl: https://stream.freefm.de/Studio
+  bitrate: 192
+  codec: MP3
+  favicon: https://freefm.de/sites/all/themes/freefm/favicon.ico
+  homepage: https://freefm.de/
+  country: DE
+  status: stream-only
+  stationuuid: c91a49fb-dfe3-4a22-b4ec-dcd8f93eaa1e
+  changeuuid: 9209fb4e-d1e3-40cd-b4b2-f1ab11f8e31d
+  reviewedAt: "2026-05-04"
+
+- id: de-fu-ball-bundesliga-spiel-6
+  broadcaster: independent
+  name: "Fußball-Bundesliga: Spiel 6"
+  streamUrl: https://wdr-sportschau-liga1spiel6.icecastssl.wdr.de/wdr/sportschau/liga1spiel6/mp3/high
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.sportschau.de/resources/assets/image/favicon/apple-icon-120x120.png
+  homepage: https://livecenter.sportschau.de/
+  country: DE
+  status: stream-only
+  stationuuid: d8ab13f9-e757-4302-a2bf-8c926d58c5fb
+  changeuuid: 6762bfd7-3fa7-44ce-be99-4acf55167374
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-back-in-itime
+  broadcaster: independent
+  name: Radio Back in Itime
+  streamUrl: https://stream.laut.fm/back_in_time?ref=radiode
+  bitrate: 128
+  codec: MP3
+  favicon: https://cdn.website-editor.net/04b5fe00bd1b4aac97417392b1ec949a/site_favicon_16_1685893203381.ico
+  homepage: https://www.hitparadenkult.de/
+  country: DE
+  status: stream-only
+  stationuuid: 2eb192c9-10fc-4198-a7f7-bc0998e726df
+  changeuuid: 9ab08d74-efe2-4638-b956-b227c6e57fd2
+  reviewedAt: "2026-05-04"
+
+- id: de-rock-antenne-90er-rock-2
+  broadcaster: independent
+  name: Rock Antenne - 90er Rock
+  streamUrl: https://stream.rockantenne.de/90er-rock/stream/mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png
+  homepage: https://www.rockantenne.de/rockhoeren/streams/90er-rock
+  country: DE
+  status: stream-only
+  stationuuid: 798d8fff-1391-48f6-adc5-f34f37ffa7d0
+  changeuuid: a1a36ce0-4dbc-4c6a-b6fe-fc9fd064e1ae
+  reviewedAt: "2026-05-04"
+
+- id: de-animealive
+  broadcaster: independent
+  name: animealive
+  streamUrl: https://stream.laut.fm/animealive
+  bitrate: 128
+  codec: MP3
+  homepage: https://laut.fm/animealive
+  country: DE
+  status: stream-only
+  stationuuid: b6c2f644-f857-400c-8404-3785774831c5
+  changeuuid: f20ed428-bbd9-40e7-ba00-bdc04d506379
+  reviewedAt: "2026-05-04"
+
+- id: de-ice-radio-waldkraiburg-2-bahnbrechende-schlager-
+  broadcaster: independent
+  name: ICE RADIO WALDKRAIBURG 2 +++  Bahnbrechende Schlager aus 60 Jahren +++ Deutschsprachig und Mundart Hits aus Deutschland - Österreich - Schweiz
+  streamUrl: https://irw.tunefm.de:8410/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.irwradio.de/apple-icon-120x120.png
+  homepage: https://www.irwradio.de/
+  country: DE
+  status: stream-only
+  stationuuid: bcb9ec7f-0341-4516-85a0-101256d11400
+  changeuuid: e7097b1c-8c3b-43f5-8a98-3a851d3db0a2
+  reviewedAt: "2026-05-04"
+
+- id: de-mabu-beatz-radio-techno
+  broadcaster: independent
+  name: MABU Beatz Radio - Techno
+  streamUrl: https://audio.mabu-beatz-radio.com:8003/techno
+  bitrate: 128
+  codec: MP3
+  favicon: https://i.postimg.cc/vHDM8brn/OIP.jpg
+  homepage: https://mabu-beatz-radio.com/streams/techno/
+  country: DE
+  status: stream-only
+  stationuuid: 941ccfa4-798e-48ca-878d-c84e499fede1
+  changeuuid: 64d8896f-0fae-425a-9102-16e66e1ab28e
+  reviewedAt: "2026-05-04"
+
+- id: de-mother-earth-radio
+  broadcaster: independent
+  name: Mother Earth Radio
+  streamUrl: https://stream.motherearthradio.de/listen/motherearth/motherearth.aac
+  bitrate: 320
+  codec: AAC
+  favicon: https://motherearthradio.de/wp-content/uploads/2024/03/mergoldcube512.png
+  homepage: https://motherearthradio.de/
+  country: DE
+  status: stream-only
+  stationuuid: c716896e-7c7c-44ef-8ce8-2fb8d0a9c97e
+  changeuuid: 1b383d9c-92f5-4371-af6c-e5a6069ec83a
+  reviewedAt: "2026-05-04"
+
+- id: de-rock-antenne-hamburg-aac
+  broadcaster: independent
+  name: Rock Antenne Hamburg (AAC)
+  streamUrl: https://stream.rockantenne.de/rockantenne-hamburg/stream/aacp
+  codec: AAC
+  favicon: https://www.rockantenne.de/media/cache/3/version/13/rahh-v1.jpg/fccb3fcb0a2733dd2265a4d6eb6ad375.webp
+  homepage: https://www.rockantenne.de/
+  country: DE
+  status: stream-only
+  stationuuid: 5a3a93e0-ad75-42a1-8d0f-07266121c4fc
+  changeuuid: 2061a53c-cc28-41a4-8645-427806855000
+  reviewedAt: "2026-05-04"
+
+- id: de-rock-antenne-punkrock
+  broadcaster: independent
+  name: Rock Antenne Punkrock
+  streamUrl: https://s3-webradio.rockantenne.de/punkrock/stream/mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.rockantenne.de/rockhoeren/streams/punk-rock
+  country: DE
+  status: stream-only
+  stationuuid: 3a363c7c-0b66-4d78-9972-e62ab56ee61c
+  changeuuid: 020413c4-56c8-466b-a117-d17522350e67
+  reviewedAt: "2026-05-04"
+
+- id: de-swr-4-heilbronn
+  broadcaster: independent
+  name: SWR 4 Heilbronn
+  streamUrl: https://liveradio.swr.de/sw282p3/swr4hn/
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.swr.de/assets/swr/swr4/favicon.ico
+  homepage: https://www.swr.de/swr4/index.html
+  country: DE
+  status: stream-only
+  stationuuid: b93e1446-9d39-4c1f-b74a-ad88c73930d6
+  changeuuid: 8b27b959-316c-49c6-bc34-83155b851dc5
+  reviewedAt: "2026-05-04"
+
+- id: de-1000-80-hits
+  broadcaster: independent
+  name: 1000 80 Hits
+  streamUrl: https://ais-sa9.cdnstream1.com/1898_128
+  bitrate: 128
+  codec: MP3
+  homepage: https://1000hits80s.eu/
+  country: DE
+  status: stream-only
+  stationuuid: 80db7fe1-86b0-48af-9bb1-b6f2b1e4e612
+  changeuuid: 01ec10b6-6f85-44ed-87ad-f84c84ffd4ad
+  reviewedAt: "2026-05-04"
+
+- id: de-94-3-rs2
+  broadcaster: independent
+  name: 94.3 rs2
+  streamUrl: https://stream.rs2.de/rs2/mp3-128/playlist
+  bitrate: 128
+  codec: MP3
+  favicon: null
+  homepage: https://webradio.rs2de/livestream.m3u
+  country: DE
+  status: stream-only
+  stationuuid: 420cdacb-f875-4717-8e29-2f738be1375e
+  changeuuid: 603c95b9-a5d2-4f7a-9609-f6c7c6754136
+  reviewedAt: "2026-05-04"
+
+- id: de-a-passing-feeling
+  broadcaster: independent
+  name: A Passing Feeling
+  streamUrl: https://apassingfeeling.stream.laut.fm/a_passing_feeling
+  bitrate: 128
+  codec: MP3
+  favicon: https://cdn.onlineradiobox.com/img/l/8/44488.v1.png
+  homepage: https://www.tumblr.com/apfelsindie
+  country: DE
+  status: stream-only
+  stationuuid: 29b1a6f5-2b22-4985-bd1d-b6485c0916f5
+  changeuuid: dfceba9b-d018-4474-9bcf-e48764cb0dd6
+  reviewedAt: "2026-05-04"
+
+- id: de-ella-radio-mellow-smooth-jazz
+  broadcaster: independent
+  name: Ella Radio - Mellow Smooth Jazz
+  streamUrl: https://stream.ella-radio.de/ella-mellow-smooth-jazz/mp3-192/?ref=radio-browser
+  bitrate: 192
+  codec: MP3
+  favicon: https://ella-radio.de/uplink/Ella_Mellow-Smooth-Jazz.jpg
+  homepage: https://www.ella-radio.de/
+  country: DE
+  status: stream-only
+  stationuuid: ea2d7419-d7cc-4928-8e32-4f3794258ba5
+  changeuuid: a27fae5c-b73e-43be-96a9-26babedc13e1
+  reviewedAt: "2026-05-04"
+
+- id: de-ella-radio-saxophon-jazz
+  broadcaster: independent
+  name: Ella Radio - Saxophon Jazz
+  streamUrl: https://stream.ella-radio.de/ella-saxophon-jazz/mp3-192/%20?ref=radio-browser
+  bitrate: 192
+  codec: MP3
+  favicon: https://ella-radio.de/uplink/Ella_Saxophone-Jazz.jpg
+  homepage: https://www.ella-radio.de/
+  country: DE
+  status: stream-only
+  stationuuid: c6536e49-6426-4786-b216-f4d6469479e1
+  changeuuid: feefdc54-2a5c-43e1-a3e4-039f4cdf0e89
+  reviewedAt: "2026-05-04"
+
+- id: de-radiosilesia
+  broadcaster: independent
+  name: RadioSilesia
+  streamUrl: https://s1.slotex.pl/shoutcast/7350/stream
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radiosilesia.de/
+  country: DE
+  status: stream-only
+  stationuuid: a3bda8fd-55c8-47fd-9488-b3dfd2d36501
+  changeuuid: 693c797c-61d8-4380-8b1d-86208a3fa736
+  reviewedAt: "2026-05-04"
+
+- id: de-schwany-2-schlager
+  broadcaster: independent
+  name: Schwany 2 Schlager
+  streamUrl: https://schlager.sp.radio.fm/stream
+  bitrate: 320
+  codec: MP3
+  favicon: https://www.schwany.de/images/Hoamatwelle-Logo-320-x-240-px.webp
+  homepage: https://schwany.de/schwany-schlager.html
+  country: DE
+  status: stream-only
+  stationuuid: e9931b28-7151-4feb-b4b5-cf232bf21359
+  changeuuid: 0ecaab8a-1ac7-4208-adde-4a6328689428
+  reviewedAt: "2026-05-04"
+
+- id: de-slonski-musikbox
+  broadcaster: independent
+  name: Slonski MusikBox
+  streamUrl: https://s1.slotex.pl:7550/stream/
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.slonski-musikbox.de/
+  country: DE
+  status: stream-only
+  stationuuid: 16fffb5e-8c4d-4f01-bec6-4ef692184a9f
+  changeuuid: 4491296e-8b4c-469e-b805-bdaf8c279264
+  reviewedAt: "2026-05-04"
+
+- id: de-swr1-rp
+  broadcaster: independent
+  name: SWR1 RP
+  streamUrl: https://liveradio.swr.de/sw282p3/swr1rp/
+  bitrate: 128
+  codec: MP3
+  favicon: https://s3.eu-central-1.amazonaws.com/radioportals/livewebradio-de/images/stations/swr1-rheinland-pfalz-cover.png
+  homepage: https://www.swr.de/swr1/rp/index.html
+  country: DE
+  status: stream-only
+  stationuuid: 20d94705-7563-451e-b4f0-5666a319f9cb
+  changeuuid: 3c17ab99-f994-4d01-98c6-0d243b7344e1
+  reviewedAt: "2026-05-04"
+
+- id: de-ac-plus
+  broadcaster: independent
+  name: AC-PLUS
+  streamUrl: https://stream.laut.fm/ac-plus
+  bitrate: 128
+  codec: MP3
+  homepage: https://ac-plus.de.tl/
+  country: DE
+  status: stream-only
+  stationuuid: 72926cdc-fb67-11e9-bbf2-52543be04c81
+  changeuuid: 889c4a98-0d7e-4de5-98b6-2ef061d7d72c
+  reviewedAt: "2026-05-04"
+
+- id: de-babaganousha-labs
+  broadcaster: independent
+  name: Babaganousha Labs
+  streamUrl: https://babacast.ddns.net/listen/baba_archives/baba-labs.mp3
+  bitrate: 96
+  codec: AAC
+  favicon: https://babaganousha.net/images/baba/baba_logo_001.jpg
+  homepage: https://babaganousha.net/
+  country: DE
+  status: stream-only
+  stationuuid: 3b590c1e-7422-455c-b1fe-c67bb4792da5
+  changeuuid: 69cabca4-77b3-483b-b23c-f833c7c1f812
+  reviewedAt: "2026-05-04"
+
+- id: de-babaganousha-radio
+  broadcaster: independent
+  name: Babaganousha Radio
+  streamUrl: https://babacast.ddns.net/listen/babaazu/baba-radio.mp3
+  bitrate: 96
+  codec: AAC
+  favicon: https://babaganousha.net/media/templates/site/cassiopeia/images/favicon.ico
+  homepage: https://babaganousha.net/
+  country: DE
+  status: stream-only
+  stationuuid: 25992af3-a2cc-4487-b9f5-af75171c231a
+  changeuuid: 44e4d40d-7f2b-4929-869c-3f32f937a08a
+  reviewedAt: "2026-05-04"
+
+- id: de-fmrausch-fm-rausch-radio
+  broadcaster: independent
+  name: "FMRausch: FM Rausch Radio"
+  streamUrl: https://fmrausch.stream.laut.fm/fmrausch
+  bitrate: 128
+  codec: MP3
+  homepage: https://laut.fm/fmrausch
+  country: DE
+  status: stream-only
+  stationuuid: 90e838c6-b16c-11e9-acb2-52543be04c81
+  changeuuid: 8637b15a-f2a5-4db8-bb4d-f615b0db9b62
+  reviewedAt: "2026-05-04"
+
+- id: de-fu-ball-bundesliga-2-spiel-5
+  broadcaster: independent
+  name: "Fußball-Bundesliga 2: Spiel 5"
+  streamUrl: https://wdr-sportschau-liga2spiel5.icecastssl.wdr.de/wdr/sportschau/liga2spiel5/mp3/high
+  bitrate: 128
+  codec: MP3
+  favicon: https://www1.wdr.de/sport/fussball/logo-dfl-fussball-zweite-liga-zweitausendachtzehn-100~_v-ARDKleinerTeaser.jpg
+  homepage: https://livecenter.sportschau.de/
+  country: DE
+  status: stream-only
+  stationuuid: cd9eb98d-6546-4726-b007-3296c95e1a79
+  changeuuid: 83a0f44c-3a59-4c06-8314-8898f87d48c3
+  reviewedAt: "2026-05-04"
+
+- id: de-odinsmetalrockclub
+  broadcaster: independent
+  name: ODINSMETALROCKCLUB
+  streamUrl: https://odinsmetalrockclub.stream.laut.fm/odinsmetalrockclub?pl=m3u&t302=2026-01-15_06-47-08&uuid=a3f143a2-3f6a-450e-ab7a-0c9f463704ff
+  bitrate: 128
+  codec: MP3
+  homepage: https://stream.laut.fm/odinsmetalrockclub
+  country: DE
+  status: stream-only
+  stationuuid: 51daaa30-b408-4d05-b5b7-a2a3c377b20a
+  changeuuid: fb9ba01f-3c5c-49e6-8d21-439a8ff584a1
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-91-2
+  broadcaster: independent
+  name: Radio 91.2
+  streamUrl: https://radio912--di--nacs-ais-lgc--02--cdn.cast.addradio.de/radio912/live/mp3/high
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.radio912.de/assets/images/favicons/radio912/favicon_x96.png
+  homepage: https://www.radio912.de/index.html
+  country: DE
+  status: stream-only
+  stationuuid: 3a3d7d26-ebbb-4ed5-b431-00a2e58d1ad9
+  changeuuid: 7257d4c0-0e39-48e1-b5a0-4d896564e284
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-ffn-dance-only
+  broadcaster: independent
+  name: Radio ffn - Dance Only
+  streamUrl: https://ffn-stream20.radiohost.de/ffn-dance_only_mp3-192?ref=radio-browser
+  bitrate: 192
+  codec: MP3
+  favicon: https://player.ffn.de/assets/channels/ffn_Logo_Play_Dance_only_srgb.png
+  homepage: https://www.ffn.de/
+  country: DE
+  status: stream-only
+  stationuuid: 868879e1-388e-427b-be01-7c3b15fcde16
+  changeuuid: d681e12f-1a08-4961-8a6a-cfe2bdb96093
+  reviewedAt: "2026-05-04"
+
+- id: de-rautemusik-progressive-aac-48-kbps
+  broadcaster: independent
+  name: "RauteMusik Progressive | AAC 48 kbps"
+  streamUrl: https://progressive-aacp.rautemusik.fm/
+  bitrate: 47
+  codec: AAC+
+  favicon: https://www.rm.fm/favicon.ico
+  homepage: https://www.rautemusik.fm/
+  country: DE
+  status: stream-only
+  stationuuid: f18d1ae2-5d0a-4988-85d1-54b3202467c0
+  changeuuid: 3f28312b-1c1d-4561-b990-72e75c22a87d
+  reviewedAt: "2026-05-04"
+
+- id: de-reyfm-deutschrap
+  broadcaster: independent
+  name: "REYFM - #Deutschrap"
+  streamUrl: https://listen.reyfm.de/reyfm-deutschrap/
+  bitrate: 320
+  codec: MP3
+  favicon: https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png
+  homepage: https://rey.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 75939fb5-c46b-40ac-a20d-b0c500c2ca8e
+  changeuuid: 19f02353-af9f-43ed-a50c-8792665ad695
+  reviewedAt: "2026-05-04"
+
+- id: de-technoszene
+  broadcaster: independent
+  name: technoszene
+  streamUrl: https://technoszene.stream.laut.fm/technoszene?t302=2024-06-04_21-07-42&uuid=f61f723b-42b8-4886-aafb-273a4d87d2f6
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.technoszene.com/core/wp-content/uploads/2015/09/cropped-icon512-180x180.png
+  homepage: https://www.technoszene.com/radio/
+  country: DE
+  status: stream-only
+  stationuuid: 0e6669b5-b58c-4eff-a69e-2cc5381b5df8
+  changeuuid: 38cd29e5-5958-4249-9283-6f13bda6fda4
+  reviewedAt: "2026-05-04"
+
+- id: de-tide-radio
+  broadcaster: independent
+  name: TIDE.radio
+  streamUrl: https://rcstream0001.redcastle.net/radio/8000/tide-128.mp3?rp_source=1&=&&___cb=916093692175132
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.tidenet.de/assets/icons/android-icon-192x192.png
+  homepage: http://www.tidenet.de/radio
+  country: DE
+  status: stream-only
+  stationuuid: b57f1ce9-00ce-4f7e-95bf-c83c2e0a78f7
+  changeuuid: 3f516bf5-3a4e-4b0f-a161-df429bdc4b50
+  reviewedAt: "2026-05-04"
+
+- id: de-0r-classical-hotel-lounge-classical-classical-lo
+  broadcaster: independent
+  name: "0R - CLASSICAL HOTEL LOUNGE - CLASSICAL || Classical, Lounge, Piano, Strings, Elegant, Relax, Instrumental, Calm, Soft, Background, Timeless, Melodic, Sophisticated, Evening, Smooth"
+  streamUrl: https://0nlineradio.radioho.st/classical-classical-hotel-lounge?ref=radio-browser26
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/ZRZdcBkj/Classical-Hotel-Lounge.png
+  homepage: https://plus.rm.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 88538943-08ca-42a9-8363-50321821da20
+  changeuuid: 27c66c7d-2028-4272-8280-1d3fba58c197
+  reviewedAt: "2026-05-04"
+
+- id: de-ffn-tannenbaum
+  broadcaster: independent
+  name: ffn Tannenbaum
+  streamUrl: https://stream.ffn.de/tannenbaum/mp3-192/
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.ffn.de/
+  country: DE
+  status: stream-only
+  stationuuid: 3db12c0b-f97b-11e8-a97a-52543be04c81
+  changeuuid: 7902582a-b8fc-48de-82f2-73ad7c472fb9
+  reviewedAt: "2026-05-04"
+
+- id: de-ilovegerman-rap-1st-new-german-rap-hip-hop
+  broadcaster: independent
+  name: "ILOVEGERMAN RAP 1ST | New German Rap & Hip Hop"
+  streamUrl: https://ilm.stream35.radiohost.de/ilm_ilovedeutschrapfirst_mp3-192?upd-meta&upd-scheme=https&_art=dD0xNzY4NDY0MTc4JmQ9ODk0YjlkMGU1M2JlOTk1ODFlYWM
+  bitrate: 192
+  codec: MP3
+  favicon: https://ilovemusic.de/fileadmin/user_upload/ilm2024_ilovedeutschrapfirst1x1_02_440x440.jpg
+  homepage: https://ilovemusic.de/ilovedeutschrapfirst/
+  country: DE
+  status: stream-only
+  stationuuid: 3baf7f80-9641-497f-86b5-da645394d328
+  changeuuid: 4d82f63f-af9a-402c-b474-13a20ce1f381
+  reviewedAt: "2026-05-04"
+
+- id: de-jazz-christmas
+  broadcaster: independent
+  name: Jazz Christmas
+  streamUrl: https://jazzchristmas.stream.laut.fm/jazzchristmas?t302=2023-12-19_08-05-17&uuid=43cac575-4695-4eca-baf1-5d2f18f5897b
+  bitrate: 128
+  codec: MP3
+  homepage: https://jazzchristmas.stream.laut.fm/jazzchristmas?t302=2023-12-19_08-05-17&uuid=43cac575-4695-4eca-baf1-5d2f18f5897b
+  country: DE
+  status: stream-only
+  stationuuid: e14cb23e-01de-4969-b30f-0bdb73b26182
+  changeuuid: b0a4a3c0-1395-4f19-8337-d54b7d7fdcb9
+  reviewedAt: "2026-05-04"
+
+- id: de-laut-fm-hardcoremusik
+  broadcaster: independent
+  name: laut.fm HARDCOREMUSIK
+  streamUrl: https://stream.laut.fm/hardcoremusik
+  bitrate: 128
+  codec: MP3
+  homepage: https://laut.fm/hardcoremusik
+  country: DE
+  status: stream-only
+  stationuuid: db540c7f-7280-4789-96ff-f13c47307a7d
+  changeuuid: 68609770-240d-422e-a61a-e3c7809e7466
+  reviewedAt: "2026-05-04"
+
+- id: de-nius
+  broadcaster: independent
+  name: NiUS
+  streamUrl: https://nius--di--nacs-ais-lgc--0a--cdn.cast.addradio.de/nius/live/mp3/high
+  bitrate: 192
+  codec: MP3
+  homepage: https://nius.de/
+  country: DE
+  status: stream-only
+  stationuuid: 732ac56d-6bf3-4583-996c-e12457503c7c
+  changeuuid: d8b84dcd-5d69-40a2-9f48-d7b8b596250a
+  reviewedAt: "2026-05-04"
+
+- id: de-wdr-lokalzeit-dortmund
+  broadcaster: independent
+  name: WDR Lokalzeit Dortmund
+  streamUrl: https://wdrlokalzeit.akamaized.net/hls/live/2018022/wdrlz_dortmund/index.m3u8
+  codec: UNKNOWN
+  homepage: https://www1.wdr.de/fernsehen/startseite/
+  country: DE
+  status: stream-only
+  stationuuid: 557e1265-5fce-4a70-abc8-ce551bb46fe7
+  changeuuid: 13dd345a-34b8-4bf6-a57f-36a59dcbda0f
+  reviewedAt: "2026-05-04"
+
+- id: de-blues-und-rock-garage
+  broadcaster: independent
+  name: Blues und Rock Garage
+  streamUrl: https://stream.laut.fm/bluesundrockgarage
+  bitrate: 128
+  codec: MP3
+  homepage: https://laut.fm/bluesundrockgarage
+  country: DE
+  status: stream-only
+  stationuuid: 850c4119-94c0-4bbd-8ec6-c0ff17546386
+  changeuuid: 34f72433-a590-4e5b-b6b1-94964083621a
+  reviewedAt: "2026-05-04"
+
+- id: de-ella-radio-love-smooth-jazz
+  broadcaster: independent
+  name: Ella Radio - Love Smooth Jazz
+  streamUrl: https://stream.ella-radio.de/ella-love-smooth-jazz/mp3-192/?ref=radio-browser
+  bitrate: 192
+  codec: MP3
+  favicon: https://ella-radio.de/uplink/Ella_Love-Smooth-Jazz.jpg
+  homepage: https://www.ella-radio.de/
+  country: DE
+  status: stream-only
+  stationuuid: 8d748a5f-a4e7-498c-9697-a4776d0b8363
+  changeuuid: 8f05de26-101f-4c5a-9a43-7fc8f01f1fb1
+  reviewedAt: "2026-05-04"
+
+- id: de-ella-radio-mellow-piano-jazz
+  broadcaster: independent
+  name: Ella Radio - Mellow Piano Jazz
+  streamUrl: https://stream.ella-radio.de/ella-mellow-piano-jazz/mp3-192/?ref=radio-browser
+  bitrate: 192
+  codec: MP3
+  favicon: https://ella-radio.de/uplink/Ella_Mellow-Piano-Jazz.jpg
+  homepage: https://www.ella-radio.de/
+  country: DE
+  status: stream-only
+  stationuuid: 8a8d74f5-bd82-4a25-8b64-b444c75f2394
+  changeuuid: 6c73929a-8b46-4430-9756-665579bb7a06
+  reviewedAt: "2026-05-04"
+
+- id: de-fu-ball-bundesliga-2-spiel-9
+  broadcaster: independent
+  name: "Fußball-Bundesliga 2: Spiel 9"
+  streamUrl: https://wdr-sportschau-liga2spiel9.icecastssl.wdr.de/wdr/sportschau/liga2spiel9/mp3/high
+  bitrate: 128
+  codec: MP3
+  homepage: https://livecenter.sportschau.de/
+  country: DE
+  status: stream-only
+  stationuuid: e20b0af3-f341-46f3-9db6-337213939014
+  changeuuid: ce9927b5-5b48-4bdc-8371-4b4d74bf9229
+  reviewedAt: "2026-05-04"
+
+- id: de-i-love-rock-radio-i-love-music
+  broadcaster: independent
+  name: I Love Rock Radio - I Love Music
+  streamUrl: https://ilm.stream35.radiohost.de/ilm_iloveradiorock_mp3-192?upd-meta&upd-scheme=https&_art=dD0xNzc0MzQxMDA2JmQ9NGNlOGVhNTRlY2Q1MGJmNTAwYTA
+  bitrate: 192
+  codec: MP3
+  homepage: https://ilovemusic.de/iloverockradio/
+  country: DE
+  status: stream-only
+  stationuuid: 0bca7243-a25f-4413-95f9-45f32711fd6f
+  changeuuid: a91f0aff-7876-4c15-b95b-26df2f49a3d0
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-dreyeckland
+  broadcaster: independent
+  name: Radio Dreyeckland
+  streamUrl: https://stream.rdl.de/rdl
+  bitrate: 128
+  codec: MP3
+  favicon: https://rdl.de/sites/default/files/images/2022/09/rdl-logo-new-complete-circle.png
+  homepage: https://rdl.de/
+  country: DE
+  status: stream-only
+  stationuuid: b1390dc3-c6e7-418b-8db2-bb832623ea1c
+  changeuuid: 5a923948-bef8-4278-85e8-315135163616
+  reviewedAt: "2026-05-04"
+
+- id: de-rock-antenne-lagerfeuer-rock
+  broadcaster: independent
+  name: Rock Antenne - Lagerfeuer Rock
+  streamUrl: https://stream.rockantenne.de/lagerfeuer-rock/stream/mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png
+  homepage: https://www.rockantenne.de/rockhoeren/streams/lagerfeuer-rock
+  country: DE
+  status: stream-only
+  stationuuid: 1ae1d752-e931-476d-9014-fe009aad948b
+  changeuuid: 37f2094a-cf2e-481a-8cdc-47a775fb08fb
+  reviewedAt: "2026-05-04"
+
+- id: de-54-house-fm
+  broadcaster: independent
+  name: 54 House fm
+  streamUrl: https://54house.fm:9013/stream
+  bitrate: 192
+  codec: MP3
+  favicon: https://firebasestorage.googleapis.com/v0/b/radiogalaxy-580f4.appspot.com/o/images%2FIMG_20240306_191630247.jpg?alt=media&token=591c780d-a9ff-4cf1-9e7c-7f2127d7d944
+  homepage: https://www.54house.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 28c8598a-5b06-4a1e-a397-e43d9dff7c7b
+  changeuuid: 570b13b2-4a81-4167-9977-46fdf266d54d
+  reviewedAt: "2026-05-04"
+
+- id: de-allgauhit-dein-allgau-dein-radio-ein-hitmix-aus-
+  broadcaster: independent
+  name: "AllgäuHIT - Dein Allgäu. Dein Radio - Ein Hitmix aus aktuellen Pop- und Rocktiteln, ergänzt um echte Klassiker aus den 80er und 90er Jahren + Austropop. "
+  streamUrl: https://allgaeu.stream06.radiohost.de/allgaeuhit_mp3-192?ref=radio-browser&upd-meta&upd-scheme=https&_art=dD0xNzY4NDQ1NDU3JmQ9NDQ3ZDk4MmJkOTk3NzA2OTAzNzQ
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/DRNQfnc/Allg-u-HIT-800x800.jpg 
+  homepage: https://www.allgaeuhit.de/
+  country: DE
+  status: stream-only
+  stationuuid: f0a82204-c8c5-465c-839b-3bb01dc47cff
+  changeuuid: b3275f15-47f7-4647-bf78-6f2cc597481e
+  reviewedAt: "2026-05-04"
+
+- id: de-antenne-bad-kreuznach
+  broadcaster: independent
+  name: Antenne Bad Kreuznach
+  streamUrl: https://stream.radiogroup.de/antenne-badkreuznach/mp3-192/?ref=website
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.antenne-kh.de/wp-content/uploads/2021/01/cropped-button-1-88x88.png
+  homepage: https://www.antenne-kh.de/
+  country: DE
+  status: stream-only
+  stationuuid: fefb247d-b189-430b-9c38-d1f170e75c0f
+  changeuuid: 92b30d3f-a7aa-49da-9008-56382dc01268
+  reviewedAt: "2026-05-04"
+
+- id: de-antenne-bayern-coffee-music
+  broadcaster: independent
+  name: Antenne Bayern Coffee Music
+  streamUrl: https://stream.antenne.de/coffee/stream/mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.antenne.de/webradio/coffeemusic
+  country: DE
+  status: stream-only
+  stationuuid: 99814227-85bf-4b51-b573-09a1f33951d0
+  changeuuid: d599be1d-f2d5-46bb-ab55-9bddc12a57ba
+  reviewedAt: "2026-05-04"
+
+- id: de-ella-radio-paris-cafe
+  broadcaster: independent
+  name: Ella Radio - Paris Café
+  streamUrl: https://stream.ella-radio.de/ella-paris-cafe/mp3-192/?ref=radio-browser
+  bitrate: 192
+  codec: MP3
+  favicon: https://ella-radio.de/uplink/Ella_Paris-Cafe.jpg
+  homepage: https://www.ella-radio.de/
+  country: DE
+  status: stream-only
+  stationuuid: 795eec3c-d54e-4662-8e29-7e7f34720fee
+  changeuuid: 70d96da0-f1df-47c4-9287-b04aeb19eefd
+  reviewedAt: "2026-05-04"
+
+- id: de-ella-radio-piano-jazz
+  broadcaster: independent
+  name: Ella Radio - Piano Jazz
+  streamUrl: https://stream.ella-radio.de/ella-piano-jazz/mp3-192?ref=radio-browser
+  bitrate: 192
+  codec: MP3
+  favicon: https://ella-radio.de/uplink/Ella_Piano-Jazz.jpg
+  homepage: https://www.ella-radio.de/
+  country: DE
+  status: stream-only
+  stationuuid: 25521044-8d84-4f47-b669-e1ffdcd799cf
+  changeuuid: 642589e5-0b29-40a9-be6b-d841416bd889
+  reviewedAt: "2026-05-04"
+
+- id: de-freies-radio-stuttgart
+  broadcaster: independent
+  name: Freies Radio Stuttgart
+  streamUrl: https://streaming.fueralle.org/frs-hi.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.freies-radio.de/
+  country: DE
+  status: stream-only
+  stationuuid: a75db90a-591c-4d67-9036-cbaecd8b98ec
+  changeuuid: c9854db7-d069-4a27-a7cd-de1ce5ed774a
+  reviewedAt: "2026-05-04"
+
+- id: de-hr1-osthessen
+  broadcaster: independent
+  name: hr1 Osthessen
+  streamUrl: https://dispatcher.rndfnk.com/hr/hr1/osthessen/high
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.hr1.de/favicon.png?v=3.84.2
+  homepage: https://www.hr1.de/
+  country: DE
+  status: stream-only
+  stationuuid: 7caad7cb-5751-4e13-8ca4-6b2970128ab4
+  changeuuid: 90af1e29-33f9-45e7-8215-9e32bc6f534f
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-pm-events
+  broadcaster: independent
+  name: Radio PM Events
+  streamUrl: https://server7.streamserver24.com:61414/;stream.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radio-pmevents.de/
+  country: DE
+  status: stream-only
+  stationuuid: eb8c2b8e-5e83-4ae5-a5e3-cef1c41131cf
+  changeuuid: 07fa54de-e8b8-47f8-94a9-b526935aad16
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-siegen-dein-90er-radio
+  broadcaster: independent
+  name: Radio Siegen Dein 90er Radio
+  streamUrl: https://stream.lokalradio.nrw/444zm3b
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.radiosiegen.de/assets/images/favicons/radiosiegen/favicon_x96.png
+  homepage: https://www.radiosiegen.de/index.html
+  country: DE
+  status: stream-only
+  stationuuid: 5e96e672-e207-4d25-9f38-7f39a95f44e5
+  changeuuid: 36788254-a79a-4dce-93ee-aaaefd625fdb
+  reviewedAt: "2026-05-04"
+
+- id: de-tagesschau24-hd
+  broadcaster: independent
+  name: tagesschau24 HD
+  streamUrl: https://tagesschau.akamaized.net/hls/live/2020115/tagesschau/tagesschau_1/master.m3u8
+  bitrate: 1672
+  codec: AAC
+  homepage: https://programm.ard.de/TV/tagesschau24/Startseite
+  country: DE
+  status: stream-only
+  stationuuid: cbbc0f08-f19c-4712-a9be-79d48b5ea8c1
+  changeuuid: a030bc79-1f75-4acc-bf12-48f1e6034bab
+  reviewedAt: "2026-05-04"
+
+- id: de-alternative-radio
+  broadcaster: independent
+  name: Alternative Radio
+  streamUrl: https://alternative-radio.stream.laut.fm/alternative-radio?
+  bitrate: 128
+  codec: MP3
+  favicon: https://m.media-amazon.com/images/I/51hQAwIpHCL._UXNaN_FMjpg_QL85_.jpg
+  homepage: https://laut.fm/alternative-radio
+  country: DE
+  status: stream-only
+  stationuuid: 78f7ab9f-55b1-4756-bf34-a9dd9396d46f
+  changeuuid: ca5e0dd8-c93e-4641-a317-457ec7673eac
+  reviewedAt: "2026-05-04"
+
+- id: de-country-antenne
+  broadcaster: independent
+  name: country Antenne
+  streamUrl: https://s8-webradio.rockantenne.de/country-antenne/stream?
+  bitrate: 128
+  codec: MP3
+  country: DE
+  status: stream-only
+  stationuuid: fe483287-5ed0-4e6d-9a7d-7a14af8588f9
+  changeuuid: c3f49177-322c-4584-9429-b64edeaceacf
+  reviewedAt: "2026-05-04"
+
+- id: de-ella-radio-berlin-jazz
+  broadcaster: independent
+  name: Ella Radio - Berlin Jazz
+  streamUrl: https://stream.ella-radio.de/ella-berlin-jazz/mp3-192/?ref=radio-browser
+  bitrate: 192
+  codec: MP3
+  favicon: https://ella-radio.de/uplink/Ella_Berlin-Jazz.jpg
+  homepage: https://www.ella-radio.de/
+  country: DE
+  status: stream-only
+  stationuuid: b93a7ff8-6ff0-4aa3-bcfe-d430f877c9e4
+  changeuuid: 24b77b03-6c92-4ff8-bb20-d5f5d124f864
+  reviewedAt: "2026-05-04"
+
+- id: de-ella-radio-blues
+  broadcaster: independent
+  name: Ella Radio - Blues
+  streamUrl: https://stream.ella-radio.de/ella-blues/mp3-192/?ref=radio-browser
+  bitrate: 192
+  codec: MP3
+  favicon: https://ella-radio.de/uplink/Ella_Blues.jpg
+  homepage: https://www.ella-radio.de/
+  country: DE
+  status: stream-only
+  stationuuid: 7558dca9-dbd0-43b0-bd6c-e5a909066160
+  changeuuid: bd8175f6-55c7-401c-848a-f1627423021a
+  reviewedAt: "2026-05-04"
+
+- id: de-ella-radio-smooth-jazz-24-7
+  broadcaster: independent
+  name: Ella Radio - Smooth Jazz 24/7
+  streamUrl: https://stream.ella-radio.de/ella-smooth-jazz-247/mp3-192/?ref=radio-browser
+  bitrate: 192
+  codec: MP3
+  favicon: https://ella-radio.de/uplink/Ella_Smooth-Jazz-247.jpg
+  homepage: https://www.ella-radio.de/
+  country: DE
+  status: stream-only
+  stationuuid: 7326e2d2-a6e2-4114-ab41-57982d196f26
+  changeuuid: 12a43e2a-95a5-48fa-be67-dbf389ffa4ff
+  reviewedAt: "2026-05-04"
+
+- id: de-ella-radio-vocal-legends
+  broadcaster: independent
+  name: Ella Radio - Vocal Legends
+  streamUrl: https://stream.ella-radio.de/ella-vocal-legends/mp3-192/?ref=radio-browser
+  bitrate: 192
+  codec: MP3
+  favicon: https://ella-radio.de/uplink/Ella_Vocal-Legends.jpg
+  homepage: https://www.ella-radio.de/
+  country: DE
+  status: stream-only
+  stationuuid: 85d3b97d-d060-43a5-b5c5-a431bbc2d77c
+  changeuuid: bbe5bb51-5d03-444c-a528-cfb02f86945d
+  reviewedAt: "2026-05-04"
+
+- id: de-exogaming
+  broadcaster: independent
+  name: EXOGAMING
+  streamUrl: https://exogaming.stream.laut.fm/exogaming?pl=m3u&t302=2026-01-15_04-32-19&uuid=26045880-323b-46fa-86ae-1edc8318dc7d
+  bitrate: 128
+  codec: MP3
+  homepage: https://exogaming.stream.laut.fm/
+  country: DE
+  status: stream-only
+  stationuuid: 7a92f951-d7a4-495a-bbed-0a41ca2cd8b8
+  changeuuid: b1886f65-ba44-4dd9-bdb5-1967187f1920
+  reviewedAt: "2026-05-04"
+
+- id: de-ilovedance-history-dancefloor-anthems-all-time-c
+  broadcaster: independent
+  name: "ILOVEDANCE HISTORY | Dancefloor Anthems & All-time-Classics"
+  streamUrl: https://ilm.stream35.radiohost.de/ilm_ilovedancehistory_mp3-192?upd-meta&upd-scheme=https&_art=dD0xNzY4NDUxNDA2JmQ9NTg5MmY0ZDBhNDE5MGI2ZjJmYWY
+  bitrate: 192
+  codec: MP3
+  favicon: https://ilovemusic.de/fileadmin/user_upload/ilm2025_ilovedancehistory1_440x440.jpg
+  homepage: https://ilovemusic.de/ilovedancehistory/
+  country: DE
+  status: stream-only
+  stationuuid: 4bd3fa0a-67dc-499f-b808-1eb8211098fe
+  changeuuid: 901c48c7-ec52-4c26-b2a1-5ccd75c5932c
+  reviewedAt: "2026-05-04"
+
+- id: de-living-radio
+  broadcaster: independent
+  name: Living Radio
+  streamUrl: https://livingradio.stream.laut.fm/living_radio?t302=2021-03-18_15-39-39&uuid=60ce31c3-421a-478e-bdaa-4378c287adeb
+  bitrate: 128
+  codec: MP3
+  homepage: https://liveradio.de/living-radio
+  country: DE
+  status: stream-only
+  stationuuid: d65bf0e0-4e97-4a9e-8c5b-920193001507
+  changeuuid: 28e5f1e2-629d-422b-8fa8-774457e5aa89
+  reviewedAt: "2026-05-04"
+
+- id: de-mbg-harsewinkel-gottesdienst
+  broadcaster: independent
+  name: MBG Harsewinkel Gottesdienst
+  streamUrl: https://stream.mbg-hsw.de/radio/8000/radio.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.mbg-hsw.de/
+  country: DE
+  status: stream-only
+  stationuuid: 647688f2-1209-417c-83cf-00bc4558bb57
+  changeuuid: 5c9ebd65-7010-489e-9cfb-3e976b1785c0
+  reviewedAt: "2026-05-04"
+
+- id: de-mother-earth-instrumental
+  broadcaster: independent
+  name: Mother Earth Instrumental
+  streamUrl: https://stream.motherearthradio.de/listen/motherearth_instrumental/motherearth.instrumental.aac
+  bitrate: 320
+  codec: AAC
+  favicon: https://motherearthradio.de/wp-content/uploads/2024/03/mergoldcube512.png
+  homepage: https://motherearthradio.de/
+  country: DE
+  status: stream-only
+  stationuuid: c2065a71-3586-4adc-b970-59ba7b424d8f
+  changeuuid: 3cf915b7-2e0f-4514-83fb-419041a86035
+  reviewedAt: "2026-05-04"
+
+- id: de-nice-mix
+  broadcaster: independent
+  name: nice MIX
+  streamUrl: https://mix-hd-radio.nice-radiotv.de/
+  bitrate: 256
+  codec: MP3
+  favicon: https://nice-radiotv.de/wp-content/uploads/2017/01/nice-Mix-Player-Logo.png
+  homepage: https://nice-radiotv.de/radiochannel/nice-mix/
+  country: DE
+  status: stream-only
+  stationuuid: 5e0653b0-f7c3-43c6-8d82-bb47d27b8d3b
+  changeuuid: 13cf340e-e69c-4112-a25b-39a98847278c
+  reviewedAt: "2026-05-04"
+
+- id: de-osradio-104-8
+  broadcaster: independent
+  name: Osradio 104,8
+  streamUrl: https://live.radio-aktiv.de:8443/os-radio.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.osradio.de/favicon.ico
+  homepage: https://www.osradio.de/
+  country: DE
+  status: stream-only
+  stationuuid: ea450840-5829-4e24-81c5-710b59c84669
+  changeuuid: 549a8870-30d9-4bcc-b46d-9522c9506d4c
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-cottbus
+  broadcaster: independent
+  name: Radio Cottbus
+  streamUrl: https://stream.radiogroup.de/radio-cottbus/mp3-192/
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.radio-cottbus.de/
+  country: DE
+  status: stream-only
+  stationuuid: 536844d1-4533-42d6-b8d0-d7bdef60eb26
+  changeuuid: 4eff9957-6796-4eba-861a-7271592acfa8
+  reviewedAt: "2026-05-04"
+
+- id: de-swr-4-bw
+  broadcaster: independent
+  name: SWR 4 BW
+  streamUrl: https://liveradio.swr.de/sw331ch/swr4bw/
+  bitrate: 96
+  codec: AAC
+  favicon: https://api.ardmediathek.de/image-service/images/urn:ard:image:f607d39888879ec7?w=512
+  country: DE
+  status: stream-only
+  stationuuid: 431ad43c-db9f-4b5b-b529-c708416d2f75
+  changeuuid: c15ebb16-16ab-40df-8231-a3ef08987d7b
+  reviewedAt: "2026-05-04"
+
+- id: de-0nlineradio-deutsch
+  broadcaster: independent
+  name: 0nlineradio DEUTSCH
+  streamUrl: https://stream.0nlineradio.com/deutsch?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  homepage: https://0nlineradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 6e749783-6f24-42c1-ad60-26d476a87fa0
+  changeuuid: 79038986-558d-4aae-b521-e1f1c3989bdb
+  reviewedAt: "2026-05-04"
+
+- id: de-anixe-hd
+  broadcaster: independent
+  name: ANIXE HD
+  streamUrl: https://ma.anixa.tv/clips/stream/anixehd/index.m3u8
+  bitrate: 2249
+  codec: AAC
+  favicon: https://www.anixehd.tv/favicon.ico
+  homepage: https://www.anixehd.tv/
+  country: DE
+  status: stream-only
+  stationuuid: 1ce6d0ae-1d9f-4528-b4b5-d604446412c7
+  changeuuid: 0690d801-0bc1-414d-ae92-0e25a4ffa958
+  reviewedAt: "2026-05-04"
+
+- id: de-autodj
+  broadcaster: independent
+  name: AutoDJ
+  streamUrl: https://radiophoenixx.sp.radio.fm/stream
+  bitrate: 320
+  codec: MP3
+  country: DE
+  status: stream-only
+  stationuuid: 18949b98-bca6-43ea-a138-429d7dceb43a
+  changeuuid: cd155f73-599c-48ca-900c-2268eac2d7b5
+  reviewedAt: "2026-05-04"
+
+- id: de-cashmere-radio-show
+  broadcaster: independent
+  name: Cashmere Radio Show
+  streamUrl: https://cashmereradio.out.airtime.pro/cashmereradio_b
+  bitrate: 192
+  codec: MP3
+  favicon: https://backstage.cashmereradio.com/wp-content/themes/cashmereradio/icons/android-icon-192x192.png
+  homepage: https://cashmereradio.com/
+  country: DE
+  status: stream-only
+  stationuuid: 20c914bb-ac6f-4bad-8576-7bd269d97d43
+  changeuuid: 7be71080-c396-435b-897a-5739a78a2f46
+  reviewedAt: "2026-05-04"
+
+- id: de-ella-radio-livestream
+  broadcaster: independent
+  name: Ella Radio - Livestream
+  streamUrl: https://stream.ella-radio.de/ella-livestream/mp3-192/?ref=radio-browser
+  bitrate: 192
+  codec: MP3
+  favicon: https://ella-radio.de/uplink/Ella_Livestream.jpg
+  homepage: https://www.ella-radio.de/
+  country: DE
+  status: stream-only
+  stationuuid: d6e308a9-7968-4373-94b9-f168a2d82482
+  changeuuid: 72237f03-5069-4e70-bdc4-321a06863ea6
+  reviewedAt: "2026-05-04"
+
+- id: de-hr-hd
+  broadcaster: independent
+  name: HR HD
+  streamUrl: https://hrhls.akamaized.net/hls/live/2024525/hrhls/master.m3u8
+  bitrate: 2147
+  codec: AAC
+  homepage: https://www.hr-fernsehen.de/
+  country: DE
+  status: stream-only
+  stationuuid: a52e7c19-4844-4699-9848-947e96e9a1dc
+  changeuuid: caf9b27c-87b6-4b62-9027-08cfd8217b7f
+  reviewedAt: "2026-05-04"
+
+- id: de-i-mashup
+  broadcaster: independent
+  name: I♥MASHUP
+  streamUrl: https://ilm.stream35.radiohost.de/ilm_ilovemashup_mp3-192?context=fHA6LTE=&upd-meta&upd-scheme=https&_art=dD0xNzY4NDUyNzg2JmQ9ZjM1N2NiYWEwYjkwYmUyOWNhYmE
+  bitrate: 192
+  codec: MP3
+  favicon: https://play-lh.googleusercontent.com/9Bsg9IdeIU-PUUGdKBrTuW4YVf7A27s3Gb5xzIba-9snvadpIUxG61qwue_ooxmnww=w480-h960
+  country: DE
+  status: stream-only
+  stationuuid: e5254d4f-457d-4561-af10-6e70270e3e6b
+  changeuuid: e5c26844-9238-4bfb-9592-ed74202d4907
+  reviewedAt: "2026-05-04"
+
+- id: de-maretimo-latin-radio
+  broadcaster: independent
+  name: Maretimo Latin Radio
+  streamUrl: https://s35.derstream.net/maretimo-latin.mp3?
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.maretimo-records.com/wp-content/uploads/2022/09/favicon.png
+  homepage: https://www.maretimo-records.com/
+  country: DE
+  status: stream-only
+  stationuuid: ba4a6bcb-df87-49fd-954f-b38e783b3034
+  changeuuid: 988ae512-ac81-4556-b680-1dc32c8037ad
+  reviewedAt: "2026-05-04"
+
+- id: de-punkrockers-radio-2
+  broadcaster: independent
+  name: Punkrockers Radio
+  streamUrl: https://stream.punkrockers-radio.de:8443/ogg?1727422503
+  bitrate: 192
+  codec: OGG
+  favicon: https://www.punkrockers-radio.de/img/play_button_rund.png
+  homepage: https://www.punkrockers-radio.de/
+  country: DE
+  status: stream-only
+  stationuuid: cd8da4c9-b5b9-44ab-a3d7-d16b5f02e541
+  changeuuid: c7d1a299-4488-4174-b554-6dd05eb3ec23
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-diefflen
+  broadcaster: independent
+  name: Radio Diefflen
+  streamUrl: https://radiodiefflen.stream.laut.fm/radiodiefflen?pl=m3u&t302=2026-01-15_06-03-50&uuid=9a3fd861-dd28-4228-b902-e69eda1b80e4
+  bitrate: 128
+  codec: MP3
+  homepage: https://radiodiefflen.de/
+  country: DE
+  status: stream-only
+  stationuuid: b506cb9c-fa13-489b-a2ba-b1f74c0e37ed
+  changeuuid: 63de550f-dc2d-4190-b083-6100064322ce
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-home-of-rock
+  broadcaster: independent
+  name: Radio Home of Rock
+  streamUrl: https://server24094.streamplus.de/stream.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.radio.de/images/broadcasts/e6/e2/25726/c300.png
+  homepage: https://home-of-rock.de/
+  country: DE
+  status: stream-only
+  stationuuid: 146903c4-805a-41ea-907a-c7e30192905d
+  changeuuid: 88ad3b15-c84e-4e67-b82c-2581e1f59845
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-schwany-2-schlager
+  broadcaster: independent
+  name: Radio Schwany 2 - Schlager
+  streamUrl: https://schwany.streampanel.cloud/2-schlager
+  bitrate: 320
+  codec: MP3
+  favicon: https://static.mytuner.mobi/media/radios-150px/FT5Ds7t8Ba.jpg
+  homepage: https://www.schwany.de/index.html
+  country: DE
+  status: stream-only
+  stationuuid: 093b4d13-863a-4657-bf61-a904462e281f
+  changeuuid: 632765f1-2338-4afa-82bc-d670173f6483
+  reviewedAt: "2026-05-04"
+
+- id: de-rautemusik-main
+  broadcaster: independent
+  name: RauteMusik Main
+  streamUrl: https://main-aacp.rautemusik.fm/
+  bitrate: 48
+  codec: AAC+
+  favicon: https://www.rm.fm/favicon.ico
+  homepage: https://www.rm.fm/main
+  country: DE
+  status: stream-only
+  stationuuid: 39963bce-a2ba-40e2-b53b-b886713aa398
+  changeuuid: 14115a7f-f1be-441f-9ad8-5dec4c1dac60
+  reviewedAt: "2026-05-04"
+
+- id: de-1-splash-christmas
+  broadcaster: independent
+  name: "#1 Splash Christmas"
+  streamUrl: https://ais-sa2.cdnstream1.com/2553_128.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.splashradio.eu/
+  country: DE
+  status: stream-only
+  stationuuid: 18a450ea-3575-4e78-89d3-8aa30b4760f4
+  changeuuid: ac9ffe24-bccf-4eb5-98d7-8af703b7b0ff
+  reviewedAt: "2026-05-04"
+
+- id: de-917xfm
+  broadcaster: independent
+  name: 917xfm
+  streamUrl: https://rockantenne-hh-stream07.radiohost.de/917xfm_mp3-192?
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.917xfm.de/
+  country: DE
+  status: stream-only
+  stationuuid: e36a33c7-4071-42b2-9a39-f20ac137ebe1
+  changeuuid: f930f59a-2601-49c5-b093-783f43c1943a
+  reviewedAt: "2026-05-04"
+
+- id: de-animeradio-de
+  broadcaster: independent
+  name: AnimeRadio.de
+  streamUrl: https://stream.animeradio.de/animeradio.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.animeradio.de/img/animeradio-stream-mp3-192.jpg
+  homepage: https://www.animeradio.de/
+  country: DE
+  status: stream-only
+  stationuuid: 47f9de9e-d5b9-45e9-8fa9-18ed10f08629
+  changeuuid: 63b62596-d218-41b0-90a1-4da4e87de992
+  reviewedAt: "2026-05-04"
+
+- id: de-classic-progrock-saar
+  broadcaster: independent
+  name: Classic Progrock Saar
+  streamUrl: https://classic-progrock-fm.stream.laut.fm/classic-progrock-fm?t302=2025-03-10_17-34-10&uuid=8e6c3b96-2d13-44bc-a51b-386795198f38
+  bitrate: 128
+  codec: MP3
+  homepage: https://classic-progrock-fm.stream.laut.fm/classic-progrock-fm?t302=2025-03-10_17-34-10&uuid=8e6c3b96-2d13-44bc-a51b-386795198f38
+  country: DE
+  status: stream-only
+  stationuuid: c547329d-b809-408d-84b2-252e8153832a
+  changeuuid: 15d4cfcd-e3fc-4f42-adf2-352204e3b578
+  reviewedAt: "2026-05-04"
+
+- id: de-dressfm-new-yorker-germany
+  broadcaster: independent
+  name: DressFM (New Yorker Germany)
+  streamUrl: https://streams.fluxfm.de/nyir-ger/mp3-320/
+  codec: MP3
+  favicon: https://pbs.twimg.com/profile_images/469051279486906368/QLjkWvWr.jpeg
+  homepage: https://cloud.rundfunkkombinat.de/
+  country: DE
+  status: stream-only
+  stationuuid: f610dca6-de55-4d59-b1b8-8b3cb0794566
+  changeuuid: c5082876-4f99-4e25-9454-a5b2de533dce
+  reviewedAt: "2026-05-04"
+
+- id: de-egofm-riff-lq
+  broadcaster: independent
+  name: "egoFM Riff [LQ]"
+  streamUrl: https://cast.egofm.de/egoriff.aac?ar-distributor=ffa0&aw_0_req.gdpr=true
+  bitrate: 63
+  codec: AAC+
+  favicon: https://streams.egofm.de/img/alexa/egoFM%20Riff-256x256.png
+  homepage: https://www.egofm.de/streams/egoriff
+  country: DE
+  status: stream-only
+  stationuuid: 2fa3f9b1-c3b9-4a4b-a8f4-241a4cf3243b
+  changeuuid: 9f382ede-f9a0-4122-8431-9af5f55f72da
+  reviewedAt: "2026-05-04"
+
+- id: de-ella-radio-mellow-jazz
+  broadcaster: independent
+  name: Ella Radio - Mellow Jazz
+  streamUrl: https://stream.ella-radio.de/ella-mellow-jazz/mp3-192/?ref=radio-browser
+  bitrate: 192
+  codec: MP3
+  favicon: https://ella-radio.de/uplink/Ella_Mellow-Jazz.jpg
+  homepage: https://www.ella-radio.de/
+  country: DE
+  status: stream-only
+  stationuuid: 1dfd7cf9-7189-4f7f-9f63-04fd51c63f2b
+  changeuuid: d0cfde9b-a3b4-4edb-8562-b49d0382a8b3
+  reviewedAt: "2026-05-04"
+
+- id: de-ella-radio-smooth-vocals
+  broadcaster: independent
+  name: Ella Radio - Smooth Vocals
+  streamUrl: https://stream.ella-radio.de/ella-smooth-vocals/mp3-192/?ref=radio-browser
+  bitrate: 192
+  codec: MP3
+  favicon: https://ella-radio.de/uplink/Ella_Smooth-Vocals.jpg
+  homepage: https://www.ella-radio.de/
+  country: DE
+  status: stream-only
+  stationuuid: 02c7f26f-3a8a-4ee0-8658-988eba1e5c11
+  changeuuid: faf5f7f5-8b1d-45ee-aa4c-746a1b94aee7
+  reviewedAt: "2026-05-04"
+
+- id: de-gute-laune-welle
+  broadcaster: independent
+  name: Gute Laune Welle
+  streamUrl: https://gute-laune-welle.stream.laut.fm/gute-laune-welle?;stream.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://gutelaunewelle.de/favicon.ico
+  homepage: https://gutelaunewelle.de/
+  country: DE
+  status: stream-only
+  stationuuid: 0f2e437a-fd43-48d0-ac26-4c84f83ef05b
+  changeuuid: 1f14ff85-ce9b-4bcb-a2d6-cf721b7d26bc
+  reviewedAt: "2026-05-04"
+
+- id: de-i-dance-jahrescharts-ilovemusic
+  broadcaster: independent
+  name: I♥DANCE - Jahrescharts - ILoveMusic
+  streamUrl: https://ilm.stream18.radiohost.de/ilm_dance-2023-jahrescharts_mp3-192?upd-meta&upd-scheme=https&_art=dD0xNzY4NDM1NTQwJmQ9NjE5NTc1MDA0NWQ3MjNhMGQ3OTU
+  bitrate: 192
+  codec: MP3
+  favicon: https://ilovemusic.de/typo3conf/ext/ep_channel/Resources/Public/img/favicon.php
+  homepage: https://ilovemusic.de/dance-2024-jahrescharts
+  country: DE
+  status: stream-only
+  stationuuid: 46281580-b044-4d23-a411-a20a0cac1116
+  changeuuid: d0c0d7da-2e39-4302-b908-a8352c76c2bf
+  reviewedAt: "2026-05-04"
+
+- id: de-laut-fm-chiliguerilla
+  broadcaster: independent
+  name: Laut.FM - Chiliguerilla
+  streamUrl: https://chiliguerilla.stream.laut.fm/chiliguerilla?1735142890284=&t302=2024-12-25_16-08-10&uuid=e211741c-3970-413c-a099-fdd330787564
+  bitrate: 128
+  codec: MP3
+  favicon: https://assets.laut.fm/1847edc1b6fee124c1f12e3f4295bb57?t=_120x120
+  homepage: https://laut.fm/chiliguerilla
+  country: DE
+  status: stream-only
+  stationuuid: 52c8e507-51e2-49f9-a978-4b86d78a6695
+  changeuuid: aa63d3b1-2a64-490c-854f-3b40c79feeb5
+  reviewedAt: "2026-05-04"
+
+- id: de-max-dance
+  broadcaster: independent
+  name: MAX.DANCE
+  streamUrl: https://maxdance.stream.laut.fm/maxdance
+  bitrate: 128
+  codec: MP3
+  homepage: https://maxradio.live/
+  country: DE
+  status: stream-only
+  stationuuid: 8a7bf632-3a0c-44fa-a496-883ee29119bf
+  changeuuid: aa0f1d45-ef3b-47cf-907d-ef3e957aea7a
+  reviewedAt: "2026-05-04"
+
+- id: de-mdr-sputnik-einfach-die-beste-musik-deine-liebli
+  broadcaster: independent
+  name: MDR SPUTNIK - Einfach die beste Musik - Deine Lieblingsmusik
+  streamUrl: https://mdr-radio-hls.akamaized.net/hls/live/2112905/mdr-284330-0-hls/index.m3u8
+  bitrate: 102
+  codec: AAC
+  favicon: https://www.sputnik.de/channels/channel-sputnik-onair-100-resimage_v-variantSmall1x1_w-512.png
+  homepage: https://www.sputnik.de/home/index.html
+  country: DE
+  status: stream-only
+  stationuuid: 5c0caf59-c11a-4921-8c3b-8f0da45e216d
+  changeuuid: 69287dc0-7da8-49a3-aa71-44ac436a942f
+  reviewedAt: "2026-05-04"
+
+- id: de-nrw-paradiso
+  broadcaster: independent
+  name: NRW Paradiso
+  streamUrl: https://streams.paradiso.de/Para-NRW/aac-64/Web/?aw_0_req.userConsentV2=CPw9PgAPw9PgAAFADBDEDTCsAP_AAEPAAAYgHvQBgAWAFzAP2AvMBuAD3gLzgBAFzAXmAAAA.YAAAAAAAAAAA
+  bitrate: 64
+  codec: AAC+
+  favicon: https://www.paradiso.de/assets/favicons/apple-icon-120x120.png
+  homepage: https://www.paradiso.de/paradiso-nrw
+  country: DE
+  status: stream-only
+  stationuuid: bf503245-928f-499b-9f70-d5dee4a7c3f6
+  changeuuid: 93c0942f-02ff-4e9a-ad09-b600117d33b0
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-matchbox
+  broadcaster: independent
+  name: Radio Matchbox
+  streamUrl: https://stream.radio-matchbox.de/listen/matchbox/radio.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://radio-matchbox.de/favicon.ico
+  homepage: https://radio-matchbox.de/de/
+  country: DE
+  status: stream-only
+  stationuuid: b066bc6d-8602-4ff9-82fc-2c5b7bc29ba0
+  changeuuid: 3ec7f044-9257-47de-a6b5-a0fca70c01d4
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-wmw
+  broadcaster: independent
+  name: Radio WMW
+  streamUrl: https://rnrw.cast.addradio.de/rnrw-01a8/deinevent/high/stream.mp3?1707016884
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.radiowmw.de/assets/images/senderlogos/radio_wmw.png
+  homepage: https://www.radiowmw.de/
+  country: DE
+  status: stream-only
+  stationuuid: 022192c4-21f5-435a-93b2-6db87263ff4e
+  changeuuid: 207533ab-31c1-4f48-af1a-eba012136160
+  reviewedAt: "2026-05-04"
+
+- id: de-sg-radio
+  broadcaster: independent
+  name: SG Radio
+  streamUrl: https://synthesizergreatest.stream.laut.fm/synthesizergreatest
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.sgradio.eu/
+  country: DE
+  status: stream-only
+  stationuuid: 05c7dea1-bdc9-4493-95a6-f0e6541fc260
+  changeuuid: b954dd6e-0d0a-43d3-a476-9885b97a3fd0
+  reviewedAt: "2026-05-04"
+
+- id: de-antenne-koblenz
+  broadcaster: independent
+  name: Antenne Koblenz
+  streamUrl: https://radiogroup-stream32.radiohost.de//antenne-koblenz_mp3-192
+  bitrate: 192
+  codec: MP3
+  homepage: https://antenne-koblenz.de/
+  country: DE
+  status: stream-only
+  stationuuid: 6c2f7638-d69f-491c-86b4-82a7135fc74b
+  changeuuid: 32157e9a-1a83-435b-a116-b5e2b06c110e
+  reviewedAt: "2026-05-04"
+
+- id: de-bremen-vier-heuckzeug
+  broadcaster: independent
+  name: Bremen Vier Heuckzeug
+  streamUrl: https://icecast.radiobremen.de/rb/webchannel3/mp3/128/stream.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.bremenvier.de/static/img/favicons/apple-touch-icon-180.png?v=3
+  homepage: https://www.bremenvier.de/
+  country: DE
+  status: stream-only
+  stationuuid: 2e9ec91b-1530-44e8-9e6f-b11b0d31c1b4
+  changeuuid: 5b2c502e-9157-4df3-8b70-ea184f621e1a
+  reviewedAt: "2026-05-04"
+
+- id: de-dreampop-radio-https
+  broadcaster: independent
+  name: DREAMPOP-RADIO (https)
+  streamUrl: https://dreampopradio.stream.laut.fm/dreampopradio
+  bitrate: 128
+  codec: MP3
+  favicon: https://assets.laut.fm/edf172a4c43423f76e381ac31d188342
+  homepage: https://laut.fm/dreampopradio
+  country: DE
+  status: stream-only
+  stationuuid: 9bf91181-8cad-4384-bc85-3dc59d760130
+  changeuuid: 5d84d89d-d427-45a8-9237-474c60b55edf
+  reviewedAt: "2026-05-04"
+
+- id: de-egofm-rap-lq
+  broadcaster: independent
+  name: "egoFM Rap [LQ]"
+  streamUrl: https://cast.egofm.de/egorap.aac?ar-distributor=ffa0&aw_0_req.gdpr=true
+  bitrate: 64
+  codec: AAC+
+  favicon: https://streams.egofm.de/img/alexa/egoFM%20Rap-256x256.png
+  homepage: https://www.egofm.de/streams/egorap
+  country: DE
+  status: stream-only
+  stationuuid: 59b72224-ac2a-474d-bee3-c88a0b31e3b4
+  changeuuid: bd8b22a0-c977-46cf-91ed-9542e3535f14
+  reviewedAt: "2026-05-04"
+
+- id: de-ella-radio-jazz-ballads
+  broadcaster: independent
+  name: Ella Radio - Jazz Ballads
+  streamUrl: https://stream.ella-radio.de/ella-jazz-ballads/mp3-192/?ref=radio-browser
+  bitrate: 192
+  codec: MP3
+  favicon: https://ella-radio.de/uplink/Ella_Jazz-Ballads.jpg
+  homepage: https://www.ella-radio.de/
+  country: DE
+  status: stream-only
+  stationuuid: 2b2c8589-4116-40e3-9a2e-5a273d549fed
+  changeuuid: 41261a31-8038-473c-af07-423d9049c60c
+  reviewedAt: "2026-05-04"
+
+- id: de-ffn-708090
+  broadcaster: independent
+  name: ffn 708090
+  streamUrl: https://ffn-de-hz-fal-stream09-cluster01.radiohost.de/ffn-708090_mp3-192
+  bitrate: 192
+  codec: MP3
+  favicon: https://player.ffn.de/assets/channels/ffn708090.png
+  homepage: https://www.ffn.de/
+  country: DE
+  status: stream-only
+  stationuuid: 7fd9ffbb-52d8-4f10-8d69-1642fcb156ef
+  changeuuid: a2a929a8-9ba4-48db-9b0e-508a2906884a
+  reviewedAt: "2026-05-04"
+
+- id: de-footbalisfamily
+  broadcaster: independent
+  name: Footbalisfamily
+  streamUrl: https://footballisfamily.stream.laut.fm/footballisfamily?ref=radiode&t302-2023-08-27_10-19-59&uuid=05ecbd31-4021-4e68-86f8-05a740d6d465
+  bitrate: 128
+  codec: MP3
+  country: DE
+  status: stream-only
+  stationuuid: 95b5997d-e54e-4310-a392-0ceebd28d54f
+  changeuuid: f12add78-718b-44e6-b75a-8ceba2b3eed5
+  reviewedAt: "2026-05-04"
+
+- id: de-iceradio-germany
+  broadcaster: independent
+  name: Iceradio Germany
+  streamUrl: https://www.iceradio.net/listen
+  bitrate: 192
+  codec: MP3
+  homepage: http://www.iceradio.net/
+  country: DE
+  status: stream-only
+  stationuuid: 325cca45-da7d-40d4-bb77-897b7a122d52
+  changeuuid: fe3d8fbd-7553-47fa-be5d-6f6619985e74
+  reviewedAt: "2026-05-04"
+
+- id: de-max-retro
+  broadcaster: independent
+  name: MAX.RETRO
+  streamUrl: https://maxretro.stream.laut.fm/maxretro
+  bitrate: 128
+  codec: MP3
+  favicon: https://maxradio.live/static/icons/production/120.png
+  homepage: https://maxradio.live/
+  country: DE
+  status: stream-only
+  stationuuid: f7bf8aec-1b08-4bf1-bb29-a84e750cca67
+  changeuuid: 707ccc80-ecf6-435d-af00-0eb7ced6d4c7
+  reviewedAt: "2026-05-04"
+
+- id: de-mother-earth-klassik
+  broadcaster: independent
+  name: Mother Earth Klassik
+  streamUrl: https://stream.motherearthradio.de/listen/motherearth_klassik/motherearth.klassik.aac
+  bitrate: 320
+  codec: AAC
+  favicon: https://motherearthradio.de/wp-content/uploads/2024/03/mergoldcube512.png
+  homepage: https://motherearthradio.de/
+  country: DE
+  status: stream-only
+  stationuuid: f8be9353-dc99-4a02-8b08-59cee0c3c4d1
+  changeuuid: 33ee78b7-af35-4083-853a-c7c3c9ac38f1
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-rfm-rundfunk-meissner-e-v
+  broadcaster: independent
+  name: Radio RFM (Rundfunk Meissner e.V.)
+  streamUrl: https://icecast.radiorfm.de/rfm.ogg
+  bitrate: 96
+  codec: OGG
+  favicon: https://radiorfm.de/wp-content/uploads/2020/06/cropped-Logo_RFM_300dpi_20x20cm_CMYK_frei-192x192.jpg
+  homepage: https://radiorfm.de/
+  country: DE
+  status: stream-only
+  stationuuid: 710c3d5a-209c-405f-9a5a-9889736416db
+  changeuuid: 25b9ab77-d3b3-4d3e-8474-799af8063f40
+  reviewedAt: "2026-05-04"
+
+- id: de-radio-t
+  broadcaster: independent
+  name: Radio T
+  streamUrl: https://streaming.fueralle.org/radiot_192.mp3
+  codec: MP3
+  homepage: https://radiot-chemnitz.de/
+  country: DE
+  status: stream-only
+  stationuuid: bc05bc47-8a41-484b-bf77-8fa147bbdfca
+  changeuuid: df51e844-5276-49cc-a6fa-a6d902258091
+  reviewedAt: "2026-05-04"
+
+- id: de-radioaktuell
+  broadcaster: independent
+  name: RadioAktuell
+  streamUrl: https://www.radioaktuell.de/aktuell/aktuell.mp3
+  codec: MP3
+  favicon: https://www.radioaktuell.de/wp-content/uploads/2022/07/cropped-radioaktuell.png
+  homepage: https://www.radioaktuell.de/
+  country: DE
+  status: stream-only
+  stationuuid: 1ad2bc32-df17-4e60-aa58-fd661b28633c
+  changeuuid: 642e234b-5a0b-4b8a-b725-8f9296e7a60f
+  reviewedAt: "2026-05-04"
+
+- id: de-tape-hits
+  broadcaster: independent
+  name: Tape Hits
+  streamUrl: https://tapehits.com:8005/stream?x=1620481556916
+  bitrate: 256
+  codec: MP3
+  favicon: https://cdn.onlineradiobox.com/img/l/2/103532.v1.png
+  country: DE
+  status: stream-only
+  stationuuid: 8b71e646-a7bf-46c3-9872-dae57946adcd
+  changeuuid: 9f8112ae-6b00-4b84-b17d-0a46dcce4afd
+  reviewedAt: "2026-05-04"
+
+- id: de-technikradio
+  broadcaster: independent
+  name: TechnikRADIO
+  streamUrl: https://server31053.streamplus.de/;stream.mp3
+  bitrate: 64
+  codec: MP3
+  favicon: https://technikradio.de/wp-content/uploads/2017/01/apple-touch-icon-120x120.png
+  homepage: https://technikradio.de/
+  country: DE
+  status: stream-only
+  stationuuid: 9ce73d9d-1c62-49d8-ae08-b01c730aa813
+  changeuuid: 87901d3e-72f5-4678-b8a3-14ab0a6af09c
+  reviewedAt: "2026-05-04"
+
+- id: de-yesterday-fm
+  broadcaster: independent
+  name: Yesterday.FM
+  streamUrl: https://yesterdayfm.schlagerparadies.de/yesterdayfm
+  bitrate: 192
+  codec: MP3
+  homepage: http://www.rockhausradio.de/
+  country: DE
+  status: stream-only
+  stationuuid: b059f79c-e89a-44c1-92e1-96f9a40f4713
+  changeuuid: 3c9f099f-69a6-4e77-9fc4-2702f6373c14
+  reviewedAt: "2026-05-04"

--- a/data/stations.yaml
+++ b/data/stations.yaml
@@ -695,6 +695,1641 @@
   country: CH
   status: icy-only
 
+# ─── CH — Radio Browser sweep 2026-05-04 (106 stations) ───
+# Imported from rb-analysis-CH.json: verdict=ok/ok-hls, not curated, not dupe.
+# Status: stream-only. Logos, metadata, fetchers are manual curation work.
+
+- id: ch-80s-forever-we-keep-the-80s-alive
+  stationuuid: 32fed468-cfe3-11e9-a861-52543be04c81
+  changeuuid: f7fc2903-81d9-48f7-b68d-397e54d57fa1
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: 80s Forever - We Keep The 80s Alive
+  streamUrl: https://premium.shoutcastsolutions.com/radio/8050/256.mp3
+  bitrate: 256
+  codec: MP3
+  tags: [pop, indie, rock, oldies, switzerland]
+  favicon: https://www.80sforever.radio/favicon.ico
+  homepage: https://www.80sforever.radio/
+  country: CH
+  status: stream-only
+
+- id: ch-ambi-nature-radio
+  stationuuid: fb1add5d-4b7b-45cf-9be4-a1e8df712553
+  changeuuid: 7ab2059a-4471-41fa-a2c5-25e2794c39da
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Ambi Nature Radio
+  streamUrl: https://nature-rex.radioca.st/stream
+  bitrate: 320
+  codec: MP3
+  tags: [ambient, switzerland]
+  favicon: https://cdn-radiotime-logos.tunein.com/s266086d.png
+  homepage: https://www.ambinature.xyz/
+  country: CH
+  status: stream-only
+
+- id: ch-spoon-radio-classic-rock
+  stationuuid: a879facb-7b92-4210-a1d3-578de4662736
+  changeuuid: c6b6ace3-c6ae-4b83-ab66-2af573b65371
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Spoon Radio - Classic Rock
+  streamUrl: https://spoonradioclassicrock.ice.infomaniak.ch/spoon-classicrock-hd.aac
+  bitrate: 128
+  codec: AAC
+  tags: [rock, classical, switzerland]
+  homepage: https://www.spoonradio.com/
+  country: CH
+  status: stream-only
+
+- id: ch-spoon-radio-hard-rock
+  stationuuid: 4488dc76-a690-4e51-a46c-3600be8195c4
+  changeuuid: bf6fb05f-2733-4d27-bea1-bf8ec9c94dc4
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Spoon Radio - Hard Rock
+  streamUrl: https://spoonradiohardrock.ice.infomaniak.ch/spoon-hardrock-hd.aac
+  bitrate: 128
+  codec: AAC
+  tags: [rock, switzerland]
+  homepage: https://www.spoonradio.com/
+  country: CH
+  status: stream-only
+
+- id: ch-spoon-radio-rock-ballads
+  stationuuid: ebfd9ee6-f7a5-41ab-9c0c-cc104d996067
+  changeuuid: af27c40d-3c1d-4263-9759-a9dc62d01690
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Spoon Radio - Rock Ballads
+  streamUrl: https://spoonradiorockballads.ice.infomaniak.ch/spoon-rockballads-hd.aac
+  bitrate: 128
+  codec: AAC
+  tags: [rock, switzerland]
+  homepage: https://www.spoonradio.com/
+  country: CH
+  status: stream-only
+
+- id: ch-one-dance-ticino
+  stationuuid: b9660eb9-34f9-11e9-8f31-52543be04c81
+  changeuuid: 33e4ea93-7c31-4bbc-8c50-7b85e26472ee
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: One Dance Ticino
+  streamUrl: https://ice15.fluidstream.net/onedancech.aac
+  bitrate: 128
+  codec: AAC
+  tags: [electronic, pop, switzerland]
+  homepage: https://onedancefm.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-1-fm-beloved-ballads
+  stationuuid: ab911d7a-cc43-4640-96f0-771a651ccd25
+  changeuuid: 9452095b-b64c-4bc0-8993-3519ea84f812
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: 1.FM Beloved Ballads
+  streamUrl: https://strm112.1.fm/onelive_mobile_mp3?
+  bitrate: 192
+  codec: MP3
+  tags: [switzerland]
+  country: CH
+  status: stream-only
+
+- id: ch-spoon-radio-modern-rock
+  stationuuid: c68224d9-0082-47fb-976f-6c08e2e05b21
+  changeuuid: 34efc97a-2029-4cff-a51c-2faa45f23a9a
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Spoon Radio - Modern Rock
+  streamUrl: https://spoonradiomodernrock.ice.infomaniak.ch/spoon-modernrock-hd.aac
+  bitrate: 128
+  codec: AAC
+  tags: [rock, switzerland]
+  homepage: https://www.spoonradio.com/
+  country: CH
+  status: stream-only
+
+- id: ch-swiss-groove
+  stationuuid: 6d4127ba-cd83-45c2-90ad-57dfd90b1457
+  changeuuid: c8a08fe6-cd71-46dd-9899-fec2ca344589
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: SWISS GROOVE
+  streamUrl: https://relay2.swissgroove.ch/;
+  bitrate: 128
+  codec: MP3
+  tags: [jazz, latin, lounge, soul, switzerland]
+  favicon: https://swissgroove.ch/favicon.ico
+  homepage: https://swissgroove.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-skuizz-hits-90s-00s
+  stationuuid: aa98e5e6-63d3-4469-a0f7-e2868efd96a0
+  changeuuid: eda453bd-95a8-4c6e-8fca-cb51fd6bb8a0
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Skuizz Hits 90s-00s
+  streamUrl: https://traxx024.ice.infomaniak.ch/traxx024-1.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [pop, rock, oldies, switzerland]
+  homepage: https://skuizz.com/
+  country: CH
+  status: stream-only
+
+- id: ch-a-fine-jazz-gumbo-radio
+  stationuuid: 40e0da97-9fd2-4729-8e86-4c65cdba7910
+  changeuuid: 812a70af-701d-4220-9078-a7a8e90faee6
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: A Fine Jazz Gumbo Radio
+  streamUrl: https://streaming.smartradio.ch:9502/stream
+  bitrate: 48
+  codec: AAC
+  tags: [jazz, switzerland]
+  favicon: https://jazzgumboradio.com/favicon.ico
+  homepage: https://jazzgumboradio.com/
+  country: CH
+  status: stream-only
+
+- id: ch-radio-maxxima
+  stationuuid: fb056b8d-24ae-4bc5-80dd-2a7020415383
+  changeuuid: 42da1869-362a-4abf-9a8b-97c5d6cfef96
+  reviewedAt: 2026-05-04
+  geo: [46.587, 7.753]
+  broadcaster: independent
+  name: Radio Maxxima
+  streamUrl: https://maxxima.mine.nu/maxxima.mp3
+  bitrate: 192
+  codec: MP3
+  tags: [switzerland]
+  homepage: https://www.maxxima.org/
+  country: CH
+  status: stream-only
+
+- id: ch-rtn
+  stationuuid: 96094a59-0601-11e8-ae97-52543be04c81
+  changeuuid: a48a88e6-b2c0-4f05-b1ca-b44f25e3fefd
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: RTN
+  streamUrl: https://rtn.ice.infomaniak.ch/rtn-high.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  homepage: http://www.rtn.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-one-fm-2000s
+  stationuuid: ee47b64d-ebaf-4d26-90e6-e9cd25f32958
+  changeuuid: 1e3213c9-cb94-4372-8c2c-bad168777d72
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: One FM 2000s
+  streamUrl: https://webradio0009.ice.infomaniak.ch/webradio0009-128.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://www.onefm.ch/wp-content/uploads/2018/08/favicon.png
+  homepage: https://www.onefm.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-spoon-radio-acoustic-rock
+  stationuuid: dbcbdefe-8448-4997-ad46-1c921edd0174
+  changeuuid: ebd33dfc-5a03-4862-ac7b-aa436a7fe902
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Spoon Radio - Acoustic Rock
+  streamUrl: https://spoonradioacousticrock.ice.infomaniak.ch/spoon-acousticrock-hd.aac
+  bitrate: 128
+  codec: AAC
+  tags: [rock, switzerland]
+  homepage: https://www.spoonradio.com/
+  country: CH
+  status: stream-only
+
+- id: ch-radio-lac
+  stationuuid: 3718f163-5868-11e9-a622-52543be04c81
+  changeuuid: b19f6176-4aea-4c93-ab3b-1dfb63d2f4f4
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Radio Lac
+  streamUrl: https://radiolac.ice.infomaniak.ch/radiolac-high.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://www.radiolac.ch/favicon.ico
+  homepage: https://www.radiolac.ch/direct/player/
+  country: CH
+  status: stream-only
+
+- id: ch-goat-radio
+  stationuuid: 4f6119c9-3e96-494d-8b79-696cd97f9a3d
+  changeuuid: 3a26dfe6-cbaf-4f10-ad5e-5ac3cf9ad412
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: GOAT Radio
+  streamUrl: https://20min.dmd2streaming.com/20minuten_radio_64.aac
+  bitrate: 64
+  codec: AAC
+  tags: [switzerland]
+  favicon: https://cdn.unitycms.io/images/DQapoIlBq478hc9HagcAw7.png
+  homepage: https://audio.20min.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-basspistol-radio
+  stationuuid: 876d62ba-1be4-4406-86fd-e0454839e325
+  changeuuid: daf929b4-2f1d-4639-9670-7016564fc7bf
+  reviewedAt: 2026-05-04
+  geo: [46.207, 6.156]
+  broadcaster: independent
+  name: Basspistol Radio
+  streamUrl: https://radio.basspistol.com/radio.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [electronic, hip-hop, indie, switzerland]
+  favicon: https://basspistol.com/siteicon.png
+  homepage: https://basspistol.com/radio
+  country: CH
+  status: stream-only
+
+- id: ch-radio-zurisee
+  stationuuid: 495a3710-7aae-4122-83b5-a49757c0a812
+  changeuuid: 9a8546be-74ad-4417-a916-4e25464b683b
+  reviewedAt: 2026-05-04
+  geo: [47.226, 8.817]
+  broadcaster: independent
+  name: Radio Zürisee
+  streamUrl: https://mp3.radio.ch/radiozuerisee256k
+  bitrate: 256
+  codec: MP3
+  tags: [rock, pop, switzerland]
+  favicon: https://www.radiozuerisee.ch/assets/favicons/apple-icon-120x120.png
+  homepage: https://www.radiozuerisee.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-spoon-radio-alternative-rock
+  stationuuid: 5d216765-e434-4a60-87f0-40cecb5236fa
+  changeuuid: 94998b5e-c7a6-4cb9-9b68-ccdac34ed8b0
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Spoon Radio - Alternative Rock
+  streamUrl: https://spoonradioalternativerock.ice.infomaniak.ch/spoon-alternativerock-hd.aac
+  bitrate: 128
+  codec: AAC
+  tags: [alternative, rock, switzerland]
+  homepage: https://www.spoonradio.com/
+  country: CH
+  status: stream-only
+
+- id: ch-radio1-ch
+  stationuuid: b614ffcb-684a-4fac-8395-17420f6ee27c
+  changeuuid: dce96e86-c7a4-43e9-ae0c-7886586b8a9a
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Radio1.ch
+  streamUrl: https://stream.radio1.ch/128k
+  bitrate: 128
+  codec: MP3
+  tags: [pop, switzerland]
+  homepage: https://radio1.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-break-radio
+  stationuuid: 3cd03534-0100-4055-ab57-4d39c2ae52d0
+  changeuuid: bdcbd885-2ed0-4d60-8644-ba449f98ccdf
+  reviewedAt: 2026-05-04
+  geo: [46.225, 7.352]
+  broadcaster: independent
+  name: Break Radio
+  streamUrl: https://breakradio.ice.infomaniak.ch/breakradio-192.mp3
+  bitrate: 192
+  codec: MP3
+  tags: [hip-hop, switzerland]
+  favicon: https://www.breakradio.ch/apple-touch-icon.png
+  homepage: https://www.breakradio.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-radio-rocket
+  stationuuid: 7e0a8594-c455-4e7a-be89-efe7e955944c
+  changeuuid: f2580886-fed3-4065-9a7f-a04aa5a15a44
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Radio Rocket
+  streamUrl: https://i9.streams.ovh/sc/radioroc/stream
+  bitrate: 320
+  codec: MP3
+  tags: [alternative, rock, switzerland]
+  homepage: https://radiorocket.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-one-fm-90s
+  stationuuid: 871eef57-289c-47f5-9cd4-17b9bd7846a5
+  changeuuid: c87d6c9b-db50-42cd-b974-cc451fd8fc64
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: One FM 90s
+  streamUrl: https://webradio0006.ice.infomaniak.ch/webradio0006-128.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [oldies, switzerland]
+  favicon: https://www.onefm.ch/wp-content/uploads/2018/08/favicon.png
+  homepage: https://www.onefm.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-wrs-swiss-radio-in-english
+  stationuuid: e8686dd3-443b-4a9f-b23f-ed8388bb6b77
+  changeuuid: 24d244c2-6e8a-49ef-ba4e-9c6dfc6649aa
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: WRS "Swiss Radio in English"
+  streamUrl: https://uksouth.streaming.broadcast.radio:10290/wrs?_=443217
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://mmo.aiircdn.com/29/61eaca66a914b.png
+  homepage: https://www.worldradio.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-arc-musique
+  stationuuid: 96205a50-0601-11e8-ae97-52543be04c81
+  changeuuid: 90972f8c-74a6-41ef-a7ed-0e09784821d9
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Arc Musique
+  streamUrl: https://arcmusique.ice.infomaniak.ch/arcmusique-128.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  homepage: http://arcmusique.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-happy-radio
+  stationuuid: ed16b66c-340e-470f-bd76-1e45b145055e
+  changeuuid: 32c4952f-e0fa-4acd-a45e-a83188afb925
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Happy Radio
+  streamUrl: https://uksoutha.streaming.broadcast.radio/stream/11340/gtradio?1672903939995
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://goodtimeradio.broadcast.radio/favicon.ico
+  homepage: https://www.happy-radio.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-radio-summernight
+  stationuuid: 53fefaca-0e1e-11e9-a80b-52543be04c81
+  changeuuid: 3580a705-067d-40f1-a6f8-fea08bc68bb2
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Radio Summernight
+  streamUrl: https://stream.laut.fm/radiosummernight
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  homepage: https://radiosummernight.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-radio-top-ostschweiz
+  stationuuid: 3e7dcb14-de8b-4c9c-85de-272148ff92a1
+  changeuuid: 7fdb7fbd-a0e6-4190-a8c7-bd48bb8204b8
+  reviewedAt: 2026-05-04
+  geo: [47.505, 8.714]
+  broadcaster: independent
+  name: Radio Top (Ostschweiz)
+  streamUrl: https://radiotop.ice.infomaniak.ch/radiotop96.aac
+  bitrate: 96
+  codec: AAC
+  tags: [news, pop, switzerland]
+  favicon: https://www.toponline.ch/fileadmin/templates/logos/apple-touch-icon.png
+  homepage: https://www.toponline.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-radio-gloria
+  stationuuid: a85ace81-8a73-4146-93c5-6d030429e52f
+  changeuuid: def591d3-9fd7-4f2a-88a9-605f04e531a7
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Radio Gloria
+  streamUrl: https://ch-be06-ice.dmd2streaming.com/radiogloria_lo
+  bitrate: 96
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://radiogloria.ch/favicon.ico
+  homepage: https://radiogloria.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-1-fm-classic-rock
+  stationuuid: c3086993-34c3-47cb-9323-540fb675fe46
+  changeuuid: ea86771a-707c-4be6-ae54-80100960a088
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: 1.fm classic rock
+  streamUrl: https://strm112.1.fm/crock_mobile_mp3
+  bitrate: 192
+  codec: MP3
+  tags: [rock, classical, switzerland]
+  homepage: https://www.1.fm/station/crock
+  country: CH
+  status: stream-only
+
+- id: ch-bear-metal-radio
+  stationuuid: 1901f7f2-727f-4fb1-b9d8-bf3f50e1419c
+  changeuuid: d6b44a36-a672-4484-b575-cccf850dc6ab
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Bear Metal Radio
+  streamUrl: https://cast5.asurahosting.com/proxy/bear?mp=/stream
+  bitrate: 192
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://www.bearmetalradio.com/images/logo.png
+  homepage: https://www.bearmetalradio.com/
+  country: CH
+  status: stream-only
+
+- id: ch-rfj
+  stationuuid: 960a893c-0601-11e8-ae97-52543be04c81
+  changeuuid: d89085a6-aca9-49a1-891e-264c6f95db7d
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: RFJ
+  streamUrl: https://rfj.ice.infomaniak.ch/rfj-high.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  homepage: http://www.rfj.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-energy-bern
+  stationuuid: 489f3786-3ff8-46c1-ad14-2a7c5d9cea99
+  changeuuid: 8d33e3c9-9135-4b3c-87c9-96fe0ef2e5f8
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.448]
+  broadcaster: independent
+  name: Energy Bern
+  streamUrl: https://energybern.ice.infomaniak.ch/energybern-high.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://cdn.energy.ch/energych-broadcast/covers/channels/logo_v2_bern_1638178870.svg
+  homepage: https://energy.ch/stations/energy-bern
+  country: CH
+  status: stream-only
+
+- id: ch-radio-lora-97-5
+  stationuuid: 37d4ee78-88a9-4fbd-82f6-81d5eb0b3477
+  changeuuid: 8c19b46c-f3c8-44cd-a82b-e626eb91c177
+  reviewedAt: 2026-05-04
+  geo: [47.378, 8.529]
+  broadcaster: independent
+  name: Radio LoRa 97.5
+  streamUrl: https://livestream.lora.ch/lora.mp3
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://www.lora.ch/images/favicon/apple-touch-icon.png
+  homepage: https://www.lora.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-20minuten-radio-dab-goat-radio
+  stationuuid: eb540959-9fa2-4f04-b822-b74cf761126b
+  changeuuid: b3f936d6-9c82-4222-a260-a4b96c4f5ddc
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: 20minuten.radio DAB+ (GOAT Radio)
+  streamUrl: https://www.digris.ch/stream/897a2939-b6db-42c6-8760-28908bcf8b25
+  bitrate: 256
+  codec: MP3
+  tags: [switzerland]
+  homepage: https://www.20min.ch/radio
+  country: CH
+  status: stream-only
+
+- id: ch-james-fm
+  stationuuid: 6b59a526-91c9-44dc-a615-267d64934bb2
+  changeuuid: 85527b0f-7084-4d7e-b60c-3a66ba46cc4f
+  reviewedAt: 2026-05-04
+  geo: [47.162, 8.437]
+  broadcaster: independent
+  name: JAMES FM
+  streamUrl: https://jamesfm.ice.infomaniak.ch/jamesfm.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  homepage: https://www.jamesfm.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-radio-fribourg
+  stationuuid: e2af125a-58df-4264-9d82-589d96a7ab39
+  changeuuid: 7c1eb02e-c6e3-4c7e-ad4d-881718623c96
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Radio Fribourg
+  streamUrl: https://radiofribourg.ice.infomaniak.ch/radiofribourg-high.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://radiofr.ch/favicons/apple-touch-icon.png
+  homepage: https://radiofr.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-radio-grenzenlos-radio-grenzenlos-spcast
+  stationuuid: 80a7f390-73d1-11e9-af37-52543be04c81
+  changeuuid: 72450e5c-9b10-4d44-b978-a9ff9b38f059
+  reviewedAt: 2026-05-04
+  geo: [47.476, 7.733]
+  broadcaster: independent
+  name: Radio grenzenlos,Radio grenzenlos [SPCast]
+  streamUrl: https://grenzenlos.sp.radio.fm/stream
+  bitrate: 320
+  codec: MP3
+  tags: [electronic, pop, switzerland]
+  favicon: https://radio.grenzenlos.ch/logo.png
+  country: CH
+  status: stream-only
+
+- id: ch-radio-drachenblut
+  stationuuid: 4992d90f-2bed-445d-abc6-6065e7faa38e
+  changeuuid: eeeba9db-ba66-4da0-82e3-d24393725283
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Radio-Drachenblut
+  streamUrl: https://radio-drachenblut.ch:8443/listen.mp3
+  bitrate: 192
+  codec: MP3
+  tags: [rock, switzerland]
+  homepage: https://radio-drachenblut.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-bachata-nation-radio
+  stationuuid: 1eaa7a2e-8fbe-4936-b71c-18190cfb25e8
+  changeuuid: 40d3d674-a051-4014-9110-791922341f53
+  reviewedAt: 2026-05-04
+  geo: [47.375, 8.542]
+  broadcaster: independent
+  name: Bachata Nation Radio
+  streamUrl: https://stream.zeno.fm/vwcq5n2rruhvv
+  codec: MP3
+  tags: [latin, switzerland]
+  homepage: https://stream.zeno.fm/
+  country: CH
+  status: stream-only
+
+- id: ch-one-fm-new-hits
+  stationuuid: 3eab2963-3d0d-43ee-bcba-d686a569e0ce
+  changeuuid: 6860576d-9d78-41c5-9ab0-23b4e1939299
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: One FM New-Hits
+  streamUrl: https://webradio0001.ice.infomaniak.ch/webradio0001-128.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [pop, switzerland]
+  favicon: https://www.onefm.ch/wp-content/uploads/2017/07/logos-1.png
+  homepage: https://onefm.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-canal3-deutsch
+  stationuuid: f91aa755-2979-451e-a4fe-1393f5dd1ed8
+  changeuuid: aecabb5f-fdd8-4976-a774-58a1a0e102a9
+  reviewedAt: 2026-05-04
+  geo: [47.136, 7.243]
+  broadcaster: independent
+  name: Canal3 deutsch
+  streamUrl: https://radio.upstream-cloud.ch/canal3allemand-192.aac
+  bitrate: 192
+  codec: AAC
+  tags: [news, pop, switzerland]
+  favicon: https://web.canal3.ch/de/sites/all/themes/canal3_theme_v2/favicon.ico
+  homepage: https://web.canal3.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-uzic-ch-techno-minimal-best-of-electronic-with-t
+  stationuuid: f0df6e39-68b5-4026-9d83-51af63ddfdc6
+  changeuuid: f3019bab-b4b7-4dd2-8718-9866a6f6aaf3
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: "UZIC.CH"
+  streamUrl: https://uzic.ice.infomaniak.ch/uzic-128.aac
+  bitrate: 128
+  codec: AAC
+  tags: [electronic, switzerland]
+  favicon: https://uzic.ch/wp-content/uploads/2025/06/logo_uzic-150x150.png
+  homepage: https://uzic.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-electrons-libres
+  stationuuid: f02a2856-5044-4b35-a7a2-341d4124fc95
+  changeuuid: 70dc5e13-5a00-4ff0-8b8c-fe678618da32
+  reviewedAt: 2026-05-04
+  geo: [46.951, 7.067]
+  broadcaster: independent
+  name: Electrons Libres
+  streamUrl: https://listen.radioking.com/radio/427889/stream/481505
+  bitrate: 192
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://electronslibres.ch/wp-content/uploads/2021/06/cropped-LogoRadioSimpleSansTxt-1.png
+  homepage: https://electronslibres.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-radio-grischa
+  stationuuid: db6893f4-cead-4749-83e6-a1b1dfb6f61b
+  changeuuid: c0211630-2e5b-4cac-a2cc-c2cf07243d31
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Radio Grischa
+  streamUrl: https://somedia-4.streaming.deliver.media/radiogrischa_mp3_128
+  bitrate: 128
+  codec: MP3
+  tags: [news, switzerland]
+  favicon: https://www.radiogrischa.ch/themes/custom/grischa/images/logos/RG_Signet.png
+  homepage: https://www.radiogrischa.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-radio-s
+  stationuuid: 8d558fc8-b5ca-481b-b192-3f901eb76624
+  changeuuid: 02b61ace-12fc-453c-ac32-7c9d55ed6e3e
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Radio S
+  streamUrl: https://stream.radio-s.ch/stream
+  bitrate: 185
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://static.wixstatic.com/media/d168f9_11af99f87f4448daaf0e1bda1d1a1169~mv2.png/v1/fill/w_180,h_125,al_c,q_85,usm_0.66_1.00_0.01,enc_auto/LOGO%20Radio%20S.png
+  homepage: https://stream.radio-s.ch/stream
+  country: CH
+  status: stream-only
+
+- id: ch-christmas-radio-fm
+  stationuuid: 3f92bfe7-33a4-4246-ae2d-0333a50c7961
+  changeuuid: ea62e8fe-e3d4-41e5-aa00-e1750f36f5dd
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Christmas Radio FM
+  streamUrl: https://xmasfm1.dmd2streaming.com/christmasradiofm-128.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  homepage: http://christmasradio.fm/christmasgateway/
+  country: CH
+  status: stream-only
+
+- id: ch-sabaton
+  stationuuid: 258cfafa-41ac-4d08-9246-7128f5175b6a
+  changeuuid: 4fef89bc-56e6-4831-9e3b-3109aba4d21d
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Sabaton радио
+  streamUrl: https://stream.pcradio.ru/sabaton-hi
+  codec: AAC
+  tags: [switzerland]
+  favicon: null
+  homepage: https://pcradio.ru/
+  country: CH
+  status: stream-only
+
+- id: ch-ip-music-slow-aacplus-96-kb-s
+  stationuuid: f46955a2-77e7-4a30-96af-abdd89c70a2e
+  changeuuid: aaff9c4f-2e4c-4a31-82cc-db4006cb9076
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: IP music SLOW - aacPlus@96 Kb/s
+  streamUrl: https://live9.avf.ch/ipmusicslowaacp96
+  bitrate: 96
+  codec: AAC
+  tags: [switzerland]
+  favicon: https://www.ipmusicslow.ch/images/logo-ipmusicslow.png
+  homepage: https://www.ipmusicslow.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-lfm
+  stationuuid: 52d101dc-3a83-4e4e-8505-8b235065fb0b
+  changeuuid: a01a4a08-c5eb-4ca1-9f9a-5c64e002a23e
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: LFM
+  streamUrl: https://lausannefm.ice.infomaniak.ch/lausannefm-high.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://www.lfm.ch/wp-content/uploads/2021/07/cropped-radio-lausanne-fm-sa-icone-du-site-180x180.png
+  homepage: https://www.lfm.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-neo1
+  stationuuid: 4cde8f3b-17fc-4802-ba40-e8feae5395a1
+  changeuuid: b4bcde74-0a58-4285-b89d-269b3778b41a
+  reviewedAt: 2026-05-04
+  geo: [46.939, 7.784]
+  broadcaster: independent
+  name: Neo1
+  streamUrl: https://neo1.ice.infomaniak.ch/neo1.mp3
+  bitrate: 192
+  codec: MP3
+  tags: [pop, rock, switzerland]
+  favicon: https://www.neo1.ch/fileadmin/user_upload/newsaudio/2018/11/neo1-logo.jpg
+  homepage: https://www.neo1.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-country-radio-switzerland
+  stationuuid: 9d570191-0359-4398-af57-bc8d3e37b417
+  changeuuid: 14b882e4-c379-45af-8ea2-85fac3a17a30
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Country Radio Switzerland
+  streamUrl: https://countryradioswitzerland.ice.infomaniak.ch/crs-128.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [country, switzerland]
+  country: CH
+  status: stream-only
+
+- id: ch-driftfm
+  stationuuid: 613afd76-188c-479b-9585-edddc1059a17
+  changeuuid: ab410fc0-7c8e-4296-b82e-45dc34e57d03
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: driftFM
+  streamUrl: https://s4.radio.co/s5729f2e59/listen
+  bitrate: 192
+  codec: MP3
+  tags: [country, switzerland]
+  favicon: https://www.drift.fm/wp-content/uploads/2020/06/Drift-FM_Logo_transparent_400px_00c8007a1_1367.png
+  homepage: https://www.drift.fm/
+  country: CH
+  status: stream-only
+
+- id: ch-radio-munot
+  stationuuid: 7f32184f-e7f0-46e6-a5e4-516daa062ec7
+  changeuuid: 7b5f9df1-9e0f-44c5-ae90-48fb4be91ce7
+  reviewedAt: 2026-05-04
+  geo: [47.692, 8.626]
+  broadcaster: independent
+  name: Radio Munot
+  streamUrl: https://munot.ch-central-4.streaming.deliver.media/munot_mp3_128
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://www.radiomunot.ch/assets/favicons/android-icon-192x192.png
+  homepage: https://www.radiomunot.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-radio-stadtfilter-dab
+  stationuuid: f427a049-76f7-4d31-b063-e72e55865e99
+  changeuuid: c2aa6e5e-2894-46ac-b20e-95b824399751
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Radio Stadtfilter (DAB+)
+  streamUrl: https://www.digris.ch/stream/8a1a42f0-3f59-4113-b544-aad9275d34a7
+  bitrate: 160
+  codec: MP3
+  tags: [pop, switzerland]
+  homepage: https://stadtfilter.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-radio3i
+  stationuuid: 0064bd20-d2bc-4d1f-808b-3e6b1bf63604
+  changeuuid: 3362ce79-d99a-42f7-b0e1-dc7cae125001
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Radio3i
+  streamUrl: https://vstream-cdn.ch/hls/radio3i.m3u8
+  bitrate: 2628
+  codec: HLS
+  tags: [switzerland]
+  favicon: https://radio3i.ch/assets/images/app-logo.png
+  homepage: https://radio3i.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-rockstar-radio
+  stationuuid: 7b74f47d-5bf2-4ddf-866c-c4738d5cc561
+  changeuuid: a0ade4f9-4cdd-42e2-9cc6-a6318eafb00d
+  reviewedAt: 2026-05-04
+  geo: [46.521, 6.633]
+  broadcaster: independent
+  name: Rockstar Radio
+  streamUrl: https://dr2101.ice.infomaniak.ch/dr2102.mp3
+  bitrate: 192
+  codec: MP3
+  tags: [rock, switzerland]
+  favicon: https://dr21.mediaonegroup.ch/apps/assets/logo_rockstar_2.svg
+  homepage: https://rockstarradio.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-wildmountain-radio
+  stationuuid: c9eb3feb-9c48-4fde-aef7-eda15d2173fd
+  changeuuid: ab95743d-5c5b-4884-a5b7-f740996e6233
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Wildmountain Radio
+  streamUrl: https://wildmountain.ice.infomaniak.ch/wmr.mp3
+  bitrate: 192
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://www.wildmountain.ch/favicon.png
+  homepage: https://www.wildmountain.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-back2noize-radio
+  stationuuid: 29c2975b-3ca9-4f4e-b5fb-1bfdc2e0eba2
+  changeuuid: af428891-1b6f-4dfd-9b3b-547c6de99433
+  reviewedAt: 2026-05-04
+  geo: [46.556, 6.510]
+  broadcaster: independent
+  name: Back2Noize Radio
+  streamUrl: https://securestreams4.autopo.st:1558/Back2Noize
+  bitrate: 320
+  codec: MP3
+  tags: [electronic, switzerland]
+  favicon: https://back2noize.com/wp-content/uploads/2019/08/back2noize-logo-round-300x300.jpg
+  homepage: https://back2noize.com/
+  country: CH
+  status: stream-only
+
+- id: ch-radio-r-louange
+  stationuuid: 5b884101-b14c-4377-8b96-7593ade7a2d1
+  changeuuid: d24e7b72-dc92-4876-9480-11fefb993667
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Radio R Louange
+  streamUrl: https://radiorlouange.ice.infomaniak.ch/radiorlouange-96.aac?ver=666978
+  bitrate: 96
+  codec: AAC
+  tags: [gospel, switzerland]
+  favicon: https://radio-r.ch/wp-content/uploads/2024/03/radio-r-louange_cover_cropOK_1080x1080px-170x170.png
+  homepage: https://radio-r.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-radio-rasa-schaffhausen
+  stationuuid: 64bf4040-d07a-418b-a7a3-9cec29107091
+  changeuuid: c204e651-980f-4f27-a63f-e0ec5d2fc5c0
+  reviewedAt: 2026-05-04
+  geo: [47.696, 8.634]
+  broadcaster: independent
+  name: Radio Rasa Schaffhausen
+  streamUrl: https://radio.upstream-cloud.ch/radiorasa-128.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [alternative, indie, switzerland]
+  favicon: https://www.rasa.ch/favicon.ico
+  homepage: https://www.rasa.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-dream-sequence
+  stationuuid: 2c3ae89a-977a-445b-9a8a-bef76cd0ebfa
+  changeuuid: 675612a0-9311-4733-b0e0-49157428cd7b
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Dream Sequence
+  streamUrl: https://listen.radioking.com/radio/453296/stream/508976
+  bitrate: 192
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://static.wixstatic.com/media/e05539_cbaf7759467242c1843d8bac2619e127~mv2.png/v1/crop/x_9,y_0,w_3107,h_1875/fill/w_490,h_296,al_c,q_85,usm_0.66_1.00_0.01,enc_auto/customcolor_logo_transparent_background.png
+  homepage: https://www.dreamsequence.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-80ies-dot-radio
+  stationuuid: 89cf48cc-719a-4807-ac86-963196fc0107
+  changeuuid: 3fcdc1d2-8a1a-40cc-9e5a-3977841ed06e
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: 80ies dot radio
+  streamUrl: https://stream.radiojar.com/6cbvkaa1mrruv?1643199882
+  codec: MP3
+  tags: [oldies, switzerland]
+  homepage: https://www.80ies.radio/
+  country: CH
+  status: stream-only
+
+- id: ch-kiss-collector-radio
+  stationuuid: 3684bcbb-8af6-4755-9db8-0e240824f0fa
+  changeuuid: d64cb330-ab01-469c-9afe-628e300e6c7c
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Kiss Collector Radio
+  streamUrl: https://dr2101.ice.infomaniak.ch/dr2101.mp3
+  bitrate: 320
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://kisscollector.ch/favicon.ico
+  homepage: https://kisscollector.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-one-fm-rock-oldies
+  stationuuid: 7396ca2e-f495-4e74-ac43-7e6870cebc3d
+  changeuuid: 925a696d-52ff-4a77-a1b7-6f9799c93a96
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: One FM Rock Oldies
+  streamUrl: https://webradio0002.ice.infomaniak.ch/webradio0002-128.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [rock, oldies, switzerland]
+  favicon: https://www.onefm.ch/wp-content/themes/mog-child/webradios/ONE_app_WEBRADIO_Rock.png
+  homepage: https://www.onefm.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-ktfm-geneva-the-best-of-70-s-and-80-s
+  stationuuid: 0a29e7a5-96b9-45a6-a8e5-86611b2f31ff
+  changeuuid: bbd5aec5-a216-47dc-ad0a-7e54cf1d744c
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: KTfm Geneva - THE BEST OF 70'S AND 80'S
+  streamUrl: https://ktfm.ice.infomaniak.ch/ktfm-high.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [pop, oldies, switzerland]
+  favicon: https://i0.wp.com/ktfm-radio.ch/wp-content/uploads/2019/12/KTFM-1.png?fit=50%2C50&ssl=1
+  homepage: https://ktfm-radio.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-radio-alta
+  stationuuid: ac5fdde2-5bc3-435a-a016-37e93dfe79bc
+  changeuuid: 0a18e450-5623-48b8-9557-ff8244ad2ffd
+  reviewedAt: 2026-05-04
+  geo: [46.310, -6.300]
+  broadcaster: independent
+  name: Radio Alta
+  streamUrl: https://transmiss.ion.ovh/listen/alta/radio.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [gospel, switzerland]
+  homepage: https://transmiss.ion.ovh/public/alta
+  country: CH
+  status: stream-only
+
+- id: ch-spoon-rock
+  stationuuid: ff6de11b-718f-480e-804b-79f4f3f6ea8e
+  changeuuid: 61272ca5-2f96-4914-b173-add462280111
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Spoon Rock
+  streamUrl: https://ic2527.c972.fastserv.com:80/spoonradio_mp3_192
+  bitrate: 192
+  codec: MP3
+  tags: [rock, switzerland]
+  favicon: https://www.spoonradio.com/newimages/logo.png
+  homepage: https://www.spoonradio.com/
+  country: CH
+  status: stream-only
+
+- id: ch-rockstation
+  stationuuid: 292bb9ec-496f-47dc-8531-4be97c572297
+  changeuuid: f8dce236-9ecb-413e-9b6c-fbcd0ac89ada
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: ROCKSTATION
+  streamUrl: https://radio2.stream24.net:8130/live.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [rock, switzerland]
+  favicon: https://rockstation.ch/wp-content/uploads/2023/03/cropped-favicon-basis-192x192.jpg
+  homepage: https://rockstation.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-open-broadcast
+  stationuuid: 60d9dd7c-3509-4dba-9e27-b87e9ea3ff6a
+  changeuuid: 5ec45bd1-6658-4663-b800-011fe0c1705e
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Open Broadcast
+  streamUrl: https://www.digris.ch/stream/092210ed-4eb4-483b-814f-21df6ecb1352
+  bitrate: 320
+  codec: MP3
+  tags: [switzerland]
+  homepage: https://openbroadcast.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-rundfunk-fm
+  stationuuid: cfad47f6-45dd-458a-a2fa-f9883cc239e9
+  changeuuid: 0fd11ce8-aaee-41ed-9c5a-d8e5323fce75
+  reviewedAt: 2026-05-04
+  geo: [47.379, 8.541]
+  broadcaster: independent
+  name: Rundfunk.fm
+  streamUrl: https://rundfunkfm.broadcast.brandsarelive.com/listen/rundfunk.fm/radio.mp3
+  bitrate: 320
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://rundfunk.fm/static/assets/favicon/apple-touch-icon.png
+  homepage: https://rundfunk.fm/
+  country: CH
+  status: stream-only
+
+- id: ch-my105-x-mas
+  stationuuid: 989e9111-51fb-48ea-985b-1d5110dacde1
+  changeuuid: 14238ed7-b86d-44ed-ac12-bd8857b15ff5
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: my105 X-MAS
+  streamUrl: https://stream01.my105.ch/my105xmas.mp3
+  bitrate: 192
+  codec: MP3
+  tags: [switzerland]
+  homepage: https://www.my105.ch/x-mas
+  country: CH
+  status: stream-only
+
+- id: ch-radio-neue-hoffnung
+  stationuuid: 446160e9-ec70-4499-bba4-bd56f5c0d75c
+  changeuuid: 3461650e-4afc-47bf-8227-7075a620d07e
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Radio Neue Hoffnung
+  streamUrl: https://stream.mnr.ch/rnh-mp3
+  bitrate: 192
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://www.mnr.ch/favicon.ico
+  homepage: https://www.mnr.ch/radio/
+  country: CH
+  status: stream-only
+
+- id: ch-ta-radio
+  stationuuid: d391db6e-6bc9-4805-9f87-044601efc9ef
+  changeuuid: d3463303-7d54-4b66-8cdd-479063be885c
+  reviewedAt: 2026-05-04
+  geo: [47.009, 7.011]
+  broadcaster: independent
+  name: Ta Radio
+  streamUrl: https://stream.taradio.ch/dab
+  bitrate: 96
+  codec: AAC
+  tags: [electronic, pop, rock, switzerland]
+  homepage: https://www.taradio.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-traxx-fm-hits
+  stationuuid: 42aab7fd-98d5-4816-bcf4-30dd2e563abd
+  changeuuid: a96a5e0b-114d-495b-a31a-ff37b4687dcb
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Traxx FM - Hits
+  streamUrl: https://traxx010.ice.infomaniak.ch/traxx010-low.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  homepage: http://www.traxx.fm/
+  country: CH
+  status: stream-only
+
+- id: ch-lux-radio
+  stationuuid: 0f42b130-e1dd-4ed4-982e-92659b038780
+  changeuuid: 5b188ba9-f70f-4e68-9165-8d1566e17681
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: LUX RADIO
+  streamUrl: https://live7.avf.ch/lux_main
+  bitrate: 1200
+  codec: OGG
+  tags: [switzerland]
+  favicon: https://luxradio.ch/wp-content/uploads/2022/03/Logo-Colour.png
+  homepage: https://luxradio.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-radio-electrons-libres
+  stationuuid: f41d60a2-28c0-4637-87d8-274edc988871
+  changeuuid: 53433c19-5f86-4e3f-8db8-302a805dc619
+  reviewedAt: 2026-05-04
+  geo: [46.951, 7.067]
+  broadcaster: independent
+  name: Radio Electrons Libres
+  streamUrl: https://listen.radioking.com/radio/427889/stream/481499
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://electronslibres.ch/favicon.ico
+  homepage: https://electronslibres.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-radio-vintage
+  stationuuid: b081d89a-ded2-42a6-aac1-ac8879870b44
+  changeuuid: 899f745f-06e1-47dd-aadb-535de74b2464
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: RADIO VINTAGE
+  streamUrl: https://radiovintage.ice.infomaniak.ch/radiovintage-128.mp3?ua=RADIO%20VINTAGE%20-%20audio%20player%201
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://www.radio-vintage.com/wp-content/uploads/2020/12/cropped-logo-4.png
+  homepage: https://www.radio-vintage.com/
+  country: CH
+  status: stream-only
+
+- id: ch-radio-sudostschweiz
+  stationuuid: 4b8d625c-a8fc-4e4c-bbbf-62af99e78568
+  changeuuid: fe8ee51a-4670-4e8c-99ac-92bfff68b1ca
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Radio Südostschweiz
+  streamUrl: https://somedia-1.streaming.deliver.media/rso_mp3_128?suffix0=RSO
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://www.suedostschweiz.ch/themes/suedostschweiz/logo.svg
+  homepage: https://rso.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-one-fm
+  stationuuid: 23184af4-6a87-4cb4-a47f-5936ffd0f673
+  changeuuid: 53d93299-a56c-41d8-b8bf-2602d4dc2612
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: One FM
+  streamUrl: https://onefm.ice.infomaniak.ch/onefm-high.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://cdn-profiles.tunein.com/s7567/images/bannerx.jpg?t=636482377033470000
+  homepage: https://www.onefm.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-vertical-radio
+  stationuuid: de81082f-b5cb-4450-a9d5-a1f6b5ebe5f4
+  changeuuid: 9792ce6f-e4ef-4109-82d8-529189e6dc75
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Vertical Radio
+  streamUrl: https://verticalradio.ice.infomaniak.ch/verticalradio-128.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://www.verticalradio.ch/media/image/11/base/logo-vertical-green.svg?undefined
+  homepage: https://www.verticalradio.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-radio-3fach
+  stationuuid: 8d36363c-f60f-45d8-afe1-659c9fc4071c
+  changeuuid: 7ac71437-7ce7-4e65-9ea1-d0fbcbcee43c
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Radio 3FACH
+  streamUrl: https://stream01.3fach.ch/live
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://3fach.ch/themes/3fach/assets/logo_black@2x.png
+  homepage: https://3fach.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-diks
+  stationuuid: 2334b1a6-5eaa-42a3-a03c-799554914a20
+  changeuuid: d833af07-8997-4c99-8c2d-5dedcaf78d82
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: DIKS ДИКС
+  streamUrl: https://icecast.correctiv.net/sacharow
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  homepage: https://icecast.correctiv.net/sacharow
+  country: CH
+  status: stream-only
+
+- id: ch-radio-zurich-nord
+  stationuuid: 2b96ded7-dcf5-4a27-bfd8-2ad09295b0e0
+  changeuuid: 0ffd4435-0f62-4eae-a7ee-3fad0f9448e7
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Radio Zürich Nord
+  streamUrl: https://bayern.streampanel.cloud:11145/stream
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  homepage: https://bayern.streampanel.cloud:11145/stream
+  country: CH
+  status: stream-only
+
+- id: ch-radiofr-fresh
+  stationuuid: 69641b03-0907-45e1-888f-79fadb9fe6bf
+  changeuuid: bfc9b6b2-6566-40c3-98d3-e9f01b0ca74c
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: RadioFr. Fresh
+  streamUrl: https://radiofresh.ice.infomaniak.ch/radiofresh.aac
+  bitrate: 128
+  codec: AAC
+  tags: [pop, switzerland]
+  homepage: https://www.radiofr.ch/fresh
+  country: CH
+  status: stream-only
+
+- id: ch-walts-welt
+  stationuuid: ac25562f-560b-499c-b945-3e5adc399d00
+  changeuuid: 40aecf87-7f70-489b-91d3-1efeb4cb6794
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: WALTS WELT
+  streamUrl: https://waltswelt.out.airtime.pro/waltswelt_a?_ga=2.33964516.474222732.1669644968-446937151.1669306237
+  bitrate: 64
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://waltswelt.ch/wp-content/uploads/2017/06/cropped-favicon_512x512_2-150x150.png
+  homepage: https://waltswelt.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-urbn-radio
+  stationuuid: 65309759-6273-4340-a287-67ce6cca538f
+  changeuuid: dd45ee92-6ab8-45eb-af94-b1966ee7fe7b
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: URBN Radio
+  streamUrl: https://dr2101.ice.infomaniak.ch/dr2103.mp3
+  bitrate: 192
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://urbnradio.ch/favicon.ico
+  homepage: https://urbnradio.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-jukebox-nonstop-music
+  stationuuid: 9edf64c6-40f0-41d8-88de-ef77fb3803c7
+  changeuuid: b066f3bf-e1f7-4deb-a4d5-1d9e9d60677a
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Jukebox - Nonstop Music
+  streamUrl: https://kreuzbergswiss.sp.radio.fm/stream.hls
+  bitrate: 320
+  codec: HLS
+  tags: [switzerland]
+  favicon: https://jukebox.kreuzbergswiss.ch/images/favicon.ico
+  homepage: https://jukebox.kreuzbergswiss.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-radio-ouistiti
+  stationuuid: aaa4e936-93aa-4e4c-a53d-cf0a019b0df0
+  changeuuid: 957e2718-2977-4aa1-b99c-5d4cf7cf9082
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: RADIO OUISTITI
+  streamUrl: https://radioouistiti2.ice.infomaniak.ch/radioouistiti-high.mp3?_=1
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://www.radioouistiti.ch/wp-content/uploads/2024/11/radioouistiti_logo.png
+  homepage: https://www.radioouistiti.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-radio-2go
+  stationuuid: 56f7dd34-4213-4773-88ae-7337ed2ca422
+  changeuuid: 60e16030-07b6-4c14-92b8-1f60062a7089
+  reviewedAt: 2026-05-04
+  geo: [47.480, 8.211]
+  broadcaster: independent
+  name: Radio 2Go
+  streamUrl: https://uksoutha.streaming.broadcast.radio:15830/radio2go
+  codec: MP3
+  tags: [pop, switzerland]
+  favicon: https://radio2go.fm/wp-content/uploads/2020/06/favicon.png
+  homepage: https://www.radio2go.fm/
+  country: CH
+  status: stream-only
+
+- id: ch-radio-rocher
+  stationuuid: 1e255d42-ef19-4060-aaa5-a0f2f0c2a2d7
+  changeuuid: 837e641e-6776-473d-8e85-9532eabcd0df
+  reviewedAt: 2026-05-04
+  geo: [46.998, 6.934]
+  broadcaster: independent
+  name: Radio Rocher
+  streamUrl: https://play.radioking.io/radio-rocher/429886
+  bitrate: 192
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://image.radioking.io/radios/321905/logo/26ca805b-11bd-49c0-a13d-d357fb33ffd0.jpeg
+  homepage: https://www.radio-rocher.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-abdulbasit-abdulsamad
+  stationuuid: 5b91451d-b697-48f5-8b41-9d36c586b30d
+  changeuuid: e45893c4-226e-4a33-b866-ef6529ad996e
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: . Abdulbasit Abdulsamad
+  streamUrl: https://radio.mp3islam.com/listen/abdulbasit/radio.mp3
+  bitrate: 192
+  codec: MP3
+  tags: [switzerland]
+  favicon: null
+  homepage: https://mp3islam.com/
+  country: CH
+  status: stream-only
+
+
+- id: ch-la-radio-du-bord-de-l-eau
+  stationuuid: 5ff66832-e6b3-486b-bac8-e00ca29b6f67
+  changeuuid: fcb2333e-91d4-449a-b065-d0fd1257bae6
+  reviewedAt: 2026-05-04
+  geo: [46.291, 7.531]
+  broadcaster: independent
+  name: La Radio du bord de l’eau
+  streamUrl: https://listen.radioking.com/radio/181657/stream/223420
+  bitrate: 128
+  codec: MP3
+  tags: [electronic, switzerland]
+  favicon: https://image.radioking.io/radios/181657/logo/098b1c15-74cf-4638-b264-517fb9b06eac.jpeg
+  homepage: https://www.auborddeleau.bar/radio/
+  country: CH
+  status: stream-only
+
+- id: ch-radio-bollwerk
+  stationuuid: e1b48285-78a9-4e33-b0bd-cfc1bb59b838
+  changeuuid: ac2ad179-a785-4770-8002-634ced8a6448
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Radio Bollwerk
+  streamUrl: https://radio.radio-bollwerk.ch/listen/radio_bollwerk/radio.mp3
+  bitrate: 320
+  codec: MP3
+  tags: [switzerland]
+  homepage: https://www.radio-bollwerk.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-trasformatorio
+  stationuuid: 5f46b851-bd50-4891-8229-1d86e2cf4cfd
+  changeuuid: a5d9824a-8db9-4a79-97dd-8ea590bc3d58
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Trasformatorio
+  streamUrl: https://radio.dyne.org/trasformatorio-archives.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://trasformatorio.net/wp-content/uploads/2013/07/cropped-logotondo-2.png
+  homepage: https://trasformatorio.net/
+  country: CH
+  status: stream-only
+
+- id: ch-cm-radio-crans-montana
+  stationuuid: e31e2db4-5b41-4318-8665-62b0b244f85f
+  changeuuid: c11a3663-f4a1-49f8-9eb3-d4da995e6f9c
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: CM Radio Crans-Montana
+  streamUrl: https://listen.radioking.com/radio/605899/stream/669205
+  bitrate: 320
+  codec: MP3
+  tags: [switzerland]
+  homepage: https://www.crans-montana.radio/
+  country: CH
+  status: stream-only
+
+- id: ch-jam-on-radio
+  stationuuid: a805fab4-126a-4d4a-9801-19295138d569
+  changeuuid: 10ff589f-983f-4a7c-9ccc-6c50085659e6
+  reviewedAt: 2026-05-04
+  geo: [47.182, 8.521]
+  broadcaster: independent
+  name: Jam On Radio
+  streamUrl: https://jam-on.ice.infomaniak.ch/jam-on-128.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://jam-on.ch/img/apple-touch-icon.png
+  homepage: https://jam-on.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-onflow-hot
+  stationuuid: 549ffb7b-879e-474f-8eda-806d8e2b05a2
+  changeuuid: bfdfdc62-2773-48c2-bf0c-df43ad46fd84
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: OnFlow Hot
+  streamUrl: https://stream.zeno.fm/pxqdhcb7gqutv
+  codec: MP3
+  tags: [switzerland]
+  homepage: https://api.zeno.fm/mounts/metadata/subscribe/aeppezbhdfkvv
+  country: CH
+  status: stream-only
+
+- id: ch-provoda-ch-legacy-mp3
+  stationuuid: d6bcb339-3b71-43d8-8bd7-43cbeb9d9e28
+  changeuuid: cbee7a8f-f0c4-4996-b203-79c4e7eac3e1
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Provoda.ch LEGACY MP3
+  streamUrl: https://station.waveradio.org/provodach.mp3?irqlzgjdlfohjixsouex
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://provoda.ch/favicon.ico
+  homepage: http://provoda.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-queer-radio
+  stationuuid: 508271d8-11db-4a9c-940d-d109b56c09c7
+  changeuuid: ac34fc2e-0011-4fe4-85fd-5f8a70d7939a
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: QUEER RADIO
+  streamUrl: https://solid67.streamupsolutions.com/proxy/eyprxrqz?mp=/stream
+  bitrate: 192
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://www.queerradio.ch/wp-content/uploads/2019/10/QUEER-RADIO-HEART-PLAYER-180-180-pixel-150x150.jpg
+  homepage: https://www.queerradio.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-agaune-radio
+  stationuuid: b473bb7b-5d62-42ce-9c92-3f61a65c6f2f
+  changeuuid: 350d55cd-9a41-46e4-86a5-ea0929907e50
+  reviewedAt: 2026-05-04
+  geo: [46.215, 7.004]
+  broadcaster: independent
+  name: Agaune Radio
+  streamUrl: https://stream.zeno.fm/0r0xa792kwzuv
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://www.agaune.radio/upload/design/69a67c2b9ba951.58189328.png
+  homepage: https://www.agaune.radio/
+  country: CH
+  status: stream-only
+
+- id: ch-anntenne-jesus-live
+  stationuuid: 6f774e8a-12d1-4835-acfe-9d398075aaed
+  changeuuid: 126d708f-adda-4577-9654-04b40b9689e2
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Anntenne Jesus Live
+  streamUrl: https://radio.antennejesus.live/listen/antennejesuslive/radio.mp3
+  bitrate: 192
+  codec: MP3
+  tags: [gospel, switzerland]
+  homepage: https://antennejesus.live/
+  country: CH
+  status: stream-only
+
+- id: ch-pureglow-radio
+  stationuuid: 9d43d519-7eeb-4161-a73a-734108fb3f4c
+  changeuuid: 22d1a1ae-5e5c-4d2a-85ff-372fb18881fe
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: PureGlow Radio
+  streamUrl: https://pureglowradio.ice.infomaniak.ch/pureglowradio.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://2023.pureglowradio.com/wp-content/uploads/2016/09/logo-dark-pgr-2.png
+  homepage: https://www.pureglowradio.com/
+  country: CH
+  status: stream-only
+
+- id: ch-radio-freundes-dienst-schweiz
+  stationuuid: 015d2e92-e261-450a-8fe0-8f62b11d4a6e
+  changeuuid: bfdd5561-87da-4e28-bf78-6c77d64bd0ef
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Radio Freundes-Dienst Schweiz
+  streamUrl: https://stream.radiofd.ch/radiofd/mp3_128/radiobrowser
+  bitrate: 128
+  codec: MP3
+  tags: [news, switzerland]
+  homepage: https://www.radiofd.ch/
+  country: CH
+  status: stream-only
 # ─── FR — Radio France public broadcaster (2026-04-29) ───
 # Pattern: https://icecast.radiofrance.fr/<slug>-hifi.aac (192 AAC).
 # RB stores http:// for the same hosts → broken-mixed; HTTPS works.

--- a/public/station-duplicates.json
+++ b/public/station-duplicates.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-05-04T13:56:23.914Z",
-  "totalScanned": 906,
+  "generatedAt": "2026-05-04T14:05:14.256Z",
+  "totalScanned": 936,
   "collisionCount": 0,
   "byKind": {
     "stationuuid": 0,

--- a/public/station-duplicates.json
+++ b/public/station-duplicates.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-05-04T14:20:41.243Z",
-  "totalScanned": 1410,
+  "generatedAt": "2026-05-04T14:22:04.170Z",
+  "totalScanned": 1878,
   "collisionCount": 0,
   "byKind": {
     "stationuuid": 0,

--- a/public/station-duplicates.json
+++ b/public/station-duplicates.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-05-04T13:45:00.157Z",
-  "totalScanned": 876,
+  "generatedAt": "2026-05-04T13:56:23.914Z",
+  "totalScanned": 906,
   "collisionCount": 0,
   "byKind": {
     "stationuuid": 0,

--- a/public/station-duplicates.json
+++ b/public/station-duplicates.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-05-04T08:09:24.649Z",
-  "totalScanned": 771,
+  "generatedAt": "2026-05-04T13:45:00.157Z",
+  "totalScanned": 876,
   "collisionCount": 0,
   "byKind": {
     "stationuuid": 0,

--- a/public/station-duplicates.json
+++ b/public/station-duplicates.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-05-04T14:05:14.256Z",
-  "totalScanned": 936,
+  "generatedAt": "2026-05-04T14:20:41.243Z",
+  "totalScanned": 1410,
   "collisionCount": 0,
   "byKind": {
     "stationuuid": 0,

--- a/public/stations.json
+++ b/public/stations.json
@@ -917,6 +917,2025 @@
       "status": "icy-only"
     },
     {
+      "id": "ch-80s-forever-we-keep-the-80s-alive",
+      "name": "80s Forever - We Keep The 80s Alive",
+      "broadcaster": "independent",
+      "streamUrl": "https://premium.shoutcastsolutions.com/radio/8050/256.mp3",
+      "homepage": "https://www.80sforever.radio/",
+      "country": "CH",
+      "tags": [
+        "pop",
+        "indie",
+        "rock",
+        "oldies",
+        "switzerland"
+      ],
+      "favicon": "https://www.80sforever.radio/favicon.ico",
+      "bitrate": 256,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-ambi-nature-radio",
+      "name": "Ambi Nature Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://nature-rex.radioca.st/stream",
+      "homepage": "https://www.ambinature.xyz/",
+      "country": "CH",
+      "tags": [
+        "ambient",
+        "switzerland"
+      ],
+      "favicon": "https://cdn-radiotime-logos.tunein.com/s266086d.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-spoon-radio-classic-rock",
+      "name": "Spoon Radio - Classic Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://spoonradioclassicrock.ice.infomaniak.ch/spoon-classicrock-hd.aac",
+      "homepage": "https://www.spoonradio.com/",
+      "country": "CH",
+      "tags": [
+        "rock",
+        "classical",
+        "switzerland"
+      ],
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-spoon-radio-hard-rock",
+      "name": "Spoon Radio - Hard Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://spoonradiohardrock.ice.infomaniak.ch/spoon-hardrock-hd.aac",
+      "homepage": "https://www.spoonradio.com/",
+      "country": "CH",
+      "tags": [
+        "rock",
+        "switzerland"
+      ],
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-spoon-radio-rock-ballads",
+      "name": "Spoon Radio - Rock Ballads",
+      "broadcaster": "independent",
+      "streamUrl": "https://spoonradiorockballads.ice.infomaniak.ch/spoon-rockballads-hd.aac",
+      "homepage": "https://www.spoonradio.com/",
+      "country": "CH",
+      "tags": [
+        "rock",
+        "switzerland"
+      ],
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-one-dance-ticino",
+      "name": "One Dance Ticino",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice15.fluidstream.net/onedancech.aac",
+      "homepage": "https://onedancefm.ch/",
+      "country": "CH",
+      "tags": [
+        "electronic",
+        "pop",
+        "switzerland"
+      ],
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-1-fm-beloved-ballads",
+      "name": "1.FM Beloved Ballads",
+      "broadcaster": "independent",
+      "streamUrl": "https://strm112.1.fm/onelive_mobile_mp3?",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-spoon-radio-modern-rock",
+      "name": "Spoon Radio - Modern Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://spoonradiomodernrock.ice.infomaniak.ch/spoon-modernrock-hd.aac",
+      "homepage": "https://www.spoonradio.com/",
+      "country": "CH",
+      "tags": [
+        "rock",
+        "switzerland"
+      ],
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-swiss-groove",
+      "name": "SWISS GROOVE",
+      "broadcaster": "independent",
+      "streamUrl": "https://relay2.swissgroove.ch/;",
+      "homepage": "https://swissgroove.ch/",
+      "country": "CH",
+      "tags": [
+        "jazz",
+        "latin",
+        "lounge",
+        "soul",
+        "switzerland"
+      ],
+      "favicon": "https://swissgroove.ch/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-skuizz-hits-90s-00s",
+      "name": "Skuizz Hits 90s-00s",
+      "broadcaster": "independent",
+      "streamUrl": "https://traxx024.ice.infomaniak.ch/traxx024-1.mp3",
+      "homepage": "https://skuizz.com/",
+      "country": "CH",
+      "tags": [
+        "pop",
+        "rock",
+        "oldies",
+        "switzerland"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-a-fine-jazz-gumbo-radio",
+      "name": "A Fine Jazz Gumbo Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.smartradio.ch:9502/stream",
+      "homepage": "https://jazzgumboradio.com/",
+      "country": "CH",
+      "tags": [
+        "jazz",
+        "switzerland"
+      ],
+      "favicon": "https://jazzgumboradio.com/favicon.ico",
+      "bitrate": 48,
+      "codec": "AAC",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-maxxima",
+      "name": "Radio Maxxima",
+      "broadcaster": "independent",
+      "streamUrl": "https://maxxima.mine.nu/maxxima.mp3",
+      "homepage": "https://www.maxxima.org/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        46.587,
+        7.753
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-rtn",
+      "name": "RTN",
+      "broadcaster": "independent",
+      "streamUrl": "https://rtn.ice.infomaniak.ch/rtn-high.mp3",
+      "homepage": "http://www.rtn.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-one-fm-2000s",
+      "name": "One FM 2000s",
+      "broadcaster": "independent",
+      "streamUrl": "https://webradio0009.ice.infomaniak.ch/webradio0009-128.mp3",
+      "homepage": "https://www.onefm.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://www.onefm.ch/wp-content/uploads/2018/08/favicon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-spoon-radio-acoustic-rock",
+      "name": "Spoon Radio - Acoustic Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://spoonradioacousticrock.ice.infomaniak.ch/spoon-acousticrock-hd.aac",
+      "homepage": "https://www.spoonradio.com/",
+      "country": "CH",
+      "tags": [
+        "rock",
+        "switzerland"
+      ],
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-lac",
+      "name": "Radio Lac",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiolac.ice.infomaniak.ch/radiolac-high.mp3",
+      "homepage": "https://www.radiolac.ch/direct/player/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://www.radiolac.ch/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-goat-radio",
+      "name": "GOAT Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://20min.dmd2streaming.com/20minuten_radio_64.aac",
+      "homepage": "https://audio.20min.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://cdn.unitycms.io/images/DQapoIlBq478hc9HagcAw7.png",
+      "bitrate": 64,
+      "codec": "AAC",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-basspistol-radio",
+      "name": "Basspistol Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.basspistol.com/radio.mp3",
+      "homepage": "https://basspistol.com/radio",
+      "country": "CH",
+      "tags": [
+        "electronic",
+        "hip-hop",
+        "indie",
+        "switzerland"
+      ],
+      "favicon": "https://basspistol.com/siteicon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.207,
+        6.156
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-zurisee",
+      "name": "Radio Zürisee",
+      "broadcaster": "independent",
+      "streamUrl": "https://mp3.radio.ch/radiozuerisee256k",
+      "homepage": "https://www.radiozuerisee.ch/",
+      "country": "CH",
+      "tags": [
+        "rock",
+        "pop",
+        "switzerland"
+      ],
+      "favicon": "https://www.radiozuerisee.ch/assets/favicons/apple-icon-120x120.png",
+      "bitrate": 256,
+      "codec": "MP3",
+      "geo": [
+        47.226,
+        8.817
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-spoon-radio-alternative-rock",
+      "name": "Spoon Radio - Alternative Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://spoonradioalternativerock.ice.infomaniak.ch/spoon-alternativerock-hd.aac",
+      "homepage": "https://www.spoonradio.com/",
+      "country": "CH",
+      "tags": [
+        "alternative",
+        "rock",
+        "switzerland"
+      ],
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio1-ch",
+      "name": "Radio1.ch",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radio1.ch/128k",
+      "homepage": "https://radio1.ch/",
+      "country": "CH",
+      "tags": [
+        "pop",
+        "switzerland"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-break-radio",
+      "name": "Break Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://breakradio.ice.infomaniak.ch/breakradio-192.mp3",
+      "homepage": "https://www.breakradio.ch/",
+      "country": "CH",
+      "tags": [
+        "hip-hop",
+        "switzerland"
+      ],
+      "favicon": "https://www.breakradio.ch/apple-touch-icon.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        46.225,
+        7.352
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-rocket",
+      "name": "Radio Rocket",
+      "broadcaster": "independent",
+      "streamUrl": "https://i9.streams.ovh/sc/radioroc/stream",
+      "homepage": "https://radiorocket.ch/",
+      "country": "CH",
+      "tags": [
+        "alternative",
+        "rock",
+        "switzerland"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-one-fm-90s",
+      "name": "One FM 90s",
+      "broadcaster": "independent",
+      "streamUrl": "https://webradio0006.ice.infomaniak.ch/webradio0006-128.mp3",
+      "homepage": "https://www.onefm.ch/",
+      "country": "CH",
+      "tags": [
+        "oldies",
+        "switzerland"
+      ],
+      "favicon": "https://www.onefm.ch/wp-content/uploads/2018/08/favicon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-wrs-swiss-radio-in-english",
+      "name": "WRS \"Swiss Radio in English\"",
+      "broadcaster": "independent",
+      "streamUrl": "https://uksouth.streaming.broadcast.radio:10290/wrs?_=443217",
+      "homepage": "https://www.worldradio.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://mmo.aiircdn.com/29/61eaca66a914b.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-arc-musique",
+      "name": "Arc Musique",
+      "broadcaster": "independent",
+      "streamUrl": "https://arcmusique.ice.infomaniak.ch/arcmusique-128.mp3",
+      "homepage": "http://arcmusique.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-happy-radio",
+      "name": "Happy Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://uksoutha.streaming.broadcast.radio/stream/11340/gtradio?1672903939995",
+      "homepage": "https://www.happy-radio.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://goodtimeradio.broadcast.radio/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-summernight",
+      "name": "Radio Summernight",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/radiosummernight",
+      "homepage": "https://radiosummernight.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-top-ostschweiz",
+      "name": "Radio Top (Ostschweiz)",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiotop.ice.infomaniak.ch/radiotop96.aac",
+      "homepage": "https://www.toponline.ch/",
+      "country": "CH",
+      "tags": [
+        "news",
+        "pop",
+        "switzerland"
+      ],
+      "favicon": "https://www.toponline.ch/fileadmin/templates/logos/apple-touch-icon.png",
+      "bitrate": 96,
+      "codec": "AAC",
+      "geo": [
+        47.505,
+        8.714
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-gloria",
+      "name": "Radio Gloria",
+      "broadcaster": "independent",
+      "streamUrl": "https://ch-be06-ice.dmd2streaming.com/radiogloria_lo",
+      "homepage": "https://radiogloria.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://radiogloria.ch/favicon.ico",
+      "bitrate": 96,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-1-fm-classic-rock",
+      "name": "1.fm classic rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://strm112.1.fm/crock_mobile_mp3",
+      "homepage": "https://www.1.fm/station/crock",
+      "country": "CH",
+      "tags": [
+        "rock",
+        "classical",
+        "switzerland"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-bear-metal-radio",
+      "name": "Bear Metal Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast5.asurahosting.com/proxy/bear?mp=/stream",
+      "homepage": "https://www.bearmetalradio.com/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://www.bearmetalradio.com/images/logo.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-rfj",
+      "name": "RFJ",
+      "broadcaster": "independent",
+      "streamUrl": "https://rfj.ice.infomaniak.ch/rfj-high.mp3",
+      "homepage": "http://www.rfj.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-energy-bern",
+      "name": "Energy Bern",
+      "broadcaster": "independent",
+      "streamUrl": "https://energybern.ice.infomaniak.ch/energybern-high.mp3",
+      "homepage": "https://energy.ch/stations/energy-bern",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://cdn.energy.ch/energych-broadcast/covers/channels/logo_v2_bern_1638178870.svg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.448
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-lora-97-5",
+      "name": "Radio LoRa 97.5",
+      "broadcaster": "independent",
+      "streamUrl": "https://livestream.lora.ch/lora.mp3",
+      "homepage": "https://www.lora.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://www.lora.ch/images/favicon/apple-touch-icon.png",
+      "codec": "MP3",
+      "geo": [
+        47.378,
+        8.529
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-20minuten-radio-dab-goat-radio",
+      "name": "20minuten.radio DAB+ (GOAT Radio)",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.digris.ch/stream/897a2939-b6db-42c6-8760-28908bcf8b25",
+      "homepage": "https://www.20min.ch/radio",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "bitrate": 256,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-james-fm",
+      "name": "JAMES FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://jamesfm.ice.infomaniak.ch/jamesfm.mp3",
+      "homepage": "https://www.jamesfm.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        47.162,
+        8.437
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-fribourg",
+      "name": "Radio Fribourg",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiofribourg.ice.infomaniak.ch/radiofribourg-high.mp3",
+      "homepage": "https://radiofr.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://radiofr.ch/favicons/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-grenzenlos-radio-grenzenlos-spcast",
+      "name": "Radio grenzenlos,Radio grenzenlos [SPCast]",
+      "broadcaster": "independent",
+      "streamUrl": "https://grenzenlos.sp.radio.fm/stream",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "CH",
+      "tags": [
+        "electronic",
+        "pop",
+        "switzerland"
+      ],
+      "favicon": "https://radio.grenzenlos.ch/logo.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        47.476,
+        7.733
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-drachenblut",
+      "name": "Radio-Drachenblut",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio-drachenblut.ch:8443/listen.mp3",
+      "homepage": "https://radio-drachenblut.ch/",
+      "country": "CH",
+      "tags": [
+        "rock",
+        "switzerland"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-bachata-nation-radio",
+      "name": "Bachata Nation Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.zeno.fm/vwcq5n2rruhvv",
+      "homepage": "https://stream.zeno.fm/",
+      "country": "CH",
+      "tags": [
+        "latin",
+        "switzerland"
+      ],
+      "codec": "MP3",
+      "geo": [
+        47.375,
+        8.542
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-one-fm-new-hits",
+      "name": "One FM New-Hits",
+      "broadcaster": "independent",
+      "streamUrl": "https://webradio0001.ice.infomaniak.ch/webradio0001-128.mp3",
+      "homepage": "https://onefm.ch/",
+      "country": "CH",
+      "tags": [
+        "pop",
+        "switzerland"
+      ],
+      "favicon": "https://www.onefm.ch/wp-content/uploads/2017/07/logos-1.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-canal3-deutsch",
+      "name": "Canal3 deutsch",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.upstream-cloud.ch/canal3allemand-192.aac",
+      "homepage": "https://web.canal3.ch/",
+      "country": "CH",
+      "tags": [
+        "news",
+        "pop",
+        "switzerland"
+      ],
+      "favicon": "https://web.canal3.ch/de/sites/all/themes/canal3_theme_v2/favicon.ico",
+      "bitrate": 192,
+      "codec": "AAC",
+      "geo": [
+        47.136,
+        7.243
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-uzic-ch-techno-minimal-best-of-electronic-with-t",
+      "name": "UZIC.CH",
+      "broadcaster": "independent",
+      "streamUrl": "https://uzic.ice.infomaniak.ch/uzic-128.aac",
+      "homepage": "https://uzic.ch/",
+      "country": "CH",
+      "tags": [
+        "electronic",
+        "switzerland"
+      ],
+      "favicon": "https://uzic.ch/wp-content/uploads/2025/06/logo_uzic-150x150.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-electrons-libres",
+      "name": "Electrons Libres",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/427889/stream/481505",
+      "homepage": "https://electronslibres.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://electronslibres.ch/wp-content/uploads/2021/06/cropped-LogoRadioSimpleSansTxt-1.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        46.951,
+        7.067
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-grischa",
+      "name": "Radio Grischa",
+      "broadcaster": "independent",
+      "streamUrl": "https://somedia-4.streaming.deliver.media/radiogrischa_mp3_128",
+      "homepage": "https://www.radiogrischa.ch/",
+      "country": "CH",
+      "tags": [
+        "news",
+        "switzerland"
+      ],
+      "favicon": "https://www.radiogrischa.ch/themes/custom/grischa/images/logos/RG_Signet.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-s",
+      "name": "Radio S",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radio-s.ch/stream",
+      "homepage": "https://stream.radio-s.ch/stream",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://static.wixstatic.com/media/d168f9_11af99f87f4448daaf0e1bda1d1a1169~mv2.png/v1/fill/w_180,h_125,al_c,q_85,usm_0.66_1.00_0.01,enc_auto/LOGO%20Radio%20S.png",
+      "bitrate": 185,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-christmas-radio-fm",
+      "name": "Christmas Radio FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://xmasfm1.dmd2streaming.com/christmasradiofm-128.mp3",
+      "homepage": "http://christmasradio.fm/christmasgateway/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-sabaton",
+      "name": "Sabaton радио",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.pcradio.ru/sabaton-hi",
+      "homepage": "https://pcradio.ru/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "codec": "AAC",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-ip-music-slow-aacplus-96-kb-s",
+      "name": "IP music SLOW - aacPlus@96 Kb/s",
+      "broadcaster": "independent",
+      "streamUrl": "https://live9.avf.ch/ipmusicslowaacp96",
+      "homepage": "https://www.ipmusicslow.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://www.ipmusicslow.ch/images/logo-ipmusicslow.png",
+      "bitrate": 96,
+      "codec": "AAC",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-lfm",
+      "name": "LFM",
+      "broadcaster": "independent",
+      "streamUrl": "https://lausannefm.ice.infomaniak.ch/lausannefm-high.mp3",
+      "homepage": "https://www.lfm.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://www.lfm.ch/wp-content/uploads/2021/07/cropped-radio-lausanne-fm-sa-icone-du-site-180x180.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-neo1",
+      "name": "Neo1",
+      "broadcaster": "independent",
+      "streamUrl": "https://neo1.ice.infomaniak.ch/neo1.mp3",
+      "homepage": "https://www.neo1.ch/",
+      "country": "CH",
+      "tags": [
+        "pop",
+        "rock",
+        "switzerland"
+      ],
+      "favicon": "https://www.neo1.ch/fileadmin/user_upload/newsaudio/2018/11/neo1-logo.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        46.939,
+        7.784
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-country-radio-switzerland",
+      "name": "Country Radio Switzerland",
+      "broadcaster": "independent",
+      "streamUrl": "https://countryradioswitzerland.ice.infomaniak.ch/crs-128.mp3",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "CH",
+      "tags": [
+        "country",
+        "switzerland"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-driftfm",
+      "name": "driftFM",
+      "broadcaster": "independent",
+      "streamUrl": "https://s4.radio.co/s5729f2e59/listen",
+      "homepage": "https://www.drift.fm/",
+      "country": "CH",
+      "tags": [
+        "country",
+        "switzerland"
+      ],
+      "favicon": "https://www.drift.fm/wp-content/uploads/2020/06/Drift-FM_Logo_transparent_400px_00c8007a1_1367.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-munot",
+      "name": "Radio Munot",
+      "broadcaster": "independent",
+      "streamUrl": "https://munot.ch-central-4.streaming.deliver.media/munot_mp3_128",
+      "homepage": "https://www.radiomunot.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://www.radiomunot.ch/assets/favicons/android-icon-192x192.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        47.692,
+        8.626
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-stadtfilter-dab",
+      "name": "Radio Stadtfilter (DAB+)",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.digris.ch/stream/8a1a42f0-3f59-4113-b544-aad9275d34a7",
+      "homepage": "https://stadtfilter.ch/",
+      "country": "CH",
+      "tags": [
+        "pop",
+        "switzerland"
+      ],
+      "bitrate": 160,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio3i",
+      "name": "Radio3i",
+      "broadcaster": "independent",
+      "streamUrl": "https://vstream-cdn.ch/hls/radio3i.m3u8",
+      "homepage": "https://radio3i.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://radio3i.ch/assets/images/app-logo.png",
+      "bitrate": 2628,
+      "codec": "HLS",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-rockstar-radio",
+      "name": "Rockstar Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://dr2101.ice.infomaniak.ch/dr2102.mp3",
+      "homepage": "https://rockstarradio.ch/",
+      "country": "CH",
+      "tags": [
+        "rock",
+        "switzerland"
+      ],
+      "favicon": "https://dr21.mediaonegroup.ch/apps/assets/logo_rockstar_2.svg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        46.521,
+        6.633
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-wildmountain-radio",
+      "name": "Wildmountain Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://wildmountain.ice.infomaniak.ch/wmr.mp3",
+      "homepage": "https://www.wildmountain.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://www.wildmountain.ch/favicon.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-back2noize-radio",
+      "name": "Back2Noize Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://securestreams4.autopo.st:1558/Back2Noize",
+      "homepage": "https://back2noize.com/",
+      "country": "CH",
+      "tags": [
+        "electronic",
+        "switzerland"
+      ],
+      "favicon": "https://back2noize.com/wp-content/uploads/2019/08/back2noize-logo-round-300x300.jpg",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        46.556,
+        6.51
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-r-louange",
+      "name": "Radio R Louange",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiorlouange.ice.infomaniak.ch/radiorlouange-96.aac?ver=666978",
+      "homepage": "https://radio-r.ch/",
+      "country": "CH",
+      "tags": [
+        "gospel",
+        "switzerland"
+      ],
+      "favicon": "https://radio-r.ch/wp-content/uploads/2024/03/radio-r-louange_cover_cropOK_1080x1080px-170x170.png",
+      "bitrate": 96,
+      "codec": "AAC",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-rasa-schaffhausen",
+      "name": "Radio Rasa Schaffhausen",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.upstream-cloud.ch/radiorasa-128.mp3",
+      "homepage": "https://www.rasa.ch/",
+      "country": "CH",
+      "tags": [
+        "alternative",
+        "indie",
+        "switzerland"
+      ],
+      "favicon": "https://www.rasa.ch/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        47.696,
+        8.634
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-dream-sequence",
+      "name": "Dream Sequence",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/453296/stream/508976",
+      "homepage": "https://www.dreamsequence.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://static.wixstatic.com/media/e05539_cbaf7759467242c1843d8bac2619e127~mv2.png/v1/crop/x_9,y_0,w_3107,h_1875/fill/w_490,h_296,al_c,q_85,usm_0.66_1.00_0.01,enc_auto/customcolor_logo_transparent_background.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-80ies-dot-radio",
+      "name": "80ies dot radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radiojar.com/6cbvkaa1mrruv?1643199882",
+      "homepage": "https://www.80ies.radio/",
+      "country": "CH",
+      "tags": [
+        "oldies",
+        "switzerland"
+      ],
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-kiss-collector-radio",
+      "name": "Kiss Collector Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://dr2101.ice.infomaniak.ch/dr2101.mp3",
+      "homepage": "https://kisscollector.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://kisscollector.ch/favicon.ico",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-one-fm-rock-oldies",
+      "name": "One FM Rock Oldies",
+      "broadcaster": "independent",
+      "streamUrl": "https://webradio0002.ice.infomaniak.ch/webradio0002-128.mp3",
+      "homepage": "https://www.onefm.ch/",
+      "country": "CH",
+      "tags": [
+        "rock",
+        "oldies",
+        "switzerland"
+      ],
+      "favicon": "https://www.onefm.ch/wp-content/themes/mog-child/webradios/ONE_app_WEBRADIO_Rock.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-ktfm-geneva-the-best-of-70-s-and-80-s",
+      "name": "KTfm Geneva - THE BEST OF 70'S AND 80'S",
+      "broadcaster": "independent",
+      "streamUrl": "https://ktfm.ice.infomaniak.ch/ktfm-high.mp3",
+      "homepage": "https://ktfm-radio.ch/",
+      "country": "CH",
+      "tags": [
+        "pop",
+        "oldies",
+        "switzerland"
+      ],
+      "favicon": "https://i0.wp.com/ktfm-radio.ch/wp-content/uploads/2019/12/KTFM-1.png?fit=50%2C50&ssl=1",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-alta",
+      "name": "Radio Alta",
+      "broadcaster": "independent",
+      "streamUrl": "https://transmiss.ion.ovh/listen/alta/radio.mp3",
+      "homepage": "https://transmiss.ion.ovh/public/alta",
+      "country": "CH",
+      "tags": [
+        "gospel",
+        "switzerland"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.31,
+        -6.3
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-spoon-rock",
+      "name": "Spoon Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://ic2527.c972.fastserv.com:80/spoonradio_mp3_192",
+      "homepage": "https://www.spoonradio.com/",
+      "country": "CH",
+      "tags": [
+        "rock",
+        "switzerland"
+      ],
+      "favicon": "https://www.spoonradio.com/newimages/logo.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-rockstation",
+      "name": "ROCKSTATION",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio2.stream24.net:8130/live.mp3",
+      "homepage": "https://rockstation.ch/",
+      "country": "CH",
+      "tags": [
+        "rock",
+        "switzerland"
+      ],
+      "favicon": "https://rockstation.ch/wp-content/uploads/2023/03/cropped-favicon-basis-192x192.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-open-broadcast",
+      "name": "Open Broadcast",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.digris.ch/stream/092210ed-4eb4-483b-814f-21df6ecb1352",
+      "homepage": "https://openbroadcast.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-rundfunk-fm",
+      "name": "Rundfunk.fm",
+      "broadcaster": "independent",
+      "streamUrl": "https://rundfunkfm.broadcast.brandsarelive.com/listen/rundfunk.fm/radio.mp3",
+      "homepage": "https://rundfunk.fm/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://rundfunk.fm/static/assets/favicon/apple-touch-icon.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        47.379,
+        8.541
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-my105-x-mas",
+      "name": "my105 X-MAS",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream01.my105.ch/my105xmas.mp3",
+      "homepage": "https://www.my105.ch/x-mas",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-neue-hoffnung",
+      "name": "Radio Neue Hoffnung",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.mnr.ch/rnh-mp3",
+      "homepage": "https://www.mnr.ch/radio/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://www.mnr.ch/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-ta-radio",
+      "name": "Ta Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.taradio.ch/dab",
+      "homepage": "https://www.taradio.ch/",
+      "country": "CH",
+      "tags": [
+        "electronic",
+        "pop",
+        "rock",
+        "switzerland"
+      ],
+      "bitrate": 96,
+      "codec": "AAC",
+      "geo": [
+        47.009,
+        7.011
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-traxx-fm-hits",
+      "name": "Traxx FM - Hits",
+      "broadcaster": "independent",
+      "streamUrl": "https://traxx010.ice.infomaniak.ch/traxx010-low.mp3",
+      "homepage": "http://www.traxx.fm/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-lux-radio",
+      "name": "LUX RADIO",
+      "broadcaster": "independent",
+      "streamUrl": "https://live7.avf.ch/lux_main",
+      "homepage": "https://luxradio.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://luxradio.ch/wp-content/uploads/2022/03/Logo-Colour.png",
+      "bitrate": 1200,
+      "codec": "OGG",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-electrons-libres",
+      "name": "Radio Electrons Libres",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/427889/stream/481499",
+      "homepage": "https://electronslibres.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://electronslibres.ch/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.951,
+        7.067
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-vintage",
+      "name": "RADIO VINTAGE",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiovintage.ice.infomaniak.ch/radiovintage-128.mp3?ua=RADIO%20VINTAGE%20-%20audio%20player%201",
+      "homepage": "https://www.radio-vintage.com/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://www.radio-vintage.com/wp-content/uploads/2020/12/cropped-logo-4.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-sudostschweiz",
+      "name": "Radio Südostschweiz",
+      "broadcaster": "independent",
+      "streamUrl": "https://somedia-1.streaming.deliver.media/rso_mp3_128?suffix0=RSO",
+      "homepage": "https://rso.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://www.suedostschweiz.ch/themes/suedostschweiz/logo.svg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-one-fm",
+      "name": "One FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://onefm.ice.infomaniak.ch/onefm-high.mp3",
+      "homepage": "https://www.onefm.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://cdn-profiles.tunein.com/s7567/images/bannerx.jpg?t=636482377033470000",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-vertical-radio",
+      "name": "Vertical Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://verticalradio.ice.infomaniak.ch/verticalradio-128.mp3",
+      "homepage": "https://www.verticalradio.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://www.verticalradio.ch/media/image/11/base/logo-vertical-green.svg?undefined",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-3fach",
+      "name": "Radio 3FACH",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream01.3fach.ch/live",
+      "homepage": "https://3fach.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://3fach.ch/themes/3fach/assets/logo_black@2x.png",
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-diks",
+      "name": "DIKS ДИКС",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.correctiv.net/sacharow",
+      "homepage": "https://icecast.correctiv.net/sacharow",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-zurich-nord",
+      "name": "Radio Zürich Nord",
+      "broadcaster": "independent",
+      "streamUrl": "https://bayern.streampanel.cloud:11145/stream",
+      "homepage": "https://bayern.streampanel.cloud:11145/stream",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radiofr-fresh",
+      "name": "RadioFr. Fresh",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiofresh.ice.infomaniak.ch/radiofresh.aac",
+      "homepage": "https://www.radiofr.ch/fresh",
+      "country": "CH",
+      "tags": [
+        "pop",
+        "switzerland"
+      ],
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-walts-welt",
+      "name": "WALTS WELT",
+      "broadcaster": "independent",
+      "streamUrl": "https://waltswelt.out.airtime.pro/waltswelt_a?_ga=2.33964516.474222732.1669644968-446937151.1669306237",
+      "homepage": "https://waltswelt.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://waltswelt.ch/wp-content/uploads/2017/06/cropped-favicon_512x512_2-150x150.png",
+      "bitrate": 64,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-urbn-radio",
+      "name": "URBN Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://dr2101.ice.infomaniak.ch/dr2103.mp3",
+      "homepage": "https://urbnradio.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://urbnradio.ch/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-jukebox-nonstop-music",
+      "name": "Jukebox - Nonstop Music",
+      "broadcaster": "independent",
+      "streamUrl": "https://kreuzbergswiss.sp.radio.fm/stream.hls",
+      "homepage": "https://jukebox.kreuzbergswiss.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://jukebox.kreuzbergswiss.ch/images/favicon.ico",
+      "bitrate": 320,
+      "codec": "HLS",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-ouistiti",
+      "name": "RADIO OUISTITI",
+      "broadcaster": "independent",
+      "streamUrl": "https://radioouistiti2.ice.infomaniak.ch/radioouistiti-high.mp3?_=1",
+      "homepage": "https://www.radioouistiti.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://www.radioouistiti.ch/wp-content/uploads/2024/11/radioouistiti_logo.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-2go",
+      "name": "Radio 2Go",
+      "broadcaster": "independent",
+      "streamUrl": "https://uksoutha.streaming.broadcast.radio:15830/radio2go",
+      "homepage": "https://www.radio2go.fm/",
+      "country": "CH",
+      "tags": [
+        "pop",
+        "switzerland"
+      ],
+      "favicon": "https://radio2go.fm/wp-content/uploads/2020/06/favicon.png",
+      "codec": "MP3",
+      "geo": [
+        47.48,
+        8.211
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-rocher",
+      "name": "Radio Rocher",
+      "broadcaster": "independent",
+      "streamUrl": "https://play.radioking.io/radio-rocher/429886",
+      "homepage": "https://www.radio-rocher.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://image.radioking.io/radios/321905/logo/26ca805b-11bd-49c0-a13d-d357fb33ffd0.jpeg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        46.998,
+        6.934
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-abdulbasit-abdulsamad",
+      "name": ". Abdulbasit Abdulsamad",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.mp3islam.com/listen/abdulbasit/radio.mp3",
+      "homepage": "https://mp3islam.com/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-la-radio-du-bord-de-l-eau",
+      "name": "La Radio du bord de l’eau",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/181657/stream/223420",
+      "homepage": "https://www.auborddeleau.bar/radio/",
+      "country": "CH",
+      "tags": [
+        "electronic",
+        "switzerland"
+      ],
+      "favicon": "https://image.radioking.io/radios/181657/logo/098b1c15-74cf-4638-b264-517fb9b06eac.jpeg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.291,
+        7.531
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-bollwerk",
+      "name": "Radio Bollwerk",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.radio-bollwerk.ch/listen/radio_bollwerk/radio.mp3",
+      "homepage": "https://www.radio-bollwerk.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-trasformatorio",
+      "name": "Trasformatorio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.dyne.org/trasformatorio-archives.mp3",
+      "homepage": "https://trasformatorio.net/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://trasformatorio.net/wp-content/uploads/2013/07/cropped-logotondo-2.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-cm-radio-crans-montana",
+      "name": "CM Radio Crans-Montana",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/605899/stream/669205",
+      "homepage": "https://www.crans-montana.radio/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-jam-on-radio",
+      "name": "Jam On Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://jam-on.ice.infomaniak.ch/jam-on-128.mp3",
+      "homepage": "https://jam-on.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://jam-on.ch/img/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        47.182,
+        8.521
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-onflow-hot",
+      "name": "OnFlow Hot",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.zeno.fm/pxqdhcb7gqutv",
+      "homepage": "https://api.zeno.fm/mounts/metadata/subscribe/aeppezbhdfkvv",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-provoda-ch-legacy-mp3",
+      "name": "Provoda.ch LEGACY MP3",
+      "broadcaster": "independent",
+      "streamUrl": "https://station.waveradio.org/provodach.mp3?irqlzgjdlfohjixsouex",
+      "homepage": "http://provoda.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://provoda.ch/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-queer-radio",
+      "name": "QUEER RADIO",
+      "broadcaster": "independent",
+      "streamUrl": "https://solid67.streamupsolutions.com/proxy/eyprxrqz?mp=/stream",
+      "homepage": "https://www.queerradio.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://www.queerradio.ch/wp-content/uploads/2019/10/QUEER-RADIO-HEART-PLAYER-180-180-pixel-150x150.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-agaune-radio",
+      "name": "Agaune Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.zeno.fm/0r0xa792kwzuv",
+      "homepage": "https://www.agaune.radio/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://www.agaune.radio/upload/design/69a67c2b9ba951.58189328.png",
+      "codec": "MP3",
+      "geo": [
+        46.215,
+        7.004
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-anntenne-jesus-live",
+      "name": "Anntenne Jesus Live",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.antennejesus.live/listen/antennejesuslive/radio.mp3",
+      "homepage": "https://antennejesus.live/",
+      "country": "CH",
+      "tags": [
+        "gospel",
+        "switzerland"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-pureglow-radio",
+      "name": "PureGlow Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://pureglowradio.ice.infomaniak.ch/pureglowradio.mp3",
+      "homepage": "https://www.pureglowradio.com/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://2023.pureglowradio.com/wp-content/uploads/2016/09/logo-dark-pgr-2.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-freundes-dienst-schweiz",
+      "name": "Radio Freundes-Dienst Schweiz",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radiofd.ch/radiofd/mp3_128/radiobrowser",
+      "homepage": "https://www.radiofd.ch/",
+      "country": "CH",
+      "tags": [
+        "news",
+        "switzerland"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
       "id": "builtin-france-inter",
       "name": "France Inter",
       "broadcaster": "radio-france",

--- a/public/stations.json
+++ b/public/stations.json
@@ -19861,6 +19861,8852 @@
         37.6173
       ],
       "status": "stream-only"
+    },
+    {
+      "id": "de-top-100-club-charts-dance-dj-mix-radio-24-hours-",
+      "name": "# TOP 100 CLUB CHARTS - DANCE & DJ MIX RADIO - 24 HOURS NON-STOP MUSIC @ TikTok Hits, Ibiza House, Sunset Lounge, Melodic Music, EDM, Deep House, Dance Music, Techno & Hypertechno, Rave Charts, Top 40 Charts, Latin, Reggaeton Music, Moombahton, Urban Hits, HipHop, Party & Clubbing Radio, Trending Chartmusic, R&B, Urban, Mixtape - & LIVE DJ SET ",
+      "broadcaster": "independent",
+      "streamUrl": "https://breakz-2012-high.rautemusik.fm/?ref=radiobrowser-top100-clubcharts",
+      "homepage": "https://rm.fm/breakz/team",
+      "country": "DE",
+      "tags": [
+        "#",
+        "#charts",
+        "#club",
+        "#djmix",
+        "#mashup",
+        "#radio"
+      ],
+      "favicon": "https://i.ibb.co/T1gH75m/rb-top100clubcharts.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.2508,
+        6.7654
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-top-100-dj-charts-dj-remix-charts-radio-tiktok-c",
+      "name": "# TOP 100 DJ CHARTS - DJ REMIX & CHARTS RADIO @ TikTok Charts, Electronic Music, EDM, House, Deep House, Dance Music, Techno & Hypertechno, Top40, Latin Charts, Reggaeton, Urban, HipHop, Club & Party Radio - & LIVE DJ SETS ",
+      "broadcaster": "independent",
+      "streamUrl": "https://breakz-high.rautemusik.fm/?ref=radiobrowser-top100-djcharts",
+      "homepage": "https://rm.fm/breakz",
+      "country": "DE",
+      "tags": [
+        "#90s",
+        "#charts",
+        "2000s",
+        "2010s",
+        "bass house",
+        "beachclub"
+      ],
+      "favicon": "https://i.ibb.co/jMmvLjz/TOP100-DJ-CHARTS-RADIO.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.8988,
+        6.9771
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-deutschlandfunk-dlf-opus-24k",
+      "name": "Deutschlandfunk | DLF | OPUS 24k",
+      "broadcaster": "independent",
+      "streamUrl": "https://st01.sslstream.dlf.de/dlf/01/low/opus/stream.opus?aggregator=web",
+      "homepage": "https://www.deutschlandfunk.de/",
+      "country": "DE",
+      "tags": [
+        "culture",
+        "news",
+        "public service",
+        "information"
+      ],
+      "favicon": "https://www.deutschlandfunk.de/static/img/deutschlandfunk/icons/apple-touch-icon-128x128.png",
+      "bitrate": 24,
+      "codec": "OGG",
+      "geo": [
+        52.4803,
+        13.3348
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-deutschlandfunk-dlf-aac-48k",
+      "name": "Deutschlandfunk | DLF | AAC 48k",
+      "broadcaster": "independent",
+      "streamUrl": "https://st01.sslstream.dlf.de/dlf/01/low/aac/stream.aac?aggregator=web",
+      "homepage": "https://www.deutschlandfunk.de/",
+      "country": "DE",
+      "tags": [
+        "culture",
+        "news",
+        "public service",
+        "information"
+      ],
+      "favicon": "https://www.deutschlandfunk.de/static/img/deutschlandfunk/icons/apple-touch-icon-128x128.png",
+      "bitrate": 48,
+      "codec": "AAC",
+      "geo": [
+        52.4803,
+        13.3348
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-deutschlandfunk-dlf-aac-96k",
+      "name": "Deutschlandfunk | DLF | AAC 96k",
+      "broadcaster": "independent",
+      "streamUrl": "https://st01.sslstream.dlf.de/dlf/01/mid/aac/stream.aac?aggregator=web",
+      "homepage": "https://www.deutschlandfunk.de/",
+      "country": "DE",
+      "tags": [
+        "culture",
+        "news",
+        "public service",
+        "information"
+      ],
+      "favicon": "https://www.deutschlandfunk.de/static/img/deutschlandfunk/icons/apple-touch-icon-128x128.png",
+      "bitrate": 96,
+      "codec": "AAC",
+      "geo": [
+        52.4803,
+        13.3348
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-remix-partybreaks-your-house-edm-hiphop-rnb-tech",
+      "name": "# REMIX & PARTYBREAKS - Your House - EDM - HipHop - RnB - Techno - TechHouse - Top 40 Charts - Latin - DJ Mixtape RADIO",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.breakz.fm/?ref=radiobrowser-remix-partybreaks-radio",
+      "homepage": "https://rm.fm/breakz",
+      "country": "DE",
+      "tags": [
+        "#",
+        "#00s",
+        "#90",
+        "#dj",
+        "#partybreaks",
+        "#top100"
+      ],
+      "favicon": "https://i.ibb.co/1bdF482/REMIX-PARTYNBREAKS-LOGO-1.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-deutschlandfunk-dlf-aac-192k",
+      "name": "Deutschlandfunk | DLF | AAC 192k",
+      "broadcaster": "independent",
+      "streamUrl": "https://st01.sslstream.dlf.de/dlf/01/high/aac/stream.aac?aggregator=web",
+      "homepage": "https://www.deutschlandfunk.de/",
+      "country": "DE",
+      "tags": [
+        "culture",
+        "news",
+        "public service",
+        "information"
+      ],
+      "favicon": "https://www.deutschlandfunk.de/static/img/deutschlandfunk/icons/apple-touch-icon-128x128.png",
+      "bitrate": 256,
+      "codec": "AAC",
+      "geo": [
+        52.4803,
+        13.3348
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-trap-by-rautemusik-rm-fm",
+      "name": "__TRAP__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://trap-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://www.rm.fm/",
+      "country": "DE",
+      "tags": [
+        "drum & bass",
+        "drum 'n' bass",
+        "drum and bass",
+        "hip-hop",
+        "hiphop",
+        "trap"
+      ],
+      "favicon": "https://www.rm.fm/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-br-klassik",
+      "name": "BR-Klassik",
+      "broadcaster": "independent",
+      "streamUrl": "https://dispatcher.rndfnk.com/br/brklassik/live/mp3/high",
+      "homepage": "https://www.br-klassik.de/index.html",
+      "country": "DE",
+      "tags": [
+        "classical"
+      ],
+      "favicon": "https://api.ardmediathek.de/image-service/images/urn:ard:image:476e47d76c4bbf78?w=512",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1-a-oldies-von-1a-radio",
+      "name": "- 1 A - Oldies von 1A Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://1a-oldies.radionetz.de/1a-oldies.mp3",
+      "homepage": "http://www.1aradio.com/",
+      "country": "DE",
+      "tags": [
+        "60er",
+        "60s",
+        "70er",
+        "70s",
+        "80er",
+        "80s"
+      ],
+      "favicon": "https://www.1aradio.com/logos/1a-oldies_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-technolovers-bass-house",
+      "name": "Technolovers - BASS HOUSE",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.technolovers.fm/bass-house?ref=radiobrowser",
+      "homepage": "https://technolovers.fm/",
+      "country": "DE",
+      "tags": [
+        "bass",
+        "club house",
+        "deep house",
+        "electro",
+        "electronic",
+        "elektro"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-gothic-on-radio",
+      "name": "- 0 N - Gothic on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-gothic.radionetz.de/0n-gothic.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "darkwave",
+        "ebm",
+        "goth",
+        "gothic",
+        "industrial",
+        "medieval"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-gothic_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-swr2",
+      "name": "SWR2",
+      "broadcaster": "independent",
+      "streamUrl": "https://f111.rndfnk.com/ard/swr/swr2/live/mp3/256/stream.mp3?aggregator=web&sid=28ew6Usq6cch83eglcsXwLlNRS3&token=Ip5bwQ_T81Lq_mqKc3HUjnxrk94ek2bDcfNyNHuqRGk&tvf=XFsRgyq06xZmMTExLnJuZGZuay5jb20",
+      "homepage": "https://www.swr.de/swr2/index.html",
+      "country": "DE",
+      "tags": [
+        "classical"
+      ],
+      "favicon": "https://www.swr.de/assets/swr/swrkultur/apple-touch-icon.png",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-pop-on-radio",
+      "name": "- 0 N - Pop on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-pop.radionetz.de/0n-pop.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "black",
+        "dance",
+        "hiphop",
+        "hits",
+        "pop",
+        "rock"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-pop_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-bass-by-rautemusik-rm-fm",
+      "name": "__BASS__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://bass-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://www.rm.fm/bass",
+      "country": "DE",
+      "tags": [
+        "chilled trap",
+        "drum & bass",
+        "drum 'n' bass",
+        "drum and bass",
+        "hip-hop",
+        "hiphop"
+      ],
+      "favicon": "https://www.rm.fm/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-house-by-rautemusik-rm-fm",
+      "name": "__HOUSE__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://house-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://www.rm.fm/house",
+      "country": "DE",
+      "tags": [
+        "dance",
+        "deep house",
+        "edm",
+        "electro house",
+        "electronic",
+        "electropop"
+      ],
+      "favicon": "https://www.rm.fm/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-technolovers-handsup",
+      "name": "Technolovers HANDSUP",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.technolovers.fm/handsup?ref=radiobrowser",
+      "homepage": "https://technolovers.fm/",
+      "country": "DE",
+      "tags": [
+        "club",
+        "club dance",
+        "club hits",
+        "club sounds",
+        "hands up",
+        "handsup"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.9065,
+        7.207
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-goldies-by-rautemusik-rm-fm",
+      "name": "__GOLDIES__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://goldies-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://www.rm.fm/goldies",
+      "country": "DE",
+      "tags": [
+        "1960s",
+        "1970s",
+        "1980s",
+        "1990s",
+        "60er",
+        "60s"
+      ],
+      "favicon": "https://www.rm.fm/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-oldies-on-radio",
+      "name": "- 0 N - Oldies on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-oldies.radionetz.de/0n-oldies.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "60er",
+        "60s",
+        "70er",
+        "70s",
+        "80er",
+        "80s"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-oldies_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-romantic-piano-by-epic-piano",
+      "name": "ROMANTIC PIANO by Epic Piano",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-piano.com/romantic-piano?ref=radiobrowser",
+      "homepage": "https://epic-piano.com/",
+      "country": "DE",
+      "tags": [
+        "classic",
+        "classical",
+        "classical music",
+        "classical piano",
+        "classics",
+        "instrumental"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.1277,
+        7.9102
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-technolovers-ibiza-house",
+      "name": "Technolovers - IBIZA HOUSE",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.technolovers.fm/ibiza-house?ref=radiobrowser",
+      "homepage": "https://technolovers.fm/",
+      "country": "DE",
+      "tags": [
+        "balearic house",
+        "chill house",
+        "chillout",
+        "deep house",
+        "house",
+        "ibiza"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-nightride-fm-darksynth",
+      "name": "Nightride FM - Darksynth",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.nightride.fm/darksynth.mp3",
+      "homepage": "https://nightride.fm/",
+      "country": "DE",
+      "tags": [
+        "cyberpunk",
+        "darksynth",
+        "horror"
+      ],
+      "favicon": "https://nightride.fm/thumbnail.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-lounge-chillout-lounge",
+      "name": "Epic Lounge - CHILLOUT LOUNGE",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-lounge.com/chillout-lounge?ref=radiobrowser",
+      "homepage": "https://epic-lounge.com/",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "ambient and relaxation music",
+        "chill",
+        "chillout",
+        "chillout+lounge",
+        "lounge"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-80s-on-radio",
+      "name": "- 0 N - 80s on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-80s.radionetz.de/0n-80s.aac",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "80er",
+        "80s",
+        "oldies",
+        "pop"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-80s_600x600.jpg",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-you-fm-mp3-high",
+      "name": "YOU FM (mp3/high)",
+      "broadcaster": "independent",
+      "streamUrl": "https://dispatcher.rndfnk.com/hr/youfm/live/mp3/high",
+      "homepage": "https://www.you-fm.de/",
+      "country": "DE",
+      "favicon": "https://www.you-fm.de/favicon.png?v=3.85.2",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.1366,
+        8.6798
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-technolovers-uplifting-trance",
+      "name": "Technolovers - UPLIFTING TRANCE",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.technolovers.fm/uplifting-trance?ref=radiobrowser",
+      "homepage": "https://technolovers.fm/",
+      "country": "DE",
+      "tags": [
+        "trance",
+        "trance uplifting",
+        "uplifting",
+        "uplifting trance"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-schwarzwaldradio",
+      "name": "Schwarzwaldradio",
+      "broadcaster": "independent",
+      "streamUrl": "https://edge80.streamonkey.net/fho-schwarzwaldradiolive/stream/mp3?aggregator=smk-m3u-mp3",
+      "homepage": "https://schwarzwaldradio.com/",
+      "country": "DE",
+      "tags": [
+        "60er",
+        "70er",
+        "80er",
+        "90er",
+        "oldies",
+        "rock"
+      ],
+      "favicon": "https://schwarzwaldradio.com/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        18.8127,
+        -38.9219
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-countryhits-fm-by-rautemusik-rm-fm",
+      "name": "__COUNTRYHITS.FM__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://country-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://countryhits.fm/",
+      "country": "DE",
+      "tags": [
+        "alternative country",
+        "alternative rock",
+        "americana",
+        "classic country",
+        "classic rock",
+        "country"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-melodic-house-techno-technolovers-fm-chillout-be",
+      "name": "Melodic House & Techno @ Technolovers.FM (Chillout, Beach, Festival, Sundowner, Relax, Ibiza, Sea, Ocean Music, Beachclub, Cocktailbar, 2024, 2025, 2026 Future Rave 126, 128, 124 Beats per Minute , BPM)",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.technolovers.fm/melodic-house-techno?ref=radiobrowser-2",
+      "homepage": "https://technolovers.fm/",
+      "country": "DE",
+      "tags": [
+        "#",
+        "beach",
+        "beachclub",
+        "chill",
+        "chillout",
+        "chillout+lounge"
+      ],
+      "favicon": "https://i.ibb.co/mFjn8LB/TL-Melodic-House-Techno-png.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        49.9284,
+        8.6999
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-rock-antenne-80er-rock-aac",
+      "name": "ROCK ANTENNE 80er Rock (AAC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rockantenne.de/80er-rock/stream/aacp",
+      "homepage": "https://www.rockantenne.de/",
+      "country": "DE",
+      "tags": [
+        "80's",
+        "classic rock"
+      ],
+      "favicon": "https://www.rockantenne.de/logos/rock-antenne/apple-touch-icon.png",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ostseewelle",
+      "name": "Ostseewelle ",
+      "broadcaster": "independent",
+      "streamUrl": "https://addrad.io/4454pjf",
+      "homepage": "https://www.ostseewelle.de/",
+      "country": "DE",
+      "favicon": "https://www.ostseewelle.de/assets/icons/apple-touch-icon.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-dw-tv",
+      "name": "DW TV",
+      "broadcaster": "independent",
+      "streamUrl": "https://dwamdstream104.akamaized.net/hls/live/2015530/dwstream104/index.m3u8",
+      "homepage": "https://www.dw.com/es/tv-en-vivo/s-100837",
+      "country": "DE",
+      "tags": [
+        "cultural"
+      ],
+      "favicon": "https://www.dw.com/images/icons/favicon-120x120.png",
+      "bitrate": 1060,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-lounge-radio-ibiza",
+      "name": "Lounge Radio Ibiza",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/lounge-radio-ibiza",
+      "homepage": "https://lounge-radio-ibiza.com/",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "chillout+lounge",
+        "deep house",
+        "electronic"
+      ],
+      "favicon": "https://lounge-radio-ibiza.com/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        53.0766,
+        8.8064
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-classical-classical-pan-flute",
+      "name": "EPIC CLASSICAL - Classical Pan Flute",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-classical.com/classical-pan-flute?ref=liveradio",
+      "homepage": "https://epic-classical.com/",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "ambient and relaxation music",
+        "classic",
+        "classical",
+        "flute",
+        "instrumental"
+      ],
+      "favicon": "https://i.ibb.co/R2FqgKq/Pan-Flute.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-top-40-on-radio",
+      "name": "- 0 N - Top 40 on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-top40.radionetz.de/0n-top40.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "dance",
+        "hits",
+        "house",
+        "pop",
+        "rock",
+        "top40"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-top-40_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-partyhits-dein-musikmix-aus-ballermann-apres-ski",
+      "name": "# PartyHits - Dein Musikmix aus Ballermann, Apres Ski, Wiesn, Karneval, Silvesterparty, TOP 100 Party, Malle, Nonstop, DJ LIVE, Abriss, Feier, Bass, Feiermusik, Partymusik, Apres ski Party, Fussball Hits",
+      "broadcaster": "independent",
+      "streamUrl": "https://partyhits-high.rautemusik.fm/?ref=radio-browser-ph2",
+      "homepage": "https://rm.fm/partyhits",
+      "country": "DE",
+      "tags": [
+        "\"bob\"",
+        "#",
+        "0",
+        "11.11",
+        "abriss",
+        "abrissparty"
+      ],
+      "favicon": "https://i.ibb.co/GFBh5tm/rautemusik-partyhits.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.9423,
+        6.9406
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-absolute-relax",
+      "name": "absolute relax",
+      "broadcaster": "independent",
+      "streamUrl": "https://absolut-relax.live-sm.absolutradio.de/absolut-relax/stream/mp3",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "DE",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-dw-english-hd",
+      "name": "DW English HD",
+      "broadcaster": "independent",
+      "streamUrl": "https://dwamdstream102.akamaized.net/hls/live/2015525/dwstream102/index.m3u8",
+      "homepage": "https://www.dw.com/en/live-tv/channel-english",
+      "country": "DE",
+      "tags": [
+        "3sat",
+        "ard",
+        "auslandsfernsehen",
+        "berlin",
+        "bundestag",
+        "deutsche welle"
+      ],
+      "bitrate": 1060,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-swr3-96k-aac",
+      "name": "SWR3 - 96K AAC",
+      "broadcaster": "independent",
+      "streamUrl": "https://liveradio.swr.de/sw331ch/swr3/play.aac",
+      "homepage": "http://swr3.de/",
+      "country": "DE",
+      "favicon": "https://www.swr3.de/assets/swr3/icons/favicon.ico",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-top-200-dj-charts-just-music-dj-remix-charts-rad",
+      "name": "#TOP 200 DJ CHARTS - JUST MUSIC - DJ REMIX & CHARTS RADIO @ TikTok Charts, Electronic Music, EDM, House, Deep House, Dance Music, Techno & Hypertechno, Top40, Latin Charts, Reggaeton, Urban, HipHop, Club & Party Radio - & LIVE DJ SETS @ Festival Melodic House, Melodic Techno. Best 100 Lounge, Mixed Radio Station @ PartyHits / Schlager Remix Top 50",
+      "broadcaster": "independent",
+      "streamUrl": "https://breakz-high.rautemusik.fm/stream.mp3?ref=DJCHARTSRB",
+      "homepage": "https://www.breakz.fm/",
+      "country": "DE",
+      "tags": [
+        "#00s",
+        "#80",
+        "#top200",
+        "90's",
+        "90s",
+        "bass"
+      ],
+      "favicon": "https://i.ibb.co/Gc5TMjP/Top-200-Dj-Charts-breakz-logo.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        49.994,
+        8.6446
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-double-bass-fm-viel-mehr-als-nur-mainstream",
+      "name": "Double Bass FM – Viel mehr als nur Mainstream!",
+      "broadcaster": "independent",
+      "streamUrl": "https://double-bass-fm.stream.laut.fm/double-bass-fm",
+      "homepage": "https://doublebass.fm/",
+      "country": "DE",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-absolut-germany",
+      "name": "Absolut Germany",
+      "broadcaster": "independent",
+      "streamUrl": "https://absolut-germany.live-sm.absolutradio.de/absolut-germany/stream/mp3?aggregator",
+      "homepage": "https://absolutradio.de/germany",
+      "country": "DE",
+      "favicon": "https://absolutradio.de/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-chopin-by-epic-piano",
+      "name": "CHOPIN by Epic Piano",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-piano.com/chopin?ref=radiobrowser",
+      "homepage": "https://epic-piano.com/",
+      "country": "DE",
+      "tags": [
+        "chopin",
+        "classic",
+        "classical",
+        "classics",
+        "instrumental",
+        "piano"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.461,
+        7.9102
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-punkrockers-radio",
+      "name": "punkrockers-radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.punkrockers-radio.de:8443/prr.flac",
+      "homepage": "http://punkrockers-radio.de/",
+      "country": "DE",
+      "tags": [
+        "punk",
+        "punk oi ska"
+      ],
+      "favicon": "https://www.punkrockers-radio.de/img/punkrockers-radio_play-button.png",
+      "codec": "OGG",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-charthits-fm-by-rautemusik-rm-fm",
+      "name": "__CHARTHITS.FM__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://charthits-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://www.charthits.fm/",
+      "country": "DE",
+      "tags": [
+        "charts",
+        "dance",
+        "edm",
+        "electro house",
+        "electronic",
+        "electronica"
+      ],
+      "favicon": "https://www.charthits.fm/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-rock-on-radio",
+      "name": "- 0 N - Rock on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-rock.radionetz.de/0n-rock.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "alternative",
+        "classic rock",
+        "hard rock",
+        "metal",
+        "rock",
+        "soft rock"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-rock_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-i-love-radio-hip-hop",
+      "name": "I love Radio Hip Hop",
+      "broadcaster": "independent",
+      "streamUrl": "https://ilm.stream18.radiohost.de/ilm_ilovehiphop_mp3-192?upd-meta&upd-scheme=https&_art=dD0xNzY4NDY1NTU0JmQ9MGE3MmM0MmIxN2YzNDljYmY1Zjc",
+      "homepage": "https://www.ilovemusic.de/ilovehiphop.m3u",
+      "country": "DE",
+      "favicon": "https://www.ilovemusic.de/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-i-love-hardstyle",
+      "name": "I love Hardstyle",
+      "broadcaster": "independent",
+      "streamUrl": "https://ilm.stream35.radiohost.de/ilm_ilovehardstyle_mp3-192?upd-meta&upd-scheme=https&_art=dD0xNzY4NDYxNzc3JmQ9MjgxZDVmMTU4NTg2ODU1MTE3NjQ",
+      "homepage": "https://www.ilovemusic.de/ilovehardstyle.m3u",
+      "country": "DE",
+      "favicon": "https://www.ilovemusic.de/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-new-wave-on-radio",
+      "name": "- 0 N - New Wave on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-newwave.radionetz.de/0n-newwave.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "80s",
+        "alternative",
+        "new wave",
+        "oldies",
+        "wave"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-newwave_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-jazz-on-radio",
+      "name": "- 0 N - Jazz on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-jazz.radionetz.de/0n-jazz.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "jazz",
+        "smooth jazz",
+        "swing"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-jazz_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-90s-on-radio",
+      "name": "- 0 N - 90s on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-90s.radionetz.de/0n-90s.aac",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "90er",
+        "90s",
+        "dance",
+        "oldies",
+        "pop",
+        "rock"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-90s_600x600.jpg",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-deutschlandfunk-kultur-dlf-aac-96k",
+      "name": "Deutschlandfunk Kultur | DLF | AAC 96k",
+      "broadcaster": "independent",
+      "streamUrl": "https://st02.sslstream.dlf.de/dlf/02/mid/aac/stream.aac?aggregator=web",
+      "homepage": "https://www.deutschlandfunkkultur.de/",
+      "country": "DE",
+      "tags": [
+        "culture",
+        "news",
+        "public service",
+        "information"
+      ],
+      "favicon": "https://www.deutschlandfunkkultur.de/static/img/deutschlandfunk_kultur/icons/apple-touch-icon-128x128.png",
+      "bitrate": 96,
+      "codec": "AAC",
+      "geo": [
+        52.4803,
+        13.3348
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-technolovers-future-house",
+      "name": "Technolovers FUTURE HOUSE",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.technolovers.fm/future-house?ref=radiobrowser",
+      "homepage": "https://technolovers.fm/",
+      "country": "DE",
+      "tags": [
+        "dance",
+        "edm",
+        "electro",
+        "electronic",
+        "elektro",
+        "elektronik"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.9786,
+        6.9841
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ballermann-radio-club-style",
+      "name": "Ballermann Radio Club Style",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.bmr-radio.de/bmr-clubstyle.mp3",
+      "homepage": "https://www.ballermann-radio.de/stream/ballermannradio-clubstyle/",
+      "country": "DE",
+      "favicon": "https://www.ballermann-radio.de/wp-content/uploads/2024/02/stream-ballermann-radio-clubstyle-750x750.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-juka-radio-kpop",
+      "name": "juka radio kpop",
+      "broadcaster": "independent",
+      "streamUrl": "https://juka-kpop.stream.laut.fm/juka-kpop?t302=2021-04-01_09-03-35&uuid=6aa06ca0-9a01-407d-91af-155d24c5c405",
+      "homepage": "https://juka-radio.de/",
+      "country": "DE",
+      "tags": [
+        "k-pop",
+        "kpop"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ballermann-radio-ab-18",
+      "name": "Ballermann Radio Ab 18",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.bmr-radio.de/bmr-ab18.mp3",
+      "homepage": "https://www.ballermann-radio.de/stream/ballermannradio-ab18/",
+      "country": "DE",
+      "favicon": "https://www.ballermann-radio.de/wp-content/uploads/2024/02/stream-ballermann-radio-ab-18-750x750.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-soft-rock-on-radio",
+      "name": "- 0 N - Soft Rock on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-softrock.radionetz.de/0n-softrock.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "balladen",
+        "rock",
+        "soft rock"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-soft-rock_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-the-christmas-channel-by-rautemusik-rm-fm",
+      "name": "__THE CHRISTMAS CHANNEL__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://christmas-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://christmas-channel.com/",
+      "country": "DE",
+      "tags": [
+        "balada",
+        "baladas",
+        "christmas",
+        "christmas music",
+        "holiday",
+        "klassik weihnachten christmas"
+      ],
+      "favicon": "https://christmas-channel.com/wp-content/themes/christmaschannel2020/img/favicon.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-80000",
+      "name": "Radio 80000",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio80k.out.airtime.pro:8000/radio80k_a",
+      "homepage": "https://www.radio80k.de/",
+      "country": "DE",
+      "tags": [
+        "community radio",
+        "freeform",
+        "variety"
+      ],
+      "favicon": "https://www.radio80k.de/app/uploads/2022/10/cropped-favicon-8000-192x192.gif",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        48.158,
+        11.55
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0nlineradio-vivaldi",
+      "name": "0nlineradio VIVALDI",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.0nlineradio.com/vivaldi?ref=radiobrowser",
+      "homepage": "https://0nlineradio.com/",
+      "country": "DE",
+      "tags": [
+        "classic",
+        "classical",
+        "classical music",
+        "classics",
+        "instrumental",
+        "klassik"
+      ],
+      "favicon": "https://i.ibb.co/HKNTfSQ/VIVALDI-NEW.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.461,
+        7.9102
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-day-dee-eurodance",
+      "name": "Day Dee Eurodance",
+      "broadcaster": "independent",
+      "streamUrl": "https://daydeeeurodance.stream.laut.fm/daydeeeurodance",
+      "homepage": "http://eurodance.ga/",
+      "country": "DE",
+      "tags": [
+        "90s",
+        "day dee",
+        "eurodance",
+        "radio"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-technolovers-hardcore",
+      "name": "Technolovers HARDCORE",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.technolovers.fm/hardcore?ref=radiobrowser",
+      "homepage": "https://technolovers.fm/",
+      "country": "DE",
+      "tags": [
+        "electronic",
+        "electronica",
+        "elektro",
+        "elektronik",
+        "happy hardcore",
+        "hardcore"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.1277,
+        8.2617
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-swr-2",
+      "name": "SWR 2",
+      "broadcaster": "independent",
+      "streamUrl": "https://liveradio.swr.de/sw331ch/swr2/play.aac",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "DE",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0nlineradio-country",
+      "name": "0nlineradio COUNTRY",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.0nlineradio.com/country?ref=radiobrowser",
+      "homepage": "https://0nlineradio.com/",
+      "country": "DE",
+      "tags": [
+        "alternative country",
+        "classic country",
+        "classic rock",
+        "country",
+        "country music",
+        "country rock"
+      ],
+      "favicon": "https://i.ibb.co/qmK33Rk/country.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.5134,
+        8.2617
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-k-pop-on-radio",
+      "name": "- 0 N - K-Pop on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-kpop.radionetz.de/0n-kpop.aac",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "asian",
+        "k-pop",
+        "kpop",
+        "world music"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-k-pop_600x600.jpg",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-lounge-piano-jazz-bar",
+      "name": "Epic Lounge - PIANO & JAZZ BAR",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-lounge.com/piano-jazz-bar?ref=radiobrowser",
+      "homepage": "https://epic-lounge.com/",
+      "country": "DE",
+      "tags": [
+        "classical piano",
+        "jazz",
+        "lounge",
+        "lounge music",
+        "piano",
+        "piano jazz"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-rock-antenne-gothic",
+      "name": "Rock Antenne Gothic",
+      "broadcaster": "independent",
+      "streamUrl": "https://s6-webradio.rockantenne.de/gothic/stream/mp3",
+      "homepage": "https://www.rockantenne.de/webradio/gothic",
+      "country": "DE",
+      "tags": [
+        "gothic",
+        "gothic rock",
+        "metal"
+      ],
+      "favicon": "https://www.rockantenne.de/logos/station-rock-antenne/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-oriental-by-rautemusik-rm-fm",
+      "name": "__ORIENTAL__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://oriental-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://www.rm.fm/oriental",
+      "country": "DE",
+      "tags": [
+        "arabic",
+        "arabic music",
+        "hits",
+        "oriental",
+        "variety"
+      ],
+      "favicon": "https://www.rm.fm/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ballermann-radio-top-40",
+      "name": "Ballermann Radio Top 40",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.bmr-radio.de/bmr-top30.mp3",
+      "homepage": "https://www.ballermann-radio.de/stream/ballermannradio-top30/",
+      "country": "DE",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-eurodance",
+      "name": "Eurodance",
+      "broadcaster": "independent",
+      "streamUrl": "https://eurodance.stream.laut.fm/eurodance",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "DE",
+      "tags": [
+        "electronic"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-relax-on-radio",
+      "name": "- 0 N - Relax on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-relax.radionetz.de/0n-relax.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "80er",
+        "80s",
+        "90er",
+        "90s",
+        "easy listening",
+        "hits"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-relax_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-classical-classical-piano",
+      "name": "EPIC CLASSICAL - Classical Piano",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-classical.com/classical-piano",
+      "homepage": "https://epic-classical.com/",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "ambiental",
+        "chill",
+        "chillout",
+        "classic",
+        "classical"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.5995,
+        9.9609
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-deutschlandfunk-dlf-opus-64k",
+      "name": "Deutschlandfunk | DLF | OPUS 64k",
+      "broadcaster": "independent",
+      "streamUrl": "https://st01.sslstream.dlf.de/dlf/01/high/opus/stream.opus?aggregator=web",
+      "homepage": "https://www.deutschlandfunk.de/",
+      "country": "DE",
+      "tags": [
+        "culture",
+        "news",
+        "public service",
+        "information"
+      ],
+      "favicon": "https://www.deutschlandfunk.de/static/img/deutschlandfunk/icons/apple-touch-icon-128x128.png",
+      "bitrate": 64,
+      "codec": "OGG",
+      "geo": [
+        52.4803,
+        13.3348
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ffn",
+      "name": "ffn",
+      "broadcaster": "independent",
+      "streamUrl": "https://ffn-de-hz-fal-stream04-cluster01.radiohost.de/ffn_mp3-192",
+      "homepage": "https://www.ffn.de/",
+      "country": "DE",
+      "tags": [
+        "pop"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-filmradio",
+      "name": "Filmradio",
+      "broadcaster": "independent",
+      "streamUrl": "https://filmradio.stream.laut.fm/filmradio?t302=2018-03-10_04-44-05&uuid=59ca68e0-84a4-492d-9b0b-36c45690cd59",
+      "homepage": "https://laut.fm/filmradio",
+      "country": "DE",
+      "tags": [
+        "film music",
+        "instrumental",
+        "movies",
+        "ost",
+        "score",
+        "soundtracks"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-technolovers-electro",
+      "name": "Technolovers  ELECTRO",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.technolovers.fm/electro?ref=radiobrowser",
+      "homepage": "https://technolovers.fm/",
+      "country": "DE",
+      "tags": [
+        "dance",
+        "dance music",
+        "edm",
+        "electro",
+        "electro house",
+        "electronic"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.461,
+        7.9102
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-progressive-trance-mix",
+      "name": "Progressive Trance Mix",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/progressive-trance-mix",
+      "homepage": "https://www.laut.fm/progressive-trance-mix",
+      "country": "DE",
+      "tags": [
+        "progressive",
+        "trance"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1-a-70er-von-1a-radio",
+      "name": "- 1 A - 70er von 1A Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://1a-70er.radionetz.de/1a-70er.mp3",
+      "homepage": "http://www.1aradio.com/",
+      "country": "DE",
+      "tags": [
+        "70er",
+        "70s",
+        "oldies",
+        "pop"
+      ],
+      "favicon": "https://www.1aradio.com/logos/1a-70er_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-technolovers-hardstyle",
+      "name": "Technolovers HARDSTYLE",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.technolovers.fm/hardstyle?ref=radiobrowser",
+      "homepage": "https://technolovers.fm/",
+      "country": "DE",
+      "tags": [
+        "dance",
+        "electronic",
+        "elektronik",
+        "hardcore",
+        "hardstyle"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.461,
+        8.9648
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-classical-classical-coffee-bar",
+      "name": "EPIC CLASSICAL - Classical Coffee Bar",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-classical.com/classical-coffee-bar",
+      "homepage": "https://epic-classical.com/",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "ambient and relaxation music",
+        "ambiental",
+        "chillout",
+        "classic",
+        "classical"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ndr-info-schleswig-holstein",
+      "name": "NDR Info Schleswig-Holstein",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.ndr.de/ndr/ndrinfo/schleswigholstein/mp3/128/stream.mp3",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "DE",
+      "favicon": "https://static-media.streema.com/media/cache/9d/b3/9db365c0d939c0980e7eb7383156ec78.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-50s-on-radio",
+      "name": "- 0 N - 50s on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-50s.radionetz.de/0n-50s.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "50s",
+        "60er",
+        "oldies",
+        "rock 'n' roll",
+        "twist"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-50s_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-classical-classical-meditation",
+      "name": "EPIC CLASSICAL - Classical Meditation",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-classical.com/classical-meditation",
+      "homepage": "https://epic-classical.com/",
+      "country": "DE",
+      "tags": [
+        "ambient and relaxation music",
+        "chill",
+        "chillout",
+        "classic",
+        "classical",
+        "klassik"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-technolovers-afro-house",
+      "name": "Technolovers - AFRO HOUSE",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.technolovers.fm/afro-house?ref=radiobrowser",
+      "homepage": "https://technolovers.fm/",
+      "country": "DE",
+      "tags": [
+        "african music",
+        "afro vocal",
+        "afrobeats",
+        "club house",
+        "house",
+        "soulful house"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-heavy-metal-on-radio",
+      "name": "- 0 N - Heavy Metal on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-heavymetal.radionetz.de/0n-heavymetal.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "hard rock",
+        "hevy metal",
+        "metal",
+        "rock"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-heavymetal_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-laut-fm-chillharmonie",
+      "name": "Laut.FM Chillharmonie",
+      "broadcaster": "independent",
+      "streamUrl": "https://chillharmonie.stream.laut.fm/chillharmonie",
+      "homepage": "http://laut.fm/chillharmonie",
+      "country": "DE",
+      "tags": [
+        "classical",
+        "jazz",
+        "new age",
+        "piano",
+        "soundtrack"
+      ],
+      "favicon": "https://lh3.ggpht.com/a4M_Oyz2Jek1bkcRe8I7v3A8clEOoOI8Y-NiYuuICuw0wOHwaZgMUit4rRgC18mGZMo_=w300",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-lounge-nature-sounds",
+      "name": "Epic Lounge - NATURE SOUNDS",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-lounge.com/nature-sounds?ref=radiobrowser",
+      "homepage": "https://epic-lounge.com/",
+      "country": "DE",
+      "tags": [
+        "chill",
+        "chillout",
+        "nature",
+        "relax",
+        "relaxing",
+        "sounds of nature"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-wackenradio-by-rautemusik-rm-fm",
+      "name": "__WACKENRADIO__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://wackenradio-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://www.rm.fm/wacken",
+      "country": "DE",
+      "tags": [
+        "alternative rock",
+        "classic rock",
+        "hard rock",
+        "heavy metal",
+        "wacken",
+        "radio bob"
+      ],
+      "favicon": "https://i.ibb.co/rGpB2Bx/wackenradio.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1-a-schlager-gold-von-1a-radio",
+      "name": "- 1 A - Schlager Gold von 1A Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://1a-schlagergold.radionetz.de/1a-schlagergold.mp3",
+      "homepage": "http://www.1aradio.com/",
+      "country": "DE",
+      "tags": [
+        "50er",
+        "50s",
+        "60er",
+        "60s",
+        "oldies",
+        "rock 'n' roll"
+      ],
+      "favicon": "https://www.1aradio.com/logos/1a-schlager-gold_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-91-2-dortmund",
+      "name": "Radio 91.2 Dortmund",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio912--di--nacs-ais-lgc--0c--cdn.cast.addradio.de/radio912/live/mp3/high",
+      "homepage": "https://www.radio912.de/",
+      "country": "DE",
+      "favicon": "https://www.radio912.de/assets/images/favicons/radio912/favicon_x96.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-house-vs-hip-hop-rap-deutschrap-r-b-trap-techno-",
+      "name": "House vs. Hip-Hop, Rap, Deutschrap, R&B, Trap, Techno, House, EDM, Deep House, Hardstyle, Trance, Drum & Bass, Lo-Fi, Chillout, Festival, Club, Party, Afterhour, Beats, Underground, Hype, Techno, TechHouse - Top 40 Charts - DJ Mixtape RADIO",
+      "broadcaster": "independent",
+      "streamUrl": "https://breakz-office.rautemusik.fm/?ref=rb-festival",
+      "homepage": "https://www.breakz.fm/",
+      "country": "DE",
+      "tags": [
+        "#",
+        "#00",
+        "#clubradio",
+        "#dj",
+        "#festival",
+        "#liveset"
+      ],
+      "favicon": "https://i.ibb.co/DgmQsmPW/festival-vibes.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-classical-classical-guitar",
+      "name": "EPIC CLASSICAL - Classical Guitar",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-classical.com/classical-guitar",
+      "homepage": "https://epic-classical.com/",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "classic",
+        "classical",
+        "classical guitar",
+        "guitar",
+        "klassik"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0nlineradio-80s-rock",
+      "name": "0nlineradio 80s ROCK",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.0nlineradio.com/80s-rock?ref=radiobrowser",
+      "homepage": "https://0nlineradio.com/",
+      "country": "DE",
+      "tags": [
+        "1980s",
+        "80er",
+        "80s",
+        "80s rock",
+        "classic rock",
+        "classic rock oldies"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.5134,
+        8.6133
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0nlineradio-handel",
+      "name": "0nlineradio HÄNDEL",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.0nlineradio.com/haendel?ref=radiobrowser",
+      "homepage": "https://0nlineradio.com/",
+      "country": "DE",
+      "tags": [
+        "classic",
+        "classic jazz",
+        "classical",
+        "classical music",
+        "classics",
+        "instrumental"
+      ],
+      "favicon": "https://i.ibb.co/y8Pcv7T/HA-NDEL-NEW.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.9065,
+        8.6133
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ballermann-radio",
+      "name": "Ballermann Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.bmr-radio.de/ballermann-radio.mp3",
+      "homepage": "https://www.ballermann-radio.de/stream/ballermannradio/",
+      "country": "DE",
+      "favicon": "https://www.ballermann-radio.de/wp-content/uploads/2024/02/stream-ballermann-radio-750x750.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-technolovers-techhouse",
+      "name": "Technolovers - TECHHOUSE",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.technolovers.fm/techhouse?ref=radiobrowser",
+      "homepage": "https://technolovers.fm/",
+      "country": "DE",
+      "tags": [
+        "deep tech house",
+        "electronic",
+        "minimal techno",
+        "tech house",
+        "techno"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-wdr-2-ruhrgebiet",
+      "name": "WDR 2 Ruhrgebiet",
+      "broadcaster": "independent",
+      "streamUrl": "https://wdr-wdr2-ruhrgebiet.icecastssl.wdr.de/wdr/wdr2/ruhrgebiet/mp3/128/stream.mp3",
+      "homepage": "https://www1.wdr.de/radio/wdr2/wdrzwei-startseite-102.html",
+      "country": "DE",
+      "tags": [
+        "adult contemporary",
+        "news talk music"
+      ],
+      "favicon": "https://www1.wdr.de/resources-v5.139.1/img/favicon/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-happy-hardcore-by-rautemusik-rm-fm",
+      "name": "__HAPPY HARDCORE__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://happyhardcore-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://www.rm.fm/happyhardcore",
+      "country": "DE",
+      "tags": [
+        "hardcore",
+        "hardstyle",
+        "hits",
+        "hot",
+        "hot hits",
+        "speedcore"
+      ],
+      "favicon": "https://www.rm.fm/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-nightride-fm-ebsm",
+      "name": "Nightride FM - EBSM",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.nightride.fm/ebsm.mp3",
+      "homepage": "https://nightride.fm/",
+      "country": "DE",
+      "tags": [
+        "clubbing",
+        "ebsm",
+        "industrial"
+      ],
+      "favicon": "https://nightride.fm/thumbnail.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-br24live",
+      "name": "BR24live",
+      "broadcaster": "independent",
+      "streamUrl": "https://dispatcher.rndfnk.com/br/br24live/live/mp3/mid",
+      "homepage": "https://www.br.de/radio/br24/index.html",
+      "country": "DE",
+      "tags": [
+        "news"
+      ],
+      "favicon": "https://api.ardmediathek.de/image-service/images/urn:ard:image:c3ab9296f3b282bf?w=512",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-deutschlandfunk-kultur-dlf-aac-192k",
+      "name": "Deutschlandfunk Kultur | DLF | AAC 192k",
+      "broadcaster": "independent",
+      "streamUrl": "https://st02.sslstream.dlf.de/dlf/02/high/aac/stream.aac?aggregator=web",
+      "homepage": "https://www.deutschlandfunkkultur.de/",
+      "country": "DE",
+      "tags": [
+        "culture",
+        "news",
+        "public service",
+        "information"
+      ],
+      "favicon": "https://www.deutschlandfunkkultur.de/static/img/deutschlandfunk_kultur/icons/apple-touch-icon-128x128.png",
+      "bitrate": 192,
+      "codec": "AAC",
+      "geo": [
+        52.4803,
+        13.3348
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-classical-classical-violin",
+      "name": "EPIC CLASSICAL - Classical Violin",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-classical.com/classical-violin",
+      "homepage": "https://epic-classical.com/",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "ambient and relaxation music",
+        "classic",
+        "classical",
+        "instrumental",
+        "klassiek"
+      ],
+      "favicon": "https://i.ibb.co/DkDPhcZ/Violin.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-metal-only-http-www-metal-only-de-metal-only-htt",
+      "name": "METAL ONLY - http://www.metal-only.de,METAL ONLY - http://www.metal-only.de - 24h Black Death Heavy Metal Rock und mehr!",
+      "broadcaster": "independent",
+      "streamUrl": "https://metal-only.sp.radio.fm/stream",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "DE",
+      "tags": [
+        "metal"
+      ],
+      "favicon": "https://www.metal-only.de/fileadmin/tpl//fav.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1-a-chillout-von-1a-radio",
+      "name": "- 1 A - Chillout von 1A Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://1a-chillout.radionetz.de/1a-chillout.mp3",
+      "homepage": "http://www.1aradio.com/",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "chillout",
+        "easy listening",
+        "electro"
+      ],
+      "favicon": "https://www.1aradio.com/logos/1a-chillout_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-deutschrap-classic-by-rautemusik-rm-fm",
+      "name": "__DEUTSCHRAP CLASSIC__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://deutschrap-classic-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://www.rm.fm/deutschrap-classic",
+      "country": "DE",
+      "tags": [
+        "chilled trap",
+        "deutsch",
+        "german",
+        "hip-hop",
+        "hiphop",
+        "rap"
+      ],
+      "favicon": "https://www.rm.fm/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1-a-2000er-von-1a-radio",
+      "name": "- 1 A - 2000er von 1A Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://1a-2000er.radionetz.de/1a-2000er.mp3",
+      "homepage": "http://www.1aradio.com/",
+      "country": "DE",
+      "tags": [
+        "00er",
+        "00s",
+        "2000er",
+        "2000s",
+        "dance",
+        "hits"
+      ],
+      "favicon": "https://www.1aradio.com/logos/1a-2000er_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-nightride-fm",
+      "name": "Nightride FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.nightride.fm/nightride.mp3",
+      "homepage": "https://nightride.fm/",
+      "country": "DE",
+      "tags": [
+        "outrun",
+        "retrowave",
+        "synthwave"
+      ],
+      "favicon": "https://nightride.fm/thumbnail.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ffh-eurodance-2",
+      "name": "FFH Eurodance",
+      "broadcaster": "independent",
+      "streamUrl": "https://mp3.ffh.de/ffhchannels/hqeurodance.aac",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "DE",
+      "tags": [
+        "electronic"
+      ],
+      "bitrate": 128,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-paloma-100-deutscher-schlager",
+      "name": "Radio Paloma - 100% Deutscher Schlager!",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.silvacast.com/RPLive/mp3-128/RadioPaloma_Homepage",
+      "homepage": "https://schlager.radio/",
+      "country": "DE",
+      "favicon": "https://schlager.radio/wp-content/uploads/2020/11/cropped-radio-paloma-fav-180x180.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ebm",
+      "name": "EBM",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/ebm",
+      "homepage": "https://flatlinesradio.de/",
+      "country": "DE",
+      "tags": [
+        "dark wave",
+        "ebm",
+        "electronic",
+        "electronica",
+        "experimental",
+        "industrial"
+      ],
+      "favicon": "https://i0.wp.com/flatlinesradio.de/storage/2021/11/244611397_1194785584320990_6265045071816304131_n-1.jpg?fit=180%2c180&#038;ssl=1",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-techhouse-by-rautemusik-rm-fm",
+      "name": "__TECHHOUSE__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://techhouse-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://www.rm.fm/techhouse",
+      "country": "DE",
+      "tags": [
+        "charts",
+        "edm",
+        "electro house",
+        "hits",
+        "house",
+        "minimal"
+      ],
+      "favicon": "https://www.rm.fm/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-lounge-soft-house-lounge",
+      "name": "Epic Lounge - SOFT HOUSE LOUNGE",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-lounge.com/soft-house-lounge?ref=radiobrowser",
+      "homepage": "https://epic-lounge.com/",
+      "country": "DE",
+      "tags": [
+        "chillout",
+        "chillout+lounge",
+        "deep house",
+        "house",
+        "lounge",
+        "lounge music"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-hits-on-radio",
+      "name": "- 0 N - Hits on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-hits.radionetz.de/0n-hits.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "black",
+        "dance",
+        "hiphop",
+        "hits",
+        "pop",
+        "rock"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-hits_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0nlineradio-mozart",
+      "name": "0nlineradio MOZART",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.0nlineradio.com/mozart?ref=radiobrowser",
+      "homepage": "https://0nlineradio.com/",
+      "country": "DE",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-technolovers-gabber",
+      "name": "Technolovers - GABBER",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.technolovers.fm/gabber?ref=radiobrowser",
+      "homepage": "https://technolovers.fm/",
+      "country": "DE",
+      "tags": [
+        "90er",
+        "90s",
+        "electronic",
+        "gabber",
+        "gabberdisco"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-laut-fm-freestyle",
+      "name": "laut.fm freestyle",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/freestyle",
+      "homepage": "https://laut.fm/freestyle",
+      "country": "DE",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1-a-60er-von-1a-radio",
+      "name": "- 1 A - 60er von 1A Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://1a-60er.radionetz.de/1a-60er.mp3",
+      "homepage": "http://www.1aradio.com/",
+      "country": "DE",
+      "tags": [
+        "60er",
+        "60s",
+        "funk",
+        "oldies",
+        "rock 'n' roll",
+        "soul"
+      ],
+      "favicon": "https://www.1aradio.com/logos/1a-60er_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1-a-classic-rock-von-1a-radio",
+      "name": "- 1 A - Classic Rock von 1A Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://1a-classicrock.radionetz.de/1a-classicrock.mp3",
+      "homepage": "http://www.1aradio.com/",
+      "country": "DE",
+      "tags": [
+        "80er",
+        "80s",
+        "90er",
+        "90s",
+        "classic rock",
+        "rock"
+      ],
+      "favicon": "https://www.1aradio.com/logos/1a-classic-rock_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-deutschrap-by-rautemusik-rm-fm",
+      "name": "__DEUTSCHRAP__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://deutschrap-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://www.rm.fm/",
+      "country": "DE",
+      "tags": [
+        "deutsch",
+        "german",
+        "hip-hop",
+        "hiphop",
+        "rap",
+        "rap hiphop rnb"
+      ],
+      "favicon": "https://i.ibb.co/jMH358Y/deutschrap.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1-a-90er-von-1a-radio",
+      "name": "- 1 A - 90er von 1A Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://1a-90er.radionetz.de/1a-90er.aac",
+      "homepage": "http://www.1aradio.com/",
+      "country": "DE",
+      "tags": [
+        "90er",
+        "90s",
+        "dance",
+        "oldies",
+        "pop",
+        "rock"
+      ],
+      "favicon": "https://www.1aradio.com/logos/1a-90er_600x600.jpg",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-rautemusik-club-aac-48-kbps",
+      "name": "RauteMusik Club | AAC 48 kbps",
+      "broadcaster": "independent",
+      "streamUrl": "https://club-aacp.rautemusik.fm/",
+      "homepage": "https://www.rautemusik.fm/",
+      "country": "DE",
+      "tags": [
+        "48 kbps",
+        "dance",
+        "edm",
+        "handsup",
+        "hits",
+        "techno"
+      ],
+      "favicon": "https://www.rm.fm/favicon.ico",
+      "bitrate": 48,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-reyfm-kpop",
+      "name": "REYFM - #kpop",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.reyfm.de/kpop_320kbps.mp3",
+      "homepage": "https://www.reyfm.de/",
+      "country": "DE",
+      "tags": [
+        "kpop"
+      ],
+      "favicon": "https://www.reyfm.de/_nuxt/icons/icon_64x64.88ab9f.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-top40-by-rautemusik-rm-fm",
+      "name": "__TOP40__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://top40-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://www.rm.fm/top40",
+      "country": "DE",
+      "tags": [
+        "charts",
+        "dance",
+        "electronic",
+        "german",
+        "german pop",
+        "german rap"
+      ],
+      "favicon": "https://www.rm.fm/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-swr-4-bw-stuttgart-128k",
+      "name": "SWR 4 BW Stuttgart (128k)",
+      "broadcaster": "independent",
+      "streamUrl": "https://liveradio.swr.de/sw282p3/swr4bw/play.mp3",
+      "homepage": "https://liveradio.swr.de/sw282p3/swr4bw",
+      "country": "DE",
+      "favicon": "https://liveradio.swr.de/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-berliner-rundfunk-non-stop-musik",
+      "name": "Berliner Rundfunk - Non-Stop Musik",
+      "broadcaster": "independent",
+      "streamUrl": "https://topradio-de-hz-fal-stream10-cluster01.radiohost.de/brf-pure_mp3-128",
+      "homepage": "https://www.berliner-rundfunk.de/",
+      "country": "DE",
+      "favicon": "https://upload.berliner-rundfunk.de/production/static/1659973942875/icons/icon_64.a80y02808w0.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-schlager-radio-b2-berlin-brandenburg",
+      "name": "schlager radio B2 - Berlin Brandenburg",
+      "broadcaster": "independent",
+      "streamUrl": "https://addrad.io/4454rnz",
+      "homepage": "https://www.schlagerradio.de/",
+      "country": "DE",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0nlineradio-50s",
+      "name": "0nlineradio 50s",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.0nlineradio.com/50s?ref=radiobrowser",
+      "homepage": "https://0nlineradio.com/",
+      "country": "DE",
+      "tags": [
+        "50s",
+        "60s",
+        "classic rock oldies soul",
+        "discofox oldies",
+        "golden oldies",
+        "goldies"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.2893,
+        7.9102
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-90s90s-rock-hls",
+      "name": "90s90s Rock (HLS)",
+      "broadcaster": "independent",
+      "streamUrl": "https://streams.90s90s.de/rock/mp3-192/streams.90s90s.de/play.m3u8",
+      "homepage": "http://www.90s90s.de/",
+      "country": "DE",
+      "tags": [
+        "90s",
+        "alternative rock",
+        "hard rock",
+        "rock"
+      ],
+      "favicon": "https://www.radio.de/images/broadcasts/8d/ce/185038/1/c300.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-alpin-fm",
+      "name": "Alpin FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://s16.myradiostream.com/:6390/stream/3/listen.mp3",
+      "homepage": "https://alpin.fm/",
+      "country": "DE",
+      "tags": [
+        "alpenrock",
+        "austropop",
+        "bairische popmusik",
+        "bairische rockmusik"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-wdr-5-nachrichten",
+      "name": "WDR 5 Nachrichten",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.wdr.de/realaudio/radio/nachrichten/nachrichten_wdr5.mp3",
+      "homepage": "https://www1.wdr.de/radio/wdr5/index.html",
+      "country": "DE",
+      "tags": [
+        "hourly news",
+        "nachrichten",
+        "news",
+        "world news"
+      ],
+      "favicon": "https://www1.wdr.de/resources-v5.134.2/img/favicon/favicon.ico",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-schwany-souvenir-2",
+      "name": "Schwany  Souvenir 2",
+      "broadcaster": "independent",
+      "streamUrl": "https://souvenir2.spcast.eu:443/stream?time=1768459221",
+      "homepage": "http://schwany.de/",
+      "country": "DE",
+      "tags": [
+        "schlager"
+      ],
+      "favicon": "http://schwany.de/favicon.ico",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-2010s-on-radio",
+      "name": "- 0 N - 2010s on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-2010s.radionetz.de/0n-2010s.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "10er",
+        "10s",
+        "2010er",
+        "2010s",
+        "dance",
+        "hits"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-2010s_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-solo-piano-by-epic-piano",
+      "name": "SOLO PIANO by Epic Piano",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-piano.com/solo-piano?ref=radiobrowser",
+      "homepage": "https://epic-piano.com/",
+      "country": "DE",
+      "tags": [
+        "classic",
+        "classical",
+        "classical piano",
+        "classics",
+        "instrumental",
+        "new age piano"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.2118,
+        7.766
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1-a-schlager-kult-von-1a-radio",
+      "name": "- 1 A - Schlager Kult von 1A Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://1a-schlagerkult.radionetz.de/1a-schlagerkult.mp3",
+      "homepage": "http://www.1aradio.com/",
+      "country": "DE",
+      "tags": [
+        "oldies",
+        "schlager",
+        "world music"
+      ],
+      "favicon": "https://www.1aradio.com/logos/1a-schlager-kult_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ndr-1-niedersachsen-ol",
+      "name": "NDR 1 Niedersachsen (OL)",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.ndr.de/ndr/ndr1niedersachsen/oldenburg/mp3/128/stream.mp3",
+      "homepage": "https://www.ndr.de/ndr1niedersachsen/index.html",
+      "country": "DE",
+      "tags": [
+        "ndr",
+        "ndr 1",
+        "ndr 1 niedersachsen",
+        "ndr 1 ol",
+        "ndr 1 oldenburg",
+        "ndr1"
+      ],
+      "favicon": "https://www.phonostar.de/images/auto_created/NDR1_Niedersachsen2184x184.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-reyfm-dance",
+      "name": "REYFM - #Dance",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.reyfm.de/reyfm-dance/",
+      "homepage": "https://rey.fm/",
+      "country": "DE",
+      "tags": [
+        "dance",
+        "music"
+      ],
+      "favicon": "https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-deutschlandfunk-kultur-dlf-opus-24k",
+      "name": "Deutschlandfunk Kultur | DLF | OPUS 24k",
+      "broadcaster": "independent",
+      "streamUrl": "https://st02.sslstream.dlf.de/dlf/02/low/opus/stream.opus?aggregator=web",
+      "homepage": "https://www.deutschlandfunkkultur.de/",
+      "country": "DE",
+      "tags": [
+        "culture",
+        "news",
+        "public service",
+        "information"
+      ],
+      "favicon": "https://www.deutschlandfunkkultur.de/static/img/deutschlandfunk_kultur/icons/apple-touch-icon-128x128.png",
+      "bitrate": 24,
+      "codec": "OGG",
+      "geo": [
+        52.4803,
+        13.3348
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-reyfm-lofi",
+      "name": "REYFM -#LOFI",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.reyfm.de/lofi_320kbps.mp3",
+      "homepage": "http://reyfm.de/",
+      "country": "DE",
+      "tags": [
+        "chill",
+        "lofi"
+      ],
+      "favicon": "http://reyfm.de/_nuxt/icons/icon_64x64.88ab9f.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0nlineradio-60s",
+      "name": "0nlineradio 60s",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.0nlineradio.com/60s?ref=radiobrowser",
+      "homepage": "https://0nlineradio.com/",
+      "country": "DE",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-swr3-48k-aac",
+      "name": "SWR3 | 48k aac",
+      "broadcaster": "independent",
+      "streamUrl": "https://liveradio.swr.de/sw890cl/swr3/",
+      "homepage": "https://www.swr3.de/",
+      "country": "DE",
+      "tags": [
+        "music"
+      ],
+      "favicon": "https://www.swr3.de/assets/swr3/icons/apple-touch-icon.png",
+      "bitrate": 96,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-salsa-by-rautemusik-rm-fm",
+      "name": "__SALSA__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://salsa-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://www.rm.fm/salsa",
+      "country": "DE",
+      "tags": [
+        "bachata",
+        "kultur",
+        "latin",
+        "latino",
+        "merengue bachata",
+        "musica latina"
+      ],
+      "favicon": "https://www.rm.fm/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-bigcitybeats-fm-by-rautemusik-rm-fm",
+      "name": "__BIGCITYBEATS.FM__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.bigcitybeats.de/bcb-radio/mp3-192/radiobrowser",
+      "homepage": "https://bigcitybeats.de/",
+      "country": "DE",
+      "tags": [
+        "charts",
+        "dance",
+        "deejay",
+        "dj",
+        "dj sets",
+        "edm"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-swr1-rheinland-pfalz-48k-aac",
+      "name": "SWR1 – Rheinland-Pfalz | 48k aac",
+      "broadcaster": "independent",
+      "streamUrl": "https://liveradio.swr.de/sw890cl/swr1rp/",
+      "homepage": "https://www.swr.de/swr1/rp/index.html",
+      "country": "DE",
+      "favicon": "https://www.swr.de/assets/swr/swr1/apple-touch-icon-180x180.png",
+      "bitrate": 96,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-house-on-radio",
+      "name": "- 0 N - House on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-house.radionetz.de/0n-house.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "dance",
+        "electro",
+        "electronic",
+        "house",
+        "minimal",
+        "techno"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-house_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-rautemusik-k-pop",
+      "name": "RauteMusik K-POP",
+      "broadcaster": "independent",
+      "streamUrl": "https://streams.rautemusik.fm/k-pop/mp3-192?ref=radiobrowser",
+      "homepage": "https://rm.fm/k-pop",
+      "country": "DE",
+      "tags": [
+        "#",
+        "#charts",
+        "asian",
+        "asian pop",
+        "charts",
+        "hits"
+      ],
+      "favicon": "https://i.ibb.co/Kbvr4xf/k-pop-400x400.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.461,
+        8.6133
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0nlineradio-70s",
+      "name": "0nlineradio 70s",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.0nlineradio.com/70s?ref=radiobrowser",
+      "homepage": "https://0nlineradio.com/",
+      "country": "DE",
+      "tags": [
+        "70s",
+        "80s",
+        "golden oldies",
+        "goldies",
+        "oldies",
+        "oldies 50's/60's"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        49.838,
+        8.6133
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-wdr-cosmo-afrobeats",
+      "name": "WDR COSMO - Afrobeats",
+      "broadcaster": "independent",
+      "streamUrl": "https://wdr-cosmo-afrobeat.icecastssl.wdr.de/wdr/cosmo/afrobeat/mp3/128/stream.mp3",
+      "homepage": "https://www1.wdr.de/radio/cosmo/channels/afrobeats-channel-106.html",
+      "country": "DE",
+      "tags": [
+        "afrobeats",
+        "dance",
+        "r&b"
+      ],
+      "favicon": "https://www1.wdr.de/radio/cosmo/resources-v5.128.1/img/favicon/favicon-32x32.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-bonn-rhein-sieg",
+      "name": "Radio Bonn / Rhein-Sieg",
+      "broadcaster": "independent",
+      "streamUrl": "https://rbrs-live.cast.addradio.de/rbrs/live/mp3/high",
+      "homepage": "https://www.radiobonn.de/",
+      "country": "DE",
+      "tags": [
+        "regional"
+      ],
+      "favicon": "https://www.radiobonn.de/assets/images/senderlogos/radio_brs_webradio.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-workout-by-rautemusik-rm-fm",
+      "name": "__WORKOUT__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://workout-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://www.rm.fm/workout",
+      "country": "DE",
+      "tags": [
+        "dance",
+        "hip hop",
+        "hits",
+        "non-stop music",
+        "training",
+        "workout"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-schlager-on-radio",
+      "name": "- 0 N - Schlager on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-schlager.radionetz.de/0n-schlager.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "discofox",
+        "pop",
+        "schlager",
+        "various",
+        "world music"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-schlager_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1-a-schlager-von-1a-radio",
+      "name": "- 1 A - Schlager von 1A Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://1a-schlager.radionetz.de/1a-schlager.mp3",
+      "homepage": "http://www.1aradio.com/",
+      "country": "DE",
+      "tags": [
+        "discofox",
+        "pop",
+        "schlager",
+        "various",
+        "world music"
+      ],
+      "favicon": "https://www.1aradio.com/logos/1a-schlager_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-christmas-schlager-by-rautemusik-rm-fm",
+      "name": "__CHRISTMAS SCHLAGER__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://christmas-schlager-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://www.rm.fm/christmas-schlager",
+      "country": "DE",
+      "tags": [
+        "christmas",
+        "christmas music",
+        "discofox",
+        "klassik weihnachten christmas",
+        "schlager",
+        "schlagerhits"
+      ],
+      "favicon": "https://www.rm.fm/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0nlineradio-metal",
+      "name": "0nlineradio METAL",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.0nlineradio.com/metal?ref=radiobrowser",
+      "homepage": "https://0nlineradio.com/",
+      "country": "DE",
+      "tags": [
+        "death metal",
+        "hard rock",
+        "heavy metal",
+        "metal",
+        "nu metal",
+        "rock"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-technolovers-tropical-house",
+      "name": "Technolovers TROPICAL HOUSE",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.technolovers.fm/tropical-house?ref=radiobrowser",
+      "homepage": "https://technolovers.fm/",
+      "country": "DE",
+      "tags": [
+        "balearic house",
+        "deep house",
+        "house",
+        "musica tropical",
+        "tropical",
+        "tropical house"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.3375,
+        8.9062
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-lounge-coffee-bar-lounge",
+      "name": "Epic Lounge - COFFEE BAR LOUNGE",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-lounge.com/coffee-bar-lounge?ref=radiobrowser",
+      "homepage": "https://epic-lounge.com/",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "ambient and relaxation music",
+        "lounge",
+        "lounge music",
+        "relax",
+        "relaxation"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-hirschmilch-radio",
+      "name": "Hirschmilch Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://hirschmilch.de:7001/chillout.mp3",
+      "homepage": "https://hirschmilch.de:7001/chillout.mp3",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "chillout",
+        "relax"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-emergency",
+      "name": "Radio Emergency",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.radioemergency.de/radioemergency.mp3",
+      "homepage": "https://www.radioemergency.de/",
+      "country": "DE",
+      "tags": [
+        "rock"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0nlineradio-greatest-hits",
+      "name": "0nlineradio GREATEST HITS",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.0nlineradio.com/greatest-hits?ref=radiobrowser",
+      "homepage": "https://0nlineradio.com/",
+      "country": "DE",
+      "tags": [
+        "70er",
+        "70s",
+        "80er",
+        "80s",
+        "90er",
+        "90s"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.2893,
+        7.9102
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-classical-classical-relax",
+      "name": "EPIC CLASSICAL - Classical Relax",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-classical.com/classical-relax",
+      "homepage": "https://epic-classical.com/",
+      "country": "DE",
+      "tags": [
+        "+",
+        "ambient and relaxation music",
+        "chillout",
+        "classic",
+        "classical",
+        "klassik"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-study-by-rautemusik-rm-fm",
+      "name": "__STUDY__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://study-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://www.rm.fm/study",
+      "country": "DE",
+      "tags": [
+        "classic hits",
+        "easy listening",
+        "hits",
+        "music for study",
+        "pop",
+        "student"
+      ],
+      "favicon": "https://www.rm.fm/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1-reggae-joint",
+      "name": "1 reggae joint",
+      "broadcaster": "independent",
+      "streamUrl": "https://jointil.com/stream-reggae",
+      "homepage": "https://www.jointil.com/radio/",
+      "country": "DE",
+      "tags": [
+        "dub",
+        "dub reggae",
+        "reggae",
+        "reggeton",
+        "roots reggae",
+        "smooth reggae"
+      ],
+      "favicon": "https://www.jointil.com/broadcast/images/joint.radio330X330.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-aida-radio-flac",
+      "name": "AIDa radio Flac",
+      "broadcaster": "independent",
+      "streamUrl": "https://cdn05.radio.cloud:8128/AIDA-OMNIA-GAI",
+      "homepage": "https://aidaradio.de/",
+      "country": "DE",
+      "tags": [
+        "holiday"
+      ],
+      "bitrate": 2000,
+      "codec": "OGG",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-christmas-on-radio",
+      "name": "- 0 N - Christmas on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-christmas.radionetz.de/0n-christmas.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "christmas",
+        "holiday",
+        "jazz",
+        "oldies",
+        "season",
+        "weihnachten"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-christmas_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-schlagerradio-fm-by-rautemusik-rm-fm",
+      "name": "__SCHLAGERRADIO.FM__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://schlager-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://www.rm.fm/schlager",
+      "country": "DE",
+      "tags": [
+        "charts",
+        "dance",
+        "disco",
+        "discofox",
+        "discofox oldies",
+        "discofox+schlager"
+      ],
+      "favicon": "https://www.rm.fm/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-lounge-on-radio",
+      "name": "- 0 N - Lounge on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-lounge.radionetz.de/0n-lounge.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "chillout",
+        "easy listening",
+        "lounge"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-lounge_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-12punks-fm-by-rautemusik-rm-fm",
+      "name": "__12PUNKS.FM__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://12punks-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://www.rm.fm/12punks",
+      "country": "DE",
+      "tags": [
+        "alternativ rock",
+        "classic rock",
+        "heavy metal",
+        "metal",
+        "new rock",
+        "punk"
+      ],
+      "favicon": "https://www.rm.fm/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-refuge-worldwide",
+      "name": "Refuge Worldwide",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.radio.co/s3699c5e49/listen",
+      "homepage": "https://refugeworldwide.com/",
+      "country": "DE",
+      "tags": [
+        "community radio",
+        "variety"
+      ],
+      "favicon": "https://refugeworldwide.com/apple-touch-icon.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        52.4834,
+        13.4411
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-black-on-radio",
+      "name": "- 0 N - Black on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-black.radionetz.de/0n-black.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "black",
+        "hip hop",
+        "hiphop",
+        "pop",
+        "r&b",
+        "top 40"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-black_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-schlager-gold-on-radio",
+      "name": "- 0 N - Schlager Gold on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-schlagergold.radionetz.de/0n-schlagergold.aac",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "50er",
+        "50s",
+        "60er",
+        "60s",
+        "oldies",
+        "rock 'n' roll"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-schlager-gold_600x600.jpg",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-soft-pop-on-radio",
+      "name": "- 0 N - Soft Pop on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-softpop.radionetz.de/0n-softpop.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "balladen",
+        "lovesongs",
+        "pop",
+        "soft pop",
+        "soft rock"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-soft-pop_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1-a-relax-von-1a-radio",
+      "name": "- 1 A - Relax von 1A Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://1a-relax.radionetz.de/1a-relax.mp3",
+      "homepage": "http://www.1aradio.com/",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "chillout",
+        "easy listening",
+        "electro"
+      ],
+      "favicon": "https://www.1aradio.com/logos/1a-relax_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-laut-fm-madonna",
+      "name": "Laut FM Madonna",
+      "broadcaster": "independent",
+      "streamUrl": "https://extraradioweb-radio.stream.laut.fm/extraradio_web-radio?t302",
+      "homepage": "https://laut.fm/",
+      "country": "DE",
+      "tags": [
+        "pop"
+      ],
+      "favicon": "https://laut.fm/assets/touch-icons/apple-touch-icon.png?9e172e15",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-techno-by-rautemusik-fm",
+      "name": "__TECHNO__ by rautemusik.fm",
+      "broadcaster": "independent",
+      "streamUrl": "https://streams.rautemusik.fm/techno/mp3-192/?ref=radiobrowser",
+      "homepage": "https://rm.fm/techno",
+      "country": "DE",
+      "tags": [
+        "ambient techno",
+        "deep techno",
+        "dub techno",
+        "hard techno",
+        "house techno",
+        "minimal techno"
+      ],
+      "favicon": "https://rm.fm/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.461,
+        8.2617
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0nlineradio-90s",
+      "name": "0nlineradio 90s",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.0nlineradio.com/90s?ref=radiobrowser",
+      "homepage": "https://0nlineradio.com/",
+      "country": "DE",
+      "tags": [
+        "1990s",
+        "90's",
+        "90er",
+        "90s",
+        "discofox oldies",
+        "goldies"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.9584,
+        6.8555
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-i-love-music-i-love-chillhop",
+      "name": "I Love Music - I Love Chillhop",
+      "broadcaster": "independent",
+      "streamUrl": "https://ilm.stream35.radiohost.de/ilm_ilovechillhop_mp3-192?upd-meta&upd-scheme=https&_art=dD0xNzY4NDUwMTU1JmQ9MzQxNTMxNDFhODdjYmQ4MjA5NjE",
+      "homepage": "https://www.ilovemusic.de/ilovechillhop/",
+      "country": "DE",
+      "tags": [
+        "chill beats",
+        "chillhop",
+        "lofi hip hop",
+        "music for study",
+        "relax"
+      ],
+      "favicon": "https://www.ilovemusic.de/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0nlineradio-80s",
+      "name": "0nlineradio 80s",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.0nlineradio.com/80s?ref=radiobrowser",
+      "homepage": "https://0nlineradio.com/",
+      "country": "DE",
+      "tags": [
+        "1980s",
+        "80er",
+        "80s",
+        "discofox oldies",
+        "goldies",
+        "oldies"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.7365,
+        8.2617
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0nlineradio-beethoven",
+      "name": "0nlineradio BEETHOVEN",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.0nlineradio.com/beethoven?ref=radiobrowser",
+      "homepage": "https://0nlineradio.com/",
+      "country": "DE",
+      "tags": [
+        "boston",
+        "boston symphony orchestra",
+        "classic",
+        "classic hits",
+        "classical",
+        "symphonic"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        49.6107,
+        7.9102
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-lounge-french-cafe-lounge",
+      "name": "Epic Lounge - FRENCH CAFÉ LOUNGE",
+      "broadcaster": "independent",
+      "streamUrl": "https://0nlineradio.stream42.radiohost.de/lounge-french-cafe-lounge?ref=radiobrowser&upd-meta&upd-scheme=https&_art=dD0xNzY4NDQ1MTE3JmQ9ODA5N2Q3ZjM4NTY5ZGM3NzdlNTM",
+      "homepage": "https://epic-lounge.com/",
+      "country": "DE",
+      "tags": [
+        "cafe",
+        "classical music",
+        "french",
+        "french music",
+        "lounge",
+        "lounge music"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-maretimo-chill-radio",
+      "name": "Maretimo Chill Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s35.derstream.net/chillradio.mp3?",
+      "homepage": "https://www.maretimo-records.com/",
+      "country": "DE",
+      "tags": [
+        "chill out"
+      ],
+      "favicon": "https://www.maretimo-records.com/wp-content/uploads/2022/09/favicon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.8365,
+        10.1074
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-harder-by-rautemusik-rm-fm",
+      "name": "__HARDER__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://harder-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://www.rm.fm/harder",
+      "country": "DE",
+      "tags": [
+        "dance",
+        "edm",
+        "electro",
+        "electronic",
+        "hardcore",
+        "hardstyle"
+      ],
+      "favicon": "https://www.rm.fm/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-classical-classical-background-music",
+      "name": "EPIC CLASSICAL - Classical Background Music",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-classical.com/classical-background-music",
+      "homepage": "https://epic-classical.com/",
+      "country": "DE",
+      "tags": [
+        "chill",
+        "chillout",
+        "classic",
+        "classic jazz",
+        "classical",
+        "classical music"
+      ],
+      "favicon": "https://i.ibb.co/251sfzx/Background-Music.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.1173,
+        9.2578
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-movies-on-radio",
+      "name": "- 0 N - Movies on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-movies.radionetz.de/0n-movies.aac",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "classical",
+        "movies",
+        "musical",
+        "soundtrack",
+        "soundtracks"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-movies_600x600.jpg",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-antenne-bayern-happy-hits",
+      "name": "Antenne Bayern Happy Hits",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.antenne.de/happy-hits/stream/mp3",
+      "homepage": "https://antenne.de/",
+      "country": "DE",
+      "favicon": "https://antenne.de/logos/station-antenne-bayern/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.1283,
+        11.5823
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1000-techno",
+      "name": "1000 Techno",
+      "broadcaster": "independent",
+      "streamUrl": "https://1000techno.stream.laut.fm/1000techno?pl=m3u&t302=2026-01-15_05-44-54&uuid=6755f28b-3f75-4762-916c-484df706ef7d",
+      "homepage": "http://rsn.li/",
+      "country": "DE",
+      "tags": [
+        "deep techno",
+        "hard techno",
+        "techno"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-technolovers-melbourne-bounce",
+      "name": "Technolovers MELBOURNE BOUNCE",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.technolovers.fm/melbourne-bounce?ref=radiobrowser",
+      "homepage": "https://technolovers.fm/",
+      "country": "DE",
+      "tags": [
+        "bass",
+        "club dance",
+        "dance",
+        "dance music",
+        "dutch",
+        "electro"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.9065,
+        7.9102
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-flower-power-radio",
+      "name": "Flower Power Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://nl1.streamingpulse.com/ssl/flowerpowerradio",
+      "homepage": "https://www.flowerpowerradio.com/",
+      "country": "DE",
+      "tags": [
+        "classic rock",
+        "decades",
+        "funk",
+        "motown",
+        "pop rock",
+        "psychedelic"
+      ],
+      "favicon": "https://www.flowerpowerradio.com/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        49.0066,
+        8.4045
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0nlineradio-house",
+      "name": "0nlineradio HOUSE",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.0nlineradio.com/house?ref=radiobrowser",
+      "homepage": "https://0nlineradio.com/",
+      "country": "DE",
+      "tags": [
+        "dance",
+        "dance music",
+        "edm",
+        "electro",
+        "electronic",
+        "house"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.3992,
+        8.2617
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-technolovers-frenchcore",
+      "name": "Technolovers - FRENCHCORE",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.technolovers.fm/frenchcore?ref=radiobrowser",
+      "homepage": "https://technolovers.fm/",
+      "country": "DE",
+      "tags": [
+        "electro",
+        "electronic",
+        "happy hardcore",
+        "hardcore",
+        "hardstyle",
+        "uptempo hardcore"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-nightride-fm-horrorsynth",
+      "name": "Nightride FM - Horrorsynth",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.nightride.fm/horrorsynth.mp3",
+      "homepage": "https://nightride.fm/",
+      "country": "DE",
+      "tags": [
+        "cyberpunk",
+        "darksynth",
+        "horror"
+      ],
+      "favicon": "https://nightride.fm/thumbnail.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1-a-rock-von-1a-radio",
+      "name": "- 1 A - Rock von 1A Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://1a-rock.radionetz.de/1a-rock.mp3",
+      "homepage": "http://www.1aradio.com/",
+      "country": "DE",
+      "tags": [
+        "alternative",
+        "classic rock",
+        "hard rock",
+        "metal",
+        "rock",
+        "soft rock"
+      ],
+      "favicon": "https://www.1aradio.com/logos/1a-rock_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-technolovers-house",
+      "name": "Technolovers HOUSE",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.technolovers.fm/house?ref=radiobrowser",
+      "homepage": "https://technolovers.fm/",
+      "country": "DE",
+      "tags": [
+        "dance",
+        "dance music",
+        "electro",
+        "electro house",
+        "electronic",
+        "electronic dance music"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.6843,
+        8.6133
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-solopiano-by-rautemusik-rm-fm",
+      "name": "__SOLOPIANO__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://solopiano-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://www.rm.fm/solopiano",
+      "country": "DE",
+      "tags": [
+        "hits",
+        "instrumental",
+        "klavier",
+        "new age piano",
+        "piano",
+        "piano jazz"
+      ],
+      "favicon": "https://www.rm.fm/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-rbb-24-inforadio",
+      "name": "RBB 24 Inforadio",
+      "broadcaster": "independent",
+      "streamUrl": "https://f121.rndfnk.com/ard/rbb/inforadio/live/mp3/128/stream.mp3?cid=01FC1WYDPN76K6HSCD8QCR9D3S&sid=2QcLzffN32wHfW1lVCzlxHze7qi&token=pGWtFx8DdsdTygJQfppoygwrmQAJ9neXn-Oapylzh_E&tvf=RIPifb2zZBdmMTIxLnJuZGZuay5jb20",
+      "homepage": "http://inforadio.de/",
+      "country": "DE",
+      "tags": [
+        "local news",
+        "news"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-classical-classical-chillout",
+      "name": "EPIC CLASSICAL - Classical Chillout",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-classical.com/classical-chillout?ref=liveradio",
+      "homepage": "https://epic-classical.com/",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "ambient and relaxation music",
+        "chill",
+        "chillout",
+        "chillout+lounge",
+        "classic"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-russia-today-germany",
+      "name": "Russia Today Germany",
+      "broadcaster": "independent",
+      "streamUrl": "https://rt-ger.rttv.com/dvr/rtdeutsch/playlist.m3u8",
+      "homepage": "https://de.rt.com/",
+      "country": "DE",
+      "tags": [
+        "ard",
+        "bbc world news",
+        "deutsche welle",
+        "deutschland",
+        "dw deutsch",
+        "dw english"
+      ],
+      "favicon": "https://th.bing.com/th/id/OIP.fFhTxl0dHi7zOZGQEOor6wAAAA",
+      "bitrate": 4664,
+      "codec": "AAC,H.264",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1-a-80er-von-1a-radio",
+      "name": "- 1 A - 80er von 1A Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://1a-80er.radionetz.de/1a-80er.mp3",
+      "homepage": "http://www.1aradio.com/",
+      "country": "DE",
+      "tags": [
+        "80er",
+        "80s",
+        "oldies",
+        "pop"
+      ],
+      "favicon": "https://www.1aradio.com/logos/1a-80er_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-rock-antenne-live-rock",
+      "name": "ROCK ANTENNE Live Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rockantenne.de/live-rock/stream/aacp",
+      "homepage": "https://www.rockantenne.de/",
+      "country": "DE",
+      "favicon": "https://www.rockantenne.de/logos/station-rock-antenne/apple-touch-icon.png",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-70-s-80-s-90-s-riw-vintage-channel",
+      "name": "70's 80's 90's Riw Vintage Channel",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/70s-80s-90s-riw-vintage-channel",
+      "homepage": "https://laut.fm/70s-80s-90s-riw-vintage-channel",
+      "country": "DE",
+      "tags": [
+        "128 kbit/s",
+        "128 kbps",
+        "1970s",
+        "1980's",
+        "1990s",
+        "70"
+      ],
+      "favicon": "https://static.wixstatic.com/media/f361b3_3b8537296cb04e049fdfe55af2a45900~mv2.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        47.6582,
+        9.1756
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-rock-by-rautemusik-rm-fm",
+      "name": "__ROCK__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://rock-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://www.rm.fm/rock",
+      "country": "DE",
+      "tags": [
+        "alternative rock",
+        "classic rock",
+        "hard rock",
+        "heavy metal",
+        "metal",
+        "pop rock"
+      ],
+      "favicon": "https://www.rm.fm/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-piano-coverhits-by-epic-piano",
+      "name": "PIANO COVERHITS by Epic Piano",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-piano.com/piano-coverhits?ref=radiobrowser",
+      "homepage": "https://epic-piano.com/",
+      "country": "DE",
+      "tags": [
+        "charts",
+        "classical piano",
+        "covers",
+        "hits",
+        "piano"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.9065,
+        8.2617
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-swr2-48k-aac",
+      "name": "SWR2 | 48k aac",
+      "broadcaster": "independent",
+      "streamUrl": "https://liveradio.swr.de/sw890cl/swr2/",
+      "homepage": "https://www.swr.de/swr2/index.html",
+      "country": "DE",
+      "favicon": "https://www.swr.de/assets/swr/swr2/apple-touch-icon.png",
+      "bitrate": 96,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-technolovers-trance",
+      "name": "Technolovers TRANCE",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.technolovers.fm/trance?ref=radiobrowser",
+      "homepage": "https://technolovers.fm/",
+      "country": "DE",
+      "tags": [
+        "melodic trance",
+        "progressive trance",
+        "trance",
+        "trance uplifting"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.6738,
+        9.6094
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0nlineradio-2000er",
+      "name": "0nlineradio 2000er",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.0nlineradio.com/2000er?ref=radiobrowser",
+      "homepage": "https://0nlineradio.com/",
+      "country": "DE",
+      "tags": [
+        "2000er",
+        "2000s",
+        "größte pop-hits der 2000er",
+        "hiphop",
+        "pop",
+        "rnb"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.5134,
+        8.6133
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-neofolk",
+      "name": "NEOFOLK",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/neofolk",
+      "homepage": "https://flatlinesradio.de/",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "darkfolk",
+        "experimental",
+        "industrial",
+        "martial industrial",
+        "mittelalter"
+      ],
+      "favicon": "https://i0.wp.com/flatlinesradio.de/storage/2021/11/244611397_1194785584320990_6265045071816304131_n-1.jpg?fit=180%2c180&#038;ssl=1",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-dark-pulse",
+      "name": "Radio Dark Pulse",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiodarkpulse.stream.laut.fm/radiodarkpulse",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "DE",
+      "tags": [
+        "rock"
+      ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/1/35171.v1.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-christmas-chor-by-rautemusik-rm-fm",
+      "name": "__CHRISTMAS CHOR__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://christmas-chor-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://www.rm.fm/christmas-chor",
+      "country": "DE",
+      "tags": [
+        "choral",
+        "christmas",
+        "christmas music",
+        "church",
+        "church of christ",
+        "klassik weihnachten christmas"
+      ],
+      "favicon": "https://www.rm.fm/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-98-2-radio-paradiso",
+      "name": "98.2 Radio Paradiso",
+      "broadcaster": "independent",
+      "streamUrl": "https://streams.paradiso.de/Berlin/mp3-128/Web/?pkey=web-radioparadiso-de&tcstring=CPXGs4APXGs4AAFADBDECKCgAAAAAAAAAAYgAAAAAAAA.YAAAAAAAAAAA",
+      "homepage": "https://www.paradiso.de/",
+      "country": "DE",
+      "tags": [
+        "adult contemporary"
+      ],
+      "favicon": "https://www.paradiso.de/assets/favicons/apple-icon-120x120.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        52.4183,
+        13.1643
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-deutschlandfunk-nova-dlf-opus-64k",
+      "name": "Deutschlandfunk Nova | DLF | OPUS 64k",
+      "broadcaster": "independent",
+      "streamUrl": "https://st03.sslstream.dlf.de/dlf/03/high/opus/stream.opus?aggregator=web",
+      "homepage": "https://www.deutschlandfunknova.de/",
+      "country": "DE",
+      "tags": [
+        "culture",
+        "news",
+        "public service",
+        "information"
+      ],
+      "favicon": "https://www.deutschlandfunknova.de/apple-touch-icon.png",
+      "bitrate": 64,
+      "codec": "OGG",
+      "geo": [
+        52.4803,
+        13.3348
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-classical-classical-romance",
+      "name": "EPIC CLASSICAL - Classical Romance",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-classical.com/classical-romance",
+      "homepage": "https://epic-classical.com/",
+      "country": "DE",
+      "tags": [
+        "chillout",
+        "classical",
+        "classical music",
+        "classical piano",
+        "jazz",
+        "klassik"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.8961,
+        8.9062
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-rock-antenne-symphonic-rock",
+      "name": "Rock Antenne Symphonic Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2-webradio.rockantenne.de/symphonic-rock/stream",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "DE",
+      "tags": [
+        "rock"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-gold-on-radio",
+      "name": "- 0 N - Gold on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-gold.radionetz.de/0n-gold.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "50er",
+        "50s",
+        "60er",
+        "60s",
+        "funk",
+        "oldies"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-gold_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-top-100-dj-charts-remix-deejay-radio-club-radio-",
+      "name": "- TOP 100 - DJ Charts - / - REMIX DEEJAY RADIO - CLUB RADIO - HOUSE - EDM - TECHHOUSE - TECHNO - DANCE - TOP100 - TOP40 - RNB - BLACKMUSIC - HIPHOP - URBAN - REGGEATON - MIXTAPE RADIO - RAVE MUSIC -  LIVE DEEJAY RADIO - LIVE EVENTS",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio2.breakz.fm/?ref=rb-gpt-t100",
+      "homepage": "https://www.breakz.fm/",
+      "country": "DE",
+      "tags": [
+        "#top100",
+        "- dj charts",
+        "24/7",
+        "adult contemporary",
+        "club",
+        "club dance"
+      ],
+      "favicon": "https://i.ibb.co/b7gfKT6/TOP-100-DJ-CHARTS-GPT.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        52.4879,
+        13.4683
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-christmas-piano-by-epic-piano",
+      "name": "CHRISTMAS PIANO by Epic Piano",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-piano.com/christmas-piano?ref=radiobrowser",
+      "homepage": "https://epic-piano.com/",
+      "country": "DE",
+      "tags": [
+        "christian",
+        "christmas",
+        "classic",
+        "classical",
+        "classics",
+        "instrumental"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.9065,
+        8.2617
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-80s-by-rautemusik-rm-fm",
+      "name": "__80S__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://80s-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://www.rm.fm/80s",
+      "country": "DE",
+      "tags": [
+        "1980s",
+        "80",
+        "80's",
+        "80er",
+        "80s",
+        "golden oldies"
+      ],
+      "favicon": "https://www.rm.fm/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1-splash-70s",
+      "name": "#1 Splash 70s",
+      "broadcaster": "independent",
+      "streamUrl": "https://c4.auracast.net/radio/8040/radio.mp3",
+      "homepage": "https://www.splashradio.eu/",
+      "country": "DE",
+      "tags": [
+        "1960s and 1970s",
+        "1970s",
+        "70er",
+        "70s",
+        "70s disco",
+        "disco"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-lounge-new-york-lounge",
+      "name": "Epic Lounge - NEW YORK LOUNGE",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-lounge.com/new-york-lounge",
+      "homepage": "https://epic-lounge.com/",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "ambient and relaxation music",
+        "chill",
+        "chillout",
+        "chillout+lounge",
+        "lounge"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-technolovers-trap",
+      "name": "Technolovers TRAP",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.technolovers.fm/trap?ref=radiobrowser",
+      "homepage": "https://technolovers.fm/",
+      "country": "DE",
+      "tags": [
+        "chilled trap",
+        "dub",
+        "dubstep",
+        "liquid trap",
+        "post dubstep",
+        "trap"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.2367,
+        7.5586
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-classical-classical-study",
+      "name": "EPIC CLASSICAL - Classical Study",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-classical.com/classical-study",
+      "homepage": "https://epic-classical.com/",
+      "country": "DE",
+      "tags": [
+        "adult contemporary",
+        "ambient",
+        "chillout",
+        "chillout+lounge",
+        "classical",
+        "jazz"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.3375,
+        9.2578
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-swr-4-rp-mainz-128k",
+      "name": "SWR 4 RP Mainz (128k)",
+      "broadcaster": "independent",
+      "streamUrl": "https://liveradio.swr.de/sw282p3/swr4rp/play.mp3",
+      "homepage": "https://liveradio.swr.de/sw282p3/swr4rp",
+      "country": "DE",
+      "favicon": "https://liveradio.swr.de/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-technolovers-dirty-house",
+      "name": "Technolovers DIRTY HOUSE",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.technolovers.fm/dirty-house?ref=radiobrowser",
+      "homepage": "https://technolovers.fm/",
+      "country": "DE",
+      "tags": [
+        "club dance",
+        "edm",
+        "electro house",
+        "electronic dance music",
+        "house",
+        "houseparty"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.4505,
+        8.9062
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-deutschlandfunk-nova-dlf-aac-48k",
+      "name": "Deutschlandfunk Nova | DLF | AAC 48k",
+      "broadcaster": "independent",
+      "streamUrl": "https://st03.sslstream.dlf.de/dlf/03/low/aac/stream.aac?aggregator=web",
+      "homepage": "https://www.deutschlandfunknova.de/",
+      "country": "DE",
+      "tags": [
+        "culture",
+        "news",
+        "public service",
+        "information"
+      ],
+      "favicon": "https://www.deutschlandfunknova.de/apple-touch-icon.png",
+      "bitrate": 48,
+      "codec": "AAC",
+      "geo": [
+        52.4803,
+        13.3348
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-fu-ball-bundesliga-konferenz",
+      "name": "Fußball-Bundesliga: Konferenz",
+      "broadcaster": "independent",
+      "streamUrl": "https://wdr-sportschau-liga1konferenz.icecastssl.wdr.de/wdr/sportschau/liga1konferenz/mp3/high",
+      "homepage": "https://livecenter.sportschau.de/",
+      "country": "DE",
+      "tags": [
+        "football",
+        "live sports",
+        "sport"
+      ],
+      "favicon": "https://www.sportschau.de/resources/assets/image/favicon/apple-icon-120x120.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-munchen-256kb",
+      "name": "Radio München 256kb",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radiomuenchen.net/rm256.mp3",
+      "homepage": "https://radiomuenchen.net/",
+      "country": "DE",
+      "tags": [
+        "independent music",
+        "independent news"
+      ],
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-antenne-nrw",
+      "name": "Antenne NRW",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.antenne.de/antenne-nrw/stream/aacp",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "DE",
+      "tags": [
+        "classical"
+      ],
+      "bitrate": 47,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-gay-on-radio",
+      "name": "- 0 N - Gay on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-gay.radionetz.de/0n-gay.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "dance",
+        "gay",
+        "hits",
+        "lgbt",
+        "pop",
+        "top40"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-gay_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-erf-plus",
+      "name": "ERF plus",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.erfplus.de/erf-1a64/aac-64?ar-distributor=ffa5",
+      "homepage": "https://erf.de/",
+      "country": "DE",
+      "favicon": "https://erf.de/apple-touch-icon.png?v=pbzut9eb",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-swr-aktuell-48k-aac",
+      "name": "SWR Aktuell | 48k aac",
+      "broadcaster": "independent",
+      "streamUrl": "https://liveradio.swr.de/sw890cl/swraktuell/",
+      "homepage": "https://www.swr.de/swraktuell/index.html",
+      "country": "DE",
+      "tags": [
+        "news"
+      ],
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-deutschlandfunk-dokumente-und-debatten-dlf-mp3-1",
+      "name": "Deutschlandfunk Dokumente und Debatten | DLF | MP3 128k",
+      "broadcaster": "independent",
+      "streamUrl": "https://st04.sslstream.dlf.de/dlf/04/128/mp3/stream.mp3?aggregator=web",
+      "homepage": "https://www.deutschlandradio.de/dokumente-und-debatten-102.html",
+      "country": "DE",
+      "tags": [
+        "debate",
+        "debatten",
+        "documentation",
+        "sondersendungen",
+        "special broadcast",
+        "talk"
+      ],
+      "favicon": "https://www.deutschlandradio.de/static/img/deutschlandradio/icons/apple-touch-icon-128x128.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        52.4803,
+        13.3348
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-showagenten-radio",
+      "name": "ShowAgenten Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/395746/stream/449383",
+      "homepage": "https://de.radioking.com/radio/showagenten",
+      "country": "DE",
+      "favicon": "https://www.radioking.com/wp-content/uploads/2023/06/cropped-faviconrk-180x180.webp",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-laut-fm-shoegaze",
+      "name": "Laut.FM Shoegaze",
+      "broadcaster": "independent",
+      "streamUrl": "https://shoegaze.stream.laut.fm/shoegaze",
+      "homepage": "https://laut.fm/shoegaze",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "dream pop",
+        "electro",
+        "indie",
+        "post-punk",
+        "rock"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1000-weihnachten",
+      "name": "1000 Weihnachten",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/1000weihnachten",
+      "homepage": "http://radiosummernight.ch/",
+      "country": "DE",
+      "tags": [
+        "christmas",
+        "christmas music",
+        "klassik weihnachten christmas",
+        "weihnachten"
+      ],
+      "favicon": "http://radiosummernight.ch/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-classical-classical-orchestral",
+      "name": "EPIC CLASSICAL - Classical Orchestral",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-classical.com/classical-orchestral?ref=liveradio",
+      "homepage": "https://epic-classical.com/",
+      "country": "DE",
+      "tags": [
+        "classic",
+        "classical",
+        "klassik",
+        "klassisk",
+        "orchestra",
+        "orchestral"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0nlineradio-gospel",
+      "name": "0nlineradio GOSPEL",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.0nlineradio.com/gospel?ref=radiobrowser",
+      "homepage": "https://0nlineradio.com/",
+      "country": "DE",
+      "tags": [
+        "christian-gospel",
+        "gospel",
+        "gospel music",
+        "gospel pop",
+        "southern gospel"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.7365,
+        8.2617
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-lounge-beach-club-lounge",
+      "name": "Epic Lounge - BEACH CLUB LOUNGE",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-lounge.com/beach-club-lounge?ref=radiobrowser",
+      "homepage": "https://epic-lounge.com/",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "ambient and relaxation music",
+        "chill house",
+        "chillout",
+        "chillout+lounge",
+        "lounge"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.5566,
+        9.2578
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-lounge-spa-lounge",
+      "name": "Epic Lounge - SPA LOUNGE",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-lounge.com/spa-lounge?ref=radiobrowser",
+      "homepage": "https://epic-lounge.com/",
+      "country": "DE",
+      "tags": [
+        "#",
+        "ambient",
+        "ambient and relaxation music",
+        "chill",
+        "chillout",
+        "lounge"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-i-love-hip-hop",
+      "name": "I love Hip Hop",
+      "broadcaster": "independent",
+      "streamUrl": "https://ilm.stream12.radiohost.de/ilm_ilovehiphop_mp3-192?upd-meta&upd-scheme=https&_art=dD0xNzY4NDQyMzAyJmQ9YjViMzFhNzk1ZjkxNTJhMmMwZTM",
+      "homepage": "https://www.ilovemusic.de/",
+      "country": "DE",
+      "favicon": "https://www.ilovemusic.de/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-lagerfeuermetal",
+      "name": "LAGERFEUERMETAL",
+      "broadcaster": "independent",
+      "streamUrl": "https://lagerfeuermetal.stream.laut.fm/lagerfeuermetal?pl=m3u&t302=2026-01-14_23-49-48&uuid=021d8a2b-c686-453c-9525-49713d9cebab",
+      "homepage": "https://laut.fm/lagerfeuermetal",
+      "country": "DE",
+      "tags": [
+        "hard rock",
+        "heavy metal",
+        "power metal"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-antenne-bayern-2010er-hits",
+      "name": "Antenne Bayern - 2010er Hits",
+      "broadcaster": "independent",
+      "streamUrl": "https://s8-webradio.antenne.de/2010er-hits/stream/mp3",
+      "homepage": "https://www.antenne.de/",
+      "country": "DE",
+      "tags": [
+        "pop"
+      ],
+      "favicon": "https://www.antenne.de/logos/station-antenne-bayern/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        49.4379,
+        11.1127
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1-a-hits-von-1a-radio",
+      "name": "- 1 A - Hits von 1A Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://1a-hits.radionetz.de/1a-hits.mp3",
+      "homepage": "http://www.1aradio.com/",
+      "country": "DE",
+      "tags": [
+        "black",
+        "dance",
+        "hiphop",
+        "hits",
+        "pop",
+        "rock"
+      ],
+      "favicon": "https://www.1aradio.com/logos/1a-hits_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-indie-on-radio",
+      "name": "- 0 N - Indie on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-indie.radionetz.de/0n-indie.aac",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "alternative",
+        "electro",
+        "hip hop",
+        "indie",
+        "rock"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-indie_600x600.jpg",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-lippe",
+      "name": "Radio Lippe",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiolippe-live.cast.addradio.de/radiolippe/live/mp3/high",
+      "homepage": "https://www.radiolippe.de/home.html",
+      "country": "DE",
+      "favicon": "https://www.radiolippe.de/icons/apple-icon-120.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1-a-weihnachten-von-1a-radio",
+      "name": "- 1 A - Weihnachten von 1A Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://1a-weihnachten.radionetz.de/1a-weihnachten.mp3",
+      "homepage": "http://www.1aradio.com/",
+      "country": "DE",
+      "tags": [
+        "christliche musik",
+        "discofox",
+        "schlager",
+        "weihnachten"
+      ],
+      "favicon": "https://www.1aradio.com/logos/1a-weihnachten_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-charts-on-radio",
+      "name": "- 0 N - Charts on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-charts.radionetz.de/0n-charts.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "dance",
+        "hits",
+        "house",
+        "pop",
+        "rock",
+        "top40"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-charts_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-berliner-rundfunk-60er-70er",
+      "name": "Berliner Rundfunk 60er & 70er",
+      "broadcaster": "independent",
+      "streamUrl": "https://topradio-stream19.radiohost.de/brf-60er-70er_mp3-128",
+      "homepage": "https://www.berliner-rundfunk.de/clone-of-60er-70er-love-peace-rock-n-roll",
+      "country": "DE",
+      "tags": [
+        "60er",
+        "70er"
+      ],
+      "favicon": "https://upload.berliner-rundfunk.de/production/static/1713539285366/icons/icon_64.a80y02808w0.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1-splash-60s",
+      "name": "#1 Splash 60s",
+      "broadcaster": "independent",
+      "streamUrl": "https://c4.auracast.net/radio/8020/radio.mp3",
+      "homepage": "https://www.splashradio.eu/",
+      "country": "DE",
+      "tags": [
+        "1960s",
+        "60's",
+        "60er",
+        "60s",
+        "golden music",
+        "golden oldies"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-music-of-china",
+      "name": "Music of China 中国音乐",
+      "broadcaster": "independent",
+      "streamUrl": "https://vip.wongsong.cn/proxy/wongsong/stream-mp3-WongSong",
+      "homepage": "https://wongsong.cn/",
+      "country": "DE",
+      "tags": [
+        "music"
+      ],
+      "favicon": "https://wongsong.cn/img/fav.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1live-top-hits",
+      "name": "1LIVE Top Hits",
+      "broadcaster": "independent",
+      "streamUrl": "https://wdr-1live-tophits.icecast.wdr.de/wdr/1live/tophits/mp3/128/stream.mp3",
+      "homepage": "https://www1.wdr.de/radio/1live/musik/1live-streams/loopstream-1live-top-hits-100.html",
+      "country": "DE",
+      "tags": [
+        "top hits"
+      ],
+      "favicon": "https://www1.wdr.de/radio/1live/app/loopstream-cover-1live-top-hits-100~_v-TeaserAufmacher.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-80s-90s",
+      "name": "80s-90s",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/80s-90s",
+      "homepage": "https://stream.laut.fm/80s-90s",
+      "country": "DE",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-nightride-fm-datawave",
+      "name": "Nightride FM - Datawave",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.nightride.fm/datawave.mp3",
+      "homepage": "https://nightride.fm/",
+      "country": "DE",
+      "tags": [
+        "glitchy synthwave",
+        "idm",
+        "retro computing"
+      ],
+      "favicon": "https://nightride.fm/thumbnail.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-rockantenne-hamburg-64-kbps-aac",
+      "name": "ROCKANTENNE Hamburg (64 kbps AAC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://mp3channels.rockantenne.hamburg/rockantenne-hamburg.aac",
+      "homepage": "https://www.rockantenne.de/",
+      "country": "DE",
+      "tags": [
+        "rock"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-lounge-sax-house-lounge",
+      "name": "Epic Lounge - SAX HOUSE LOUNGE",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-lounge.com/sax-house-lounge?ref=radiobrowser",
+      "homepage": "https://epic-lounge.com/",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "ambient and relaxation music",
+        "house",
+        "lounge",
+        "lounge music",
+        "relax"
+      ],
+      "favicon": "https://i.ibb.co/LJByzTs/sax-house-lounge.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.3758,
+        9.6094
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-berliner-rundfunk-91-4-ostrock-pop",
+      "name": "Berliner Rundfunk 91.4 - Ostrock & Pop ",
+      "broadcaster": "independent",
+      "streamUrl": "https://topradio-de-hz-fal-stream08-cluster01.radiohost.de/brf-oldies_mp3-128?ref=homepage&amsparams=homepage&listenerid=31363231303734323636-37372e32322e36382e3830-3439333932-4d6f7a696c6c612f352e30202857696e646f7773",
+      "homepage": "https://www.berliner-rundfunk.de/",
+      "country": "DE",
+      "tags": [
+        "pop music",
+        "rock"
+      ],
+      "favicon": "https://upload.berliner-rundfunk.de/production/static/1659973942875/icons/icon_64.a80y02808w0.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        52.4739,
+        13.3336
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-blasmusikradio-mit-bernd",
+      "name": "\tBlasmusikradio mit Bernd",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/blasmusikradio_mit_bernd",
+      "homepage": "https://laut.fm/blasmusikradio_mit_bernd",
+      "country": "DE",
+      "tags": [
+        "blasmusik",
+        "folk",
+        "marsch",
+        "polka"
+      ],
+      "favicon": "https://assets.laut.fm/b22749b7fdb382b8912269e3d8054380?t=_120x120",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-schwany-souvenir-1",
+      "name": "Schwany  Souvenir 1",
+      "broadcaster": "independent",
+      "streamUrl": "https://souvenir.spcast.eu:443/stream?time=1768465529",
+      "homepage": "http://schwany.de/",
+      "country": "DE",
+      "tags": [
+        "schlager"
+      ],
+      "favicon": "http://schwany.de/favicon.ico",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1000-dance",
+      "name": "1000 Dance",
+      "broadcaster": "independent",
+      "streamUrl": "https://1000dance.stream.laut.fm/1000dance?pl=m3u&t302=2026-01-15_07-29-36&uuid=997342b3-8538-4ed6-b66f-15bb7009d340",
+      "homepage": "http://radiosummernight.ch/",
+      "country": "DE",
+      "tags": [
+        "dance",
+        "italo dance",
+        "pop dance"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0nlineradio-neue-deutsche-welle",
+      "name": "0nlineradio NEUE DEUTSCHE WELLE",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.0nlineradio.com/neuedeutschewelle?ref=radiobrowser",
+      "homepage": "https://0nlineradio.com/",
+      "country": "DE",
+      "tags": [
+        "deutsch",
+        "deutsch pop",
+        "deutschrock",
+        "ndw",
+        "neue deutsche härte"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-deutschlandfunk-kultur-dlf-aac-48k",
+      "name": "Deutschlandfunk Kultur | DLF | AAC 48k",
+      "broadcaster": "independent",
+      "streamUrl": "https://st02.sslstream.dlf.de/dlf/02/low/aac/stream.aac?aggregator=web",
+      "homepage": "https://www.deutschlandfunkkultur.de/",
+      "country": "DE",
+      "tags": [
+        "culture",
+        "news",
+        "public service",
+        "information"
+      ],
+      "favicon": "https://www.deutschlandfunkkultur.de/static/img/deutschlandfunk_kultur/icons/apple-touch-icon-128x128.png",
+      "bitrate": 48,
+      "codec": "AAC",
+      "geo": [
+        52.4803,
+        13.3348
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1-a-party-von-1a-radio",
+      "name": "- 1 A - Party von 1A Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://1a-party.radionetz.de/1a-party.mp3",
+      "homepage": "http://www.1aradio.com/",
+      "country": "DE",
+      "tags": [
+        "dance",
+        "discofox",
+        "pop",
+        "schlager"
+      ],
+      "favicon": "https://www.1aradio.com/logos/1a-party_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-lounge-lounge-covers",
+      "name": "Epic Lounge - LOUNGE COVERS",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-lounge.com/lounge-covers?ref=radiobrowser",
+      "homepage": "https://epic-lounge.com/",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "classic hits",
+        "covers",
+        "hits",
+        "jazz",
+        "lounge"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-great-piano-concerts-by-epic-piano",
+      "name": "GREAT PIANO CONCERTS by Epic Piano",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-piano.com/great-piano-concerts?ref=radiobrowser",
+      "homepage": "https://epic-piano.com/",
+      "country": "DE",
+      "tags": [
+        "classic",
+        "classical",
+        "classical piano",
+        "classics",
+        "piano"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-happy-by-rautemusik-rm-fm",
+      "name": "__HAPPY__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://happy-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://www.rm.fm/happy",
+      "country": "DE",
+      "tags": [
+        "charts",
+        "happy",
+        "happy hits",
+        "happyhits",
+        "hits",
+        "hot hits"
+      ],
+      "favicon": "https://www.rm.fm/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-reggae-on-radio",
+      "name": "- 0 N - Reggae on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-reggae.radionetz.de/0n-reggae.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "dancehall",
+        "latin",
+        "reggae",
+        "reggaeton"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-reggae_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-dance-family-radio",
+      "name": "Dance Family Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://dance-family-radio.stream.laut.fm/dance-family-radio",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "DE",
+      "tags": [
+        "electronic"
+      ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/1/52351.v3.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-deutschlandfunk-nova-dlf-opus-24k",
+      "name": "Deutschlandfunk Nova | DLF | OPUS 24k",
+      "broadcaster": "independent",
+      "streamUrl": "https://st03.sslstream.dlf.de/dlf/03/low/opus/stream.opus?aggregator=web",
+      "homepage": "https://www.deutschlandfunknova.de/",
+      "country": "DE",
+      "tags": [
+        "culture",
+        "news",
+        "public service",
+        "information"
+      ],
+      "favicon": "https://www.deutschlandfunknova.de/apple-touch-icon.png",
+      "bitrate": 24,
+      "codec": "OGG",
+      "geo": [
+        52.4803,
+        13.3348
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-lounge-jazzhop",
+      "name": "Epic Lounge - JAZZHOP",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-lounge.com/jazzhop-lounge?ref=radiobrowser",
+      "homepage": "https://epic-lounge.com/",
+      "country": "DE",
+      "tags": [
+        "hiphop",
+        "instrumental",
+        "jazz",
+        "lo-fi",
+        "lounge",
+        "lounge music"
+      ],
+      "favicon": "https://i.ibb.co/9Hc5TxR/Jazz-Hop-Lounge.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0nlineradio-schlager",
+      "name": "0nlineradio SCHLAGER",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.0nlineradio.com/schlager?ref=radiobrowser",
+      "homepage": "https://0nlineradio.com/",
+      "country": "DE",
+      "tags": [
+        "dance",
+        "dance music",
+        "disco",
+        "discofox",
+        "discofox+schlager",
+        "schlager"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-weihnachten-on-radio",
+      "name": "- 0 N - Weihnachten on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-weihnachten.radionetz.de/0n-weihnachten.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "christliche musik",
+        "discofox",
+        "schlager",
+        "weihnachten"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-weihnachten_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-schwany-heimatwelle",
+      "name": "Schwany Heimatwelle",
+      "broadcaster": "independent",
+      "streamUrl": "https://hoamatwelle.schwany.de/",
+      "homepage": "http://schwany.de/",
+      "country": "DE",
+      "tags": [
+        "volksmusik"
+      ],
+      "favicon": "http://schwany.de/favicon.ico",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-die-sendung-mit-der-maus-zum-horen",
+      "name": "Die Sendung mit der Maus zum Hören",
+      "broadcaster": "independent",
+      "streamUrl": "https://wdrhf.akamaized.net/hls/live/2028167/diemaus/master.m3u8",
+      "homepage": "https://www.wdrmaus.de/hoeren/",
+      "country": "DE",
+      "favicon": "https://www.wdrmaus.de/icon/apple-icon-120x120.png",
+      "bitrate": 102,
+      "codec": "AAC",
+      "geo": [
+        50.9939,
+        7.0475
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-plattenkiste-von-oldies-aus-den-50er-n-bis-zu-hi",
+      "name": "Plattenkiste - von Oldies aus den 50er'n bis zu Hits von morgen",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/plattenkiste",
+      "homepage": "https://www.laut.fm/plattenkiste",
+      "country": "DE",
+      "tags": [
+        "50er",
+        "60er",
+        "70er",
+        "80er",
+        "90er",
+        "hits"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-malle-fm",
+      "name": "Malle FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/malle-fm?ref=web-app&start_time=1687953524529",
+      "homepage": "https://laut.fm/malle-fm",
+      "country": "DE",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ndr-2-hamburg",
+      "name": "NDR 2 Hamburg",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.ndr.de/ndr/ndr2/hamburg/mp3/128/stream.mp3?1728423809880&aggregator=web",
+      "homepage": "https://www.ndr.de/ndr2/",
+      "country": "DE",
+      "tags": [
+        "music",
+        "pop",
+        "rock"
+      ],
+      "favicon": "https://www.phonostar.de/images/auto_created/NDR22184x184.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-volksmusik-fm-by-rautemusik-rm-fm",
+      "name": "__VOLKSMUSIK.FM__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://volksmusik-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://www.volksmusik.fm/",
+      "country": "DE",
+      "tags": [
+        "blasmusik",
+        "charts",
+        "discofox",
+        "german",
+        "hits",
+        "schlager"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0nlineradio-schlager-evergreens",
+      "name": "0nlineradio SCHLAGER EVERGREENS",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.0nlineradio.com/schlager-evergreens?ref=radiobrowser",
+      "homepage": "https://0nlineradio.com/",
+      "country": "DE",
+      "tags": [
+        "disco",
+        "discofox",
+        "discofox+schlager",
+        "hits",
+        "oldies",
+        "schlager"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-lounge-dinner-lounge",
+      "name": "Epic Lounge - DINNER LOUNGE",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-lounge.com/dinner-lounge",
+      "homepage": "https://epic-lounge.com/",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "ambient and relaxation music",
+        "chill",
+        "chillout",
+        "lounge",
+        "lounge music"
+      ],
+      "favicon": "https://i.ibb.co/MhFMB2k/Dinner-Lounge.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-hellweg-radio",
+      "name": "Hellweg Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.lokalradio.nrw/4453zcj",
+      "homepage": "https://www.hellwegradio.de/",
+      "country": "DE",
+      "favicon": "https://www.hellwegradio.de/assets/images/favicons/hellwegradio/favicon_x96.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ndw",
+      "name": "NDW",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/ndw",
+      "homepage": "https://laut.fm/ndw",
+      "country": "DE",
+      "tags": [
+        "80s",
+        "ndw"
+      ],
+      "favicon": "https://assets.laut.fm/d17d1513505a2c0740d7013a4a68f5a0?t=_120x120",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-love-on-radio",
+      "name": "- 0 N - Love on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-love.radionetz.de/0n-love.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "balladen",
+        "love songs",
+        "pop",
+        "soft pop",
+        "soft rock"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-love_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-deutsche-hits-by-rautemusik-rm-fm",
+      "name": "__DEUTSCHE HITS__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://deutsche-hits-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://www.rm.fm/deutsche-hits",
+      "country": "DE",
+      "tags": [
+        "charts",
+        "dance",
+        "german",
+        "hits",
+        "pop",
+        "pop music"
+      ],
+      "favicon": "https://www.rm.fm/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-classical-classical-hotel-lounge",
+      "name": "EPIC CLASSICAL - Classical Hotel Lounge",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-classical.com/classical-hotel-lounge",
+      "homepage": "https://epic-classical.com/",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "ambient and relaxation music",
+        "chillout+lounge",
+        "clasica",
+        "classical",
+        "classical music"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.4106,
+        8.9062
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-modern-talking-pc",
+      "name": "Modern Talking PC",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream05.pcradio.ru/Modern_Talking-med",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "DE",
+      "tags": [
+        "electronic"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-tagesschau24",
+      "name": "tagesschau24",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.tagesschau.de/ndr/tagesschau24/live/mp3/128/stream.mp3",
+      "homepage": "https://tagesschau.de/",
+      "country": "DE",
+      "tags": [
+        "ard",
+        "nachrichten",
+        "ndr",
+        "tagesschau",
+        "tagesschau24"
+      ],
+      "favicon": "https://tagesschau.de/resources/assets/image/favicon/apple-icon-120x120.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-jukebox-on-radio",
+      "name": "- 0 N - Jukebox on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-jukebox.radionetz.de/0n-jukebox.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "60er",
+        "60s",
+        "70er",
+        "70s",
+        "80er",
+        "80s"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-jukebox_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0nlineradio-schubert",
+      "name": "0nlineradio SCHUBERT",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.0nlineradio.com/schubert?ref=radiobrowser",
+      "homepage": "https://0nlineradio.com/",
+      "country": "DE",
+      "tags": [
+        "boston symphony orchestra",
+        "classic",
+        "classic hits",
+        "classical",
+        "symphonic",
+        "symphony"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.5134,
+        8.2617
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-i-love-dance-first",
+      "name": "I Love - Dance first!",
+      "broadcaster": "independent",
+      "streamUrl": "https://ilm.stream35.radiohost.de/ilm_ilovedancefirst_mp3-192?upd-meta&upd-scheme=https&_art=dD0xNzY4NDU2NzE2JmQ9OGJiYTc3MmNmYjNjMWZkMjkxZGY",
+      "homepage": "https://streams.ilovemusic.de/",
+      "country": "DE",
+      "tags": [
+        "edm",
+        "i love dance first!",
+        "ilove dance first!"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-antenne-bayern-oldies-but-goldies",
+      "name": "Antenne Bayern - Oldies but Goldies",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.oldie-antenne.de/oldie-antenne/stream/mp3",
+      "homepage": "https://antenne.de/",
+      "country": "DE",
+      "tags": [
+        "misc"
+      ],
+      "favicon": "https://antenne.de/logos/station-antenne-bayern/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-bdj-eurodance-90s",
+      "name": "BDJ Eurodance 90s",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-90s.bdjradio.com/",
+      "homepage": "https://bdjradio.com/90s/index.html",
+      "country": "DE",
+      "favicon": "https://bdjradio.com/media/images/bdj-eurodance-90s-456214.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1000-70er-laut-fm",
+      "name": "1000 70er - laut.fm",
+      "broadcaster": "independent",
+      "streamUrl": "https://100070er.stream.laut.fm/100070er",
+      "homepage": "https://laut.fm/100070er",
+      "country": "DE",
+      "tags": [
+        "70er",
+        "oldies",
+        "pop",
+        "rock",
+        "soul"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0nlineradio-schlager-oldies",
+      "name": "0nlineradio SCHLAGER OLDIES",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.0nlineradio.com/schlager-oldies?ref=radiobrowser",
+      "homepage": "https://0nlineradio.com/",
+      "country": "DE",
+      "tags": [
+        "70s",
+        "80s",
+        "90s",
+        "disco",
+        "discofox",
+        "discofox+schlager"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-techno-on-radio",
+      "name": "- 0 N - Techno on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-techno.radionetz.de/0n-techno.mp3",
+      "homepage": "https://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "dance",
+        "deephouse",
+        "electro",
+        "electronic",
+        "techhouse",
+        "techno"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-techno_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-wdr3-256",
+      "name": "wdr3 256",
+      "broadcaster": "independent",
+      "streamUrl": "https://wdr-wdr3-live.icecastssl.wdr.de/wdr/wdr3/live/mp3/256/stream.mp3",
+      "homepage": "https://wdr-wdr3-live.icecastssl.wdr.de/wdr/wdr3/live/mp3/256/stream.mp3",
+      "country": "DE",
+      "tags": [
+        "klassik"
+      ],
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-klassik-by-rautemusik-rm-fm",
+      "name": "__KLASSIK__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://klassik-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://www.rm.fm/klassik",
+      "country": "DE",
+      "tags": [
+        "classic",
+        "classic hits",
+        "classical",
+        "klassik"
+      ],
+      "favicon": "https://www.rm.fm/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-rock-antenne-70er-rock-mp3",
+      "name": "ROCK ANTENNE 70er Rock (MP3)",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2-webradio.rockantenne.de/70er-rock/stream/mp3",
+      "homepage": "https://www.rockantenne.de/",
+      "country": "DE",
+      "tags": [
+        "70's",
+        "classic rock"
+      ],
+      "favicon": "https://www.rockantenne.de/logos/station-rock-antenne/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-schwany-weihnacht",
+      "name": "Schwany Weihnacht",
+      "broadcaster": "independent",
+      "streamUrl": "https://schwany.streampanel.cloud/14-weihnacht",
+      "homepage": "http://schwany.de/",
+      "country": "DE",
+      "tags": [
+        "volksmusik",
+        "weihnachten"
+      ],
+      "favicon": "http://schwany.de/images/Radio-Schwany-Weihnacht-Logo-600-x-600-px-mit-www.jpg",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1-a-entspannt-von-1a-radio",
+      "name": "- 1 A - Entspannt von 1A Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://1a-entspannt.radionetz.de/1a-entspannt.mp3",
+      "homepage": "http://www.1aradio.com/",
+      "country": "DE",
+      "tags": [
+        "chillout",
+        "easy listening",
+        "jazz",
+        "various"
+      ],
+      "favicon": "https://www.1aradio.com/logos/1a-entspannt_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1-a-deutsch-rap-von-1a-radio",
+      "name": "- 1 A - Deutsch Rap von 1A Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://1a-deutschrap.radionetz.de/1a-deutschrap.mp3",
+      "homepage": "http://www.1aradio.com/",
+      "country": "DE",
+      "tags": [
+        "hip hop",
+        "rap",
+        "urban"
+      ],
+      "favicon": "https://www.1aradio.com/logos/1a-deutsch-rap_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-swr1",
+      "name": "SWR1",
+      "broadcaster": "independent",
+      "streamUrl": "https://f121.rndfnk.com/ard/swr/swr1/bw/mp3/128/stream.mp3?cid=01FC1X3K2Z71SMDKMEC68DM7MW&sid=38Gm6dGXmN9qJODTt2jxHj3IW9Q&token=BzI6w0PSAZ9vG7xsgGi3EnRu1ppRlMe7KsArb4c9qK0&tvf=fAp2mhjRihhmMTIxLnJuZGZuay5jb20",
+      "homepage": "https://www.swr.de/swr1/index.html",
+      "country": "DE",
+      "favicon": "https://www.swr.de/assets/swr/swr1/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-80er-revival",
+      "name": "80er-Revival",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/80er-revival",
+      "homepage": "https://www.80er-revival.de/",
+      "country": "DE",
+      "tags": [
+        "1980s",
+        "80er",
+        "italo disco",
+        "ndw",
+        "new wave",
+        "oldies"
+      ],
+      "favicon": "https://www.80er-revival.de/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-antenne-bayern-bayerische-weihnacht",
+      "name": "Antenne Bayern - Bayerische Weihnacht",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.antenne.de/bayerische-weihnacht/stream/mp3",
+      "homepage": "https://www.antenne.de/webradio/bayerische-weihnacht",
+      "country": "DE",
+      "tags": [
+        "christmas",
+        "classical"
+      ],
+      "favicon": "https://www.antenne.de/logos/station-antenne-bayern/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ne-ws-89-4",
+      "name": "NE-WS 89.4",
+      "broadcaster": "independent",
+      "streamUrl": "https://news894--di--nacs-ais-lgc--0a--cdn.cast.addradio.de/news894/live/mp3/high",
+      "homepage": "https://www.news894.de/",
+      "country": "DE",
+      "favicon": "https://www.news894.de/assets/images/favicons/news894/favicon_x96.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0nlineradio-cinema-hits",
+      "name": "0nlineradio CINEMA HITS",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.0nlineradio.com/cinema-hits?ref=radiobrowser",
+      "homepage": "https://0nlineradio.com/",
+      "country": "DE",
+      "tags": [
+        "cinema",
+        "movie",
+        "movie soundtracks",
+        "movies",
+        "soundtracks"
+      ],
+      "favicon": "https://i.ibb.co/NysqyMR/cinema-hits.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.2893,
+        8.2617
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-antenne-bayern-2000er-hits",
+      "name": "Antenne Bayern - 2000er Hits",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2-webradio.antenne.de/2000er-hits",
+      "homepage": "https://www.antenne.de/",
+      "country": "DE",
+      "favicon": "https://www.antenne.de/logos/station-antenne-bayern/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-kuschelrock",
+      "name": "Kuschelrock",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/kuschelrock",
+      "homepage": "https://softrock.ch/",
+      "country": "DE",
+      "favicon": "https://softrock.ch/wp-content/uploads/2020/12/cropped-cropped-4aba99803d183f31ddfb950ca799e9c6-150x150-1-180x180.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-rock-antenne-80er-rock-mp3",
+      "name": "ROCK ANTENNE 80er Rock (MP3)",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rockantenne.de/80er-rock/stream/mp3",
+      "homepage": "https://www.rockantenne.de/",
+      "country": "DE",
+      "tags": [
+        "80's",
+        "classic rock"
+      ],
+      "favicon": "https://www.rockantenne.de/logos/station-rock-antenne/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-karneval-by-rautemusik-rm-fm",
+      "name": "__KARNEVAL__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://karneval-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://www.rm.fm/karneval",
+      "country": "DE",
+      "tags": [
+        "carnaval",
+        "carnival",
+        "cologne",
+        "disco",
+        "discofox",
+        "german"
+      ],
+      "favicon": "https://i.ibb.co/GHPKzgV/karneval.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-evergreens-on-radio",
+      "name": "- 0 N - Evergreens on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-evergreens.radionetz.de/0n-evergreens.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "60er",
+        "60s",
+        "70er",
+        "70s",
+        "80er",
+        "80s"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-evergreens_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-juka-radio-tophits",
+      "name": "juka radio tophits",
+      "broadcaster": "independent",
+      "streamUrl": "https://juka-radio.stream.laut.fm/juka-radio?t302=2021-04-01_09-08-21&uuid=ecbcab5b-a799-4581-bc34-b292c056efbd",
+      "homepage": "https://juka-radio.de/",
+      "country": "DE",
+      "tags": [
+        "24/7",
+        "hot hits",
+        "top 100",
+        "top hits"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0nlineradio-classic-rock",
+      "name": "0nlineradio CLASSIC ROCK",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.0nlineradio.com/classic-rock?ref=radiobrowser",
+      "homepage": "https://0nlineradio.com/",
+      "country": "DE",
+      "tags": [
+        "active rock",
+        "classic rock",
+        "classical",
+        "classics",
+        "rock",
+        "rock'n'roll"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.9584,
+        8.6133
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-party-on-radio",
+      "name": "- 0 N - Party on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-party.radionetz.de/0n-party.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "dance",
+        "discofox",
+        "pop",
+        "schlager"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-party_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-dish-fm",
+      "name": "Dish FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://server27166.streamplus.de/stream.mp3?shoutcast",
+      "homepage": "https://www.dishfm.de/",
+      "country": "DE",
+      "tags": [
+        "chill",
+        "electronic",
+        "house",
+        "internet radio",
+        "music",
+        "radio online"
+      ],
+      "favicon": "https://www.dishfm.de/images/logo.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1-a-volksmusik-von-1a-radio",
+      "name": "- 1 A - Volksmusik von 1A Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://1a-volksmusik.radionetz.de/1a-volksmusik.mp3",
+      "homepage": "http://www.1aradio.com/",
+      "country": "DE",
+      "tags": [
+        "schlager",
+        "volksmusik"
+      ],
+      "favicon": "https://www.1aradio.com/logos/1a-volksmusik_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-sr2-kulturradio",
+      "name": "SR2 Kulturradio",
+      "broadcaster": "independent",
+      "streamUrl": "https://f131.rndfnk.com/ard/sr/sr2/mp3/128/stream.mp3?aggregator=web&sid=2AcIChGD4UajakncGfrTM4Luw2m&token=22MZpE9iYFWN_F5-aAwNzTTXesRGdOZS5XLWXw1bDT8&tvf=pXLt81Xk-BZmMTMxLnJuZGZuay5jb20",
+      "homepage": "https://www.sr.de/sr/sr2/index.html",
+      "country": "DE",
+      "favicon": "https://www.sr.de/sr/static/images/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1live-rnb-hip-hop",
+      "name": "1LIVE RnB & Hip Hop",
+      "broadcaster": "independent",
+      "streamUrl": "https://wdr-1live-hiphoprnb.icecast.wdr.de/wdr/1live/hiphoprnb/mp3/128/stream.mp3",
+      "homepage": "https://www1.wdr.de/radio/1live/musik/1live-streams/loopstream-1live-rnb-hiphop-100.html",
+      "country": "DE",
+      "tags": [
+        "hip hop",
+        "rap hiphop rnb",
+        "rnb"
+      ],
+      "favicon": "https://www1.wdr.de/radio/1live/app/loopstream-1live-rnb-hip-hop-100~_v-TeaserAufmacher.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-lounge-hotel-lounge",
+      "name": "Epic Lounge - HOTEL LOUNGE",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-lounge.com/hotel-lounge?ref=radiobrowser",
+      "homepage": "https://epic-lounge.com/",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "jazz",
+        "lounge",
+        "lounge music"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-klassik-on-radio",
+      "name": "- 0 N - Klassik on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-klassik.radionetz.de/0n-klassik.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "classical",
+        "klassik"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-klassik_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-bayern-1-schwaben",
+      "name": "Bayern 1 Schwaben",
+      "broadcaster": "independent",
+      "streamUrl": "https://dispatcher.rndfnk.com/br/br1/schwaben/mp3/mid",
+      "homepage": "https://www.br.de/radio/bayern1/index.html",
+      "country": "DE",
+      "tags": [
+        "oldies"
+      ],
+      "favicon": "https://api.ardmediathek.de/image-service/images/urn:ard:image:b366004f6196d70c?w=512",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-lounge-restaurant-lounge",
+      "name": "Epic Lounge - RESTAURANT LOUNGE",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-lounge.com/restaurant-lounge?ref=radiobrowser",
+      "homepage": "https://epic-lounge.com/",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "ambient and relaxation music",
+        "chill",
+        "chillout",
+        "chillout+lounge",
+        "lounge"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.0759,
+        9.6094
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radiomonster-fm-evergreens",
+      "name": "Radiomonster.FM - Evergreens",
+      "broadcaster": "independent",
+      "streamUrl": "https://ic.radiomonster.fm/evergreens.ultra",
+      "homepage": "http://www.radiomonster.fm/",
+      "country": "DE",
+      "tags": [
+        "evergreens",
+        "radiomonster"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ultra-dark-radio",
+      "name": "Ultra Dark Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ultradarkradio.stream.laut.fm/ultradarkradio",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "DE",
+      "tags": [
+        "rock"
+      ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/2/34162.v1.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1-a-christmas-on-radio",
+      "name": "- 1 A - Christmas on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://1a-christmas.radionetz.de/1a-christmas.mp3",
+      "homepage": "http://www.1aradio.com/",
+      "country": "DE",
+      "tags": [
+        "christmas",
+        "holiday",
+        "jazz",
+        "oldies",
+        "season",
+        "weihnachten"
+      ],
+      "favicon": "https://www.1aradio.com/logos/1a-christmas_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-swr4-ulm",
+      "name": "SWR4 Ulm",
+      "broadcaster": "independent",
+      "streamUrl": "https://liveradio.swr.de/sw282p3/swr4ul/",
+      "homepage": "https://www.swr.de/swraktuell/baden-wuerttemberg/ulm/index.html",
+      "country": "DE",
+      "tags": [
+        "easy listening"
+      ],
+      "favicon": "https://www.swr.de/assets/swr/swraktuell/apple-touch-icon-120x120.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-100-5-das-hitradio-alemannia-livestream",
+      "name": "100,5 DAS HITRADIO Alemannia-Livestream",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.dashitradio.de/alemannia/mp3-128/stream.mp3",
+      "homepage": "https://stream.dashitradio.de/alemannia/mp3-128/stream.mp3",
+      "country": "DE",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.7756,
+        6.0839
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-gold",
+      "name": "radio Gold",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiogold-live.cast.addradio.de/radiogold/live/mp3/high/stream.mp3",
+      "homepage": "https://www.radiogold.de/",
+      "country": "DE",
+      "tags": [
+        "american top 40",
+        "at40"
+      ],
+      "favicon": "https://www.radiogold.de/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        52.4814,
+        13.3594
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-berliner-rundfunk",
+      "name": "Berliner Rundfunk",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.berliner-rundfunk.de/brf/mp3-128/?ref=radioplayer&=&&___cb=339744594540955",
+      "homepage": "https://www.berliner-rundfunk.de/",
+      "country": "DE",
+      "favicon": "https://upload.berliner-rundfunk.de/production/static/1688453791035/icons/icon_512.a80y02808w0.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-synthwave-neon-city-laut-fm",
+      "name": "Synthwave Neon City laut.fm",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/synthwave",
+      "homepage": "https://laut.fm/synthwave",
+      "country": "DE",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-egofm-soundtrack",
+      "name": "egoFM Soundtrack",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast.egofm.de/egofmsoundtrack.mp3",
+      "homepage": "https://www.egofm.de/",
+      "country": "DE",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-deutsch-pop-on-radio",
+      "name": "- 0 N - Deutsch Pop on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-deutschpop.radionetz.de/0n-deutschpop.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "balladen",
+        "pop",
+        "rock",
+        "schlager"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-deutsch-pop_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-berliner-rundfunk-100-deutsch",
+      "name": "Berliner Rundfunk - 100% deutsch",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.berliner-rundfunk.de/brf-100prozent-deutsch/mp3-128/?ref=radiode",
+      "homepage": "https://www.berliner-rundfunk.de/",
+      "country": "DE",
+      "favicon": "https://upload.berliner-rundfunk.de/production/static/1693298496587/icons/icon_64.a80y02808w0.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-classical-classical-love-music",
+      "name": "EPIC CLASSICAL - Classical Love Music",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-classical.com/classical-love-music",
+      "homepage": "https://epic-classical.com/",
+      "country": "DE",
+      "tags": [
+        "ambient and relaxation music",
+        "classic",
+        "classical",
+        "klassik",
+        "love",
+        "love songs"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-swr1-baden-wurttemberg",
+      "name": "SWR1 Baden Württemberg ",
+      "broadcaster": "independent",
+      "streamUrl": "https://liveradio.swr.de/sw890cl/swr1bw/",
+      "homepage": "https://swr1.de/",
+      "country": "DE",
+      "tags": [
+        "classic rock",
+        "news",
+        "pop music"
+      ],
+      "favicon": "https://swr1.de/favicon.ico",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-liszt-by-epic-piano",
+      "name": "LISZT by Epic Piano",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-piano.com/liszt?ref=radiobrowser",
+      "homepage": "https://epic-piano.com/",
+      "country": "DE",
+      "tags": [
+        "classic",
+        "classical",
+        "classical music",
+        "classical piano",
+        "classics",
+        "klassik"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.461,
+        8.2617
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-mdr-jump-im-osten-zu-hause-und-immer-deine-liebl",
+      "name": "MDR JUMP - Im Osten zu Hause und immer deine Lieblingshits!",
+      "broadcaster": "independent",
+      "streamUrl": "https://mdr-radio-hls.akamaized.net/hls/live/2112904/mdr-284320-0-hls/index.m3u8",
+      "homepage": "https://www.mdrjump.de/radio/index.html",
+      "country": "DE",
+      "tags": [
+        "2000er",
+        "2010er",
+        "2020er",
+        "80er",
+        "90er",
+        "ard"
+      ],
+      "favicon": "https://www.mdrjump.de/resources/jump/img/favicons/favicon-512x512.png",
+      "bitrate": 102,
+      "codec": "AAC",
+      "geo": [
+        51.4813,
+        11.9646
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-die-neue-107-7-oldies",
+      "name": "Die Neue 107.7 - OLDIES",
+      "broadcaster": "independent",
+      "streamUrl": "https://dieneue1077.cast.addradio.de/dieneue1077/oldie/high/stream.mp3?ar-purpose=web&ar-distributor=f0b7",
+      "homepage": "https://dieneue1077.de/radioplayer/oldies/",
+      "country": "DE",
+      "favicon": "https://upload.dieneue1077.de/production/static/1713539298713/icons/icon_64.ax1w460g800.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-vinyl-maxi-fm",
+      "name": "Vinyl Maxi FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://vinyl-maxi-fm.stream.laut.fm/vinyl-maxi-fm?t302=2026-01-15_00-13-00&uuid=1d247b88-8cbe-462c-be39-bc2af72ca582",
+      "homepage": "https://laut.fm/vinyl-maxi-fm",
+      "country": "DE",
+      "tags": [
+        "decades"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-krasse-weihnachten-by-rautemusik-rm-fm",
+      "name": "__KRASSE WEIHNACHTEN__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://weihnachten-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://www.rm.fm/weihnachten",
+      "country": "DE",
+      "tags": [
+        "baladas",
+        "christmas",
+        "christmas music",
+        "classic hits",
+        "hits",
+        "klassik weihnachten christmas"
+      ],
+      "favicon": "https://www.rm.fm/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-hot-on-radio",
+      "name": "- 0 N - Hot on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-hot.radionetz.de/0n-hot.aac",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "dance",
+        "hits",
+        "house",
+        "pop",
+        "rock",
+        "top40"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-hot_600x600.jpg",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1000-goldies",
+      "name": "1000 GOLDIES",
+      "broadcaster": "independent",
+      "streamUrl": "https://1000goldies.stream.laut.fm/1000goldies?t302=2026-01-15_05-47-39&uuid=3ab95a19-1c96-4c55-8e81-bef2637010de",
+      "homepage": "https://laut.fm/1000goldies",
+      "country": "DE",
+      "tags": [
+        "60s",
+        "70s",
+        "80s",
+        "90s",
+        "goldies",
+        "oldies"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        53.0799,
+        8.8148
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-tschaikowski-by-epic-piano",
+      "name": "TSCHAIKOWSKI by Epic Piano",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-piano.com/tschaikowski?ref=radiobrowser",
+      "homepage": "https://epic-piano.com/",
+      "country": "DE",
+      "tags": [
+        "classical",
+        "classical piano",
+        "instrumental",
+        "klassik",
+        "piano",
+        "piano jazz"
+      ],
+      "favicon": "https://i.ibb.co/hLKJJQS/Tschaikovski-PIANO.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.6843,
+        8.6133
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-deutschlandfunk-nova-dlf-aac-96k",
+      "name": "Deutschlandfunk Nova | DLF | AAC 96k",
+      "broadcaster": "independent",
+      "streamUrl": "https://st03.sslstream.dlf.de/dlf/03/mid/aac/stream.aac?aggregator=web",
+      "homepage": "https://www.deutschlandfunknova.de/",
+      "country": "DE",
+      "tags": [
+        "culture",
+        "news",
+        "public service",
+        "information"
+      ],
+      "favicon": "https://www.deutschlandfunknova.de/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        52.4803,
+        13.3348
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-lovehits-by-rautemusik-rm-fm",
+      "name": "__LOVEHITS__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://lovehits-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://www.rm.fm/lovehits",
+      "country": "DE",
+      "tags": [
+        "hits",
+        "hot hits",
+        "liebe",
+        "liebeslieder",
+        "love",
+        "love songs"
+      ],
+      "favicon": "https://i.ibb.co/thKTGN3/lovehits.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-deutschlandfunk-dokumente-und-debatten-dlf-aac-4",
+      "name": "Deutschlandfunk Dokumente und Debatten | DLF | AAC 48k",
+      "broadcaster": "independent",
+      "streamUrl": "https://st04.sslstream.dlf.de/dlf/04/low/aac/stream.aac?aggregator=web",
+      "homepage": "https://www.deutschlandradio.de/dokumente-und-debatten-102.html",
+      "country": "DE",
+      "tags": [
+        "debate",
+        "debatten",
+        "documentation",
+        "sondersendungen",
+        "special broadcast",
+        "talk"
+      ],
+      "favicon": "https://www.deutschlandradio.de/static/img/deutschlandradio/icons/apple-touch-icon-128x128.png",
+      "bitrate": 48,
+      "codec": "AAC",
+      "geo": [
+        52.4803,
+        13.3348
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-westfalica",
+      "name": "Radio Westfalica",
+      "broadcaster": "independent",
+      "streamUrl": "https://addrad.io/444zbcj",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "DE",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-technolovers-latin-house",
+      "name": "Technolovers LATIN HOUSE",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.technolovers.fm/latinhouse?ref=radiobrowser",
+      "homepage": "https://technolovers.fm/",
+      "country": "DE",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-rock-antenne-modern-metal",
+      "name": "Rock Antenne Modern Metal",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rockantenne.de/modern-metal/stream/mp3",
+      "homepage": "https://www.rockantenne.de/",
+      "country": "DE",
+      "tags": [
+        "heavy metal",
+        "metal"
+      ],
+      "favicon": "https://www.rockantenne.de/logos/station-rock-antenne/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-deutsche-welle-tv",
+      "name": "Deutsche Welle TV",
+      "broadcaster": "independent",
+      "streamUrl": "https://dwamdstream102.akamaized.net/hls/live/2015525/dwstream102/stream05/streamPlaylist.m3u8",
+      "homepage": "https://www.dw.com/de/live-tv/channel-english",
+      "country": "DE",
+      "tags": [
+        "auslandsfernsehen",
+        "deutsche welle",
+        "dw english",
+        "dw hd",
+        "livestream",
+        "staatsfunk"
+      ],
+      "codec": "UNKNOWN",
+      "geo": [
+        52.5106,
+        13.3794
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-world-club-dome-radio-das-offizielle-radio-des-w",
+      "name": "WORLD CLUB DOME Radio - Das offizielle Radio des WORLD CLUB DOME Festivals mit den besten DJ-Sets und dem Livestream vom größten Club der Welt - Dance, Electro, EDM, Techno, DJ Live Sets",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.worldclubdome.com/wcd-radio/mp3-192?ref=radiobrowser",
+      "homepage": "https://www.worldclubdome.com/radio",
+      "country": "DE",
+      "tags": [
+        "#dj",
+        "#edm",
+        "bigroom",
+        "dance",
+        "dance house club  electronic techhouse",
+        "dance music"
+      ],
+      "favicon": "https://i.ibb.co/xtxNVZnG/Logo-WORLD-CLUB-DOME-Radio-2500x2500.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        49.9378,
+        8.7713
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-bayern-1-niederbayern-oberpfalz",
+      "name": "Bayern 1 Niederbayern / Oberpfalz",
+      "broadcaster": "independent",
+      "streamUrl": "https://dispatcher.rndfnk.com/br/br1/nbopf/mp3/mid",
+      "homepage": "https://www.br.de/radio/bayern1/index.html",
+      "country": "DE",
+      "tags": [
+        "oldies"
+      ],
+      "favicon": "https://api.ardmediathek.de/image-service/images/urn:ard:image:b366004f6196d70c?w=512",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-i-love-the-beach",
+      "name": "I love the beach",
+      "broadcaster": "independent",
+      "streamUrl": "https://ilm.stream35.radiohost.de/ilm_ilovethebeach_mp3-192?upd-meta&upd-scheme=https&_art=dD0xNzY4NDUwODI4JmQ9YWVjYzRkNzE5MzNhN2E2Nzk0NWI",
+      "homepage": "https://www.ilovemusic.de/ilovethebeach/",
+      "country": "DE",
+      "tags": [
+        "chillout",
+        "deep house",
+        "pool beach bar"
+      ],
+      "favicon": "https://www.ilovemusic.de/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ibiza-chillout-lounge-ambient-deep-house-baleari",
+      "name": "IBIZA CHILLOUT LOUNGE - Ambient, Deep House, Balearic, Smooth Jazz, Acoustic, Chill House, Lo-Fi, Chillwave, Dream Pop, Electro, Tropical House, Sunset Chill, Café del Mar, Soft Electronica, Slow House, Ambient, Relax, Easy Listening, Beach Vibes, Summer",
+      "broadcaster": "independent",
+      "streamUrl": "https://0nlineradio.radioho.st/lounge-ibiza-chillout-lounge?ref=rb26",
+      "homepage": "https://0nlineradio.com/",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "balearic",
+        "balearic house",
+        "beach",
+        "club dance",
+        "dance"
+      ],
+      "favicon": "https://i.ibb.co/jPkfdprq/rb-Ibiza.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.1433,
+        6.8112
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-swr4-koblenz",
+      "name": "swr4 koblenz",
+      "broadcaster": "independent",
+      "streamUrl": "https://liveradio.swr.de/sw282p3/swr4ko/",
+      "homepage": "https://www.swr.de/",
+      "country": "DE",
+      "tags": [
+        "oldies",
+        "schlagerhits",
+        "volksmusik"
+      ],
+      "favicon": "https://www.swr.de/assets/swr/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3521,
+        7.619
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-classical-classical-restaurant-music",
+      "name": "EPIC CLASSICAL - Classical Restaurant Music",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-classical.com/classical-restaurant-music",
+      "homepage": "https://epic-classical.com/",
+      "country": "DE",
+      "tags": [
+        "#",
+        "chillout",
+        "classic",
+        "classical",
+        "classical music",
+        "instrumental"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.2585,
+        7.793
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-classical-modern-classical",
+      "name": "EPIC CLASSICAL - Modern Classical ",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-classical.com/modern-classical",
+      "homepage": "https://epic-classical.com/",
+      "country": "DE",
+      "tags": [
+        "classical",
+        "classical music",
+        "jazz",
+        "klassik",
+        "modern",
+        "modern classical"
+      ],
+      "favicon": "https://i.ibb.co/375rVWt/Modern.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-i-love-music-mainstage-madness",
+      "name": "I Love Music - Mainstage Madness",
+      "broadcaster": "independent",
+      "streamUrl": "https://ilm.stream18.radiohost.de/ilm_ilovemainstagemadness_mp3-192?upd-meta&upd-scheme=https&_art=dD0xNzY4NDM5NjA5JmQ9OTFlNjYyYTM4Zjk3MjY1ZDg2NmM",
+      "homepage": "https://www.ilovemusic.de/",
+      "country": "DE",
+      "tags": [
+        "bigroom",
+        "electro",
+        "hardstyle",
+        "house",
+        "party"
+      ],
+      "favicon": "https://www.ilovemusic.de/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-classical-classical-lounge",
+      "name": "EPIC CLASSICAL - Classical Lounge",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-classical.com/classical-lounge",
+      "homepage": "https://epic-classical.com/",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "ambient and relaxation music",
+        "ambiental",
+        "chillout",
+        "chillout+lounge",
+        "classical"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-reyfm-hits2k",
+      "name": "REYFM - #Hits2K",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.reyfm.de/reyfm-hits2k/",
+      "homepage": "https://rey.fm/",
+      "country": "DE",
+      "tags": [
+        "hits",
+        "music"
+      ],
+      "favicon": "https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1live-chillout",
+      "name": "1LIVE Chillout",
+      "broadcaster": "independent",
+      "streamUrl": "https://wdr-1live-chillout.icecast.wdr.de/wdr/1live/chillout/mp3/128/stream.mp3",
+      "homepage": "https://www1.wdr.de/radio/1live/musik/1live-streams/loopstream-1live-chillout-100.html",
+      "country": "DE",
+      "tags": [
+        "chillout"
+      ],
+      "favicon": "https://www1.wdr.de/radio/1live/resources-v5.143.2/img/favicon/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-netlabel-org-germany",
+      "name": "Netlabel.org (Germany)",
+      "broadcaster": "independent",
+      "streamUrl": "https://netlabelorg.stream.laut.fm/netlabel_org",
+      "homepage": "https://netlabel.org/",
+      "country": "DE",
+      "tags": [
+        "accoustic",
+        "dj sets",
+        "drum and bass",
+        "electronic",
+        "house",
+        "madewithheart"
+      ],
+      "favicon": "https://netlabel.org/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-just-90s",
+      "name": "Just 90s",
+      "broadcaster": "independent",
+      "streamUrl": "https://just90s.stream.laut.fm/just90s",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "DE",
+      "tags": [
+        "pop"
+      ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/0/54170.v8.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-deutschlandfunk-kultur-dlf-opus-64k",
+      "name": "Deutschlandfunk Kultur | DLF | OPUS 64k",
+      "broadcaster": "independent",
+      "streamUrl": "https://st02.sslstream.dlf.de/dlf/02/high/opus/stream.opus?aggregator=web",
+      "homepage": "https://www.deutschlandfunkkultur.de/",
+      "country": "DE",
+      "tags": [
+        "culture",
+        "news",
+        "public service",
+        "information"
+      ],
+      "favicon": "https://www.deutschlandfunkkultur.de/static/img/deutschlandfunk_kultur/icons/apple-touch-icon-128x128.png",
+      "bitrate": 64,
+      "codec": "OGG",
+      "geo": [
+        52.4803,
+        13.3348
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-i-love-bass-by-hbz",
+      "name": "I Love Bass by HBz",
+      "broadcaster": "independent",
+      "streamUrl": "https://ilm.stream35.radiohost.de/ilm_ilovebass_mp3-192?upd-meta&upd-scheme=https&_art=dD0xNzY4NDMzMDg5JmQ9MjI5MmNkY2FhZWZjZDg0OThjMGY",
+      "homepage": "https://www.ilovemusic.de/ilovebass/",
+      "country": "DE",
+      "favicon": "https://www.ilovemusic.de/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-trigger-fm",
+      "name": "Trigger.FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://takeoff.jetstre.am/?account=bbm&file=trigger128SD&type=live&service=icecast&protocol=https&port=8000&output=pls",
+      "homepage": "http://www.trigger.fm/",
+      "country": "DE",
+      "favicon": "https://triggerfm.com/wp-content/uploads/2023/09/512x512-trigger-logo.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-gamernetfm",
+      "name": "GamerNETfm",
+      "broadcaster": "independent",
+      "streamUrl": "https://gamernetfm.stream.laut.fm/gamernetfm",
+      "homepage": "https://gamernet.eu/Radio",
+      "country": "DE",
+      "tags": [
+        "bass",
+        "gaming",
+        "hardbass",
+        "hardstyle",
+        "remix",
+        "remixes"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-sunrise",
+      "name": "Radio Sunrise",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio-sunrise.stream.laut.fm/radio-sunrise",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "DE",
+      "tags": [
+        "electronic"
+      ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/8/60498.v4.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0nlineradio-2010er",
+      "name": "0nlineradio 2010er",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.0nlineradio.com/2010er?ref=radiobrowser",
+      "homepage": "https://0nlineradio.com/",
+      "country": "DE",
+      "tags": [
+        "2010's",
+        "2010er",
+        "2010s",
+        "charts",
+        "edm",
+        "electro"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.1793,
+        8.6133
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-lounge-summer-lounge",
+      "name": "Epic Lounge - SUMMER LOUNGE",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-lounge.com/summer-lounge",
+      "homepage": "https://epic-lounge.com/",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "ambient and relaxation music",
+        "chillout",
+        "lounge",
+        "relax",
+        "relaxation music"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-rock-antenne-modern-rock",
+      "name": "Rock Antenne Modern Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://s4-webradio.rockantenne.de/modern-rock/stream",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "DE",
+      "tags": [
+        "rock"
+      ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/0/102910.v1.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-lounge-soul-lounge",
+      "name": "Epic Lounge - SOUL LOUNGE",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-lounge.com/soul-lounge?ref=radiobrowser",
+      "homepage": "https://epic-lounge.com/",
+      "country": "DE",
+      "tags": [
+        "ambient and relaxation music",
+        "chill",
+        "chillout",
+        "chillout+lounge",
+        "classic soul",
+        "lounge"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.8961,
+        8.9062
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-sportschau-live-1-bundesliga-spiel-7",
+      "name": "Sportschau live: 1.Bundesliga / Spiel 7",
+      "broadcaster": "independent",
+      "streamUrl": "https://wdr-sportschau-liga1spiel7.icecastssl.wdr.de/wdr/sportschau/liga1spiel7/mp3/high?file=.mp3",
+      "homepage": "https://www.sportschau.de/sportimradio/audiostream-netcast-uebersicht-100.html",
+      "country": "DE",
+      "tags": [
+        "live sports"
+      ],
+      "favicon": "https://www.sportschau.de/resources/assets/image/favicon/apple-icon-152x152.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-alpenweihnacht",
+      "name": "Alpenweihnacht",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/alpenweihnacht",
+      "homepage": "https://alpenweihnacht.de/",
+      "country": "DE",
+      "tags": [
+        "alpen",
+        "volksmusik",
+        "weihnachten"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        47.8368,
+        12.1289
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-deutschlandfunk-dokumente-und-debatten-dlf-aac-1",
+      "name": "Deutschlandfunk Dokumente und Debatten | DLF | AAC 192k",
+      "broadcaster": "independent",
+      "streamUrl": "https://st04.sslstream.dlf.de/dlf/04/high/aac/stream.aac?aggregator=web",
+      "homepage": "https://www.deutschlandradio.de/dokumente-und-debatten-102.html",
+      "country": "DE",
+      "tags": [
+        "debate",
+        "debatten",
+        "documentation",
+        "sondersendungen",
+        "special broadcast",
+        "talk"
+      ],
+      "favicon": "https://www.deutschlandradio.de/static/img/deutschlandradio/icons/apple-touch-icon-128x128.png",
+      "bitrate": 192,
+      "codec": "AAC",
+      "geo": [
+        52.4803,
+        13.3348
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-pop-lounge-cafe",
+      "name": "POP LOUNGE CAFE ",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/poploungecafe",
+      "homepage": "https://poploungecafe.com/",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "chillout",
+        "deep house",
+        "electronic",
+        "lounge",
+        "pop"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        53.0757,
+        8.8071
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-ffn-80er",
+      "name": "Radio FFN - 80er",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.ffn.de/ffn-80er/?ref=radio-browser",
+      "homepage": "https://www.ffn.de/",
+      "country": "DE",
+      "tags": [
+        "1980s",
+        "80er",
+        "80s",
+        "golden oldies",
+        "goldies",
+        "oldies"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-volksmusik-on-radio",
+      "name": "- 0 N - Volksmusik on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-volksmusik.radionetz.de/0n-volksmusik.aac",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "schlager",
+        "volksmusik"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-volksmusik_600x600.jpg",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-80s-mix-radio",
+      "name": "80s Mix Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://80s-mix-radio.stream.laut.fm/80s-mix-radio",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "DE",
+      "tags": [
+        "decades"
+      ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/7/82797.v7.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0nlineradio-deutschrock",
+      "name": "0nlineradio DEUTSCHROCK",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.0nlineradio.com/deutschrock?ref=radiobrowser",
+      "homepage": "https://0nlineradio.com/",
+      "country": "DE",
+      "tags": [
+        "deutschrock",
+        "german"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-japanradio-de",
+      "name": "Japanradio.de",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.japanradio.de/live",
+      "homepage": "https://www.japanradio.de/",
+      "country": "DE",
+      "tags": [
+        "anime",
+        "eurobeat",
+        "jpop",
+        "jrock",
+        "metal",
+        "video game music"
+      ],
+      "favicon": "https://japanradio.de/wp-content/uploads/2020/05/japanradiodeR01.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-lounge-cocktail-lounge",
+      "name": "Epic Lounge - COCKTAIL LOUNGE",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-lounge.com/cocktail-lounge?ref=radiobrowser",
+      "homepage": "https://epic-lounge.com/",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "ambient and relaxation music",
+        "chill",
+        "chillout",
+        "lounge",
+        "lounge music"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.5566,
+        9.6094
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-grieg-by-epic-piano",
+      "name": "GRIEG by Epic Piano",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-piano.com/grieg?ref=radiobrowser",
+      "homepage": "https://epic-piano.com/",
+      "country": "DE",
+      "tags": [
+        "classic hits",
+        "classical",
+        "classical piano",
+        "classics",
+        "instrumental",
+        "klassik"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.461,
+        8.6133
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ndr-kultur-aac-192",
+      "name": "NDR Kultur (AAC 192)",
+      "broadcaster": "independent",
+      "streamUrl": "https://f131.rndfnk.com/ard/ndr/ndrkultur/live/aac/192/stream.aac?aggregator=web&cid=01FBQ2EJ6T7QK3WENQ5KT9S2FB&sid=2aWrl15TtQvWg6RQ9hvrVfdh99E&token=cgylLQKukz6c0ajNCSHCboafG1Q474A1QN0WA3_K3Hg&tvf=4vGFz6J7pxdmMTMxLnJuZGZuay5jb20",
+      "homepage": "https://www.ndr.de/kultur/live/stationndrkultur102-radioplayer_livestream-livestream1112.html",
+      "country": "DE",
+      "favicon": "https://www.ndr.de/kultur/radio/audiothekndrkultur100_v-podcast.jpg",
+      "bitrate": 256,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-lounge-massage-lounge",
+      "name": "Epic Lounge - Massage Lounge",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-lounge.com/massage-lounge",
+      "homepage": "https://epic-lounge.com/",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "ambient lounge",
+        "chillout",
+        "chillout+lounge",
+        "easy listening",
+        "lounge"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.4505,
+        9.9609
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-classical-classical-oldies",
+      "name": "EPIC CLASSICAL - Classical Oldies",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-classical.com/classical-oldies",
+      "homepage": "https://epic-classical.com/",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "ambiente",
+        "classic",
+        "goldies",
+        "jazz",
+        "klassik"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-laut-fm-80er-pop",
+      "name": "Laut.FM 80er, Pop",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/80er",
+      "homepage": "https://laut.fm/80er",
+      "country": "DE",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-zusa",
+      "name": "Radio Zusa",
+      "broadcaster": "independent",
+      "streamUrl": "https://funkturm.radio-zusa.net:8443/opus",
+      "homepage": "http://zusa.de/",
+      "country": "DE",
+      "favicon": "http://zusa.de/images/favicon.ico",
+      "codec": "OGG",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0nlineradio-volksmusik",
+      "name": "0nlineradio VOLKSMUSIK",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.0nlineradio.com/volksmusik?ref=radiobrowser",
+      "homepage": "https://0nlineradio.com/",
+      "country": "DE",
+      "tags": [
+        "blasmusik",
+        "disco",
+        "discofox",
+        "german",
+        "schlager",
+        "volksmusik"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-classical-classical-christmas",
+      "name": "EPIC CLASSICAL - Classical Christmas",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-classical.com/classical-christmas",
+      "homepage": "https://epic-classical.com/",
+      "country": "DE",
+      "tags": [
+        "christian",
+        "christmas music",
+        "classic",
+        "classical",
+        "klassik",
+        "klassik weihnachten christmas"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-technolovers-lounge",
+      "name": "Technolovers - LOUNGE",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.technolovers.fm/lounge?ref=radiobrowser",
+      "homepage": "https://technolovers.fm/",
+      "country": "DE",
+      "tags": [
+        "chill",
+        "chillout",
+        "chillout+lounge",
+        "deep house",
+        "house",
+        "lounge"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-blues-on-radio",
+      "name": "- 0 N - Blues on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-blues.radionetz.de/0n-blues.aac",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "blues",
+        "r&b",
+        "rhythm & blues",
+        "soul"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-blues_600x600.jpg",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-best-of-80s",
+      "name": "Best of 80s",
+      "broadcaster": "independent",
+      "streamUrl": "https://bestof80s.stream.laut.fm/best_of_80s",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "DE",
+      "tags": [
+        "decades"
+      ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/0/42610.v1.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-maretimo-house-radio",
+      "name": "Maretimo House Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s35.derstream.net/house.mp3",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "DE",
+      "tags": [
+        "misc"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0nlineradio-party",
+      "name": "0nlineradio PARTY",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.0nlineradio.com/party?ref=radiobrowser",
+      "homepage": "https://0nlineradio.com/",
+      "country": "DE",
+      "tags": [
+        "apresski",
+        "dance",
+        "disco",
+        "discofox",
+        "discofox+schlager",
+        "edm"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-ffn-gold",
+      "name": "Radio FFN - Gold",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.ffn.de/ffn-gold/mp3-192?ref=radio-browser",
+      "homepage": "https://www.ffn.de/",
+      "country": "DE",
+      "tags": [
+        "60er",
+        "60s",
+        "70er",
+        "70s",
+        "80er",
+        "80s"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-ffn-hits",
+      "name": "Radio FFN - Hits*",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.ffn.de/ffn-hits/mp3-192?ref=radio-browser",
+      "homepage": "https://www.ffn.de/",
+      "country": "DE",
+      "tags": [
+        "charts",
+        "hits",
+        "pop",
+        "top 40",
+        "top charts",
+        "top40"
+      ],
+      "favicon": "https://i.ibb.co/h28n6TR/Logo-ffn-Hits.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-rock-antenne-gothic-2",
+      "name": "Rock Antenne - Gothic",
+      "broadcaster": "independent",
+      "streamUrl": "https://s3-webradio.rockantenne.de/gothic",
+      "homepage": "https://www.rockantenne.de/webradio/gothic",
+      "country": "DE",
+      "tags": [
+        "dark wave",
+        "ebm",
+        "gothic",
+        "metal",
+        "punk"
+      ],
+      "favicon": "https://www.rockantenne.de/logos/station-rock-antenne/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-ostfriesland-burgerradio",
+      "name": "Radio Ostfriesland Bürgerradio",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.radio-ostfriesland.de/ostfriesland.mp3",
+      "homepage": "https://ww2.radio-ostfriesland.de/",
+      "country": "DE",
+      "tags": [
+        "alternative",
+        "pop",
+        "rock"
+      ],
+      "favicon": "https://ww2.radio-ostfriesland.de/wp-content/uploads/2020/05/favicon.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        53.3694,
+        7.205
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-rock-antenne-biker-rock",
+      "name": "Rock Antenne Biker Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rockantenne.de/biker-rock/stream/",
+      "homepage": "https://www.rockantenne.de/",
+      "country": "DE",
+      "tags": [
+        "rock"
+      ],
+      "favicon": "https://www.rockantenne.de/logos/station-rock-antenne/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        52.0271,
+        9.7559
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-mk",
+      "name": "Radio MK",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.lokalradio.nrw/44542bb",
+      "homepage": "https://www.radiomk.de/",
+      "country": "DE",
+      "tags": [
+        "lokalradio",
+        "märkischer kreis",
+        "nordrhein-westfalen"
+      ],
+      "favicon": "https://www.radiomk.de/assets/images/senderlogos/radio_mk.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-oldie-antenne-80er-hits",
+      "name": "Oldie Antenne - 80er Hits",
+      "broadcaster": "independent",
+      "streamUrl": "https://s7-webradio.oldie-antenne.de/oldie-antenne-80er-hits/stream/mp3?aw_0_1st.playerid=OldieAntenneWebPlayer&aw_0_1st.skey=1706378427399&aw_0_req.userConsentV2=CP5CssAP5CssAAFADBDEAlEgAAAAAAAAAAYgAAAAAAEhIAMAAQL2DQAYAAgXsIgAwABAvYVABgACBewyADAAEC9h0AGAAIF7EIAMAAQL2JQAYAAgXsUgAwABAvYA.YAAAAAAAAAAA&companionAds=false&companion_zone_alias=41%2C42%2C40%2C731%2C752%2C756%2C768",
+      "homepage": "https://www.oldie-antenne.de/mediathek/webradio/80er-hits",
+      "country": "DE",
+      "tags": [
+        "80er",
+        "80s",
+        "oldies",
+        "pop",
+        "rock"
+      ],
+      "favicon": "https://www.oldie-antenne.de/media/cache/3/version/37897/oldie_80er_hits_2000x2000-v1.png/7e89fb3888c0cba3f06e0881fc336952.webp",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-pto-piratenteam-ostfriesland",
+      "name": "PTO - Piratenteam Ostfriesland",
+      "broadcaster": "independent",
+      "streamUrl": "https://c01.lexycast.de:4200/listen1",
+      "homepage": "https://piratenteam-ostfriesland.de/",
+      "country": "DE",
+      "tags": [
+        "diverses"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-antenne-unna",
+      "name": "Antenne Unna",
+      "broadcaster": "independent",
+      "streamUrl": "https://antenneunna--di--nacs-ais-lgc--07--cdn.cast.addradio.de/antenneunna/live/mp3/high",
+      "homepage": "https://www.antenneunna.de/",
+      "country": "DE",
+      "tags": [
+        "news",
+        "pop"
+      ],
+      "favicon": "https://www.antenneunna.de/assets/images/senderlogos/antenne_unna.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.5347,
+        7.689
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-rautemusik-caribbean-wave",
+      "name": "RauteMusik Caribbean Wave",
+      "broadcaster": "independent",
+      "streamUrl": "https://streams.rautemusik.fm/caribbean-wave/mp3-192/?ref=radiobrowser",
+      "homepage": "https://www.rm.fm/caribbean-wave",
+      "country": "DE",
+      "tags": [
+        "afro",
+        "afro-latin music",
+        "afro-pop",
+        "afrobeats",
+        "caribbean",
+        "caribbean music"
+      ],
+      "favicon": "https://i.ibb.co/nL15LGH/cw.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.9065,
+        8.2617
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-schlager-kult-on-radio",
+      "name": "- 0 N - Schlager Kult on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-schlagerkult.radionetz.de/0n-schlagerkult.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "oldies",
+        "schlager",
+        "world music"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-schlager-kult_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0nlineradio-brazil",
+      "name": "0nlineradio BRAZIL",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.0nlineradio.com/brazil?ref=radiobrowser",
+      "homepage": "https://0nlineradio.com/",
+      "country": "DE",
+      "tags": [
+        "bachata",
+        "brasil",
+        "brasilia",
+        "brazilian music",
+        "latin",
+        "latin music"
+      ],
+      "favicon": "https://i.ibb.co/s90pDjm/brazil.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.5134,
+        8.2617
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0nlineradio-karneval",
+      "name": "0nlineradio KARNEVAL",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.0nlineradio.com/karneval?ref=radiobrowser",
+      "homepage": "https://0nlineradio.com/",
+      "country": "DE",
+      "tags": [
+        "carnival",
+        "hits",
+        "karneval",
+        "live",
+        "party",
+        "rock"
+      ],
+      "favicon": "https://i.ibb.co/CJkTX9Q/karneval.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.7365,
+        8.3203
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-deutscher-soldatensender-von-1970",
+      "name": "Deutscher Soldatensender von 1970",
+      "broadcaster": "independent",
+      "streamUrl": "https://deutschersoldatensendervon1970.stream.laut.fm/deutscher_soldatensender_von_1970?t302=2026-01-15_07-15-24&uuid=12738ea1-febe-467d-8212-2b73cbf6c5a0",
+      "homepage": "http://laut.fm/Deutscher_Soldatensender_von_1970",
+      "country": "DE",
+      "tags": [
+        "70er",
+        "ohrwürmer",
+        "oldies",
+        "superhits"
+      ],
+      "favicon": "https://www.youtube.com/watch?v=DQ_sGpvSe0w",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        52.0882,
+        11.6226
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-lounge-workday-lounge",
+      "name": "Epic Lounge - WORKDAY LOUNGE",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-lounge.com/workday-lounge?ref=radiobrowser",
+      "homepage": "https://epic-lounge.com/",
+      "country": "DE",
+      "tags": [
+        "ambient and relaxation music",
+        "chillout",
+        "chillout+lounge",
+        "lo-fi",
+        "lofi",
+        "lounge"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.1173,
+        9.2578
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-rock-antenne-hard-rock",
+      "name": "Rock Antenne - Hard Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rockantenne.de/rock-antenne-hard-rock/stream/mp3",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "DE",
+      "tags": [
+        "hard rock",
+        "music",
+        "rock"
+      ],
+      "favicon": "https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-showagenten-radio-alles-deutsch",
+      "name": "SHOWAGENTEN RADIO - ALLES DEUTSCH",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.radioking.com/play/alles-deutsch/599126",
+      "homepage": "https://www.showagenten-radio.de/",
+      "country": "DE",
+      "favicon": "https://www.radioking.com/api/track/cover/bb2b5cc2-106a-419e-9b6e-b688c2040a45?width=160&height=160",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-str-space-travel-radio",
+      "name": "STR - Space Travel Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://spacetravelradio.de:2893/stream/2/",
+      "homepage": "https://www.spacetravelradio.de/",
+      "country": "DE",
+      "tags": [
+        "chillout",
+        "space"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-wdr-cosmo-vintage",
+      "name": "WDR Cosmo Vintage",
+      "broadcaster": "independent",
+      "streamUrl": "https://wdr-cosmo-special.icecastssl.wdr.de/wdr/cosmo/special/mp3/128/stream.mp3",
+      "homepage": "https://www1.wdr.de/radio/cosmo/musik/webradio-108.html",
+      "country": "DE",
+      "tags": [
+        "intercultural",
+        "music",
+        "vintage"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.9375,
+        6.9592
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-flux-electronic-chillout",
+      "name": "Flux Electronic Chillout",
+      "broadcaster": "independent",
+      "streamUrl": "https://sfn.edge-ovh-gra5.streams.radiosphere.io/557b7263-9216-46b5-a813-a156ffbc9acb/channels/aa1a53ce-7743-444d-a0b9-115ba01c7321/stream.aac?quality=4&quality=4&source=fluxmusic.api.radiosphere.io&companionAds=true&aw_0_req.userConsentV2=CQLQfCgQLQfCgAfLoBDEBYFsAP_AAEPAAAigF7QFQACAAVAAuAB4AEEAJwAoABkADQAI4AXwAwgBuAGrAO4A7wB-gF1AOAAfsBFQC3gF7AH7AJAAqABcADwAIAAZAA0ACPAO4A7wB-gAAA",
+      "homepage": "https://www.fluxfm.de/",
+      "country": "DE",
+      "tags": [
+        "beat",
+        "chillout",
+        "electronic"
+      ],
+      "favicon": "https://fluxmusic.cdn.radiosphere.io/images/5d37d59f-ee04-41ef-b0ca-9b5b16810197_1705489427.webp.90",
+      "codec": "AAC",
+      "geo": [
+        52.5068,
+        13.3903
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-trigger-fm-max",
+      "name": "Trigger.FM MAX",
+      "broadcaster": "independent",
+      "streamUrl": "https://max-hd-radio.triggerfm.de/",
+      "homepage": "https://triggerfm.com/radiochannel/trigger-fm-max-80er-90er-mix/",
+      "country": "DE",
+      "tags": [
+        "80er",
+        "90er"
+      ],
+      "favicon": "https://triggerfm.com/wp-content/uploads/2023/10/triggerMAX-512x512-1.png",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ffh-soundtrack",
+      "name": "FFH SOUNDTRACK",
+      "broadcaster": "independent",
+      "streamUrl": "https://mp3.ffh.de/ffhchannels/hqsoundtrack.aac",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "DE",
+      "tags": [
+        "classical"
+      ],
+      "bitrate": 128,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ffn-607080",
+      "name": "ffn 607080",
+      "broadcaster": "independent",
+      "streamUrl": "https://ffn-de-hz-fal-stream03-cluster01.radiohost.de/ffn-607080radio_mp3-192",
+      "homepage": "https://player.ffn.de/ffn",
+      "country": "DE",
+      "tags": [
+        "60's",
+        "70's",
+        "80's",
+        "oldies"
+      ],
+      "favicon": "https://www.ffn.de/fileadmin/ffn.de/musik/streams/607080radio.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-cafe-zimmermann",
+      "name": "Radio Cafe Zimmermann",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radio-cafezimmermann.de/klassik/mp3-192/",
+      "homepage": "http://www.radio-cafezimmermann.de/",
+      "country": "DE",
+      "tags": [
+        "classical"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-techno-paradize",
+      "name": "techno paradize",
+      "broadcaster": "independent",
+      "streamUrl": "https://techno-paradize.stream.laut.fm/techno-paradize?t302=2021-12-12_09-00-32&uuid=8fb20a49-0aa6-427a-b0ff-2f65e43898b4",
+      "homepage": "https://www.facebook.com/TechnoParadize",
+      "country": "DE",
+      "tags": [
+        "deep",
+        "edm",
+        "house",
+        "minimal",
+        "techno"
+      ],
+      "favicon": "https://www.facebook.com/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-reyfm-original",
+      "name": "ReyFM - Original",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.reyfm.de/original_192kbps.mp3",
+      "homepage": "https://www.reyfm.de/",
+      "country": "DE",
+      "tags": [
+        "dance",
+        "hits"
+      ],
+      "favicon": "https://www.reyfm.de/_nuxt/icons/icon_64x64.88ab9f.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1000-80er-laut-fm",
+      "name": "1000 80er - laut.fm",
+      "broadcaster": "independent",
+      "streamUrl": "https://100080er.stream.laut.fm/100080er",
+      "homepage": "https://laut.fm/100080er",
+      "country": "DE",
+      "tags": [
+        "80er",
+        "pop"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-harmony-70er",
+      "name": "harmony +70er",
+      "broadcaster": "independent",
+      "streamUrl": "https://mp3.harmonyfm.de/hrmplus/hq70er.aac?context=fHA6LTE=&amsparams=playerid:harmonyPopup;skey:1631618108&rtffh=ef12279c-76fc-410a-9bd8-4e7cafc7308f&listenerid=ef12279c-76fc-410a-9bd8-4e7cafc7308f",
+      "homepage": "https://webradio.harmonyfm.de/harmonyplus70er",
+      "country": "DE",
+      "tags": [
+        "70s",
+        "oldies",
+        "pop"
+      ],
+      "bitrate": 128,
+      "codec": "AAC+",
+      "geo": [
+        50.1884,
+        8.7465
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-die-neue-welle",
+      "name": "Die Neue Welle",
+      "broadcaster": "independent",
+      "streamUrl": "https://dieneuewelle-90er.cast.addradio.de/dieneuewelle/90er/mp3/high",
+      "homepage": "https://www.die-neue-welle.de/",
+      "country": "DE",
+      "tags": [
+        "pop"
+      ],
+      "favicon": "https://www.die-neue-welle.de/storage/thumbs/192x192/r:1694597173/483228.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-egofm-chillout",
+      "name": "egofm Chillout",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast.egofm.de/egofmchillout.mp3?ar-distributor=ffa0&aw_0_req.gdpr=true",
+      "homepage": "http://www.egofm.de/",
+      "country": "DE",
+      "tags": [
+        "chillout"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-lounge-shisha-lounge",
+      "name": "Epic Lounge - SHISHA LOUNGE",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-lounge.com/shisha-lounge?ref=radiobrowser",
+      "homepage": "https://epic-lounge.com/",
+      "country": "DE",
+      "tags": [
+        "german",
+        "hiphop",
+        "lounge",
+        "lounge music",
+        "oriental",
+        "rap hiphop rnb"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-bayern-1-mainfranken",
+      "name": "Bayern 1 Mainfranken",
+      "broadcaster": "independent",
+      "streamUrl": "https://dispatcher.rndfnk.com/br/br1/mainfranken/mp3/mid",
+      "homepage": "https://www.br.de/radio/bayern1/index.html",
+      "country": "DE",
+      "tags": [
+        "oldies"
+      ],
+      "favicon": "https://api.ardmediathek.de/image-service/images/urn:ard:image:b366004f6196d70c?w=512",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-swr-4-bw-karlsruhe-128k",
+      "name": "SWR 4 BW Karlsruhe (128K)",
+      "broadcaster": "independent",
+      "streamUrl": "https://liveradio.swr.de/sw282p3/swr4ka/play.mp3",
+      "homepage": "https://liveradio.swr.de/sw282p3/swr4ka",
+      "country": "DE",
+      "favicon": "https://liveradio.swr.de/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1-a-charts-von-1a-radio",
+      "name": "- 1 A - Charts von 1A Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://1a-charts.radionetz.de/1a-charts.mp3",
+      "homepage": "http://www.1aradio.com/",
+      "country": "DE",
+      "tags": [
+        "dance",
+        "hits",
+        "house",
+        "pop",
+        "rock",
+        "top40"
+      ],
+      "favicon": "https://www.1aradio.com/logos/1a-charts_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-100-80er-90er-laut-fm",
+      "name": "0-100 80er/90er - laut.fm",
+      "broadcaster": "independent",
+      "streamUrl": "https://0-100-80er-90er.stream.laut.fm/0-100-80er-90er",
+      "homepage": "https://laut.fm/0-100-80er-90er",
+      "country": "DE",
+      "tags": [
+        "80er",
+        "90er",
+        "charts",
+        "hits"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-classical-classical-pop",
+      "name": "EPIC CLASSICAL - Classical Pop",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-classical.com/classical-pop",
+      "homepage": "https://epic-classical.com/",
+      "country": "DE",
+      "tags": [
+        "classic hits",
+        "classical",
+        "instrumental",
+        "klassik",
+        "música pop",
+        "piano"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-schwany-3-echte-volksmusik",
+      "name": "Radio Schwany 3 - Echte Volksmusik",
+      "broadcaster": "independent",
+      "streamUrl": "https://schwany.streampanel.cloud/3-dieechte",
+      "homepage": "https://www.schwany.de/index.html",
+      "country": "DE",
+      "tags": [
+        "bayern",
+        "echte volksmusik",
+        "schwany",
+        "volksmusik"
+      ],
+      "favicon": "https://static.mytuner.mobi/media/radios-150px/Lw8GVPVZuA.jpg",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        48.8438,
+        12.6189
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-rock-antenne-coversongs",
+      "name": "ROCK ANTENNE Coversongs",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rockantenne.de/coversongs/stream/aacp",
+      "homepage": "https://www.rockantenne.de/",
+      "country": "DE",
+      "tags": [
+        "covers",
+        "metal",
+        "rock"
+      ],
+      "favicon": "https://www.rockantenne.de/logos/station-rock-antenne/apple-touch-icon.png",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-ffn-bollerwagen",
+      "name": "Radio FFN - Bollerwagen",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.ffn.de/radiobollerwagen/mp3-192?ref=radio-browser",
+      "homepage": "https://www.ffn.de/",
+      "country": "DE",
+      "tags": [
+        "dance",
+        "edm",
+        "party",
+        "party hits",
+        "rock",
+        "schlager"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-hsf",
+      "name": "Radio HSF",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radio-hsf.de/hsf.mp3",
+      "homepage": "https://radio-hsf.de/",
+      "country": "DE",
+      "tags": [
+        "campus radio"
+      ],
+      "favicon": "https://radio-hsf.de/favicon.ico",
+      "codec": "MP3",
+      "geo": [
+        50.6823,
+        10.9321
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0nlineradio-latin",
+      "name": "0nlineradio LATIN",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.0nlineradio.com/latin?ref=radiobrowser",
+      "homepage": "https://0nlineradio.com/",
+      "country": "DE",
+      "tags": [
+        "hiphop",
+        "latin",
+        "latin music",
+        "latino",
+        "moombahton",
+        "musica latina"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.0322,
+        8.3203
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-lounge-poolside-lounge",
+      "name": "Epic Lounge - POOLSIDE LOUNGE",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-lounge.com/poolside-lounge?ref=streema",
+      "homepage": "https://epic-lounge.com/",
+      "country": "DE",
+      "tags": [
+        "ambient and relaxation music",
+        "chill",
+        "chillout",
+        "lounge",
+        "lounge music",
+        "relax"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ffh-hit-radio-aac-128-kbps",
+      "name": "FFH Hit Radio. AAC 128 kbps",
+      "broadcaster": "independent",
+      "streamUrl": "https://mp3.ffh.de/radioffh/hqlivestream.aac",
+      "homepage": "https://www.ffh.de/",
+      "country": "DE",
+      "bitrate": 128,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-flatlines-radio",
+      "name": "Flatlines Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/flatlines",
+      "homepage": "https://www.flatlinesradio.de/",
+      "country": "DE",
+      "tags": [
+        "darkwave",
+        "ebm",
+        "folk",
+        "gothic",
+        "industrial",
+        "melodic rock"
+      ],
+      "favicon": "https://i0.wp.com/flatlinesradio.de/storage/2021/11/244611397_1194785584320990_6265045071816304131_n-1.jpg?fit=180%2c180&#038;ssl=1",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-fu-ball-bundesliga-2-konferenz",
+      "name": "Fußball-Bundesliga 2: Konferenz",
+      "broadcaster": "independent",
+      "streamUrl": "https://wdr-sportschau-liga2konferenz.icecastssl.wdr.de/wdr/sportschau/liga2konferenz/mp3/high",
+      "homepage": "https://livecenter.sportschau.de/",
+      "country": "DE",
+      "tags": [
+        "football",
+        "live sports",
+        "sport"
+      ],
+      "favicon": "https://www.sportschau.de/resources/assets/image/favicon/apple-icon-120x120.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-hr3-rhein-main",
+      "name": "hr3 Rhein-Main",
+      "broadcaster": "independent",
+      "streamUrl": "https://hlshr3.akamaized.net/hls/live/2016536/hr3rheinmain/master.m3u8",
+      "homepage": "https://www.hr3.de/",
+      "country": "DE",
+      "tags": [
+        "pop"
+      ],
+      "favicon": "https://www.hr3.de/favicon.ico?v=4.3.2",
+      "bitrate": 200,
+      "codec": "AAC",
+      "geo": [
+        50.1088,
+        8.6344
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-swr4-freiburg",
+      "name": "SWR4 Freiburg",
+      "broadcaster": "independent",
+      "streamUrl": "https://liveradio.swr.de/sw282p3/swr4fr/",
+      "homepage": "https://www.swr.de/swr4/nachrichten/suedbaden/index.html",
+      "country": "DE",
+      "tags": [
+        "oldies",
+        "schlager"
+      ],
+      "favicon": "https://www.swr.de/assets/swr/swr4/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        47.9552,
+        7.8049
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1live-dance-hits",
+      "name": "1LIVE Dance Hits",
+      "broadcaster": "independent",
+      "streamUrl": "https://wdr-1live-dancehits.icecast.wdr.de/wdr/1live/dancehits/mp3/128/stream.mp3",
+      "homepage": "https://www1.wdr.de/radio/1live/musik/1live-streams/loopstream-1live-dance-hits-100.html",
+      "country": "DE",
+      "tags": [
+        "dance",
+        "hits"
+      ],
+      "favicon": "https://www1.wdr.de/radio/1live/resources-v5.145.2/img/favicon/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-classical-classical-sunrise",
+      "name": "EPIC CLASSICAL - Classical Sunrise",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-classical.com/classical-sunrise",
+      "homepage": "https://epic-classical.com/",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "ambient and relaxation music",
+        "chillout",
+        "classic",
+        "classical",
+        "klassik"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-schwany-radio-blass",
+      "name": "Schwany Radio Bläss",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio-blaess.spcast.eu:443/stream?time=1768462942",
+      "homepage": "http://schwany.de/",
+      "country": "DE",
+      "tags": [
+        "oldies",
+        "volksmusik"
+      ],
+      "favicon": "http://schwany.de/favicon.ico",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0nlineradio-american-christmas",
+      "name": "0nlineradio AMERICAN CHRISTMAS",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.0nlineradio.com/us-christmas?ref=radiobrowser",
+      "homepage": "https://0nlineradio.com/",
+      "country": "DE",
+      "tags": [
+        "americana",
+        "ballads",
+        "christian",
+        "christian contemporary",
+        "christian music",
+        "christmas"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.1277,
+        7.5586
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1000-90er-laut-fm",
+      "name": "1000 90er - laut.fm",
+      "broadcaster": "independent",
+      "streamUrl": "https://100090er.stream.laut.fm/100090er",
+      "homepage": "https://laut.fm/100090er",
+      "country": "DE",
+      "tags": [
+        "90er",
+        "dance",
+        "pop"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-laut-fm-deutschrock-station",
+      "name": "Laut.FM DeutschRock Station",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/deutschrock-station",
+      "homepage": "http://laut.fm/deutschrock-station",
+      "country": "DE",
+      "tags": [
+        "pop rock"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-metal-only-https-www-metal-only-de-metal-only-ht",
+      "name": "METAL ONLY - https://www.metal-only.de,METAL ONLY - http://www.metal-only.de - 24h Black Death Heavy Metal Rock und mehr!",
+      "broadcaster": "independent",
+      "streamUrl": "https://metalonly.sp.radio.fm/stream",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "DE",
+      "tags": [
+        "metal"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0r-piano-jazz-lounge-jazz-piano-lounge-smooth-ch",
+      "name": "0R - PIANO JAZZ LOUNGE || Jazz, Piano, Lounge, Smooth, Chill, Relax, Soft, Acoustic, Instrumental, Evening, Romantic, Background, Coffee, Mellow, Elegant",
+      "broadcaster": "independent",
+      "streamUrl": "https://0nlineradio.radioho.st/lounge-piano-jazz-bar?ref=radio-browser26",
+      "homepage": "https://plus.rm.fm/",
+      "country": "DE",
+      "tags": [
+        "acoustic",
+        "ambient",
+        "ambient and relaxation music",
+        "ambient lounge",
+        "classical piano",
+        "coffee"
+      ],
+      "favicon": "https://i.ibb.co/MkhwYrRM/Piano-Jazz-Lounge.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-main-by-rautemusik-rm-fm",
+      "name": "__MAIN__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://main-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://www.rm.fm/main",
+      "country": "DE",
+      "tags": [
+        "80s",
+        "90s",
+        "charts",
+        "dance",
+        "hits",
+        "live show"
+      ],
+      "favicon": "https://www.rm.fm/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0r-coffee-lounge-background-music-jazz-lounge-ch",
+      "name": "0R - COFFEE LOUNGE || Background Music, Jazz, Lounge, Chill, Smooth, Acoustic, Soft Pop, Easy Listening, Relax, Cafe, Background, Mellow, Evening, Instrumental, Romantic, Soft Jazz",
+      "broadcaster": "independent",
+      "streamUrl": "https://0nlineradio.radioho.st/lounge-coffee-bar-lounge?ref=radio-browser26",
+      "homepage": "https://plus.rm.fm/",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "background",
+        "chillout+lounge",
+        "easy listening",
+        "jazz",
+        "lounge"
+      ],
+      "favicon": "https://i.ibb.co/LDb4Ctnb/COFFEE-LOUNGE.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1001-trumpet-song",
+      "name": "1001 TRUMPET SONG ",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/1001-trumpet-song",
+      "homepage": "https://laut.fm/1001-trumpet-song",
+      "country": "DE",
+      "tags": [
+        "classic - instrumental",
+        "classic jazz",
+        "instrumental",
+        "instrumental music",
+        "jazz",
+        "jazz fusion"
+      ],
+      "favicon": "https://d1ujqdpfgkvqfi.cloudfront.net/favicon-generator/htdocs/favicons/2023-05-29/6c4c8493efb0625e9df12380c53b3826.ico.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.644,
+        11.1731
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-classical-classical-nighttime",
+      "name": "EPIC CLASSICAL - Classical Nighttime",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-classical.com/classical-nighttime",
+      "homepage": "https://epic-classical.com/",
+      "country": "DE",
+      "tags": [
+        "classic",
+        "classical",
+        "nightlife"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-take-a-dj-radio",
+      "name": "TAKE A DJ - RADIO",
+      "broadcaster": "independent",
+      "streamUrl": "https://takeadj-radio.stream.laut.fm/takeadj-radio",
+      "homepage": "https://www.takeadj.com/radio-stream/",
+      "country": "DE",
+      "tags": [
+        "deep house",
+        "house",
+        "melodic house",
+        "minimal techno",
+        "tech house",
+        "techno"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-schwany-1-volksmusik",
+      "name": "Radio Schwany 1 - Volksmusik",
+      "broadcaster": "independent",
+      "streamUrl": "https://volkstuemlich.spcast.eu:443/stream?time=1768458052",
+      "homepage": "https://www.schwany.de/index.html",
+      "country": "DE",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-schwany-herzklang",
+      "name": "Schwany Herzklang",
+      "broadcaster": "independent",
+      "streamUrl": "https://herzklang.spcast.eu:443/stream?time=1768441193",
+      "homepage": "http://schwany.de/",
+      "country": "DE",
+      "tags": [
+        "schlager"
+      ],
+      "favicon": "http://schwany.de/favicon.ico",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-deutsch-rock-on-radio",
+      "name": "- 0 N - Deutsch Rock on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-deutschrock.radionetz.de/0n-deutschrock.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "alternative",
+        "deutsch rock",
+        "hard rock",
+        "rock"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-deutsch-rock_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-chillout-ibiza-fm",
+      "name": "Chillout Ibiza FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://edge3.peta.live365.net/b05055_128mp3",
+      "homepage": "https://edge3.peta.live365.net/",
+      "country": "DE",
+      "tags": [
+        "lounge"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-classical-classical-dinner",
+      "name": "EPIC CLASSICAL - Classical Dinner",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-classical.com/classical-dinner",
+      "homepage": "https://epic-classical.com/",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "chillout",
+        "classical",
+        "classical piano",
+        "jazz",
+        "klassik"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.3375,
+        8.2031
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ffh-rock",
+      "name": "FFH Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://mp3.ffh.de/ffhchannels/hqrock.aac",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "DE",
+      "tags": [
+        "rock"
+      ],
+      "bitrate": 128,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-gutersloh",
+      "name": "Radio Gütersloh",
+      "broadcaster": "independent",
+      "streamUrl": "https://ams.stream43.radiohost.de/ams-radioguetersloh_mp3-192?addradio&upd-meta&upd-scheme=https&_art=dD0xNzY4NDQ5Njg5JmQ9ZDg4NDYwMWI2ZjhmNDUzYmI2YjI",
+      "homepage": "https://www.radioguetersloh.de/",
+      "country": "DE",
+      "tags": [
+        "borgholzhausen",
+        "clarholz",
+        "gütersloh",
+        "halle",
+        "harsewinkel",
+        "herzebrock"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.9109,
+        8.3826
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-neandertal",
+      "name": "Radio Neandertal",
+      "broadcaster": "independent",
+      "streamUrl": "https://neandertal-live.cast.addradio.de/neandertal/live/mp3/high?ar-distributor=ffa3",
+      "homepage": "https://www.radioneandertal.de/",
+      "country": "DE",
+      "favicon": "https://www.radioneandertal.de/assets/images/favicons/radioneandertal/favicon_x96.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-wdr-cosmo-chill",
+      "name": "WDR Cosmo - Chill",
+      "broadcaster": "independent",
+      "streamUrl": "https://wdr-cosmo-chillout.icecastssl.wdr.de/wdr/cosmo/chillout/mp3/128/stream.mp3",
+      "homepage": "https://www1.wdr.de/radio/cosmo/channels/chill-out-channel-100.html",
+      "country": "DE",
+      "favicon": "https://www1.wdr.de/radio/cosmo/resources-v5.128.1/img/favicon/favicon-32x32.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-rautemusik-cofee-music",
+      "name": "RauteMusik COFEE-MUSIC",
+      "broadcaster": "independent",
+      "streamUrl": "https://streams.rautemusik.fm/coffee-music/mp3-192/?ref=radiobrowser",
+      "homepage": "https://rm.fm/coffee-music",
+      "country": "DE",
+      "tags": [
+        "chill",
+        "chillout",
+        "chillout+lounge",
+        "jazz lounge",
+        "lounge",
+        "lounge music"
+      ],
+      "favicon": "https://rm.fm/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.461,
+        8.2617
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-rock-antenne-xmas-rock",
+      "name": "ROCK ANTENNE Xmas Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rockantenne.de/xmas-rock/stream/aacp",
+      "homepage": "https://www.rockantenne.de/",
+      "country": "DE",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-meditation-1000",
+      "name": "Meditation 1000",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/meditation",
+      "homepage": "https://laut.fm/meditation",
+      "country": "DE",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-deutsch-rap-on-radio",
+      "name": "- 0 N - Deutsch Rap on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-deutschrap.radionetz.de/0n-deutschrap.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "hip hop",
+        "rap",
+        "urban"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-deutsch-rap_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-dasding-48k-aac",
+      "name": "DASDING | 48k aac",
+      "broadcaster": "independent",
+      "streamUrl": "https://liveradio.swr.de/sw890cl/dasding/",
+      "homepage": "https://www.dasding.de/",
+      "country": "DE",
+      "tags": [
+        "music"
+      ],
+      "favicon": "https://www.dasding.de/assets/dasding/apple-touch-icon-152x152.png",
+      "bitrate": 96,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-schwany-volksmusik-instrumental",
+      "name": "Radio Schwany - Volksmusik instrumental",
+      "broadcaster": "independent",
+      "streamUrl": "https://instrumental-volksmusik.spcast.eu:443/stream?time=1768446385",
+      "homepage": "https://www.schwany.de/index.html",
+      "country": "DE",
+      "tags": [
+        "bayern",
+        "instrumental",
+        "schwany",
+        "volksmusik",
+        "volksmusik instrumental"
+      ],
+      "favicon": "https://static.mytuner.mobi/media/radios-150px/a6cncjqwaf6x.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        48.8449,
+        12.6196
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-classic-videogames-radio",
+      "name": "Classic Videogames RADIO",
+      "broadcaster": "independent",
+      "streamUrl": "https://lead-server.de:1551/stream/2/",
+      "homepage": "https://www.radio.classic-videogames.de/",
+      "country": "DE",
+      "tags": [
+        "retro games",
+        "videogame music"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-deutschlandfunk-nachrichten",
+      "name": "DeutschlandFunk Nachrichten",
+      "broadcaster": "independent",
+      "streamUrl": "https://ondemand-mp3.dradio.de/file/dradio/nachrichten/nachrichten.mp3",
+      "homepage": "https://deutschlandfunk.de/",
+      "country": "DE",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio2day",
+      "name": "Radio2day",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio2day.ip-streaming.net/radio2day",
+      "homepage": "https://radio2day.de/",
+      "country": "DE",
+      "tags": [
+        "00s",
+        "80s",
+        "90s"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-mdr-klassik-mp3-256",
+      "name": "MDR Klassik MP3 256",
+      "broadcaster": "independent",
+      "streamUrl": "https://mdr-284350-0.sslcast.mdr.de/mdr/284350/0/mp3/max/stream.mp3",
+      "homepage": "https://www.mdr.de/klassik/index.html",
+      "country": "DE",
+      "tags": [
+        "classical"
+      ],
+      "favicon": "https://www.mdr.de/resources/global/img/mdrde/favicons/android-icon-192x192.png",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0nlineradio-lo-fi",
+      "name": "0nlineradio LO-FI",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.0nlineradio.com/lo-fi?ref=radiobrowser",
+      "homepage": "https://0nlineradio.com/",
+      "country": "DE",
+      "tags": [
+        "chillout",
+        "easy listening",
+        "easy listning",
+        "lofi",
+        "relax",
+        "relaxing"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.8846,
+        8.6719
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-antenne-wiesbaden",
+      "name": "antenne WIESBADEN",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.antenne-wiesbaden.de/antennewiesbaden-live/mp3-192?ref=radio-browser",
+      "homepage": "https://antenne-wiesbaden.de/",
+      "country": "DE",
+      "tags": [
+        "1980s",
+        "80's",
+        "80s",
+        "adult contemporary",
+        "charts",
+        "classic hits"
+      ],
+      "favicon": "https://i.ibb.co/LDxCj60L/logo-up-2200.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-bremen-eins-beat-club",
+      "name": "Bremen Eins Beat-Club",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.radiobremen.de/rb/webchannel6/mp3/128/stream.mp3",
+      "homepage": "https://www.bremeneins.de/",
+      "country": "DE",
+      "favicon": "https://www.bremeneins.de/static/img/favicons/apple-touch-icon-180.png?v=4",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-classical-classical-fairy-tales",
+      "name": "EPIC CLASSICAL - Classical Fairy Tales",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-classical.com/classical-fairy-tales",
+      "homepage": "https://epic-classical.com/",
+      "country": "DE",
+      "tags": [
+        "classic",
+        "classic hits",
+        "classical",
+        "disney",
+        "fairytales",
+        "klassik"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-oldiefans-das-original",
+      "name": "Oldiefans - Das Original",
+      "broadcaster": "independent",
+      "streamUrl": "https://server7.streamserver24.com:8080/proxy/stekonig?mp=/stream",
+      "homepage": "https://oldiefans.com/",
+      "country": "DE",
+      "tags": [
+        "2000er",
+        "60er",
+        "70er",
+        "80er",
+        "90er",
+        "oldies"
+      ],
+      "bitrate": 256,
+      "codec": "MP3",
+      "geo": [
+        53.3339,
+        10.4377
+      ],
+      "status": "stream-only"
     }
   ]
 }

--- a/public/stations.json
+++ b/public/stations.json
@@ -28707,6 +28707,7685 @@
         10.4377
       ],
       "status": "stream-only"
+    },
+    {
+      "id": "de-bayernwelle-sudost",
+      "name": "Bayernwelle SüdOst",
+      "broadcaster": "independent",
+      "streamUrl": "https://bayernwelle-live.cast.addradio.de/bayernwelle/live/mp3/high?ar-distributor=f0b7",
+      "homepage": "https://www.bayernwelle.de/",
+      "country": "DE",
+      "tags": [
+        "bayern",
+        "berchtesgadener land",
+        "chiemgau",
+        "chiemsee",
+        "oberbayern",
+        "rosenheim"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-schlager-radio-hor-auf-dein-herz",
+      "name": "Schlager Radio- Hör auf dein herz",
+      "broadcaster": "independent",
+      "streamUrl": "https://addrad.io/4454r93",
+      "homepage": "https://www.schlagerradio.de/",
+      "country": "DE",
+      "tags": [
+        "schlager",
+        "schlagerhits"
+      ],
+      "favicon": "https://www.schlagerradio.de/wp-content/uploads/2021/10/cropped-Favicon_SchlagerRadio_Herzen_wei%C3%9Faufrot_rund-32x32.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        52.6533,
+        13.3484
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0nlineradio-urban",
+      "name": "0nlineradio URBAN",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.0nlineradio.com/urban?ref=radiobrowser",
+      "homepage": "https://0nlineradio.com/",
+      "country": "DE",
+      "tags": [
+        "german rap",
+        "hiphop",
+        "latin",
+        "latino",
+        "rap hiphop rnb",
+        "rnb"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-lounge-plus",
+      "name": "lounge plus",
+      "broadcaster": "independent",
+      "streamUrl": "https://addrad.io/4455g42",
+      "homepage": "http://www.loungeplus.de/",
+      "country": "DE",
+      "tags": [
+        "chillout radio"
+      ],
+      "favicon": "https://www.loungeplus.de/wp-content/uploads/2024/01/cropped-favicon-32x32-1-180x180.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-antenne-bayern-munich-city-nights",
+      "name": "Antenne Bayern Munich City Nights",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rockantenne.de/munich-city-nights/stream/mp3",
+      "homepage": "https://www.rockantenne.de/",
+      "country": "DE",
+      "tags": [
+        "undefined"
+      ],
+      "favicon": "https://www.rockantenne.de/logos/station-rock-antenne/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-coco-und-jambo",
+      "name": "Coco und Jambo",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/cocoundjambo",
+      "homepage": "https://www.cocoundjambo.de/",
+      "country": "DE",
+      "tags": [
+        "90s",
+        "dance"
+      ],
+      "favicon": "https://static.wixstatic.com/media/33fb6a_25e82fc9f2e44a41a93b29ecefadc02d~mv2.png/v1/fill/w_820,h_312,al_c/33fb6a_25e82fc9f2e44a41a93b29ecefadc02d~mv2.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-erft",
+      "name": "Radio Erft",
+      "broadcaster": "independent",
+      "streamUrl": "https://radioerft--di--nacs-ais-lgc--04--cdn.cast.addradio.de/radioerft/live/mp3/high",
+      "homepage": "https://www.radioerft.de/",
+      "country": "DE",
+      "tags": [
+        "adult contemporary",
+        "top 40"
+      ],
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/thumb/6/66/Radio_Erft_Logo.svg/800px-Radio_Erft_Logo.svg.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-rock-antenne-70er-rock-2",
+      "name": "Rock Antenne - 70er Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rockantenne.de/70er-rock/stream/mp3",
+      "homepage": "https://www.rockantenne.de/rockhoeren/streams/70er-rock",
+      "country": "DE",
+      "tags": [
+        "70s",
+        "music",
+        "rock"
+      ],
+      "favicon": "https://super-radio-mobile.devhub.top/logo/70e4d4.webp",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-fratz",
+      "name": "Radio Fratz",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radio-fratz.de/stream_high.mp3",
+      "homepage": "https://www.radio-fratz.de/",
+      "country": "DE",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0nlineradio-chillout",
+      "name": "0nlineradio CHILLOUT",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.0nlineradio.com/chillout?ref=radiobrowser",
+      "homepage": "https://0nlineradio.com/",
+      "country": "DE",
+      "tags": [
+        "chill",
+        "chillout",
+        "downtempo",
+        "easy listening",
+        "relax",
+        "relaxing"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.9584,
+        8.6133
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-rock-antenne-deutsch-rock",
+      "name": "Rock Antenne - Deutsch Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://s1-webradio.rockantenne.de/deutschrock/stream/aacp",
+      "homepage": "https://www.rockantenne.de/",
+      "country": "DE",
+      "tags": [
+        "rock"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-schwany-3",
+      "name": "Schwany 3",
+      "broadcaster": "independent",
+      "streamUrl": "https://schwany3volksmusik.hoamatwelle.de/",
+      "homepage": "http://schwany.de/",
+      "country": "DE",
+      "favicon": "http://schwany.de/favicon.ico",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-wdr-2-rheinland-mp3-128-kbit-s",
+      "name": "WDR 2 – Rheinland | mp3, 128 kBit/s",
+      "broadcaster": "independent",
+      "streamUrl": "https://wdr-wdr2-rheinland.icecastssl.wdr.de/wdr/wdr2/rheinland/mp3/128/stream.mp3",
+      "homepage": "https://www1.wdr.de/radio/wdr2/index.html",
+      "country": "DE",
+      "favicon": "https://www1.wdr.de/resources-v5.124.1/img/favicon/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1-a-deutsch-pop-von-1a-radio",
+      "name": "- 1 A - Deutsch Pop von 1A Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://1a-deutschpop.radionetz.de/1a-deutschpop.mp3",
+      "homepage": "http://www.1aradio.com/",
+      "country": "DE",
+      "tags": [
+        "balladen",
+        "pop",
+        "rock",
+        "schlager"
+      ],
+      "favicon": "https://www.1aradio.com/logos/1a-deutsch-pop_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1-splash-classical",
+      "name": "#1 Splash Classical",
+      "broadcaster": "independent",
+      "streamUrl": "https://ais-sa2.cdnstream1.com/2208_128.mp3",
+      "homepage": "https://www.splashradio.eu/",
+      "country": "DE",
+      "tags": [
+        "baroque",
+        "chamber",
+        "classical",
+        "classical baroque",
+        "classical music",
+        "classical organ music"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-absolut-lovesongs",
+      "name": "Absolut Lovesongs",
+      "broadcaster": "independent",
+      "streamUrl": "https://n06.radiojar.com/5bdyvqa9bm8uv",
+      "homepage": "https://absolutradio.de/",
+      "country": "DE",
+      "favicon": "https://absolutradio.de/apple-touch-icon.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-egofm-bayern",
+      "name": "egoFM Bayern",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast.egofm.de/egofm.mp3?ar-distributor=radio-browser",
+      "homepage": "https://egofm.de/",
+      "country": "DE",
+      "tags": [
+        "alternativer radiosender",
+        "munich",
+        "musik entdecken",
+        "musikentdecker",
+        "münchen",
+        "popkultur"
+      ],
+      "favicon": "https://streams.egofm.de/img/alexa/egoFM%20Simulcast-256x256.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.1841,
+        11.5851
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ndr2-mv",
+      "name": "NDR2 MV",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.ndr.de/ndr/ndr2/mecklenburgvorpommern/mp3/128/stream.mp3?1681641486761&aggregator=web",
+      "homepage": "https://www.ndr.de/ndr2/epg/stationndrzwei102-radioplayer_livestream-livestream605.html",
+      "country": "DE",
+      "tags": [
+        "germany",
+        "mv",
+        "ndr",
+        "ndr2"
+      ],
+      "favicon": "https://www.ndr.de/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0nlineradio-schumann",
+      "name": "0nlineradio SCHUMANN",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.0nlineradio.com/schumann?ref=radiobrowser",
+      "homepage": "https://0nlineradio.com/",
+      "country": "DE",
+      "tags": [
+        "boston symphony orchestra",
+        "classic hits",
+        "classical",
+        "symphonic",
+        "symphony"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.9584,
+        7.9102
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-krautrockworld",
+      "name": "Krautrockworld",
+      "broadcaster": "independent",
+      "streamUrl": "https://krautrockworld.stream.laut.fm/krautrockworld",
+      "homepage": "http://www.krautrock-world.com/",
+      "country": "DE",
+      "favicon": "http://img.sedoparking.com/templates/logos/sedo_logo.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-lounge-christmas-lounge",
+      "name": "Epic Lounge - CHRISTMAS LOUNGE",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-lounge.com/christmas-lounge?ref=radiobrowser",
+      "homepage": "https://epic-lounge.com/",
+      "country": "DE",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-horspielprojekt-bielefeld",
+      "name": "Hörspielprojekt Bielefeld",
+      "broadcaster": "independent",
+      "streamUrl": "https://hoerspiel.stream.laut.fm/hoerspiel?pl=m3u&t302=2026-01-15_05-53-38&uuid=486935e5-a7e5-4f5f-9c23-f986524e38e3",
+      "homepage": "https://www.hoerspielprojekt.de/",
+      "country": "DE",
+      "tags": [
+        "radio plays"
+      ],
+      "favicon": "https://www.hoerspielprojekt.de/wp-content/uploads/2018/12/cropped-headphone-96x96.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-absolut-top-club-night",
+      "name": "Absolut TOP club night",
+      "broadcaster": "independent",
+      "streamUrl": "https://n0c.radiojar.com/s1gwvam92hhvv?___cb=248720992580709",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "DE",
+      "favicon": "https://absolutradio.de/images/stations/2924_handheld_default_square_image600.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-discosound-radio",
+      "name": "Discosound-Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/discosound-radio",
+      "homepage": "https://www.discosound-radio.de/",
+      "country": "DE",
+      "tags": [
+        "70er",
+        "80er",
+        "90er",
+        "discofox",
+        "schlager"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-i-love-bass-by-ilovemusic-de",
+      "name": "I Love Bass by ilovemusic.de",
+      "broadcaster": "independent",
+      "streamUrl": "https://ilm.stream18.radiohost.de/ilm_ilovebass_mp3-192?upd-meta&upd-scheme=https&_art=dD0xNzY4NDU5MjExJmQ9Zjk2M2M3Y2Y0MmRkZGViYTVlMmQ",
+      "homepage": "https://www.ilovemusic.de/",
+      "country": "DE",
+      "favicon": "https://www.ilovemusic.de/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-schwany-4-blasmusik",
+      "name": "Radio Schwany 4 - Blasmusik",
+      "broadcaster": "independent",
+      "streamUrl": "https://blasmusik.spcast.eu:443/stream?time=1768433624",
+      "homepage": "https://www.schwany.de/index.html",
+      "country": "DE",
+      "tags": [
+        "bayern",
+        "blasmusik",
+        "brass",
+        "schwany"
+      ],
+      "favicon": "https://static.mytuner.mobi/media/radios-150px/MKV7TT95v9.jpg",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        48.8443,
+        12.6185
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-wdr-cosmo-https",
+      "name": "WDR COSMO -- (https)",
+      "broadcaster": "independent",
+      "streamUrl": "https://wdr-cosmo-live.icecastssl.wdr.de/wdr/cosmo/live/mp3/128/stream.mp3",
+      "homepage": "https://www1.wdr.de/radio/cosmo/index.html",
+      "country": "DE",
+      "tags": [
+        "diversity",
+        "global",
+        "international",
+        "multicultural",
+        "pop",
+        "talk"
+      ],
+      "favicon": "https://www1.wdr.de/radio/cosmo/resources-v5.142.2/img/favicon/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.7742,
+        8.3207
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0r-music-for-sleep-sleep-relax-calm-meditation-n",
+      "name": "0R - MUSIC FOR SLEEP || Sleep, Relax, Calm, Meditation, Nature, Ambient, Soft Music, Piano, Deep Sleep, Peaceful, Chill, Background, Slow, Gentle, Instrumental",
+      "broadcaster": "independent",
+      "streamUrl": "https://0nlineradio.radioho.st/classical-classical-music-for-sleep?ref=radio-browser26",
+      "homepage": "https://plus.rm.fm/",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "background",
+        "calm",
+        "chillout",
+        "classical",
+        "easy listening"
+      ],
+      "favicon": "https://i.ibb.co/whsdTsct/MUSIC-FOR-SLEEP.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        52.4856,
+        13.2825
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-fu-ball-bundesliga-spiel-1",
+      "name": "Fußball-Bundesliga: Spiel 1",
+      "broadcaster": "independent",
+      "streamUrl": "https://wdr-sportschau-liga1spiel1.icecastssl.wdr.de/wdr/sportschau/liga1spiel1/mp3/high",
+      "homepage": "https://livecenter.sportschau.de/",
+      "country": "DE",
+      "tags": [
+        "football",
+        "live sports",
+        "sport"
+      ],
+      "favicon": "https://www.sportschau.de/resources/assets/image/favicon/apple-icon-120x120.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-radio-on-radio",
+      "name": "- 0 N - Radio on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-radio.radionetz.de/0n-radio.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "hits",
+        "oldies",
+        "pop",
+        "top 40"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-radio_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0r-nature-relax-nature-sounds-sleep-relax-calm-f",
+      "name": "0R - NATURE RELAX || Nature Sounds, Sleep, Relax, Calm, Forest, Ocean, Rain, Ambient, Meditation, Peaceful, Spa, Yoga, Gentle, Soothing, Background, Sleep",
+      "broadcaster": "independent",
+      "streamUrl": "https://0nlineradio.radioho.st/lounge-nature-sounds?ref=radio-browser26",
+      "homepage": "https://plus.rm.fm/",
+      "country": "DE",
+      "tags": [
+        "alternative",
+        "background",
+        "chillout",
+        "easy listening",
+        "lounge",
+        "natura"
+      ],
+      "favicon": "https://i.ibb.co/NgtLbFs6/Nature-Relax-Sound.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-kolncampus",
+      "name": "Kölncampus",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.koelncampus.com/live",
+      "homepage": "https://www.koelncampus.com/",
+      "country": "DE",
+      "tags": [
+        "alternative",
+        "campus radio"
+      ],
+      "favicon": "https://static.koelncampus.com/apple-touch-icon-precomposed.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.9283,
+        6.9294
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-oldie-welle-ingolstadt",
+      "name": "oldie-welle-Ingolstadt",
+      "broadcaster": "independent",
+      "streamUrl": "https://funkhaus-ingolstadt.stream24.net/oldie-welle-ingolstadt.mp3",
+      "homepage": "https://www.funkhaus-ingolstadt.de/",
+      "country": "DE",
+      "tags": [
+        "local news",
+        "oldies"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-100-radio-zoom-de",
+      "name": "100% Radio-Zoom.de",
+      "broadcaster": "independent",
+      "streamUrl": "https://office.radio-zoom.de/webplayer",
+      "homepage": "http://www.radio-zoom.de/",
+      "country": "DE",
+      "tags": [
+        "pop rock country original score decades electronic"
+      ],
+      "favicon": "https://www.radio-zoom.de/fileadmin/template_2022/image/favicon.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-antenne-bayern-ndw",
+      "name": "Antenne Bayern NDW",
+      "broadcaster": "independent",
+      "streamUrl": "https://s5-webradio.antenne.de/antenne-bayern-ndw/stream/mp3",
+      "homepage": "https://www.antenne.de/webradio/ndw",
+      "country": "DE",
+      "tags": [
+        "80's",
+        "80er",
+        "80s",
+        "ndw"
+      ],
+      "favicon": "https://www.antenne.de/logos/station-antenne-bayern/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-laut-fm-after-hours",
+      "name": "Laut.fm - After Hours",
+      "broadcaster": "independent",
+      "streamUrl": "https://after-hours.stream.laut.fm/after-hours?t302=2019-09-27_06-07-17&uuid=64f3acda-820a-4912-9df6-fe85b9cd99a2",
+      "homepage": "https://laut.fm/",
+      "country": "DE",
+      "tags": [
+        "free jazz",
+        "jazz fusion",
+        "world fusion"
+      ],
+      "favicon": "https://laut.fm/assets/touch-icons/apple-touch-icon.png?9e172e15",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1-a-jazz-von-1a-radio",
+      "name": "- 1 A - Jazz von 1A Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://1a-jazz.radionetz.de/1a-jazz.mp3",
+      "homepage": "http://www.1aradio.com/",
+      "country": "DE",
+      "tags": [
+        "jazz",
+        "smooth jazz",
+        "swing"
+      ],
+      "favicon": "https://www.1aradio.com/logos/1a-jazz_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-jam-by-rautemusik-rm-fm",
+      "name": "__JAM__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://jam-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://www.rm.fm/jam",
+      "country": "DE",
+      "tags": [
+        "hip-hop",
+        "hiphop",
+        "latin",
+        "moombahton",
+        "rap",
+        "reggaeton"
+      ],
+      "favicon": "https://www.rm.fm/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0nlineradio-lovehits",
+      "name": "0nlineradio LOVEHITS",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.0nlineradio.com/lovehits?ref=radiobrowser",
+      "homepage": "https://0nlineradio.com/",
+      "country": "DE",
+      "tags": [
+        "liebe",
+        "liebeslieder",
+        "love",
+        "love song",
+        "love songs",
+        "lovesongs"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.4723,
+        8.3203
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-bremen-vier-rockt",
+      "name": "Bremen Vier Rockt",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.radiobremen.de/rb/webchannel8/mp3/128/stream.mp3",
+      "homepage": "https://www.bremenvier.de/",
+      "country": "DE",
+      "tags": [
+        "rock"
+      ],
+      "favicon": "https://www.bremenvier.de/static/img/favicons/apple-touch-icon-180.png?v=3",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-chillout-archiv",
+      "name": "Chillout Archiv",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/chillout-archiv",
+      "homepage": "https://laut.fm/",
+      "country": "DE",
+      "tags": [
+        "chillout",
+        "lounge"
+      ],
+      "favicon": "https://laut.fm/assets/touch-icons/apple-touch-icon.png?9e172e15",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.6028,
+        9.8438
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-herford",
+      "name": "Radio Herford",
+      "broadcaster": "independent",
+      "streamUrl": "https://addrad.io/444z8vj",
+      "homepage": "https://www.radioherford.de/",
+      "country": "DE",
+      "favicon": "https://www.radioherford.de/icons-hf/apple-icon-120.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-potsdam",
+      "name": "Radio Potsdam",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radiogroup.de/radio-potsdam/mp3-192/?ref=website",
+      "homepage": "https://www.radio-potsdam.de/",
+      "country": "DE",
+      "favicon": "https://www.radio-potsdam.de/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-rock-antenne-rockabilly",
+      "name": "Rock Antenne - Rockabilly ",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rockantenne.de/rockabilly/stream/aacp",
+      "homepage": "http://www.rockantenne.de/",
+      "country": "DE",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-swr3-visual-radio",
+      "name": "SWR3 Visual Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://swrswr3vr-hls.akamaized.net/hls/live/2018683/swr3vr/master.m3u8",
+      "homepage": "https://www.swr3.de/",
+      "country": "DE",
+      "bitrate": 2147,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ffn-comedy",
+      "name": "FFN Comedy",
+      "broadcaster": "independent",
+      "streamUrl": "https://ffn.stream36.radiohost.de/ffn-comedy_mp3-192",
+      "homepage": "https://player.ffn.de/ffnfruehstyxradio",
+      "country": "DE",
+      "tags": [
+        "comedy",
+        "deutsch",
+        "ffn",
+        "fruehstyxradio",
+        "german",
+        "hannover"
+      ],
+      "favicon": "https://player.ffn.de/assets/channels/ffn-fruehstyxradio.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ilovemusic-ilovegreatesthits",
+      "name": "ilovemusic: ilovegreatesthits",
+      "broadcaster": "independent",
+      "streamUrl": "https://ilm.stream12.radiohost.de/ilm_ilovegreatesthits_mp3-192?upd-meta&upd-scheme=https&_art=dD0xNzY4NDU3MzY3JmQ9YTQyMTExMTdmZTI3ZWM5MzUyZGE",
+      "homepage": "https://www.ilovemusic.de/",
+      "country": "DE",
+      "favicon": "https://www.ilovemusic.de/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1live-rock-hits",
+      "name": "1LIVE Rock Hits",
+      "broadcaster": "independent",
+      "streamUrl": "https://wdr-1live-rockhits.icecast.wdr.de/wdr/1live/rockhits/mp3/128/stream.mp3",
+      "homepage": "https://www1.wdr.de/radio/1live/musik/1live-streams/loopstreams-1live-rock-hits-100.html",
+      "country": "DE",
+      "tags": [
+        "rock"
+      ],
+      "favicon": "https://www1.wdr.de/radio/1live/app/loopstream-cover-1live-rock-hits-100~_v-TeaserAufmacher.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-boney-m",
+      "name": "Boney M",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.pcradio.ru/BoneyM-hi",
+      "homepage": "https://pcradio.ru/",
+      "country": "DE",
+      "tags": [
+        "discography"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-ffn-peppermint",
+      "name": "Radio FFN - Peppermint",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.ffn.de/peppermintfm/mp3-192/",
+      "homepage": "https://www.ffn.de/",
+      "country": "DE",
+      "tags": [
+        "dance",
+        "funk",
+        "house",
+        "soul"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-yourtime-fm",
+      "name": "YourTime-FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/yourtime-fm",
+      "homepage": "https://www.yourtimefm.de/",
+      "country": "DE",
+      "tags": [
+        "dance",
+        "electronic",
+        "mainstream",
+        "pop",
+        "top100",
+        "young adults"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0nlineradio",
+      "name": "0nlineradio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.0nlineradio.com/jazz?ref=radiobrowser",
+      "homepage": "https://0nlineradio.com/",
+      "country": "DE",
+      "tags": [
+        "acid jazz",
+        "classic jazz",
+        "cool jazz",
+        "jazz",
+        "smooth jazz",
+        "vocal jazz"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.7633,
+        7.9687
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-dwg-pur",
+      "name": "DWG Pur",
+      "broadcaster": "independent",
+      "streamUrl": "https://server25531.streamplus.de/stream.mp3",
+      "homepage": "https://radio.dwgradio.net/de/radio-pur-lyra/",
+      "country": "DE",
+      "tags": [
+        "christian"
+      ],
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-frankisch-spoken",
+      "name": "Radio Fränkisch Spoken",
+      "broadcaster": "independent",
+      "streamUrl": "https://fraenkisch-spoken.stream.laut.fm/fraenkisch-spoken?t302=2026-01-15_02-52-07&uuid=c85f8f39-a411-48cf-9c1c-fbb11e26c345",
+      "homepage": "https://www.zachmeier.de/blog/radio/",
+      "country": "DE",
+      "tags": [
+        "chanson",
+        "folk",
+        "pop",
+        "rock"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        49.4549,
+        11.0785
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0nlineradio-trending-charts",
+      "name": "0nlineradio - TRENDING CHARTS",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.0nlineradio.com/trending-charts",
+      "homepage": "https://0nlineradio.com/",
+      "country": "DE",
+      "tags": [
+        "2023s",
+        "charts",
+        "dance",
+        "electro",
+        "electronic",
+        "hits"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.4505,
+        8.9062
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-endstation",
+      "name": "Radio Endstation",
+      "broadcaster": "independent",
+      "streamUrl": "https://funkturm.radio-endstation.de/hls/radio-endstation/live.m3u8",
+      "homepage": "https://radio-enderation.de/",
+      "country": "DE",
+      "tags": [
+        "oi!",
+        "oi-punk",
+        "punk",
+        "punkrock",
+        "ska",
+        "skin"
+      ],
+      "bitrate": 52,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-reyfm-lofi-2",
+      "name": "REYFM - #lofi",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.reyfm.de/lofi_64kbps.mp3",
+      "homepage": "https://www.reyfm.de/",
+      "country": "DE",
+      "tags": [
+        "lo-fi",
+        "lofi"
+      ],
+      "favicon": "https://www.reyfm.de/_nuxt/icons/icon_64x64.88ab9f.png",
+      "bitrate": 63,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-wdr4a",
+      "name": "WDR4a",
+      "broadcaster": "independent",
+      "streamUrl": "https://wdrhf.akamaized.net/hls/live/2027995/wdr4/master.m3u8",
+      "homepage": "https://www.wdr4.de/",
+      "country": "DE",
+      "favicon": "https://www1.wdr.de/radio/wdr4/wdrvier_logo~_v-ARDAustauschformat.jpg",
+      "bitrate": 102,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-50s-60s-radio",
+      "name": "50s 60s Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://50s60s-radio.stream.laut.fm/50s60s-radio?",
+      "homepage": "https://50s60s-radio.stream.laut.fm/",
+      "country": "DE",
+      "tags": [
+        "oldies"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-antenne-bayern-bayern-sound",
+      "name": "Antenne Bayern - Bayern Sound",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.antenne.de/bayern-sound/stream/mp3",
+      "homepage": "https://www.antenne.de/webradio/bayern-sound",
+      "country": "DE",
+      "favicon": "https://cdn-profiles.tunein.com/s309706/images/logod.jpg?t=637538489160000000",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.1397,
+        11.5521
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-landeswelle-deutsch",
+      "name": "LandesWelle Deutsch",
+      "broadcaster": "independent",
+      "streamUrl": "https://edge19.streamonkey.net/landeswelle-deutsch?aggregator=rewrite/mp3-192/rin/",
+      "homepage": "http://www.landeswelle.de/",
+      "country": "DE",
+      "tags": [
+        "german pop",
+        "pop",
+        "rock"
+      ],
+      "favicon": "http://www.landeswelle.de/images/landeswelle/favicons/touch-icon120.png",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-gay-fm",
+      "name": "Gay FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://icepool.silvacast.com/GAYFM.mp3",
+      "homepage": "https://www.gayfm.de/",
+      "country": "DE",
+      "favicon": "https://www.gayfm.de/images/logos/logo.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-hr4-mittelhessen",
+      "name": "hr4 Mittelhessen",
+      "broadcaster": "independent",
+      "streamUrl": "https://dispatcher.rndfnk.com/hr/hr4/mittelhessen/high",
+      "homepage": "https://www.hr4.de/",
+      "country": "DE",
+      "tags": [
+        "oldies",
+        "schlager",
+        "volksmusik"
+      ],
+      "favicon": "https://www.hr4.de/favicon.png?v=3.84.2",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.5828,
+        8.6723
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-antenne-thuringen-fm-mitte-mp3-192k",
+      "name": "Antenne Thüringen (fm) (Mitte) (mp3 192k)",
+      "broadcaster": "independent",
+      "streamUrl": "https://edge24.streamonkey.net/antthue-mitte?aggregator=rewrite/",
+      "homepage": "https://www.antennethueringen.de/",
+      "country": "DE",
+      "tags": [
+        "pop",
+        "regional radio"
+      ],
+      "favicon": "https://www.antennethueringen.de/assets/favicons/apple-icon-120x120.png",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-enigma",
+      "name": "Enigma",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.pcradio.ru/Enigma-hi",
+      "homepage": "https://pcradio.ru/",
+      "country": "DE",
+      "tags": [
+        "discography"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-hr3-nordhessen",
+      "name": "hr3 Nordhessen",
+      "broadcaster": "independent",
+      "streamUrl": "https://dispatcher.rndfnk.com/hr/hr3/nordhessen/high",
+      "homepage": "https://www.hr3.de/",
+      "country": "DE",
+      "tags": [
+        "pop"
+      ],
+      "favicon": "https://www.hr3.de/favicon.png?v=3.84.2",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.3151,
+        9.4939
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-superfly-hiphop",
+      "name": "Superfly HipHop",
+      "broadcaster": "independent",
+      "streamUrl": "https://web.stream.superfly.fm/superfly-hiphop",
+      "homepage": "https://superfly.fm/player/index.php?stream=darko_hiphop_app_playlist",
+      "country": "DE",
+      "favicon": "https://superfly.fm/player/img/s_logo.png?cb=V3000008",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-techno-bunker",
+      "name": "techno bunker",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/technobunkerfm",
+      "homepage": "https://laut.fm/technobunkerfm",
+      "country": "DE",
+      "tags": [
+        "techno"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.8926,
+        11.1841
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-wdr-3-adaptive-bitrate",
+      "name": "WDR 3 (adaptive bitrate)",
+      "broadcaster": "independent",
+      "streamUrl": "https://wdrhf.akamaized.net/hls/live/2027994/wdr3/master.m3u8",
+      "homepage": "https://www1.wdr.de/radio/wdr3/index.html",
+      "country": "DE",
+      "tags": [
+        "classical",
+        "culture",
+        "jazz"
+      ],
+      "favicon": "https://www1.wdr.de/resources/img/favicon/apple-touch-icon.png",
+      "bitrate": 102,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0nlineradio-christmas",
+      "name": "0nlineradio CHRISTMAS",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.0nlineradio.com/christmas?ref=radiobrowser",
+      "homepage": "https://0nlineradio.com/",
+      "country": "DE",
+      "tags": [
+        "ballade",
+        "ballads",
+        "christian",
+        "christmas",
+        "christmas music",
+        "weihnachten"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.7365,
+        8.6133
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ambient-radio",
+      "name": "Ambient Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/ambient",
+      "homepage": "https://laut.fm/ambient",
+      "country": "DE",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        53.5725,
+        9.9765
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-leas-s-fox-schlager",
+      "name": "LEAS´s FOX SCHLAGER",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio2.myhitmusic.de/Fresh-Hit.mp3",
+      "homepage": "https://myhitmusic.de/schlager-radio/",
+      "country": "DE",
+      "favicon": "http://myhitmusic.de/wp-content/uploads/2016/06/Leas-Fox-HD.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-primavera",
+      "name": "Radio Primavera",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.stream.primavera24.de/primavera24-radioprimavera/stream/mp3",
+      "homepage": "https://www.primavera24.de/",
+      "country": "DE",
+      "tags": [
+        "80s",
+        "90s",
+        "local news",
+        "local radio",
+        "pop",
+        "soft pop"
+      ],
+      "favicon": "https://www.blm.de/files/png2/primavera_neu_gr.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-swr1-die-80er",
+      "name": "SWR1 Die 80er",
+      "broadcaster": "independent",
+      "streamUrl": "https://d121.rndfnk.com/ard/swr/swr/raka16/aac/96/stream.aac?aggregator=web&cid=01FCZAZ2K8SF1QJ7BNCNNGRXJJ&sid=2JDHAZvGoxO64wmxiXn4rAmZmqH&token=g5ndVaCdxQRbT8tS0Xb2n2rXMu3QrDWyRkyg-2rFK58&tvf=Voz6vhLQMhdkMTIxLnJuZGZuay5jb20",
+      "homepage": "https://www.swr.de/swr1/swr1-webradio-kanal-die80er-100.html",
+      "country": "DE",
+      "tags": [
+        "80er",
+        "80s",
+        "oldies",
+        "pop"
+      ],
+      "favicon": "https://www.swr.de/unternehmen/kommunikation/1653432715862%2Clogos-swr1-116~_v-16x9@2dM_-ad6791ade5eb8b5c935dd377130b903c4b5781d8.jpg",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0r-hotel-lounge-chill-jazz-smooth-relax-soft-mus",
+      "name": "0R - HOTEL LOUNGE || Chill, Jazz, Smooth, Relax, Soft Music, Acoustic, Background, Dinner, Romantic, Evening, Calm, Cafe, Instrumental, Soft Pop",
+      "broadcaster": "independent",
+      "streamUrl": "https://0nlineradio.radioho.st/lounge-hotel-lounge?ref=radio-browser26",
+      "homepage": "https://plus.rm.fm/",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "ambient and relaxation music",
+        "ambiental",
+        "background",
+        "calm",
+        "chamber"
+      ],
+      "favicon": "https://i.ibb.co/GLkKPMc/Hotel-Lounge.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-antenne-mainz",
+      "name": "Antenne Mainz",
+      "broadcaster": "independent",
+      "streamUrl": "https://antennemainz-live.cast.addradio.de/antennemainz/live/mp3/high",
+      "homepage": "https://www.antenne-mainz.de/",
+      "country": "DE",
+      "tags": [
+        "germany",
+        "mainz",
+        "rheinland-pfalz"
+      ],
+      "favicon": "https://antenne-mainz.de/wp-content/uploads/2024/07/cropped-favicon-180x180.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-antenne-niederrhein",
+      "name": "Antenne Niederrhein",
+      "broadcaster": "independent",
+      "streamUrl": "https://antennenr--di--nacs-ais-lgc--05--cdn.cast.addradio.de/antennenr/live/mp3/high",
+      "homepage": "https://www.antenneniederrhein.de/",
+      "country": "DE",
+      "tags": [
+        "local radio"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.7871,
+        6.1309
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-darkclub-radio",
+      "name": "DARKCLUB-RADIO",
+      "broadcaster": "independent",
+      "streamUrl": "https://darkclubradio.stream.laut.fm/darkclubradio?pl=m3u&t302=2026-01-15_01-25-24&uuid=071b4561-c61e-4f53-bb60-527b9528ba2d",
+      "homepage": "https://laut.fm/darkclubradio",
+      "country": "DE",
+      "tags": [
+        "ebm",
+        "futurepop",
+        "gothic",
+        "industrial",
+        "synthpop",
+        "wave"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-hr1-mittelhessen",
+      "name": "hr1 Mittelhessen",
+      "broadcaster": "independent",
+      "streamUrl": "https://dispatcher.rndfnk.com/hr/hr1/mittelhessen/high",
+      "homepage": "https://www.hr1.de/",
+      "country": "DE",
+      "favicon": "https://www.hr1.de/favicon.png?v=3.84.2",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-melodic-radio",
+      "name": "Melodic Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.tunefm.de:2000/stream/melodicradio",
+      "homepage": "https://melodicradio.eu/",
+      "country": "DE",
+      "tags": [
+        "melodic rock",
+        "rock"
+      ],
+      "favicon": "https://melodicradio.eu/wp-content/uploads/2023/08/mr_logo_130x130.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radiofunandmore-radiofunandmore",
+      "name": "RadioFunAndMore,RadioFunAndMore",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiofunandmore.sp.radio.fm/stream",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "DE",
+      "tags": [
+        "2000er",
+        "70er",
+        "80er",
+        "90er",
+        "chart-hits",
+        "deutsch-pop"
+      ],
+      "favicon": "https://radiofunandmore.de/images/bilder/radiologo.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-traurig-by-rautemusik-rm-fm",
+      "name": "__TRAURIG__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://traurig-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://www.rm.fm/traurig",
+      "country": "DE",
+      "tags": [
+        "easy listening",
+        "feelings",
+        "slow",
+        "traurig",
+        "yordi rosado"
+      ],
+      "favicon": "https://www.rm.fm/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-charivari-munchen-live-hits",
+      "name": "Charivari München - Live Hits",
+      "broadcaster": "independent",
+      "streamUrl": "https://rs24.stream24.net/live-hits?ref=charivari.de&aw_0_1st.playerid=radioplayer.de",
+      "homepage": "https://www.charivari.de/",
+      "country": "DE",
+      "tags": [
+        "charivari",
+        "live",
+        "live concert"
+      ],
+      "favicon": "https://www.charivari.de/apple-icon-120x120.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-cosmo-dance",
+      "name": "Cosmo Dance",
+      "broadcaster": "independent",
+      "streamUrl": "https://wdr-cosmo-dance.icecastssl.wdr.de/wdr/cosmo/dance/mp3/128/stream.mp3",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "DE",
+      "tags": [
+        "electronic"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-oldie-antenne-60er-hits",
+      "name": "Oldie Antenne - 60er Hits",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.oldie-antenne.de/oldie-antenne-60er-hits/stream/mp3",
+      "homepage": "https://www.oldie-antenne.de/",
+      "country": "DE",
+      "tags": [
+        "60's",
+        "60er",
+        "oldies"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-rock",
+      "name": "rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rockantenne.de/rockantenne/stream/mp3",
+      "homepage": "https://www.rockantenne.de/",
+      "country": "DE",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-rt1-classic-rock",
+      "name": "RT1 Classic Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://frontend.streamonkey.net/rt1-ch01/stream/mp3?aggregator=rt1_web&aw_0_1st.playerid=rt1_web&aw_0_1st.source=imsuden_web",
+      "homepage": "https://rt1.imsueden.de/rt1-classic-rock",
+      "country": "DE",
+      "tags": [
+        "classic rock"
+      ],
+      "favicon": "https://rt1.imsueden.de/storage/thumbs/192x192/r:1678126825/1618.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.3663,
+        10.8872
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-skyline-efm-hard-trance",
+      "name": "Skyline EFM Hard Trance",
+      "broadcaster": "independent",
+      "streamUrl": "https://hard-trance.stream.laut.fm/hard-trance?pl=m3u",
+      "homepage": "https://laut.fm/hard-trance",
+      "country": "DE",
+      "tags": [
+        "hard trance"
+      ],
+      "favicon": "https://assets.laut.fm/b7de7a0f8a75ec5698a6b97e25de99da?t=_120x120",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.3694,
+        10.8936
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-90er-revival",
+      "name": "90er-Revival",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/90er-revival",
+      "homepage": "https://http//laut.fm/90er-revival",
+      "country": "DE",
+      "tags": [
+        "90s",
+        "pop",
+        "techno"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-absolut-wave",
+      "name": "Absolut Wave",
+      "broadcaster": "independent",
+      "streamUrl": "https://absolut-wave.live.absolutradio.de/",
+      "homepage": "https://absolutradio.de/wave/player",
+      "country": "DE",
+      "tags": [
+        "smooth lounge",
+        "wavemix"
+      ],
+      "favicon": "https://assets.radioplayer.org/276/2762711/600/600/kyaf2ebi.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-club-fm-mp3-192-kbit-s",
+      "name": "Club FM MP3 192 kbit/s",
+      "broadcaster": "independent",
+      "streamUrl": "https://rs7.stream24.net/clubfm.mp3",
+      "homepage": "https://clubfm.de/empfang/",
+      "country": "DE",
+      "tags": [
+        "party",
+        "party hits",
+        "pop",
+        "pop music"
+      ],
+      "favicon": "https://www.clubfm.de/storage/thumbs/192x192/r:1695642276/zdiljpqk3fvaz.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        49.8916,
+        10.8868
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-deutschrock",
+      "name": "Deutschrock",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/deutschrock",
+      "homepage": "https://deutschrock.eu/",
+      "country": "DE",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-ankerherz",
+      "name": "Radio Ankerherz ",
+      "broadcaster": "independent",
+      "streamUrl": "https://fra-pioneer08.dedicateware.com:3035/stream",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "DE",
+      "tags": [
+        "pop"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-victoria-100-4",
+      "name": "Radio Victoria 100,4",
+      "broadcaster": "independent",
+      "streamUrl": "https://a8.asurahosting.com:6700/radio.mp3",
+      "homepage": "https://radio-victoria.com/",
+      "country": "DE",
+      "favicon": "https://radio-victoria.com/wp-content/uploads/2025/03/logo-sq-noframe.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        48.7589,
+        8.2405
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-rammstein",
+      "name": "Rammstein Радио",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.pcradio.ru/Rammstein-hi",
+      "homepage": "https://pcradio.ru/",
+      "country": "DE",
+      "tags": [
+        "discography"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-swr1-bw",
+      "name": "SWR1 BW",
+      "broadcaster": "independent",
+      "streamUrl": "https://liveradio.swr.de/sw331ch/swr1bw/",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "DE",
+      "favicon": "https://api.ardmediathek.de/image-service/images/urn:ard:image:fcd6835b90ee9466?w=512",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-tango-berlin",
+      "name": "Tango Berlin",
+      "broadcaster": "independent",
+      "streamUrl": "https://tango.stream.laut.fm/tango?pl=m3u&t302=2026-01-14_23-52-14&uuid=c524b053-f88b-4e37-a732-f6248baa637f",
+      "homepage": "https://tango-radio-berlin.de/",
+      "country": "DE",
+      "tags": [
+        "milonga",
+        "tango",
+        "traditional"
+      ],
+      "favicon": "https://assets.laut.fm/0b99c828b64a9160d9a51463ffc09e1a?t=_120x120",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        52.5055,
+        13.4033
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-htd-radio-hit-the-dark",
+      "name": "HTD Radio - Hit the Dark",
+      "broadcaster": "independent",
+      "streamUrl": "https://htd-radio.stream.laut.fm/htd-radio?pl=pls&t302=2026-01-15_07-45-57&uuid=f054998e-93c0-400a-911a-92895c0501f8",
+      "homepage": "https://www.htd-radio.de/",
+      "country": "DE",
+      "tags": [
+        "darkwave",
+        "ebm",
+        "futurepop",
+        "gothic",
+        "electropop",
+        "synth-pop"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-modern-talking",
+      "name": "Modern Talking",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.pcradio.ru/Modern_Talking-hi",
+      "homepage": "https://pcradio.ru/",
+      "country": "DE",
+      "tags": [
+        "discography"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-rock-antenne-hamburg",
+      "name": "Rock Antenne Hamburg",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rockantenne.hamburg/rockantenne-hamburg/stream/mp3",
+      "homepage": "https://www.rockantenne.hamburg/",
+      "country": "DE",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0nlineradio-rock",
+      "name": "0nlineradio ROCK",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.0nlineradio.com/rock?ref=radiobrowser",
+      "homepage": "https://0nlineradio.com/",
+      "country": "DE",
+      "tags": [
+        "active rock",
+        "alternative rock",
+        "classic rock",
+        "hard rock",
+        "pop rock",
+        "progressive rock"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-accept",
+      "name": "Accept",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.pcradio.ru/accept-hi",
+      "homepage": "https://pcradio.ru/",
+      "country": "DE",
+      "tags": [
+        "discography"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-karneval-radio-de",
+      "name": "karneval-radio.de",
+      "broadcaster": "independent",
+      "streamUrl": "https://karneval-radio.stream.laut.fm/karneval-radio?t302=2026-01-15_06-55-01&uuid=bf3abab4-e369-4895-9f3d-7098920eb398",
+      "homepage": "https://karneval-radio.de/",
+      "country": "DE",
+      "tags": [
+        "colgne",
+        "disco",
+        "jeck",
+        "karneval",
+        "köln",
+        "kölsch"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-laut-fm-cinemaitaliano",
+      "name": "laut.fm Cinemaitaliano",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/cinemaitaliano",
+      "homepage": "https://laut.fm/cinemaitaliano",
+      "country": "DE",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-megaradiomix",
+      "name": "MEGARADIOmix",
+      "broadcaster": "independent",
+      "streamUrl": "https://play.megaradiomix.de/megaradiomix-berlin/mp3-192/",
+      "homepage": "https://megaradiomix.de/",
+      "country": "DE",
+      "tags": [
+        "dance",
+        "dj mixes",
+        "house",
+        "in the mix",
+        "mixed music",
+        "pop"
+      ],
+      "favicon": "https://megaradiomix.de/wp-content/uploads/2022/03/Radiologo600_600.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        48.3697,
+        10.8971
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-schlagerparadies",
+      "name": "Radio Schlagerparadies",
+      "broadcaster": "independent",
+      "streamUrl": "https://webstream.schlagerparadies.de/schlagerparadies128.mp3",
+      "homepage": "https://schlagerparadies.de/player/webplayer",
+      "country": "DE",
+      "favicon": "https://schlagerparadies.de/images/rsp_setup/apple-icon-180x180.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-rock-antenne-country-antenne",
+      "name": "Rock Antenne - Country Antenne",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rockantenne.de/country-antenne/stream/mp3",
+      "homepage": "https://www.rockantenne.de/rockhoeren/streams/country-antenne",
+      "country": "DE",
+      "tags": [
+        "country",
+        "music",
+        "rock"
+      ],
+      "favicon": "https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-swr2-archivradio",
+      "name": "SWR2 Archivradio ",
+      "broadcaster": "independent",
+      "streamUrl": "https://liveradio.swr.de/sw331ch/raka02/",
+      "homepage": "https://www.swr.de/swr2/wissen/archivradio/swr2-archivradio-ueber-uns-100.html",
+      "country": "DE",
+      "favicon": "https://www.swr.de/assets/swr/swr2/apple-touch-icon-120x120.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        48.7902,
+        9.223
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-swr4-kaiserslautern",
+      "name": "swr4 kaiserslautern",
+      "broadcaster": "independent",
+      "streamUrl": "https://liveradio.swr.de/sw282p3/swr4kl/",
+      "homepage": "https://www.swr.de/",
+      "country": "DE",
+      "favicon": "https://www.swr.de/assets/swr/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        49.4525,
+        7.7727
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0r-80s-80s-pop-80s-hits-synthpop-new-wave-dance-",
+      "name": "0R - 80s || 80s Pop, 80s Hits, Synthpop, New Wave, Dance, Disco, Pop Classics, Retro, Teen Pop, Funk, Pop Rock, Chart Hits, 80s Dance, Nostalgic, Hit Songs",
+      "broadcaster": "independent",
+      "streamUrl": "https://0nlineradio.radioho.st/0r-80s?ref=radio-browser26",
+      "homepage": "https://plus.rm.fm/",
+      "country": "DE",
+      "tags": [
+        "#80s",
+        "1980s",
+        "80er",
+        "80s",
+        "classic hits",
+        "goldies"
+      ],
+      "favicon": "https://i.ibb.co/Xxj9zX6w/80s.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.1525,
+        6.7072
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ballermann-radio-classic",
+      "name": "Ballermann Radio Classic",
+      "broadcaster": "independent",
+      "streamUrl": "https://audio.bmr-radio.de/classics/mp3-192/Webplayer",
+      "homepage": "https://www.ballermann-radio.de/stream/ballermannradio-classics/",
+      "country": "DE",
+      "favicon": "https://www.ballermann-radio.de/wp-content/uploads/2024/02/stream-ballermann-radio-classics-750x750.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-hr4-sudhessen",
+      "name": "hr4 Südhessen",
+      "broadcaster": "independent",
+      "streamUrl": "https://dispatcher.rndfnk.com/hr/hr4/suedhessen/high",
+      "homepage": "https://www.hr4.de/",
+      "country": "DE",
+      "tags": [
+        "oldies",
+        "schlager",
+        "volksmusik"
+      ],
+      "favicon": "https://www.hr4.de/favicon.png?v=3.84.2",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        49.8712,
+        8.6504
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-m-era-luna-fm",
+      "name": "M'era Luna FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://meralunafm.radionetz.de:8001/meralunafm.mp3",
+      "homepage": "https://meraluna.de/en/",
+      "country": "DE",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ostrock-und-ostpop",
+      "name": "Ostrock und Ostpop",
+      "broadcaster": "independent",
+      "streamUrl": "https://topradio-de-hz-fal-stream07-cluster01.radiohost.de/brf-ostrock-pop_mp3-128",
+      "homepage": "https://www.berliner-rundfunk.de/musik/streams/ostrock-und-ostpop",
+      "country": "DE",
+      "tags": [
+        "ostpop",
+        "ostrock"
+      ],
+      "favicon": "https://upload.berliner-rundfunk.de/production/static/1713539285366/icons/icon_64.a80y02808w0.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-flora",
+      "name": "radio flora",
+      "broadcaster": "independent",
+      "streamUrl": "https://radioflora.de:8443/stream/live192.mp3",
+      "homepage": "https://radioflora.de/",
+      "country": "DE",
+      "tags": [
+        "community radio",
+        "freies radio",
+        "hannover"
+      ],
+      "favicon": "https://radioflora.de/wp-content/uploads/2018/07/flora-logo-3.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        52.3764,
+        9.7109
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-you-fm",
+      "name": "you-fm",
+      "broadcaster": "independent",
+      "streamUrl": "https://hlsyoufm.akamaized.net/hls/live/2016538/youfm/master.m3u8",
+      "homepage": "https://www.you-fm.de/index.html",
+      "country": "DE",
+      "tags": [
+        "dance",
+        "pop",
+        "pop music"
+      ],
+      "favicon": "https://www.you-fm.de/favicon.png?v=3.84.2",
+      "bitrate": 200,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-blues-rock-cafe",
+      "name": "Blues Rock Cafe",
+      "broadcaster": "independent",
+      "streamUrl": "https://bluesrockcafe.stream.laut.fm/bluesrockcafe?pl=m3u&t302=2026-01-15_01-42-17&uuid=93a25a07-e5e9-4200-b906-3ba3dac32e96",
+      "homepage": "https://laut.fm/bluesrockcafe",
+      "country": "DE",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ddreins",
+      "name": "ddreins",
+      "broadcaster": "independent",
+      "streamUrl": "https://ddreins.stream.laut.fm/ddr_eins?t302=2021-04-10_23-03-54&uuid=43c8d3cf-54c4-4ee1-b109-b667d8878cc4",
+      "homepage": "https://www.ddreins.de/",
+      "country": "DE",
+      "favicon": "https://duckduckgo.com/?q=ddreins&iax=images&ia=images&iai=https%3A%2F%2Fradio-marabu.de%2Fwordpress%2Fwp-content%2Fuploads%2F2020%2F11%2Fddreins...logo_large-1024x311.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0nlineradio-deutschrap",
+      "name": "0nlineradio DEUTSCHRAP",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.0nlineradio.com/deutschrap?ref=radiobrowser",
+      "homepage": "https://0nlineradio.com/",
+      "country": "DE",
+      "tags": [
+        "deutsch",
+        "deutsche lieder",
+        "deutschrap",
+        "gangst rap",
+        "german",
+        "hiphop"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.5134,
+        8.2617
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-psr-80er",
+      "name": "RADIO PSR 80er",
+      "broadcaster": "independent",
+      "streamUrl": "https://streams.radiopsr.de/psr-80er/mp3-192/www.radio-browser.info/play.m3u8",
+      "homepage": "https://www.radiopsr.de/",
+      "country": "DE",
+      "tags": [
+        "80er",
+        "classic dance",
+        "pop",
+        "pop rock",
+        "rock"
+      ],
+      "favicon": "https://upload.radiopsr.de/production/static/1693298881101/icons/icon_64.cawac0w0200.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0r-80s-rock-classic-rock-hard-rock-pop-rock-rock",
+      "name": "0R - 80s ROCK || Classic Rock, Hard Rock, Pop Rock, Rock Hits, Guitar, Ballads, Hair Metal, Rock Anthems, Retro, Vintage, Arena Rock, Party Rock, Rock Classics, Melodic Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://0nlineradio.radioho.st/0r-80s-rock?ref=radio-browser26",
+      "homepage": "https://0nlineradio.com/",
+      "country": "DE",
+      "tags": [
+        "1980s",
+        "80s",
+        "alternative rock",
+        "blues rock",
+        "classic rock",
+        "hard rock"
+      ],
+      "favicon": "https://i.ibb.co/hFC0q0h8/80s-Rock.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.2141,
+        6.7679
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ostseewelle-hamburg-schleswig-holstein",
+      "name": "Ostseewelle Hamburg & Schleswig-Holstein",
+      "broadcaster": "independent",
+      "streamUrl": "https://addrad.io/4459gsm",
+      "homepage": "https://www.ostseewelle.de/",
+      "country": "DE",
+      "tags": [
+        "pop"
+      ],
+      "favicon": "https://www.ostseewelle.de/assets/icons/apple-touch-icon.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        54.1225,
+        10.4205
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-prysm-radio-nu-disco",
+      "name": "Prysm Radio Nu Disco",
+      "broadcaster": "independent",
+      "streamUrl": "https://streamingv2.shoutcast.com/prysm-nu-disco",
+      "homepage": "https://www.prysmradio.com/",
+      "country": "DE",
+      "tags": [
+        "euro disco",
+        "nu disco"
+      ],
+      "favicon": "https://secure.gravatar.com/avatar/3d417d46e874e8c99e0283550d4a429e?s=36&#038;d=mm&#038;r=g",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-laut-fm-freakquency",
+      "name": "[laut.fm] Freakquency",
+      "broadcaster": "independent",
+      "streamUrl": "https://freakquency.stream.laut.fm/freakquency?pl=pls&t302=2026-01-15_07-18-13&uuid=5162a938-aa72-4ea6-9bca-c737541068ff",
+      "homepage": "https://laut.fm/freakquency",
+      "country": "DE",
+      "tags": [
+        "alternative rock",
+        "americana",
+        "blues rock",
+        "classic rock",
+        "jazz-rock",
+        "progressive rock"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0r-deep-house-chillout-ambient-house-chill-loung",
+      "name": "0R - DEEP HOUSE || Chillout, Ambient House, Chill, Lounge, Electronic, Dance, Smooth, Vocal, Club, Night, Party, Groove, Melodic, Summer, Beat",
+      "broadcaster": "independent",
+      "streamUrl": "https://0nlineradio.radioho.st/technolovers-deep-house?ref=radio-browser26",
+      "homepage": "https://plus.rm.fm/",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "club house",
+        "deep house",
+        "easy listening",
+        "electro house",
+        "electronic"
+      ],
+      "favicon": "https://i.ibb.co/Y7PzyGxb/Deep-House-TL.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0r-restaurant-lounge-lounge-jazz-chill-soft-musi",
+      "name": "0R - RESTAURANT LOUNGE || Lounge, Jazz, Chill, Soft Music, Background, Acoustic, Easy Listening, Dinner, Relax, Romantic, Smooth, Cafe, Evening, Instrumental, Calm",
+      "broadcaster": "independent",
+      "streamUrl": "https://0nlineradio.radioho.st/lounge-restaurant-lounge?ref=radio-browser26",
+      "homepage": "https://plus.rm.fm/",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "ambient and relaxation music",
+        "ambient lounge",
+        "background",
+        "cafe background music",
+        "chillout"
+      ],
+      "favicon": "https://i.ibb.co/xKZ5J8jt/Restaurant-Lounge.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ffh-itunes-top-40-aac-128-kbps",
+      "name": "FFH iTunes Top 40. AAC 128 kbps",
+      "broadcaster": "independent",
+      "streamUrl": "https://mp3.ffh.de/ffhchannels/hqtop40.aac",
+      "homepage": "https://www.ffh.de/",
+      "country": "DE",
+      "bitrate": 128,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-moviedance",
+      "name": "Moviedance",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/moviedance",
+      "homepage": "https://laut.fm/moviedance",
+      "country": "DE",
+      "tags": [
+        "soundtracks"
+      ],
+      "favicon": "https://assets.laut.fm/924196b9b3a8abfb760a4d145b12ee06",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-schlagerheilo",
+      "name": "Schlagerheilo",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.tunefm.de:2000/stream/schlagerheilo",
+      "homepage": "https://phonostar.de/radio/schlagerheilo",
+      "country": "DE",
+      "tags": [
+        "schlager"
+      ],
+      "favicon": "https://www.phonostar.de//images/auto_created/radio_schlagerheilo54x54.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-swr-2-aac-96k",
+      "name": "SWR 2  [AAC 96k]",
+      "broadcaster": "independent",
+      "streamUrl": "https://liveradio.swr.de/sw331ch/swr2/",
+      "homepage": "https://www.swr.de/swr2/index.html",
+      "country": "DE",
+      "tags": [
+        "classical music",
+        "culture",
+        "information",
+        "jazz"
+      ],
+      "favicon": "https://www.swr.de/assets/swr/swr2/apple-touch-icon-120x120.png",
+      "bitrate": 96,
+      "codec": "AAC",
+      "geo": [
+        48.7932,
+        9.2037
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0r-romantic-piano-piano-romantic-soft-classical-",
+      "name": "0R - ROMANTIC PIANO || Piano, Romantic, Soft, Classical, Ballads, Love, Calm, Relaxing, Slow, Instrumental, Evening, Peaceful, Background, Melodic, Gentle",
+      "broadcaster": "independent",
+      "streamUrl": "https://0nlineradio.radioho.st/piano-romantic-piano?ref=radio-browser26",
+      "homepage": "https://plus.rm.fm/",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "background",
+        "classical piano",
+        "easy listening",
+        "instrumental",
+        "jazz"
+      ],
+      "favicon": "https://i.ibb.co/1tW9hJhd/Romantic-Piano.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-iloveradio",
+      "name": "ILoveRadio",
+      "broadcaster": "independent",
+      "streamUrl": "https://play.ilovemusic.de/ilm_iloveradio/",
+      "homepage": "http://iloveradio.de/",
+      "country": "DE",
+      "favicon": "http://iloveradio.de/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-legende",
+      "name": "Radio Legende",
+      "broadcaster": "independent",
+      "streamUrl": "https://einfach-webradio.de:10443/radio/8050/radio.mp3",
+      "homepage": "https://www.radio-legende.de/",
+      "country": "DE",
+      "tags": [
+        "folk",
+        "medieval",
+        "mittelalter"
+      ],
+      "favicon": "https://www.radio-legende.de/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-wdr-cosmo-italia",
+      "name": "WDR COSMO - Italia",
+      "broadcaster": "independent",
+      "streamUrl": "https://dispatcher.rndfnk.com/wdr/cosmo/italia/mp3/128/stream.mp3",
+      "homepage": "https://www1.wdr.de/radio/cosmo/channels/italia-channel-100.html",
+      "country": "DE",
+      "tags": [
+        "italia-sounds",
+        "italo"
+      ],
+      "favicon": "https://www1.wdr.de/radio/cosmo/resources-v5.128.1/img/favicon/favicon-32x32.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-laut-fm-lofi",
+      "name": "[laut.fm] lofi",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/lofi",
+      "homepage": "https://laut.fm/",
+      "country": "DE",
+      "tags": [
+        "hiphop",
+        "instrumental",
+        "instrumental music",
+        "lofi"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.1485,
+        11.5444
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0nlineradio-top40",
+      "name": "0nlineradio TOP40",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.0nlineradio.com/top40?ref=radiobrowser",
+      "homepage": "https://0nlineradio.com/",
+      "country": "DE",
+      "tags": [
+        "charts",
+        "german",
+        "hits",
+        "pop",
+        "rap",
+        "rock"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-lounge-gaming-lounge",
+      "name": "Epic Lounge - GAMING LOUNGE",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-lounge.com/gaming-lounge?ref=radiobrowser",
+      "homepage": "https://epic-lounge.com/",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "ambient and relaxation music",
+        "chill",
+        "chillout",
+        "chillout+lounge",
+        "classic hip hop"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.1173,
+        9.2578
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-flashbass-fm",
+      "name": "Flashbass.fm",
+      "broadcaster": "independent",
+      "streamUrl": "https://flashbass-fm.stream.laut.fm/flashbass-fm",
+      "homepage": "https://flashbass.fm/",
+      "country": "DE",
+      "favicon": "https://flashbass.fm/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-laut-fm-post-rock",
+      "name": "Laut.fm Post-Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://post-rock.stream.laut.fm/post-rock?pl=m3u&t302=2026-01-14_23-35-11&uuid=93c98b91-e6ff-4ab5-9657-597cdbf44605",
+      "homepage": "https://laut.fm/post-rock",
+      "country": "DE",
+      "tags": [
+        "instrumental rock",
+        "post-rock"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-soundsindie",
+      "name": "Soundsindie",
+      "broadcaster": "independent",
+      "streamUrl": "https://soundsindie.stream.laut.fm/soundsindie?t302=2026-01-15_00-39-17&uuid=b964e14b-acde-48cc-9208-0a783f2e7667",
+      "homepage": "https://stream.laut.fm/soundsindie",
+      "country": "DE",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-startrek",
+      "name": "startrek",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/startrek",
+      "homepage": "https://www.radio.net/s/lautfm-startrek",
+      "country": "DE",
+      "tags": [
+        "ost",
+        "soundtrack",
+        "star trek"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        52.5027,
+        13.3639
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1-splash-80s",
+      "name": "#1 Splash 80s",
+      "broadcaster": "independent",
+      "streamUrl": "https://makri.cdnstream.com/1898_128",
+      "homepage": "https://www.splashradio.eu/",
+      "country": "DE",
+      "tags": [
+        "80er",
+        "80s",
+        "80s radio",
+        "all 80s"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1000-2000er-laut-fm",
+      "name": "1000 2000er - laut.fm",
+      "broadcaster": "independent",
+      "streamUrl": "https://10002000er.stream.laut.fm/10002000er",
+      "homepage": "https://laut.fm/10002000er",
+      "country": "DE",
+      "tags": [
+        "aktuell",
+        "hip-hop",
+        "pop"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-laut-fm-radio-weihnacht",
+      "name": "laut.fm Radio-Weihnacht",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio-weihnacht.stream.laut.fm/radio-weihnacht?t302=2018-12-13_20-18-51&uuid=eb287bfb-fed0-4200-8702-c70ca537756b",
+      "homepage": "https://laut.fm/radio-weihnacht",
+      "country": "DE",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-nordpolradio",
+      "name": "Nordpolradio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/nordpolradio",
+      "homepage": "https://www.nordpolradio.de/",
+      "country": "DE",
+      "tags": [
+        "christmas",
+        "christmas music",
+        "holiday",
+        "klassik weihnachten christmas",
+        "natal",
+        "navidad"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-planet-more-music-radio",
+      "name": "planet more music radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://mp3.planetradio.de/planetradio/hqlivestream.aac",
+      "homepage": "https://www.planetradio.de/musik/webradio/29-planet-radio.html",
+      "country": "DE",
+      "favicon": "https://static.planetradio.de/fileadmin/_processed_/7/0/csm_planet_simulcast_1x1_6362baa9c1.jpg",
+      "bitrate": 128,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-punktum-hd-regionalfernsehen-mansfeld-sudharz",
+      "name": "PUNKTum HD - Regionalfernsehen Mansfeld-Südharz",
+      "broadcaster": "independent",
+      "streamUrl": "https://h056.video-stream-hosting.de/medienasa-live/_definst_/mp4:punktum_high/playlist.m3u8",
+      "homepage": "https://www.punktum-fernsehen.de/",
+      "country": "DE",
+      "tags": [
+        "iptv",
+        "lokalfernsehen",
+        "mansfeld südharz",
+        "punktum fernsehen",
+        "querfurt"
+      ],
+      "bitrate": 2512,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-schwany-5-oberkrainer-musik",
+      "name": "Radio Schwany 5 - Oberkrainer Musik",
+      "broadcaster": "independent",
+      "streamUrl": "https://schwany.streampanel.cloud/5-oberkrain",
+      "homepage": "https://www.schwany.de/index.html",
+      "country": "DE",
+      "tags": [
+        "bayern",
+        "oberkrain",
+        "schwany",
+        "slowenien",
+        "volksmusik"
+      ],
+      "favicon": "https://static.mytuner.mobi/media/radios-150px/vndDV9QKFr.jpg",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        48.845,
+        12.6196
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-rpi-radio-peissnitz-international-world-music-ra",
+      "name": "RPI Radio Peissnitz International – World Music Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://rpi-world-music-radio.stream.laut.fm/rpi-world-music-radio",
+      "homepage": "https://www.rpiworld.com/",
+      "country": "DE",
+      "favicon": "https://u.jimcdn.com/cms/o/s3920b80322ec5d13/img/favicon.png?t=1438726612",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-8-ansbach-de",
+      "name": "Radio 8 - Ansbach DE",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.radio8.de:8003/liver8",
+      "homepage": "https://www.radio8.de/",
+      "country": "DE",
+      "favicon": "https://www.radio8.de/storage/thumbs/270x270/f:png/r:1518431307/27773.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-fips-89-0-fm",
+      "name": "Radio Fips 89.0 FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://streams.radiofips.de/fipsmp3",
+      "homepage": "https://www.radiofips.de/",
+      "country": "DE",
+      "tags": [
+        "independent"
+      ],
+      "favicon": "https://www.radiofips.de/wp-content/uploads/2019/01/cropped-radiofips-f-transparent-8-180x180.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-techno",
+      "name": "TECHNO",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/techno",
+      "homepage": "https://laut.fm/techno",
+      "country": "DE",
+      "tags": [
+        "deutschrap",
+        "edm",
+        "techno"
+      ],
+      "favicon": "https://assets.laut.fm/e837bb137d5e31a048d55632f3f84394?t=_120x120",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-wdr-3-klassik",
+      "name": "WDR 3 Klassik",
+      "broadcaster": "independent",
+      "streamUrl": "https://wdr-wdr3-klassik.icecast.wdr.de/wdr/wdr3/klassik/mp3/128/stream.mp3",
+      "homepage": "https://www1.wdr.de/radio/player/radioplayer106~_layout-popupVersion.html",
+      "country": "DE",
+      "tags": [
+        "classical",
+        "klassik"
+      ],
+      "favicon": "https://www1.wdr.de/resources/img/wdr/logo/epgmodule/wdr3_logo.svg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-wdr-cosmo-dem-power",
+      "name": "WDR COSMO dem:power",
+      "broadcaster": "independent",
+      "streamUrl": "https://f111.rndfnk.com/ard/wdr/cosmo/trap/mp3/128/stream.mp3?sid=250K8iAHEo0RuhvRIk3RiKsyUlJ&token=Vrq7nq_P_2K14sZf6TFoipEdEtiCqH2SZUkgrdpfywg&tvf=f7SxSsAT0xZmMTExLnJuZGZuay5jb20",
+      "homepage": "https://www1.wdr.de/radio/cosmo/channels/fempower-channel-100.html",
+      "country": "DE",
+      "tags": [
+        "female vocalists",
+        "female voices",
+        "femalevocals"
+      ],
+      "favicon": "https://www1.wdr.de/radio/cosmo/resources-v5.142.2/img/favicon/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-wohltat-radio",
+      "name": "Wohltat Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://soundvis.eu/stream/wohltat",
+      "homepage": "https://radio.wir-schaffen.de/",
+      "country": "DE",
+      "tags": [
+        "various"
+      ],
+      "favicon": "https://radio.wir-schaffen.de/wp-content/uploads/2023/11/cropped-wohltatradio.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        50.866,
+        6.1
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1-a-pop-von-1a-radio",
+      "name": "- 1 A - Pop von 1A Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://1a-pop.radionetz.de/1a-pop.mp3",
+      "homepage": "http://www.1aradio.com/",
+      "country": "DE",
+      "tags": [
+        "black",
+        "dance",
+        "hiphop",
+        "hits",
+        "pop",
+        "rock"
+      ],
+      "favicon": "https://www.1aradio.com/logos/1a-pop_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1st-house",
+      "name": "1st-House",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/1st-house",
+      "homepage": "https://laut.fm/1st-house",
+      "country": "DE",
+      "tags": [
+        "house"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-club-radio",
+      "name": "club radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.multhielemedia.de/radio/8010/clubradio.mp3",
+      "homepage": "https://www.club.radio/",
+      "country": "DE",
+      "bitrate": 160,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-fu-ball-bundesliga-2-spiel-1",
+      "name": "Fußball-Bundesliga 2: Spiel 1",
+      "broadcaster": "independent",
+      "streamUrl": "https://wdr-sportschau-liga2spiel1.icecastssl.wdr.de/wdr/sportschau/liga2spiel1/mp3/high",
+      "homepage": "https://livecenter.sportschau.de/",
+      "country": "DE",
+      "tags": [
+        "football",
+        "live sports",
+        "sport"
+      ],
+      "favicon": "https://www.sportschau.de/resources/assets/image/favicon/apple-icon-120x120.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-kika-hd-kinderkanal-von-ard-und-zdf",
+      "name": "KiKA HD - Kinderkanal von ARD und ZDF",
+      "broadcaster": "independent",
+      "streamUrl": "https://kikageohls.akamaized.net/hls/live/2022693/livetvkika_de/master.m3u8",
+      "homepage": "https://www.kika.de/",
+      "country": "DE",
+      "tags": [
+        "ard",
+        "cartoon network",
+        "checkeins",
+        "children tv",
+        "disney channel",
+        "iptv"
+      ],
+      "bitrate": 1672,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-musical-radio",
+      "name": "Musical Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiostreamserver.de/musicalradio.mp3",
+      "homepage": "https://musicalradio.de/index.php",
+      "country": "DE",
+      "tags": [
+        "musical"
+      ],
+      "favicon": "https://musicalradio.de/images/seitenelemente/favicon180.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-galaxy-ingolstadt",
+      "name": "Radio Galaxy Ingolstadt",
+      "broadcaster": "independent",
+      "streamUrl": "https://funkhaus-ingolstadt.stream24.net/galaxy-ingolstadt.mp3",
+      "homepage": "https://www.galaxy-ingolstadt.de/",
+      "country": "DE",
+      "favicon": "https://www.galaxy-ingolstadt.de/storage/thumbs/192x192/r:1670490964/463.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-waf",
+      "name": "Radio WAF",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiowaf--di--nacs-ais-lgc--05--cdn.cast.addradio.de/radiowaf/live/mp3/high",
+      "homepage": "https://www.radiowaf.de/home.html",
+      "country": "DE",
+      "tags": [
+        "pop"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.952,
+        7.9925
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radiomonster-fm-2000s",
+      "name": "Radiomonster.FM - 2000s",
+      "broadcaster": "independent",
+      "streamUrl": "https://ic.radiomonster.fm/2000s.ultra",
+      "homepage": "http://www.radiomonster.fm/",
+      "country": "DE",
+      "tags": [
+        "rock"
+      ],
+      "favicon": "https://www.radiomonster.fm/wp-content/uploads/2020/06/cropped-radiomonster_logo_compact_transparent_2000px-180x180.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0r-bach-classical-classical-baroque-orchestra-pi",
+      "name": "0R - BACH - CLASSICAL || Classical, Baroque, Orchestra, Piano, Strings, Chamber Music, Solo Instrument, Sacred, Symphonies, Concertos, Melodic, Calm, Relaxing, Instrumental, Elegant",
+      "broadcaster": "independent",
+      "streamUrl": "https://0nlineradio.radioho.st/0r-bach?ref=radio-browser26",
+      "homepage": "https://plus.rm.fm/",
+      "country": "DE",
+      "tags": [
+        "bach",
+        "chamber",
+        "classical",
+        "instrumental",
+        "klassik",
+        "orchestral"
+      ],
+      "favicon": "https://i.ibb.co/FbmVd1LG/Bach-KL.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.9242,
+        7.0093
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0r-mozart-classical-orchestra-piano-strings-cham",
+      "name": "0R - MOZART - CLASSICAL || Orchestra, Piano, Strings, Chamber, Symphony, Solo Instrument, Elegant, Melodic, Calm, Relaxing, Timeless, Instrumental, Soft, Meditative",
+      "broadcaster": "independent",
+      "streamUrl": "https://0nlineradio.radioho.st/0r-mozart?ref=radio-browser26",
+      "homepage": "https://plus.rm.fm/",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "classical",
+        "classical piano",
+        "easy listening",
+        "elegant",
+        "light orchestral"
+      ],
+      "favicon": "https://i.ibb.co/Z67qTCXr/Mozart-KL.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ella-radio-coffee-jazz",
+      "name": "Ella Radio - Coffee Jazz",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.ella-radio.de/ella-coffee-jazz/mp3-192/?ref=radio-browser",
+      "homepage": "https://www.ella-radio.de/",
+      "country": "DE",
+      "tags": [
+        "jazz"
+      ],
+      "favicon": "https://ella-radio.de/uplink/Ella_Coffee-Jazz.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-m1-fm-90s",
+      "name": "M1.FM 90s",
+      "broadcaster": "independent",
+      "streamUrl": "https://tuner.m1.fm/90er.aac",
+      "homepage": "http://m1.fm/90er.php",
+      "country": "DE",
+      "tags": [
+        "90s",
+        "dance",
+        "eurodance"
+      ],
+      "favicon": "http://m1.fm/favicon.ico",
+      "bitrate": 48,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-aktiv-hameln",
+      "name": "radio aktiv Hameln",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.radio-aktiv.de/r-aktiv.mp3",
+      "homepage": "https://www.radio-aktiv.de/",
+      "country": "DE",
+      "tags": [
+        "pop",
+        "talk"
+      ],
+      "bitrate": 256,
+      "codec": "MP3",
+      "geo": [
+        52.1044,
+        9.3628
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-cafe-zimmermann-aac-48",
+      "name": "Radio Cafe Zimmermann (AAC 48)",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radio-cafezimmermann.de/klassik/aac-48/",
+      "homepage": "http://www.radio-cafezimmermann.de/",
+      "country": "DE",
+      "tags": [
+        "classical"
+      ],
+      "favicon": "https://www.phonostar.de/images/auto_created/Radio_Cafe_Zimmermann184x184.png",
+      "bitrate": 48,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-saarmaxxi-vinyls",
+      "name": "SaarMaxxi Vinyls",
+      "broadcaster": "independent",
+      "streamUrl": "https://maxxi-fm.stream.laut.fm/maxxi-fm?t302=2025-03-03_21-07-02&uuid=11487338-935e-4c70-9579-e3772de51ac2",
+      "homepage": "http://www.saarlandsender.de/Startseite/",
+      "country": "DE",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-technothorium",
+      "name": "TECHNOTHORIUM",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/technothorium",
+      "homepage": "https://laut.fm/technothorium",
+      "country": "DE",
+      "tags": [
+        "dark techno",
+        "techno"
+      ],
+      "favicon": "https://assets.laut.fm/9658828545e209b495a0f7594937e470?t=_120x120",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-shredded-by-rautemusik-rm-fm",
+      "name": "__SHREDDED__ by RauteMusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://streams.rautemusik.fm/shredded/mp3-192/stream.mp3",
+      "homepage": "https://www.rm.fm/shredded/",
+      "country": "DE",
+      "tags": [
+        "hardcore",
+        "heavy metal",
+        "metal"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-dwg-lyra",
+      "name": "DWG Lyra",
+      "broadcaster": "independent",
+      "streamUrl": "https://server34599.streamplus.de/stream.mp3",
+      "homepage": "https://radio.dwgradio.net/de/radio-pur-lyra/",
+      "country": "DE",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-music-fm",
+      "name": "MUSIC FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://music-fm.stream.laut.fm/music-fm-",
+      "homepage": "https://music-fm.de/",
+      "country": "DE",
+      "tags": [
+        "charts",
+        "dance",
+        "pop",
+        "top charts"
+      ],
+      "favicon": "https://music-fm.de/wp-content/uploads/2024/10/cropped-mfm_web_icon-180x180.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-italo-germanysaar",
+      "name": "Radio Italo GermanySaar",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio-italo.stream.laut.fm/radio-italo?t302=2025-03-03_21-43-43&uuid=27547de2-b116-4ee7-ad1b-44b79baac89d",
+      "homepage": "http://www.saarlandsender.de/Startseite/",
+      "country": "DE",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-blk-tv-hd-regionalfernsehen-burgenlandkreis",
+      "name": "BLK TV HD - Regionalfernsehen Burgenlandkreis",
+      "broadcaster": "independent",
+      "streamUrl": "https://h056.video-stream-hosting.de/medienasa-live/_definst_/mp4:BLKonline_high/playlist.m3u8",
+      "homepage": "https://www.blkregional.de/",
+      "country": "DE",
+      "tags": [
+        "blk tv",
+        "burgenlandkreis",
+        "iptv",
+        "lokalfernsehen",
+        "regionalfernsehen"
+      ],
+      "bitrate": 2447,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-castlefm",
+      "name": "CastleFM",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/castlefm",
+      "homepage": "https://castlefm.de/",
+      "country": "DE",
+      "tags": [
+        "2000s",
+        "2010s",
+        "castlefm",
+        "christian",
+        "dance",
+        "pop"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-hr1-nordhessen",
+      "name": "hr1 Nordhessen",
+      "broadcaster": "independent",
+      "streamUrl": "https://dispatcher.rndfnk.com/hr/hr1/nordhessen/high",
+      "homepage": "https://www.hr1.de/",
+      "country": "DE",
+      "tags": [
+        "adult contemporary"
+      ],
+      "favicon": "https://www.hr1.de/favicon.png?v=3.84.2",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.3164,
+        9.4982
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-reyfm-summer",
+      "name": "REYFM - #Summer",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.reyfm.de/reyfm-summer/",
+      "homepage": "https://rey.fm/",
+      "country": "DE",
+      "tags": [
+        "music"
+      ],
+      "favicon": "https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-rock-antenne-party-rock",
+      "name": "Rock Antenne - Party Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rockantenne.de/rock-antenne-party-rock/stream/mp3",
+      "homepage": "https://www.rockantenne.de/rockhoeren/streams/party-rock",
+      "country": "DE",
+      "tags": [
+        "music",
+        "party",
+        "rock"
+      ],
+      "favicon": "https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-burnfm-musik-intensiv",
+      "name": "BurnFM - musik intensiv!",
+      "broadcaster": "independent",
+      "streamUrl": "https://burnfm.radionetz.de/burn-fm.mp3",
+      "homepage": "http://www.burn-fm.de/",
+      "country": "DE",
+      "tags": [
+        "alternative",
+        "hard rock",
+        "metal",
+        "rock"
+      ],
+      "favicon": "https://www.1aradio.com/logos/burnfm.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.3115,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-hertz-87-9-campusradio-fur-bielefeld-mp3-hq",
+      "name": "Hertz 87.9 - Campusradio für Bielefeld | MP3 HQ",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radiohertz.de/hertz-hq.mp3",
+      "homepage": "https://www.hertz879.de/",
+      "country": "DE",
+      "tags": [
+        "bielefeld",
+        "campus radio",
+        "local news",
+        "pop",
+        "rock",
+        "student"
+      ],
+      "favicon": "https://www.hertz879.de/wp-content/themes/wp-hertz/assets/img/favicon.ico",
+      "codec": "MP3",
+      "geo": [
+        52.0381,
+        8.4943
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-laut-fm-punk-and-disorderly-the-80s",
+      "name": "Laut.FM - Punk and Disorderly The 80s",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/punkanddisorderly-the80s",
+      "homepage": "https://laut.fm/punkanddisorderly-the80s",
+      "country": "DE",
+      "tags": [
+        "80's",
+        "punk rock"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-laut-fm-elektroradio",
+      "name": "Laut.fm | Elektroradio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/elektroradio",
+      "homepage": "https://laut.fm/elektroradio",
+      "country": "DE",
+      "tags": [
+        "electro",
+        "elektro"
+      ],
+      "favicon": "https://assets.laut.fm/e837bb137d5e31a048d55632f3f84394?t=_120x120",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-britpop-laut-fm",
+      "name": "Britpop (Laut.FM)",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/britpop",
+      "homepage": "https://laut.fm/britpop",
+      "country": "DE",
+      "tags": [
+        "britpop"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ella-radio-smooth-bossa-nova",
+      "name": "Ella Radio - Smooth Bossa Nova",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.ella-radio.de/ella-smooth-bossa-nova/mp3-192/?ref=radio-browser",
+      "homepage": "https://www.ella-radio.de/",
+      "country": "DE",
+      "tags": [
+        "bossa nova",
+        "jazz",
+        "smooth jazz"
+      ],
+      "favicon": "https://ella-radio.de/uplink/Ella_Smooth-Bossa-Nova.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-gohappy-laut-fm",
+      "name": "Gohappy-Laut FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://gohappy-fm.stream.laut.fm/gohappy-fm?t302=2026-01-15_08-02-25&uuid=6a77bf8e-869c-4448-962c-2271e90ce762",
+      "homepage": "https://laut.fm/gohappy-fm",
+      "country": "DE",
+      "tags": [
+        "italo disco"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-kulturalkanal-laut-fm",
+      "name": "Kulturalkanal-Laut.fm",
+      "broadcaster": "independent",
+      "streamUrl": "https://kulturkanal.stream.laut.fm/kulturkanal?t302=2026-01-15_05-22-09&uuid=89312619-bb03-4568-b161-630a21ee3098",
+      "homepage": "https://laut.fm/",
+      "country": "DE",
+      "tags": [
+        "classical",
+        "cultural",
+        "kultur"
+      ],
+      "favicon": "https://laut.fm/assets/touch-icons/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0r-spa-lounge-relax-spa-calm-meditation-nature-a",
+      "name": "0R - SPA LOUNGE || Relax, Spa, Calm, Meditation, Nature, Ambient, Soft, Yoga, Peaceful, Instrumental, Chill, Wellness, Background, Gentle, Healing",
+      "broadcaster": "independent",
+      "streamUrl": "https://0nlineradio.radioho.st/lounge-spa-lounge?ref=radio-browser26",
+      "homepage": "https://plus.rm.fm/",
+      "country": "DE",
+      "tags": [
+        "background",
+        "chill",
+        "chillout",
+        "chillout+lounge",
+        "easy",
+        "easy listening"
+      ],
+      "favicon": "https://i.ibb.co/nMy1KKtY/SPA-LOUNGE.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-dnbradio",
+      "name": "DNBRadio",
+      "broadcaster": "independent",
+      "streamUrl": "https://azura.drmnbss.org:8000/radio.mp3",
+      "homepage": "https://dnbradio.com/",
+      "country": "DE",
+      "favicon": "https://azura.drmnbss.org/static/uploads/dnbradio/album_art.1720523017.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-rock-antenne-bayern",
+      "name": "Rock Antenne Bayern",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rockantenne.bayern/rockantenne-bayern/stream/mp3",
+      "homepage": "https://www.rockantenne.bayern/",
+      "country": "DE",
+      "tags": [
+        "heavy metal",
+        "rock"
+      ],
+      "favicon": "https://www.rockantenne.bayern/logos/station-rock-antenne-bayern/station.svg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.2231,
+        11.6686
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-schwany-6-mundart",
+      "name": "Schwany 6 Mundart",
+      "broadcaster": "independent",
+      "streamUrl": "https://oldie.spcast.eu:443/stream?time=1768443493",
+      "homepage": "http://schwany.de/",
+      "country": "DE",
+      "tags": [
+        "mundart"
+      ],
+      "favicon": "http://schwany.de/favicon.ico",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-antenne-bayern-80-er-party",
+      "name": "Antenne Bayern 80-er party",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.antenne.de/antenne-bayern-80er-party/stream/aacp",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "DE",
+      "favicon": "https://www.antenne.de/webradio/80er-party",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-bremen-zwei-sounds",
+      "name": "Bremen Zwei Sounds",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.radiobremen.de/rb/webchannel7/mp3/128/stream.mp3",
+      "homepage": "https://www.bremenzwei.de/",
+      "country": "DE",
+      "favicon": "https://www.bremenzwei.de/static/img/favicons/favicon-32.png?v=4",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-fu-ball-bundesliga-spiel-4",
+      "name": "Fußball-Bundesliga: Spiel 4",
+      "broadcaster": "independent",
+      "streamUrl": "https://wdr-sportschau-liga1spiel4.icecastssl.wdr.de/wdr/sportschau/liga1spiel4/mp3/high",
+      "homepage": "https://livecenter.sportschau.de/",
+      "country": "DE",
+      "tags": [
+        "football",
+        "live sports",
+        "sport"
+      ],
+      "favicon": "https://www1.wdr.de/sport/fussball/logo-dfl-fussball-bundesliga-zweitausendachtzehn-100~_v-ARDKleinerTeaser.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-mdf1-hd-regionalfernsehen-magdeburg",
+      "name": "MDF1 HD - Regionalfernsehen Magdeburg",
+      "broadcaster": "independent",
+      "streamUrl": "https://h056.video-stream-hosting.de/medienasa-live/_definst_/mp4:mdf1_high/playlist.m3u8",
+      "homepage": "http://www.mdf1.de/",
+      "country": "DE",
+      "tags": [
+        "halle (saale)",
+        "lokalfernsehen",
+        "magdeburg",
+        "mdf1",
+        "regionalfernsehen",
+        "tv halle"
+      ],
+      "bitrate": 2468,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ohrfunk-de",
+      "name": "Ohrfunk.de",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.multhielemedia.de/radio/8000/ohrfunk",
+      "homepage": "https://ohrfunk.de/",
+      "country": "DE",
+      "tags": [
+        "blind",
+        "pop"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-wdr-cosmo-concerts",
+      "name": "WDR Cosmo - Concerts",
+      "broadcaster": "independent",
+      "streamUrl": "https://wdr-cosmo-coslive.icecastssl.wdr.de/wdr/cosmo/coslive/mp3/128/stream.mp3",
+      "homepage": "https://www1.wdr.de/radio/cosmo/programm/sendungen/live/cosmo-konzerte-120.html",
+      "country": "DE",
+      "favicon": "https://www1.wdr.de/radio/cosmo/resources-v5.128.1/img/favicon/favicon-32x32.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-egornb-hq",
+      "name": "egoRNB [HQ]",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast.egofm.de/egofmrnb.mp3?ar-distributor=ffa0&aw_0_req.gdpr=true",
+      "homepage": "https://www.egofm.de/streams/egofmrnb",
+      "country": "DE",
+      "tags": [
+        "egofm",
+        "r&b",
+        "rhythm and blues",
+        "rnb"
+      ],
+      "favicon": "https://streams.egofm.de/img/alexa/egoFM%20RNB-256x256.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-hr1-sudhessen",
+      "name": "hr1 Südhessen",
+      "broadcaster": "independent",
+      "streamUrl": "https://dispatcher.rndfnk.com/hr/hr1/suedhessen/high",
+      "homepage": "https://www.hr1.de/",
+      "country": "DE",
+      "tags": [
+        "adult contemporary"
+      ],
+      "favicon": "https://www.hr1.de/favicon.png?v=3.84.2",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        49.873,
+        8.6476
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-mabu-beatz-radio-minimal",
+      "name": "MABU Beatz Radio - Minimal",
+      "broadcaster": "independent",
+      "streamUrl": "https://audio.mabu-beatz-radio.com:8003/minimal",
+      "homepage": "https://mabu-beatz-radio.com/streams/minimal/",
+      "country": "DE",
+      "tags": [
+        "minimal",
+        "minimal techno"
+      ],
+      "favicon": "https://i.postimg.cc/vHDM8brn/OIP.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-nightride-fm-rektory",
+      "name": "Nightride FM - Rektory",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.nightride.fm/rektory.mp3",
+      "homepage": "https://stream.nightride.fm/rektory.mp3",
+      "country": "DE",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-onkelz-radio",
+      "name": "Onkelz Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/b_o",
+      "homepage": "https://laut.fm/",
+      "country": "DE",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-ginseng",
+      "name": "Radio Ginseng",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream1.datenkollektiv.net/ginseng.mp3?_=1",
+      "homepage": "https://radioginseng.de/",
+      "country": "DE",
+      "tags": [
+        "60s",
+        "70s"
+      ],
+      "favicon": "https://radioginseng.de/favicon.ico",
+      "bitrate": 256,
+      "codec": "MP3",
+      "geo": [
+        52.4277,
+        13.8191
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-reyfm-xmas",
+      "name": "REYFM - #xmas",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.reyfm.de/xmas_320kbps.mp3",
+      "homepage": "https://www.reyfm.de/",
+      "country": "DE",
+      "tags": [
+        "christmas",
+        "christmas music",
+        "xmas"
+      ],
+      "favicon": "https://www.reyfm.de/_nuxt/icons/icon_64x64.88ab9f.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-suedstadt-techno",
+      "name": "SUEDSTADT TECHNO",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/suedstadt-techno",
+      "homepage": "https://laut.fm/suedstadt-techno",
+      "country": "DE",
+      "tags": [
+        "deep house",
+        "house",
+        "minimal",
+        "tech house",
+        "techno"
+      ],
+      "favicon": "https://assets.laut.fm/bd951c3cd672db98f8c3240bd4b8a8b9?t=_120x120",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0nlineradio-queer",
+      "name": "0nlineradio QUEER",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.0nlineradio.com/queer?ref=radiobrowser",
+      "homepage": "https://0nlineradio.com/",
+      "country": "DE",
+      "tags": [
+        "charts",
+        "dance",
+        "edm",
+        "electronic",
+        "gay",
+        "german"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-christmas-radio",
+      "name": "Christmas Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://lebkuchen-radio.stream.laut.fm/lebkuchen-radio",
+      "homepage": "https://lebkuchen-radio.de/",
+      "country": "DE",
+      "tags": [
+        "christmas",
+        "weihnachten",
+        "x-mas",
+        "xmas"
+      ],
+      "favicon": "https://lebkuchen-radio.de/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-egofm-snow",
+      "name": "egoFM Snow",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast.egofm.de/egosnow.mp3?ar-distributor=ffa0&aw_0_req.gdpr=true",
+      "homepage": "https://player.egofm.de/radioplayer/?stream=egosnow",
+      "country": "DE",
+      "tags": [
+        "snow"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-hr3-sudhessen",
+      "name": "hr3 Südhessen",
+      "broadcaster": "independent",
+      "streamUrl": "https://dispatcher.rndfnk.com/hr/hr3/suedhessen/high",
+      "homepage": "https://www.hr3.de/",
+      "country": "DE",
+      "tags": [
+        "pop"
+      ],
+      "favicon": "https://www.hr3.de/favicon.png?v=3.84.2",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        49.882,
+        8.6456
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-isw",
+      "name": "Radio ISW",
+      "broadcaster": "independent",
+      "streamUrl": "https://radioisw.icecaststream.de/stream/radioisw",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "DE",
+      "tags": [
+        "misc"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-reyfm-chillout",
+      "name": "REYFM - #chillout",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.reyfm.de/chillout_64kbps.mp3",
+      "homepage": "https://www.reyfm.de/",
+      "country": "DE",
+      "tags": [
+        "chillout"
+      ],
+      "favicon": "https://www.reyfm.de/favicon.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-club-charts-top-100-immer-aktuell-dj-charts-hous",
+      "name": "#CLUB CHARTS -> TOP 100 || IMMER AKTUELL || DJ CHARTS || HOUSE, EDM, DEEP HOUSE - TECH HOUSE - TECHNO - MELODIC TECHNO - EDM - ELECTRONIC DANCE MUSIC - CLUB - DJ - DJ MIX - REMIX - FESTIVAL - FESTIVAL RADIO - IBIZA - IBIZA HOUSE - SUMMER HOUSE - BEACH CLUB - CHILLOUT - LOUNGE - RAVE - PARTY MUSIC - NIGHTLIFE - URBAN - HIP HOP - RNB - AFRO HOUSE - LATIN HOUSE - TRANCE - HARDSTYLE - HARDCORE",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.breakz.fm/?ref=club2-71",
+      "homepage": "https://breakz.fm/trackliste/",
+      "country": "DE",
+      "tags": [
+        "24/7",
+        "ambient",
+        "charts",
+        "chillout",
+        "dance",
+        "dance pop"
+      ],
+      "favicon": "https://i.ibb.co/m5jrHLWC/DJ-CLUB-CHARTS.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        48.1265,
+        11.58
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0r-dinner-lounge-lounge-chill-jazz-soft-music-ac",
+      "name": "0R - DINNER LOUNGE || Lounge, Chill, Jazz, Soft Music, Acoustic, Easy Listening, Background, Romantic, Dinner, Smooth, Instrumental, Evening, Relax, Calm, Cafe",
+      "broadcaster": "independent",
+      "streamUrl": "https://0nlineradio.radioho.st/lounge-dinner-lounge?ref=radio-browser26",
+      "homepage": "https://plus.rm.fm/",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "chillout+lounge",
+        "easy listening",
+        "instrumental",
+        "lounge",
+        "lounge music"
+      ],
+      "favicon": "https://i.ibb.co/JjYRX77z/Dinner-Lounge.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.0555,
+        8.6775
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-fu-ball-bundesliga-spiel-3",
+      "name": "Fußball-Bundesliga: Spiel 3",
+      "broadcaster": "independent",
+      "streamUrl": "https://wdr-sportschau-liga1spiel3.icecastssl.wdr.de/wdr/sportschau/liga1spiel3/mp3/high",
+      "homepage": "https://livecenter.sportschau.de/",
+      "country": "DE",
+      "tags": [
+        "football",
+        "live sports",
+        "sport"
+      ],
+      "favicon": "https://www.sportschau.de/resources/assets/image/favicon/apple-icon-120x120.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-fu-ball-bundesliga-spiel-8",
+      "name": "Fußball-Bundesliga: Spiel 8",
+      "broadcaster": "independent",
+      "streamUrl": "https://wdr-sportschau-liga1spiel8.icecastssl.wdr.de/wdr/sportschau/liga1spiel8/mp3/high",
+      "homepage": "https://livecenter.sportschau.de/",
+      "country": "DE",
+      "tags": [
+        "football",
+        "live sports",
+        "sport"
+      ],
+      "favicon": "https://www.sportschau.de/resources/assets/image/favicon/apple-icon-120x120.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-hr2-kultur-128kb-mp3",
+      "name": "hr2-kultur 128kb mp3",
+      "broadcaster": "independent",
+      "streamUrl": "https://dispatcher.rndfnk.com/hr/hr2/live/medium",
+      "homepage": "https://www.hr2.de/",
+      "country": "DE",
+      "tags": [
+        "classical music",
+        "jazz"
+      ],
+      "favicon": "https://www.hr2.de/favicon.png?v=3.89.1",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-i-love-radio-chillout-beats",
+      "name": "I Love Radio - Chillout Beats",
+      "broadcaster": "independent",
+      "streamUrl": "https://ilm.stream35.radiohost.de/ilm-ichillout_beats_mp3-192?upd-meta&upd-scheme=https&_art=dD0xNzY4NDUxNDA3JmQ9ZmUyMzQ0YmFjMjg5MTE2YTM3OGY",
+      "homepage": "https://www.iloveradio.de/",
+      "country": "DE",
+      "tags": [
+        "afrobeats",
+        "chill",
+        "chillout",
+        "electronic",
+        "lounge",
+        "mashup"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-m1-fm-kuschelschlager",
+      "name": "M1.FM - Kuschelschlager",
+      "broadcaster": "independent",
+      "streamUrl": "https://tuner.m1.fm/kuschelschlager.mp3",
+      "homepage": "https://m1.fm/kuschelschlager.php",
+      "country": "DE",
+      "tags": [
+        "schlager"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-101-madonna",
+      "name": "Radio 101 Madonna",
+      "broadcaster": "independent",
+      "streamUrl": "https://pub0202.101.ru:8443/stream/pro/aac/64/128",
+      "homepage": "https://101.ru/",
+      "country": "DE",
+      "tags": [
+        "pop music"
+      ],
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-sr1",
+      "name": "SR1",
+      "broadcaster": "independent",
+      "streamUrl": "https://liveradio.sr.de/sr/sr1/mp3/128/stream.mp3",
+      "homepage": "https://www.sr.de/sr/livestream/sr1/index.html",
+      "country": "DE",
+      "favicon": "https://www.sr.de/sr/static/images/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        49.237,
+        6.9763
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0r-soft-rock-rock-pop-rock-ballads-classic-rock-",
+      "name": "0R - SOFT ROCK || Rock, Pop Rock, Ballads, Classic Rock, Soft, Guitar, Melodic, 70s, 80s, 90s, Easy Listening, Romantic, Hits, Mellow, Nostalgic",
+      "broadcaster": "independent",
+      "streamUrl": "https://0nlineradio.radioho.st/0r-soft-rock?ref=radio-browser26",
+      "homepage": "https://www.ella-radio.de/",
+      "country": "DE",
+      "tags": [
+        "adult contemporary",
+        "alternative rock",
+        "blues rock",
+        "classic rock",
+        "hits",
+        "non-stop music"
+      ],
+      "favicon": "https://i.ibb.co/ZpnRsBPM/Soft-Rock.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-deutschfm",
+      "name": "deutschFM",
+      "broadcaster": "independent",
+      "streamUrl": "https://server14768.streamplus.de/stream.mp3",
+      "homepage": "http://www.deutschfmonair.de/",
+      "country": "DE",
+      "tags": [
+        "deutschfm",
+        "neudeutsch",
+        "vzfdm"
+      ],
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-dwg-radio-cesky",
+      "name": "DWG Radio Český",
+      "broadcaster": "independent",
+      "streamUrl": "https://server25530.streamplus.de/;stream.mp3",
+      "homepage": "https://radio.dwgradio.net/cz/",
+      "country": "DE",
+      "tags": [
+        "christian",
+        "christian praise&worship"
+      ],
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-fu-ball-bundesliga-spiel-9",
+      "name": "Fußball-Bundesliga: Spiel 9",
+      "broadcaster": "independent",
+      "streamUrl": "https://wdr-sportschau-liga1spiel9.icecastssl.wdr.de/wdr/sportschau/liga1spiel9/mp3/high",
+      "homepage": "https://livecenter.sportschau.de/",
+      "country": "DE",
+      "tags": [
+        "football",
+        "live sports",
+        "sport"
+      ],
+      "favicon": "https://www1.wdr.de/sport/fussball/logo-dfl-fussball-bundesliga-zweitausendachtzehn-100~_v-ARDKleinerTeaser.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ohrka-radio-gute-musik-und-horspiele-von-ohrka-d",
+      "name": "Ohrka Radio - Gute Musik und Hörspiele von Ohrka.de",
+      "broadcaster": "independent",
+      "streamUrl": "https://ohrka.stream.laut.fm/ohrka?t302=2026-01-15_03-39-54&uuid=1b4d685c-7bdc-4eec-a744-dbf3bb2dadd5",
+      "homepage": "https://www.ohrka.de/",
+      "country": "DE",
+      "tags": [
+        "dance",
+        "familie",
+        "family",
+        "kids",
+        "kinderdisco",
+        "kinderlieder"
+      ],
+      "favicon": "https://assets.laut.fm/f0131b4118a6fa5af3d175ec4f30651f?t=_120x120",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        52.466,
+        13.3234
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-rock-antenne-rock-n-roll",
+      "name": "Rock Antenne - Rock 'n' Roll",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rockantenne.de/rockandroll/stream/mp3",
+      "homepage": "https://www.rockantenne.de/rockhoeren/streams/rock-n-roll",
+      "country": "DE",
+      "tags": [
+        "music",
+        "rock"
+      ],
+      "favicon": "https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-blackspot",
+      "name": "Blackspot",
+      "broadcaster": "independent",
+      "streamUrl": "https://blackspot.stream.laut.fm/blackspot",
+      "homepage": "https://www.blackspot.me/",
+      "country": "DE",
+      "tags": [
+        "electronic",
+        "gothic",
+        "industrial",
+        "synthpop"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-egofm-kavka-hq",
+      "name": "egoFM Kavka [HQ]",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast.egofm.de/egofmkavka.mp3?ar-distributor=ffa0&aw_0_req.gdpr=true",
+      "homepage": "https://www.egofm.de/streams/egofmkavka",
+      "country": "DE",
+      "tags": [
+        "egofm",
+        "markus kavka"
+      ],
+      "favicon": "https://streams.egofm.de/img/alexa/egoFM%20Kavka-256x256.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-sr-2-kulturradio-mp3-256",
+      "name": "SR 2 KulturRadio MP3 256",
+      "broadcaster": "independent",
+      "streamUrl": "https://liveradio.sr.de/sr/sr2/mp3/256/stream.mp3",
+      "homepage": "https://www.sr.de/sr/sr2/index.html",
+      "country": "DE",
+      "tags": [
+        "classical",
+        "culture",
+        "sr"
+      ],
+      "favicon": "https://assets.radioplayer.org/276/276367/600/600/kzh8gidn.png",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1-splash-love",
+      "name": "#1 Splash Love",
+      "broadcaster": "independent",
+      "streamUrl": "https://ais-sa2.cdnstream1.com/2210_128.mp3",
+      "homepage": "https://www.splashradio.eu/",
+      "country": "DE",
+      "tags": [
+        "downtempo",
+        "easy listening",
+        "love",
+        "love song",
+        "love songs",
+        "lovesongs"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0r-soft-house-chill-lounge-dance-deep-house-smoo",
+      "name": "0R - SOFT HOUSE || Chill, Lounge, Dance, Deep House, Smooth, Vocal, Party, Electronic, Club, Night, Beat, Melodic, Summer, Relax",
+      "broadcaster": "independent",
+      "streamUrl": "https://0nlineradio.radioho.st/lounge-soft-house-lounge?ref=radio-browser26",
+      "homepage": "https://plus.rm.fm/",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "ambient and relaxation music",
+        "chill",
+        "chillout",
+        "dance",
+        "deep house"
+      ],
+      "favicon": "https://i.ibb.co/S7ZpK6VV/Soft-House.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-arcano-mundo",
+      "name": "Arcano Mundo",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/arcano-mundo",
+      "homepage": "https://laut.fm/arcano-mundo",
+      "country": "DE",
+      "tags": [
+        "soundtrack"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-bremen-eins-spezial",
+      "name": "Bremen Eins Spezial",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.radiobremen.de/rb/webchannel5/mp3/128/stream.mp3",
+      "homepage": "https://www.bremeneins.de/",
+      "country": "DE",
+      "tags": [
+        "pop"
+      ],
+      "favicon": "https://www.bremeneins.de/static/img/favicons/apple-touch-icon-180.png?v=4",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-club-fm",
+      "name": "Club FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://rs7.stream24.net/clubfm.aac",
+      "homepage": "https://clubfm.de/empfang/",
+      "country": "DE",
+      "favicon": "https://www.clubfm.de/storage/thumbs/192x192/r:1695642276/zdiljpqk3fvaz.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "geo": [
+        49.8916,
+        10.8868
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-fu-ball-bundesliga-spiel-2",
+      "name": "Fußball-Bundesliga: Spiel 2",
+      "broadcaster": "independent",
+      "streamUrl": "https://wdr-sportschau-liga1spiel2.icecastssl.wdr.de/wdr/sportschau/liga1spiel2/mp3/high",
+      "homepage": "https://livecenter.sportschau.de/",
+      "country": "DE",
+      "tags": [
+        "football",
+        "live sports",
+        "sport"
+      ],
+      "favicon": "https://www.sportschau.de/resources/assets/image/favicon/apple-icon-120x120.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-gartenheim-radio-gartenheim-radio",
+      "name": "Gartenheim-Radio,Gartenheim-Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://gartenheimradio.sp.radio.fm/stream",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "DE",
+      "tags": [
+        "2000er",
+        "2000er und schlager-pop",
+        "70er",
+        "80er",
+        "90er",
+        "chart-hits"
+      ],
+      "favicon": "https://gartenheim-radio.de/bilder/logo-radio-Gartenheim-fav.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-bielefeld-80er",
+      "name": "Radio Bielefeld 80er",
+      "broadcaster": "independent",
+      "streamUrl": "https://addrad.io/4455rqg",
+      "homepage": "https://www.radio-bielefeld.de/",
+      "country": "DE",
+      "tags": [
+        "80s",
+        "80s radio"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-neue-hoffnung-aac-96-kbps",
+      "name": "Radio Neue Hoffnung (AAC 96 kbps)",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.mnr.ch/rnh",
+      "homepage": "https://www.mnr.ch/radio/",
+      "country": "DE",
+      "tags": [
+        "bible",
+        "christian",
+        "jesus"
+      ],
+      "favicon": "https://www.mnr.ch/favicon.ico",
+      "bitrate": 96,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-psr-90er",
+      "name": "Radio PSR 90er",
+      "broadcaster": "independent",
+      "streamUrl": "https://streams.radiopsr.de/psr-90er/mp3-192/www.radio-browser.info/play.m3u8",
+      "homepage": "https://www.radiopsr.de/",
+      "country": "DE",
+      "tags": [
+        "90er",
+        "dance",
+        "pop"
+      ],
+      "favicon": "https://upload.radiopsr.de/production/static/1693298881101/icons/icon_64.cawac0w0200.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-rattlesnake-radio",
+      "name": "Rattlesnake Radio ",
+      "broadcaster": "independent",
+      "streamUrl": "https://server3755.streamplus.de/stream.mp3",
+      "homepage": "http://www.rattlesnake-radio.de/Rattlesnake_Radio/Willkommen.html",
+      "country": "DE",
+      "tags": [
+        "country"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.1468,
+        11.568
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-wdr-5-aac",
+      "name": "WDR 5 [aac]",
+      "broadcaster": "independent",
+      "streamUrl": "https://wdrhf.akamaized.net/hls/live/2027996-b/wdr5/192/seglist.m3u8",
+      "homepage": "https://www1.wdr.de/radio/wdr5/index.html",
+      "country": "DE",
+      "tags": [
+        "information",
+        "news talk",
+        "political talk",
+        "science"
+      ],
+      "codec": "UNKNOWN",
+      "geo": [
+        50.9398,
+        6.9514
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-dancefox-radio",
+      "name": "Dancefox Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s35.derstream.net/dancefox-radio.mp3",
+      "homepage": "https://dancefox-radio.de/",
+      "country": "DE",
+      "tags": [
+        "international"
+      ],
+      "favicon": "https://dancefox-radio.de/dancefox-radio.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-egofm-bw-hq",
+      "name": "egoFM BW [HQ]",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast.egofm.de/egofmbw.mp3?ar-distributor=ffa0&aw_0_req.gdpr=true",
+      "homepage": "https://www.egofm.de/",
+      "country": "DE",
+      "favicon": "https://streams.egofm.de/img/alexa/egoFM%20BW-256x256.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-egofm-jazz",
+      "name": "egoFM Jazz",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast.egofm.de/egofmjazz.mp3",
+      "homepage": "https://www.egofm.de/",
+      "country": "DE",
+      "tags": [
+        "classic rock"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-electrozombies",
+      "name": "Electrozombies",
+      "broadcaster": "independent",
+      "streamUrl": "https://electrozombies.stream.laut.fm/electrozombies",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "DE",
+      "tags": [
+        "electronic"
+      ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/1/43221.v1.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-kiepenkerl-songwriter",
+      "name": "Kiepenkerl Songwriter",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.lokalradio.nrw/44565q3",
+      "homepage": "https://www.radiokiepenkerl.de/",
+      "country": "DE",
+      "favicon": "https://www.radiokiepenkerl.de/assets/images/favicons/radiokiepenkerl/favicon_x96.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.9418,
+        7.1613
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ndr-fernsehen-hamburg",
+      "name": "NDR Fernsehen Hamburg",
+      "broadcaster": "independent",
+      "streamUrl": "https://mcdn.ndr.de/ndr/hls/ndr_fs/ndr_hh/master.m3u8",
+      "homepage": "https://www.ndr.de/fernsehen/index.html",
+      "country": "DE",
+      "tags": [
+        "ard",
+        "drittes programm",
+        "hallo niedersachsen",
+        "hamburg journal",
+        "iptv",
+        "livestream"
+      ],
+      "bitrate": 1672,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-rfh-hd-regionalfernsehen-harz",
+      "name": "RFH HD - Regionalfernsehen Harz",
+      "broadcaster": "independent",
+      "streamUrl": "https://h056.video-stream-hosting.de/medienasa-live/_definst_/mp4:RFH_high/playlist.m3u8",
+      "homepage": "https://www.rfh-tv.de/",
+      "country": "DE",
+      "tags": [
+        "iptv",
+        "livestream",
+        "lokalfernsehen",
+        "regionalfernsehen harz"
+      ],
+      "bitrate": 2613,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-swr-1",
+      "name": "SWR 1",
+      "broadcaster": "independent",
+      "streamUrl": "https://liveradio.swr.de/sw282p3/swr1bw/",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "DE",
+      "tags": [
+        "pop"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-zappa-stream-radio",
+      "name": "Zappa Stream Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streams.norbert.de/zappa.ogg",
+      "homepage": "https://www.norbert.de/index.php?id=10",
+      "country": "DE",
+      "favicon": "https://www.norbert.de/typo3conf/ext/start/Resources/Public/Images/favicon.ico",
+      "bitrate": 128,
+      "codec": "OGG",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-berliner-rundfunk-91-4",
+      "name": "Berliner Rundfunk 91.4",
+      "broadcaster": "independent",
+      "streamUrl": "https://topradio-de-hz-fal-stream10-cluster01.radiohost.de/brf_mp3-128",
+      "homepage": "https://berliner-rundfunk.de/",
+      "country": "DE",
+      "favicon": "https://upload.berliner-rundfunk.de/production/static/1693298496587/icons/icon_64.a80y02808w0.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-christliches-radio-munchen",
+      "name": "Christliches Radio München",
+      "broadcaster": "independent",
+      "streamUrl": "https://crm924.stream.laut.fm/crm924",
+      "homepage": "https://christlichesradio.de/",
+      "country": "DE",
+      "tags": [
+        "religion"
+      ],
+      "favicon": "https://christlichesradio.de/storage/thumbs/192x192/r:1729866404/791lo3107c01q.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ella-radio-swing-big-band",
+      "name": "Ella Radio - Swing & Big Band",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.ella-radio.de/ella-swing-and-bigband/mp3-192/?ref=radio-browser",
+      "homepage": "https://www.ella-radio.de/",
+      "country": "DE",
+      "tags": [
+        "big band",
+        "jazz"
+      ],
+      "favicon": "https://ella-radio.de/uplink/Ella_Swing-Big-Band.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-hr-info-2",
+      "name": "hr-info",
+      "broadcaster": "independent",
+      "streamUrl": "https://dispatcher.rndfnk.com/hr/hrinfo-sued/mp3/high",
+      "homepage": "https://www.hr-inforadio.de/",
+      "country": "DE",
+      "tags": [
+        "information"
+      ],
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/49/HR-Info_Logo_2023.svg/1024px-HR-Info_Logo_2023.svg.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.1301,
+        8.6847
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-hr4-nordhessen",
+      "name": "hr4 Nordhessen",
+      "broadcaster": "independent",
+      "streamUrl": "https://dispatcher.rndfnk.com/hr/hr4/nordhessen/high",
+      "homepage": "https://www.hr4.de/",
+      "country": "DE",
+      "tags": [
+        "oldies",
+        "volksmusik"
+      ],
+      "favicon": "https://www.hr4.de/favicon.png?v=3.84.2",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.3155,
+        9.4939
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-munchen-tv",
+      "name": "münchen.tv",
+      "broadcaster": "independent",
+      "streamUrl": "https://muenchentv.iptv-playoutcenter.de/muenchentv/muenchentv.stream_1/playlist.m3u8",
+      "homepage": "https://www.muenchen.tv/",
+      "country": "DE",
+      "tags": [
+        "münchen",
+        "tv"
+      ],
+      "favicon": "https://raw.githubusercontent.com/jnk22/kodinerds-iptv/master/logos/tv/muenchentv.png",
+      "bitrate": 3199,
+      "codec": "AAC,H.264",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-b2",
+      "name": "radio b2",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiob2-national.cast.addradio.de/radiob2/national/mp3/high/stream.mp3?ar-distributor=f0b7&token=c3RhcnRUaW1lPTIwMTkwMjA2MTE0ODAxJmVuZFRpbWU9MjAxOTAyMDYxMzQ4MDEmaXB2ND0xODEuMjI2LjE1OS43MS8yNCZkaWdlc3Q9N2U1MmQxYTAwY2EzMGMwZDBhNzczZTg2OTVlZTBhZGU",
+      "homepage": "https://www.radiob2.de/",
+      "country": "DE",
+      "tags": [
+        "pop",
+        "schlager"
+      ],
+      "favicon": "https://www.radiob2.de/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-berg",
+      "name": "Radio Berg",
+      "broadcaster": "independent",
+      "streamUrl": "https://radioberg--di--nacs-ais-lgc--0b--cdn.cast.addradio.de/radioberg/live/mp3/high?ar-distributor=ffa0&_art=dj0yJmlwPTIxMi4xODcuMjQ0LjgmaWQ9aWNzY3hsLWlxaGZhc2ltYiZ0PTE3MTA5NDMyNzQmcz03ODY2ZjI5YyNiODQwNGVlMjlkMDhmMGM4MDMzYTM0ZjM1YWZlZTFjOA",
+      "homepage": "https://www.radioberg.de/",
+      "country": "DE",
+      "tags": [
+        "pop music"
+      ],
+      "favicon": "https://www.radioberg.de/assets/images/senderlogos/radio_berg_webradio.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-rbw-hd-regionalfernsehen-bitterfeld-wolfen",
+      "name": "RBW HD - Regionalfernsehen Bitterfeld-Wolfen",
+      "broadcaster": "independent",
+      "streamUrl": "https://h056.video-stream-hosting.de/medienasa-live/_definst_/mp4:rbw_high/playlist.m3u8",
+      "homepage": "https://www.rbwonline.de/",
+      "country": "DE",
+      "tags": [
+        "bitterfeld wolfen",
+        "lokalfernsehen",
+        "rbw",
+        "regionalfernsehen"
+      ],
+      "bitrate": 2574,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-reyfm-deutschrap-gold",
+      "name": "REYFM - #Deutschrap Gold",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.reyfm.de/reyfm-deutschrap_gold/",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "DE",
+      "tags": [
+        "music",
+        "rap"
+      ],
+      "favicon": "https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-southern-rock-radio",
+      "name": "Southern Rock Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/southern-rock_radio",
+      "homepage": "https://laut.fm/southern",
+      "country": "DE",
+      "tags": [
+        "blues",
+        "classic rock",
+        "country",
+        "hard rock",
+        "melodic rock",
+        "progressive rock"
+      ],
+      "favicon": "https://assets.laut.fm/ac123050ec59b3718d98712e0435746",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-wdr-2-bewrgisch-land",
+      "name": "WDR-2 Bewrgisch Land",
+      "broadcaster": "independent",
+      "streamUrl": "https://wdr-wdr2-bergischesland.icecastssl.wdr.de/wdr/wdr2/bergischesland/mp3/128/stream.mp3",
+      "homepage": "https://www1.wdr.de/radio/wdr2",
+      "country": "DE",
+      "tags": [
+        "news",
+        "pop"
+      ],
+      "favicon": "https://www1.wdr.de/radio/startseite/symbolbilder/dummy-logo108~_v-gseagaleriexl.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-70s-oldies-70er-disco-funk-soul-classic-pop-retr",
+      "name": "* 70s || Oldies, 70er, Disco, Funk, Soul, Classic Pop, Retro, Kultsongs, Evergreens, Vinyl Vibes, Groovy, Feel Good, Nostalgie, Zeitlos, Charts",
+      "broadcaster": "independent",
+      "streamUrl": "https://0nlineradio.radioho.st/0r-70s?ref=rb26",
+      "homepage": "https://plus.rm.fm/",
+      "country": "DE",
+      "tags": [
+        "1970s",
+        "70",
+        "70 80 hits",
+        "70's",
+        "70er",
+        "70s"
+      ],
+      "favicon": "https://i.ibb.co/B2YbXkQG/70s.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0r-beethoven-classical-classical-orchestra-symph",
+      "name": "0R - BEETHOVEN - CLASSICAL || Classical, Orchestra, Symphony, Piano, Strings, Chamber Music, Concertos, Solo Instrument, Elegant, Relaxing, Timeless, Melodic, Instrumental, Calm, Meditative",
+      "broadcaster": "independent",
+      "streamUrl": "https://0nlineradio.radioho.st/0r-beethoven?ref=radio-browser26",
+      "homepage": "https://plus.rm.fm/",
+      "country": "DE",
+      "tags": [
+        "beethoven",
+        "chamber",
+        "classical",
+        "concert",
+        "easy listening",
+        "elegant"
+      ],
+      "favicon": "https://i.ibb.co/6JrNQTzQ/BEETHOVEN-KL.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.9453,
+        6.86
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0r-piano-classical-klassik-solopiano-elegant-rel",
+      "name": "0R - PIANO CLASSICAL || Klassik, Solopiano, Elegant, Relax, Calm, Instrumental, Melodic, Soft, Meditation, Romantic, Strings, Timeless, Background, Peaceful",
+      "broadcaster": "independent",
+      "streamUrl": "https://0nlineradio.radioho.st/classical-classical-piano?ref=radio-browser26",
+      "homepage": "https://plus.rm.fm/",
+      "country": "DE",
+      "tags": [
+        "classical",
+        "classical piano",
+        "instrumental",
+        "klassik",
+        "orchestral",
+        "piano"
+      ],
+      "favicon": "https://i.ibb.co/Tq7d6MMp/PIANO-only.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-deeredradio-red-zone",
+      "name": "DEEREDRADIO RED ZONE",
+      "broadcaster": "independent",
+      "streamUrl": "https://webcast.deeredradio.com:8420/stream_aac_128",
+      "homepage": "https://www.deeredradio.com/webcastred",
+      "country": "DE",
+      "favicon": "https://sub60.tobit.com/l/64380-03776?size=128&f=none",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-deeredrdradio-black-zone",
+      "name": "DEEREDRDRADIO BLACK ZONE",
+      "broadcaster": "independent",
+      "streamUrl": "https://webcast.deeredradio.com:8410/stream_aac_128",
+      "homepage": "https://www.deeredradio.com/webcastblack",
+      "country": "DE",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ella-radio-modern-vocal-jazz",
+      "name": "Ella Radio - Modern Vocal Jazz",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.ella-radio.de/ella-modern-vocal-jazz/mp3-192/?ref=radio-browser",
+      "homepage": "https://www.ella-radio.de/",
+      "country": "DE",
+      "tags": [
+        "jazz",
+        "vocal jazz"
+      ],
+      "favicon": "https://ella-radio.de/uplink/Ella_Vocal-Jazz.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-hr-fernsehen-hd",
+      "name": "hr-fernsehen HD",
+      "broadcaster": "independent",
+      "streamUrl": "https://hrhlsde.akamaized.net/hls/live/2024526/hrhlsde/index.m3u8",
+      "homepage": "https://www.hr-fernsehen.de/",
+      "country": "DE",
+      "tags": [
+        "ard",
+        "drittes programm",
+        "hd",
+        "hessischer rundfunk",
+        "hr",
+        "hr-fernsehen"
+      ],
+      "codec": "UNKNOWN",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-lovebeats-laut-fm",
+      "name": "LoveBeats - laut.fm",
+      "broadcaster": "independent",
+      "streamUrl": "https://lovebeats.stream.laut.fm/lovebeats",
+      "homepage": "https://laut.fm/lovebeats",
+      "country": "DE",
+      "tags": [
+        "kuschelrock",
+        "liebe",
+        "liebeslieder",
+        "love",
+        "lovebeat",
+        "lovesongs"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-soul-rnb-lovers-radio",
+      "name": "Soul RnB Lovers Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s10.streamingcloud.online/stream/13580",
+      "homepage": "https://www.soulrnbloversradio.com/",
+      "country": "DE",
+      "tags": [
+        "rnb",
+        "soul"
+      ],
+      "favicon": "https://scontent-mty2-1.xx.fbcdn.net/v/t39.30808-6/403857353_122093636606138816_321048698194500544_n.jpg?_nc_cat=106&ccb=1-7&_nc_sid=6ee11a&_nc_ohc=iOMPoUwq6v0Q7kNvgGkTTjE&_nc_oc=AdhZmOyIG_v355RPmYzldtz_BNfKq0-DOnGkVSDv_DTJBSoOJDItw3ri6lkvjdwT1Ec&_nc_zt=23&_nc_ht=scontent-mty2-1.xx&_nc_gid=AQFx4ruh-kP6Wan4LKiIoje&oh=00_AYBq9HWSMCevYYNRfCKbqKasU1spgCr8wrX5THlg7KCoNg&oe=67B1B0B1",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-swr3-rock",
+      "name": "SWR3 Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://liveradio.swr.de/sw331ch/raka05/",
+      "homepage": "https://www.swr.de/",
+      "country": "DE",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-wdr-cosmo-neu-in-cosmo",
+      "name": "WDR COSMO - Neu in Cosmo",
+      "broadcaster": "independent",
+      "streamUrl": "https://wdr-cosmo-neuincosmo.icecastssl.wdr.de/wdr/cosmo/neuincosmo/mp3/128/stream.mp3",
+      "homepage": "https://www1.wdr.de/radio/cosmo/channels/neu-in-cosmo-channel-102.html",
+      "country": "DE",
+      "tags": [
+        "world music"
+      ],
+      "favicon": "https://www1.wdr.de/radio/cosmo/resources-v5.128.1/img/favicon/favicon-32x32.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-welt-tv-1080p",
+      "name": "WELT TV 1080p",
+      "broadcaster": "independent",
+      "streamUrl": "https://welt.personalstream.tv/v1/master.m3u8",
+      "homepage": "https://www.welt.de/mediathek/",
+      "country": "DE",
+      "tags": [
+        "axel springer",
+        "fernsehen",
+        "n24",
+        "nachrichtensender",
+        "news",
+        "ntv"
+      ],
+      "bitrate": 1128,
+      "codec": "UNKNOWN",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ahoy",
+      "name": "ahoy",
+      "broadcaster": "independent",
+      "streamUrl": "https://s37.derstream.net/ahoy-radio.mp3",
+      "homepage": "https://www.ahoyradio.de/",
+      "country": "DE",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-antenne-bayern-weihnachtslounge",
+      "name": "Antenne Bayern - Weihnachtslounge",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.antenne.de/lounge/stream/mp3",
+      "homepage": "https://www.antenne.de/webradio/lounge",
+      "country": "DE",
+      "favicon": "https://www.antenne.de/logos/station-antenne-bayern/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-denge-cudi",
+      "name": "Denge Cudi",
+      "broadcaster": "independent",
+      "streamUrl": "https://denge-cudi.stream.laut.fm/denge-cudi",
+      "homepage": "https://laut.fm/denge-cudi",
+      "country": "DE",
+      "favicon": "https://i1.sndcdn.com/avatars-000206444760-te747f-t500x500.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ella-radio-blues-rock",
+      "name": "Ella Radio - Blues Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.ella-radio.de/ella-blues-rock/mp3-192/?ref=radio-browser",
+      "homepage": "https://www.ella-radio.de/",
+      "country": "DE",
+      "tags": [
+        "blues rock",
+        "jazz"
+      ],
+      "favicon": "https://ella-radio.de/uplink/Ella_Blues-Rock.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-fun80sfm",
+      "name": "Fun80sFM",
+      "broadcaster": "independent",
+      "streamUrl": "https://fun80sfm.stream.laut.fm/fun80sfm",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "DE",
+      "tags": [
+        "decades"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-sr-fernsehen-hd",
+      "name": "SR Fernsehen HD",
+      "broadcaster": "independent",
+      "streamUrl": "https://srfs.akamaized.net/hls/live/689649/srfsgeo/index.m3u8",
+      "homepage": "https://www.sr.de/sr/fernsehen/index.html",
+      "country": "DE",
+      "tags": [
+        "aktueller bericht",
+        "ard",
+        "drittes programm",
+        "iptv",
+        "livestream",
+        "regionalmagazin"
+      ],
+      "bitrate": 1672,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-techliveradio",
+      "name": "TechLiveRadio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/techliveradio",
+      "homepage": "https://techliveradio.de/",
+      "country": "DE",
+      "tags": [
+        "charts",
+        "news",
+        "pop",
+        "tech",
+        "technews",
+        "technik"
+      ],
+      "favicon": "https://hitradiod1.de/wp-content/uploads/2023/06/192.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1000-hamburg",
+      "name": "1000 Hamburg",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/1000hamburg",
+      "homepage": "https://1000.hamburg/",
+      "country": "DE",
+      "tags": [
+        "charts",
+        "dance",
+        "electronic",
+        "pop",
+        "top 40"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        53.5762,
+        9.9899
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-dancefloor-fm",
+      "name": "Dancefloor FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://dancefloor-fm.stream.laut.fm/dancefloor-fm?t302=2025-03-03_21-41-17&uuid=ebadfaf0-8781-4c90-bb05-6652467979a2",
+      "homepage": "http://www.saarlandsender.de/Startseite/",
+      "country": "DE",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ndr-fernsehen-niedersachsen",
+      "name": "NDR Fernsehen Niedersachsen",
+      "broadcaster": "independent",
+      "streamUrl": "https://mcdn.ndr.de/ndr/hls/ndr_fs/ndr_nds/master.m3u8",
+      "homepage": "https://www.ndr.de/fernsehen/index.html",
+      "country": "DE",
+      "tags": [
+        "ard",
+        "drittes programm",
+        "hallo niedersachsen",
+        "hamburg journal",
+        "iptv",
+        "livestream"
+      ],
+      "bitrate": 1672,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ran1-hd-regionalfernsehen-dessau-ro-lau",
+      "name": "RAN1 HD - Regionalfernsehen Dessau-Roßlau",
+      "broadcaster": "independent",
+      "streamUrl": "https://h056.video-stream-hosting.de/medienasa-live/_definst_/mp4:ran1_high/playlist.m3u8",
+      "homepage": "https://www.ran1.de/",
+      "country": "DE",
+      "tags": [
+        "dessau rosslau",
+        "iptv",
+        "lokalfernsehen",
+        "ran1",
+        "regionalfernsehen"
+      ],
+      "bitrate": 2575,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-scorpions",
+      "name": "Scorpions",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.pcradio.ru/Scorpions-hi",
+      "homepage": "https://pcradio.ru/",
+      "country": "DE",
+      "tags": [
+        "discography"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-studentenfunk-universitat-regensburg",
+      "name": "Studentenfunk (Universität Regensburg)",
+      "broadcaster": "independent",
+      "streamUrl": "https://studentenfunk.out.airtime.pro/studentenfunk_a#",
+      "homepage": "https://studentenfunk-regensburg.de/",
+      "country": "DE",
+      "tags": [
+        "campus radio",
+        "student radio"
+      ],
+      "favicon": "https://studentenfunk-regensburg.de/wp-content/themes/studentenfunk/images/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-country-country-pop-country-rock-nashville-ameri",
+      "name": "* COUNTRY || Country Pop, Country Rock, Nashville, Americana, Folk, Southern Rock, Roadtrip, Storytelling, Acoustic, Feel Good, Heartland, Modern Country, Classic Country, Chill, Roots",
+      "broadcaster": "independent",
+      "streamUrl": "https://0nlineradio.radioho.st/0r-country?ref=rb26",
+      "homepage": "https://plus.rm.fm/",
+      "country": "DE",
+      "tags": [
+        "alternative country",
+        "blues rock",
+        "classic country",
+        "classic rock",
+        "contemporary country",
+        "country"
+      ],
+      "favicon": "https://i.ibb.co/GyTyFSC/Country.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0r-lo-fi-lofi-chill-study-hip-hop-relax-backgrou",
+      "name": "0R - LO-FI || LoFi, Chill, Study, Hip Hop, Relax, Background, Calm, Instrumental, Smooth, Beats, Coffee, Work, Focus, Soft, Chillhop",
+      "broadcaster": "independent",
+      "streamUrl": "https://0nlineradio.radioho.st/0r-lo-fi?ref=radio-browser26",
+      "homepage": "https://plus.rm.fm/",
+      "country": "DE",
+      "tags": [
+        "calm",
+        "chill",
+        "easy listening",
+        "easy music",
+        "learn",
+        "lo-fi"
+      ],
+      "favicon": "https://i.ibb.co/v6hT16qV/LOFI.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-deep-house-sounds",
+      "name": "Deep House Sounds",
+      "broadcaster": "independent",
+      "streamUrl": "https://deep-house-sounds.stream.laut.fm/deep-house-sounds",
+      "homepage": "https://laut.fm/deep-house-sounds",
+      "country": "DE",
+      "tags": [
+        "deep house",
+        "house"
+      ],
+      "favicon": "https://www.radio.net/300/lautfm-deep-house-sounds.jpeg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.9836,
+        11.3259
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-fu-fball-bundesliga-2-spiel-2",
+      "name": "Fußfball-Bundesliga 2: Spiel 2",
+      "broadcaster": "independent",
+      "streamUrl": "https://wdr-sportschau-liga2spiel2.icecastssl.wdr.de/wdr/sportschau/liga2spiel2/mp3/high",
+      "homepage": "https://livecenter.sportschau.de/",
+      "country": "DE",
+      "tags": [
+        "football",
+        "live sports",
+        "sport"
+      ],
+      "favicon": "https://www1.wdr.de/sport/fussball/logo-dfl-fussball-zweite-liga-zweitausendachtzehn-100~_v-ARDKleinerTeaser.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-i-love-workout",
+      "name": "I Love Workout",
+      "broadcaster": "independent",
+      "streamUrl": "https://ilm.stream12.radiohost.de/ilm_iloveworkout_mp3-192?upd-meta&upd-scheme=https&_art=dD0xNzY4NDMyNzY0JmQ9YTIxNjc2ZmE5ZWYzZWI3ZGI0ZmM",
+      "homepage": "https://ilovemusic.de/iloveworkout/",
+      "country": "DE",
+      "tags": [
+        "dance",
+        "mix"
+      ],
+      "favicon": "https://ilovemusic.de/fileadmin/user_upload/ilm2024_iloveworkout1x1_05_440x440.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ndr-fernsehen-mv",
+      "name": "NDR Fernsehen MV",
+      "broadcaster": "independent",
+      "streamUrl": "https://mcdn.ndr.de/ndr/hls/ndr_fs/ndr_mv/master.m3u8",
+      "homepage": "https://www.ndr.de/fernsehen/index.html",
+      "country": "DE",
+      "tags": [
+        "ard",
+        "drittes programm",
+        "hallo niedersachsen",
+        "hamburg journal",
+        "iptv",
+        "livestream"
+      ],
+      "bitrate": 1672,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-novoe-radio",
+      "name": "Novoe Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://emgspb.hostingradio.ru:80/novoespb64.mp3",
+      "homepage": "https://emgspb.hostingradio.ru:80/novoespb64.mp3",
+      "country": "DE",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-reyfm-hip-hop-gold",
+      "name": "REYFM - #Hip-Hop Gold",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.reyfm.de/reyfm-hip-hop_gold/",
+      "homepage": "https://rey.fm/",
+      "country": "DE",
+      "tags": [
+        "hiphop",
+        "music"
+      ],
+      "favicon": "https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-reyfm-original-64kbps",
+      "name": "REYFM - #original (64kbps)",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.reyfm.de/original_64kbps.mp3",
+      "homepage": "https://www.reyfm.de/",
+      "country": "DE",
+      "tags": [
+        "dance",
+        "house"
+      ],
+      "favicon": "https://www.reyfm.de/favicon.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-weihnachten-mit-antenne-bayern",
+      "name": "Weihnachten mit ANTENNE BAYERN",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.antenne.de/weihnachts-hits/stream/aacp",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "DE",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-wiphopbeatz",
+      "name": "wiphopbeatz",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/wiphopbeatz",
+      "homepage": "https://laut.fm/wiphopbeatz",
+      "country": "DE",
+      "tags": [
+        "hip hop",
+        "hip-hop",
+        "rap"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-wunschradio-fm",
+      "name": "WunschRadio FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiostreamserver.de/wunschradio.mp3",
+      "homepage": "https://wunschradio.de/",
+      "country": "DE",
+      "tags": [
+        "adult contemporary"
+      ],
+      "favicon": "https://wunschradio.de/images/seitenelemente/favicon180.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-fu-ball-bundesliga-2-spiel-4",
+      "name": "Fußball-Bundesliga 2: Spiel 4",
+      "broadcaster": "independent",
+      "streamUrl": "https://wdr-sportschau-liga2spiel4.icecastssl.wdr.de/wdr/sportschau/liga2spiel4/mp3/high",
+      "homepage": "https://livecenter.sportschau.de/",
+      "country": "DE",
+      "tags": [
+        "football",
+        "live sports",
+        "sport"
+      ],
+      "favicon": "https://www.sportschau.de/resources/assets/image/favicon/apple-icon-120x120.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-fu-ball-bundesliga-spiel-5",
+      "name": "Fußball-Bundesliga: Spiel 5",
+      "broadcaster": "independent",
+      "streamUrl": "https://wdr-sportschau-liga1spiel5.icecastssl.wdr.de/wdr/sportschau/liga1spiel5/mp3/high",
+      "homepage": "https://livecenter.sportschau.de/",
+      "country": "DE",
+      "tags": [
+        "football",
+        "live sports",
+        "sport"
+      ],
+      "favicon": "https://www.sportschau.de/resources/assets/image/favicon/apple-icon-120x120.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-lazerradio",
+      "name": "LazerRadio",
+      "broadcaster": "independent",
+      "streamUrl": "https://lazerradio.stream.laut.fm/lazerradio",
+      "homepage": "https://laut.fm/lazerradio",
+      "country": "DE",
+      "tags": [
+        "future funk"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-landau",
+      "name": "Radio Landau",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiolandau.stream.laut.fm/radiolandau?autoplay=1&t302=2026-01-15_04-32-23&uuid=e7434870-47a3-40c8-b36b-28961178b681",
+      "homepage": "https://www.radiolandau.com/",
+      "country": "DE",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-antenne-bayern-top-100u",
+      "name": "Antenne Bayern Top 100ü",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.antenne.de/top-1000/stream/mp3",
+      "homepage": "https://www.antenne.de/",
+      "country": "DE",
+      "tags": [
+        "charts",
+        "hits",
+        "pop"
+      ],
+      "favicon": "https://www.antenne.de/media/cache/3/version/7347/streamlogo_top_1000_aby-v1.jpg/4274d87abb43dc80855d5b4f13c77b47.webp",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.1372,
+        11.5729
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-bdj-radio-80s-90s",
+      "name": "BDJ Radio - 80s & 90s",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-bdj80s90s.bdjradio.com/",
+      "homepage": "https://bdjradio.com/",
+      "country": "DE",
+      "favicon": "https://bdjradio.com/media/images/bdj-80s90s-456214.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-bibel-tv-impuls",
+      "name": "Bibel TV Impuls",
+      "broadcaster": "independent",
+      "streamUrl": "https://bibeltv02.iptv-playoutcenter.de/bibeltv02/bibeltv02.stream_1/playlist.m3u8",
+      "homepage": "https://www.bibeltv.de/livestreams/impuls/",
+      "country": "DE",
+      "tags": [
+        "bibel",
+        "christian",
+        "tv"
+      ],
+      "favicon": "https://www.bibeltv.de/assets/images/btv_logo.svg",
+      "bitrate": 3358,
+      "codec": "AAC,H.264",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-bibel-tv-musik",
+      "name": "Bibel TV Musik",
+      "broadcaster": "independent",
+      "streamUrl": "https://bibeltv03.iptv-playoutcenter.de/bibeltv03/bibeltv03.stream_all/bibeltv03/bibeltv03.stream_1/chunks.m3u8",
+      "homepage": "https://beta.bibeltv.de/livestreams/musik/",
+      "country": "DE",
+      "tags": [
+        "bibel",
+        "christian",
+        "musik",
+        "tv"
+      ],
+      "favicon": "https://beta.bibeltv.de/livestreams/favicon.ico",
+      "codec": "UNKNOWN",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-fu-ball-bundesliga-2-spiel-3",
+      "name": "Fußball-Bundesliga 2: Spiel 3",
+      "broadcaster": "independent",
+      "streamUrl": "https://wdr-sportschau-liga2spiel3.icecastssl.wdr.de/wdr/sportschau/liga2spiel3/mp3/high",
+      "homepage": "https://livecenter.sportschau.de/",
+      "country": "DE",
+      "tags": [
+        "football",
+        "live sports",
+        "sport"
+      ],
+      "favicon": "https://www1.wdr.de/sport/fussball/logo-dfl-fussball-zweite-liga-zweitausendachtzehn-100~_v-ARDKleinerTeaser.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-fu-ball-bundesliga-2-spiel-8",
+      "name": "Fußball-Bundesliga 2: Spiel 8",
+      "broadcaster": "independent",
+      "streamUrl": "https://wdr-sportschau-liga2spiel8.icecastssl.wdr.de/wdr/sportschau/liga2spiel8/mp3/high",
+      "homepage": "https://livecenter.sportschau.de/",
+      "country": "DE",
+      "tags": [
+        "football",
+        "live sports",
+        "sport"
+      ],
+      "favicon": "https://www.sportschau.de/resources/assets/image/favicon/apple-icon-120x120.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-corax",
+      "name": "Radio CORAX",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.fueralle.org/corax_192.mp3",
+      "homepage": "https://radiocorax.de/",
+      "country": "DE",
+      "tags": [
+        "community radio",
+        "freies radio",
+        "halle (saale)",
+        "local news",
+        "nichtkommerzielles lokalradio",
+        "non-commercial"
+      ],
+      "favicon": "https://radiocorax.de/favicon.ico",
+      "codec": "MP3",
+      "geo": [
+        51.4877,
+        11.9706
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-reyfm-hip-hop",
+      "name": "REYFM - #Hip-Hop",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.reyfm.de/reyfm-hip-hop/",
+      "homepage": "https://rey.fm/",
+      "country": "DE",
+      "tags": [
+        "hiphop",
+        "music"
+      ],
+      "favicon": "https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-techno-classics",
+      "name": "Techno Classics",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/techno_classics",
+      "homepage": "https://laut.fm/techno_classics",
+      "country": "DE",
+      "tags": [
+        "techno classics"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-afro-house-afro-tech-deep-house-organic-house-tr",
+      "name": "* AFRO HOUSE || Afro Tech, Deep House, Organic House, Tribal House, Melodic House, Tropical House, Ethnic House, Latin House, Percussion House, Beach Vibes, Summer Vibes, Sunset Grooves, Ibiza Vibes, Warm Up Grooves",
+      "broadcaster": "independent",
+      "streamUrl": "https://0nlineradio.radioho.st/technolovers-afro-house?ref=radio-browser26",
+      "homepage": "https://plus.rm.fm/",
+      "country": "DE",
+      "tags": [
+        "afro",
+        "afro house",
+        "afrohouse",
+        "charts",
+        "dance",
+        "drums"
+      ],
+      "favicon": "https://i.ibb.co/gbM5ns1q/Afro-House.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0r-euro-dance-eurodance-90s-dance-pop-dance-club",
+      "name": "0R - EURO DANCE || Eurodance, 90s Dance, Pop, Dance, Club, Party, Trance, Techno, Electronic, Vocal, Hits, Energetic, Beat, Night, Dancefloor",
+      "broadcaster": "independent",
+      "streamUrl": "https://0nlineradio.radioho.st/technolovers-eurodance?ref=radio-browser26",
+      "homepage": "https://plus.rm.fm/",
+      "country": "DE",
+      "tags": [
+        "1980s",
+        "70s",
+        "80s",
+        "90s",
+        "dance",
+        "euro disco"
+      ],
+      "favicon": "https://i.ibb.co/7dJcRxVv/EURODANCE.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-bn-radio",
+      "name": "BN-Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radio-unicc.de:8000/bn-radio.aacp",
+      "homepage": "http://www.bn-radio.de/",
+      "country": "DE",
+      "tags": [
+        "electronic"
+      ],
+      "favicon": "https://stream.radio-unicc.de/images/Logo-Radio_UNiCC.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "geo": [
+        50.8144,
+        12.9311
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-egofm-fame",
+      "name": "egoFM Fame",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast.egofm.de/egofmhalloffame.mp3",
+      "homepage": "https://www.egofm.de/",
+      "country": "DE",
+      "tags": [
+        "classic rock"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ilovemusic-ilove2dance",
+      "name": "ilovemusic: ilove2dance",
+      "broadcaster": "independent",
+      "streamUrl": "https://ilm.stream35.radiohost.de/ilm_ilove2dance_mp3-192?upd-meta&upd-scheme=https&_art=dD0xNzY4NDYzODAxJmQ9N2RlNDJmYjRiNDI1YjcxZjVjOTc",
+      "homepage": "https://www.ilovemusic.de/",
+      "country": "DE",
+      "favicon": "https://www.ilovemusic.de/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-onedrop",
+      "name": "Onedrop",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/onedrop",
+      "homepage": "https://laut.fm/onedrop",
+      "country": "DE",
+      "tags": [
+        "dub",
+        "reggae"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-rock-antenne-young-stars",
+      "name": "ROCK ANTENNE Young Stars",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rockantenne.de/young-stars/stream/aacp",
+      "homepage": "https://www.rockantenne.de/",
+      "country": "DE",
+      "tags": [
+        "metal",
+        "rock"
+      ],
+      "favicon": "https://www.rockantenne.de/logos/station-rock-antenne/apple-touch-icon.png",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-unifm-88-4",
+      "name": "UniFM 88,4",
+      "broadcaster": "independent",
+      "streamUrl": "https://unifm-streams.uni-freiburg.de/unifm.mp3",
+      "homepage": "https://www.unicross.uni-freiburg.de/",
+      "country": "DE",
+      "tags": [
+        "indie music"
+      ],
+      "favicon": "https://www.unicross.uni-freiburg.de/favicon.ico",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-hypertechno-techno-hard-techno-hands-up-industri",
+      "name": "* HYPERTECHNO || Techno, Hard Techno, Hands Up, Industrial Techno, Rave, Acid Techno, Peak Time, Warehouse, Underground, Driving Beats, High Energy, Dark, Fast BPM, Club, Festival, Night",
+      "broadcaster": "independent",
+      "streamUrl": "https://0nlineradio.radioho.st/technolovers-hypertechno?ref=radio-browser26",
+      "homepage": "https://plus.rm.fm/",
+      "country": "DE",
+      "tags": [
+        "dark techno",
+        "dj remix",
+        "early hardstyle",
+        "edm",
+        "electronic",
+        "hands up"
+      ],
+      "favicon": "https://i.ibb.co/JRb5Cj0K/Hypertechno.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0nlineradio-gran-prix",
+      "name": "0nlineradio GRAN PRIX",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.0nlineradio.com/grandprix?ref=radiobrowser",
+      "homepage": "https://0nlineradio.com/",
+      "country": "DE",
+      "tags": [
+        "charts",
+        "dance",
+        "euro hits",
+        "eurodance",
+        "european",
+        "european music"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.2893,
+        7.9102
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0r-beach-club-lounge-lounge-chill-deep-house-bal",
+      "name": "0R - BEACH CLUB LOUNGE || Lounge, Chill, Deep House, Balearic, Summer, Relax, Tropical, Beach, Cafe, Cocktails, Smooth, Sunset, Downtempo, Background, Vibes",
+      "broadcaster": "independent",
+      "streamUrl": "https://0nlineradio.radioho.st/lounge-beach-club-lounge?ref=radio-browser26",
+      "homepage": "https://plus.rm.fm/",
+      "country": "DE",
+      "tags": [
+        "beachclub",
+        "chillout",
+        "club",
+        "club dance",
+        "house",
+        "lounge"
+      ],
+      "favicon": "https://i.ibb.co/j9rLGNvn/Beach-club-lounge.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        52.493,
+        13.388
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-a-tv-augsburg",
+      "name": "a.tv Augsburg",
+      "broadcaster": "independent",
+      "streamUrl": "https://augsburgtv.iptv-playoutcenter.de/augsburgtv/augsburgtv.stream_1/playlist.m3u8",
+      "homepage": "https://www.augsburg.tv/",
+      "country": "DE",
+      "tags": [
+        "tv"
+      ],
+      "favicon": "https://www.augsburg.tv/storage/thumbs/192x192/r:1610477804/118847.png",
+      "bitrate": 3205,
+      "codec": "AAC,H.264",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-callshop-radio",
+      "name": "Callshop Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.callshopradio.com/callshopradio",
+      "homepage": "https://callshopradio.com/",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "electro",
+        "electronic",
+        "hip-hop",
+        "house",
+        "r&b"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-defjay",
+      "name": "DefJay",
+      "broadcaster": "independent",
+      "streamUrl": "https://icepool.silvacast.com/DEFJAY.mp3",
+      "homepage": "http://defjay.com/",
+      "country": "DE",
+      "favicon": "https://fility.com/wp-content/uploads/2020/07/defjay.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-fu-ball-bundesliga-2-spiel-6",
+      "name": "Fußball-Bundesliga 2: Spiel 6",
+      "broadcaster": "independent",
+      "streamUrl": "https://wdr-sportschau-liga2spiel6.icecastssl.wdr.de/wdr/sportschau/liga2spiel6/mp3/high",
+      "homepage": "https://livecenter.sportschau.de/",
+      "country": "DE",
+      "tags": [
+        "football",
+        "live sports",
+        "sport"
+      ],
+      "favicon": "https://www.sportschau.de/resources/assets/image/favicon/apple-icon-120x120.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-jesus-deine-hoffnung-radio",
+      "name": "jesus-deine-hoffnung-radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://jesus-deine-hoffnung-radio.stream.laut.fm/jesus-deine-hoffnung-radio",
+      "homepage": "https://www.jesus-deine-hoffnung.org/",
+      "country": "DE",
+      "tags": [
+        "christian",
+        "predigten"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-mother-earth-jazz",
+      "name": "Mother Earth Jazz",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.motherearthradio.de/listen/motherearth_jazz/motherearth.jazz.mp4",
+      "homepage": "https://motherearthradio.de/",
+      "country": "DE",
+      "tags": [
+        "jazz"
+      ],
+      "favicon": "https://motherearthradio.de/wp-content/uploads/2024/03/mergoldcube512.png",
+      "bitrate": 320,
+      "codec": "AAC",
+      "geo": [
+        48.137,
+        11.576
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-galaxy-mittelfranken",
+      "name": "Radio Galaxy Mittelfranken",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.galaxy-mittelfranken.de/galaxy-mittelfranken.mp3",
+      "homepage": "https://www.galaxy-mittelfranken.de/",
+      "country": "DE",
+      "tags": [
+        "charts",
+        "pop"
+      ],
+      "favicon": "https://assets.radioplayer.de/stationimages/389_programme_image.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        49.3006,
+        10.5345
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-reeperbahn-weihnachten",
+      "name": "RADIO Reeperbahn Weihnachten",
+      "broadcaster": "independent",
+      "streamUrl": "https://s35.derstream.net/reeperbahn-ch3.mp3",
+      "homepage": "https://radio-reeperbahn.de/",
+      "country": "DE",
+      "tags": [
+        "weihnachten",
+        "xmas"
+      ],
+      "favicon": "https://www.radio-reeperbahn.de/wp-content/uploads/Logo-RR-Weihnachten-2200x2200-1.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        53.5433,
+        9.9893
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-antenne-munster-deutsch-pop",
+      "name": "Antenne Münster Deutsch Pop",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.lokalradio.nrw/4457nc9",
+      "homepage": "https://www.antennemuenster.de/",
+      "country": "DE",
+      "tags": [
+        "german pop",
+        "pop"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-dengeqamishlo",
+      "name": "dengeqamishlo",
+      "broadcaster": "independent",
+      "streamUrl": "https://dengeqamishlo.stream.laut.fm/dengeqamishlo",
+      "homepage": "https://onlineradiobox.com/de/dengeqamishlo/?lang=tr",
+      "country": "DE",
+      "favicon": "https://cdn.onlineradiobox.com/img/apple-touch-icon-120x120.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-dublab-de",
+      "name": "dublab DE",
+      "broadcaster": "independent",
+      "streamUrl": "https://dublabde.out.airtime.pro/dublabde_a",
+      "homepage": "https://dublab.de/",
+      "country": "DE",
+      "tags": [
+        "community",
+        "electronic",
+        "experimental"
+      ],
+      "favicon": "https://pbs.twimg.com/profile_images/882223798275231745/rEbH-Yry_400x400.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.9496,
+        6.9547
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ice-radio-waldkraiburg-3-dolce-vita-mit-italieni",
+      "name": "ICE RADIO WALDKRAIBURG 3 Dolce Vita mit Italienischen Hits",
+      "broadcaster": "independent",
+      "streamUrl": "https://irw.tunefm.de:8050/stream",
+      "homepage": "https://irwradio.de/",
+      "country": "DE",
+      "favicon": "https://irwradio.de/apple-icon-120x120.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ndr-fernsehen-sh",
+      "name": "NDR Fernsehen SH",
+      "broadcaster": "independent",
+      "streamUrl": "https://mcdn.ndr.de/ndr/hls/ndr_fs/ndr_sh/master.m3u8",
+      "homepage": "https://www.ndr.de/fernsehen/index.html",
+      "country": "DE",
+      "tags": [
+        "ard",
+        "drittes programm",
+        "hallo niedersachsen",
+        "hamburg journal",
+        "iptv",
+        "livestream"
+      ],
+      "bitrate": 1672,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-altstastwelle",
+      "name": "Radio Altstastwelle",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.multhielemedia.de/radio/8040/rheinradio.mp3",
+      "homepage": "https://altstadtwelle.de/",
+      "country": "DE",
+      "tags": [
+        "karnevalsmusik",
+        "kölsche balladen",
+        "kölsche musik"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.9235,
+        6.9557
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-fred-film-radio-deutsch",
+      "name": "Fred Film Radio(Deutsch)",
+      "broadcaster": "independent",
+      "streamUrl": "https://s10.webradio-hosting.com/proxy/fredradioge/stream",
+      "homepage": "http://www.fred.fm/",
+      "country": "DE",
+      "tags": [
+        "culture",
+        "film",
+        "movie"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-freies-sender-kombinat-hamburg",
+      "name": "Freies Sender Kombinat Hamburg",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.fueralle.org/fsk.ogg",
+      "homepage": "https://www.fsk-hh.org/",
+      "country": "DE",
+      "favicon": "https://www.fsk-hh.org/favicon.ico",
+      "bitrate": 320,
+      "codec": "OGG",
+      "geo": [
+        53.5644,
+        10.0058
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-fu-ball-bundesliga-2-spiel-7",
+      "name": "Fußball-Bundesliga 2: Spiel 7",
+      "broadcaster": "independent",
+      "streamUrl": "https://wdr-sportschau-liga2spiel7.icecastssl.wdr.de/wdr/sportschau/liga2spiel7/mp3/high",
+      "homepage": "https://livecenter.sportschau.de/",
+      "country": "DE",
+      "tags": [
+        "football",
+        "live sports",
+        "sport"
+      ],
+      "favicon": "https://www.sportschau.de/resources/assets/image/favicon/apple-icon-120x120.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-i-love-x-mas",
+      "name": "i love x-mas",
+      "broadcaster": "independent",
+      "streamUrl": "https://ilm.stream18.radiohost.de/ilm_ilovexmas_mp3-192?upd-meta&upd-scheme=https&_art=dD0xNzY4NDU4MzE2JmQ9ZmJlN2QyNDY5YWUzODc0OWFlNGY",
+      "homepage": "http://www.iloveradio.de/",
+      "country": "DE",
+      "favicon": "http://www.iloveradio.de/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-primal-fm-dresden",
+      "name": "PRIMAL.FM DRESDEN",
+      "broadcaster": "independent",
+      "streamUrl": "https://main.stream.primal.fm/dresden",
+      "homepage": "https://primal.fm/",
+      "country": "DE",
+      "tags": [
+        "hardstyle/handsup/edm"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-frankfurt",
+      "name": "Radio Frankfurt",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiogroup-stream32.radiohost.de/radio-frankfurt_mp3-192",
+      "homepage": "https://radiofrankfurt.de/",
+      "country": "DE",
+      "tags": [
+        "adult contemporary"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.1087,
+        8.6819
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radioselection",
+      "name": "RadioSelection",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.radio-selection.de/onair",
+      "homepage": "https://www.radioselection.de/",
+      "country": "DE",
+      "tags": [
+        "hitselection",
+        "public radio",
+        "saturdayselection",
+        "schlagerselection",
+        "selection"
+      ],
+      "favicon": "https://www.radioselection.de/favicon.ico",
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        50.5114,
+        12.1201
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-retrowelle",
+      "name": "Retrowelle",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/retrowelle",
+      "homepage": "https://laut.fm/retrowelle",
+      "country": "DE",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0r-90s-90s-pop-90s-hits-eurodance-hip-hop-r-b-gr",
+      "name": "0R - 90s || 90s Pop, 90s Hits, Eurodance, Hip Hop, R&B, Grunge, Alternative, Techno, Trance, Dance, Chill, Boyband, Girlband, Pop Rock, Nostalgic",
+      "broadcaster": "independent",
+      "streamUrl": "https://0nlineradio.radioho.st/0r-90s?ref=radio-browser26",
+      "homepage": "https://plus.rm.fm/",
+      "country": "DE",
+      "tags": [
+        "1990s",
+        "1990s hits",
+        "1990s pop music",
+        "90's",
+        "90er",
+        "90er hitmix"
+      ],
+      "favicon": "https://i.ibb.co/S4y9mSR9/90s.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        52.5569,
+        13.4657
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-brexit-laut-fm",
+      "name": "Brexit - Laut.FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://brexit.stream.laut.fm/brexit?ref=web-app&start_time=1702103555811&t302=2023-12-09_07-32-35&uuid=4db366ed-fe79-45d1-a858-be3945ba5b7f",
+      "homepage": "https://laut.fm/brexit",
+      "country": "DE",
+      "tags": [
+        "britpop",
+        "indie"
+      ],
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/d/d4/BREXIT.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ella-radio-classic-jazz",
+      "name": "Ella Radio - Classic Jazz",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.ella-radio.de/ella-classic-jazz/mp3-192/?ref=radio-browser",
+      "homepage": "https://www.ella-radio.de/",
+      "country": "DE",
+      "tags": [
+        "classic jazz",
+        "jazz"
+      ],
+      "favicon": "https://ella-radio.de/uplink/Ella_Classic-Jazz.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-freefm",
+      "name": "Freefm",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.freefm.de/Studio",
+      "homepage": "https://freefm.de/",
+      "country": "DE",
+      "favicon": "https://freefm.de/sites/all/themes/freefm/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        48.3997,
+        10.0008
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-fu-ball-bundesliga-spiel-6",
+      "name": "Fußball-Bundesliga: Spiel 6",
+      "broadcaster": "independent",
+      "streamUrl": "https://wdr-sportschau-liga1spiel6.icecastssl.wdr.de/wdr/sportschau/liga1spiel6/mp3/high",
+      "homepage": "https://livecenter.sportschau.de/",
+      "country": "DE",
+      "tags": [
+        "football",
+        "live sports",
+        "sport"
+      ],
+      "favicon": "https://www.sportschau.de/resources/assets/image/favicon/apple-icon-120x120.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-back-in-itime",
+      "name": "Radio Back in Itime",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/back_in_time?ref=radiode",
+      "homepage": "https://www.hitparadenkult.de/",
+      "country": "DE",
+      "tags": [
+        "80s",
+        "90s",
+        "hitparadenkult",
+        "oldies",
+        "retro",
+        "schlagerrallye"
+      ],
+      "favicon": "https://cdn.website-editor.net/04b5fe00bd1b4aac97417392b1ec949a/site_favicon_16_1685893203381.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-rock-antenne-90er-rock-2",
+      "name": "Rock Antenne - 90er Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rockantenne.de/90er-rock/stream/mp3",
+      "homepage": "https://www.rockantenne.de/rockhoeren/streams/90er-rock",
+      "country": "DE",
+      "tags": [
+        "90s",
+        "music",
+        "rock"
+      ],
+      "favicon": "https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-animealive",
+      "name": "animealive",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/animealive",
+      "homepage": "https://laut.fm/animealive",
+      "country": "DE",
+      "tags": [
+        "anime openings",
+        "anime radio"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ice-radio-waldkraiburg-2-bahnbrechende-schlager-",
+      "name": "ICE RADIO WALDKRAIBURG 2 +++  Bahnbrechende Schlager aus 60 Jahren +++ Deutschsprachig und Mundart Hits aus Deutschland - Österreich - Schweiz",
+      "broadcaster": "independent",
+      "streamUrl": "https://irw.tunefm.de:8410/stream",
+      "homepage": "https://www.irwradio.de/",
+      "country": "DE",
+      "favicon": "https://www.irwradio.de/apple-icon-120x120.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-mabu-beatz-radio-techno",
+      "name": "MABU Beatz Radio - Techno",
+      "broadcaster": "independent",
+      "streamUrl": "https://audio.mabu-beatz-radio.com:8003/techno",
+      "homepage": "https://mabu-beatz-radio.com/streams/techno/",
+      "country": "DE",
+      "tags": [
+        "techno"
+      ],
+      "favicon": "https://i.postimg.cc/vHDM8brn/OIP.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-mother-earth-radio",
+      "name": "Mother Earth Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.motherearthradio.de/listen/motherearth/motherearth.aac",
+      "homepage": "https://motherearthradio.de/",
+      "country": "DE",
+      "tags": [
+        "eclectic"
+      ],
+      "favicon": "https://motherearthradio.de/wp-content/uploads/2024/03/mergoldcube512.png",
+      "bitrate": 320,
+      "codec": "AAC",
+      "geo": [
+        48.137,
+        11.576
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-rock-antenne-hamburg-aac",
+      "name": "Rock Antenne Hamburg (AAC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rockantenne.de/rockantenne-hamburg/stream/aacp",
+      "homepage": "https://www.rockantenne.de/",
+      "country": "DE",
+      "tags": [
+        "rock"
+      ],
+      "favicon": "https://www.rockantenne.de/media/cache/3/version/13/rahh-v1.jpg/fccb3fcb0a2733dd2265a4d6eb6ad375.webp",
+      "codec": "AAC",
+      "geo": [
+        53.548,
+        10.0001
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-rock-antenne-punkrock",
+      "name": "Rock Antenne Punkrock",
+      "broadcaster": "independent",
+      "streamUrl": "https://s3-webradio.rockantenne.de/punkrock/stream/mp3",
+      "homepage": "https://www.rockantenne.de/rockhoeren/streams/punk-rock",
+      "country": "DE",
+      "tags": [
+        "hardcore",
+        "punkrock"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-swr-4-heilbronn",
+      "name": "SWR 4 Heilbronn",
+      "broadcaster": "independent",
+      "streamUrl": "https://liveradio.swr.de/sw282p3/swr4hn/",
+      "homepage": "https://www.swr.de/swr4/index.html",
+      "country": "DE",
+      "tags": [
+        "easy listening",
+        "nachrichten",
+        "regional",
+        "schlager"
+      ],
+      "favicon": "https://www.swr.de/assets/swr/swr4/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        49.1411,
+        9.2153
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1000-80-hits",
+      "name": "1000 80 Hits",
+      "broadcaster": "independent",
+      "streamUrl": "https://ais-sa9.cdnstream1.com/1898_128",
+      "homepage": "https://1000hits80s.eu/",
+      "country": "DE",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-94-3-rs2",
+      "name": "94.3 rs2",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rs2.de/rs2/mp3-128/playlist",
+      "homepage": "https://webradio.rs2de/livestream.m3u",
+      "country": "DE",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-a-passing-feeling",
+      "name": "A Passing Feeling",
+      "broadcaster": "independent",
+      "streamUrl": "https://apassingfeeling.stream.laut.fm/a_passing_feeling",
+      "homepage": "https://www.tumblr.com/apfelsindie",
+      "country": "DE",
+      "tags": [
+        "alternative",
+        "indie",
+        "pop",
+        "rock"
+      ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/8/44488.v1.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        53.1389,
+        8.2142
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ella-radio-mellow-smooth-jazz",
+      "name": "Ella Radio - Mellow Smooth Jazz",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.ella-radio.de/ella-mellow-smooth-jazz/mp3-192/?ref=radio-browser",
+      "homepage": "https://www.ella-radio.de/",
+      "country": "DE",
+      "tags": [
+        "jazz",
+        "smooth jazz"
+      ],
+      "favicon": "https://ella-radio.de/uplink/Ella_Mellow-Smooth-Jazz.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ella-radio-saxophon-jazz",
+      "name": "Ella Radio - Saxophon Jazz",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.ella-radio.de/ella-saxophon-jazz/mp3-192/%20?ref=radio-browser",
+      "homepage": "https://www.ella-radio.de/",
+      "country": "DE",
+      "tags": [
+        "jazz",
+        "saxophone"
+      ],
+      "favicon": "https://ella-radio.de/uplink/Ella_Saxophone-Jazz.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radiosilesia",
+      "name": "RadioSilesia",
+      "broadcaster": "independent",
+      "streamUrl": "https://s1.slotex.pl/shoutcast/7350/stream",
+      "homepage": "https://www.radiosilesia.de/",
+      "country": "DE",
+      "tags": [
+        "folk",
+        "schlager"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.4306,
+        7.766
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-schwany-2-schlager",
+      "name": "Schwany 2 Schlager",
+      "broadcaster": "independent",
+      "streamUrl": "https://schlager.sp.radio.fm/stream",
+      "homepage": "https://schwany.de/schwany-schlager.html",
+      "country": "DE",
+      "favicon": "https://www.schwany.de/images/Hoamatwelle-Logo-320-x-240-px.webp",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-slonski-musikbox",
+      "name": "Slonski MusikBox",
+      "broadcaster": "independent",
+      "streamUrl": "https://s1.slotex.pl:7550/stream/",
+      "homepage": "https://www.slonski-musikbox.de/",
+      "country": "DE",
+      "tags": [
+        "80s",
+        "folk music"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-swr1-rp",
+      "name": "SWR1 RP",
+      "broadcaster": "independent",
+      "streamUrl": "https://liveradio.swr.de/sw282p3/swr1rp/",
+      "homepage": "https://www.swr.de/swr1/rp/index.html",
+      "country": "DE",
+      "favicon": "https://s3.eu-central-1.amazonaws.com/radioportals/livewebradio-de/images/stations/swr1-rheinland-pfalz-cover.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ac-plus",
+      "name": "AC-PLUS",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/ac-plus",
+      "homepage": "https://ac-plus.de.tl/",
+      "country": "DE",
+      "tags": [
+        "80s",
+        "90s",
+        "charts",
+        "dance",
+        "electronic",
+        "pop"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-babaganousha-labs",
+      "name": "Babaganousha Labs",
+      "broadcaster": "independent",
+      "streamUrl": "https://babacast.ddns.net/listen/baba_archives/baba-labs.mp3",
+      "homepage": "https://babaganousha.net/",
+      "country": "DE",
+      "tags": [
+        "goa",
+        "psychedelic",
+        "psytrance"
+      ],
+      "favicon": "https://babaganousha.net/images/baba/baba_logo_001.jpg",
+      "bitrate": 96,
+      "codec": "AAC",
+      "geo": [
+        53.5511,
+        9.9937
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-babaganousha-radio",
+      "name": "Babaganousha Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://babacast.ddns.net/listen/babaazu/baba-radio.mp3",
+      "homepage": "https://babaganousha.net/",
+      "country": "DE",
+      "favicon": "https://babaganousha.net/media/templates/site/cassiopeia/images/favicon.ico",
+      "bitrate": 96,
+      "codec": "AAC",
+      "geo": [
+        53.5487,
+        9.9799
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-fmrausch-fm-rausch-radio",
+      "name": "FMRausch: FM Rausch Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://fmrausch.stream.laut.fm/fmrausch",
+      "homepage": "https://laut.fm/fmrausch",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "avantgarde",
+        "classical",
+        "lounge",
+        "vocal"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-fu-ball-bundesliga-2-spiel-5",
+      "name": "Fußball-Bundesliga 2: Spiel 5",
+      "broadcaster": "independent",
+      "streamUrl": "https://wdr-sportschau-liga2spiel5.icecastssl.wdr.de/wdr/sportschau/liga2spiel5/mp3/high",
+      "homepage": "https://livecenter.sportschau.de/",
+      "country": "DE",
+      "tags": [
+        "football",
+        "live sports",
+        "sport"
+      ],
+      "favicon": "https://www1.wdr.de/sport/fussball/logo-dfl-fussball-zweite-liga-zweitausendachtzehn-100~_v-ARDKleinerTeaser.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-odinsmetalrockclub",
+      "name": "ODINSMETALROCKCLUB",
+      "broadcaster": "independent",
+      "streamUrl": "https://odinsmetalrockclub.stream.laut.fm/odinsmetalrockclub?pl=m3u&t302=2026-01-15_06-47-08&uuid=a3f143a2-3f6a-450e-ab7a-0c9f463704ff",
+      "homepage": "https://stream.laut.fm/odinsmetalrockclub",
+      "country": "DE",
+      "tags": [
+        "gothic",
+        "gothic rock",
+        "heavy metal",
+        "metal",
+        "mittelalter",
+        "rock"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-91-2",
+      "name": "Radio 91.2",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio912--di--nacs-ais-lgc--02--cdn.cast.addradio.de/radio912/live/mp3/high",
+      "homepage": "https://www.radio912.de/index.html",
+      "country": "DE",
+      "favicon": "https://www.radio912.de/assets/images/favicons/radio912/favicon_x96.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-ffn-dance-only",
+      "name": "Radio ffn - Dance Only",
+      "broadcaster": "independent",
+      "streamUrl": "https://ffn-stream20.radiohost.de/ffn-dance_only_mp3-192?ref=radio-browser",
+      "homepage": "https://www.ffn.de/",
+      "country": "DE",
+      "favicon": "https://player.ffn.de/assets/channels/ffn_Logo_Play_Dance_only_srgb.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-rautemusik-progressive-aac-48-kbps",
+      "name": "RauteMusik Progressive | AAC 48 kbps",
+      "broadcaster": "independent",
+      "streamUrl": "https://progressive-aacp.rautemusik.fm/",
+      "homepage": "https://www.rautemusik.fm/",
+      "country": "DE",
+      "tags": [
+        "48 kbps",
+        "progressive"
+      ],
+      "favicon": "https://www.rm.fm/favicon.ico",
+      "bitrate": 47,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-reyfm-deutschrap",
+      "name": "REYFM - #Deutschrap",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.reyfm.de/reyfm-deutschrap/",
+      "homepage": "https://rey.fm/",
+      "country": "DE",
+      "tags": [
+        "music",
+        "rap"
+      ],
+      "favicon": "https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-technoszene",
+      "name": "technoszene",
+      "broadcaster": "independent",
+      "streamUrl": "https://technoszene.stream.laut.fm/technoszene?t302=2024-06-04_21-07-42&uuid=f61f723b-42b8-4886-aafb-273a4d87d2f6",
+      "homepage": "https://www.technoszene.com/radio/",
+      "country": "DE",
+      "favicon": "https://www.technoszene.com/core/wp-content/uploads/2015/09/cropped-icon512-180x180.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-tide-radio",
+      "name": "TIDE.radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://rcstream0001.redcastle.net/radio/8000/tide-128.mp3?rp_source=1&=&&___cb=916093692175132",
+      "homepage": "http://www.tidenet.de/radio",
+      "country": "DE",
+      "tags": [
+        "misc"
+      ],
+      "favicon": "https://www.tidenet.de/assets/icons/android-icon-192x192.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0r-classical-hotel-lounge-classical-classical-lo",
+      "name": "0R - CLASSICAL HOTEL LOUNGE - CLASSICAL || Classical, Lounge, Piano, Strings, Elegant, Relax, Instrumental, Calm, Soft, Background, Timeless, Melodic, Sophisticated, Evening, Smooth",
+      "broadcaster": "independent",
+      "streamUrl": "https://0nlineradio.radioho.st/classical-classical-hotel-lounge?ref=radio-browser26",
+      "homepage": "https://plus.rm.fm/",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "ambient and relaxation music",
+        "ambiental",
+        "background",
+        "chillout+lounge",
+        "classic hits"
+      ],
+      "favicon": "https://i.ibb.co/ZRZdcBkj/Classical-Hotel-Lounge.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ffn-tannenbaum",
+      "name": "ffn Tannenbaum",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.ffn.de/tannenbaum/mp3-192/",
+      "homepage": "https://www.ffn.de/",
+      "country": "DE",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ilovegerman-rap-1st-new-german-rap-hip-hop",
+      "name": "ILOVEGERMAN RAP 1ST | New German Rap & Hip Hop",
+      "broadcaster": "independent",
+      "streamUrl": "https://ilm.stream35.radiohost.de/ilm_ilovedeutschrapfirst_mp3-192?upd-meta&upd-scheme=https&_art=dD0xNzY4NDY0MTc4JmQ9ODk0YjlkMGU1M2JlOTk1ODFlYWM",
+      "homepage": "https://ilovemusic.de/ilovedeutschrapfirst/",
+      "country": "DE",
+      "tags": [
+        "hiphop",
+        "rap"
+      ],
+      "favicon": "https://ilovemusic.de/fileadmin/user_upload/ilm2024_ilovedeutschrapfirst1x1_02_440x440.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-jazz-christmas",
+      "name": "Jazz Christmas",
+      "broadcaster": "independent",
+      "streamUrl": "https://jazzchristmas.stream.laut.fm/jazzchristmas?t302=2023-12-19_08-05-17&uuid=43cac575-4695-4eca-baf1-5d2f18f5897b",
+      "homepage": "https://jazzchristmas.stream.laut.fm/jazzchristmas?t302=2023-12-19_08-05-17&uuid=43cac575-4695-4eca-baf1-5d2f18f5897b",
+      "country": "DE",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-laut-fm-hardcoremusik",
+      "name": "laut.fm HARDCOREMUSIK",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/hardcoremusik",
+      "homepage": "https://laut.fm/hardcoremusik",
+      "country": "DE",
+      "tags": [
+        "hardcore"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-nius",
+      "name": "NiUS",
+      "broadcaster": "independent",
+      "streamUrl": "https://nius--di--nacs-ais-lgc--0a--cdn.cast.addradio.de/nius/live/mp3/high",
+      "homepage": "https://nius.de/",
+      "country": "DE",
+      "tags": [
+        "das beste von heute",
+        "musik der 80er",
+        "musik der 90er",
+        "news",
+        "pop"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        52.5316,
+        13.3541
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-wdr-lokalzeit-dortmund",
+      "name": "WDR Lokalzeit Dortmund",
+      "broadcaster": "independent",
+      "streamUrl": "https://wdrlokalzeit.akamaized.net/hls/live/2018022/wdrlz_dortmund/index.m3u8",
+      "homepage": "https://www1.wdr.de/fernsehen/startseite/",
+      "country": "DE",
+      "codec": "UNKNOWN",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-blues-und-rock-garage",
+      "name": "Blues und Rock Garage",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/bluesundrockgarage",
+      "homepage": "https://laut.fm/bluesundrockgarage",
+      "country": "DE",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ella-radio-love-smooth-jazz",
+      "name": "Ella Radio - Love Smooth Jazz",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.ella-radio.de/ella-love-smooth-jazz/mp3-192/?ref=radio-browser",
+      "homepage": "https://www.ella-radio.de/",
+      "country": "DE",
+      "tags": [
+        "jazz",
+        "smooth jazz"
+      ],
+      "favicon": "https://ella-radio.de/uplink/Ella_Love-Smooth-Jazz.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ella-radio-mellow-piano-jazz",
+      "name": "Ella Radio - Mellow Piano Jazz",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.ella-radio.de/ella-mellow-piano-jazz/mp3-192/?ref=radio-browser",
+      "homepage": "https://www.ella-radio.de/",
+      "country": "DE",
+      "tags": [
+        "jazz"
+      ],
+      "favicon": "https://ella-radio.de/uplink/Ella_Mellow-Piano-Jazz.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-fu-ball-bundesliga-2-spiel-9",
+      "name": "Fußball-Bundesliga 2: Spiel 9",
+      "broadcaster": "independent",
+      "streamUrl": "https://wdr-sportschau-liga2spiel9.icecastssl.wdr.de/wdr/sportschau/liga2spiel9/mp3/high",
+      "homepage": "https://livecenter.sportschau.de/",
+      "country": "DE",
+      "tags": [
+        "football",
+        "live sports",
+        "sport"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-i-love-rock-radio-i-love-music",
+      "name": "I Love Rock Radio - I Love Music",
+      "broadcaster": "independent",
+      "streamUrl": "https://ilm.stream35.radiohost.de/ilm_iloveradiorock_mp3-192?upd-meta&upd-scheme=https&_art=dD0xNzc0MzQxMDA2JmQ9NGNlOGVhNTRlY2Q1MGJmNTAwYTA",
+      "homepage": "https://ilovemusic.de/iloverockradio/",
+      "country": "DE",
+      "tags": [
+        "pop rock",
+        "rock"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-dreyeckland",
+      "name": "Radio Dreyeckland",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rdl.de/rdl",
+      "homepage": "https://rdl.de/",
+      "country": "DE",
+      "favicon": "https://rdl.de/sites/default/files/images/2022/09/rdl-logo-new-complete-circle.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-rock-antenne-lagerfeuer-rock",
+      "name": "Rock Antenne - Lagerfeuer Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rockantenne.de/lagerfeuer-rock/stream/mp3",
+      "homepage": "https://www.rockantenne.de/rockhoeren/streams/lagerfeuer-rock",
+      "country": "DE",
+      "tags": [
+        "music",
+        "rock"
+      ],
+      "favicon": "https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-54-house-fm",
+      "name": "54 House fm",
+      "broadcaster": "independent",
+      "streamUrl": "https://54house.fm:9013/stream",
+      "homepage": "https://www.54house.fm/",
+      "country": "DE",
+      "favicon": "https://firebasestorage.googleapis.com/v0/b/radiogalaxy-580f4.appspot.com/o/images%2FIMG_20240306_191630247.jpg?alt=media&token=591c780d-a9ff-4cf1-9e7c-7f2127d7d944",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-allgauhit-dein-allgau-dein-radio-ein-hitmix-aus-",
+      "name": "AllgäuHIT - Dein Allgäu. Dein Radio - Ein Hitmix aus aktuellen Pop- und Rocktiteln, ergänzt um echte Klassiker aus den 80er und 90er Jahren + Austropop. ",
+      "broadcaster": "independent",
+      "streamUrl": "https://allgaeu.stream06.radiohost.de/allgaeuhit_mp3-192?ref=radio-browser&upd-meta&upd-scheme=https&_art=dD0xNzY4NDQ1NDU3JmQ9NDQ3ZDk4MmJkOTk3NzA2OTAzNzQ",
+      "homepage": "https://www.allgaeuhit.de/",
+      "country": "DE",
+      "tags": [
+        "1980s",
+        "80's",
+        "80s",
+        "classic rock",
+        "pop",
+        "pop music"
+      ],
+      "favicon": "https://i.ibb.co/DRNQfnc/Allg-u-HIT-800x800.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-antenne-bad-kreuznach",
+      "name": "Antenne Bad Kreuznach",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radiogroup.de/antenne-badkreuznach/mp3-192/?ref=website",
+      "homepage": "https://www.antenne-kh.de/",
+      "country": "DE",
+      "favicon": "https://www.antenne-kh.de/wp-content/uploads/2021/01/cropped-button-1-88x88.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-antenne-bayern-coffee-music",
+      "name": "Antenne Bayern Coffee Music",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.antenne.de/coffee/stream/mp3",
+      "homepage": "https://www.antenne.de/webradio/coffeemusic",
+      "country": "DE",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ella-radio-paris-cafe",
+      "name": "Ella Radio - Paris Café",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.ella-radio.de/ella-paris-cafe/mp3-192/?ref=radio-browser",
+      "homepage": "https://www.ella-radio.de/",
+      "country": "DE",
+      "tags": [
+        "jazz"
+      ],
+      "favicon": "https://ella-radio.de/uplink/Ella_Paris-Cafe.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ella-radio-piano-jazz",
+      "name": "Ella Radio - Piano Jazz",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.ella-radio.de/ella-piano-jazz/mp3-192?ref=radio-browser",
+      "homepage": "https://www.ella-radio.de/",
+      "country": "DE",
+      "tags": [
+        "jazz",
+        "piano jazz"
+      ],
+      "favicon": "https://ella-radio.de/uplink/Ella_Piano-Jazz.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-freies-radio-stuttgart",
+      "name": "Freies Radio Stuttgart",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.fueralle.org/frs-hi.mp3",
+      "homepage": "https://www.freies-radio.de/",
+      "country": "DE",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-hr1-osthessen",
+      "name": "hr1 Osthessen",
+      "broadcaster": "independent",
+      "streamUrl": "https://dispatcher.rndfnk.com/hr/hr1/osthessen/high",
+      "homepage": "https://www.hr1.de/",
+      "country": "DE",
+      "tags": [
+        "adult contemporary"
+      ],
+      "favicon": "https://www.hr1.de/favicon.png?v=3.84.2",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.5534,
+        9.6824
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-pm-events",
+      "name": "Radio PM Events",
+      "broadcaster": "independent",
+      "streamUrl": "https://server7.streamserver24.com:61414/;stream.mp3",
+      "homepage": "https://www.radio-pmevents.de/",
+      "country": "DE",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-siegen-dein-90er-radio",
+      "name": "Radio Siegen Dein 90er Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.lokalradio.nrw/444zm3b",
+      "homepage": "https://www.radiosiegen.de/index.html",
+      "country": "DE",
+      "tags": [
+        "90s"
+      ],
+      "favicon": "https://www.radiosiegen.de/assets/images/favicons/radiosiegen/favicon_x96.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-tagesschau24-hd",
+      "name": "tagesschau24 HD",
+      "broadcaster": "independent",
+      "streamUrl": "https://tagesschau.akamaized.net/hls/live/2020115/tagesschau/tagesschau_1/master.m3u8",
+      "homepage": "https://programm.ard.de/TV/tagesschau24/Startseite",
+      "country": "DE",
+      "tags": [
+        "tv"
+      ],
+      "bitrate": 1672,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-alternative-radio",
+      "name": "Alternative Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://alternative-radio.stream.laut.fm/alternative-radio?",
+      "homepage": "https://laut.fm/alternative-radio",
+      "country": "DE",
+      "tags": [
+        "alternative",
+        "indie"
+      ],
+      "favicon": "https://m.media-amazon.com/images/I/51hQAwIpHCL._UXNaN_FMjpg_QL85_.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-country-antenne",
+      "name": "country Antenne",
+      "broadcaster": "independent",
+      "streamUrl": "https://s8-webradio.rockantenne.de/country-antenne/stream?",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "DE",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ella-radio-berlin-jazz",
+      "name": "Ella Radio - Berlin Jazz",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.ella-radio.de/ella-berlin-jazz/mp3-192/?ref=radio-browser",
+      "homepage": "https://www.ella-radio.de/",
+      "country": "DE",
+      "tags": [
+        "jazz"
+      ],
+      "favicon": "https://ella-radio.de/uplink/Ella_Berlin-Jazz.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ella-radio-blues",
+      "name": "Ella Radio - Blues",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.ella-radio.de/ella-blues/mp3-192/?ref=radio-browser",
+      "homepage": "https://www.ella-radio.de/",
+      "country": "DE",
+      "tags": [
+        "blues",
+        "jazz"
+      ],
+      "favicon": "https://ella-radio.de/uplink/Ella_Blues.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ella-radio-smooth-jazz-24-7",
+      "name": "Ella Radio - Smooth Jazz 24/7",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.ella-radio.de/ella-smooth-jazz-247/mp3-192/?ref=radio-browser",
+      "homepage": "https://www.ella-radio.de/",
+      "country": "DE",
+      "tags": [
+        "jazz",
+        "smooth jazz"
+      ],
+      "favicon": "https://ella-radio.de/uplink/Ella_Smooth-Jazz-247.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ella-radio-vocal-legends",
+      "name": "Ella Radio - Vocal Legends",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.ella-radio.de/ella-vocal-legends/mp3-192/?ref=radio-browser",
+      "homepage": "https://www.ella-radio.de/",
+      "country": "DE",
+      "tags": [
+        "jazz",
+        "vocal jazz"
+      ],
+      "favicon": "https://ella-radio.de/uplink/Ella_Vocal-Legends.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-exogaming",
+      "name": "EXOGAMING",
+      "broadcaster": "independent",
+      "streamUrl": "https://exogaming.stream.laut.fm/exogaming?pl=m3u&t302=2026-01-15_04-32-19&uuid=26045880-323b-46fa-86ae-1edc8318dc7d",
+      "homepage": "https://exogaming.stream.laut.fm/",
+      "country": "DE",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ilovedance-history-dancefloor-anthems-all-time-c",
+      "name": "ILOVEDANCE HISTORY | Dancefloor Anthems & All-time-Classics",
+      "broadcaster": "independent",
+      "streamUrl": "https://ilm.stream35.radiohost.de/ilm_ilovedancehistory_mp3-192?upd-meta&upd-scheme=https&_art=dD0xNzY4NDUxNDA2JmQ9NTg5MmY0ZDBhNDE5MGI2ZjJmYWY",
+      "homepage": "https://ilovemusic.de/ilovedancehistory/",
+      "country": "DE",
+      "tags": [
+        "history",
+        "hits"
+      ],
+      "favicon": "https://ilovemusic.de/fileadmin/user_upload/ilm2025_ilovedancehistory1_440x440.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-living-radio",
+      "name": "Living Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://livingradio.stream.laut.fm/living_radio?t302=2021-03-18_15-39-39&uuid=60ce31c3-421a-478e-bdaa-4378c287adeb",
+      "homepage": "https://liveradio.de/living-radio",
+      "country": "DE",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-mbg-harsewinkel-gottesdienst",
+      "name": "MBG Harsewinkel Gottesdienst",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.mbg-hsw.de/radio/8000/radio.mp3",
+      "homepage": "https://www.mbg-hsw.de/",
+      "country": "DE",
+      "tags": [
+        "christian",
+        "kirche"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-mother-earth-instrumental",
+      "name": "Mother Earth Instrumental",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.motherearthradio.de/listen/motherearth_instrumental/motherearth.instrumental.aac",
+      "homepage": "https://motherearthradio.de/",
+      "country": "DE",
+      "tags": [
+        "instrumental"
+      ],
+      "favicon": "https://motherearthradio.de/wp-content/uploads/2024/03/mergoldcube512.png",
+      "bitrate": 320,
+      "codec": "AAC",
+      "geo": [
+        48.137,
+        11.576
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-nice-mix",
+      "name": "nice MIX",
+      "broadcaster": "independent",
+      "streamUrl": "https://mix-hd-radio.nice-radiotv.de/",
+      "homepage": "https://nice-radiotv.de/radiochannel/nice-mix/",
+      "country": "DE",
+      "tags": [
+        "2000er",
+        "90er",
+        "dance",
+        "dj mixes",
+        "musik der 80er",
+        "pop"
+      ],
+      "favicon": "https://nice-radiotv.de/wp-content/uploads/2017/01/nice-Mix-Player-Logo.png",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-osradio-104-8",
+      "name": "Osradio 104,8",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.radio-aktiv.de:8443/os-radio.mp3",
+      "homepage": "https://www.osradio.de/",
+      "country": "DE",
+      "favicon": "https://www.osradio.de/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        52.2339,
+        8.0283
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-cottbus",
+      "name": "Radio Cottbus",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radiogroup.de/radio-cottbus/mp3-192/",
+      "homepage": "https://www.radio-cottbus.de/",
+      "country": "DE",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.7463,
+        14.3336
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-swr-4-bw",
+      "name": "SWR 4 BW",
+      "broadcaster": "independent",
+      "streamUrl": "https://liveradio.swr.de/sw331ch/swr4bw/",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "DE",
+      "favicon": "https://api.ardmediathek.de/image-service/images/urn:ard:image:f607d39888879ec7?w=512",
+      "bitrate": 96,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0nlineradio-deutsch",
+      "name": "0nlineradio DEUTSCH",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.0nlineradio.com/deutsch?ref=radiobrowser",
+      "homepage": "https://0nlineradio.com/",
+      "country": "DE",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.5134,
+        8.9648
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-anixe-hd",
+      "name": "ANIXE HD",
+      "broadcaster": "independent",
+      "streamUrl": "https://ma.anixa.tv/clips/stream/anixehd/index.m3u8",
+      "homepage": "https://www.anixehd.tv/",
+      "country": "DE",
+      "tags": [
+        "tv"
+      ],
+      "favicon": "https://www.anixehd.tv/favicon.ico",
+      "bitrate": 2249,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-autodj",
+      "name": "AutoDJ",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiophoenixx.sp.radio.fm/stream",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "DE",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        48.8426,
+        -9.3305
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-cashmere-radio-show",
+      "name": "Cashmere Radio Show",
+      "broadcaster": "independent",
+      "streamUrl": "https://cashmereradio.out.airtime.pro/cashmereradio_b",
+      "homepage": "https://cashmereradio.com/",
+      "country": "DE",
+      "tags": [
+        "avant-garde"
+      ],
+      "favicon": "https://backstage.cashmereradio.com/wp-content/themes/cashmereradio/icons/android-icon-192x192.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        52.5191,
+        13.3855
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ella-radio-livestream",
+      "name": "Ella Radio - Livestream",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.ella-radio.de/ella-livestream/mp3-192/?ref=radio-browser",
+      "homepage": "https://www.ella-radio.de/",
+      "country": "DE",
+      "tags": [
+        "jazz"
+      ],
+      "favicon": "https://ella-radio.de/uplink/Ella_Livestream.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        52.5119,
+        13.3785
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-hr-hd",
+      "name": "HR HD",
+      "broadcaster": "independent",
+      "streamUrl": "https://hrhls.akamaized.net/hls/live/2024525/hrhls/master.m3u8",
+      "homepage": "https://www.hr-fernsehen.de/",
+      "country": "DE",
+      "tags": [
+        "tv"
+      ],
+      "bitrate": 2147,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-i-mashup",
+      "name": "I♥MASHUP",
+      "broadcaster": "independent",
+      "streamUrl": "https://ilm.stream35.radiohost.de/ilm_ilovemashup_mp3-192?context=fHA6LTE=&upd-meta&upd-scheme=https&_art=dD0xNzY4NDUyNzg2JmQ9ZjM1N2NiYWEwYjkwYmUyOWNhYmE",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "DE",
+      "favicon": "https://play-lh.googleusercontent.com/9Bsg9IdeIU-PUUGdKBrTuW4YVf7A27s3Gb5xzIba-9snvadpIUxG61qwue_ooxmnww=w480-h960",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-maretimo-latin-radio",
+      "name": "Maretimo Latin Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s35.derstream.net/maretimo-latin.mp3?",
+      "homepage": "https://www.maretimo-records.com/",
+      "country": "DE",
+      "tags": [
+        "latin music"
+      ],
+      "favicon": "https://www.maretimo-records.com/wp-content/uploads/2022/09/favicon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.7809,
+        10.5469
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-punkrockers-radio-2",
+      "name": "Punkrockers Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.punkrockers-radio.de:8443/ogg?1727422503",
+      "homepage": "https://www.punkrockers-radio.de/",
+      "country": "DE",
+      "favicon": "https://www.punkrockers-radio.de/img/play_button_rund.png",
+      "bitrate": 192,
+      "codec": "OGG",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-diefflen",
+      "name": "Radio Diefflen",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiodiefflen.stream.laut.fm/radiodiefflen?pl=m3u&t302=2026-01-15_06-03-50&uuid=9a3fd861-dd28-4228-b902-e69eda1b80e4",
+      "homepage": "https://radiodiefflen.de/",
+      "country": "DE",
+      "tags": [
+        "alternative",
+        "metal",
+        "pop",
+        "rock"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-home-of-rock",
+      "name": "Radio Home of Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://server24094.streamplus.de/stream.mp3",
+      "homepage": "https://home-of-rock.de/",
+      "country": "DE",
+      "tags": [
+        "blues rock",
+        "classic rock",
+        "hard rock",
+        "indie rock",
+        "progressive rock",
+        "rock"
+      ],
+      "favicon": "https://www.radio.de/images/broadcasts/e6/e2/25726/c300.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        49.4584,
+        11.0945
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-schwany-2-schlager",
+      "name": "Radio Schwany 2 - Schlager",
+      "broadcaster": "independent",
+      "streamUrl": "https://schwany.streampanel.cloud/2-schlager",
+      "homepage": "https://www.schwany.de/index.html",
+      "country": "DE",
+      "tags": [
+        "bayern",
+        "schlager",
+        "schwany"
+      ],
+      "favicon": "https://static.mytuner.mobi/media/radios-150px/FT5Ds7t8Ba.jpg",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        48.8427,
+        12.6179
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-rautemusik-main",
+      "name": "RauteMusik Main",
+      "broadcaster": "independent",
+      "streamUrl": "https://main-aacp.rautemusik.fm/",
+      "homepage": "https://www.rm.fm/main",
+      "country": "DE",
+      "favicon": "https://www.rm.fm/favicon.ico",
+      "bitrate": 48,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1-splash-christmas",
+      "name": "#1 Splash Christmas",
+      "broadcaster": "independent",
+      "streamUrl": "https://ais-sa2.cdnstream1.com/2553_128.mp3",
+      "homepage": "https://www.splashradio.eu/",
+      "country": "DE",
+      "tags": [
+        "christmas",
+        "christmas music",
+        "klassik weihnachten christmas",
+        "splash",
+        "weihnachten"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-917xfm",
+      "name": "917xfm",
+      "broadcaster": "independent",
+      "streamUrl": "https://rockantenne-hh-stream07.radiohost.de/917xfm_mp3-192?",
+      "homepage": "https://www.917xfm.de/",
+      "country": "DE",
+      "tags": [
+        "indie"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-animeradio-de",
+      "name": "AnimeRadio.de",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.animeradio.de/animeradio.mp3",
+      "homepage": "https://www.animeradio.de/",
+      "country": "DE",
+      "favicon": "https://www.animeradio.de/img/animeradio-stream-mp3-192.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-classic-progrock-saar",
+      "name": "Classic Progrock Saar",
+      "broadcaster": "independent",
+      "streamUrl": "https://classic-progrock-fm.stream.laut.fm/classic-progrock-fm?t302=2025-03-10_17-34-10&uuid=8e6c3b96-2d13-44bc-a51b-386795198f38",
+      "homepage": "https://classic-progrock-fm.stream.laut.fm/classic-progrock-fm?t302=2025-03-10_17-34-10&uuid=8e6c3b96-2d13-44bc-a51b-386795198f38",
+      "country": "DE",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-dressfm-new-yorker-germany",
+      "name": "DressFM (New Yorker Germany)",
+      "broadcaster": "independent",
+      "streamUrl": "https://streams.fluxfm.de/nyir-ger/mp3-320/",
+      "homepage": "https://cloud.rundfunkkombinat.de/",
+      "country": "DE",
+      "tags": [
+        "grunge"
+      ],
+      "favicon": "https://pbs.twimg.com/profile_images/469051279486906368/QLjkWvWr.jpeg",
+      "codec": "MP3",
+      "geo": [
+        51.2936,
+        12.5522
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-egofm-riff-lq",
+      "name": "egoFM Riff [LQ]",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast.egofm.de/egoriff.aac?ar-distributor=ffa0&aw_0_req.gdpr=true",
+      "homepage": "https://www.egofm.de/streams/egoriff",
+      "country": "DE",
+      "tags": [
+        "alternative",
+        "egofm",
+        "indie",
+        "punk",
+        "rock",
+        "singer-songwriter"
+      ],
+      "favicon": "https://streams.egofm.de/img/alexa/egoFM%20Riff-256x256.png",
+      "bitrate": 63,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ella-radio-mellow-jazz",
+      "name": "Ella Radio - Mellow Jazz",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.ella-radio.de/ella-mellow-jazz/mp3-192/?ref=radio-browser",
+      "homepage": "https://www.ella-radio.de/",
+      "country": "DE",
+      "tags": [
+        "jazz"
+      ],
+      "favicon": "https://ella-radio.de/uplink/Ella_Mellow-Jazz.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ella-radio-smooth-vocals",
+      "name": "Ella Radio - Smooth Vocals",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.ella-radio.de/ella-smooth-vocals/mp3-192/?ref=radio-browser",
+      "homepage": "https://www.ella-radio.de/",
+      "country": "DE",
+      "tags": [
+        "jazz",
+        "smooth jazz",
+        "vocal jazz"
+      ],
+      "favicon": "https://ella-radio.de/uplink/Ella_Smooth-Vocals.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-gute-laune-welle",
+      "name": "Gute Laune Welle",
+      "broadcaster": "independent",
+      "streamUrl": "https://gute-laune-welle.stream.laut.fm/gute-laune-welle?;stream.mp3",
+      "homepage": "https://gutelaunewelle.de/",
+      "country": "DE",
+      "tags": [
+        "80's",
+        "90's",
+        "now",
+        "pop"
+      ],
+      "favicon": "https://gutelaunewelle.de/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-i-dance-jahrescharts-ilovemusic",
+      "name": "I♥DANCE - Jahrescharts - ILoveMusic",
+      "broadcaster": "independent",
+      "streamUrl": "https://ilm.stream18.radiohost.de/ilm_dance-2023-jahrescharts_mp3-192?upd-meta&upd-scheme=https&_art=dD0xNzY4NDM1NTQwJmQ9NjE5NTc1MDA0NWQ3MjNhMGQ3OTU",
+      "homepage": "https://ilovemusic.de/dance-2024-jahrescharts",
+      "country": "DE",
+      "favicon": "https://ilovemusic.de/typo3conf/ext/ep_channel/Resources/Public/img/favicon.php",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-laut-fm-chiliguerilla",
+      "name": "Laut.FM - Chiliguerilla",
+      "broadcaster": "independent",
+      "streamUrl": "https://chiliguerilla.stream.laut.fm/chiliguerilla?1735142890284=&t302=2024-12-25_16-08-10&uuid=e211741c-3970-413c-a099-fdd330787564",
+      "homepage": "https://laut.fm/chiliguerilla",
+      "country": "DE",
+      "tags": [
+        "alternative",
+        "alternative rock",
+        "indie",
+        "indie-pop",
+        "indie-rock",
+        "rock"
+      ],
+      "favicon": "https://assets.laut.fm/1847edc1b6fee124c1f12e3f4295bb57?t=_120x120",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.4553,
+        10.2761
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-max-dance",
+      "name": "MAX.DANCE",
+      "broadcaster": "independent",
+      "streamUrl": "https://maxdance.stream.laut.fm/maxdance",
+      "homepage": "https://maxradio.live/",
+      "country": "DE",
+      "tags": [
+        "dance",
+        "deep house",
+        "house",
+        "latin house",
+        "tribal house"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-mdr-sputnik-einfach-die-beste-musik-deine-liebli",
+      "name": "MDR SPUTNIK - Einfach die beste Musik - Deine Lieblingsmusik",
+      "broadcaster": "independent",
+      "streamUrl": "https://mdr-radio-hls.akamaized.net/hls/live/2112905/mdr-284330-0-hls/index.m3u8",
+      "homepage": "https://www.sputnik.de/home/index.html",
+      "country": "DE",
+      "tags": [
+        "ard",
+        "charts",
+        "halle",
+        "jugend",
+        "leipzig",
+        "lieblingsmusik musik stars news infos radio livestream dab+"
+      ],
+      "favicon": "https://www.sputnik.de/channels/channel-sputnik-onair-100-resimage_v-variantSmall1x1_w-512.png",
+      "bitrate": 102,
+      "codec": "AAC",
+      "geo": [
+        51.4812,
+        11.9647
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-nrw-paradiso",
+      "name": "NRW Paradiso",
+      "broadcaster": "independent",
+      "streamUrl": "https://streams.paradiso.de/Para-NRW/aac-64/Web/?aw_0_req.userConsentV2=CPw9PgAPw9PgAAFADBDEDTCsAP_AAEPAAAYgHvQBgAWAFzAP2AvMBuAD3gLzgBAFzAXmAAAA.YAAAAAAAAAAA",
+      "homepage": "https://www.paradiso.de/paradiso-nrw",
+      "country": "DE",
+      "tags": [
+        "70s",
+        "80s",
+        "90s",
+        "classic hits",
+        "hits"
+      ],
+      "favicon": "https://www.paradiso.de/assets/favicons/apple-icon-120x120.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-matchbox",
+      "name": "Radio Matchbox",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radio-matchbox.de/listen/matchbox/radio.mp3",
+      "homepage": "https://radio-matchbox.de/de/",
+      "country": "DE",
+      "favicon": "https://radio-matchbox.de/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-wmw",
+      "name": "Radio WMW",
+      "broadcaster": "independent",
+      "streamUrl": "https://rnrw.cast.addradio.de/rnrw-01a8/deinevent/high/stream.mp3?1707016884",
+      "homepage": "https://www.radiowmw.de/",
+      "country": "DE",
+      "favicon": "https://www.radiowmw.de/assets/images/senderlogos/radio_wmw.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-sg-radio",
+      "name": "SG Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://synthesizergreatest.stream.laut.fm/synthesizergreatest",
+      "homepage": "https://www.sgradio.eu/",
+      "country": "DE",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-antenne-koblenz",
+      "name": "Antenne Koblenz",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiogroup-stream32.radiohost.de//antenne-koblenz_mp3-192",
+      "homepage": "https://antenne-koblenz.de/",
+      "country": "DE",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.3606,
+        7.5964
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-bremen-vier-heuckzeug",
+      "name": "Bremen Vier Heuckzeug",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.radiobremen.de/rb/webchannel3/mp3/128/stream.mp3",
+      "homepage": "https://www.bremenvier.de/",
+      "country": "DE",
+      "favicon": "https://www.bremenvier.de/static/img/favicons/apple-touch-icon-180.png?v=3",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-dreampop-radio-https",
+      "name": "DREAMPOP-RADIO (https)",
+      "broadcaster": "independent",
+      "streamUrl": "https://dreampopradio.stream.laut.fm/dreampopradio",
+      "homepage": "https://laut.fm/dreampopradio",
+      "country": "DE",
+      "tags": [
+        "acoustic",
+        "alternative",
+        "chillout",
+        "electropop",
+        "folk",
+        "indie pop"
+      ],
+      "favicon": "https://assets.laut.fm/edf172a4c43423f76e381ac31d188342",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-egofm-rap-lq",
+      "name": "egoFM Rap [LQ]",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast.egofm.de/egorap.aac?ar-distributor=ffa0&aw_0_req.gdpr=true",
+      "homepage": "https://www.egofm.de/streams/egorap",
+      "country": "DE",
+      "tags": [
+        "egofm",
+        "hip hop",
+        "rap"
+      ],
+      "favicon": "https://streams.egofm.de/img/alexa/egoFM%20Rap-256x256.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ella-radio-jazz-ballads",
+      "name": "Ella Radio - Jazz Ballads",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.ella-radio.de/ella-jazz-ballads/mp3-192/?ref=radio-browser",
+      "homepage": "https://www.ella-radio.de/",
+      "country": "DE",
+      "tags": [
+        "jazz"
+      ],
+      "favicon": "https://ella-radio.de/uplink/Ella_Jazz-Ballads.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-ffn-708090",
+      "name": "ffn 708090",
+      "broadcaster": "independent",
+      "streamUrl": "https://ffn-de-hz-fal-stream09-cluster01.radiohost.de/ffn-708090_mp3-192",
+      "homepage": "https://www.ffn.de/",
+      "country": "DE",
+      "tags": [
+        "70's",
+        "80's",
+        "90's",
+        "oldies"
+      ],
+      "favicon": "https://player.ffn.de/assets/channels/ffn708090.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        52.3776,
+        9.7313
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-footbalisfamily",
+      "name": "Footbalisfamily",
+      "broadcaster": "independent",
+      "streamUrl": "https://footballisfamily.stream.laut.fm/footballisfamily?ref=radiode&t302-2023-08-27_10-19-59&uuid=05ecbd31-4021-4e68-86f8-05a740d6d465",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "DE",
+      "tags": [
+        "decades"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-iceradio-germany",
+      "name": "Iceradio Germany",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.iceradio.net/listen",
+      "homepage": "http://www.iceradio.net/",
+      "country": "DE",
+      "tags": [
+        "electro industrial darkwave ebm futurepop synthpop goth"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.9263,
+        7.3595
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-max-retro",
+      "name": "MAX.RETRO",
+      "broadcaster": "independent",
+      "streamUrl": "https://maxretro.stream.laut.fm/maxretro",
+      "homepage": "https://maxradio.live/",
+      "country": "DE",
+      "tags": [
+        "90s",
+        "dance",
+        "eurodance",
+        "house"
+      ],
+      "favicon": "https://maxradio.live/static/icons/production/120.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-mother-earth-klassik",
+      "name": "Mother Earth Klassik",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.motherearthradio.de/listen/motherearth_klassik/motherearth.klassik.aac",
+      "homepage": "https://motherearthradio.de/",
+      "country": "DE",
+      "tags": [
+        "classical"
+      ],
+      "favicon": "https://motherearthradio.de/wp-content/uploads/2024/03/mergoldcube512.png",
+      "bitrate": 320,
+      "codec": "AAC",
+      "geo": [
+        48.137,
+        11.576
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-rfm-rundfunk-meissner-e-v",
+      "name": "Radio RFM (Rundfunk Meissner e.V.)",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.radiorfm.de/rfm.ogg",
+      "homepage": "https://radiorfm.de/",
+      "country": "DE",
+      "tags": [
+        "community radio"
+      ],
+      "favicon": "https://radiorfm.de/wp-content/uploads/2020/06/cropped-Logo_RFM_300dpi_20x20cm_CMYK_frei-192x192.jpg",
+      "bitrate": 96,
+      "codec": "OGG",
+      "geo": [
+        51.1896,
+        10.0585
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-t",
+      "name": "Radio T",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.fueralle.org/radiot_192.mp3",
+      "homepage": "https://radiot-chemnitz.de/",
+      "country": "DE",
+      "tags": [
+        "chemnitz",
+        "community radio",
+        "freies radio",
+        "nichtkommerzielles lokalradio",
+        "non-commercial",
+        "radio t"
+      ],
+      "codec": "MP3",
+      "geo": [
+        50.8434,
+        12.9237
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radioaktuell",
+      "name": "RadioAktuell",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.radioaktuell.de/aktuell/aktuell.mp3",
+      "homepage": "https://www.radioaktuell.de/",
+      "country": "DE",
+      "tags": [
+        "nachrichten",
+        "news"
+      ],
+      "favicon": "https://www.radioaktuell.de/wp-content/uploads/2022/07/cropped-radioaktuell.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-tape-hits",
+      "name": "Tape Hits",
+      "broadcaster": "independent",
+      "streamUrl": "https://tapehits.com:8005/stream?x=1620481556916",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "DE",
+      "tags": [
+        "misc"
+      ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/2/103532.v1.png",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-technikradio",
+      "name": "TechnikRADIO",
+      "broadcaster": "independent",
+      "streamUrl": "https://server31053.streamplus.de/;stream.mp3",
+      "homepage": "https://technikradio.de/",
+      "country": "DE",
+      "tags": [
+        "pop rock",
+        "technikradio"
+      ],
+      "favicon": "https://technikradio.de/wp-content/uploads/2017/01/apple-touch-icon-120x120.png",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "de-yesterday-fm",
+      "name": "Yesterday.FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://yesterdayfm.schlagerparadies.de/yesterdayfm",
+      "homepage": "http://www.rockhausradio.de/",
+      "country": "DE",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
     }
   ]
 }

--- a/public/stations.json
+++ b/public/stations.json
@@ -8833,6 +8833,618 @@
       "status": "stream-only"
     },
     {
+      "id": "de-maretimo-lounge",
+      "name": "Maretimo Lounge",
+      "broadcaster": "independent",
+      "streamUrl": "https://s35.derstream.net/lounge.mp3",
+      "homepage": "http://www.maretimo-lounge-radio.com/",
+      "country": "DE",
+      "tags": [
+        "lounge",
+        "germany"
+      ],
+      "favicon": "https://d3kle7qwymxpcy.cloudfront.net/images/broadcasts/08/a3/107873/5/c175.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-nightride-fm-chillsynth",
+      "name": "Nightride FM - Chillsynth",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.nightride.fm/chillsynth.mp3",
+      "homepage": "https://nightride.fm/",
+      "country": "DE",
+      "tags": [
+        "lounge",
+        "ambient",
+        "germany"
+      ],
+      "favicon": "https://nightride.fm/thumbnail.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-antenne-bayern-coffeemusic",
+      "name": "Antenne Bayern - CoffeeMusic",
+      "broadcaster": "independent",
+      "streamUrl": "https://mp3channels.webradio.de/coffee",
+      "homepage": "https://www.webradio.de/antenne-bayern/coffeemusic",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "pop",
+        "germany"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-rock-antenne-hair-metal",
+      "name": "ROCK ANTENNE Hair Metal",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rockantenne.de/hair-metal/stream/aacp",
+      "homepage": "https://www.rockantenne.de/",
+      "country": "DE",
+      "tags": [
+        "rock",
+        "germany"
+      ],
+      "codec": "AAC",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-rock-radio",
+      "name": "Epic Rock Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://securestreams6.autopo.st:2222/stream",
+      "homepage": "https://www.epicrockradio.com/",
+      "country": "DE",
+      "tags": [
+        "rock",
+        "germany"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-sex-by-rautemusik-rm-fm",
+      "name": "__SEX__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://sex-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://www.rm.fm/sex",
+      "country": "DE",
+      "tags": [
+        "pop",
+        "germany"
+      ],
+      "favicon": "https://i.ibb.co/sQNvYtT/sex.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-technolovers-drum-n-bass",
+      "name": "Technolovers DRUM N BASS",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.technolovers.fm/drummnbass?ref=radiobrowser",
+      "homepage": "https://technolovers.fm/",
+      "country": "DE",
+      "tags": [
+        "electronic",
+        "germany"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.684,
+        7.91
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-chillout-piano-by-epic-piano",
+      "name": "CHILLOUT PIANO by Epic Piano",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-piano.com/chillout-piano?ref=radiobrowser",
+      "homepage": "https://epic-piano.com/",
+      "country": "DE",
+      "tags": [
+        "classical",
+        "lounge",
+        "germany"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.237,
+        7.91
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-disco-on-radio",
+      "name": "- 0 N - Disco on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-disco.radionetz.de/0n-disco.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "pop",
+        "oldies",
+        "electronic",
+        "soul",
+        "germany"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-disco_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.312,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-rockantenne-alternative-mp3",
+      "name": "ROCKANTENNE Alternative (mp3)",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rockantenne.de/alternative/stream/mp3",
+      "homepage": "https://www.rockantenne.de/",
+      "country": "DE",
+      "tags": [
+        "rock",
+        "germany"
+      ],
+      "favicon": "https://www.rockantenne.de/logos/station-rock-antenne/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-lounge-ibiza-chillout-lounge",
+      "name": "Epic Lounge - IBIZA CHILLOUT LOUNGE",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-lounge.com/ibiza-chillout-lounge?ref=radiobrowser",
+      "homepage": "https://epic-lounge.com/",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "lounge",
+        "germany"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.748,
+        8.555
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-rock-antenne-blues-rock",
+      "name": "ROCK ANTENNE Blues rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rockantenne.de/blues-rock/stream/mp3",
+      "homepage": "https://www.rockantenne.de/",
+      "country": "DE",
+      "tags": [
+        "rock",
+        "germany"
+      ],
+      "favicon": "https://www.rockantenne.de/logos/station-rock-antenne/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-schwany-5-oberkrain",
+      "name": "Schwany 5 Oberkrain",
+      "broadcaster": "independent",
+      "streamUrl": "https://schwany5oberkrain.hoamatwelle.de/",
+      "homepage": "http://schwany.de/",
+      "country": "DE",
+      "tags": [
+        "classical",
+        "germany"
+      ],
+      "favicon": "http://schwany.de/favicon.ico",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-dance-on-radio",
+      "name": "- 0 N - Dance on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-dance.radionetz.de/0n-dance.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "electronic",
+        "germany"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-dance_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.312,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-technolovers-psytrance",
+      "name": "Technolovers - PSYTRANCE",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.technolovers.fm/psytrance?ref=radiobrowser",
+      "homepage": "https://technolovers.fm/",
+      "country": "DE",
+      "tags": [
+        "electronic",
+        "germany"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-technolovers-minimal",
+      "name": "Technolovers - MINIMAL",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.technolovers.fm/minimal?ref=radiobrowser",
+      "homepage": "https://technolovers.fm/",
+      "country": "DE",
+      "tags": [
+        "electronic",
+        "germany"
+      ],
+      "favicon": "https://i.ibb.co/LncDTYz/MINIMAL-TL.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-technolovers-techno",
+      "name": "Technolovers - TECHNO",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.technolovers.fm/techno?ref=radiobrowser",
+      "homepage": "https://technolovers.fm/",
+      "country": "DE",
+      "tags": [
+        "electronic",
+        "germany"
+      ],
+      "favicon": "https://i.ibb.co/ScwBQ49/TECHNO-TL.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-smooth-jazz-on-radio",
+      "name": "- 0 N - Smooth Jazz on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-smoothjazz.radionetz.de/0n-smoothjazz.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "jazz",
+        "germany"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-smooth-jazz_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.312,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-90s-by-rautemusik-rm-fm",
+      "name": "__90S__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://90s-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://www.rm.fm/90s",
+      "country": "DE",
+      "tags": [
+        "pop",
+        "electronic",
+        "hip-hop",
+        "oldies",
+        "germany"
+      ],
+      "favicon": "https://www.rm.fm/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-hr2-kultur",
+      "name": "hr2-kultur",
+      "broadcaster": "independent",
+      "streamUrl": "https://dispatcher.rndfnk.com/hr/hr2/live/mp3/high",
+      "homepage": "https://www.hr2.de/",
+      "country": "DE",
+      "tags": [
+        "public radio",
+        "germany"
+      ],
+      "favicon": "https://www.hr2.de/favicon.png?v=3.84.2",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-country-on-radio",
+      "name": "- 0 N - Country on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-country.radionetz.de/0n-country.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "country",
+        "pop",
+        "rock",
+        "germany"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-country_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.312,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-charivari-munchen-lounge-music",
+      "name": "Charivari München - Lounge Music",
+      "broadcaster": "independent",
+      "streamUrl": "https://rs24.stream24.net/lounge.aac?ref=charivari.de&aw_0_1st.playerid=radioplayer.de",
+      "homepage": "https://www.charivari.de/",
+      "country": "DE",
+      "tags": [
+        "lounge",
+        "germany"
+      ],
+      "favicon": "https://www.charivari.de/apple-icon-120x120.png",
+      "codec": "AAC",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-deutsche-welle-radio",
+      "name": "Deutsche Welle Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://dw.audiostream.io/dw/1027/mp3/64/dw08",
+      "homepage": "https://dw.com/",
+      "country": "DE",
+      "tags": [
+        "news",
+        "public radio",
+        "germany"
+      ],
+      "bitrate": 64,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-seefunk",
+      "name": "Radio Seefunk",
+      "broadcaster": "independent",
+      "streamUrl": "https://webradio.radio-seefunk.de/",
+      "homepage": "https://www.dasneueradioseefunk.de/",
+      "country": "DE",
+      "tags": [
+        "pop",
+        "electronic",
+        "germany"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-70s-on-radio",
+      "name": "- 0 N - 70s on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-70s.radionetz.de/0n-70s.aac",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "pop",
+        "oldies",
+        "germany"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-70s_600x600.jpg",
+      "bitrate": 64,
+      "codec": "AAC",
+      "geo": [
+        50.312,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-deutschlandfunk-dokumente-und-debatten-dlf-aac-9",
+      "name": "Deutschlandfunk Dokumente und Debatten | DLF | AAC 96k",
+      "broadcaster": "independent",
+      "streamUrl": "https://st04.sslstream.dlf.de/dlf/04/mid/aac/stream.aac?aggregator=web",
+      "homepage": "https://www.deutschlandradio.de/dokumente-und-debatten-102.html",
+      "country": "DE",
+      "tags": [
+        "news",
+        "electronic",
+        "public radio",
+        "germany"
+      ],
+      "favicon": "https://www.deutschlandradio.de/static/img/deutschlandradio/icons/apple-touch-icon-128x128.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        52.48,
+        13.335
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-lounge-by-rautemusik-rm-fm",
+      "name": "__LOUNGE__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://lounge-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://www.rm.fm/lounge",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "lounge",
+        "germany"
+      ],
+      "favicon": "https://www.rm.fm/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-best-of-schlager-by-rautemusik-rm-fm",
+      "name": "__BEST OF SCHLAGER__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://best-of-schlager-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://www.rm.fm/best-of-schlager",
+      "country": "DE",
+      "tags": [
+        "oldies",
+        "pop",
+        "schlager",
+        "germany"
+      ],
+      "favicon": "https://www.rm.fm/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1-a-ndw-neue-deutsche-welle-von-1a-radio",
+      "name": "- 1 A - NDW (Neue Deutsche Welle) von 1A Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://1a-ndw.radionetz.de/1a-ndw.mp3",
+      "homepage": "http://www.1aradio.com/",
+      "country": "DE",
+      "tags": [
+        "pop",
+        "public radio",
+        "germany"
+      ],
+      "favicon": "https://www.1aradio.com/logos/1a-ndw_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.312,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-schlager-oldies-by-rautemusik-rm-fm",
+      "name": "__SCHLAGER OLDIES__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://schlager-oldies-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://www.rm.fm/schlager-oldies",
+      "country": "DE",
+      "tags": [
+        "pop",
+        "schlager",
+        "oldies",
+        "germany"
+      ],
+      "favicon": "https://i.ibb.co/NNxSg2H/schlageroldies.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
       "id": "builtin-cbc-radio-1-toronto",
       "name": "CBC Radio 1 Toronto",
       "broadcaster": "cbc",

--- a/public/stations.json
+++ b/public/stations.json
@@ -8222,6 +8222,617 @@
       "status": "working"
     },
     {
+      "id": "de-technolovers-edm",
+      "name": "Technolovers EDM",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.technolovers.fm/edm?ref=radiobrowser",
+      "homepage": "https://technolovers.fm/",
+      "country": "DE",
+      "tags": [
+        "electronic",
+        "germany"
+      ],
+      "favicon": "https://i.ibb.co/TmRLJsp/EDM-TL.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.906,
+        7.91
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-technobase-fm",
+      "name": "TechnoBase.FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://listener3.mp3.tb-group.fm/tb.mp3",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "DE",
+      "tags": [
+        "electronic",
+        "germany"
+      ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/0/32040.v12.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-2000s-on-radio",
+      "name": "- 0 N - 2000s on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-2000s.radionetz.de/0n-2000s.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "electronic",
+        "pop",
+        "rock",
+        "oldies",
+        "germany"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-2000s_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.312,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1000-goldschlager",
+      "name": "1000 Goldschlager",
+      "broadcaster": "independent",
+      "streamUrl": "https://1000goldschlager.stream.laut.fm/1000goldschlager",
+      "homepage": "https://1000goldschlager.de/",
+      "country": "DE",
+      "tags": [
+        "schlager",
+        "germany"
+      ],
+      "favicon": "https://1000goldschlager.de/apple-icon-120x120.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-chillout-on-radio",
+      "name": "- 0 N - Chillout on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-chillout.radionetz.de/0n-chillout.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "electronic",
+        "germany"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-chillout_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.312,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-bollerwagen",
+      "name": "Radio Bollerwagen",
+      "broadcaster": "independent",
+      "streamUrl": "https://ffn-stream19.radiohost.de/radiobollerwagen_mp3-192?ref=radioplayer&listenerid=31363233323633323031-323030333a64653a343731363a3730313a623731343a346664383a313761363a39386165-3537373636-4d6f7a696c6c612f352e3020285831313b205562",
+      "homepage": "https://player.ffn.de/radioplayer/radio-bollerwagen/",
+      "country": "DE",
+      "tags": [
+        "germany"
+      ],
+      "favicon": "https://www.radio.de/images/broadcasts/80/eb/100349/3/c300.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-italo-disco",
+      "name": "Italo Disco",
+      "broadcaster": "independent",
+      "streamUrl": "https://italo-disco.stream.laut.fm/italo-disco",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "DE",
+      "tags": [
+        "electronic",
+        "oldies",
+        "germany"
+      ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/1/44061.v2.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-technolovers-electro-house",
+      "name": "Technolovers ELECTRO HOUSE",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.technolovers.fm/electro-house?ref=radiobrowser",
+      "homepage": "https://technolovers.fm/",
+      "country": "DE",
+      "tags": [
+        "electronic",
+        "germany"
+      ],
+      "favicon": "https://i.ibb.co/B4R6kNj/Electrohouse-tl.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.235,
+        7.24
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-60s-on-radio",
+      "name": "- 0 N - 60s on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-60s.radionetz.de/0n-60s.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "pop",
+        "soul",
+        "oldies",
+        "germany"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-60s_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.312,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0nlineradio-remix",
+      "name": "0nlineradio REMIX",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.0nlineradio.com/remix?ref=radiobrowser",
+      "homepage": "https://0nlineradio.com/",
+      "country": "DE",
+      "tags": [
+        "electronic",
+        "hip-hop",
+        "pop",
+        "latin",
+        "germany"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-electro-swing-revolution",
+      "name": "Electro Swing Revolution",
+      "broadcaster": "independent",
+      "streamUrl": "https://streamer.radio.co/s2c3cc784b/listen",
+      "homepage": "https://www.electroswing-radio.com/",
+      "country": "DE",
+      "tags": [
+        "electronic",
+        "swing",
+        "germany"
+      ],
+      "favicon": "https://www.electroswing-radio.com/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-hr-info",
+      "name": "HR Info",
+      "broadcaster": "independent",
+      "streamUrl": "https://dispatcher.rndfnk.com/hr/hrinfo/live/mp3/high",
+      "homepage": "https://www.hr-inforadio.de/index.html",
+      "country": "DE",
+      "tags": [
+        "news",
+        "public radio",
+        "germany"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-i-love-radio-us-only-rap-hiphop-radio",
+      "name": "i love radio - US Only Rap&HipHop Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ilm.stream35.radiohost.de/ilm_iloveusonlyrapradio_mp3-192?upd-meta&upd-scheme=https&_art=dD0xNzY4NDU1Mjg0JmQ9YjVlNGIxYTMwOGY3YTQxZjVlZGQ",
+      "homepage": "https://www.iloveradio.de/iloveusonlyrapradio/",
+      "country": "DE",
+      "tags": [
+        "hip-hop",
+        "germany"
+      ],
+      "favicon": "https://www.iloveradio.de/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-schlagerparadies",
+      "name": "Schlagerparadies",
+      "broadcaster": "independent",
+      "streamUrl": "https://webstream.schlagerparadies.de/schlager30842",
+      "homepage": "http://www.schlagerparadies.de/",
+      "country": "DE",
+      "tags": [
+        "schlager",
+        "germany"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-classical-classical-music-for-sleep",
+      "name": "EPIC CLASSICAL - Classical Music For Sleep",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-classical.com/classical-music-for-sleep",
+      "homepage": "https://epic-classical.com/",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "classical",
+        "lounge",
+        "germany"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-bayern-1-franken",
+      "name": "Bayern 1 Franken",
+      "broadcaster": "independent",
+      "streamUrl": "https://dispatcher.rndfnk.com/br/br1/franken/mp3/mid",
+      "homepage": "https://www.br.de/radio/bayern1/index.html",
+      "country": "DE",
+      "tags": [
+        "pop",
+        "germany"
+      ],
+      "favicon": "https://api.ardmediathek.de/image-service/images/urn:ard:image:b366004f6196d70c?w=512",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-absolut-bella",
+      "name": "Absolut bella",
+      "broadcaster": "independent",
+      "streamUrl": "https://absolut-bella.live-sm.absolutradio.de/absolut-bella/stream/mp3",
+      "homepage": "https://absolutradio.de/",
+      "country": "DE",
+      "tags": [
+        "germany"
+      ],
+      "favicon": "https://absolutradio.de/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        52.506,
+        13.4
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-hip-hop-forever",
+      "name": "Hip Hop Forever",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/hiphop-forever",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "DE",
+      "tags": [
+        "hip-hop",
+        "germany"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-nightride-fm-spacesynth",
+      "name": "Nightride FM - Spacesynth",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.nightride.fm/spacesynth.mp3",
+      "homepage": "https://nightride.fm/",
+      "country": "DE",
+      "tags": [
+        "germany"
+      ],
+      "favicon": "https://nightride.fm/thumbnail.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-electro-on-radio",
+      "name": "- 0 N - Electro on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-electro.radionetz.de/0n-electro.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "electronic",
+        "germany"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-electro_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.312,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-deutschlandfunk-nova-dlf-mp3-128k",
+      "name": "Deutschlandfunk Nova | DLF | MP3 128k",
+      "broadcaster": "independent",
+      "streamUrl": "https://st03.sslstream.dlf.de/dlf/03/128/mp3/stream.mp3?aggregator=web",
+      "homepage": "https://www.deutschlandfunknova.de/",
+      "country": "DE",
+      "tags": [
+        "news",
+        "public radio",
+        "germany"
+      ],
+      "favicon": "https://www.deutschlandfunknova.de/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        52.48,
+        13.335
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-lounge-sleep-meditation",
+      "name": "Epic Lounge - SLEEP & MEDITATION",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-lounge.com/sleep-meditation?ref=radiobrowser",
+      "homepage": "https://epic-lounge.com/",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "lounge",
+        "germany"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-greatest-hits-on-radio",
+      "name": "- 0 N - Greatest Hits on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-greatesthits.radionetz.de/0n-greatesthits.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "pop",
+        "electronic",
+        "hip-hop",
+        "rock",
+        "germany"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-greatest-hits_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.312,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-club-by-rautemusik-rm-fm",
+      "name": "__CLUB__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://club-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://www.rm.fm/club",
+      "country": "DE",
+      "tags": [
+        "electronic",
+        "pop",
+        "germany"
+      ],
+      "favicon": "https://www.rm.fm/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-classic-rock-on-radio",
+      "name": "- 0 N - Classic Rock on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-classicrock.radionetz.de/0n-classicrock.aac",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "pop",
+        "rock",
+        "germany"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-classic-rock_600x600.jpg",
+      "bitrate": 64,
+      "codec": "AAC",
+      "geo": [
+        50.312,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-technolovers-eurodance",
+      "name": "Technolovers EURODANCE",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.technolovers.fm/eurodance?ref=radiobrowser",
+      "homepage": "https://technolovers.fm/",
+      "country": "DE",
+      "tags": [
+        "pop",
+        "electronic",
+        "germany"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.674,
+        9.609
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-technolovers-funky-house",
+      "name": "Technolovers - FUNKY HOUSE",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.technolovers.fm/funky-house?ref=radiobrowser",
+      "homepage": "https://technolovers.fm/",
+      "country": "DE",
+      "tags": [
+        "electronic",
+        "germany"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0nlineradio-bach",
+      "name": "0nlineradio BACH",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.0nlineradio.com/bach?ref=radiobrowser",
+      "homepage": "https://0nlineradio.com/",
+      "country": "DE",
+      "tags": [
+        "classical",
+        "germany"
+      ],
+      "favicon": "https://i.ibb.co/n1CQpDf/BACH-NEW.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.128,
+        8.965
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-technolovers-vocal-trance",
+      "name": "Technolovers VOCAL TRANCE",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.technolovers.fm/vocal-trance?ref=radiobrowser",
+      "homepage": "https://technolovers.fm/",
+      "country": "DE",
+      "tags": [
+        "electronic",
+        "germany"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.117,
+        8.906
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-deutschrap-charts-by-rautemusik-rm-fm",
+      "name": "__DEUTSCHRAP CHARTS__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://deutschrap-charts-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://www.rm.fm/deutschrap-charts",
+      "country": "DE",
+      "tags": [
+        "hip-hop",
+        "pop",
+        "germany"
+      ],
+      "favicon": "https://www.rm.fm/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
       "id": "builtin-cbc-radio-1-toronto",
       "name": "CBC Radio 1 Toronto",
       "broadcaster": "cbc",


### PR DESCRIPTION
## DE Station Curation — Tier 2 (votes 20–99)

**Branch stacked on:** `curate/de-tier1-top` (PR #108)

### Stats
- Vote range: 20–99
- Raw candidates in RB analysis: 504
- **Imported: 468**
- Skipped (stream URL already in catalog): 4
- Skipped (station name already in catalog): 32
- Skipped (stationuuid already imported): 0

### Top 3 imported by votes
1. **Bayernwelle SüdOst** — 99 votes
2. **Schlager Radio- Hör auf dein herz** — 99 votes
3. **0nlineradio URBAN** — 98 votes

### Verification
- `npm run catalog` ✓ — 1,878 stations published
- `npm run check-catalog` ✓
- `npm run check-duplicates` ✓ — 0 collisions
- `npm test -- --run` ✓ — 277/277 tests pass

All stations imported at `status: stream-only`.