### PR TITLE
curate: 30 new DE stations batch 2 (replaces #107)

### DIFF
--- a/data/stations.yaml
+++ b/data/stations.yaml
@@ -6590,6 +6590,476 @@
   country: DE
   status: stream-only
 
+# ─── DE — Radio Browser sweep batch 2 (2026-05-04) ───
+
+- id: de-maretimo-lounge
+  stationuuid: aedd2edd-c8f1-4f75-9667-9d84cd6d690c
+  changeuuid: 8b366a1f-be24-4e7a-89d6-ad6f643afabf
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: Maretimo Lounge
+  streamUrl: https://s35.derstream.net/lounge.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [lounge, germany]
+  favicon: https://d3kle7qwymxpcy.cloudfront.net/images/broadcasts/08/a3/107873/5/c175.png
+  homepage: http://www.maretimo-lounge-radio.com/
+  country: DE
+  status: stream-only
+
+- id: de-nightride-fm-chillsynth
+  stationuuid: 9067dc39-4bf4-4364-bd6b-8020cff3e15d
+  changeuuid: 36b89f53-0d32-4932-a0cc-717f7a4c16f9
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: Nightride FM - Chillsynth
+  streamUrl: https://stream.nightride.fm/chillsynth.mp3
+  bitrate: 320
+  codec: MP3
+  tags: [lounge, ambient, germany]
+  favicon: https://nightride.fm/thumbnail.png
+  homepage: https://nightride.fm/
+  country: DE
+  status: stream-only
+
+- id: de-antenne-bayern-coffeemusic
+  stationuuid: 52ba8d13-e5e7-11e8-a9cc-52543be04c81
+  changeuuid: 2a1d9403-ce4f-4aa1-a15a-e2ddaf24b3d2
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: Antenne Bayern - CoffeeMusic
+  streamUrl: https://mp3channels.webradio.de/coffee
+  bitrate: 128
+  codec: MP3
+  tags: [ambient, pop, germany]
+  homepage: https://www.webradio.de/antenne-bayern/coffeemusic
+  country: DE
+  status: stream-only
+
+- id: de-rock-antenne-hair-metal
+  stationuuid: 2ed4195c-73a1-46ab-b6cb-e1afe68ea82a
+  changeuuid: 8aace9a0-b9b4-403c-82f5-884a49ba5b4e
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: ROCK ANTENNE Hair Metal
+  streamUrl: https://stream.rockantenne.de/hair-metal/stream/aacp
+  codec: AAC
+  tags: [rock, germany]
+  homepage: https://www.rockantenne.de/
+  country: DE
+  status: stream-only
+
+- id: de-epic-rock-radio
+  stationuuid: ddf0a603-ed3a-4d52-8d1b-cc11357734f3
+  changeuuid: 8915ad8e-b213-4bb5-8835-ca627a8b0ff5
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: Epic Rock Radio
+  streamUrl: https://securestreams6.autopo.st:2222/stream
+  bitrate: 128
+  codec: MP3
+  tags: [rock, germany]
+  homepage: https://www.epicrockradio.com/
+  country: DE
+  status: stream-only
+
+- id: de-sex-by-rautemusik-rm-fm
+  stationuuid: c52f22bd-7bc4-4fd2-ab2b-c3c7f031a530
+  changeuuid: f605a241-0f32-4578-83e1-c27d0058de39
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: __SEX__ by rautemusik (rm.fm)
+  streamUrl: https://sex-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [pop, germany]
+  favicon: https://i.ibb.co/sQNvYtT/sex.jpg
+  homepage: https://www.rm.fm/sex
+  country: DE
+  status: stream-only
+
+- id: de-technolovers-drum-n-bass
+  stationuuid: cbcff885-49bb-4db1-8b78-7060e70ff06d
+  changeuuid: 771913f2-0478-4991-ada5-8a7cbdb30e69
+  reviewedAt: 2026-05-04
+  geo: [50.684, 7.910]
+  broadcaster: independent
+  name: Technolovers DRUM N BASS
+  streamUrl: https://stream.technolovers.fm/drummnbass?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [electronic, germany]
+  homepage: https://technolovers.fm/
+  country: DE
+  status: stream-only
+
+- id: de-chillout-piano-by-epic-piano
+  stationuuid: 5143bb9a-3c5e-4c53-a6ec-0108435caf5a
+  changeuuid: 27e1d142-fb95-4f31-afd8-70eff86bace2
+  reviewedAt: 2026-05-04
+  geo: [50.237, 7.910]
+  broadcaster: independent
+  name: CHILLOUT PIANO by Epic Piano
+  streamUrl: https://stream.epic-piano.com/chillout-piano?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [classical, lounge, germany]
+  homepage: https://epic-piano.com/
+  country: DE
+  status: stream-only
+
+- id: de-0-n-disco-on-radio
+  stationuuid: d6d00207-f360-11e8-a471-52543be04c81
+  changeuuid: 41b1da29-b9f4-4b51-88b5-9c46eb4cc8a0
+  reviewedAt: 2026-05-04
+  geo: [50.312, 11.923]
+  broadcaster: independent
+  name: "- 0 N - Disco on Radio"
+  streamUrl: https://0n-disco.radionetz.de/0n-disco.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [pop, oldies, electronic, soul, germany]
+  favicon: https://www.0nradio.com/logos/0n-disco_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+
+- id: de-rockantenne-alternative-mp3
+  stationuuid: d608bb74-0740-47e3-a1e2-c11edfeec91f
+  changeuuid: 81630f4e-094d-4bdc-a93e-11d24a174aa7
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: ROCKANTENNE Alternative (mp3)
+  streamUrl: https://stream.rockantenne.de/alternative/stream/mp3
+  bitrate: 128
+  codec: MP3
+  tags: [rock, germany]
+  favicon: https://www.rockantenne.de/logos/station-rock-antenne/apple-touch-icon.png
+  homepage: https://www.rockantenne.de/
+  country: DE
+  status: stream-only
+
+- id: de-epic-lounge-ibiza-chillout-lounge
+  stationuuid: bc0fc480-9229-4d6a-85b8-b91f38191f43
+  changeuuid: 03374158-4af2-44df-b1da-344ad236dbb6
+  reviewedAt: 2026-05-04
+  geo: [50.748, 8.555]
+  broadcaster: independent
+  name: Epic Lounge - IBIZA CHILLOUT LOUNGE
+  streamUrl: https://stream.epic-lounge.com/ibiza-chillout-lounge?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [ambient, lounge, germany]
+  homepage: https://epic-lounge.com/
+  country: DE
+  status: stream-only
+
+- id: de-rock-antenne-blues-rock
+  stationuuid: e54ee752-d84d-4a38-b35d-dc035fbded20
+  changeuuid: 1a9b2c82-f4ce-4b72-a219-25b728ea3457
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: ROCK ANTENNE Blues rock
+  streamUrl: https://stream.rockantenne.de/blues-rock/stream/mp3
+  bitrate: 128
+  codec: MP3
+  tags: [rock, germany]
+  favicon: https://www.rockantenne.de/logos/station-rock-antenne/apple-touch-icon.png
+  homepage: https://www.rockantenne.de/
+  country: DE
+  status: stream-only
+
+- id: de-schwany-5-oberkrain
+  stationuuid: 06f59caa-a243-4383-be08-2f6d3ceefdb2
+  changeuuid: 352dd93f-7a83-4e7c-95f6-005f1bf31d0c
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: Schwany 5 Oberkrain
+  streamUrl: https://schwany5oberkrain.hoamatwelle.de/
+  bitrate: 320
+  codec: MP3
+  tags: [classical, germany]
+  favicon: http://schwany.de/favicon.ico
+  homepage: http://schwany.de/
+  country: DE
+  status: stream-only
+
+- id: de-0-n-dance-on-radio
+  stationuuid: 8b596ce2-3a96-11e9-9b4e-52543be04c81
+  changeuuid: 3f0d2460-40b6-42cf-ac0d-9b6734b64eb2
+  reviewedAt: 2026-05-04
+  geo: [50.312, 11.923]
+  broadcaster: independent
+  name: "- 0 N - Dance on Radio"
+  streamUrl: https://0n-dance.radionetz.de/0n-dance.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [electronic, germany]
+  favicon: https://www.0nradio.com/logos/0n-dance_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+
+- id: de-technolovers-psytrance
+  stationuuid: 27d331f9-6685-47d4-a9e8-7fd16d91b66d
+  changeuuid: ca15902f-07e8-4484-878b-cfbe14d70f87
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: Technolovers - PSYTRANCE
+  streamUrl: https://stream.technolovers.fm/psytrance?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [electronic, germany]
+  homepage: https://technolovers.fm/
+  country: DE
+  status: stream-only
+
+- id: de-technolovers-minimal
+  stationuuid: 01fa3ef0-acf6-4e63-8777-f5bb4957b5ec
+  changeuuid: 20afe025-5741-4aaf-8970-cc1088a0d6eb
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: Technolovers - MINIMAL
+  streamUrl: https://stream.technolovers.fm/minimal?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [electronic, germany]
+  favicon: https://i.ibb.co/LncDTYz/MINIMAL-TL.jpg
+  homepage: https://technolovers.fm/
+  country: DE
+  status: stream-only
+
+- id: de-technolovers-techno
+  stationuuid: 2100610c-13c2-4536-879f-6a88ccb07dc8
+  changeuuid: aeff31c5-b850-49b9-8dae-a69499365049
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: Technolovers - TECHNO
+  streamUrl: https://stream.technolovers.fm/techno?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [electronic, germany]
+  favicon: https://i.ibb.co/ScwBQ49/TECHNO-TL.jpg
+  homepage: https://technolovers.fm/
+  country: DE
+  status: stream-only
+
+- id: de-0-n-smooth-jazz-on-radio
+  stationuuid: 4cd97318-3a95-11e9-9b4e-52543be04c81
+  changeuuid: 73356ac0-3fac-498e-b630-8787ad7c294e
+  reviewedAt: 2026-05-04
+  geo: [50.312, 11.923]
+  broadcaster: independent
+  name: "- 0 N - Smooth Jazz on Radio"
+  streamUrl: https://0n-smoothjazz.radionetz.de/0n-smoothjazz.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [jazz, germany]
+  favicon: https://www.0nradio.com/logos/0n-smooth-jazz_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+
+- id: de-90s-by-rautemusik-rm-fm
+  stationuuid: c87339e0-c556-4ed5-9ef2-4dd176cabbb0
+  changeuuid: dc882fea-12dc-4bb5-a1df-5990ba984f33
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: __90S__ by rautemusik (rm.fm)
+  streamUrl: https://90s-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [pop, electronic, hip-hop, oldies, germany]
+  favicon: https://www.rm.fm/favicon.ico
+  homepage: https://www.rm.fm/90s
+  country: DE
+  status: stream-only
+
+- id: de-hr2-kultur
+  stationuuid: 70614720-560e-4638-913d-0f682d3f9fa7
+  changeuuid: b744f84c-11c5-4ed2-96d8-76d99b97aef4
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: hr2-kultur
+  streamUrl: https://dispatcher.rndfnk.com/hr/hr2/live/mp3/high
+  bitrate: 128
+  codec: MP3
+  tags: [public radio, germany]
+  favicon: https://www.hr2.de/favicon.png?v=3.84.2
+  homepage: https://www.hr2.de/
+  country: DE
+  status: stream-only
+
+- id: de-0-n-country-on-radio
+  stationuuid: 5dd6437a-3a93-11e9-9b4e-52543be04c81
+  changeuuid: 3f8068ff-bda7-4c2f-bf28-470612c6309d
+  reviewedAt: 2026-05-04
+  geo: [50.312, 11.923]
+  broadcaster: independent
+  name: "- 0 N - Country on Radio"
+  streamUrl: https://0n-country.radionetz.de/0n-country.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [country, pop, rock, germany]
+  favicon: https://www.0nradio.com/logos/0n-country_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+
+- id: de-charivari-munchen-lounge-music
+  stationuuid: e0419c41-b016-11e9-acb2-52543be04c81
+  changeuuid: 27491595-01a0-46bc-8358-caab22968d43
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: Charivari München - Lounge Music
+  streamUrl: https://rs24.stream24.net/lounge.aac?ref=charivari.de&aw_0_1st.playerid=radioplayer.de
+  codec: AAC
+  tags: [lounge, germany]
+  favicon: https://www.charivari.de/apple-icon-120x120.png
+  homepage: https://www.charivari.de/
+  country: DE
+  status: stream-only
+
+- id: de-deutsche-welle-radio
+  stationuuid: bc2bbd05-59b2-4bff-86ef-a15a34e7d89e
+  changeuuid: c0aae25d-a313-4b35-ada9-5e0fbd74095a
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: Deutsche Welle Radio
+  streamUrl: https://dw.audiostream.io/dw/1027/mp3/64/dw08
+  bitrate: 64
+  codec: MP3
+  tags: [news, public radio, germany]
+  homepage: https://dw.com/
+  country: DE
+  status: stream-only
+
+- id: de-radio-seefunk
+  stationuuid: 213abeab-b8d2-4057-b570-5a6143607b2c
+  changeuuid: 1aba16e9-5aea-4da5-bf68-9fff51c116bd
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: Radio Seefunk
+  streamUrl: https://webradio.radio-seefunk.de/
+  bitrate: 128
+  codec: MP3
+  tags: [pop, electronic, germany]
+  homepage: https://www.dasneueradioseefunk.de/
+  country: DE
+  status: stream-only
+
+- id: de-0-n-70s-on-radio
+  stationuuid: b1a47819-f2c1-11e8-a471-52543be04c81
+  changeuuid: 7346d804-3534-4809-99a0-6b7ad96d2dd7
+  reviewedAt: 2026-05-04
+  geo: [50.312, 11.923]
+  broadcaster: independent
+  name: "- 0 N - 70s on Radio"
+  streamUrl: https://0n-70s.radionetz.de/0n-70s.aac
+  bitrate: 64
+  codec: AAC
+  tags: [pop, oldies, germany]
+  favicon: https://www.0nradio.com/logos/0n-70s_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+
+- id: de-deutschlandfunk-dokumente-und-debatten-dlf-aac-9
+  stationuuid: 9649888d-0601-11e8-ae97-52543be04c81
+  changeuuid: 58977477-0b33-4777-901c-5d7f17b1e5d5
+  reviewedAt: 2026-05-04
+  geo: [52.480, 13.335]
+  broadcaster: independent
+  name: "Deutschlandfunk Dokumente und Debatten | DLF | AAC 96k"
+  streamUrl: https://st04.sslstream.dlf.de/dlf/04/mid/aac/stream.aac?aggregator=web
+  bitrate: 128
+  codec: AAC
+  tags: [news, electronic, public radio, germany]
+  favicon: https://www.deutschlandradio.de/static/img/deutschlandradio/icons/apple-touch-icon-128x128.png
+  homepage: https://www.deutschlandradio.de/dokumente-und-debatten-102.html
+  country: DE
+  status: stream-only
+
+- id: de-lounge-by-rautemusik-rm-fm
+  stationuuid: 25ff1b4c-ffcb-4572-a561-9347e0e58c75
+  changeuuid: 6840f918-952b-43d1-bc03-f45f2a68c7c8
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: __LOUNGE__ by rautemusik (rm.fm)
+  streamUrl: https://lounge-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [ambient, lounge, germany]
+  favicon: https://www.rm.fm/favicon.ico
+  homepage: https://www.rm.fm/lounge
+  country: DE
+  status: stream-only
+
+- id: de-best-of-schlager-by-rautemusik-rm-fm
+  stationuuid: a3ac6250-7f5b-4246-a3ad-eb9721c29606
+  changeuuid: 99cfdf0c-4abf-4a45-95fc-9dbae19d5b38
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: __BEST OF SCHLAGER__ by rautemusik (rm.fm)
+  streamUrl: https://best-of-schlager-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [oldies, pop, schlager, germany]
+  favicon: https://www.rm.fm/favicon.ico
+  homepage: https://www.rm.fm/best-of-schlager
+  country: DE
+  status: stream-only
+
+- id: de-1-a-ndw-neue-deutsche-welle-von-1a-radio
+  stationuuid: 7f06cacb-f36f-11e8-a471-52543be04c81
+  changeuuid: 75862cdf-c875-4aa9-ba76-7f7a8d5912d7
+  reviewedAt: 2026-05-04
+  geo: [50.312, 11.923]
+  broadcaster: independent
+  name: "- 1 A - NDW (Neue Deutsche Welle) von 1A Radio"
+  streamUrl: https://1a-ndw.radionetz.de/1a-ndw.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [pop, public radio, germany]
+  favicon: https://www.1aradio.com/logos/1a-ndw_600x600.jpg
+  homepage: http://www.1aradio.com/
+  country: DE
+  status: stream-only
+
+- id: de-schlager-oldies-by-rautemusik-rm-fm
+  stationuuid: bd0b7f45-2ff6-4318-84b6-77a3490723f7
+  changeuuid: b50b78b2-bf77-4a9b-9a6b-2510188e7bd0
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: __SCHLAGER OLDIES__ by rautemusik (rm.fm)
+  streamUrl: https://schlager-oldies-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [pop, schlager, oldies, germany]
+  favicon: https://i.ibb.co/NNxSg2H/schlageroldies.jpg
+  homepage: https://www.rm.fm/schlager-oldies
+  country: DE
+  status: stream-only
 # ─── CA — CBC / Radio-Canada public broadcaster (2026-04-29) ───
 # CBC live streams are regional rather than national: every URL is
 # cbcradiolive.akamaized.net/hls/live/<liveId>/<channelCode>/master.m3u8

--- a/data/stations.yaml
+++ b/data/stations.yaml
@@ -6111,6 +6111,485 @@
   country: DE
   status: working
 
+# ─── DE — Radio Browser sweep 2026-05-04 (top 30 of 1710 candidates) ───
+# Sorted by RB votes desc. 2113 playable of 5726 total DE stations.
+
+
+
+- id: de-technolovers-edm
+  stationuuid: 5ea0c406-cc3e-4a36-9a32-37ed4d5a180e
+  changeuuid: f542c307-b541-487e-b193-31ab8670196c
+  reviewedAt: 2026-05-04
+  geo: [50.906, 7.910]
+  broadcaster: independent
+  name: Technolovers EDM
+  streamUrl: https://stream.technolovers.fm/edm?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [electronic, germany]
+  favicon: https://i.ibb.co/TmRLJsp/EDM-TL.jpg
+  homepage: https://technolovers.fm/
+  country: DE
+  status: stream-only
+
+- id: de-technobase-fm
+  stationuuid: 6058ff93-ee55-407e-9221-c6ad07fd2531
+  changeuuid: 45853b0e-a825-48e6-a706-3b18b1f36c16
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: TechnoBase.FM
+  streamUrl: https://listener3.mp3.tb-group.fm/tb.mp3
+  bitrate: 192
+  codec: MP3
+  tags: [electronic, germany]
+  favicon: https://cdn.onlineradiobox.com/img/l/0/32040.v12.png
+  country: DE
+  status: stream-only
+
+
+
+- id: de-0-n-2000s-on-radio
+  stationuuid: 1a4914a2-f35f-11e8-a471-52543be04c81
+  changeuuid: 2a0541a1-4f2d-4330-83cb-e675113d0c23
+  reviewedAt: 2026-05-04
+  geo: [50.312, 11.923]
+  broadcaster: independent
+  name: "- 0 N - 2000s on Radio"
+  streamUrl: https://0n-2000s.radionetz.de/0n-2000s.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [electronic, pop, rock, oldies, germany]
+  favicon: https://www.0nradio.com/logos/0n-2000s_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+
+- id: de-1000-goldschlager
+  stationuuid: 5f154f50-472f-11e9-aa55-52543be04c81
+  changeuuid: 9342199d-503f-4df6-8371-445e2b40cbd9
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: 1000 Goldschlager
+  streamUrl: https://1000goldschlager.stream.laut.fm/1000goldschlager
+  bitrate: 128
+  codec: MP3
+  tags: [schlager, germany]
+  favicon: https://1000goldschlager.de/apple-icon-120x120.png
+  homepage: https://1000goldschlager.de/
+  country: DE
+  status: stream-only
+
+
+
+- id: de-0-n-chillout-on-radio
+  stationuuid: 8b3e9c54-f365-11e8-a471-52543be04c81
+  changeuuid: 82c34172-3a04-48d9-8e6d-3f0179a074e3
+  reviewedAt: 2026-05-04
+  geo: [50.312, 11.923]
+  broadcaster: independent
+  name: "- 0 N - Chillout on Radio"
+  streamUrl: https://0n-chillout.radionetz.de/0n-chillout.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [ambient, electronic, germany]
+  favicon: https://www.0nradio.com/logos/0n-chillout_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+
+- id: de-radio-bollerwagen
+  stationuuid: a3a695be-35ba-4a1a-b8e7-d90815f4b942
+  changeuuid: e6622abd-983e-4057-8e48-65464a359d3e
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: Radio Bollerwagen
+  streamUrl: https://ffn-stream19.radiohost.de/radiobollerwagen_mp3-192?ref=radioplayer&listenerid=31363233323633323031-323030333a64653a343731363a3730313a623731343a346664383a313761363a39386165-3537373636-4d6f7a696c6c612f352e3020285831313b205562
+  bitrate: 192
+  codec: MP3
+  tags: [germany]
+  favicon: https://www.radio.de/images/broadcasts/80/eb/100349/3/c300.png
+  homepage: https://player.ffn.de/radioplayer/radio-bollerwagen/
+  country: DE
+  status: stream-only
+
+- id: de-italo-disco
+  stationuuid: 4a9cd8e0-1b0d-4c87-91bf-d227e06b23eb
+  changeuuid: 0f7776b9-8a63-4674-881e-369b41a868f2
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: Italo Disco
+  streamUrl: https://italo-disco.stream.laut.fm/italo-disco
+  bitrate: 128
+  codec: MP3
+  tags: [electronic, oldies, germany]
+  favicon: https://cdn.onlineradiobox.com/img/l/1/44061.v2.png
+  country: DE
+  status: stream-only
+
+- id: de-technolovers-electro-house
+  stationuuid: 830a7eff-916d-456c-842a-d7786e475658
+  changeuuid: a0a12390-135f-461d-98d7-36df3af7398e
+  reviewedAt: 2026-05-04
+  geo: [51.235, 7.240]
+  broadcaster: independent
+  name: Technolovers ELECTRO HOUSE
+  streamUrl: https://stream.technolovers.fm/electro-house?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [electronic, germany]
+  favicon: https://i.ibb.co/B4R6kNj/Electrohouse-tl.jpg
+  homepage: https://technolovers.fm/
+  country: DE
+  status: stream-only
+
+- id: de-0-n-60s-on-radio
+  stationuuid: f9533da3-f2c1-11e8-a471-52543be04c81
+  changeuuid: 0d8dc6ce-198e-4c8e-bd90-5fd4d192b661
+  reviewedAt: 2026-05-04
+  geo: [50.312, 11.923]
+  broadcaster: independent
+  name: "- 0 N - 60s on Radio"
+  streamUrl: https://0n-60s.radionetz.de/0n-60s.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [pop, soul, oldies, germany]
+  favicon: https://www.0nradio.com/logos/0n-60s_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+
+- id: de-0nlineradio-remix
+  stationuuid: a8c1c86e-e1c0-4e86-ba15-74c258ac0af9
+  changeuuid: 6f1c9806-23d8-4c8b-8407-4c4865e5139b
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: 0nlineradio REMIX
+  streamUrl: https://stream.0nlineradio.com/remix?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [electronic, hip-hop, pop, latin, germany]
+  homepage: https://0nlineradio.com/
+  country: DE
+  status: stream-only
+
+- id: de-electro-swing-revolution
+  stationuuid: 0e8da368-6917-11e8-b15b-52543be04c81
+  changeuuid: 206327f7-1354-4a9a-94ae-9da53f78eb33
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: Electro Swing Revolution
+  streamUrl: https://streamer.radio.co/s2c3cc784b/listen
+  bitrate: 192
+  codec: MP3
+  tags: [electronic, swing, germany]
+  favicon: https://www.electroswing-radio.com/favicon.ico
+  homepage: https://www.electroswing-radio.com/
+  country: DE
+  status: stream-only
+
+
+
+- id: de-hr-info
+  stationuuid: 83b7ec82-15dd-4cfe-96b4-db0a27c6b979
+  changeuuid: 21c65a5b-4609-46d7-bc91-1f23d324d123
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: HR Info
+  streamUrl: https://dispatcher.rndfnk.com/hr/hrinfo/live/mp3/high
+  bitrate: 128
+  codec: MP3
+  tags: [news, public radio, germany]
+  homepage: https://www.hr-inforadio.de/index.html
+  country: DE
+  status: stream-only
+
+- id: de-i-love-radio-us-only-rap-hiphop-radio
+  stationuuid: 7997cf34-9131-11e9-a6c6-52543be04c81
+  changeuuid: eaf3ef0f-8736-4c89-9673-1953ce6f8f0b
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: "i love radio - US Only Rap&HipHop Radio"
+  streamUrl: https://ilm.stream35.radiohost.de/ilm_iloveusonlyrapradio_mp3-192?upd-meta&upd-scheme=https&_art=dD0xNzY4NDU1Mjg0JmQ9YjVlNGIxYTMwOGY3YTQxZjVlZGQ
+  bitrate: 192
+  codec: MP3
+  tags: [hip-hop, germany]
+  favicon: https://www.iloveradio.de/favicon.ico
+  homepage: https://www.iloveradio.de/iloveusonlyrapradio/
+  country: DE
+  status: stream-only
+
+- id: de-schlagerparadies
+  stationuuid: 9607be6f-0601-11e8-ae97-52543be04c81
+  changeuuid: b557c2e5-1b79-4ac3-bac5-3d555e5c4793
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: Schlagerparadies
+  streamUrl: https://webstream.schlagerparadies.de/schlager30842
+  bitrate: 192
+  codec: MP3
+  tags: [schlager, germany]
+  homepage: http://www.schlagerparadies.de/
+  country: DE
+  status: stream-only
+
+- id: de-epic-classical-classical-music-for-sleep
+  stationuuid: 1665ae4c-74dc-44f0-bd0a-7a0d0291aa8c
+  changeuuid: a905e808-e183-40dd-beb5-c7f8fd48b183
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: EPIC CLASSICAL - Classical Music For Sleep
+  streamUrl: https://stream.epic-classical.com/classical-music-for-sleep
+  bitrate: 192
+  codec: MP3
+  tags: [ambient, classical, lounge, germany]
+  homepage: https://epic-classical.com/
+  country: DE
+  status: stream-only
+
+- id: de-bayern-1-franken
+  stationuuid: 3a0985e9-788d-11e8-83fa-52543be04c81
+  changeuuid: 5542c7fb-b910-44dd-b689-b88f4bb5e3db
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: Bayern 1 Franken
+  streamUrl: https://dispatcher.rndfnk.com/br/br1/franken/mp3/mid
+  bitrate: 128
+  codec: MP3
+  tags: [pop, germany]
+  favicon: https://api.ardmediathek.de/image-service/images/urn:ard:image:b366004f6196d70c?w=512
+  homepage: https://www.br.de/radio/bayern1/index.html
+  country: DE
+  status: stream-only
+
+- id: de-absolut-bella
+  stationuuid: df1045ec-c8ef-410f-b800-9a81cdf0d252
+  changeuuid: 9b19924b-7fcb-4db8-97a4-31f154113a3f
+  reviewedAt: 2026-05-04
+  geo: [52.506, 13.400]
+  broadcaster: independent
+  name: Absolut bella
+  streamUrl: https://absolut-bella.live-sm.absolutradio.de/absolut-bella/stream/mp3
+  bitrate: 128
+  codec: MP3
+  tags: [germany]
+  favicon: https://absolutradio.de/apple-touch-icon.png
+  homepage: https://absolutradio.de/
+  country: DE
+  status: stream-only
+
+- id: de-hip-hop-forever
+  stationuuid: 563b5435-61d9-11e9-a622-52543be04c81
+  changeuuid: 5288a728-75c5-4142-863f-d347cd3d5ce8
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: Hip Hop Forever
+  streamUrl: https://stream.laut.fm/hiphop-forever
+  bitrate: 128
+  codec: MP3
+  tags: [hip-hop, germany]
+  country: DE
+  status: stream-only
+
+- id: de-nightride-fm-spacesynth
+  stationuuid: 9aea4f9e-4170-4d8f-ad8c-67f2bfeaa9e0
+  changeuuid: ccd5f826-19be-4923-b4fa-a564feabb7dd
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: Nightride FM - Spacesynth
+  streamUrl: https://stream.nightride.fm/spacesynth.mp3
+  bitrate: 320
+  codec: MP3
+  tags: [germany]
+  favicon: https://nightride.fm/thumbnail.png
+  homepage: https://nightride.fm/
+  country: DE
+  status: stream-only
+
+- id: de-0-n-electro-on-radio
+  stationuuid: f00f65b1-f36a-11e8-a471-52543be04c81
+  changeuuid: 9dab194d-28c8-4c96-ac5d-a732a3c582c5
+  reviewedAt: 2026-05-04
+  geo: [50.312, 11.923]
+  broadcaster: independent
+  name: "- 0 N - Electro on Radio"
+  streamUrl: https://0n-electro.radionetz.de/0n-electro.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [electronic, germany]
+  favicon: https://www.0nradio.com/logos/0n-electro_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+
+- id: de-deutschlandfunk-nova-dlf-mp3-128k
+  stationuuid: 0e1a47cb-f16d-4169-851a-5985c6133055
+  changeuuid: 14c92ee1-4bb6-4cc2-bca4-8f26579fd379
+  reviewedAt: 2026-05-04
+  geo: [52.480, 13.335]
+  broadcaster: independent
+  name: "Deutschlandfunk Nova | DLF | MP3 128k"
+  streamUrl: https://st03.sslstream.dlf.de/dlf/03/128/mp3/stream.mp3?aggregator=web
+  bitrate: 128
+  codec: MP3
+  tags: [news, public radio, germany]
+  favicon: https://www.deutschlandfunknova.de/apple-touch-icon.png
+  homepage: https://www.deutschlandfunknova.de/
+  country: DE
+  status: stream-only
+
+- id: de-epic-lounge-sleep-meditation
+  stationuuid: 4c0118e7-97d9-4657-9bb8-427758a4aa85
+  changeuuid: 88fcf0bd-c0be-45fc-99fc-9684a6870d1c
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: "Epic Lounge - SLEEP & MEDITATION"
+  streamUrl: https://stream.epic-lounge.com/sleep-meditation?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [ambient, lounge, germany]
+  homepage: https://epic-lounge.com/
+  country: DE
+  status: stream-only
+
+- id: de-0-n-greatest-hits-on-radio
+  stationuuid: b8e70464-2f37-45cb-8069-512206b6d7f7
+  changeuuid: f434af7f-e655-43fd-be85-c3891ab96a4b
+  reviewedAt: 2026-05-04
+  geo: [50.312, 11.923]
+  broadcaster: independent
+  name: "- 0 N - Greatest Hits on Radio"
+  streamUrl: https://0n-greatesthits.radionetz.de/0n-greatesthits.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [pop, electronic, hip-hop, rock, germany]
+  favicon: https://www.0nradio.com/logos/0n-greatest-hits_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+
+- id: de-club-by-rautemusik-rm-fm
+  stationuuid: 5f7cdd03-86fc-4d13-89c1-2f9a0b92fc23
+  changeuuid: f1113c9d-96a2-4f45-ab1e-f01f48824f6f
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: __CLUB__ by rautemusik (rm.fm)
+  streamUrl: https://club-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [electronic, pop, germany]
+  favicon: https://www.rm.fm/favicon.ico
+  homepage: https://www.rm.fm/club
+  country: DE
+  status: stream-only
+
+- id: de-0-n-classic-rock-on-radio
+  stationuuid: fd13051d-40ec-11e9-aa55-52543be04c81
+  changeuuid: 08b238a7-3ea4-4851-bf65-7f2ca2e0487e
+  reviewedAt: 2026-05-04
+  geo: [50.312, 11.923]
+  broadcaster: independent
+  name: "- 0 N - Classic Rock on Radio"
+  streamUrl: https://0n-classicrock.radionetz.de/0n-classicrock.aac
+  bitrate: 64
+  codec: AAC
+  tags: [pop, rock, germany]
+  favicon: https://www.0nradio.com/logos/0n-classic-rock_600x600.jpg
+  homepage: http://www.0nradio.com/
+  country: DE
+  status: stream-only
+
+- id: de-technolovers-eurodance
+  stationuuid: ee6043f7-124d-4f20-b020-c1a77ca8383e
+  changeuuid: f78ac9b5-89aa-4a0d-b6c8-0775cc86b288
+  reviewedAt: 2026-05-04
+  geo: [50.674, 9.609]
+  broadcaster: independent
+  name: Technolovers EURODANCE
+  streamUrl: https://stream.technolovers.fm/eurodance?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [pop, electronic, germany]
+  homepage: https://technolovers.fm/
+  country: DE
+  status: stream-only
+
+- id: de-technolovers-funky-house
+  stationuuid: 57df1d35-5943-46e6-a76c-f9ef35ea73e7
+  changeuuid: 15c870e5-7312-4e2a-a8f2-fb5f0886bb8f
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: Technolovers - FUNKY HOUSE
+  streamUrl: https://stream.technolovers.fm/funky-house?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [electronic, germany]
+  homepage: https://technolovers.fm/
+  country: DE
+  status: stream-only
+
+- id: de-0nlineradio-bach
+  stationuuid: 5dc97c2f-566f-47df-8236-021db5906dde
+  changeuuid: d8a77fa8-5d27-40f7-84c1-12aebf6d7672
+  reviewedAt: 2026-05-04
+  geo: [51.128, 8.965]
+  broadcaster: independent
+  name: 0nlineradio BACH
+  streamUrl: https://stream.0nlineradio.com/bach?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [classical, germany]
+  favicon: https://i.ibb.co/n1CQpDf/BACH-NEW.jpg
+  homepage: https://0nlineradio.com/
+  country: DE
+  status: stream-only
+
+- id: de-technolovers-vocal-trance
+  stationuuid: 00c4c0c7-bf13-4a8b-b14f-05f9e5a4a116
+  changeuuid: 4514d297-7508-4f27-87bb-e06e042c4edf
+  reviewedAt: 2026-05-04
+  geo: [51.117, 8.906]
+  broadcaster: independent
+  name: Technolovers VOCAL TRANCE
+  streamUrl: https://stream.technolovers.fm/vocal-trance?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [electronic, germany]
+  homepage: https://technolovers.fm/
+  country: DE
+  status: stream-only
+
+- id: de-deutschrap-charts-by-rautemusik-rm-fm
+  stationuuid: 92602eb8-2cc7-4839-a739-b9132aeed6a5
+  changeuuid: ec586cd4-662b-4b1b-866c-4b3a16266825
+  reviewedAt: 2026-05-04
+  geo: [51.165, 10.451]
+  broadcaster: independent
+  name: __DEUTSCHRAP CHARTS__ by rautemusik (rm.fm)
+  streamUrl: https://deutschrap-charts-high.rautemusik.fm/?ref=radiobrowser
+  bitrate: 192
+  codec: MP3
+  tags: [hip-hop, pop, germany]
+  favicon: https://www.rm.fm/favicon.ico
+  homepage: https://www.rm.fm/deutschrap-charts
+  country: DE
+  status: stream-only
+
 # ─── CA — CBC / Radio-Canada public broadcaster (2026-04-29) ───
 # CBC live streams are regional rather than national: every URL is
 # cbcradiolive.akamaized.net/hls/live/<liveId>/<channelCode>/master.m3u8

--- a/data/stations.yaml
+++ b/data/stations.yaml
@@ -695,6 +695,1641 @@
   country: CH
   status: icy-only
 
+# ─── CH — Radio Browser sweep 2026-05-04 (106 stations) ───
+# Imported from rb-analysis-CH.json: verdict=ok/ok-hls, not curated, not dupe.
+# Status: stream-only. Logos, metadata, fetchers are manual curation work.
+
+- id: ch-80s-forever-we-keep-the-80s-alive
+  stationuuid: 32fed468-cfe3-11e9-a861-52543be04c81
+  changeuuid: f7fc2903-81d9-48f7-b68d-397e54d57fa1
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: 80s Forever - We Keep The 80s Alive
+  streamUrl: https://premium.shoutcastsolutions.com/radio/8050/256.mp3
+  bitrate: 256
+  codec: MP3
+  tags: [pop, indie, rock, oldies, switzerland]
+  favicon: https://www.80sforever.radio/favicon.ico
+  homepage: https://www.80sforever.radio/
+  country: CH
+  status: stream-only
+
+- id: ch-ambi-nature-radio
+  stationuuid: fb1add5d-4b7b-45cf-9be4-a1e8df712553
+  changeuuid: 7ab2059a-4471-41fa-a2c5-25e2794c39da
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Ambi Nature Radio
+  streamUrl: https://nature-rex.radioca.st/stream
+  bitrate: 320
+  codec: MP3
+  tags: [ambient, switzerland]
+  favicon: https://cdn-radiotime-logos.tunein.com/s266086d.png
+  homepage: https://www.ambinature.xyz/
+  country: CH
+  status: stream-only
+
+- id: ch-spoon-radio-classic-rock
+  stationuuid: a879facb-7b92-4210-a1d3-578de4662736
+  changeuuid: c6b6ace3-c6ae-4b83-ab66-2af573b65371
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Spoon Radio - Classic Rock
+  streamUrl: https://spoonradioclassicrock.ice.infomaniak.ch/spoon-classicrock-hd.aac
+  bitrate: 128
+  codec: AAC
+  tags: [rock, classical, switzerland]
+  homepage: https://www.spoonradio.com/
+  country: CH
+  status: stream-only
+
+- id: ch-spoon-radio-hard-rock
+  stationuuid: 4488dc76-a690-4e51-a46c-3600be8195c4
+  changeuuid: bf6fb05f-2733-4d27-bea1-bf8ec9c94dc4
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Spoon Radio - Hard Rock
+  streamUrl: https://spoonradiohardrock.ice.infomaniak.ch/spoon-hardrock-hd.aac
+  bitrate: 128
+  codec: AAC
+  tags: [rock, switzerland]
+  homepage: https://www.spoonradio.com/
+  country: CH
+  status: stream-only
+
+- id: ch-spoon-radio-rock-ballads
+  stationuuid: ebfd9ee6-f7a5-41ab-9c0c-cc104d996067
+  changeuuid: af27c40d-3c1d-4263-9759-a9dc62d01690
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Spoon Radio - Rock Ballads
+  streamUrl: https://spoonradiorockballads.ice.infomaniak.ch/spoon-rockballads-hd.aac
+  bitrate: 128
+  codec: AAC
+  tags: [rock, switzerland]
+  homepage: https://www.spoonradio.com/
+  country: CH
+  status: stream-only
+
+- id: ch-one-dance-ticino
+  stationuuid: b9660eb9-34f9-11e9-8f31-52543be04c81
+  changeuuid: 33e4ea93-7c31-4bbc-8c50-7b85e26472ee
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: One Dance Ticino
+  streamUrl: https://ice15.fluidstream.net/onedancech.aac
+  bitrate: 128
+  codec: AAC
+  tags: [electronic, pop, switzerland]
+  homepage: https://onedancefm.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-1-fm-beloved-ballads
+  stationuuid: ab911d7a-cc43-4640-96f0-771a651ccd25
+  changeuuid: 9452095b-b64c-4bc0-8993-3519ea84f812
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: 1.FM Beloved Ballads
+  streamUrl: https://strm112.1.fm/onelive_mobile_mp3?
+  bitrate: 192
+  codec: MP3
+  tags: [switzerland]
+  country: CH
+  status: stream-only
+
+- id: ch-spoon-radio-modern-rock
+  stationuuid: c68224d9-0082-47fb-976f-6c08e2e05b21
+  changeuuid: 34efc97a-2029-4cff-a51c-2faa45f23a9a
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Spoon Radio - Modern Rock
+  streamUrl: https://spoonradiomodernrock.ice.infomaniak.ch/spoon-modernrock-hd.aac
+  bitrate: 128
+  codec: AAC
+  tags: [rock, switzerland]
+  homepage: https://www.spoonradio.com/
+  country: CH
+  status: stream-only
+
+- id: ch-swiss-groove
+  stationuuid: 6d4127ba-cd83-45c2-90ad-57dfd90b1457
+  changeuuid: c8a08fe6-cd71-46dd-9899-fec2ca344589
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: SWISS GROOVE
+  streamUrl: https://relay2.swissgroove.ch/;
+  bitrate: 128
+  codec: MP3
+  tags: [jazz, latin, lounge, soul, switzerland]
+  favicon: https://swissgroove.ch/favicon.ico
+  homepage: https://swissgroove.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-skuizz-hits-90s-00s
+  stationuuid: aa98e5e6-63d3-4469-a0f7-e2868efd96a0
+  changeuuid: eda453bd-95a8-4c6e-8fca-cb51fd6bb8a0
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Skuizz Hits 90s-00s
+  streamUrl: https://traxx024.ice.infomaniak.ch/traxx024-1.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [pop, rock, oldies, switzerland]
+  homepage: https://skuizz.com/
+  country: CH
+  status: stream-only
+
+- id: ch-a-fine-jazz-gumbo-radio
+  stationuuid: 40e0da97-9fd2-4729-8e86-4c65cdba7910
+  changeuuid: 812a70af-701d-4220-9078-a7a8e90faee6
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: A Fine Jazz Gumbo Radio
+  streamUrl: https://streaming.smartradio.ch:9502/stream
+  bitrate: 48
+  codec: AAC
+  tags: [jazz, switzerland]
+  favicon: https://jazzgumboradio.com/favicon.ico
+  homepage: https://jazzgumboradio.com/
+  country: CH
+  status: stream-only
+
+- id: ch-radio-maxxima
+  stationuuid: fb056b8d-24ae-4bc5-80dd-2a7020415383
+  changeuuid: 42da1869-362a-4abf-9a8b-97c5d6cfef96
+  reviewedAt: 2026-05-04
+  geo: [46.587, 7.753]
+  broadcaster: independent
+  name: Radio Maxxima
+  streamUrl: https://maxxima.mine.nu/maxxima.mp3
+  bitrate: 192
+  codec: MP3
+  tags: [switzerland]
+  homepage: https://www.maxxima.org/
+  country: CH
+  status: stream-only
+
+- id: ch-rtn
+  stationuuid: 96094a59-0601-11e8-ae97-52543be04c81
+  changeuuid: a48a88e6-b2c0-4f05-b1ca-b44f25e3fefd
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: RTN
+  streamUrl: https://rtn.ice.infomaniak.ch/rtn-high.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  homepage: http://www.rtn.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-one-fm-2000s
+  stationuuid: ee47b64d-ebaf-4d26-90e6-e9cd25f32958
+  changeuuid: 1e3213c9-cb94-4372-8c2c-bad168777d72
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: One FM 2000s
+  streamUrl: https://webradio0009.ice.infomaniak.ch/webradio0009-128.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://www.onefm.ch/wp-content/uploads/2018/08/favicon.png
+  homepage: https://www.onefm.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-spoon-radio-acoustic-rock
+  stationuuid: dbcbdefe-8448-4997-ad46-1c921edd0174
+  changeuuid: ebd33dfc-5a03-4862-ac7b-aa436a7fe902
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Spoon Radio - Acoustic Rock
+  streamUrl: https://spoonradioacousticrock.ice.infomaniak.ch/spoon-acousticrock-hd.aac
+  bitrate: 128
+  codec: AAC
+  tags: [rock, switzerland]
+  homepage: https://www.spoonradio.com/
+  country: CH
+  status: stream-only
+
+- id: ch-radio-lac
+  stationuuid: 3718f163-5868-11e9-a622-52543be04c81
+  changeuuid: b19f6176-4aea-4c93-ab3b-1dfb63d2f4f4
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Radio Lac
+  streamUrl: https://radiolac.ice.infomaniak.ch/radiolac-high.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://www.radiolac.ch/favicon.ico
+  homepage: https://www.radiolac.ch/direct/player/
+  country: CH
+  status: stream-only
+
+- id: ch-goat-radio
+  stationuuid: 4f6119c9-3e96-494d-8b79-696cd97f9a3d
+  changeuuid: 3a26dfe6-cbaf-4f10-ad5e-5ac3cf9ad412
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: GOAT Radio
+  streamUrl: https://20min.dmd2streaming.com/20minuten_radio_64.aac
+  bitrate: 64
+  codec: AAC
+  tags: [switzerland]
+  favicon: https://cdn.unitycms.io/images/DQapoIlBq478hc9HagcAw7.png
+  homepage: https://audio.20min.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-basspistol-radio
+  stationuuid: 876d62ba-1be4-4406-86fd-e0454839e325
+  changeuuid: daf929b4-2f1d-4639-9670-7016564fc7bf
+  reviewedAt: 2026-05-04
+  geo: [46.207, 6.156]
+  broadcaster: independent
+  name: Basspistol Radio
+  streamUrl: https://radio.basspistol.com/radio.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [electronic, hip-hop, indie, switzerland]
+  favicon: https://basspistol.com/siteicon.png
+  homepage: https://basspistol.com/radio
+  country: CH
+  status: stream-only
+
+- id: ch-radio-zurisee
+  stationuuid: 495a3710-7aae-4122-83b5-a49757c0a812
+  changeuuid: 9a8546be-74ad-4417-a916-4e25464b683b
+  reviewedAt: 2026-05-04
+  geo: [47.226, 8.817]
+  broadcaster: independent
+  name: Radio Zürisee
+  streamUrl: https://mp3.radio.ch/radiozuerisee256k
+  bitrate: 256
+  codec: MP3
+  tags: [rock, pop, switzerland]
+  favicon: https://www.radiozuerisee.ch/assets/favicons/apple-icon-120x120.png
+  homepage: https://www.radiozuerisee.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-spoon-radio-alternative-rock
+  stationuuid: 5d216765-e434-4a60-87f0-40cecb5236fa
+  changeuuid: 94998b5e-c7a6-4cb9-9b68-ccdac34ed8b0
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Spoon Radio - Alternative Rock
+  streamUrl: https://spoonradioalternativerock.ice.infomaniak.ch/spoon-alternativerock-hd.aac
+  bitrate: 128
+  codec: AAC
+  tags: [alternative, rock, switzerland]
+  homepage: https://www.spoonradio.com/
+  country: CH
+  status: stream-only
+
+- id: ch-radio1-ch
+  stationuuid: b614ffcb-684a-4fac-8395-17420f6ee27c
+  changeuuid: dce96e86-c7a4-43e9-ae0c-7886586b8a9a
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Radio1.ch
+  streamUrl: https://stream.radio1.ch/128k
+  bitrate: 128
+  codec: MP3
+  tags: [pop, switzerland]
+  homepage: https://radio1.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-break-radio
+  stationuuid: 3cd03534-0100-4055-ab57-4d39c2ae52d0
+  changeuuid: bdcbd885-2ed0-4d60-8644-ba449f98ccdf
+  reviewedAt: 2026-05-04
+  geo: [46.225, 7.352]
+  broadcaster: independent
+  name: Break Radio
+  streamUrl: https://breakradio.ice.infomaniak.ch/breakradio-192.mp3
+  bitrate: 192
+  codec: MP3
+  tags: [hip-hop, switzerland]
+  favicon: https://www.breakradio.ch/apple-touch-icon.png
+  homepage: https://www.breakradio.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-radio-rocket
+  stationuuid: 7e0a8594-c455-4e7a-be89-efe7e955944c
+  changeuuid: f2580886-fed3-4065-9a7f-a04aa5a15a44
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Radio Rocket
+  streamUrl: https://i9.streams.ovh/sc/radioroc/stream
+  bitrate: 320
+  codec: MP3
+  tags: [alternative, rock, switzerland]
+  homepage: https://radiorocket.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-one-fm-90s
+  stationuuid: 871eef57-289c-47f5-9cd4-17b9bd7846a5
+  changeuuid: c87d6c9b-db50-42cd-b974-cc451fd8fc64
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: One FM 90s
+  streamUrl: https://webradio0006.ice.infomaniak.ch/webradio0006-128.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [oldies, switzerland]
+  favicon: https://www.onefm.ch/wp-content/uploads/2018/08/favicon.png
+  homepage: https://www.onefm.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-wrs-swiss-radio-in-english
+  stationuuid: e8686dd3-443b-4a9f-b23f-ed8388bb6b77
+  changeuuid: 24d244c2-6e8a-49ef-ba4e-9c6dfc6649aa
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: WRS "Swiss Radio in English"
+  streamUrl: https://uksouth.streaming.broadcast.radio:10290/wrs?_=443217
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://mmo.aiircdn.com/29/61eaca66a914b.png
+  homepage: https://www.worldradio.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-arc-musique
+  stationuuid: 96205a50-0601-11e8-ae97-52543be04c81
+  changeuuid: 90972f8c-74a6-41ef-a7ed-0e09784821d9
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Arc Musique
+  streamUrl: https://arcmusique.ice.infomaniak.ch/arcmusique-128.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  homepage: http://arcmusique.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-happy-radio
+  stationuuid: ed16b66c-340e-470f-bd76-1e45b145055e
+  changeuuid: 32c4952f-e0fa-4acd-a45e-a83188afb925
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Happy Radio
+  streamUrl: https://uksoutha.streaming.broadcast.radio/stream/11340/gtradio?1672903939995
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://goodtimeradio.broadcast.radio/favicon.ico
+  homepage: https://www.happy-radio.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-radio-summernight
+  stationuuid: 53fefaca-0e1e-11e9-a80b-52543be04c81
+  changeuuid: 3580a705-067d-40f1-a6f8-fea08bc68bb2
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Radio Summernight
+  streamUrl: https://stream.laut.fm/radiosummernight
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  homepage: https://radiosummernight.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-radio-top-ostschweiz
+  stationuuid: 3e7dcb14-de8b-4c9c-85de-272148ff92a1
+  changeuuid: 7fdb7fbd-a0e6-4190-a8c7-bd48bb8204b8
+  reviewedAt: 2026-05-04
+  geo: [47.505, 8.714]
+  broadcaster: independent
+  name: Radio Top (Ostschweiz)
+  streamUrl: https://radiotop.ice.infomaniak.ch/radiotop96.aac
+  bitrate: 96
+  codec: AAC
+  tags: [news, pop, switzerland]
+  favicon: https://www.toponline.ch/fileadmin/templates/logos/apple-touch-icon.png
+  homepage: https://www.toponline.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-radio-gloria
+  stationuuid: a85ace81-8a73-4146-93c5-6d030429e52f
+  changeuuid: def591d3-9fd7-4f2a-88a9-605f04e531a7
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Radio Gloria
+  streamUrl: https://ch-be06-ice.dmd2streaming.com/radiogloria_lo
+  bitrate: 96
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://radiogloria.ch/favicon.ico
+  homepage: https://radiogloria.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-1-fm-classic-rock
+  stationuuid: c3086993-34c3-47cb-9323-540fb675fe46
+  changeuuid: ea86771a-707c-4be6-ae54-80100960a088
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: 1.fm classic rock
+  streamUrl: https://strm112.1.fm/crock_mobile_mp3
+  bitrate: 192
+  codec: MP3
+  tags: [rock, classical, switzerland]
+  homepage: https://www.1.fm/station/crock
+  country: CH
+  status: stream-only
+
+- id: ch-bear-metal-radio
+  stationuuid: 1901f7f2-727f-4fb1-b9d8-bf3f50e1419c
+  changeuuid: d6b44a36-a672-4484-b575-cccf850dc6ab
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Bear Metal Radio
+  streamUrl: https://cast5.asurahosting.com/proxy/bear?mp=/stream
+  bitrate: 192
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://www.bearmetalradio.com/images/logo.png
+  homepage: https://www.bearmetalradio.com/
+  country: CH
+  status: stream-only
+
+- id: ch-rfj
+  stationuuid: 960a893c-0601-11e8-ae97-52543be04c81
+  changeuuid: d89085a6-aca9-49a1-891e-264c6f95db7d
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: RFJ
+  streamUrl: https://rfj.ice.infomaniak.ch/rfj-high.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  homepage: http://www.rfj.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-energy-bern
+  stationuuid: 489f3786-3ff8-46c1-ad14-2a7c5d9cea99
+  changeuuid: 8d33e3c9-9135-4b3c-87c9-96fe0ef2e5f8
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.448]
+  broadcaster: independent
+  name: Energy Bern
+  streamUrl: https://energybern.ice.infomaniak.ch/energybern-high.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://cdn.energy.ch/energych-broadcast/covers/channels/logo_v2_bern_1638178870.svg
+  homepage: https://energy.ch/stations/energy-bern
+  country: CH
+  status: stream-only
+
+- id: ch-radio-lora-97-5
+  stationuuid: 37d4ee78-88a9-4fbd-82f6-81d5eb0b3477
+  changeuuid: 8c19b46c-f3c8-44cd-a82b-e626eb91c177
+  reviewedAt: 2026-05-04
+  geo: [47.378, 8.529]
+  broadcaster: independent
+  name: Radio LoRa 97.5
+  streamUrl: https://livestream.lora.ch/lora.mp3
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://www.lora.ch/images/favicon/apple-touch-icon.png
+  homepage: https://www.lora.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-20minuten-radio-dab-goat-radio
+  stationuuid: eb540959-9fa2-4f04-b822-b74cf761126b
+  changeuuid: b3f936d6-9c82-4222-a260-a4b96c4f5ddc
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: 20minuten.radio DAB+ (GOAT Radio)
+  streamUrl: https://www.digris.ch/stream/897a2939-b6db-42c6-8760-28908bcf8b25
+  bitrate: 256
+  codec: MP3
+  tags: [switzerland]
+  homepage: https://www.20min.ch/radio
+  country: CH
+  status: stream-only
+
+- id: ch-james-fm
+  stationuuid: 6b59a526-91c9-44dc-a615-267d64934bb2
+  changeuuid: 85527b0f-7084-4d7e-b60c-3a66ba46cc4f
+  reviewedAt: 2026-05-04
+  geo: [47.162, 8.437]
+  broadcaster: independent
+  name: JAMES FM
+  streamUrl: https://jamesfm.ice.infomaniak.ch/jamesfm.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  homepage: https://www.jamesfm.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-radio-fribourg
+  stationuuid: e2af125a-58df-4264-9d82-589d96a7ab39
+  changeuuid: 7c1eb02e-c6e3-4c7e-ad4d-881718623c96
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Radio Fribourg
+  streamUrl: https://radiofribourg.ice.infomaniak.ch/radiofribourg-high.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://radiofr.ch/favicons/apple-touch-icon.png
+  homepage: https://radiofr.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-radio-grenzenlos-radio-grenzenlos-spcast
+  stationuuid: 80a7f390-73d1-11e9-af37-52543be04c81
+  changeuuid: 72450e5c-9b10-4d44-b978-a9ff9b38f059
+  reviewedAt: 2026-05-04
+  geo: [47.476, 7.733]
+  broadcaster: independent
+  name: Radio grenzenlos,Radio grenzenlos [SPCast]
+  streamUrl: https://grenzenlos.sp.radio.fm/stream
+  bitrate: 320
+  codec: MP3
+  tags: [electronic, pop, switzerland]
+  favicon: https://radio.grenzenlos.ch/logo.png
+  country: CH
+  status: stream-only
+
+- id: ch-radio-drachenblut
+  stationuuid: 4992d90f-2bed-445d-abc6-6065e7faa38e
+  changeuuid: eeeba9db-ba66-4da0-82e3-d24393725283
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Radio-Drachenblut
+  streamUrl: https://radio-drachenblut.ch:8443/listen.mp3
+  bitrate: 192
+  codec: MP3
+  tags: [rock, switzerland]
+  homepage: https://radio-drachenblut.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-bachata-nation-radio
+  stationuuid: 1eaa7a2e-8fbe-4936-b71c-18190cfb25e8
+  changeuuid: 40d3d674-a051-4014-9110-791922341f53
+  reviewedAt: 2026-05-04
+  geo: [47.375, 8.542]
+  broadcaster: independent
+  name: Bachata Nation Radio
+  streamUrl: https://stream.zeno.fm/vwcq5n2rruhvv
+  codec: MP3
+  tags: [latin, switzerland]
+  homepage: https://stream.zeno.fm/
+  country: CH
+  status: stream-only
+
+- id: ch-one-fm-new-hits
+  stationuuid: 3eab2963-3d0d-43ee-bcba-d686a569e0ce
+  changeuuid: 6860576d-9d78-41c5-9ab0-23b4e1939299
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: One FM New-Hits
+  streamUrl: https://webradio0001.ice.infomaniak.ch/webradio0001-128.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [pop, switzerland]
+  favicon: https://www.onefm.ch/wp-content/uploads/2017/07/logos-1.png
+  homepage: https://onefm.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-canal3-deutsch
+  stationuuid: f91aa755-2979-451e-a4fe-1393f5dd1ed8
+  changeuuid: aecabb5f-fdd8-4976-a774-58a1a0e102a9
+  reviewedAt: 2026-05-04
+  geo: [47.136, 7.243]
+  broadcaster: independent
+  name: Canal3 deutsch
+  streamUrl: https://radio.upstream-cloud.ch/canal3allemand-192.aac
+  bitrate: 192
+  codec: AAC
+  tags: [news, pop, switzerland]
+  favicon: https://web.canal3.ch/de/sites/all/themes/canal3_theme_v2/favicon.ico
+  homepage: https://web.canal3.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-uzic-ch-techno-minimal-best-of-electronic-with-t
+  stationuuid: f0df6e39-68b5-4026-9d83-51af63ddfdc6
+  changeuuid: f3019bab-b4b7-4dd2-8718-9866a6f6aaf3
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: "UZIC.CH"
+  streamUrl: https://uzic.ice.infomaniak.ch/uzic-128.aac
+  bitrate: 128
+  codec: AAC
+  tags: [electronic, switzerland]
+  favicon: https://uzic.ch/wp-content/uploads/2025/06/logo_uzic-150x150.png
+  homepage: https://uzic.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-electrons-libres
+  stationuuid: f02a2856-5044-4b35-a7a2-341d4124fc95
+  changeuuid: 70dc5e13-5a00-4ff0-8b8c-fe678618da32
+  reviewedAt: 2026-05-04
+  geo: [46.951, 7.067]
+  broadcaster: independent
+  name: Electrons Libres
+  streamUrl: https://listen.radioking.com/radio/427889/stream/481505
+  bitrate: 192
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://electronslibres.ch/wp-content/uploads/2021/06/cropped-LogoRadioSimpleSansTxt-1.png
+  homepage: https://electronslibres.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-radio-grischa
+  stationuuid: db6893f4-cead-4749-83e6-a1b1dfb6f61b
+  changeuuid: c0211630-2e5b-4cac-a2cc-c2cf07243d31
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Radio Grischa
+  streamUrl: https://somedia-4.streaming.deliver.media/radiogrischa_mp3_128
+  bitrate: 128
+  codec: MP3
+  tags: [news, switzerland]
+  favicon: https://www.radiogrischa.ch/themes/custom/grischa/images/logos/RG_Signet.png
+  homepage: https://www.radiogrischa.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-radio-s
+  stationuuid: 8d558fc8-b5ca-481b-b192-3f901eb76624
+  changeuuid: 02b61ace-12fc-453c-ac32-7c9d55ed6e3e
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Radio S
+  streamUrl: https://stream.radio-s.ch/stream
+  bitrate: 185
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://static.wixstatic.com/media/d168f9_11af99f87f4448daaf0e1bda1d1a1169~mv2.png/v1/fill/w_180,h_125,al_c,q_85,usm_0.66_1.00_0.01,enc_auto/LOGO%20Radio%20S.png
+  homepage: https://stream.radio-s.ch/stream
+  country: CH
+  status: stream-only
+
+- id: ch-christmas-radio-fm
+  stationuuid: 3f92bfe7-33a4-4246-ae2d-0333a50c7961
+  changeuuid: ea62e8fe-e3d4-41e5-aa00-e1750f36f5dd
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Christmas Radio FM
+  streamUrl: https://xmasfm1.dmd2streaming.com/christmasradiofm-128.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  homepage: http://christmasradio.fm/christmasgateway/
+  country: CH
+  status: stream-only
+
+- id: ch-sabaton
+  stationuuid: 258cfafa-41ac-4d08-9246-7128f5175b6a
+  changeuuid: 4fef89bc-56e6-4831-9e3b-3109aba4d21d
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Sabaton радио
+  streamUrl: https://stream.pcradio.ru/sabaton-hi
+  codec: AAC
+  tags: [switzerland]
+  favicon: null
+  homepage: https://pcradio.ru/
+  country: CH
+  status: stream-only
+
+- id: ch-ip-music-slow-aacplus-96-kb-s
+  stationuuid: f46955a2-77e7-4a30-96af-abdd89c70a2e
+  changeuuid: aaff9c4f-2e4c-4a31-82cc-db4006cb9076
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: IP music SLOW - aacPlus@96 Kb/s
+  streamUrl: https://live9.avf.ch/ipmusicslowaacp96
+  bitrate: 96
+  codec: AAC
+  tags: [switzerland]
+  favicon: https://www.ipmusicslow.ch/images/logo-ipmusicslow.png
+  homepage: https://www.ipmusicslow.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-lfm
+  stationuuid: 52d101dc-3a83-4e4e-8505-8b235065fb0b
+  changeuuid: a01a4a08-c5eb-4ca1-9f9a-5c64e002a23e
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: LFM
+  streamUrl: https://lausannefm.ice.infomaniak.ch/lausannefm-high.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://www.lfm.ch/wp-content/uploads/2021/07/cropped-radio-lausanne-fm-sa-icone-du-site-180x180.png
+  homepage: https://www.lfm.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-neo1
+  stationuuid: 4cde8f3b-17fc-4802-ba40-e8feae5395a1
+  changeuuid: b4bcde74-0a58-4285-b89d-269b3778b41a
+  reviewedAt: 2026-05-04
+  geo: [46.939, 7.784]
+  broadcaster: independent
+  name: Neo1
+  streamUrl: https://neo1.ice.infomaniak.ch/neo1.mp3
+  bitrate: 192
+  codec: MP3
+  tags: [pop, rock, switzerland]
+  favicon: https://www.neo1.ch/fileadmin/user_upload/newsaudio/2018/11/neo1-logo.jpg
+  homepage: https://www.neo1.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-country-radio-switzerland
+  stationuuid: 9d570191-0359-4398-af57-bc8d3e37b417
+  changeuuid: 14b882e4-c379-45af-8ea2-85fac3a17a30
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Country Radio Switzerland
+  streamUrl: https://countryradioswitzerland.ice.infomaniak.ch/crs-128.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [country, switzerland]
+  country: CH
+  status: stream-only
+
+- id: ch-driftfm
+  stationuuid: 613afd76-188c-479b-9585-edddc1059a17
+  changeuuid: ab410fc0-7c8e-4296-b82e-45dc34e57d03
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: driftFM
+  streamUrl: https://s4.radio.co/s5729f2e59/listen
+  bitrate: 192
+  codec: MP3
+  tags: [country, switzerland]
+  favicon: https://www.drift.fm/wp-content/uploads/2020/06/Drift-FM_Logo_transparent_400px_00c8007a1_1367.png
+  homepage: https://www.drift.fm/
+  country: CH
+  status: stream-only
+
+- id: ch-radio-munot
+  stationuuid: 7f32184f-e7f0-46e6-a5e4-516daa062ec7
+  changeuuid: 7b5f9df1-9e0f-44c5-ae90-48fb4be91ce7
+  reviewedAt: 2026-05-04
+  geo: [47.692, 8.626]
+  broadcaster: independent
+  name: Radio Munot
+  streamUrl: https://munot.ch-central-4.streaming.deliver.media/munot_mp3_128
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://www.radiomunot.ch/assets/favicons/android-icon-192x192.png
+  homepage: https://www.radiomunot.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-radio-stadtfilter-dab
+  stationuuid: f427a049-76f7-4d31-b063-e72e55865e99
+  changeuuid: c2aa6e5e-2894-46ac-b20e-95b824399751
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Radio Stadtfilter (DAB+)
+  streamUrl: https://www.digris.ch/stream/8a1a42f0-3f59-4113-b544-aad9275d34a7
+  bitrate: 160
+  codec: MP3
+  tags: [pop, switzerland]
+  homepage: https://stadtfilter.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-radio3i
+  stationuuid: 0064bd20-d2bc-4d1f-808b-3e6b1bf63604
+  changeuuid: 3362ce79-d99a-42f7-b0e1-dc7cae125001
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Radio3i
+  streamUrl: https://vstream-cdn.ch/hls/radio3i.m3u8
+  bitrate: 2628
+  codec: HLS
+  tags: [switzerland]
+  favicon: https://radio3i.ch/assets/images/app-logo.png
+  homepage: https://radio3i.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-rockstar-radio
+  stationuuid: 7b74f47d-5bf2-4ddf-866c-c4738d5cc561
+  changeuuid: a0ade4f9-4cdd-42e2-9cc6-a6318eafb00d
+  reviewedAt: 2026-05-04
+  geo: [46.521, 6.633]
+  broadcaster: independent
+  name: Rockstar Radio
+  streamUrl: https://dr2101.ice.infomaniak.ch/dr2102.mp3
+  bitrate: 192
+  codec: MP3
+  tags: [rock, switzerland]
+  favicon: https://dr21.mediaonegroup.ch/apps/assets/logo_rockstar_2.svg
+  homepage: https://rockstarradio.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-wildmountain-radio
+  stationuuid: c9eb3feb-9c48-4fde-aef7-eda15d2173fd
+  changeuuid: ab95743d-5c5b-4884-a5b7-f740996e6233
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Wildmountain Radio
+  streamUrl: https://wildmountain.ice.infomaniak.ch/wmr.mp3
+  bitrate: 192
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://www.wildmountain.ch/favicon.png
+  homepage: https://www.wildmountain.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-back2noize-radio
+  stationuuid: 29c2975b-3ca9-4f4e-b5fb-1bfdc2e0eba2
+  changeuuid: af428891-1b6f-4dfd-9b3b-547c6de99433
+  reviewedAt: 2026-05-04
+  geo: [46.556, 6.510]
+  broadcaster: independent
+  name: Back2Noize Radio
+  streamUrl: https://securestreams4.autopo.st:1558/Back2Noize
+  bitrate: 320
+  codec: MP3
+  tags: [electronic, switzerland]
+  favicon: https://back2noize.com/wp-content/uploads/2019/08/back2noize-logo-round-300x300.jpg
+  homepage: https://back2noize.com/
+  country: CH
+  status: stream-only
+
+- id: ch-radio-r-louange
+  stationuuid: 5b884101-b14c-4377-8b96-7593ade7a2d1
+  changeuuid: d24e7b72-dc92-4876-9480-11fefb993667
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Radio R Louange
+  streamUrl: https://radiorlouange.ice.infomaniak.ch/radiorlouange-96.aac?ver=666978
+  bitrate: 96
+  codec: AAC
+  tags: [gospel, switzerland]
+  favicon: https://radio-r.ch/wp-content/uploads/2024/03/radio-r-louange_cover_cropOK_1080x1080px-170x170.png
+  homepage: https://radio-r.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-radio-rasa-schaffhausen
+  stationuuid: 64bf4040-d07a-418b-a7a3-9cec29107091
+  changeuuid: c204e651-980f-4f27-a63f-e0ec5d2fc5c0
+  reviewedAt: 2026-05-04
+  geo: [47.696, 8.634]
+  broadcaster: independent
+  name: Radio Rasa Schaffhausen
+  streamUrl: https://radio.upstream-cloud.ch/radiorasa-128.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [alternative, indie, switzerland]
+  favicon: https://www.rasa.ch/favicon.ico
+  homepage: https://www.rasa.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-dream-sequence
+  stationuuid: 2c3ae89a-977a-445b-9a8a-bef76cd0ebfa
+  changeuuid: 675612a0-9311-4733-b0e0-49157428cd7b
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Dream Sequence
+  streamUrl: https://listen.radioking.com/radio/453296/stream/508976
+  bitrate: 192
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://static.wixstatic.com/media/e05539_cbaf7759467242c1843d8bac2619e127~mv2.png/v1/crop/x_9,y_0,w_3107,h_1875/fill/w_490,h_296,al_c,q_85,usm_0.66_1.00_0.01,enc_auto/customcolor_logo_transparent_background.png
+  homepage: https://www.dreamsequence.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-80ies-dot-radio
+  stationuuid: 89cf48cc-719a-4807-ac86-963196fc0107
+  changeuuid: 3fcdc1d2-8a1a-40cc-9e5a-3977841ed06e
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: 80ies dot radio
+  streamUrl: https://stream.radiojar.com/6cbvkaa1mrruv?1643199882
+  codec: MP3
+  tags: [oldies, switzerland]
+  homepage: https://www.80ies.radio/
+  country: CH
+  status: stream-only
+
+- id: ch-kiss-collector-radio
+  stationuuid: 3684bcbb-8af6-4755-9db8-0e240824f0fa
+  changeuuid: d64cb330-ab01-469c-9afe-628e300e6c7c
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Kiss Collector Radio
+  streamUrl: https://dr2101.ice.infomaniak.ch/dr2101.mp3
+  bitrate: 320
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://kisscollector.ch/favicon.ico
+  homepage: https://kisscollector.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-one-fm-rock-oldies
+  stationuuid: 7396ca2e-f495-4e74-ac43-7e6870cebc3d
+  changeuuid: 925a696d-52ff-4a77-a1b7-6f9799c93a96
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: One FM Rock Oldies
+  streamUrl: https://webradio0002.ice.infomaniak.ch/webradio0002-128.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [rock, oldies, switzerland]
+  favicon: https://www.onefm.ch/wp-content/themes/mog-child/webradios/ONE_app_WEBRADIO_Rock.png
+  homepage: https://www.onefm.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-ktfm-geneva-the-best-of-70-s-and-80-s
+  stationuuid: 0a29e7a5-96b9-45a6-a8e5-86611b2f31ff
+  changeuuid: bbd5aec5-a216-47dc-ad0a-7e54cf1d744c
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: KTfm Geneva - THE BEST OF 70'S AND 80'S
+  streamUrl: https://ktfm.ice.infomaniak.ch/ktfm-high.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [pop, oldies, switzerland]
+  favicon: https://i0.wp.com/ktfm-radio.ch/wp-content/uploads/2019/12/KTFM-1.png?fit=50%2C50&ssl=1
+  homepage: https://ktfm-radio.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-radio-alta
+  stationuuid: ac5fdde2-5bc3-435a-a016-37e93dfe79bc
+  changeuuid: 0a18e450-5623-48b8-9557-ff8244ad2ffd
+  reviewedAt: 2026-05-04
+  geo: [46.310, -6.300]
+  broadcaster: independent
+  name: Radio Alta
+  streamUrl: https://transmiss.ion.ovh/listen/alta/radio.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [gospel, switzerland]
+  homepage: https://transmiss.ion.ovh/public/alta
+  country: CH
+  status: stream-only
+
+- id: ch-spoon-rock
+  stationuuid: ff6de11b-718f-480e-804b-79f4f3f6ea8e
+  changeuuid: 61272ca5-2f96-4914-b173-add462280111
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Spoon Rock
+  streamUrl: https://ic2527.c972.fastserv.com:80/spoonradio_mp3_192
+  bitrate: 192
+  codec: MP3
+  tags: [rock, switzerland]
+  favicon: https://www.spoonradio.com/newimages/logo.png
+  homepage: https://www.spoonradio.com/
+  country: CH
+  status: stream-only
+
+- id: ch-rockstation
+  stationuuid: 292bb9ec-496f-47dc-8531-4be97c572297
+  changeuuid: f8dce236-9ecb-413e-9b6c-fbcd0ac89ada
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: ROCKSTATION
+  streamUrl: https://radio2.stream24.net:8130/live.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [rock, switzerland]
+  favicon: https://rockstation.ch/wp-content/uploads/2023/03/cropped-favicon-basis-192x192.jpg
+  homepage: https://rockstation.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-open-broadcast
+  stationuuid: 60d9dd7c-3509-4dba-9e27-b87e9ea3ff6a
+  changeuuid: 5ec45bd1-6658-4663-b800-011fe0c1705e
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Open Broadcast
+  streamUrl: https://www.digris.ch/stream/092210ed-4eb4-483b-814f-21df6ecb1352
+  bitrate: 320
+  codec: MP3
+  tags: [switzerland]
+  homepage: https://openbroadcast.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-rundfunk-fm
+  stationuuid: cfad47f6-45dd-458a-a2fa-f9883cc239e9
+  changeuuid: 0fd11ce8-aaee-41ed-9c5a-d8e5323fce75
+  reviewedAt: 2026-05-04
+  geo: [47.379, 8.541]
+  broadcaster: independent
+  name: Rundfunk.fm
+  streamUrl: https://rundfunkfm.broadcast.brandsarelive.com/listen/rundfunk.fm/radio.mp3
+  bitrate: 320
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://rundfunk.fm/static/assets/favicon/apple-touch-icon.png
+  homepage: https://rundfunk.fm/
+  country: CH
+  status: stream-only
+
+- id: ch-my105-x-mas
+  stationuuid: 989e9111-51fb-48ea-985b-1d5110dacde1
+  changeuuid: 14238ed7-b86d-44ed-ac12-bd8857b15ff5
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: my105 X-MAS
+  streamUrl: https://stream01.my105.ch/my105xmas.mp3
+  bitrate: 192
+  codec: MP3
+  tags: [switzerland]
+  homepage: https://www.my105.ch/x-mas
+  country: CH
+  status: stream-only
+
+- id: ch-radio-neue-hoffnung
+  stationuuid: 446160e9-ec70-4499-bba4-bd56f5c0d75c
+  changeuuid: 3461650e-4afc-47bf-8227-7075a620d07e
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Radio Neue Hoffnung
+  streamUrl: https://stream.mnr.ch/rnh-mp3
+  bitrate: 192
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://www.mnr.ch/favicon.ico
+  homepage: https://www.mnr.ch/radio/
+  country: CH
+  status: stream-only
+
+- id: ch-ta-radio
+  stationuuid: d391db6e-6bc9-4805-9f87-044601efc9ef
+  changeuuid: d3463303-7d54-4b66-8cdd-479063be885c
+  reviewedAt: 2026-05-04
+  geo: [47.009, 7.011]
+  broadcaster: independent
+  name: Ta Radio
+  streamUrl: https://stream.taradio.ch/dab
+  bitrate: 96
+  codec: AAC
+  tags: [electronic, pop, rock, switzerland]
+  homepage: https://www.taradio.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-traxx-fm-hits
+  stationuuid: 42aab7fd-98d5-4816-bcf4-30dd2e563abd
+  changeuuid: a96a5e0b-114d-495b-a31a-ff37b4687dcb
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Traxx FM - Hits
+  streamUrl: https://traxx010.ice.infomaniak.ch/traxx010-low.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  homepage: http://www.traxx.fm/
+  country: CH
+  status: stream-only
+
+- id: ch-lux-radio
+  stationuuid: 0f42b130-e1dd-4ed4-982e-92659b038780
+  changeuuid: 5b188ba9-f70f-4e68-9165-8d1566e17681
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: LUX RADIO
+  streamUrl: https://live7.avf.ch/lux_main
+  bitrate: 1200
+  codec: OGG
+  tags: [switzerland]
+  favicon: https://luxradio.ch/wp-content/uploads/2022/03/Logo-Colour.png
+  homepage: https://luxradio.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-radio-electrons-libres
+  stationuuid: f41d60a2-28c0-4637-87d8-274edc988871
+  changeuuid: 53433c19-5f86-4e3f-8db8-302a805dc619
+  reviewedAt: 2026-05-04
+  geo: [46.951, 7.067]
+  broadcaster: independent
+  name: Radio Electrons Libres
+  streamUrl: https://listen.radioking.com/radio/427889/stream/481499
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://electronslibres.ch/favicon.ico
+  homepage: https://electronslibres.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-radio-vintage
+  stationuuid: b081d89a-ded2-42a6-aac1-ac8879870b44
+  changeuuid: 899f745f-06e1-47dd-aadb-535de74b2464
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: RADIO VINTAGE
+  streamUrl: https://radiovintage.ice.infomaniak.ch/radiovintage-128.mp3?ua=RADIO%20VINTAGE%20-%20audio%20player%201
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://www.radio-vintage.com/wp-content/uploads/2020/12/cropped-logo-4.png
+  homepage: https://www.radio-vintage.com/
+  country: CH
+  status: stream-only
+
+- id: ch-radio-sudostschweiz
+  stationuuid: 4b8d625c-a8fc-4e4c-bbbf-62af99e78568
+  changeuuid: fe8ee51a-4670-4e8c-99ac-92bfff68b1ca
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Radio Südostschweiz
+  streamUrl: https://somedia-1.streaming.deliver.media/rso_mp3_128?suffix0=RSO
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://www.suedostschweiz.ch/themes/suedostschweiz/logo.svg
+  homepage: https://rso.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-one-fm
+  stationuuid: 23184af4-6a87-4cb4-a47f-5936ffd0f673
+  changeuuid: 53d93299-a56c-41d8-b8bf-2602d4dc2612
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: One FM
+  streamUrl: https://onefm.ice.infomaniak.ch/onefm-high.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://cdn-profiles.tunein.com/s7567/images/bannerx.jpg?t=636482377033470000
+  homepage: https://www.onefm.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-vertical-radio
+  stationuuid: de81082f-b5cb-4450-a9d5-a1f6b5ebe5f4
+  changeuuid: 9792ce6f-e4ef-4109-82d8-529189e6dc75
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Vertical Radio
+  streamUrl: https://verticalradio.ice.infomaniak.ch/verticalradio-128.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://www.verticalradio.ch/media/image/11/base/logo-vertical-green.svg?undefined
+  homepage: https://www.verticalradio.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-radio-3fach
+  stationuuid: 8d36363c-f60f-45d8-afe1-659c9fc4071c
+  changeuuid: 7ac71437-7ce7-4e65-9ea1-d0fbcbcee43c
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Radio 3FACH
+  streamUrl: https://stream01.3fach.ch/live
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://3fach.ch/themes/3fach/assets/logo_black@2x.png
+  homepage: https://3fach.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-diks
+  stationuuid: 2334b1a6-5eaa-42a3-a03c-799554914a20
+  changeuuid: d833af07-8997-4c99-8c2d-5dedcaf78d82
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: DIKS ДИКС
+  streamUrl: https://icecast.correctiv.net/sacharow
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  homepage: https://icecast.correctiv.net/sacharow
+  country: CH
+  status: stream-only
+
+- id: ch-radio-zurich-nord
+  stationuuid: 2b96ded7-dcf5-4a27-bfd8-2ad09295b0e0
+  changeuuid: 0ffd4435-0f62-4eae-a7ee-3fad0f9448e7
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Radio Zürich Nord
+  streamUrl: https://bayern.streampanel.cloud:11145/stream
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  homepage: https://bayern.streampanel.cloud:11145/stream
+  country: CH
+  status: stream-only
+
+- id: ch-radiofr-fresh
+  stationuuid: 69641b03-0907-45e1-888f-79fadb9fe6bf
+  changeuuid: bfc9b6b2-6566-40c3-98d3-e9f01b0ca74c
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: RadioFr. Fresh
+  streamUrl: https://radiofresh.ice.infomaniak.ch/radiofresh.aac
+  bitrate: 128
+  codec: AAC
+  tags: [pop, switzerland]
+  homepage: https://www.radiofr.ch/fresh
+  country: CH
+  status: stream-only
+
+- id: ch-walts-welt
+  stationuuid: ac25562f-560b-499c-b945-3e5adc399d00
+  changeuuid: 40aecf87-7f70-489b-91d3-1efeb4cb6794
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: WALTS WELT
+  streamUrl: https://waltswelt.out.airtime.pro/waltswelt_a?_ga=2.33964516.474222732.1669644968-446937151.1669306237
+  bitrate: 64
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://waltswelt.ch/wp-content/uploads/2017/06/cropped-favicon_512x512_2-150x150.png
+  homepage: https://waltswelt.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-urbn-radio
+  stationuuid: 65309759-6273-4340-a287-67ce6cca538f
+  changeuuid: dd45ee92-6ab8-45eb-af94-b1966ee7fe7b
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: URBN Radio
+  streamUrl: https://dr2101.ice.infomaniak.ch/dr2103.mp3
+  bitrate: 192
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://urbnradio.ch/favicon.ico
+  homepage: https://urbnradio.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-jukebox-nonstop-music
+  stationuuid: 9edf64c6-40f0-41d8-88de-ef77fb3803c7
+  changeuuid: b066f3bf-e1f7-4deb-a4d5-1d9e9d60677a
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Jukebox - Nonstop Music
+  streamUrl: https://kreuzbergswiss.sp.radio.fm/stream.hls
+  bitrate: 320
+  codec: HLS
+  tags: [switzerland]
+  favicon: https://jukebox.kreuzbergswiss.ch/images/favicon.ico
+  homepage: https://jukebox.kreuzbergswiss.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-radio-ouistiti
+  stationuuid: aaa4e936-93aa-4e4c-a53d-cf0a019b0df0
+  changeuuid: 957e2718-2977-4aa1-b99c-5d4cf7cf9082
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: RADIO OUISTITI
+  streamUrl: https://radioouistiti2.ice.infomaniak.ch/radioouistiti-high.mp3?_=1
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://www.radioouistiti.ch/wp-content/uploads/2024/11/radioouistiti_logo.png
+  homepage: https://www.radioouistiti.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-radio-2go
+  stationuuid: 56f7dd34-4213-4773-88ae-7337ed2ca422
+  changeuuid: 60e16030-07b6-4c14-92b8-1f60062a7089
+  reviewedAt: 2026-05-04
+  geo: [47.480, 8.211]
+  broadcaster: independent
+  name: Radio 2Go
+  streamUrl: https://uksoutha.streaming.broadcast.radio:15830/radio2go
+  codec: MP3
+  tags: [pop, switzerland]
+  favicon: https://radio2go.fm/wp-content/uploads/2020/06/favicon.png
+  homepage: https://www.radio2go.fm/
+  country: CH
+  status: stream-only
+
+- id: ch-radio-rocher
+  stationuuid: 1e255d42-ef19-4060-aaa5-a0f2f0c2a2d7
+  changeuuid: 837e641e-6776-473d-8e85-9532eabcd0df
+  reviewedAt: 2026-05-04
+  geo: [46.998, 6.934]
+  broadcaster: independent
+  name: Radio Rocher
+  streamUrl: https://play.radioking.io/radio-rocher/429886
+  bitrate: 192
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://image.radioking.io/radios/321905/logo/26ca805b-11bd-49c0-a13d-d357fb33ffd0.jpeg
+  homepage: https://www.radio-rocher.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-abdulbasit-abdulsamad
+  stationuuid: 5b91451d-b697-48f5-8b41-9d36c586b30d
+  changeuuid: e45893c4-226e-4a33-b866-ef6529ad996e
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: . Abdulbasit Abdulsamad
+  streamUrl: https://radio.mp3islam.com/listen/abdulbasit/radio.mp3
+  bitrate: 192
+  codec: MP3
+  tags: [switzerland]
+  favicon: null
+  homepage: https://mp3islam.com/
+  country: CH
+  status: stream-only
+
+
+- id: ch-la-radio-du-bord-de-l-eau
+  stationuuid: 5ff66832-e6b3-486b-bac8-e00ca29b6f67
+  changeuuid: fcb2333e-91d4-449a-b065-d0fd1257bae6
+  reviewedAt: 2026-05-04
+  geo: [46.291, 7.531]
+  broadcaster: independent
+  name: La Radio du bord de l’eau
+  streamUrl: https://listen.radioking.com/radio/181657/stream/223420
+  bitrate: 128
+  codec: MP3
+  tags: [electronic, switzerland]
+  favicon: https://image.radioking.io/radios/181657/logo/098b1c15-74cf-4638-b264-517fb9b06eac.jpeg
+  homepage: https://www.auborddeleau.bar/radio/
+  country: CH
+  status: stream-only
+
+- id: ch-radio-bollwerk
+  stationuuid: e1b48285-78a9-4e33-b0bd-cfc1bb59b838
+  changeuuid: ac2ad179-a785-4770-8002-634ced8a6448
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Radio Bollwerk
+  streamUrl: https://radio.radio-bollwerk.ch/listen/radio_bollwerk/radio.mp3
+  bitrate: 320
+  codec: MP3
+  tags: [switzerland]
+  homepage: https://www.radio-bollwerk.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-trasformatorio
+  stationuuid: 5f46b851-bd50-4891-8229-1d86e2cf4cfd
+  changeuuid: a5d9824a-8db9-4a79-97dd-8ea590bc3d58
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Trasformatorio
+  streamUrl: https://radio.dyne.org/trasformatorio-archives.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://trasformatorio.net/wp-content/uploads/2013/07/cropped-logotondo-2.png
+  homepage: https://trasformatorio.net/
+  country: CH
+  status: stream-only
+
+- id: ch-cm-radio-crans-montana
+  stationuuid: e31e2db4-5b41-4318-8665-62b0b244f85f
+  changeuuid: c11a3663-f4a1-49f8-9eb3-d4da995e6f9c
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: CM Radio Crans-Montana
+  streamUrl: https://listen.radioking.com/radio/605899/stream/669205
+  bitrate: 320
+  codec: MP3
+  tags: [switzerland]
+  homepage: https://www.crans-montana.radio/
+  country: CH
+  status: stream-only
+
+- id: ch-jam-on-radio
+  stationuuid: a805fab4-126a-4d4a-9801-19295138d569
+  changeuuid: 10ff589f-983f-4a7c-9ccc-6c50085659e6
+  reviewedAt: 2026-05-04
+  geo: [47.182, 8.521]
+  broadcaster: independent
+  name: Jam On Radio
+  streamUrl: https://jam-on.ice.infomaniak.ch/jam-on-128.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://jam-on.ch/img/apple-touch-icon.png
+  homepage: https://jam-on.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-onflow-hot
+  stationuuid: 549ffb7b-879e-474f-8eda-806d8e2b05a2
+  changeuuid: bfdfdc62-2773-48c2-bf0c-df43ad46fd84
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: OnFlow Hot
+  streamUrl: https://stream.zeno.fm/pxqdhcb7gqutv
+  codec: MP3
+  tags: [switzerland]
+  homepage: https://api.zeno.fm/mounts/metadata/subscribe/aeppezbhdfkvv
+  country: CH
+  status: stream-only
+
+- id: ch-provoda-ch-legacy-mp3
+  stationuuid: d6bcb339-3b71-43d8-8bd7-43cbeb9d9e28
+  changeuuid: cbee7a8f-f0c4-4996-b203-79c4e7eac3e1
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Provoda.ch LEGACY MP3
+  streamUrl: https://station.waveradio.org/provodach.mp3?irqlzgjdlfohjixsouex
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://provoda.ch/favicon.ico
+  homepage: http://provoda.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-queer-radio
+  stationuuid: 508271d8-11db-4a9c-940d-d109b56c09c7
+  changeuuid: ac34fc2e-0011-4fe4-85fd-5f8a70d7939a
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: QUEER RADIO
+  streamUrl: https://solid67.streamupsolutions.com/proxy/eyprxrqz?mp=/stream
+  bitrate: 192
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://www.queerradio.ch/wp-content/uploads/2019/10/QUEER-RADIO-HEART-PLAYER-180-180-pixel-150x150.jpg
+  homepage: https://www.queerradio.ch/
+  country: CH
+  status: stream-only
+
+- id: ch-agaune-radio
+  stationuuid: b473bb7b-5d62-42ce-9c92-3f61a65c6f2f
+  changeuuid: 350d55cd-9a41-46e4-86a5-ea0929907e50
+  reviewedAt: 2026-05-04
+  geo: [46.215, 7.004]
+  broadcaster: independent
+  name: Agaune Radio
+  streamUrl: https://stream.zeno.fm/0r0xa792kwzuv
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://www.agaune.radio/upload/design/69a67c2b9ba951.58189328.png
+  homepage: https://www.agaune.radio/
+  country: CH
+  status: stream-only
+
+- id: ch-anntenne-jesus-live
+  stationuuid: 6f774e8a-12d1-4835-acfe-9d398075aaed
+  changeuuid: 126d708f-adda-4577-9654-04b40b9689e2
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Anntenne Jesus Live
+  streamUrl: https://radio.antennejesus.live/listen/antennejesuslive/radio.mp3
+  bitrate: 192
+  codec: MP3
+  tags: [gospel, switzerland]
+  homepage: https://antennejesus.live/
+  country: CH
+  status: stream-only
+
+- id: ch-pureglow-radio
+  stationuuid: 9d43d519-7eeb-4161-a73a-734108fb3f4c
+  changeuuid: 22d1a1ae-5e5c-4d2a-85ff-372fb18881fe
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: PureGlow Radio
+  streamUrl: https://pureglowradio.ice.infomaniak.ch/pureglowradio.mp3
+  bitrate: 128
+  codec: MP3
+  tags: [switzerland]
+  favicon: https://2023.pureglowradio.com/wp-content/uploads/2016/09/logo-dark-pgr-2.png
+  homepage: https://www.pureglowradio.com/
+  country: CH
+  status: stream-only
+
+- id: ch-radio-freundes-dienst-schweiz
+  stationuuid: 015d2e92-e261-450a-8fe0-8f62b11d4a6e
+  changeuuid: bfdd5561-87da-4e28-bf78-6c77d64bd0ef
+  reviewedAt: 2026-05-04
+  geo: [46.948, 7.447]
+  broadcaster: independent
+  name: Radio Freundes-Dienst Schweiz
+  streamUrl: https://stream.radiofd.ch/radiofd/mp3_128/radiobrowser
+  bitrate: 128
+  codec: MP3
+  tags: [news, switzerland]
+  homepage: https://www.radiofd.ch/
+  country: CH
+  status: stream-only
 # ─── FR — Radio France public broadcaster (2026-04-29) ───
 # Pattern: https://icecast.radiofrance.fr/<slug>-hifi.aac (192 AAC).
 # RB stores http:// for the same hosts → broken-mixed; HTTPS works.

