### PR TITLE
curate: CH cleanup (~6 stations not yet imported)

### DIFF
--- a/data/stations.yaml
+++ b/data/stations.yaml
@@ -34680,3 +34680,73 @@
   stationuuid: c9f185e2-a1b0-4546-b0f6-1c0a6cf6ac11
   changeuuid: e64fa79f-e157-4134-9da0-fc01b83122de
   reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: ch-kontrafunk-aac-64
+  broadcaster: independent
+  name: Kontrafunk (AAC 64)
+  streamUrl: https://s5.radio.co/sca4082ebb/low
+  bitrate: 64
+  codec: AAC
+  homepage: https://kontrafunk.radio/de/
+  country: CH
+  status: stream-only
+  stationuuid: cb81fe62-e665-4469-bd2b-92bfad063453
+  changeuuid: 8f09cf4a-1381-4901-8471-3f9aaf6fb9fc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: ch-kontrafunk-mobil
+  broadcaster: independent
+  name: Kontrafunk (Mobil)
+  streamUrl: https://icecast.multhielemedia.de/listen/kontrafunk/mobil
+  bitrate: 64
+  codec: AAC
+  homepage: https://kontrafunk.radio/
+  country: CH
+  status: stream-only
+  stationuuid: 23882169-5798-4f1d-b225-1b56c08a445e
+  changeuuid: 58643734-e118-4e41-b3cb-6ef674479964
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: ch-lounge-radio-com-swiss-made
+  broadcaster: independent
+  name: LOUNGE-RADIO.COM - swiss made
+  streamUrl: https://player.streamhosting.ch/lounge64.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://lounge-radio.com/images/lounge-radio_logo.png
+  homepage: https://lounge-radio.com/
+  country: CH
+  status: stream-only
+  stationuuid: a5ebab51-dadf-41bc-8068-770aaa46db10
+  changeuuid: 0f39d171-fb07-4af3-9415-fc690f8a3ae8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: ch-my105-x-mas-radio-aac
+  broadcaster: independent
+  name: my105 X-MAS Radio (AAC)
+  streamUrl: https://stream01.my105.ch/my105xmas-aac.mp3
+  bitrate: 96
+  codec: AAC+
+  homepage: https://www.my105.ch/xmas
+  country: CH
+  status: stream-only
+  stationuuid: b308490c-1d33-4106-b008-2c85317391a8
+  changeuuid: 35e82ee8-52f0-49ce-9f9d-37f98a359bed
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: ch-radio-schlagerpark
+  broadcaster: independent
+  name: Radio Schlagerpark
+  streamUrl: https://radio.schlagerpark.com/
+  codec: OGG
+  homepage: https://www.schlagerpark.com/
+  country: CH
+  status: stream-only
+  stationuuid: b4586ab6-6242-42f0-8e33-cfd10b84a156
+  changeuuid: 5f1fc62d-2e74-4582-85d9-204da196044b
+  reviewedAt: "2026-05-04"

--- a/public/stations.json
+++ b/public/stations.json
@@ -45292,6 +45292,87 @@
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
+    },
+    {
+      "id": "ch-kontrafunk-aac-64",
+      "name": "Kontrafunk (AAC 64)",
+      "broadcaster": "independent",
+      "streamUrl": "https://s5.radio.co/sca4082ebb/low",
+      "homepage": "https://kontrafunk.radio/de/",
+      "country": "CH",
+      "tags": [
+        "conservative",
+        "news",
+        "politics",
+        "talk"
+      ],
+      "bitrate": 64,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-kontrafunk-mobil",
+      "name": "Kontrafunk (Mobil)",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.multhielemedia.de/listen/kontrafunk/mobil",
+      "homepage": "https://kontrafunk.radio/",
+      "country": "CH",
+      "tags": [
+        "news",
+        "opinion",
+        "talk"
+      ],
+      "bitrate": 64,
+      "codec": "AAC",
+      "geo": [
+        47.6688,
+        8.986
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-lounge-radio-com-swiss-made",
+      "name": "LOUNGE-RADIO.COM - swiss made",
+      "broadcaster": "independent",
+      "streamUrl": "https://player.streamhosting.ch/lounge64.aac",
+      "homepage": "https://lounge-radio.com/",
+      "country": "CH",
+      "tags": [
+        "lounge downtempo chillout ambient easy listening"
+      ],
+      "favicon": "https://lounge-radio.com/images/lounge-radio_logo.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "geo": [
+        47.4729,
+        8.3081
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-my105-x-mas-radio-aac",
+      "name": "my105 X-MAS Radio (AAC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream01.my105.ch/my105xmas-aac.mp3",
+      "homepage": "https://www.my105.ch/xmas",
+      "country": "CH",
+      "bitrate": 96,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-schlagerpark",
+      "name": "Radio Schlagerpark",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.schlagerpark.com/",
+      "homepage": "https://www.schlagerpark.com/",
+      "country": "CH",
+      "tags": [
+        "partyschlager",
+        "schlager"
+      ],
+      "codec": "OGG",
+      "status": "stream-only"
     }
   ]
 }


### PR DESCRIPTION
## Switzerland (CH) — cleanup sweep

Imports the remaining CH Radio Browser stations that have a playable verdict and no collision with existing curated rows.

### Scan stats

- Total RB stations scanned: 588
- Playable (ok + ok-hls): 162
- Already curated (isCurated=true): excluded by analyzer
- Duplicates (duplicateOf≠null): excluded by analyzer
- After uuid-dedup filter (raw candidates): 125
- Name conflicts with existing YAML: 114
- URL conflicts with existing YAML: 5
- Intra-set dedup (lower-voted duplicate URL within candidates): 1
- **Imported: 5**

### Imported stations

| Name | Votes | Stream URL |
|---|---|---|
| Kontrafunk (AAC 64) | 289 | `https://s5.radio.co/sca4082ebb/low` |
| Kontrafunk (Mobil) | 57 | `https://icecast.multhielemedia.de/listen/kontrafunk/mobil` |
| LOUNGE-RADIO.COM - swiss made | 16 | `https://player.streamhosting.ch/lounge64.aac` |
| my105 X-MAS Radio (AAC) | 15 | `https://stream01.my105.ch/my105xmas-aac.mp3` |
| Radio Schlagerpark | 1 | `https://radio.schlagerpark.com/` |

### Skipped stations and reasons

- **114 name conflicts** — existing curated rows already cover these stations (case/whitespace-normalised match). Top examples: 80s Forever, Kontrafunk, Vintage Radio, Ambi Nature Radio, all Spoon Radio channels, Swiss Groove, GOAT Radio, etc.
- **5 URL conflicts** — different RB entries pointing to a URL already in the catalog: Kontrafunk (MP3 192), Energy Basel (NRJ), Radio X FLAC, lounge-radio.com (MP3), UZIC.CH.
- **1 intra-set duplicate** — LOUNGE-RADIO.COM - swiss made appeared twice in candidates with different stream URLs; lower-voted entry (OGG variant, 14 votes) skipped.

### Verification

- `npm run catalog` ✓ — 2462 stations published
- `npm run check-catalog` ✓ — all publishable stations match JSON, HTTPS-only
- `npm run check-duplicates` ✓ — 0 collisions
- `npm test -- --run` ✓ — 281 tests passed

### Notes

- All imports are `status: stream-only`. No promotion.
- No existing rows touched.
- PR 2 (AT full sweep, ~104 stations) is stacked on this branch.