--- a/public/station-duplicates.json
+++ b/public/station-duplicates.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-05-04T13:56:23.914Z",
-  "totalScanned": 906,
+  "generatedAt": "2026-05-04T14:05:14.256Z",
+  "totalScanned": 936,
   "collisionCount": 0,
   "byKind": {
     "stationuuid": 0,

--- a/public/station-duplicates.json
+++ b/public/station-duplicates.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-05-04T13:45:00.157Z",
-  "totalScanned": 876,
+  "generatedAt": "2026-05-04T13:56:23.914Z",
+  "totalScanned": 906,
   "collisionCount": 0,
   "byKind": {
     "stationuuid": 0,

--- a/public/station-duplicates.json
+++ b/public/station-duplicates.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-05-04T08:09:24.649Z",
-  "totalScanned": 771,
+  "generatedAt": "2026-05-04T13:45:00.157Z",
+  "totalScanned": 876,
   "collisionCount": 0,
   "byKind": {
     "stationuuid": 0,

--- a/public/stations.json
+++ b/public/stations.json
@@ -917,6 +917,2025 @@
       "status": "icy-only"
     },
     {
+      "id": "ch-80s-forever-we-keep-the-80s-alive",
+      "name": "80s Forever - We Keep The 80s Alive",
+      "broadcaster": "independent",
+      "streamUrl": "https://premium.shoutcastsolutions.com/radio/8050/256.mp3",
+      "homepage": "https://www.80sforever.radio/",
+      "country": "CH",
+      "tags": [
+        "pop",
+        "indie",
+        "rock",
+        "oldies",
+        "switzerland"
+      ],
+      "favicon": "https://www.80sforever.radio/favicon.ico",
+      "bitrate": 256,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-ambi-nature-radio",
+      "name": "Ambi Nature Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://nature-rex.radioca.st/stream",
+      "homepage": "https://www.ambinature.xyz/",
+      "country": "CH",
+      "tags": [
+        "ambient",
+        "switzerland"
+      ],
+      "favicon": "https://cdn-radiotime-logos.tunein.com/s266086d.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-spoon-radio-classic-rock",
+      "name": "Spoon Radio - Classic Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://spoonradioclassicrock.ice.infomaniak.ch/spoon-classicrock-hd.aac",
+      "homepage": "https://www.spoonradio.com/",
+      "country": "CH",
+      "tags": [
+        "rock",
+        "classical",
+        "switzerland"
+      ],
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-spoon-radio-hard-rock",
+      "name": "Spoon Radio - Hard Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://spoonradiohardrock.ice.infomaniak.ch/spoon-hardrock-hd.aac",
+      "homepage": "https://www.spoonradio.com/",
+      "country": "CH",
+      "tags": [
+        "rock",
+        "switzerland"
+      ],
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-spoon-radio-rock-ballads",
+      "name": "Spoon Radio - Rock Ballads",
+      "broadcaster": "independent",
+      "streamUrl": "https://spoonradiorockballads.ice.infomaniak.ch/spoon-rockballads-hd.aac",
+      "homepage": "https://www.spoonradio.com/",
+      "country": "CH",
+      "tags": [
+        "rock",
+        "switzerland"
+      ],
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-one-dance-ticino",
+      "name": "One Dance Ticino",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice15.fluidstream.net/onedancech.aac",
+      "homepage": "https://onedancefm.ch/",
+      "country": "CH",
+      "tags": [
+        "electronic",
+        "pop",
+        "switzerland"
+      ],
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-1-fm-beloved-ballads",
+      "name": "1.FM Beloved Ballads",
+      "broadcaster": "independent",
+      "streamUrl": "https://strm112.1.fm/onelive_mobile_mp3?",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-spoon-radio-modern-rock",
+      "name": "Spoon Radio - Modern Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://spoonradiomodernrock.ice.infomaniak.ch/spoon-modernrock-hd.aac",
+      "homepage": "https://www.spoonradio.com/",
+      "country": "CH",
+      "tags": [
+        "rock",
+        "switzerland"
+      ],
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-swiss-groove",
+      "name": "SWISS GROOVE",
+      "broadcaster": "independent",
+      "streamUrl": "https://relay2.swissgroove.ch/;",
+      "homepage": "https://swissgroove.ch/",
+      "country": "CH",
+      "tags": [
+        "jazz",
+        "latin",
+        "lounge",
+        "soul",
+        "switzerland"
+      ],
+      "favicon": "https://swissgroove.ch/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-skuizz-hits-90s-00s",
+      "name": "Skuizz Hits 90s-00s",
+      "broadcaster": "independent",
+      "streamUrl": "https://traxx024.ice.infomaniak.ch/traxx024-1.mp3",
+      "homepage": "https://skuizz.com/",
+      "country": "CH",
+      "tags": [
+        "pop",
+        "rock",
+        "oldies",
+        "switzerland"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-a-fine-jazz-gumbo-radio",
+      "name": "A Fine Jazz Gumbo Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.smartradio.ch:9502/stream",
+      "homepage": "https://jazzgumboradio.com/",
+      "country": "CH",
+      "tags": [
+        "jazz",
+        "switzerland"
+      ],
+      "favicon": "https://jazzgumboradio.com/favicon.ico",
+      "bitrate": 48,
+      "codec": "AAC",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-maxxima",
+      "name": "Radio Maxxima",
+      "broadcaster": "independent",
+      "streamUrl": "https://maxxima.mine.nu/maxxima.mp3",
+      "homepage": "https://www.maxxima.org/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        46.587,
+        7.753
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-rtn",
+      "name": "RTN",
+      "broadcaster": "independent",
+      "streamUrl": "https://rtn.ice.infomaniak.ch/rtn-high.mp3",
+      "homepage": "http://www.rtn.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-one-fm-2000s",
+      "name": "One FM 2000s",
+      "broadcaster": "independent",
+      "streamUrl": "https://webradio0009.ice.infomaniak.ch/webradio0009-128.mp3",
+      "homepage": "https://www.onefm.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://www.onefm.ch/wp-content/uploads/2018/08/favicon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-spoon-radio-acoustic-rock",
+      "name": "Spoon Radio - Acoustic Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://spoonradioacousticrock.ice.infomaniak.ch/spoon-acousticrock-hd.aac",
+      "homepage": "https://www.spoonradio.com/",
+      "country": "CH",
+      "tags": [
+        "rock",
+        "switzerland"
+      ],
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-lac",
+      "name": "Radio Lac",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiolac.ice.infomaniak.ch/radiolac-high.mp3",
+      "homepage": "https://www.radiolac.ch/direct/player/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://www.radiolac.ch/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-goat-radio",
+      "name": "GOAT Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://20min.dmd2streaming.com/20minuten_radio_64.aac",
+      "homepage": "https://audio.20min.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://cdn.unitycms.io/images/DQapoIlBq478hc9HagcAw7.png",
+      "bitrate": 64,
+      "codec": "AAC",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-basspistol-radio",
+      "name": "Basspistol Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.basspistol.com/radio.mp3",
+      "homepage": "https://basspistol.com/radio",
+      "country": "CH",
+      "tags": [
+        "electronic",
+        "hip-hop",
+        "indie",
+        "switzerland"
+      ],
+      "favicon": "https://basspistol.com/siteicon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.207,
+        6.156
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-zurisee",
+      "name": "Radio Zürisee",
+      "broadcaster": "independent",
+      "streamUrl": "https://mp3.radio.ch/radiozuerisee256k",
+      "homepage": "https://www.radiozuerisee.ch/",
+      "country": "CH",
+      "tags": [
+        "rock",
+        "pop",
+        "switzerland"
+      ],
+      "favicon": "https://www.radiozuerisee.ch/assets/favicons/apple-icon-120x120.png",
+      "bitrate": 256,
+      "codec": "MP3",
+      "geo": [
+        47.226,
+        8.817
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-spoon-radio-alternative-rock",
+      "name": "Spoon Radio - Alternative Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://spoonradioalternativerock.ice.infomaniak.ch/spoon-alternativerock-hd.aac",
+      "homepage": "https://www.spoonradio.com/",
+      "country": "CH",
+      "tags": [
+        "alternative",
+        "rock",
+        "switzerland"
+      ],
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio1-ch",
+      "name": "Radio1.ch",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radio1.ch/128k",
+      "homepage": "https://radio1.ch/",
+      "country": "CH",
+      "tags": [
+        "pop",
+        "switzerland"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-break-radio",
+      "name": "Break Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://breakradio.ice.infomaniak.ch/breakradio-192.mp3",
+      "homepage": "https://www.breakradio.ch/",
+      "country": "CH",
+      "tags": [
+        "hip-hop",
+        "switzerland"
+      ],
+      "favicon": "https://www.breakradio.ch/apple-touch-icon.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        46.225,
+        7.352
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-rocket",
+      "name": "Radio Rocket",
+      "broadcaster": "independent",
+      "streamUrl": "https://i9.streams.ovh/sc/radioroc/stream",
+      "homepage": "https://radiorocket.ch/",
+      "country": "CH",
+      "tags": [
+        "alternative",
+        "rock",
+        "switzerland"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-one-fm-90s",
+      "name": "One FM 90s",
+      "broadcaster": "independent",
+      "streamUrl": "https://webradio0006.ice.infomaniak.ch/webradio0006-128.mp3",
+      "homepage": "https://www.onefm.ch/",
+      "country": "CH",
+      "tags": [
+        "oldies",
+        "switzerland"
+      ],
+      "favicon": "https://www.onefm.ch/wp-content/uploads/2018/08/favicon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-wrs-swiss-radio-in-english",
+      "name": "WRS \"Swiss Radio in English\"",
+      "broadcaster": "independent",
+      "streamUrl": "https://uksouth.streaming.broadcast.radio:10290/wrs?_=443217",
+      "homepage": "https://www.worldradio.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://mmo.aiircdn.com/29/61eaca66a914b.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-arc-musique",
+      "name": "Arc Musique",
+      "broadcaster": "independent",
+      "streamUrl": "https://arcmusique.ice.infomaniak.ch/arcmusique-128.mp3",
+      "homepage": "http://arcmusique.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-happy-radio",
+      "name": "Happy Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://uksoutha.streaming.broadcast.radio/stream/11340/gtradio?1672903939995",
+      "homepage": "https://www.happy-radio.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://goodtimeradio.broadcast.radio/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-summernight",
+      "name": "Radio Summernight",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/radiosummernight",
+      "homepage": "https://radiosummernight.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-top-ostschweiz",
+      "name": "Radio Top (Ostschweiz)",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiotop.ice.infomaniak.ch/radiotop96.aac",
+      "homepage": "https://www.toponline.ch/",
+      "country": "CH",
+      "tags": [
+        "news",
+        "pop",
+        "switzerland"
+      ],
+      "favicon": "https://www.toponline.ch/fileadmin/templates/logos/apple-touch-icon.png",
+      "bitrate": 96,
+      "codec": "AAC",
+      "geo": [
+        47.505,
+        8.714
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-gloria",
+      "name": "Radio Gloria",
+      "broadcaster": "independent",
+      "streamUrl": "https://ch-be06-ice.dmd2streaming.com/radiogloria_lo",
+      "homepage": "https://radiogloria.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://radiogloria.ch/favicon.ico",
+      "bitrate": 96,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-1-fm-classic-rock",
+      "name": "1.fm classic rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://strm112.1.fm/crock_mobile_mp3",
+      "homepage": "https://www.1.fm/station/crock",
+      "country": "CH",
+      "tags": [
+        "rock",
+        "classical",
+        "switzerland"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-bear-metal-radio",
+      "name": "Bear Metal Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast5.asurahosting.com/proxy/bear?mp=/stream",
+      "homepage": "https://www.bearmetalradio.com/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://www.bearmetalradio.com/images/logo.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-rfj",
+      "name": "RFJ",
+      "broadcaster": "independent",
+      "streamUrl": "https://rfj.ice.infomaniak.ch/rfj-high.mp3",
+      "homepage": "http://www.rfj.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-energy-bern",
+      "name": "Energy Bern",
+      "broadcaster": "independent",
+      "streamUrl": "https://energybern.ice.infomaniak.ch/energybern-high.mp3",
+      "homepage": "https://energy.ch/stations/energy-bern",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://cdn.energy.ch/energych-broadcast/covers/channels/logo_v2_bern_1638178870.svg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.448
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-lora-97-5",
+      "name": "Radio LoRa 97.5",
+      "broadcaster": "independent",
+      "streamUrl": "https://livestream.lora.ch/lora.mp3",
+      "homepage": "https://www.lora.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://www.lora.ch/images/favicon/apple-touch-icon.png",
+      "codec": "MP3",
+      "geo": [
+        47.378,
+        8.529
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-20minuten-radio-dab-goat-radio",
+      "name": "20minuten.radio DAB+ (GOAT Radio)",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.digris.ch/stream/897a2939-b6db-42c6-8760-28908bcf8b25",
+      "homepage": "https://www.20min.ch/radio",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "bitrate": 256,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-james-fm",
+      "name": "JAMES FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://jamesfm.ice.infomaniak.ch/jamesfm.mp3",
+      "homepage": "https://www.jamesfm.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        47.162,
+        8.437
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-fribourg",
+      "name": "Radio Fribourg",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiofribourg.ice.infomaniak.ch/radiofribourg-high.mp3",
+      "homepage": "https://radiofr.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://radiofr.ch/favicons/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-grenzenlos-radio-grenzenlos-spcast",
+      "name": "Radio grenzenlos,Radio grenzenlos [SPCast]",
+      "broadcaster": "independent",
+      "streamUrl": "https://grenzenlos.sp.radio.fm/stream",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "CH",
+      "tags": [
+        "electronic",
+        "pop",
+        "switzerland"
+      ],
+      "favicon": "https://radio.grenzenlos.ch/logo.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        47.476,
+        7.733
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-drachenblut",
+      "name": "Radio-Drachenblut",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio-drachenblut.ch:8443/listen.mp3",
+      "homepage": "https://radio-drachenblut.ch/",
+      "country": "CH",
+      "tags": [
+        "rock",
+        "switzerland"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-bachata-nation-radio",
+      "name": "Bachata Nation Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.zeno.fm/vwcq5n2rruhvv",
+      "homepage": "https://stream.zeno.fm/",
+      "country": "CH",
+      "tags": [
+        "latin",
+        "switzerland"
+      ],
+      "codec": "MP3",
+      "geo": [
+        47.375,
+        8.542
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-one-fm-new-hits",
+      "name": "One FM New-Hits",
+      "broadcaster": "independent",
+      "streamUrl": "https://webradio0001.ice.infomaniak.ch/webradio0001-128.mp3",
+      "homepage": "https://onefm.ch/",
+      "country": "CH",
+      "tags": [
+        "pop",
+        "switzerland"
+      ],
+      "favicon": "https://www.onefm.ch/wp-content/uploads/2017/07/logos-1.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-canal3-deutsch",
+      "name": "Canal3 deutsch",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.upstream-cloud.ch/canal3allemand-192.aac",
+      "homepage": "https://web.canal3.ch/",
+      "country": "CH",
+      "tags": [
+        "news",
+        "pop",
+        "switzerland"
+      ],
+      "favicon": "https://web.canal3.ch/de/sites/all/themes/canal3_theme_v2/favicon.ico",
+      "bitrate": 192,
+      "codec": "AAC",
+      "geo": [
+        47.136,
+        7.243
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-uzic-ch-techno-minimal-best-of-electronic-with-t",
+      "name": "UZIC.CH",
+      "broadcaster": "independent",
+      "streamUrl": "https://uzic.ice.infomaniak.ch/uzic-128.aac",
+      "homepage": "https://uzic.ch/",
+      "country": "CH",
+      "tags": [
+        "electronic",
+        "switzerland"
+      ],
+      "favicon": "https://uzic.ch/wp-content/uploads/2025/06/logo_uzic-150x150.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-electrons-libres",
+      "name": "Electrons Libres",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/427889/stream/481505",
+      "homepage": "https://electronslibres.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://electronslibres.ch/wp-content/uploads/2021/06/cropped-LogoRadioSimpleSansTxt-1.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        46.951,
+        7.067
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-grischa",
+      "name": "Radio Grischa",
+      "broadcaster": "independent",
+      "streamUrl": "https://somedia-4.streaming.deliver.media/radiogrischa_mp3_128",
+      "homepage": "https://www.radiogrischa.ch/",
+      "country": "CH",
+      "tags": [
+        "news",
+        "switzerland"
+      ],
+      "favicon": "https://www.radiogrischa.ch/themes/custom/grischa/images/logos/RG_Signet.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-s",
+      "name": "Radio S",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radio-s.ch/stream",
+      "homepage": "https://stream.radio-s.ch/stream",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://static.wixstatic.com/media/d168f9_11af99f87f4448daaf0e1bda1d1a1169~mv2.png/v1/fill/w_180,h_125,al_c,q_85,usm_0.66_1.00_0.01,enc_auto/LOGO%20Radio%20S.png",
+      "bitrate": 185,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-christmas-radio-fm",
+      "name": "Christmas Radio FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://xmasfm1.dmd2streaming.com/christmasradiofm-128.mp3",
+      "homepage": "http://christmasradio.fm/christmasgateway/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-sabaton",
+      "name": "Sabaton радио",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.pcradio.ru/sabaton-hi",
+      "homepage": "https://pcradio.ru/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "codec": "AAC",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-ip-music-slow-aacplus-96-kb-s",
+      "name": "IP music SLOW - aacPlus@96 Kb/s",
+      "broadcaster": "independent",
+      "streamUrl": "https://live9.avf.ch/ipmusicslowaacp96",
+      "homepage": "https://www.ipmusicslow.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://www.ipmusicslow.ch/images/logo-ipmusicslow.png",
+      "bitrate": 96,
+      "codec": "AAC",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-lfm",
+      "name": "LFM",
+      "broadcaster": "independent",
+      "streamUrl": "https://lausannefm.ice.infomaniak.ch/lausannefm-high.mp3",
+      "homepage": "https://www.lfm.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://www.lfm.ch/wp-content/uploads/2021/07/cropped-radio-lausanne-fm-sa-icone-du-site-180x180.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-neo1",
+      "name": "Neo1",
+      "broadcaster": "independent",
+      "streamUrl": "https://neo1.ice.infomaniak.ch/neo1.mp3",
+      "homepage": "https://www.neo1.ch/",
+      "country": "CH",
+      "tags": [
+        "pop",
+        "rock",
+        "switzerland"
+      ],
+      "favicon": "https://www.neo1.ch/fileadmin/user_upload/newsaudio/2018/11/neo1-logo.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        46.939,
+        7.784
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-country-radio-switzerland",
+      "name": "Country Radio Switzerland",
+      "broadcaster": "independent",
+      "streamUrl": "https://countryradioswitzerland.ice.infomaniak.ch/crs-128.mp3",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "CH",
+      "tags": [
+        "country",
+        "switzerland"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-driftfm",
+      "name": "driftFM",
+      "broadcaster": "independent",
+      "streamUrl": "https://s4.radio.co/s5729f2e59/listen",
+      "homepage": "https://www.drift.fm/",
+      "country": "CH",
+      "tags": [
+        "country",
+        "switzerland"
+      ],
+      "favicon": "https://www.drift.fm/wp-content/uploads/2020/06/Drift-FM_Logo_transparent_400px_00c8007a1_1367.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-munot",
+      "name": "Radio Munot",
+      "broadcaster": "independent",
+      "streamUrl": "https://munot.ch-central-4.streaming.deliver.media/munot_mp3_128",
+      "homepage": "https://www.radiomunot.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://www.radiomunot.ch/assets/favicons/android-icon-192x192.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        47.692,
+        8.626
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-stadtfilter-dab",
+      "name": "Radio Stadtfilter (DAB+)",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.digris.ch/stream/8a1a42f0-3f59-4113-b544-aad9275d34a7",
+      "homepage": "https://stadtfilter.ch/",
+      "country": "CH",
+      "tags": [
+        "pop",
+        "switzerland"
+      ],
+      "bitrate": 160,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio3i",
+      "name": "Radio3i",
+      "broadcaster": "independent",
+      "streamUrl": "https://vstream-cdn.ch/hls/radio3i.m3u8",
+      "homepage": "https://radio3i.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://radio3i.ch/assets/images/app-logo.png",
+      "bitrate": 2628,
+      "codec": "HLS",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-rockstar-radio",
+      "name": "Rockstar Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://dr2101.ice.infomaniak.ch/dr2102.mp3",
+      "homepage": "https://rockstarradio.ch/",
+      "country": "CH",
+      "tags": [
+        "rock",
+        "switzerland"
+      ],
+      "favicon": "https://dr21.mediaonegroup.ch/apps/assets/logo_rockstar_2.svg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        46.521,
+        6.633
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-wildmountain-radio",
+      "name": "Wildmountain Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://wildmountain.ice.infomaniak.ch/wmr.mp3",
+      "homepage": "https://www.wildmountain.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://www.wildmountain.ch/favicon.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-back2noize-radio",
+      "name": "Back2Noize Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://securestreams4.autopo.st:1558/Back2Noize",
+      "homepage": "https://back2noize.com/",
+      "country": "CH",
+      "tags": [
+        "electronic",
+        "switzerland"
+      ],
+      "favicon": "https://back2noize.com/wp-content/uploads/2019/08/back2noize-logo-round-300x300.jpg",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        46.556,
+        6.51
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-r-louange",
+      "name": "Radio R Louange",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiorlouange.ice.infomaniak.ch/radiorlouange-96.aac?ver=666978",
+      "homepage": "https://radio-r.ch/",
+      "country": "CH",
+      "tags": [
+        "gospel",
+        "switzerland"
+      ],
+      "favicon": "https://radio-r.ch/wp-content/uploads/2024/03/radio-r-louange_cover_cropOK_1080x1080px-170x170.png",
+      "bitrate": 96,
+      "codec": "AAC",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-rasa-schaffhausen",
+      "name": "Radio Rasa Schaffhausen",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.upstream-cloud.ch/radiorasa-128.mp3",
+      "homepage": "https://www.rasa.ch/",
+      "country": "CH",
+      "tags": [
+        "alternative",
+        "indie",
+        "switzerland"
+      ],
+      "favicon": "https://www.rasa.ch/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        47.696,
+        8.634
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-dream-sequence",
+      "name": "Dream Sequence",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/453296/stream/508976",
+      "homepage": "https://www.dreamsequence.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://static.wixstatic.com/media/e05539_cbaf7759467242c1843d8bac2619e127~mv2.png/v1/crop/x_9,y_0,w_3107,h_1875/fill/w_490,h_296,al_c,q_85,usm_0.66_1.00_0.01,enc_auto/customcolor_logo_transparent_background.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-80ies-dot-radio",
+      "name": "80ies dot radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radiojar.com/6cbvkaa1mrruv?1643199882",
+      "homepage": "https://www.80ies.radio/",
+      "country": "CH",
+      "tags": [
+        "oldies",
+        "switzerland"
+      ],
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-kiss-collector-radio",
+      "name": "Kiss Collector Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://dr2101.ice.infomaniak.ch/dr2101.mp3",
+      "homepage": "https://kisscollector.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://kisscollector.ch/favicon.ico",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-one-fm-rock-oldies",
+      "name": "One FM Rock Oldies",
+      "broadcaster": "independent",
+      "streamUrl": "https://webradio0002.ice.infomaniak.ch/webradio0002-128.mp3",
+      "homepage": "https://www.onefm.ch/",
+      "country": "CH",
+      "tags": [
+        "rock",
+        "oldies",
+        "switzerland"
+      ],
+      "favicon": "https://www.onefm.ch/wp-content/themes/mog-child/webradios/ONE_app_WEBRADIO_Rock.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-ktfm-geneva-the-best-of-70-s-and-80-s",
+      "name": "KTfm Geneva - THE BEST OF 70'S AND 80'S",
+      "broadcaster": "independent",
+      "streamUrl": "https://ktfm.ice.infomaniak.ch/ktfm-high.mp3",
+      "homepage": "https://ktfm-radio.ch/",
+      "country": "CH",
+      "tags": [
+        "pop",
+        "oldies",
+        "switzerland"
+      ],
+      "favicon": "https://i0.wp.com/ktfm-radio.ch/wp-content/uploads/2019/12/KTFM-1.png?fit=50%2C50&ssl=1",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-alta",
+      "name": "Radio Alta",
+      "broadcaster": "independent",
+      "streamUrl": "https://transmiss.ion.ovh/listen/alta/radio.mp3",
+      "homepage": "https://transmiss.ion.ovh/public/alta",
+      "country": "CH",
+      "tags": [
+        "gospel",
+        "switzerland"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.31,
+        -6.3
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-spoon-rock",
+      "name": "Spoon Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://ic2527.c972.fastserv.com:80/spoonradio_mp3_192",
+      "homepage": "https://www.spoonradio.com/",
+      "country": "CH",
+      "tags": [
+        "rock",
+        "switzerland"
+      ],
+      "favicon": "https://www.spoonradio.com/newimages/logo.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-rockstation",
+      "name": "ROCKSTATION",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio2.stream24.net:8130/live.mp3",
+      "homepage": "https://rockstation.ch/",
+      "country": "CH",
+      "tags": [
+        "rock",
+        "switzerland"
+      ],
+      "favicon": "https://rockstation.ch/wp-content/uploads/2023/03/cropped-favicon-basis-192x192.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-open-broadcast",
+      "name": "Open Broadcast",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.digris.ch/stream/092210ed-4eb4-483b-814f-21df6ecb1352",
+      "homepage": "https://openbroadcast.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-rundfunk-fm",
+      "name": "Rundfunk.fm",
+      "broadcaster": "independent",
+      "streamUrl": "https://rundfunkfm.broadcast.brandsarelive.com/listen/rundfunk.fm/radio.mp3",
+      "homepage": "https://rundfunk.fm/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://rundfunk.fm/static/assets/favicon/apple-touch-icon.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        47.379,
+        8.541
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-my105-x-mas",
+      "name": "my105 X-MAS",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream01.my105.ch/my105xmas.mp3",
+      "homepage": "https://www.my105.ch/x-mas",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-neue-hoffnung",
+      "name": "Radio Neue Hoffnung",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.mnr.ch/rnh-mp3",
+      "homepage": "https://www.mnr.ch/radio/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://www.mnr.ch/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-ta-radio",
+      "name": "Ta Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.taradio.ch/dab",
+      "homepage": "https://www.taradio.ch/",
+      "country": "CH",
+      "tags": [
+        "electronic",
+        "pop",
+        "rock",
+        "switzerland"
+      ],
+      "bitrate": 96,
+      "codec": "AAC",
+      "geo": [
+        47.009,
+        7.011
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-traxx-fm-hits",
+      "name": "Traxx FM - Hits",
+      "broadcaster": "independent",
+      "streamUrl": "https://traxx010.ice.infomaniak.ch/traxx010-low.mp3",
+      "homepage": "http://www.traxx.fm/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-lux-radio",
+      "name": "LUX RADIO",
+      "broadcaster": "independent",
+      "streamUrl": "https://live7.avf.ch/lux_main",
+      "homepage": "https://luxradio.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://luxradio.ch/wp-content/uploads/2022/03/Logo-Colour.png",
+      "bitrate": 1200,
+      "codec": "OGG",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-electrons-libres",
+      "name": "Radio Electrons Libres",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/427889/stream/481499",
+      "homepage": "https://electronslibres.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://electronslibres.ch/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.951,
+        7.067
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-vintage",
+      "name": "RADIO VINTAGE",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiovintage.ice.infomaniak.ch/radiovintage-128.mp3?ua=RADIO%20VINTAGE%20-%20audio%20player%201",
+      "homepage": "https://www.radio-vintage.com/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://www.radio-vintage.com/wp-content/uploads/2020/12/cropped-logo-4.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-sudostschweiz",
+      "name": "Radio Südostschweiz",
+      "broadcaster": "independent",
+      "streamUrl": "https://somedia-1.streaming.deliver.media/rso_mp3_128?suffix0=RSO",
+      "homepage": "https://rso.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://www.suedostschweiz.ch/themes/suedostschweiz/logo.svg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-one-fm",
+      "name": "One FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://onefm.ice.infomaniak.ch/onefm-high.mp3",
+      "homepage": "https://www.onefm.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://cdn-profiles.tunein.com/s7567/images/bannerx.jpg?t=636482377033470000",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-vertical-radio",
+      "name": "Vertical Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://verticalradio.ice.infomaniak.ch/verticalradio-128.mp3",
+      "homepage": "https://www.verticalradio.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://www.verticalradio.ch/media/image/11/base/logo-vertical-green.svg?undefined",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-3fach",
+      "name": "Radio 3FACH",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream01.3fach.ch/live",
+      "homepage": "https://3fach.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://3fach.ch/themes/3fach/assets/logo_black@2x.png",
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-diks",
+      "name": "DIKS ДИКС",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.correctiv.net/sacharow",
+      "homepage": "https://icecast.correctiv.net/sacharow",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-zurich-nord",
+      "name": "Radio Zürich Nord",
+      "broadcaster": "independent",
+      "streamUrl": "https://bayern.streampanel.cloud:11145/stream",
+      "homepage": "https://bayern.streampanel.cloud:11145/stream",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radiofr-fresh",
+      "name": "RadioFr. Fresh",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiofresh.ice.infomaniak.ch/radiofresh.aac",
+      "homepage": "https://www.radiofr.ch/fresh",
+      "country": "CH",
+      "tags": [
+        "pop",
+        "switzerland"
+      ],
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-walts-welt",
+      "name": "WALTS WELT",
+      "broadcaster": "independent",
+      "streamUrl": "https://waltswelt.out.airtime.pro/waltswelt_a?_ga=2.33964516.474222732.1669644968-446937151.1669306237",
+      "homepage": "https://waltswelt.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://waltswelt.ch/wp-content/uploads/2017/06/cropped-favicon_512x512_2-150x150.png",
+      "bitrate": 64,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-urbn-radio",
+      "name": "URBN Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://dr2101.ice.infomaniak.ch/dr2103.mp3",
+      "homepage": "https://urbnradio.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://urbnradio.ch/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-jukebox-nonstop-music",
+      "name": "Jukebox - Nonstop Music",
+      "broadcaster": "independent",
+      "streamUrl": "https://kreuzbergswiss.sp.radio.fm/stream.hls",
+      "homepage": "https://jukebox.kreuzbergswiss.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://jukebox.kreuzbergswiss.ch/images/favicon.ico",
+      "bitrate": 320,
+      "codec": "HLS",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-ouistiti",
+      "name": "RADIO OUISTITI",
+      "broadcaster": "independent",
+      "streamUrl": "https://radioouistiti2.ice.infomaniak.ch/radioouistiti-high.mp3?_=1",
+      "homepage": "https://www.radioouistiti.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://www.radioouistiti.ch/wp-content/uploads/2024/11/radioouistiti_logo.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-2go",
+      "name": "Radio 2Go",
+      "broadcaster": "independent",
+      "streamUrl": "https://uksoutha.streaming.broadcast.radio:15830/radio2go",
+      "homepage": "https://www.radio2go.fm/",
+      "country": "CH",
+      "tags": [
+        "pop",
+        "switzerland"
+      ],
+      "favicon": "https://radio2go.fm/wp-content/uploads/2020/06/favicon.png",
+      "codec": "MP3",
+      "geo": [
+        47.48,
+        8.211
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-rocher",
+      "name": "Radio Rocher",
+      "broadcaster": "independent",
+      "streamUrl": "https://play.radioking.io/radio-rocher/429886",
+      "homepage": "https://www.radio-rocher.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://image.radioking.io/radios/321905/logo/26ca805b-11bd-49c0-a13d-d357fb33ffd0.jpeg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        46.998,
+        6.934
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-abdulbasit-abdulsamad",
+      "name": ". Abdulbasit Abdulsamad",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.mp3islam.com/listen/abdulbasit/radio.mp3",
+      "homepage": "https://mp3islam.com/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-la-radio-du-bord-de-l-eau",
+      "name": "La Radio du bord de l’eau",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/181657/stream/223420",
+      "homepage": "https://www.auborddeleau.bar/radio/",
+      "country": "CH",
+      "tags": [
+        "electronic",
+        "switzerland"
+      ],
+      "favicon": "https://image.radioking.io/radios/181657/logo/098b1c15-74cf-4638-b264-517fb9b06eac.jpeg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.291,
+        7.531
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-bollwerk",
+      "name": "Radio Bollwerk",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.radio-bollwerk.ch/listen/radio_bollwerk/radio.mp3",
+      "homepage": "https://www.radio-bollwerk.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-trasformatorio",
+      "name": "Trasformatorio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.dyne.org/trasformatorio-archives.mp3",
+      "homepage": "https://trasformatorio.net/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://trasformatorio.net/wp-content/uploads/2013/07/cropped-logotondo-2.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-cm-radio-crans-montana",
+      "name": "CM Radio Crans-Montana",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/605899/stream/669205",
+      "homepage": "https://www.crans-montana.radio/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-jam-on-radio",
+      "name": "Jam On Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://jam-on.ice.infomaniak.ch/jam-on-128.mp3",
+      "homepage": "https://jam-on.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://jam-on.ch/img/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        47.182,
+        8.521
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-onflow-hot",
+      "name": "OnFlow Hot",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.zeno.fm/pxqdhcb7gqutv",
+      "homepage": "https://api.zeno.fm/mounts/metadata/subscribe/aeppezbhdfkvv",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-provoda-ch-legacy-mp3",
+      "name": "Provoda.ch LEGACY MP3",
+      "broadcaster": "independent",
+      "streamUrl": "https://station.waveradio.org/provodach.mp3?irqlzgjdlfohjixsouex",
+      "homepage": "http://provoda.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://provoda.ch/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-queer-radio",
+      "name": "QUEER RADIO",
+      "broadcaster": "independent",
+      "streamUrl": "https://solid67.streamupsolutions.com/proxy/eyprxrqz?mp=/stream",
+      "homepage": "https://www.queerradio.ch/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://www.queerradio.ch/wp-content/uploads/2019/10/QUEER-RADIO-HEART-PLAYER-180-180-pixel-150x150.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-agaune-radio",
+      "name": "Agaune Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.zeno.fm/0r0xa792kwzuv",
+      "homepage": "https://www.agaune.radio/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://www.agaune.radio/upload/design/69a67c2b9ba951.58189328.png",
+      "codec": "MP3",
+      "geo": [
+        46.215,
+        7.004
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-anntenne-jesus-live",
+      "name": "Anntenne Jesus Live",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.antennejesus.live/listen/antennejesuslive/radio.mp3",
+      "homepage": "https://antennejesus.live/",
+      "country": "CH",
+      "tags": [
+        "gospel",
+        "switzerland"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-pureglow-radio",
+      "name": "PureGlow Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://pureglowradio.ice.infomaniak.ch/pureglowradio.mp3",
+      "homepage": "https://www.pureglowradio.com/",
+      "country": "CH",
+      "tags": [
+        "switzerland"
+      ],
+      "favicon": "https://2023.pureglowradio.com/wp-content/uploads/2016/09/logo-dark-pgr-2.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-freundes-dienst-schweiz",
+      "name": "Radio Freundes-Dienst Schweiz",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radiofd.ch/radiofd/mp3_128/radiobrowser",
+      "homepage": "https://www.radiofd.ch/",
+      "country": "CH",
+      "tags": [
+        "news",
+        "switzerland"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.948,
+        7.447
+      ],
+      "status": "stream-only"
+    },
+    {
       "id": "builtin-france-inter",
       "name": "France Inter",
       "broadcaster": "radio-france",

--- a/public/stations.json
+++ b/public/stations.json
@@ -8833,6 +8833,618 @@
       "status": "stream-only"
     },
     {
+      "id": "de-maretimo-lounge",
+      "name": "Maretimo Lounge",
+      "broadcaster": "independent",
+      "streamUrl": "https://s35.derstream.net/lounge.mp3",
+      "homepage": "http://www.maretimo-lounge-radio.com/",
+      "country": "DE",
+      "tags": [
+        "lounge",
+        "germany"
+      ],
+      "favicon": "https://d3kle7qwymxpcy.cloudfront.net/images/broadcasts/08/a3/107873/5/c175.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-nightride-fm-chillsynth",
+      "name": "Nightride FM - Chillsynth",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.nightride.fm/chillsynth.mp3",
+      "homepage": "https://nightride.fm/",
+      "country": "DE",
+      "tags": [
+        "lounge",
+        "ambient",
+        "germany"
+      ],
+      "favicon": "https://nightride.fm/thumbnail.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-antenne-bayern-coffeemusic",
+      "name": "Antenne Bayern - CoffeeMusic",
+      "broadcaster": "independent",
+      "streamUrl": "https://mp3channels.webradio.de/coffee",
+      "homepage": "https://www.webradio.de/antenne-bayern/coffeemusic",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "pop",
+        "germany"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-rock-antenne-hair-metal",
+      "name": "ROCK ANTENNE Hair Metal",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rockantenne.de/hair-metal/stream/aacp",
+      "homepage": "https://www.rockantenne.de/",
+      "country": "DE",
+      "tags": [
+        "rock",
+        "germany"
+      ],
+      "codec": "AAC",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-rock-radio",
+      "name": "Epic Rock Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://securestreams6.autopo.st:2222/stream",
+      "homepage": "https://www.epicrockradio.com/",
+      "country": "DE",
+      "tags": [
+        "rock",
+        "germany"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-sex-by-rautemusik-rm-fm",
+      "name": "__SEX__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://sex-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://www.rm.fm/sex",
+      "country": "DE",
+      "tags": [
+        "pop",
+        "germany"
+      ],
+      "favicon": "https://i.ibb.co/sQNvYtT/sex.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-technolovers-drum-n-bass",
+      "name": "Technolovers DRUM N BASS",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.technolovers.fm/drummnbass?ref=radiobrowser",
+      "homepage": "https://technolovers.fm/",
+      "country": "DE",
+      "tags": [
+        "electronic",
+        "germany"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.684,
+        7.91
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-chillout-piano-by-epic-piano",
+      "name": "CHILLOUT PIANO by Epic Piano",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-piano.com/chillout-piano?ref=radiobrowser",
+      "homepage": "https://epic-piano.com/",
+      "country": "DE",
+      "tags": [
+        "classical",
+        "lounge",
+        "germany"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.237,
+        7.91
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-disco-on-radio",
+      "name": "- 0 N - Disco on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-disco.radionetz.de/0n-disco.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "pop",
+        "oldies",
+        "electronic",
+        "soul",
+        "germany"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-disco_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.312,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-rockantenne-alternative-mp3",
+      "name": "ROCKANTENNE Alternative (mp3)",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rockantenne.de/alternative/stream/mp3",
+      "homepage": "https://www.rockantenne.de/",
+      "country": "DE",
+      "tags": [
+        "rock",
+        "germany"
+      ],
+      "favicon": "https://www.rockantenne.de/logos/station-rock-antenne/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-lounge-ibiza-chillout-lounge",
+      "name": "Epic Lounge - IBIZA CHILLOUT LOUNGE",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-lounge.com/ibiza-chillout-lounge?ref=radiobrowser",
+      "homepage": "https://epic-lounge.com/",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "lounge",
+        "germany"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.748,
+        8.555
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-rock-antenne-blues-rock",
+      "name": "ROCK ANTENNE Blues rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rockantenne.de/blues-rock/stream/mp3",
+      "homepage": "https://www.rockantenne.de/",
+      "country": "DE",
+      "tags": [
+        "rock",
+        "germany"
+      ],
+      "favicon": "https://www.rockantenne.de/logos/station-rock-antenne/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-schwany-5-oberkrain",
+      "name": "Schwany 5 Oberkrain",
+      "broadcaster": "independent",
+      "streamUrl": "https://schwany5oberkrain.hoamatwelle.de/",
+      "homepage": "http://schwany.de/",
+      "country": "DE",
+      "tags": [
+        "classical",
+        "germany"
+      ],
+      "favicon": "http://schwany.de/favicon.ico",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-dance-on-radio",
+      "name": "- 0 N - Dance on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-dance.radionetz.de/0n-dance.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "electronic",
+        "germany"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-dance_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.312,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-technolovers-psytrance",
+      "name": "Technolovers - PSYTRANCE",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.technolovers.fm/psytrance?ref=radiobrowser",
+      "homepage": "https://technolovers.fm/",
+      "country": "DE",
+      "tags": [
+        "electronic",
+        "germany"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-technolovers-minimal",
+      "name": "Technolovers - MINIMAL",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.technolovers.fm/minimal?ref=radiobrowser",
+      "homepage": "https://technolovers.fm/",
+      "country": "DE",
+      "tags": [
+        "electronic",
+        "germany"
+      ],
+      "favicon": "https://i.ibb.co/LncDTYz/MINIMAL-TL.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-technolovers-techno",
+      "name": "Technolovers - TECHNO",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.technolovers.fm/techno?ref=radiobrowser",
+      "homepage": "https://technolovers.fm/",
+      "country": "DE",
+      "tags": [
+        "electronic",
+        "germany"
+      ],
+      "favicon": "https://i.ibb.co/ScwBQ49/TECHNO-TL.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-smooth-jazz-on-radio",
+      "name": "- 0 N - Smooth Jazz on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-smoothjazz.radionetz.de/0n-smoothjazz.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "jazz",
+        "germany"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-smooth-jazz_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.312,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-90s-by-rautemusik-rm-fm",
+      "name": "__90S__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://90s-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://www.rm.fm/90s",
+      "country": "DE",
+      "tags": [
+        "pop",
+        "electronic",
+        "hip-hop",
+        "oldies",
+        "germany"
+      ],
+      "favicon": "https://www.rm.fm/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-hr2-kultur",
+      "name": "hr2-kultur",
+      "broadcaster": "independent",
+      "streamUrl": "https://dispatcher.rndfnk.com/hr/hr2/live/mp3/high",
+      "homepage": "https://www.hr2.de/",
+      "country": "DE",
+      "tags": [
+        "public radio",
+        "germany"
+      ],
+      "favicon": "https://www.hr2.de/favicon.png?v=3.84.2",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-country-on-radio",
+      "name": "- 0 N - Country on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-country.radionetz.de/0n-country.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "country",
+        "pop",
+        "rock",
+        "germany"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-country_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.312,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-charivari-munchen-lounge-music",
+      "name": "Charivari München - Lounge Music",
+      "broadcaster": "independent",
+      "streamUrl": "https://rs24.stream24.net/lounge.aac?ref=charivari.de&aw_0_1st.playerid=radioplayer.de",
+      "homepage": "https://www.charivari.de/",
+      "country": "DE",
+      "tags": [
+        "lounge",
+        "germany"
+      ],
+      "favicon": "https://www.charivari.de/apple-icon-120x120.png",
+      "codec": "AAC",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-deutsche-welle-radio",
+      "name": "Deutsche Welle Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://dw.audiostream.io/dw/1027/mp3/64/dw08",
+      "homepage": "https://dw.com/",
+      "country": "DE",
+      "tags": [
+        "news",
+        "public radio",
+        "germany"
+      ],
+      "bitrate": 64,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-seefunk",
+      "name": "Radio Seefunk",
+      "broadcaster": "independent",
+      "streamUrl": "https://webradio.radio-seefunk.de/",
+      "homepage": "https://www.dasneueradioseefunk.de/",
+      "country": "DE",
+      "tags": [
+        "pop",
+        "electronic",
+        "germany"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-70s-on-radio",
+      "name": "- 0 N - 70s on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-70s.radionetz.de/0n-70s.aac",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "pop",
+        "oldies",
+        "germany"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-70s_600x600.jpg",
+      "bitrate": 64,
+      "codec": "AAC",
+      "geo": [
+        50.312,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-deutschlandfunk-dokumente-und-debatten-dlf-aac-9",
+      "name": "Deutschlandfunk Dokumente und Debatten | DLF | AAC 96k",
+      "broadcaster": "independent",
+      "streamUrl": "https://st04.sslstream.dlf.de/dlf/04/mid/aac/stream.aac?aggregator=web",
+      "homepage": "https://www.deutschlandradio.de/dokumente-und-debatten-102.html",
+      "country": "DE",
+      "tags": [
+        "news",
+        "electronic",
+        "public radio",
+        "germany"
+      ],
+      "favicon": "https://www.deutschlandradio.de/static/img/deutschlandradio/icons/apple-touch-icon-128x128.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        52.48,
+        13.335
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-lounge-by-rautemusik-rm-fm",
+      "name": "__LOUNGE__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://lounge-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://www.rm.fm/lounge",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "lounge",
+        "germany"
+      ],
+      "favicon": "https://www.rm.fm/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-best-of-schlager-by-rautemusik-rm-fm",
+      "name": "__BEST OF SCHLAGER__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://best-of-schlager-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://www.rm.fm/best-of-schlager",
+      "country": "DE",
+      "tags": [
+        "oldies",
+        "pop",
+        "schlager",
+        "germany"
+      ],
+      "favicon": "https://www.rm.fm/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1-a-ndw-neue-deutsche-welle-von-1a-radio",
+      "name": "- 1 A - NDW (Neue Deutsche Welle) von 1A Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://1a-ndw.radionetz.de/1a-ndw.mp3",
+      "homepage": "http://www.1aradio.com/",
+      "country": "DE",
+      "tags": [
+        "pop",
+        "public radio",
+        "germany"
+      ],
+      "favicon": "https://www.1aradio.com/logos/1a-ndw_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.312,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-schlager-oldies-by-rautemusik-rm-fm",
+      "name": "__SCHLAGER OLDIES__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://schlager-oldies-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://www.rm.fm/schlager-oldies",
+      "country": "DE",
+      "tags": [
+        "pop",
+        "schlager",
+        "oldies",
+        "germany"
+      ],
+      "favicon": "https://i.ibb.co/NNxSg2H/schlageroldies.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
       "id": "builtin-cbc-radio-1-toronto",
       "name": "CBC Radio 1 Toronto",
       "broadcaster": "cbc",

--- a/public/stations.json
+++ b/public/stations.json
@@ -8222,6 +8222,617 @@
       "status": "working"
     },
     {
+      "id": "de-technolovers-edm",
+      "name": "Technolovers EDM",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.technolovers.fm/edm?ref=radiobrowser",
+      "homepage": "https://technolovers.fm/",
+      "country": "DE",
+      "tags": [
+        "electronic",
+        "germany"
+      ],
+      "favicon": "https://i.ibb.co/TmRLJsp/EDM-TL.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.906,
+        7.91
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-technobase-fm",
+      "name": "TechnoBase.FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://listener3.mp3.tb-group.fm/tb.mp3",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "DE",
+      "tags": [
+        "electronic",
+        "germany"
+      ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/0/32040.v12.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-2000s-on-radio",
+      "name": "- 0 N - 2000s on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-2000s.radionetz.de/0n-2000s.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "electronic",
+        "pop",
+        "rock",
+        "oldies",
+        "germany"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-2000s_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.312,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-1000-goldschlager",
+      "name": "1000 Goldschlager",
+      "broadcaster": "independent",
+      "streamUrl": "https://1000goldschlager.stream.laut.fm/1000goldschlager",
+      "homepage": "https://1000goldschlager.de/",
+      "country": "DE",
+      "tags": [
+        "schlager",
+        "germany"
+      ],
+      "favicon": "https://1000goldschlager.de/apple-icon-120x120.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-chillout-on-radio",
+      "name": "- 0 N - Chillout on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-chillout.radionetz.de/0n-chillout.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "electronic",
+        "germany"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-chillout_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.312,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-radio-bollerwagen",
+      "name": "Radio Bollerwagen",
+      "broadcaster": "independent",
+      "streamUrl": "https://ffn-stream19.radiohost.de/radiobollerwagen_mp3-192?ref=radioplayer&listenerid=31363233323633323031-323030333a64653a343731363a3730313a623731343a346664383a313761363a39386165-3537373636-4d6f7a696c6c612f352e3020285831313b205562",
+      "homepage": "https://player.ffn.de/radioplayer/radio-bollerwagen/",
+      "country": "DE",
+      "tags": [
+        "germany"
+      ],
+      "favicon": "https://www.radio.de/images/broadcasts/80/eb/100349/3/c300.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-italo-disco",
+      "name": "Italo Disco",
+      "broadcaster": "independent",
+      "streamUrl": "https://italo-disco.stream.laut.fm/italo-disco",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "DE",
+      "tags": [
+        "electronic",
+        "oldies",
+        "germany"
+      ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/1/44061.v2.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-technolovers-electro-house",
+      "name": "Technolovers ELECTRO HOUSE",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.technolovers.fm/electro-house?ref=radiobrowser",
+      "homepage": "https://technolovers.fm/",
+      "country": "DE",
+      "tags": [
+        "electronic",
+        "germany"
+      ],
+      "favicon": "https://i.ibb.co/B4R6kNj/Electrohouse-tl.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.235,
+        7.24
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-60s-on-radio",
+      "name": "- 0 N - 60s on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-60s.radionetz.de/0n-60s.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "pop",
+        "soul",
+        "oldies",
+        "germany"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-60s_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.312,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0nlineradio-remix",
+      "name": "0nlineradio REMIX",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.0nlineradio.com/remix?ref=radiobrowser",
+      "homepage": "https://0nlineradio.com/",
+      "country": "DE",
+      "tags": [
+        "electronic",
+        "hip-hop",
+        "pop",
+        "latin",
+        "germany"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-electro-swing-revolution",
+      "name": "Electro Swing Revolution",
+      "broadcaster": "independent",
+      "streamUrl": "https://streamer.radio.co/s2c3cc784b/listen",
+      "homepage": "https://www.electroswing-radio.com/",
+      "country": "DE",
+      "tags": [
+        "electronic",
+        "swing",
+        "germany"
+      ],
+      "favicon": "https://www.electroswing-radio.com/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-hr-info",
+      "name": "HR Info",
+      "broadcaster": "independent",
+      "streamUrl": "https://dispatcher.rndfnk.com/hr/hrinfo/live/mp3/high",
+      "homepage": "https://www.hr-inforadio.de/index.html",
+      "country": "DE",
+      "tags": [
+        "news",
+        "public radio",
+        "germany"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-i-love-radio-us-only-rap-hiphop-radio",
+      "name": "i love radio - US Only Rap&HipHop Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ilm.stream35.radiohost.de/ilm_iloveusonlyrapradio_mp3-192?upd-meta&upd-scheme=https&_art=dD0xNzY4NDU1Mjg0JmQ9YjVlNGIxYTMwOGY3YTQxZjVlZGQ",
+      "homepage": "https://www.iloveradio.de/iloveusonlyrapradio/",
+      "country": "DE",
+      "tags": [
+        "hip-hop",
+        "germany"
+      ],
+      "favicon": "https://www.iloveradio.de/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-schlagerparadies",
+      "name": "Schlagerparadies",
+      "broadcaster": "independent",
+      "streamUrl": "https://webstream.schlagerparadies.de/schlager30842",
+      "homepage": "http://www.schlagerparadies.de/",
+      "country": "DE",
+      "tags": [
+        "schlager",
+        "germany"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-classical-classical-music-for-sleep",
+      "name": "EPIC CLASSICAL - Classical Music For Sleep",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-classical.com/classical-music-for-sleep",
+      "homepage": "https://epic-classical.com/",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "classical",
+        "lounge",
+        "germany"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-bayern-1-franken",
+      "name": "Bayern 1 Franken",
+      "broadcaster": "independent",
+      "streamUrl": "https://dispatcher.rndfnk.com/br/br1/franken/mp3/mid",
+      "homepage": "https://www.br.de/radio/bayern1/index.html",
+      "country": "DE",
+      "tags": [
+        "pop",
+        "germany"
+      ],
+      "favicon": "https://api.ardmediathek.de/image-service/images/urn:ard:image:b366004f6196d70c?w=512",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-absolut-bella",
+      "name": "Absolut bella",
+      "broadcaster": "independent",
+      "streamUrl": "https://absolut-bella.live-sm.absolutradio.de/absolut-bella/stream/mp3",
+      "homepage": "https://absolutradio.de/",
+      "country": "DE",
+      "tags": [
+        "germany"
+      ],
+      "favicon": "https://absolutradio.de/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        52.506,
+        13.4
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-hip-hop-forever",
+      "name": "Hip Hop Forever",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/hiphop-forever",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "DE",
+      "tags": [
+        "hip-hop",
+        "germany"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-nightride-fm-spacesynth",
+      "name": "Nightride FM - Spacesynth",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.nightride.fm/spacesynth.mp3",
+      "homepage": "https://nightride.fm/",
+      "country": "DE",
+      "tags": [
+        "germany"
+      ],
+      "favicon": "https://nightride.fm/thumbnail.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-electro-on-radio",
+      "name": "- 0 N - Electro on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-electro.radionetz.de/0n-electro.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "electronic",
+        "germany"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-electro_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.312,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-deutschlandfunk-nova-dlf-mp3-128k",
+      "name": "Deutschlandfunk Nova | DLF | MP3 128k",
+      "broadcaster": "independent",
+      "streamUrl": "https://st03.sslstream.dlf.de/dlf/03/128/mp3/stream.mp3?aggregator=web",
+      "homepage": "https://www.deutschlandfunknova.de/",
+      "country": "DE",
+      "tags": [
+        "news",
+        "public radio",
+        "germany"
+      ],
+      "favicon": "https://www.deutschlandfunknova.de/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        52.48,
+        13.335
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-epic-lounge-sleep-meditation",
+      "name": "Epic Lounge - SLEEP & MEDITATION",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.epic-lounge.com/sleep-meditation?ref=radiobrowser",
+      "homepage": "https://epic-lounge.com/",
+      "country": "DE",
+      "tags": [
+        "ambient",
+        "lounge",
+        "germany"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-greatest-hits-on-radio",
+      "name": "- 0 N - Greatest Hits on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-greatesthits.radionetz.de/0n-greatesthits.mp3",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "pop",
+        "electronic",
+        "hip-hop",
+        "rock",
+        "germany"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-greatest-hits_600x600.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.312,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-club-by-rautemusik-rm-fm",
+      "name": "__CLUB__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://club-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://www.rm.fm/club",
+      "country": "DE",
+      "tags": [
+        "electronic",
+        "pop",
+        "germany"
+      ],
+      "favicon": "https://www.rm.fm/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0-n-classic-rock-on-radio",
+      "name": "- 0 N - Classic Rock on Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://0n-classicrock.radionetz.de/0n-classicrock.aac",
+      "homepage": "http://www.0nradio.com/",
+      "country": "DE",
+      "tags": [
+        "pop",
+        "rock",
+        "germany"
+      ],
+      "favicon": "https://www.0nradio.com/logos/0n-classic-rock_600x600.jpg",
+      "bitrate": 64,
+      "codec": "AAC",
+      "geo": [
+        50.312,
+        11.923
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-technolovers-eurodance",
+      "name": "Technolovers EURODANCE",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.technolovers.fm/eurodance?ref=radiobrowser",
+      "homepage": "https://technolovers.fm/",
+      "country": "DE",
+      "tags": [
+        "pop",
+        "electronic",
+        "germany"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.674,
+        9.609
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-technolovers-funky-house",
+      "name": "Technolovers - FUNKY HOUSE",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.technolovers.fm/funky-house?ref=radiobrowser",
+      "homepage": "https://technolovers.fm/",
+      "country": "DE",
+      "tags": [
+        "electronic",
+        "germany"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-0nlineradio-bach",
+      "name": "0nlineradio BACH",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.0nlineradio.com/bach?ref=radiobrowser",
+      "homepage": "https://0nlineradio.com/",
+      "country": "DE",
+      "tags": [
+        "classical",
+        "germany"
+      ],
+      "favicon": "https://i.ibb.co/n1CQpDf/BACH-NEW.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.128,
+        8.965
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-technolovers-vocal-trance",
+      "name": "Technolovers VOCAL TRANCE",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.technolovers.fm/vocal-trance?ref=radiobrowser",
+      "homepage": "https://technolovers.fm/",
+      "country": "DE",
+      "tags": [
+        "electronic",
+        "germany"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.117,
+        8.906
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "de-deutschrap-charts-by-rautemusik-rm-fm",
+      "name": "__DEUTSCHRAP CHARTS__ by rautemusik (rm.fm)",
+      "broadcaster": "independent",
+      "streamUrl": "https://deutschrap-charts-high.rautemusik.fm/?ref=radiobrowser",
+      "homepage": "https://www.rm.fm/deutschrap-charts",
+      "country": "DE",
+      "tags": [
+        "hip-hop",
+        "pop",
+        "germany"
+      ],
+      "favicon": "https://www.rm.fm/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.165,
+        10.451
+      ],
+      "status": "stream-only"
+    },
+    {
       "id": "builtin-cbc-radio-1-toronto",
       "name": "CBC Radio 1 Toronto",
       "broadcaster": "cbc",


### PR DESCRIPTION
Recreated after PR #107 auto-closed when its base branch was deleted during the merge train. Same content as #107 — 30 DE stations, batch 2 of the original Sonnet sweep.