### PR TITLE
curate: AT full sweep (~103 stations)

### DIFF
--- a/data/stations.yaml
+++ b/data/stations.yaml
@@ -34750,3 +34750,1494 @@
   stationuuid: b4586ab6-6242-42f0-8e33-cfd10b84a156
   changeuuid: 5f1fc62d-2e74-4582-85d9-204da196044b
   reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-fm4-orf
+  broadcaster: independent
+  name: "FM4 | ORF"
+  streamUrl: https://orf-live.ors-shoutcast.at/fm4-q1a
+  bitrate: 128
+  codec: MP3
+  favicon: https://tubestatic.orf.at/mojo/1_3/storyserver//tube/fm4/images/touch-icon-iphone-retina.png
+  homepage: https://fm4.orf.at/
+  country: AT
+  status: stream-only
+  stationuuid: 206f93c5-5f3c-4ba1-82c2-19a42582fcc2
+  changeuuid: 418d4728-db06-43bd-a305-f1ecb48e3ffa
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-radio-u1-tirol
+  broadcaster: independent
+  name: Radio U1 Tirol
+  streamUrl: https://live.u1-radio.at/
+  bitrate: 192
+  codec: MP3
+  favicon: https://u1-radio.at/wp-content/uploads/2022/03/u1_favicon512x512-150x150.png
+  homepage: https://www.u1-radio.at/
+  country: AT
+  status: stream-only
+  stationuuid: c64828ba-99b9-407b-bb7f-3f1c184447d2
+  changeuuid: f162107a-3b21-43c3-b040-5691b3c09440
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-arabella-relax
+  broadcaster: independent
+  name: Arabella Relax
+  streamUrl: https://frontend.streams.arabella.at/arabella-relax?aggregator=arabella-playlistfile
+  codec: AAC
+  favicon: https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcT7GNifevkmpegEQspaFGFI-sV6_k3ZQczflw&usqp=CAU
+  homepage: https://app.arabella.at/assets/channels/image/relax-list.png
+  country: AT
+  status: stream-only
+  stationuuid: 649018d6-9239-4f28-9f9a-ae3f1732379f
+  changeuuid: e79ad1d0-8e18-47b5-a5f6-05e745e76bdc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-eurodance-x-press
+  broadcaster: independent
+  name: Eurodance-X-Press
+  streamUrl: https://secureonair.krone.at/eurodance.aac
+  bitrate: 128
+  codec: AAC
+  favicon: https://www.eurodance.at/images/logo.png
+  homepage: https://www.eurodance.at/
+  country: AT
+  status: stream-only
+  stationuuid: e58e609b-3712-4136-86cf-5ac872192918
+  changeuuid: 4fbed920-bab8-4e53-8e47-b6c7dd992476
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-mountain-reggae-radio
+  broadcaster: independent
+  name: Mountain Reggae Radio
+  streamUrl: https://mountainreggaeradio.stream.laut.fm/mountainreggaeradio
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.mountainreggae-radio.at/
+  country: AT
+  status: stream-only
+  stationuuid: c1ca7ee1-2534-4188-ae4d-be40836b59b0
+  changeuuid: e1cfaabd-cd3d-481d-aa06-06b3dc307125
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-arabella-austropop
+  broadcaster: independent
+  name: Arabella Austropop
+  streamUrl: https://frontend.streams.arabella.at/arabella-austropop/stream/mp3?aggregator=arabella-playlistfile
+  bitrate: 128
+  codec: MP3
+  favicon: https://arabella.at/static/base/img/apple-touch-icon.a3ce28a2756f.png
+  homepage: https://arabella.at/
+  country: AT
+  status: stream-only
+  stationuuid: bbd3a015-9cff-4afb-8aed-b011555a4538
+  changeuuid: 87460751-3171-4698-9413-e5f35ddcab37
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-antenne-vorarlberg-oldies-but-goldies
+  broadcaster: independent
+  name: Antenne Vorarlberg Oldies but Goldies
+  streamUrl: https://web.radio.antennevorarlberg.at/av-oldies
+  codec: AAC
+  favicon: https://www.antennevorarlberg.at/wp-content/uploads//2013/02/webradio_Icons_1000x1000-NEU_oldies-but-goldies-144x144.png
+  homepage: https://www.antennevorarlberg.at/
+  country: AT
+  status: stream-only
+  stationuuid: 9e3034a1-a33a-4663-9802-979c9535b16b
+  changeuuid: 83e62f76-490c-4426-b8c7-d1ab09db24f6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-antenne-vorarlberg-partymix
+  broadcaster: independent
+  name: Antenne Vorarlberg Partymix
+  streamUrl: https://web.radio.antennevorarlberg.at/av-partymix
+  codec: AAC
+  homepage: https://www.antennevorarlberg.at/
+  country: AT
+  status: stream-only
+  stationuuid: 95e84b33-c9a2-4b01-b54c-fdbc36fefacc
+  changeuuid: 0d44a522-f643-42dc-9d0a-6db9758685cc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-arabella-golden-oldies
+  broadcaster: independent
+  name: Arabella Golden oldies
+  streamUrl: https://frontend.streams.arabella.at/arabella-goldenoldies/stream/mp3?aggregator=arabella-playlistfile
+  bitrate: 128
+  codec: MP3
+  favicon: https://arabella.at/static/base/img/apple-touch-icon.a3ce28a2756f.png
+  homepage: https://arabella.at/
+  country: AT
+  status: stream-only
+  stationuuid: 2ce5de5b-01c0-4359-91d7-891f7c0d6bcc
+  changeuuid: 9564c683-49b5-4ef1-99e3-bd7442f1acc1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-orf-hitradio-o3
+  broadcaster: independent
+  name: ORF Hitradio Ö3
+  streamUrl: https://ors-sn03.ors-shoutcast.at/oe3-q1a
+  bitrate: 128
+  codec: MP3
+  favicon: https://tubestatic.orf.at/mojo/1_3/storyserver//tube/common/images/apple-icons/oe3.png
+  homepage: http://oe3.orf.at/
+  country: AT
+  status: stream-only
+  stationuuid: 63bb901a-e09a-478b-9c5e-b7f6a1f9efc4
+  changeuuid: 82a5800d-8fa6-44c5-8fd5-c8c9e23748df
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-radio-arabella-oberosterreich
+  broadcaster: independent
+  name: Radio Arabella Oberösterreich
+  streamUrl: https://frontend.streams.arabella.at/arabella-oberoesterreich?aggregator=tunein
+  codec: AAC
+  favicon: https://www.arabella.at/static/base/img/favicon.png
+  homepage: https://www.arabella.at/oberoesterreich/
+  country: AT
+  status: stream-only
+  stationuuid: 79a03ff6-e304-4426-8496-cf8253084f75
+  changeuuid: 36aed96d-ac79-456b-9095-d78370b3aa20
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-welle-1-oberosterreich-hq
+  broadcaster: independent
+  name: WELLE 1 - Oberösterreich - HQ
+  streamUrl: https://live.welle1.at:17256/stream
+  bitrate: 256
+  codec: MP3
+  favicon: https://welle1.at/wp-content/uploads/2020/06/cropped-radiopro_theme_icon_1080x1080_2020-180x180.png
+  homepage: https://welle1.at/
+  country: AT
+  status: stream-only
+  stationuuid: 65d4ae6a-eda2-4d2c-bc68-7b8ee6310bde
+  changeuuid: 2f985da1-1fab-42d9-92f5-dcd9e8d9f1ef
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-orf-radio-oberosterreich
+  broadcaster: independent
+  name: ORF Radio Oberösterreich
+  streamUrl: https://orf-live.ors-shoutcast.at/ooe-q1a
+  bitrate: 128
+  codec: MP3
+  favicon: https://orfodon.org/system/accounts/avatars/111/374/484/561/807/260/original/04efe58e0bc4d119.png
+  homepage: https://ooe.orf.at/player/
+  country: AT
+  status: stream-only
+  stationuuid: 1e1513bb-f951-43ca-960d-bcbc26ff0bfe
+  changeuuid: 8ba1d0b2-7c23-41a7-bbc1-550748c3f70b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-blechradio-1
+  broadcaster: independent
+  name: Blechradio 1
+  streamUrl: https://streamt.at/radio/8000/blechradio1.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://cdn.onlineradiobox.com/img/logo/5/83425.v1.png
+  homepage: https://www.blechradio.at/dr/
+  country: AT
+  status: stream-only
+  stationuuid: f17518d3-624e-4984-b66e-12f576b97c76
+  changeuuid: 5139a8ce-6fee-44cd-9c52-fab18525240c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-antenne-austro-hits
+  broadcaster: independent
+  name: Antenne Austro Hits
+  streamUrl: https://live.antenne.at/auh
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.antenne.at/radioplayer/austrohits/
+  country: AT
+  status: stream-only
+  stationuuid: 2953dfbe-64f1-40c3-9ff8-90ba0f2449b2
+  changeuuid: d99fe313-e08e-4bff-bc3e-94b944f2ee1b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-orf-radio-niederosterreich
+  broadcaster: independent
+  name: ORF Radio Niederösterreich
+  streamUrl: https://orf-live.ors-shoutcast.at/noe-q1a
+  bitrate: 128
+  codec: MP3
+  favicon: https://orfodon.org/system/accounts/avatars/111/374/434/334/698/982/original/aad9486c4d8e92f2.png
+  homepage: https://noe.orf.at/player
+  country: AT
+  status: stream-only
+  stationuuid: d6baa0a3-feb1-422f-86af-42375f5e7c0a
+  changeuuid: 3b0830fe-51a2-4c98-9844-8da3f93f96e2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-gamesboro-radio-video-game-music-24-7
+  broadcaster: independent
+  name: Gamesboro Radio - Video Game Music 24/7
+  streamUrl: https://radio.gamesboro.org/listen/gamesboro_radio/radio.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://radio.gamesboro.org/static/uploads/browser_icon/original.1693066595.png
+  homepage: https://radio.gamesboro.org/public/gamesboro_radio
+  country: AT
+  status: stream-only
+  stationuuid: 32f62475-8900-4364-9fee-d1909f06ae2d
+  changeuuid: 7a0c20f2-bf1d-4aa7-9a18-de8580b05e90
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-radio-steiermark-80er-pop
+  broadcaster: independent
+  name: Radio Steiermark 80er POP
+  streamUrl: https://live.antenne.at/80s
+  bitrate: 128
+  codec: MP3
+  homepage: http://www.antenne.at/
+  country: AT
+  status: stream-only
+  stationuuid: af3f4f8f-1c94-4c35-9dc9-3bc0873f849c
+  changeuuid: dff83226-7120-4ed9-b99a-0b377bfa9331
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-oe1-surround
+  broadcaster: independent
+  name: "oe1 surround "
+  streamUrl: https://oe1dd.mdn.ors.at/out/u/oe1dd/manifest.m3u8
+  bitrate: 410
+  codec: UNKNOWN
+  favicon: https://oe1.orf.at/favicon.ico
+  homepage: https://oe1.orf.at/artikel/583273/Oesterreich-1-neu-hoeren
+  country: AT
+  status: stream-only
+  stationuuid: 6fc0397a-efc5-4ad7-921f-5df20374d0c1
+  changeuuid: 37e657f8-63eb-4376-9ecd-b137e0adca9e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-lounge-fm-kanal-2-wien
+  broadcaster: independent
+  name: Lounge.FM Kanal 2 - Wien
+  streamUrl: https://s35.derstream.net/ukwwien.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.lounge.fm/wp-content/uploads/2014/06/loungefm_logo_colour2-300x300.jpg
+  homepage: https://www.lounge.fm/
+  country: AT
+  status: stream-only
+  stationuuid: 91cebe7e-aaa0-4f91-99da-902bead6bffe
+  changeuuid: 83f5088c-17c4-40a6-b5ae-d46ea762d28d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-up-the-irons
+  broadcaster: independent
+  name: UP THE IRONS
+  streamUrl: https://uptheirons.stream.laut.fm/up_the_irons?pl=m3u&t302=2026-01-15_07-23-30&uuid=eeb3ddd4-0adf-4a11-bf6f-eac3fb8206ff
+  bitrate: 128
+  codec: MP3
+  homepage: https://laut.fm/up_the_irons
+  country: AT
+  status: stream-only
+  stationuuid: 5bb5a826-0579-44f2-9987-149d5bb018a9
+  changeuuid: 725f05b3-e40e-4371-8551-ee40238509c2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-jazzw3
+  broadcaster: independent
+  name: JazzW3
+  streamUrl: https://air.jazz.w3.at/jazzw3.ogg
+  bitrate: 128
+  codec: OGG
+  favicon: http://jazz.w3.at/logo.png
+  homepage: http://jazz.w3.at/
+  country: AT
+  status: stream-only
+  stationuuid: 93452add-93d6-419f-81cf-9060b0aa0a4f
+  changeuuid: f42ce4a5-80fe-47e8-8a1a-58468bcc9d29
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-kronehit-tv
+  broadcaster: independent
+  name: Kronehit TV
+  streamUrl: https://bitcdn-kronehit.bitmovin.com/v2/hls/chunklist_b3128000.m3u8
+  codec: UNKNOWN
+  favicon: https://www.kronehit.at///apple-touch-icon.png
+  homepage: https://www.kronehit.at/alles-ueber-kronehit/tv/
+  country: AT
+  status: stream-only
+  stationuuid: c21c6fe6-4ac0-11e8-9b06-52543be04c81
+  changeuuid: d1666c1a-5518-459b-be9a-401abcdd9768
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-city-jazz
+  broadcaster: independent
+  name: City Jazz
+  streamUrl: https://stream.radiotechnikum.at/CITYJAZZ
+  bitrate: 128
+  codec: MP3
+  favicon: https://cityjazz.at/wp-content/uploads/2024/04/city_jazz_x40.jpg
+  homepage: https://cityjazz.at/
+  country: AT
+  status: stream-only
+  stationuuid: 87b24f29-39f3-44f1-b22e-b722bfc747c1
+  changeuuid: b91a332f-d96d-41f4-b21f-72398e021a69
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-rock-antenne-osterreich-aac
+  broadcaster: independent
+  name: Rock Antenne Österreich (AAC)
+  streamUrl: https://s7-webradio.rockantenne.at/rockantenne-oesterreich/stream/aacp
+  codec: AAC
+  favicon: https://www.rockantenne.at/logos/rock-antenne-at/apple-touch-icon.png
+  homepage: https://www.rockantenne.at/
+  country: AT
+  status: stream-only
+  stationuuid: d96aa077-7c46-408a-bdd4-563a8a7a175d
+  changeuuid: 6c846f23-7f5a-4eee-ba95-95e8fe20a8ea
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-welle-1-salzburg-hq
+  broadcaster: independent
+  name: Welle 1 - Salzburg - HQ
+  streamUrl: https://live.welle1.at:18256/stream
+  bitrate: 256
+  codec: MP3
+  favicon: https://welle1.at/wp-content/uploads/2020/06/cropped-radiopro_theme_icon_1080x1080_2020-180x180.png
+  country: AT
+  status: stream-only
+  stationuuid: 5e5cebe4-3558-4f05-b460-00866ae7bcf7
+  changeuuid: d21a2f7f-d4f1-4107-805b-af934aff9f67
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-technikum-gold
+  broadcaster: independent
+  name: Technikum Gold
+  streamUrl: https://stream.radiotechnikum.at/TECHGOLD
+  bitrate: 128
+  codec: MP3
+  homepage: https://radiotechnikum.at/
+  country: AT
+  status: stream-only
+  stationuuid: b05a7451-0239-4797-a24b-eb268a6839f9
+  changeuuid: d577015a-ec34-4c11-af49-ef6804015b20
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-welle-1-oberostereich
+  broadcaster: independent
+  name: WELLE 1 - Oberöstereich
+  streamUrl: https://live.welle1.at:17128/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://welle1.at/wp-content/uploads/2020/06/cropped-radiopro_theme_icon_1080x1080_2020-180x180.png
+  homepage: https://welle1.at/
+  country: AT
+  status: stream-only
+  stationuuid: 56a488fa-4542-4611-bac9-ab06b9b1ce2f
+  changeuuid: e4071566-5d68-4d46-accb-f9a62b0911fc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-orf-hitradio-o3-290k-hls
+  broadcaster: independent
+  name: ORF Hitradio Ö3 (290k HLS)
+  streamUrl: https://orf-live-oe3.mdn.ors.at/out/u/oe3/q4a/manifest.m3u8
+  bitrate: 300
+  codec: AAC
+  favicon: https://tubestatic.orf.at/mojo/1_3/storyserver//tube/common/images/apple-icons/oe3.png
+  homepage: https://oe3.orf.at/m/
+  country: AT
+  status: stream-only
+  stationuuid: ee637e36-55c7-4049-b730-40c339d53721
+  changeuuid: 6575cf9d-7cc5-44b5-a28b-6fb7a521b106
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-orf-o1-campus-hq
+  broadcaster: independent
+  name: "ORF Ö1 Campus | HQ"
+  streamUrl: https://orf-live.ors-shoutcast.at/campus-q2a
+  bitrate: 192
+  codec: MP3
+  favicon: https://oe1.orf.at/static/img/logo_oe1.png
+  homepage: https://oe1.orf.at/campus
+  country: AT
+  status: stream-only
+  stationuuid: ea50b1cd-b465-4935-99c5-3c7c0def4495
+  changeuuid: 69cad234-7218-46ec-88d9-48fcfdd27da2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-pirate-radio-austria
+  broadcaster: independent
+  name: Pirate Radio Austria
+  streamUrl: https://secureonair.krone.at/pirate.aac
+  bitrate: 128
+  codec: AAC
+  favicon: https://pirateradio-website.konsole-labs.com/images/logo.png
+  homepage: https://www.pirateradio.at/
+  country: AT
+  status: stream-only
+  stationuuid: 43ed1a29-6cce-4a82-95cd-e644a0579f1b
+  changeuuid: 4cb28422-c38e-4f51-bf25-a1dfff5dd272
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-proton-das-freie-radio
+  broadcaster: independent
+  name: Proton - das freie Radio
+  streamUrl: https://radioproton.at:8443/proton
+  bitrate: 192
+  codec: MP3
+  homepage: https://radioproton.at/
+  country: AT
+  status: stream-only
+  stationuuid: b2507729-0609-41bc-aaad-3ba827fb4564
+  changeuuid: 22d5b0ad-2610-4422-b0d6-40059f56cd7e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-res-radio
+  broadcaster: independent
+  name: RES.RADIO
+  streamUrl: https://edge.mixlr.com/channel/zwtuo
+  codec: MP3
+  favicon: https://res.radio/android-chrome-192x192.png
+  homepage: https://res.radio/
+  country: AT
+  status: stream-only
+  stationuuid: ba98cdae-5402-4234-bbdd-ad043324dd69
+  changeuuid: 1871f94c-01b2-47bd-a1c1-61d2d5f4c287
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-technikum-one
+  broadcaster: independent
+  name: Technikum One
+  streamUrl: https://stream.radiotechnikum.at/TECHONE
+  bitrate: 160
+  codec: MP3
+  favicon: https://www.technikumone.at/favicon.ico
+  homepage: https://www.technikumone.at/
+  country: AT
+  status: stream-only
+  stationuuid: be4f6f63-96b0-47cc-9f52-9ace9a7657c5
+  changeuuid: 3782db00-b102-4746-b3e1-4ff22d51e230
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-orf-radio-burgenland
+  broadcaster: independent
+  name: ORF Radio Burgenland
+  streamUrl: https://orf-live.ors-shoutcast.at/bgl-q1a
+  bitrate: 128
+  codec: MP3
+  favicon: https://orfodon.org/system/accounts/avatars/111/374/581/969/931/266/original/4e38a6ea240646e2.png
+  homepage: https://burgenland.orf.at/player
+  country: AT
+  status: stream-only
+  stationuuid: fa4463a4-cedf-490a-b941-3dc56b83d5b6
+  changeuuid: 26d5a6ea-af85-4898-b3c0-b84b9b26260c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-austria-first-osterreichs-patriotenradio
+  broadcaster: independent
+  name: AUSTRIA FIRST – Österreichs Patriotenradio
+  streamUrl: https://n01a-eu.rcs.revma.com/3zudpqfxh0cwv?rj-ttl=5&rj-tok=AAABm8uuzlsAWVPrc0mLiKWX-Q
+  codec: MP3
+  favicon: https://austriafirst.at/wp-content/uploads/2026/01/favicon-256x256-1.png
+  homepage: https://austriafirst.at/
+  country: AT
+  status: stream-only
+  stationuuid: 7a4ed974-1a0a-4fea-8f8a-45ba3ba6daef
+  changeuuid: c2de3230-9ae3-413f-853b-76a8eb5ddf02
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-technikum-city
+  broadcaster: independent
+  name: Technikum City
+  streamUrl: https://stream.radiotechnikum.at/TECHCITY
+  bitrate: 128
+  codec: MP3
+  homepage: http://www.radiotechnikum.at/
+  country: AT
+  status: stream-only
+  stationuuid: 8bd99b46-d275-4f75-88bc-8ebfbdf92f73
+  changeuuid: 0a4eebd8-0c84-4ba6-8b2d-67daa8156442
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-radio-god
+  broadcaster: independent
+  name: Radio GÖD
+  streamUrl: https://radiogoed.securestream.kapper.net/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.goed.at/favicon/apple-icon-72x72.png
+  homepage: https://www.goed.at/radio
+  country: AT
+  status: stream-only
+  stationuuid: 4f1fb5fa-8a10-4d72-b247-21d831272373
+  changeuuid: bfcd109a-e56d-4086-8c28-1f4e264db5a8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-viyanafm
+  broadcaster: independent
+  name: ViyanaFM
+  streamUrl: https://radyo.viyanafm.at/1453/stream
+  bitrate: 128
+  codec: AAC+
+  homepage: https://www.viyanafm.at/
+  country: AT
+  status: stream-only
+  stationuuid: 48cad816-47a4-4ec9-a1a9-8ccab1abdf71
+  changeuuid: 36dd349b-6a8a-4d96-abac-f07140daae16
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-orf-o1-290k-hls
+  broadcaster: independent
+  name: ORF Ö1 (290k HLS)
+  streamUrl: https://orf-live-oe1.mdn.ors.at/out/u/oe1/q4a/manifest.m3u8
+  bitrate: 323
+  codec: AAC
+  favicon: https://oe1.orf.at/static/img/logo_oe1.png
+  homepage: https://oe1.orf.at/
+  country: AT
+  status: stream-only
+  stationuuid: 8560d6e4-1431-442e-8dcd-dd07c643edd6
+  changeuuid: 6da00e9d-8a45-4daa-b1ff-7796f2daa969
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-styrialounge
+  broadcaster: independent
+  name: Styrialounge
+  streamUrl: https://styrialounge.out.airtime.pro/styrialounge_a
+  bitrate: 192
+  codec: MP3
+  homepage: https://styrialounge.com/
+  country: AT
+  status: stream-only
+  stationuuid: 63c4bb83-8567-42e3-ad1c-c1968b367ecf
+  changeuuid: 10cc9c39-2066-4faf-a82a-446243ceaffe
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-technikum-rock
+  broadcaster: independent
+  name: Technikum Rock
+  streamUrl: https://stream.radiotechnikum.at/TECHROCK
+  bitrate: 128
+  codec: MP3
+  favicon: https://radiotechnikum.at/img/icon_rock.png
+  homepage: https://radiotechnikum.at/
+  country: AT
+  status: stream-only
+  stationuuid: 1ad9185c-8a51-4e04-9643-b6b1c9d49ace
+  changeuuid: 361b76f9-55e1-41f4-b664-832a29942b02
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-yeshua-at-radio
+  broadcaster: independent
+  name: Yeshua.at Radio
+  streamUrl: https://yeshua.at:8443/stream
+  codec: OGG
+  homepage: https://yeshua.at/server/radioArtists/index
+  country: AT
+  status: stream-only
+  stationuuid: 51d1d5b5-dc3a-4cb0-afad-b31c37335b99
+  changeuuid: e46cc941-b38e-40ac-b433-4ea3ed74f37d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-radio-rot-wei-rot
+  broadcaster: independent
+  name: Radio Rot Weiß Rot
+  streamUrl: https://secureonair.krone.at/rwr.aac
+  bitrate: 128
+  codec: AAC
+  favicon: https://www.rotweissrot.fan/favicon.ico
+  homepage: https://www.rotweissrot.fan/
+  country: AT
+  status: stream-only
+  stationuuid: 47eb5654-12b6-4e4a-9026-e026382202cb
+  changeuuid: 8cdbdaba-46ef-4b4d-b242-4478c716ffd8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-petersplattentek
+  broadcaster: independent
+  name: PetersPlattentek
+  streamUrl: https://server7524.streamplus.de/stream.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: http://www.petersplattenthek.at/
+  country: AT
+  status: stream-only
+  stationuuid: 17b7e864-638d-11ea-be63-52543be04c81
+  changeuuid: 17b7e876-638d-11ea-be63-52543be04c81
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-soundportal
+  broadcaster: independent
+  name: Soundportal
+  streamUrl: https://rs8.stream24.net/radio-soundportal.mp3?ref=soundportal.at
+  bitrate: 128
+  codec: MP3
+  favicon: https://soundportal.at/fileadmin/_processed_/a/f/csm_logo_c56844a102.png
+  homepage: https://soundportal.at/?type=1
+  country: AT
+  status: stream-only
+  stationuuid: 024e2c60-c423-4463-a057-617833a81cb2
+  changeuuid: fcbb07d8-b3c3-4859-a742-9ea251883b35
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-popwelle-das-musikradio-autodj
+  broadcaster: independent
+  name: "Popwelle. Das Musikradio,AutoDJ"
+  streamUrl: https://popwelle.sp.radio.fm/stream
+  bitrate: 320
+  codec: MP3
+  favicon: https://popwelle.at/pimages/popwelle_logo.png
+  country: AT
+  status: stream-only
+  stationuuid: baaf6fc4-c6ef-4d19-929b-193dc21e360e
+  changeuuid: 199df608-65b6-4103-8b95-7f77486df9cb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-orf-radio-wien-290k-hls
+  broadcaster: independent
+  name: ORF Radio Wien (290k HLS)
+  streamUrl: https://orf-live-wie.mdn.ors.at/out/u/wie/q4a/manifest.m3u8
+  bitrate: 300
+  codec: AAC
+  favicon: https://orfodon.org/system/accounts/avatars/111/374/411/749/352/990/original/16c84635847ddad3.png
+  homepage: https://wien.orf.at/
+  country: AT
+  status: stream-only
+  stationuuid: 42073ce7-51c8-4148-a60b-3487c30f53b8
+  changeuuid: a21a94b9-75a8-47d0-a918-e55de35d4dcd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-orf-o1-campus
+  broadcaster: independent
+  name: ORF Ö1 Campus
+  streamUrl: https://orf-live.ors-shoutcast.at/campus-q1a
+  bitrate: 128
+  codec: MP3
+  favicon: https://oe1.orf.at/static/img/logo_oe1.png
+  homepage: https://oe1.orf.at/campus
+  country: AT
+  status: stream-only
+  stationuuid: f4c44f86-7270-462e-8317-fcaa3c5db457
+  changeuuid: 2a9a8be5-9e91-47f8-98d7-e6ba7c91408d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-radio-agora-105-5
+  broadcaster: independent
+  name: "Radio Agora 105,5"
+  streamUrl: https://livestream.agora.at/agora
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.agora.at/images/favicons/apple-touch-icon.png
+  homepage: https://www.agora.at/
+  country: AT
+  status: stream-only
+  stationuuid: 7387b7ff-2778-4b0b-b001-e4f134586961
+  changeuuid: 901e0e45-12b2-4e32-b1eb-072242df4ed5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-radio-vm1
+  broadcaster: independent
+  name: Radio VM1
+  streamUrl: https://radiovm1.fluidstream.eu/radiovm1.mp3
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/548694_ab538cd3682b46c6b81c924de1b94ee0~mv2.png/v1/fill/w_248,h_111,al_c,q_85,usm_0.66_1.00_0.01,enc_auto/Logo_vm1_edited.png
+  homepage: https://www.vm1.at/
+  country: AT
+  status: stream-only
+  stationuuid: 08ff5099-5c3b-4088-b655-8d9b8c637866
+  changeuuid: 15970c25-cb25-4a8d-aa2f-cc97d6cd25c1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-metal-radio
+  broadcaster: independent
+  name: Metal Radio
+  streamUrl: https://stream.radiotechnikum.at:80/METALRadio
+  bitrate: 128
+  codec: MP3
+  homepage: https://metalradio.at/
+  country: AT
+  status: stream-only
+  stationuuid: d6316691-8619-42ae-8dbb-75dfdd7a7eb5
+  changeuuid: 7d585959-639c-4bd2-b6cc-60b9eeaacbd2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-radio-flamingo
+  broadcaster: independent
+  name: Radio Flamingo
+  streamUrl: https://live.antenne.at/rf
+  bitrate: 64
+  codec: AAC
+  favicon: https://radioflamingo.at/uploads/medium_RF_LIVE_Vollfla_echig_Stream_Icon_4000x4000px_v1_b46a0d320f.jpg
+  homepage: https://radioflamingo.at/
+  country: AT
+  status: stream-only
+  stationuuid: ea06f3ab-dbc8-4791-843c-f52c5ef5510c
+  changeuuid: 293765aa-85df-4566-b2ed-83f464809531
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-popwelle-worthersee-autodj
+  broadcaster: independent
+  name: "Popwelle Wörthersee,AutoDJ"
+  streamUrl: https://popwellezwei.sp.radio.fm/stream
+  bitrate: 320
+  codec: MP3
+  favicon: https://lh3.googleusercontent.com/p/AF1QipO1nU_lDtIzU5-Sv6EZFzE7Wa-ttB38YYWP5f3A=s680-w680-h510
+  country: AT
+  status: stream-only
+  stationuuid: efd3f809-7224-413f-aa8b-18514083209d
+  changeuuid: eab4739f-5fad-4cf1-a400-412b85d096df
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-radio-flamingo-partyschlager
+  broadcaster: independent
+  name: Radio Flamingo Partyschlager
+  streamUrl: https://live.radioflamingo.at/rfpartyschlager
+  codec: MP3
+  favicon: https://radioflamingo.at/uploads/medium_RF_Party_Schlager_Vollfla_echig_Stream_Icon_4000x4000px_v1_cff7d6fff8.png
+  homepage: https://radioflamingo.at/
+  country: AT
+  status: stream-only
+  stationuuid: 320f41dd-2398-4e84-8601-094637542975
+  changeuuid: 0cdef392-b0bb-4e09-b862-4af39bd28081
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-antenne-steiermark-werbefrei
+  broadcaster: independent
+  name: Antenne Steiermark (werbefrei)
+  streamUrl: https://60efd7a2b4d02.streamlock.net/a_steiermark/ngrp:livestream_all/playlist.m3u8
+  bitrate: 1828
+  codec: AAC
+  favicon: https://upload.wikimedia.org/wikipedia/commons/6/63/Antenne_Logo.svg
+  homepage: https://www.antenne.at/
+  country: AT
+  status: stream-only
+  stationuuid: 17911476-e5ec-45ed-a96a-7c2e9802e2c5
+  changeuuid: f5e036f2-1813-42e2-8e81-e16efbea35d6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-soundstorm-radio
+  broadcaster: independent
+  name: Soundstorm Radio
+  streamUrl: https://stream.soundstorm-radio.com/listen/soundstorm/aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://soundstorm-radio.com/wp-content/uploads/2016/06/logo-breit-1.png
+  homepage: https://soundstorm-radio.com/
+  country: AT
+  status: stream-only
+  stationuuid: 8ac3b1ad-20d4-4f17-9a57-171f36a6aacb
+  changeuuid: e44f2740-5527-4636-915d-b7379bfceabf
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-orf-radio-salzburg
+  broadcaster: independent
+  name: ORF - Radio Salzburg
+  streamUrl: https://orf-live.ors-shoutcast.at/sbg-q1a
+  bitrate: 128
+  codec: MP3
+  favicon: https://orfodon.org/system/accounts/avatars/111/374/508/091/321/480/original/185d67318d45fbd9.png
+  homepage: https://salzburg.orf.at/player
+  country: AT
+  status: stream-only
+  stationuuid: 50890eab-41ac-4f6b-8839-022f0c20444b
+  changeuuid: 25ed8efd-da4e-4e75-9241-94e7da3f8b7d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-orf-hitradio-o3-128k-hls
+  broadcaster: independent
+  name: ORF Hitradio Ö3 (128k HLS)
+  streamUrl: https://orf-live-oe3.mdn.ors.at/out/u/oe3/q3a/manifest.m3u8
+  bitrate: 134
+  codec: AAC
+  favicon: https://tubestatic.orf.at/mojo/1_3/storyserver//tube/common/images/apple-icons/oe3.png
+  homepage: https://oe3.orf.at/
+  country: AT
+  status: stream-only
+  stationuuid: 779af9c6-7679-4b3a-ad6a-687c660024be
+  changeuuid: 4fe5e4e0-4afb-482f-ae44-8edd583cd2b0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-radio-studio-enns
+  broadcaster: independent
+  name: Radio Studio Enns
+  streamUrl: https://server4.streamserver24.com:61414/
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.studioenns.eu/
+  country: AT
+  status: stream-only
+  stationuuid: 48d9b2d6-5012-4525-9581-e19fa476a7a8
+  changeuuid: ddcabb78-59f0-4bed-9518-fc11d5ca563d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-radio-vm1-wien
+  broadcaster: independent
+  name: Radio VM1 - Wien
+  streamUrl: https://radiovm1.fluidstream.eu/radiovm1_a2.mp3
+  codec: MP3
+  favicon: https://vm1.at/wp-content/themes/radiovm1_theme/assets/images/logo.webp
+  homepage: https://vm1.at/
+  country: AT
+  status: stream-only
+  stationuuid: 77bd99ff-3de0-4c8b-9b1a-cf342614f520
+  changeuuid: 3f2adc94-4a98-4e75-850e-4ef125ca98e8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-28radio-rock
+  broadcaster: independent
+  name: 28Radio - Rock
+  streamUrl: https://streaming.28radio.cc:8000/rock.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://example.com/besticon.png
+  homepage: https://28radio.cc/
+  country: AT
+  status: stream-only
+  stationuuid: ea59d91a-bf84-4650-8817-46bdda4f72a5
+  changeuuid: a9d83c2f-da22-4a21-8880-cb97a999a83c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-osterreichradio
+  broadcaster: independent
+  name: ÖsterreichRadio
+  streamUrl: https://oesterreichradio.stream.laut.fm/oesterreichradio?t302=2026-01-15_02-12-00&uuid=e1297043-bed7-49a0-9812-1be8a36b941e
+  bitrate: 128
+  codec: MP3
+  homepage: http://www.xn--radio-iua.live/
+  country: AT
+  status: stream-only
+  stationuuid: 7663b87c-241b-491c-8181-8f0678c583e6
+  changeuuid: ff702dcd-c517-4b69-83fa-ef256c8bab9a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-i-love-radio-104
+  broadcaster: independent
+  name: I-love-Radio-104
+  streamUrl: https://ilm.stream18.radiohost.de/ilm_ilovedeutschrapfirst_mp3-192?upd-meta&upd-scheme=https&_art=dD0xNzY4NDMzMDMzJmQ9ZTFjMThiMmUzZGRlY2YxMzc4ZTE
+  bitrate: 192
+  codec: MP3
+  country: AT
+  status: stream-only
+  stationuuid: a84612cc-afec-4ea3-b0a4-e0c3aaa2ac21
+  changeuuid: 478f327b-06de-4a26-8457-49a54379084c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-radio-flamingo-volksmusik
+  broadcaster: independent
+  name: Radio Flamingo + Volksmusik
+  streamUrl: https://live.radioflamingo.at/rfplusvolksmusik
+  codec: MP3
+  favicon: https://radioflamingo.at/uploads/small_RF_Volksmusik_Vollfla_echig_Stream_Icon_4000x4000px_v1_3c3eaff79d.jpg
+  homepage: https://radioflamingo.at/
+  country: AT
+  status: stream-only
+  stationuuid: 70cc6884-7781-4d7a-8dcc-79a18b3fd0d3
+  changeuuid: 41f8ba39-046b-402d-8f68-dda68c083224
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-welle-1-salzburg
+  broadcaster: independent
+  name: Welle 1 - Salzburg
+  streamUrl: https://live.welle1.at:18128/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://welle1.at/wp-content/uploads/2020/06/cropped-radiopro_theme_icon_1080x1080_2020-180x180.png
+  homepage: https://live.welle1.at/
+  country: AT
+  status: stream-only
+  stationuuid: 4afd638b-9f4d-4a55-b4f1-b53214ae717e
+  changeuuid: 176f604d-7c4a-4148-974e-b39412ed51c1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-blechradio-2
+  broadcaster: independent
+  name: Blechradio 2
+  streamUrl: https://streamt.at:8010/website_popandrock.mp3?ver=141186
+  bitrate: 128
+  codec: MP3
+  favicon: http://player.blechradio.at/images/blechradio_2_logo.jpg
+  homepage: https://www.blechradio.at/
+  country: AT
+  status: stream-only
+  stationuuid: 5cffbadd-a6b3-45b3-a87d-f84c00aa6c81
+  changeuuid: 161ea74a-59f8-4767-9255-393b7659fa03
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-erf-sud
+  broadcaster: independent
+  name: ERF Süd
+  streamUrl: https://erfradio.com/ERF_Sued
+  bitrate: 320
+  codec: MP3
+  favicon: https://erfsued.com/site/templates/img/favicon-256x256.png
+  homepage: https://www.erfsued.com/
+  country: AT
+  status: stream-only
+  stationuuid: 8e3a37af-3c04-444e-a2b9-2577b9c6dfab
+  changeuuid: c04fd448-0984-42f3-9248-5b8ea66cba18
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-lcr-radio
+  broadcaster: independent
+  name: LCR Radio
+  streamUrl: https://streaming.radio.co/sba5c95896/listen
+  bitrate: 128
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/fb3041_490a03e52d6f4054be2342552bc1606e%7emv2.png/v1/fill/w_180%2ch_180%2clg_1%2cusm_0.66_1.00_0.01/fb3041_490a03e52d6f4054be2342552bc1606e%7emv2.png
+  homepage: https://www.unternehmen1230.at/lcr-radio
+  country: AT
+  status: stream-only
+  stationuuid: 78d03c1c-9e37-4dd2-8b32-e213fb7ce203
+  changeuuid: 6a839546-4aad-4311-aca5-4579b13d7f47
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-radio-op
+  broadcaster: independent
+  name: Radio OP
+  streamUrl: https://server4.streamserver24.com:26250/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://radioop.at/favicon.ico
+  homepage: https://radioop.at/
+  country: AT
+  status: stream-only
+  stationuuid: 70296bb5-3155-4d09-b40b-4478890a5104
+  changeuuid: ee00d3ee-f223-4bac-9706-4c094bbe6fd4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-orf-o1-128k-hls
+  broadcaster: independent
+  name: ORF Ö1 (128k HLS)
+  streamUrl: https://orf-live-oe1.mdn.ors.at/out/u/oe1/q3a/manifest.m3u8
+  bitrate: 145
+  codec: AAC
+  favicon: https://oe1.orf.at/static/img/logo_oe1.png
+  homepage: https://oe1.orf.at/
+  country: AT
+  status: stream-only
+  stationuuid: fb631dee-a75a-418d-9719-edbb9f4e2025
+  changeuuid: 2b0f4b35-e5a1-4a34-afbb-8cd036eb5c1c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-cr-94-4
+  broadcaster: independent
+  name: CR 94.4
+  streamUrl: https://cr944.at:50443/cr944
+  codec: MP3
+  homepage: https://www.fhstp.ac.at/en/campus/on-campus-media/campus-city-radio-94.4
+  country: AT
+  status: stream-only
+  stationuuid: 5fd361c7-c8be-4efb-9581-b4f514683078
+  changeuuid: bb3f2ddc-27eb-4532-9f21-0a4d32f97f28
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-freies-radio-salzkammergut
+  broadcaster: independent
+  name: Freies Radio Salzkammergut
+  streamUrl: https://streaming.xaok.org/frs.ogg
+  bitrate: 128
+  codec: OGG
+  favicon: https://freiesradio.at/wp-content/uploads/2016/11/cropped-favicon-192x192.png
+  homepage: https://freiesradio.at/
+  country: AT
+  status: stream-only
+  stationuuid: f0c824de-4b8e-49ff-a88d-a9590a8a69c2
+  changeuuid: c23f1d65-9b6f-42c4-8143-70c871811649
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-radio-flamingo-golden-hits
+  broadcaster: independent
+  name: Radio Flamingo + Golden Hits
+  streamUrl: https://live.radioflamingo.at/rfplusgoldenhits
+  codec: MP3
+  favicon: https://radioflamingo.at/uploads/medium_RF_Golden_Hits_Vollfla_echig_Stream_Icon_4000x4000px_v1_5dea39f085.jpg
+  homepage: https://radioflamingo.at/
+  country: AT
+  status: stream-only
+  stationuuid: 76e5a75c-4dad-4905-8ea5-d9c6a748faf4
+  changeuuid: 77d31e40-1758-43a8-8d08-66c5a493dc61
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-radio-flamingo-hoamat
+  broadcaster: independent
+  name: Radio Flamingo Hoamat
+  streamUrl: https://live.radioflamingo.at/rfhoamat
+  codec: MP3
+  favicon: https://radioflamingo.at/uploads/medium_RF_Hoamat_Vollfla_echig_Stream_Icon_4000x4000px_v1_0d86fbb36b.png
+  homepage: https://radioflamingo.at/
+  country: AT
+  status: stream-only
+  stationuuid: 3a47c308-33ed-4782-8c3f-dcb8193297e9
+  changeuuid: b437d1bc-24b4-4b2c-88e2-91ad6840c05e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-rock-antenne-osterreich
+  broadcaster: independent
+  name: Rock Antenne Österreich
+  streamUrl: https://s1-webradio.rockantenne.at/rockantenne-oesterreich/stream/mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://rockantenne.at/
+  country: AT
+  status: stream-only
+  stationuuid: a1e1ad0a-82c6-4848-995c-c6d4e5e8c78d
+  changeuuid: 9b603bce-d75b-4497-b935-ffde0c30b7df
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-u1-tirol
+  broadcaster: independent
+  name: U1 Tirol
+  streamUrl: https://u1-tirol-stream07.radiohost.de/u1-tirol-live_mp3-192
+  bitrate: 192
+  codec: MP3
+  favicon: https://u1-radio.at/wp-content/uploads/2022/03/u1_favicon512x512-300x300.png
+  homepage: https://u1-radio.at/
+  country: AT
+  status: stream-only
+  stationuuid: a01d985a-db11-4fec-addd-24c41d4fc377
+  changeuuid: f51694b3-df4b-42f5-9f87-6240d56d2706
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-blechradio-3
+  broadcaster: independent
+  name: Blechradio 3
+  streamUrl: https://streamt.at:8020/website_tanzlmusi.mp3?ver=800211
+  bitrate: 128
+  codec: MP3
+  favicon: http://player.blechradio.at/images/blechradio_3_logo.jpg
+  homepage: https://www.blechradio.at/
+  country: AT
+  status: stream-only
+  stationuuid: dae650e3-101d-42de-917f-28515eac543e
+  changeuuid: 4e32bf51-042d-49c1-91e6-16896916c98f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-radio-vm1-steiermark
+  broadcaster: independent
+  name: Radio VM1 - Steiermark
+  streamUrl: https://radiovm1.fluidstream.eu/radiovm1_a1.mp3
+  codec: MP3
+  favicon: https://vm1.at/wp-content/themes/radiovm1_theme/assets/images/logo.webp
+  homepage: https://vm1.at/
+  country: AT
+  status: stream-only
+  stationuuid: 77966714-4054-43f0-b175-6c5207c17d9d
+  changeuuid: f2447bd4-767b-4b34-8b29-dca062b18d31
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-power-fm-dublin
+  broadcaster: independent
+  name: Power FM Dublin
+  streamUrl: https://www.powerfm.org:8443/powerfm.mp3
+  bitrate: 320
+  codec: MP3
+  homepage: https://www.powerfm.org/#
+  country: AT
+  status: stream-only
+  stationuuid: 8c58327c-b6cc-458a-a857-3bd93a56e4df
+  changeuuid: bc04f10a-40a5-4c2c-ba75-d10072de925d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-radio-3-the-dj-johnson-somerset-remixes
+  broadcaster: independent
+  name: "Radio 3: The DJ Johnson Somerset Remixes"
+  streamUrl: https://radio.eduneu.eu:8020/radio.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.eduneu.eu/logo_radio3.png
+  homepage: https://radio.eduneu.eu/public/radio3
+  country: AT
+  status: stream-only
+  stationuuid: 8b4e495b-85ca-46e4-a598-c9e61d3c68a1
+  changeuuid: cec5739a-3e55-411e-8c89-29f37d6f6d59
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-yu-radio
+  broadcaster: independent
+  name: Yu Radio
+  streamUrl: https://stream.radiotechnikum.at:80/YURADIO
+  bitrate: 96
+  codec: MP3
+  homepage: https://www.yuradio.at/
+  country: AT
+  status: stream-only
+  stationuuid: 70c4ccac-7957-4554-85cc-9a6b7264703b
+  changeuuid: d4f338a5-2bf0-4000-997a-f9342411482d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-orf-radio-wien-128k-hls
+  broadcaster: independent
+  name: ORF Radio Wien (128k HLS)
+  streamUrl: https://orf-live-wie.mdn.ors.at/out/u/wie/q3a/manifest.m3u8
+  bitrate: 134
+  codec: AAC
+  favicon: https://orfodon.org/system/accounts/avatars/111/374/411/749/352/990/original/16c84635847ddad3.png
+  homepage: https://wien.orf.at/
+  country: AT
+  status: stream-only
+  stationuuid: 10254033-b10c-46e4-8421-4b9a022357da
+  changeuuid: a626ba03-3d3f-4b1b-864e-558f1252fb8d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-radio-flamingo-kultschlager
+  broadcaster: independent
+  name: Radio Flamingo + Kultschlager
+  streamUrl: https://live.radioflamingo.at/rfpluskultschlager
+  codec: MP3
+  favicon: https://radioflamingo.at/uploads/medium_RF_Kult_Schlager_Vollfla_echig_Stream_Icon_4000x4000px_v1_0c3c69c99a.jpg
+  homepage: https://radioflamingo.at/
+  country: AT
+  status: stream-only
+  stationuuid: b44a772b-b283-4598-a18b-318f743b342d
+  changeuuid: b7dc0fd9-52ca-48fb-806e-1ce78cf223e5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-radio-rudina
+  broadcaster: independent
+  name: Radio Rudina
+  streamUrl: https://azuracast.datea.services:8000/radio.mp3
+  bitrate: 320
+  codec: MP3
+  favicon: https://images.squarespace-cdn.com/content/v1/5ea5bd3c1bd4b07f0727b9e8/85982ce5-159e-45a2-8580-f7f69121326a/favicon.ico
+  homepage: https://www.radiorudina.com/
+  country: AT
+  status: stream-only
+  stationuuid: c24d963c-f4b5-4346-8001-ed30af0add6a
+  changeuuid: 24678dbb-6dc0-418d-9f25-1a6edda9237e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-freies-radio-innviertel
+  broadcaster: independent
+  name: Freies Radio Innviertel
+  streamUrl: https://radiofri.out.airtime.pro/radiofri_a
+  bitrate: 192
+  codec: MP3
+  favicon: https://radio-fri.at/wp-content/uploads/2022/10/cropped-FRI_FreiesRadioInnviertel_favicon-32x32.png
+  homepage: https://www.radio-fri.at/
+  country: AT
+  status: stream-only
+  stationuuid: a71d5af8-1ca1-4e5d-9372-4c839bd2443d
+  changeuuid: d35bcff4-8ba8-4009-9ce7-c4a085c511b2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-grun-weiss
+  broadcaster: independent
+  name: Grün-Weiss
+  streamUrl: https://live.gruen-weiss.at/rgw.aac
+  bitrate: 64
+  codec: AAC+
+  country: AT
+  status: stream-only
+  stationuuid: 0d61eb06-745b-464d-9745-6230a09d418d
+  changeuuid: 0b46012b-c57c-467c-92f2-e00806d21203
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-radio-flamingo-christkindl
+  broadcaster: independent
+  name: Radio Flamingo Christkindl
+  streamUrl: https://live.radioflamingo.at/rfchristkindl
+  codec: MP3
+  favicon: https://radioflamingo.at/uploads/medium_RF_Christkindl_Vollfla_echig_Stream_Icon_4000x4000px_v1_25557f0fa0.png
+  homepage: https://radioflamingo.at/
+  country: AT
+  status: stream-only
+  stationuuid: bc2dca3c-d86f-4d42-b81a-7437945eb0eb
+  changeuuid: 3d4c43ab-2d6a-4fa9-9ecb-557c78ac5a6a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-rockantenne-osterreich-live
+  broadcaster: independent
+  name: Rockantenne Österreich live
+  streamUrl: https://s5-webradio.rockantenne.at/rockantenne-oesterreich/stream/aacp
+  codec: AAC
+  homepage: https://www.rockantenne.at/
+  country: AT
+  status: stream-only
+  stationuuid: 9169bc9b-cfca-45c1-bc06-c1ad826a3245
+  changeuuid: 7bb800db-f4f8-45e9-84d8-1204656623f0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-radio-weanerisch-gspielt
+  broadcaster: independent
+  name: Radio Weanerisch gspielt
+  streamUrl: https://radiovm1.fluidstream.eu/weanarisch
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radio-weanarisch.at/
+  country: AT
+  status: stream-only
+  stationuuid: 6e577441-bc3f-4662-9256-6ec1c44cc049
+  changeuuid: 195c214a-35de-432b-a5f5-52878b5fa166
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-rrth-austria
+  broadcaster: independent
+  name: RRTH Austria
+  streamUrl: https://rrth.stream.laut.fm/rrth?pl=pls&t302=2026-01-15_03-08-56&uuid=1a4d041d-a3ec-4872-908c-a7a55a58ee15
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.rrth.at/
+  country: AT
+  status: stream-only
+  stationuuid: 2b399e05-7248-435c-a9cf-6f22a801d97b
+  changeuuid: 84c415ed-dd60-41a7-ac4a-0d2a22389a8f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-radio-m1
+  broadcaster: independent
+  name: Radio-M1
+  streamUrl: https://stream.laut.fm/m1
+  bitrate: 128
+  codec: MP3
+  favicon: http://radio-m1.com/images/m1-fx-logo.JPG
+  homepage: http://www.radio-m1.com/
+  country: AT
+  status: stream-only
+  stationuuid: feba5bdf-4bf0-4343-932d-98d1b452b979
+  changeuuid: 3b4befeb-045e-4d48-95ba-a33be747d8d3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-purzelradio
+  broadcaster: independent
+  name: Purzelradio
+  streamUrl: https://s5.radio.co/sa760ba7af/listen
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.purzelradio.net/wp-content/uploads/2023/05/cropped-PurzelradioHeader.png
+  homepage: https://www.purzelradio.net/
+  country: AT
+  status: stream-only
+  stationuuid: d8f5a292-7edb-4457-ac55-5c2e92f5df86
+  changeuuid: 8de0ae67-ccd5-47ba-a037-5ac88c60ee5d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-revisited
+  broadcaster: independent
+  name: Revisited
+  streamUrl: https://revisited.stream.laut.fm/revisited
+  bitrate: 128
+  codec: MP3
+  favicon: https://assets.laut.fm/e837bb137d5e31a048d55632f3f84394?t=_120x120
+  homepage: https://laut.fm/revisited
+  country: AT
+  status: stream-only
+  stationuuid: 61fd5d72-10f3-4cf0-ac72-91257bb4306c
+  changeuuid: 60774c7d-15c4-4ab8-8f80-22f1038d8e7d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-callshop-radio-wien
+  broadcaster: independent
+  name: Callshop Radio Wien
+  streamUrl: https://icecast.callshopradio.com/callshopradio-wien
+  bitrate: 128
+  codec: MP3
+  favicon: https://cdn.sanity.io/images/0smxd0yv/production/e21c49aec89f19279ac0b5d37a283e0a5be838c1-500x500.svg?w=300&h=300&fm=png&fit=max&auto=format
+  homepage: https://callshopradio.com/
+  country: AT
+  status: stream-only
+  stationuuid: 1d60fa7b-fb94-4a5f-ac41-1215e9c33391
+  changeuuid: 3a8743fd-29cf-44b8-ba8a-7bd9101349f3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-super80s
+  broadcaster: independent
+  name: Super80s
+  streamUrl: https://secureonair.krone.at/super80s.aac?aggregator=konsole-hp&1755065290412
+  bitrate: 128
+  codec: AAC
+  favicon: https://www.super80s.at/images/logo.png
+  homepage: https://www.super80s.at/
+  country: AT
+  status: stream-only
+  stationuuid: dc283171-259f-49d6-91b4-6c10b7b7345a
+  changeuuid: b6adc851-fe6b-4c47-b6a8-eaac34d1de2f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-halil-haydar-telci
+  broadcaster: independent
+  name: halil haydar telci
+  streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/JOYTURK_ROCK_SC?/
+  bitrate: 64
+  codec: MP3
+  favicon: https://playerservices.streamtheworld.com/api/livestream-redirect/JOYTURK_ROCK_SC?/
+  homepage: https://playerservices.streamtheworld.com/api/livestream-redirect/JOYTURK_ROCK_SC?/
+  country: AT
+  status: stream-only
+  stationuuid: cd7abbc1-2d25-4313-904e-392f6fee9f77
+  changeuuid: 0d1bb23e-b3a1-4c88-be8a-bdb7c1ecd7e6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-air-radio
+  broadcaster: independent
+  name: AIR-Radio
+  streamUrl: https://streamsrv-airradio.kechit.eu/128
+  bitrate: 128
+  codec: MP3
+  homepage: https://air-radio.at/
+  country: AT
+  status: stream-only
+  stationuuid: 254034cb-4ec9-47c7-b01f-6f9565927763
+  changeuuid: fd58143d-19d5-4870-baea-aa034e8d00c9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-infora-austria
+  broadcaster: independent
+  name: Infora Austria
+  streamUrl: https://s35.derstream.net/inforadio.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://orf.at/app-infos/sound/logos/infoRadio.png
+  country: AT
+  status: stream-only
+  stationuuid: 99effa2d-f243-4ac7-a06f-14f62d315018
+  changeuuid: 18e349c3-a0b8-4c4a-a1e8-f3d853660022
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-replayscape
+  broadcaster: independent
+  name: ReplayScape
+  streamUrl: https://radio.replayscape.com:8443/128k.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://replayscape.com/pix/logo/171206a_simpler_full_0of12_zoom_tiny_blue.jpg
+  homepage: https://replayscape.com/
+  country: AT
+  status: stream-only
+  stationuuid: a9c48772-e12c-4eb6-9fd2-39d13240fce2
+  changeuuid: a5fbfea9-30f0-4710-aa48-d7cbf77d386a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-rtv-unirea-international
+  broadcaster: independent
+  name: RTV Unirea International
+  streamUrl: https://s1.bcmsol.ro/8002/stream
+  bitrate: 320
+  codec: MP3
+  favicon: https://rtvunirea.com/wp-content/uploads/2020/06/png.png
+  homepage: https://rtvunirea.com/
+  country: AT
+  status: stream-only
+  stationuuid: b14fc2bb-f608-41f7-b343-4445b95d17d7
+  changeuuid: 09f7d012-c2e3-4f3a-9c8a-6aaf3c00c752
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-radio-wurmchen
+  broadcaster: independent
+  name: Radio Würmchen
+  streamUrl: https://vanessa-unreceptive-dia.ngrok-free.dev/stream
+  codec: MP3
+  homepage: https://vanessa-unreceptive-dia.ngrok-free.dev/
+  country: AT
+  status: stream-only
+  stationuuid: 812223d2-81b1-49c2-9bc4-b0b7b3f026c2
+  changeuuid: de77285b-cd5d-4379-8512-f6317a7a076d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: at-rock-antenne-austria
+  broadcaster: independent
+  name: Rock Antenne (Austria)
+  streamUrl: https://s6-webradio.webradio.de/rockantenne-oesterreich
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.rockantenne.at/
+  country: AT
+  status: stream-only
+  stationuuid: 1659d626-b7db-48e0-82d7-d0d645bf43ae
+  changeuuid: ee6f62b6-cc71-4f97-86ec-6e62e23cdb96
+  reviewedAt: "2026-05-04"

--- a/data/stations.yaml
+++ b/data/stations.yaml
@@ -34680,3 +34680,73 @@
   stationuuid: c9f185e2-a1b0-4546-b0f6-1c0a6cf6ac11
   changeuuid: e64fa79f-e157-4134-9da0-fc01b83122de
   reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: ch-kontrafunk-aac-64
+  broadcaster: independent
+  name: Kontrafunk (AAC 64)
+  streamUrl: https://s5.radio.co/sca4082ebb/low
+  bitrate: 64
+  codec: AAC
+  homepage: https://kontrafunk.radio/de/
+  country: CH
+  status: stream-only
+  stationuuid: cb81fe62-e665-4469-bd2b-92bfad063453
+  changeuuid: 8f09cf4a-1381-4901-8471-3f9aaf6fb9fc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: ch-kontrafunk-mobil
+  broadcaster: independent
+  name: Kontrafunk (Mobil)
+  streamUrl: https://icecast.multhielemedia.de/listen/kontrafunk/mobil
+  bitrate: 64
+  codec: AAC
+  homepage: https://kontrafunk.radio/
+  country: CH
+  status: stream-only
+  stationuuid: 23882169-5798-4f1d-b225-1b56c08a445e
+  changeuuid: 58643734-e118-4e41-b3cb-6ef674479964
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: ch-lounge-radio-com-swiss-made
+  broadcaster: independent
+  name: LOUNGE-RADIO.COM - swiss made
+  streamUrl: https://player.streamhosting.ch/lounge64.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://lounge-radio.com/images/lounge-radio_logo.png
+  homepage: https://lounge-radio.com/
+  country: CH
+  status: stream-only
+  stationuuid: a5ebab51-dadf-41bc-8068-770aaa46db10
+  changeuuid: 0f39d171-fb07-4af3-9415-fc690f8a3ae8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: ch-my105-x-mas-radio-aac
+  broadcaster: independent
+  name: my105 X-MAS Radio (AAC)
+  streamUrl: https://stream01.my105.ch/my105xmas-aac.mp3
+  bitrate: 96
+  codec: AAC+
+  homepage: https://www.my105.ch/xmas
+  country: CH
+  status: stream-only
+  stationuuid: b308490c-1d33-4106-b008-2c85317391a8
+  changeuuid: 35e82ee8-52f0-49ce-9f9d-37f98a359bed
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: ch-radio-schlagerpark
+  broadcaster: independent
+  name: Radio Schlagerpark
+  streamUrl: https://radio.schlagerpark.com/
+  codec: OGG
+  homepage: https://www.schlagerpark.com/
+  country: CH
+  status: stream-only
+  stationuuid: b4586ab6-6242-42f0-8e33-cfd10b84a156
+  changeuuid: 5f1fc62d-2e74-4582-85d9-204da196044b
+  reviewedAt: "2026-05-04"

--- a/public/stations.json
+++ b/public/stations.json
@@ -45373,6 +45373,1641 @@
       ],
       "codec": "OGG",
       "status": "stream-only"
+    },
+    {
+      "id": "at-fm4-orf",
+      "name": "FM4 | ORF",
+      "broadcaster": "independent",
+      "streamUrl": "https://orf-live.ors-shoutcast.at/fm4-q1a",
+      "homepage": "https://fm4.orf.at/",
+      "country": "AT",
+      "tags": [
+        "orf",
+        "alternative mainstream",
+        "electronic",
+        "pop",
+        "rock",
+        "public radio"
+      ],
+      "favicon": "https://tubestatic.orf.at/mojo/1_3/storyserver//tube/fm4/images/touch-icon-iphone-retina.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.1777,
+        16.2878
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "at-radio-u1-tirol",
+      "name": "Radio U1 Tirol",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.u1-radio.at/",
+      "homepage": "https://www.u1-radio.at/",
+      "country": "AT",
+      "favicon": "https://u1-radio.at/wp-content/uploads/2022/03/u1_favicon512x512-150x150.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-arabella-relax",
+      "name": "Arabella Relax",
+      "broadcaster": "independent",
+      "streamUrl": "https://frontend.streams.arabella.at/arabella-relax?aggregator=arabella-playlistfile",
+      "homepage": "https://app.arabella.at/assets/channels/image/relax-list.png",
+      "country": "AT",
+      "tags": [
+        "relaxation"
+      ],
+      "favicon": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcT7GNifevkmpegEQspaFGFI-sV6_k3ZQczflw&usqp=CAU",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-eurodance-x-press",
+      "name": "Eurodance-X-Press",
+      "broadcaster": "independent",
+      "streamUrl": "https://secureonair.krone.at/eurodance.aac",
+      "homepage": "https://www.eurodance.at/",
+      "country": "AT",
+      "tags": [
+        "90s",
+        "dance",
+        "eurodance",
+        "top40"
+      ],
+      "favicon": "https://www.eurodance.at/images/logo.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-mountain-reggae-radio",
+      "name": "Mountain Reggae Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://mountainreggaeradio.stream.laut.fm/mountainreggaeradio",
+      "homepage": "https://www.mountainreggae-radio.at/",
+      "country": "AT",
+      "tags": [
+        "hip-hop",
+        "reggae"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-arabella-austropop",
+      "name": "Arabella Austropop",
+      "broadcaster": "independent",
+      "streamUrl": "https://frontend.streams.arabella.at/arabella-austropop/stream/mp3?aggregator=arabella-playlistfile",
+      "homepage": "https://arabella.at/",
+      "country": "AT",
+      "tags": [
+        "austrian music",
+        "austropop"
+      ],
+      "favicon": "https://arabella.at/static/base/img/apple-touch-icon.a3ce28a2756f.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-antenne-vorarlberg-oldies-but-goldies",
+      "name": "Antenne Vorarlberg Oldies but Goldies",
+      "broadcaster": "independent",
+      "streamUrl": "https://web.radio.antennevorarlberg.at/av-oldies",
+      "homepage": "https://www.antennevorarlberg.at/",
+      "country": "AT",
+      "tags": [
+        "classic",
+        "classic hits",
+        "oldies"
+      ],
+      "favicon": "https://www.antennevorarlberg.at/wp-content/uploads//2013/02/webradio_Icons_1000x1000-NEU_oldies-but-goldies-144x144.png",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-antenne-vorarlberg-partymix",
+      "name": "Antenne Vorarlberg Partymix",
+      "broadcaster": "independent",
+      "streamUrl": "https://web.radio.antennevorarlberg.at/av-partymix",
+      "homepage": "https://www.antennevorarlberg.at/",
+      "country": "AT",
+      "tags": [
+        "club",
+        "dance",
+        "edm",
+        "electronic",
+        "partymix"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-arabella-golden-oldies",
+      "name": "Arabella Golden oldies",
+      "broadcaster": "independent",
+      "streamUrl": "https://frontend.streams.arabella.at/arabella-goldenoldies/stream/mp3?aggregator=arabella-playlistfile",
+      "homepage": "https://arabella.at/",
+      "country": "AT",
+      "tags": [
+        "golden oldies"
+      ],
+      "favicon": "https://arabella.at/static/base/img/apple-touch-icon.a3ce28a2756f.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-orf-hitradio-o3",
+      "name": "ORF Hitradio Ö3",
+      "broadcaster": "independent",
+      "streamUrl": "https://ors-sn03.ors-shoutcast.at/oe3-q1a",
+      "homepage": "http://oe3.orf.at/",
+      "country": "AT",
+      "tags": [
+        "orf",
+        "pop"
+      ],
+      "favicon": "https://tubestatic.orf.at/mojo/1_3/storyserver//tube/common/images/apple-icons/oe3.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.1777,
+        16.2878
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "at-radio-arabella-oberosterreich",
+      "name": "Radio Arabella Oberösterreich",
+      "broadcaster": "independent",
+      "streamUrl": "https://frontend.streams.arabella.at/arabella-oberoesterreich?aggregator=tunein",
+      "homepage": "https://www.arabella.at/oberoesterreich/",
+      "country": "AT",
+      "tags": [
+        "2000s",
+        "80s",
+        "90s",
+        "austrian music",
+        "austropop",
+        "smooth"
+      ],
+      "favicon": "https://www.arabella.at/static/base/img/favicon.png",
+      "codec": "AAC",
+      "geo": [
+        48.3044,
+        14.2898
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "at-welle-1-oberosterreich-hq",
+      "name": "WELLE 1 - Oberösterreich - HQ",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.welle1.at:17256/stream",
+      "homepage": "https://welle1.at/",
+      "country": "AT",
+      "tags": [
+        "at_welle1"
+      ],
+      "favicon": "https://welle1.at/wp-content/uploads/2020/06/cropped-radiopro_theme_icon_1080x1080_2020-180x180.png",
+      "bitrate": 256,
+      "codec": "MP3",
+      "geo": [
+        48.1855,
+        16.3468
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "at-orf-radio-oberosterreich",
+      "name": "ORF Radio Oberösterreich",
+      "broadcaster": "independent",
+      "streamUrl": "https://orf-live.ors-shoutcast.at/ooe-q1a",
+      "homepage": "https://ooe.orf.at/player/",
+      "country": "AT",
+      "tags": [
+        "orf"
+      ],
+      "favicon": "https://orfodon.org/system/accounts/avatars/111/374/484/561/807/260/original/04efe58e0bc4d119.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.2981,
+        14.3004
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "at-blechradio-1",
+      "name": "Blechradio 1",
+      "broadcaster": "independent",
+      "streamUrl": "https://streamt.at/radio/8000/blechradio1.mp3",
+      "homepage": "https://www.blechradio.at/dr/",
+      "country": "AT",
+      "tags": [
+        "brass"
+      ],
+      "favicon": "https://cdn.onlineradiobox.com/img/logo/5/83425.v1.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        47.7044,
+        14.7955
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "at-antenne-austro-hits",
+      "name": "Antenne Austro Hits",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.antenne.at/auh",
+      "homepage": "https://www.antenne.at/radioplayer/austrohits/",
+      "country": "AT",
+      "tags": [
+        "austrian music",
+        "austrohits",
+        "austropop"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-orf-radio-niederosterreich",
+      "name": "ORF Radio Niederösterreich",
+      "broadcaster": "independent",
+      "streamUrl": "https://orf-live.ors-shoutcast.at/noe-q1a",
+      "homepage": "https://noe.orf.at/player",
+      "country": "AT",
+      "tags": [
+        "orf"
+      ],
+      "favicon": "https://orfodon.org/system/accounts/avatars/111/374/434/334/698/982/original/aad9486c4d8e92f2.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.1992,
+        15.6296
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "at-gamesboro-radio-video-game-music-24-7",
+      "name": "Gamesboro Radio - Video Game Music 24/7",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.gamesboro.org/listen/gamesboro_radio/radio.mp3",
+      "homepage": "https://radio.gamesboro.org/public/gamesboro_radio",
+      "country": "AT",
+      "tags": [
+        "chiptune",
+        "game",
+        "nintendo",
+        "playstation",
+        "sega",
+        "video game music"
+      ],
+      "favicon": "https://radio.gamesboro.org/static/uploads/browser_icon/original.1693066595.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        27.9817,
+        -80.6018
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "at-radio-steiermark-80er-pop",
+      "name": "Radio Steiermark 80er POP",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.antenne.at/80s",
+      "homepage": "http://www.antenne.at/",
+      "country": "AT",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-oe1-surround",
+      "name": "oe1 surround ",
+      "broadcaster": "independent",
+      "streamUrl": "https://oe1dd.mdn.ors.at/out/u/oe1dd/manifest.m3u8",
+      "homepage": "https://oe1.orf.at/artikel/583273/Oesterreich-1-neu-hoeren",
+      "country": "AT",
+      "tags": [
+        "classique"
+      ],
+      "favicon": "https://oe1.orf.at/favicon.ico",
+      "bitrate": 410,
+      "codec": "UNKNOWN",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-lounge-fm-kanal-2-wien",
+      "name": "Lounge.FM Kanal 2 - Wien",
+      "broadcaster": "independent",
+      "streamUrl": "https://s35.derstream.net/ukwwien.mp3",
+      "homepage": "https://www.lounge.fm/",
+      "country": "AT",
+      "tags": [
+        "downtempo",
+        "easy listening",
+        "lounge",
+        "smooth jazz"
+      ],
+      "favicon": "https://www.lounge.fm/wp-content/uploads/2014/06/loungefm_logo_colour2-300x300.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.1993,
+        16.3606
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "at-up-the-irons",
+      "name": "UP THE IRONS",
+      "broadcaster": "independent",
+      "streamUrl": "https://uptheirons.stream.laut.fm/up_the_irons?pl=m3u&t302=2026-01-15_07-23-30&uuid=eeb3ddd4-0adf-4a11-bf6f-eac3fb8206ff",
+      "homepage": "https://laut.fm/up_the_irons",
+      "country": "AT",
+      "tags": [
+        "hard rock",
+        "heavy metal",
+        "metal"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-jazzw3",
+      "name": "JazzW3",
+      "broadcaster": "independent",
+      "streamUrl": "https://air.jazz.w3.at/jazzw3.ogg",
+      "homepage": "http://jazz.w3.at/",
+      "country": "AT",
+      "tags": [
+        "jazz"
+      ],
+      "favicon": "http://jazz.w3.at/logo.png",
+      "bitrate": 128,
+      "codec": "OGG",
+      "geo": [
+        48.2068,
+        16.3936
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "at-kronehit-tv",
+      "name": "Kronehit TV",
+      "broadcaster": "independent",
+      "streamUrl": "https://bitcdn-kronehit.bitmovin.com/v2/hls/chunklist_b3128000.m3u8",
+      "homepage": "https://www.kronehit.at/alles-ueber-kronehit/tv/",
+      "country": "AT",
+      "tags": [
+        "tv"
+      ],
+      "favicon": "https://www.kronehit.at///apple-touch-icon.png",
+      "codec": "UNKNOWN",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-city-jazz",
+      "name": "City Jazz",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radiotechnikum.at/CITYJAZZ",
+      "homepage": "https://cityjazz.at/",
+      "country": "AT",
+      "tags": [
+        "jazz"
+      ],
+      "favicon": "https://cityjazz.at/wp-content/uploads/2024/04/city_jazz_x40.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-rock-antenne-osterreich-aac",
+      "name": "Rock Antenne Österreich (AAC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://s7-webradio.rockantenne.at/rockantenne-oesterreich/stream/aacp",
+      "homepage": "https://www.rockantenne.at/",
+      "country": "AT",
+      "favicon": "https://www.rockantenne.at/logos/rock-antenne-at/apple-touch-icon.png",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-welle-1-salzburg-hq",
+      "name": "Welle 1 - Salzburg - HQ",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.welle1.at:18256/stream",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "AT",
+      "tags": [
+        "at_welle1"
+      ],
+      "favicon": "https://welle1.at/wp-content/uploads/2020/06/cropped-radiopro_theme_icon_1080x1080_2020-180x180.png",
+      "bitrate": 256,
+      "codec": "MP3",
+      "geo": [
+        48.1855,
+        16.3468
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "at-technikum-gold",
+      "name": "Technikum Gold",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radiotechnikum.at/TECHGOLD",
+      "homepage": "https://radiotechnikum.at/",
+      "country": "AT",
+      "tags": [
+        "goldies",
+        "oldies"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-welle-1-oberostereich",
+      "name": "WELLE 1 - Oberöstereich",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.welle1.at:17128/stream",
+      "homepage": "https://welle1.at/",
+      "country": "AT",
+      "tags": [
+        "at_welle1"
+      ],
+      "favicon": "https://welle1.at/wp-content/uploads/2020/06/cropped-radiopro_theme_icon_1080x1080_2020-180x180.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.1855,
+        16.3468
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "at-orf-hitradio-o3-290k-hls",
+      "name": "ORF Hitradio Ö3 (290k HLS)",
+      "broadcaster": "independent",
+      "streamUrl": "https://orf-live-oe3.mdn.ors.at/out/u/oe3/q4a/manifest.m3u8",
+      "homepage": "https://oe3.orf.at/m/",
+      "country": "AT",
+      "tags": [
+        "at_orf",
+        "pop"
+      ],
+      "favicon": "https://tubestatic.orf.at/mojo/1_3/storyserver//tube/common/images/apple-icons/oe3.png",
+      "bitrate": 300,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-orf-o1-campus-hq",
+      "name": "ORF Ö1 Campus | HQ",
+      "broadcaster": "independent",
+      "streamUrl": "https://orf-live.ors-shoutcast.at/campus-q2a",
+      "homepage": "https://oe1.orf.at/campus",
+      "country": "AT",
+      "tags": [
+        "orf",
+        "campus radio",
+        "experimental radio",
+        "pop",
+        "world music"
+      ],
+      "favicon": "https://oe1.orf.at/static/img/logo_oe1.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        48.1777,
+        16.2878
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "at-pirate-radio-austria",
+      "name": "Pirate Radio Austria",
+      "broadcaster": "independent",
+      "streamUrl": "https://secureonair.krone.at/pirate.aac",
+      "homepage": "https://www.pirateradio.at/",
+      "country": "AT",
+      "tags": [
+        "alternative pop",
+        "alternative rock"
+      ],
+      "favicon": "https://pirateradio-website.konsole-labs.com/images/logo.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-proton-das-freie-radio",
+      "name": "Proton - das freie Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radioproton.at:8443/proton",
+      "homepage": "https://radioproton.at/",
+      "country": "AT",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        47.4916,
+        9.7483
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "at-res-radio",
+      "name": "RES.RADIO",
+      "broadcaster": "independent",
+      "streamUrl": "https://edge.mixlr.com/channel/zwtuo",
+      "homepage": "https://res.radio/",
+      "country": "AT",
+      "tags": [
+        "culture",
+        "non-commercial",
+        "online"
+      ],
+      "favicon": "https://res.radio/android-chrome-192x192.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-technikum-one",
+      "name": "Technikum One",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radiotechnikum.at/TECHONE",
+      "homepage": "https://www.technikumone.at/",
+      "country": "AT",
+      "favicon": "https://www.technikumone.at/favicon.ico",
+      "bitrate": 160,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-orf-radio-burgenland",
+      "name": "ORF Radio Burgenland",
+      "broadcaster": "independent",
+      "streamUrl": "https://orf-live.ors-shoutcast.at/bgl-q1a",
+      "homepage": "https://burgenland.orf.at/player",
+      "country": "AT",
+      "tags": [
+        "orf"
+      ],
+      "favicon": "https://orfodon.org/system/accounts/avatars/111/374/581/969/931/266/original/4e38a6ea240646e2.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        47.8605,
+        16.526
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "at-austria-first-osterreichs-patriotenradio",
+      "name": "AUSTRIA FIRST – Österreichs Patriotenradio",
+      "broadcaster": "independent",
+      "streamUrl": "https://n01a-eu.rcs.revma.com/3zudpqfxh0cwv?rj-ttl=5&rj-tok=AAABm8uuzlsAWVPrc0mLiKWX-Q",
+      "homepage": "https://austriafirst.at/",
+      "country": "AT",
+      "tags": [
+        "conservative talk",
+        "news",
+        "patriot",
+        "pop",
+        "rock"
+      ],
+      "favicon": "https://austriafirst.at/wp-content/uploads/2026/01/favicon-256x256-1.png",
+      "codec": "MP3",
+      "geo": [
+        48.2083,
+        16.3726
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "at-technikum-city",
+      "name": "Technikum City",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radiotechnikum.at/TECHCITY",
+      "homepage": "http://www.radiotechnikum.at/",
+      "country": "AT",
+      "tags": [
+        "dab+",
+        "easy listening"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-radio-god",
+      "name": "Radio GÖD",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiogoed.securestream.kapper.net/stream",
+      "homepage": "https://www.goed.at/radio",
+      "country": "AT",
+      "tags": [
+        "60s",
+        "70s",
+        "80s",
+        "classic rock",
+        "rock"
+      ],
+      "favicon": "https://www.goed.at/favicon/apple-icon-72x72.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-viyanafm",
+      "name": "ViyanaFM",
+      "broadcaster": "independent",
+      "streamUrl": "https://radyo.viyanafm.at/1453/stream",
+      "homepage": "https://www.viyanafm.at/",
+      "country": "AT",
+      "tags": [
+        "arabesk",
+        "arabesk fantazi",
+        "pop",
+        "pop music",
+        "slow",
+        "slow radio"
+      ],
+      "bitrate": 128,
+      "codec": "AAC+",
+      "geo": [
+        48.2475,
+        16.4294
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "at-orf-o1-290k-hls",
+      "name": "ORF Ö1 (290k HLS)",
+      "broadcaster": "independent",
+      "streamUrl": "https://orf-live-oe1.mdn.ors.at/out/u/oe1/q4a/manifest.m3u8",
+      "homepage": "https://oe1.orf.at/",
+      "country": "AT",
+      "tags": [
+        "at_orf"
+      ],
+      "favicon": "https://oe1.orf.at/static/img/logo_oe1.png",
+      "bitrate": 323,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-styrialounge",
+      "name": "Styrialounge",
+      "broadcaster": "independent",
+      "streamUrl": "https://styrialounge.out.airtime.pro/styrialounge_a",
+      "homepage": "https://styrialounge.com/",
+      "country": "AT",
+      "tags": [
+        "jazz"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-technikum-rock",
+      "name": "Technikum Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radiotechnikum.at/TECHROCK",
+      "homepage": "https://radiotechnikum.at/",
+      "country": "AT",
+      "tags": [
+        "dab+",
+        "rock"
+      ],
+      "favicon": "https://radiotechnikum.at/img/icon_rock.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-yeshua-at-radio",
+      "name": "Yeshua.at Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://yeshua.at:8443/stream",
+      "homepage": "https://yeshua.at/server/radioArtists/index",
+      "country": "AT",
+      "tags": [
+        "christian"
+      ],
+      "codec": "OGG",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-radio-rot-wei-rot",
+      "name": "Radio Rot Weiß Rot",
+      "broadcaster": "independent",
+      "streamUrl": "https://secureonair.krone.at/rwr.aac",
+      "homepage": "https://www.rotweissrot.fan/",
+      "country": "AT",
+      "tags": [
+        "austrian music",
+        "austrian pop music",
+        "austropop"
+      ],
+      "favicon": "https://www.rotweissrot.fan/favicon.ico",
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        48.1963,
+        16.3861
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "at-petersplattentek",
+      "name": "PetersPlattentek",
+      "broadcaster": "independent",
+      "streamUrl": "https://server7524.streamplus.de/stream.mp3",
+      "homepage": "http://www.petersplattenthek.at/",
+      "country": "AT",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-soundportal",
+      "name": "Soundportal",
+      "broadcaster": "independent",
+      "streamUrl": "https://rs8.stream24.net/radio-soundportal.mp3?ref=soundportal.at",
+      "homepage": "https://soundportal.at/?type=1",
+      "country": "AT",
+      "favicon": "https://soundportal.at/fileadmin/_processed_/a/f/csm_logo_c56844a102.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-popwelle-das-musikradio-autodj",
+      "name": "Popwelle. Das Musikradio,AutoDJ",
+      "broadcaster": "independent",
+      "streamUrl": "https://popwelle.sp.radio.fm/stream",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "AT",
+      "tags": [
+        "indie",
+        "oldie",
+        "pop",
+        "rock"
+      ],
+      "favicon": "https://popwelle.at/pimages/popwelle_logo.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        46.6114,
+        14.0436
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "at-orf-radio-wien-290k-hls",
+      "name": "ORF Radio Wien (290k HLS)",
+      "broadcaster": "independent",
+      "streamUrl": "https://orf-live-wie.mdn.ors.at/out/u/wie/q4a/manifest.m3u8",
+      "homepage": "https://wien.orf.at/",
+      "country": "AT",
+      "tags": [
+        "at_orf"
+      ],
+      "favicon": "https://orfodon.org/system/accounts/avatars/111/374/411/749/352/990/original/16c84635847ddad3.png",
+      "bitrate": 300,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-orf-o1-campus",
+      "name": "ORF Ö1 Campus",
+      "broadcaster": "independent",
+      "streamUrl": "https://orf-live.ors-shoutcast.at/campus-q1a",
+      "homepage": "https://oe1.orf.at/campus",
+      "country": "AT",
+      "tags": [
+        "orf",
+        "campus radio",
+        "experimental radio",
+        "pop",
+        "world music"
+      ],
+      "favicon": "https://oe1.orf.at/static/img/logo_oe1.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.1777,
+        16.2878
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "at-radio-agora-105-5",
+      "name": "Radio Agora 105,5",
+      "broadcaster": "independent",
+      "streamUrl": "https://livestream.agora.at/agora",
+      "homepage": "https://www.agora.at/",
+      "country": "AT",
+      "tags": [
+        "free radio",
+        "freies radio"
+      ],
+      "favicon": "https://www.agora.at/images/favicons/apple-touch-icon.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        46.6394,
+        14.2982
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "at-radio-vm1",
+      "name": "Radio VM1",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiovm1.fluidstream.eu/radiovm1.mp3",
+      "homepage": "https://www.vm1.at/",
+      "country": "AT",
+      "tags": [
+        "folklore",
+        "schlager",
+        "volksmusik"
+      ],
+      "favicon": "https://static.wixstatic.com/media/548694_ab538cd3682b46c6b81c924de1b94ee0~mv2.png/v1/fill/w_248,h_111,al_c,q_85,usm_0.66_1.00_0.01,enc_auto/Logo_vm1_edited.png",
+      "codec": "MP3",
+      "geo": [
+        47.2511,
+        11.4011
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "at-metal-radio",
+      "name": "Metal Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radiotechnikum.at:80/METALRadio",
+      "homepage": "https://metalradio.at/",
+      "country": "AT",
+      "tags": [
+        "metal"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-radio-flamingo",
+      "name": "Radio Flamingo",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.antenne.at/rf",
+      "homepage": "https://radioflamingo.at/",
+      "country": "AT",
+      "favicon": "https://radioflamingo.at/uploads/medium_RF_LIVE_Vollfla_echig_Stream_Icon_4000x4000px_v1_b46a0d320f.jpg",
+      "bitrate": 64,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-popwelle-worthersee-autodj",
+      "name": "Popwelle Wörthersee,AutoDJ",
+      "broadcaster": "independent",
+      "streamUrl": "https://popwellezwei.sp.radio.fm/stream",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "AT",
+      "tags": [
+        "musik der 90er",
+        "oldies",
+        "oldies der 60er",
+        "oldies der 70er",
+        "oldies der 80er",
+        "popschlager"
+      ],
+      "favicon": "https://lh3.googleusercontent.com/p/AF1QipO1nU_lDtIzU5-Sv6EZFzE7Wa-ttB38YYWP5f3A=s680-w680-h510",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        46.6114,
+        14.0436
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "at-radio-flamingo-partyschlager",
+      "name": "Radio Flamingo Partyschlager",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.radioflamingo.at/rfpartyschlager",
+      "homepage": "https://radioflamingo.at/",
+      "country": "AT",
+      "favicon": "https://radioflamingo.at/uploads/medium_RF_Party_Schlager_Vollfla_echig_Stream_Icon_4000x4000px_v1_cff7d6fff8.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-antenne-steiermark-werbefrei",
+      "name": "Antenne Steiermark (werbefrei)",
+      "broadcaster": "independent",
+      "streamUrl": "https://60efd7a2b4d02.streamlock.net/a_steiermark/ngrp:livestream_all/playlist.m3u8",
+      "homepage": "https://www.antenne.at/",
+      "country": "AT",
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/6/63/Antenne_Logo.svg",
+      "bitrate": 1828,
+      "codec": "AAC",
+      "geo": [
+        47.036,
+        15.407
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "at-soundstorm-radio",
+      "name": "Soundstorm Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.soundstorm-radio.com/listen/soundstorm/aac",
+      "homepage": "https://soundstorm-radio.com/",
+      "country": "AT",
+      "favicon": "https://soundstorm-radio.com/wp-content/uploads/2016/06/logo-breit-1.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-orf-radio-salzburg",
+      "name": "ORF - Radio Salzburg",
+      "broadcaster": "independent",
+      "streamUrl": "https://orf-live.ors-shoutcast.at/sbg-q1a",
+      "homepage": "https://salzburg.orf.at/player",
+      "country": "AT",
+      "tags": [
+        "orf"
+      ],
+      "favicon": "https://orfodon.org/system/accounts/avatars/111/374/508/091/321/480/original/185d67318d45fbd9.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        47.7884,
+        13.0498
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "at-orf-hitradio-o3-128k-hls",
+      "name": "ORF Hitradio Ö3 (128k HLS)",
+      "broadcaster": "independent",
+      "streamUrl": "https://orf-live-oe3.mdn.ors.at/out/u/oe3/q3a/manifest.m3u8",
+      "homepage": "https://oe3.orf.at/",
+      "country": "AT",
+      "tags": [
+        "at_orf",
+        "pop"
+      ],
+      "favicon": "https://tubestatic.orf.at/mojo/1_3/storyserver//tube/common/images/apple-icons/oe3.png",
+      "bitrate": 134,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-radio-studio-enns",
+      "name": "Radio Studio Enns",
+      "broadcaster": "independent",
+      "streamUrl": "https://server4.streamserver24.com:61414/",
+      "homepage": "https://www.studioenns.eu/",
+      "country": "AT",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-radio-vm1-wien",
+      "name": "Radio VM1 - Wien",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiovm1.fluidstream.eu/radiovm1_a2.mp3",
+      "homepage": "https://vm1.at/",
+      "country": "AT",
+      "tags": [
+        "folklore",
+        "schlager",
+        "volksmusik"
+      ],
+      "favicon": "https://vm1.at/wp-content/themes/radiovm1_theme/assets/images/logo.webp",
+      "codec": "MP3",
+      "geo": [
+        48.2085,
+        16.3732
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "at-28radio-rock",
+      "name": "28Radio - Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.28radio.cc:8000/rock.mp3",
+      "homepage": "https://28radio.cc/",
+      "country": "AT",
+      "tags": [
+        "rac",
+        "rock",
+        "rock 'n roll",
+        "various"
+      ],
+      "favicon": "https://example.com/besticon.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        12.345,
+        -23.456
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "at-osterreichradio",
+      "name": "ÖsterreichRadio",
+      "broadcaster": "independent",
+      "streamUrl": "https://oesterreichradio.stream.laut.fm/oesterreichradio?t302=2026-01-15_02-12-00&uuid=e1297043-bed7-49a0-9812-1be8a36b941e",
+      "homepage": "http://www.xn--radio-iua.live/",
+      "country": "AT",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        47.8721,
+        14.5898
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "at-i-love-radio-104",
+      "name": "I-love-Radio-104",
+      "broadcaster": "independent",
+      "streamUrl": "https://ilm.stream18.radiohost.de/ilm_ilovedeutschrapfirst_mp3-192?upd-meta&upd-scheme=https&_art=dD0xNzY4NDMzMDMzJmQ9ZTFjMThiMmUzZGRlY2YxMzc4ZTE",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "AT",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-radio-flamingo-volksmusik",
+      "name": "Radio Flamingo + Volksmusik",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.radioflamingo.at/rfplusvolksmusik",
+      "homepage": "https://radioflamingo.at/",
+      "country": "AT",
+      "tags": [
+        "volksmusik"
+      ],
+      "favicon": "https://radioflamingo.at/uploads/small_RF_Volksmusik_Vollfla_echig_Stream_Icon_4000x4000px_v1_3c3eaff79d.jpg",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-welle-1-salzburg",
+      "name": "Welle 1 - Salzburg",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.welle1.at:18128/stream",
+      "homepage": "https://live.welle1.at/",
+      "country": "AT",
+      "tags": [
+        "at_welle1"
+      ],
+      "favicon": "https://welle1.at/wp-content/uploads/2020/06/cropped-radiopro_theme_icon_1080x1080_2020-180x180.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.1855,
+        16.3468
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "at-blechradio-2",
+      "name": "Blechradio 2",
+      "broadcaster": "independent",
+      "streamUrl": "https://streamt.at:8010/website_popandrock.mp3?ver=141186",
+      "homepage": "https://www.blechradio.at/",
+      "country": "AT",
+      "favicon": "http://player.blechradio.at/images/blechradio_2_logo.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-erf-sud",
+      "name": "ERF Süd",
+      "broadcaster": "independent",
+      "streamUrl": "https://erfradio.com/ERF_Sued",
+      "homepage": "https://www.erfsued.com/",
+      "country": "AT",
+      "tags": [
+        "inspiration radio",
+        "life stories",
+        "mindfulness",
+        "motivational talk",
+        "personal growth",
+        "positive news"
+      ],
+      "favicon": "https://erfsued.com/site/templates/img/favicon-256x256.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-lcr-radio",
+      "name": "LCR Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.radio.co/sba5c95896/listen",
+      "homepage": "https://www.unternehmen1230.at/lcr-radio",
+      "country": "AT",
+      "favicon": "https://static.wixstatic.com/media/fb3041_490a03e52d6f4054be2342552bc1606e%7emv2.png/v1/fill/w_180%2ch_180%2clg_1%2cusm_0.66_1.00_0.01/fb3041_490a03e52d6f4054be2342552bc1606e%7emv2.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-radio-op",
+      "name": "Radio OP",
+      "broadcaster": "independent",
+      "streamUrl": "https://server4.streamserver24.com:26250/stream",
+      "homepage": "https://radioop.at/",
+      "country": "AT",
+      "favicon": "https://radioop.at/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-orf-o1-128k-hls",
+      "name": "ORF Ö1 (128k HLS)",
+      "broadcaster": "independent",
+      "streamUrl": "https://orf-live-oe1.mdn.ors.at/out/u/oe1/q3a/manifest.m3u8",
+      "homepage": "https://oe1.orf.at/",
+      "country": "AT",
+      "tags": [
+        "at_orf"
+      ],
+      "favicon": "https://oe1.orf.at/static/img/logo_oe1.png",
+      "bitrate": 145,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-cr-94-4",
+      "name": "CR 94.4",
+      "broadcaster": "independent",
+      "streamUrl": "https://cr944.at:50443/cr944",
+      "homepage": "https://www.fhstp.ac.at/en/campus/on-campus-media/campus-city-radio-94.4",
+      "country": "AT",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-freies-radio-salzkammergut",
+      "name": "Freies Radio Salzkammergut",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.xaok.org/frs.ogg",
+      "homepage": "https://freiesradio.at/",
+      "country": "AT",
+      "favicon": "https://freiesradio.at/wp-content/uploads/2016/11/cropped-favicon-192x192.png",
+      "bitrate": 128,
+      "codec": "OGG",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-radio-flamingo-golden-hits",
+      "name": "Radio Flamingo + Golden Hits",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.radioflamingo.at/rfplusgoldenhits",
+      "homepage": "https://radioflamingo.at/",
+      "country": "AT",
+      "favicon": "https://radioflamingo.at/uploads/medium_RF_Golden_Hits_Vollfla_echig_Stream_Icon_4000x4000px_v1_5dea39f085.jpg",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-radio-flamingo-hoamat",
+      "name": "Radio Flamingo Hoamat",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.radioflamingo.at/rfhoamat",
+      "homepage": "https://radioflamingo.at/",
+      "country": "AT",
+      "favicon": "https://radioflamingo.at/uploads/medium_RF_Hoamat_Vollfla_echig_Stream_Icon_4000x4000px_v1_0d86fbb36b.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-rock-antenne-osterreich",
+      "name": "Rock Antenne Österreich",
+      "broadcaster": "independent",
+      "streamUrl": "https://s1-webradio.rockantenne.at/rockantenne-oesterreich/stream/mp3",
+      "homepage": "https://rockantenne.at/",
+      "country": "AT",
+      "tags": [
+        "rock"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-u1-tirol",
+      "name": "U1 Tirol",
+      "broadcaster": "independent",
+      "streamUrl": "https://u1-tirol-stream07.radiohost.de/u1-tirol-live_mp3-192",
+      "homepage": "https://u1-radio.at/",
+      "country": "AT",
+      "tags": [
+        "evergreen",
+        "schlager",
+        "volksmusik"
+      ],
+      "favicon": "https://u1-radio.at/wp-content/uploads/2022/03/u1_favicon512x512-300x300.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        47.3441,
+        11.7084
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "at-blechradio-3",
+      "name": "Blechradio 3",
+      "broadcaster": "independent",
+      "streamUrl": "https://streamt.at:8020/website_tanzlmusi.mp3?ver=800211",
+      "homepage": "https://www.blechradio.at/",
+      "country": "AT",
+      "favicon": "http://player.blechradio.at/images/blechradio_3_logo.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-radio-vm1-steiermark",
+      "name": "Radio VM1 - Steiermark",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiovm1.fluidstream.eu/radiovm1_a1.mp3",
+      "homepage": "https://vm1.at/",
+      "country": "AT",
+      "tags": [
+        "folklore",
+        "schlager",
+        "volksmusik"
+      ],
+      "favicon": "https://vm1.at/wp-content/themes/radiovm1_theme/assets/images/logo.webp",
+      "codec": "MP3",
+      "geo": [
+        47.0767,
+        15.4373
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "at-power-fm-dublin",
+      "name": "Power FM Dublin",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.powerfm.org:8443/powerfm.mp3",
+      "homepage": "https://www.powerfm.org/#",
+      "country": "AT",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-radio-3-the-dj-johnson-somerset-remixes",
+      "name": "Radio 3: The DJ Johnson Somerset Remixes",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.eduneu.eu:8020/radio.mp3",
+      "homepage": "https://radio.eduneu.eu/public/radio3",
+      "country": "AT",
+      "favicon": "https://www.eduneu.eu/logo_radio3.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-yu-radio",
+      "name": "Yu Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radiotechnikum.at:80/YURADIO",
+      "homepage": "https://www.yuradio.at/",
+      "country": "AT",
+      "bitrate": 96,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-orf-radio-wien-128k-hls",
+      "name": "ORF Radio Wien (128k HLS)",
+      "broadcaster": "independent",
+      "streamUrl": "https://orf-live-wie.mdn.ors.at/out/u/wie/q3a/manifest.m3u8",
+      "homepage": "https://wien.orf.at/",
+      "country": "AT",
+      "tags": [
+        "at_orf"
+      ],
+      "favicon": "https://orfodon.org/system/accounts/avatars/111/374/411/749/352/990/original/16c84635847ddad3.png",
+      "bitrate": 134,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-radio-flamingo-kultschlager",
+      "name": "Radio Flamingo + Kultschlager",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.radioflamingo.at/rfpluskultschlager",
+      "homepage": "https://radioflamingo.at/",
+      "country": "AT",
+      "favicon": "https://radioflamingo.at/uploads/medium_RF_Kult_Schlager_Vollfla_echig_Stream_Icon_4000x4000px_v1_0c3c69c99a.jpg",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-radio-rudina",
+      "name": "Radio Rudina",
+      "broadcaster": "independent",
+      "streamUrl": "https://azuracast.datea.services:8000/radio.mp3",
+      "homepage": "https://www.radiorudina.com/",
+      "country": "AT",
+      "tags": [
+        "chill",
+        "electronica",
+        "techno"
+      ],
+      "favicon": "https://images.squarespace-cdn.com/content/v1/5ea5bd3c1bd4b07f0727b9e8/85982ce5-159e-45a2-8580-f7f69121326a/favicon.ico",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        48.2029,
+        16.3712
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "at-freies-radio-innviertel",
+      "name": "Freies Radio Innviertel",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiofri.out.airtime.pro/radiofri_a",
+      "homepage": "https://www.radio-fri.at/",
+      "country": "AT",
+      "favicon": "https://radio-fri.at/wp-content/uploads/2022/10/cropped-FRI_FreiesRadioInnviertel_favicon-32x32.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        48.2549,
+        13.4101
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "at-grun-weiss",
+      "name": "Grün-Weiss",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.gruen-weiss.at/rgw.aac",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "AT",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-radio-flamingo-christkindl",
+      "name": "Radio Flamingo Christkindl",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.radioflamingo.at/rfchristkindl",
+      "homepage": "https://radioflamingo.at/",
+      "country": "AT",
+      "favicon": "https://radioflamingo.at/uploads/medium_RF_Christkindl_Vollfla_echig_Stream_Icon_4000x4000px_v1_25557f0fa0.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-rockantenne-osterreich-live",
+      "name": "Rockantenne Österreich live",
+      "broadcaster": "independent",
+      "streamUrl": "https://s5-webradio.rockantenne.at/rockantenne-oesterreich/stream/aacp",
+      "homepage": "https://www.rockantenne.at/",
+      "country": "AT",
+      "tags": [
+        "metal",
+        "rock"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-radio-weanerisch-gspielt",
+      "name": "Radio Weanerisch gspielt",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiovm1.fluidstream.eu/weanarisch",
+      "homepage": "https://www.radio-weanarisch.at/",
+      "country": "AT",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-rrth-austria",
+      "name": "RRTH Austria",
+      "broadcaster": "independent",
+      "streamUrl": "https://rrth.stream.laut.fm/rrth?pl=pls&t302=2026-01-15_03-08-56&uuid=1a4d041d-a3ec-4872-908c-a7a55a58ee15",
+      "homepage": "https://www.rrth.at/",
+      "country": "AT",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-radio-m1",
+      "name": "Radio-M1",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/m1",
+      "homepage": "http://www.radio-m1.com/",
+      "country": "AT",
+      "favicon": "http://radio-m1.com/images/m1-fx-logo.JPG",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-purzelradio",
+      "name": "Purzelradio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s5.radio.co/sa760ba7af/listen",
+      "homepage": "https://www.purzelradio.net/",
+      "country": "AT",
+      "favicon": "https://www.purzelradio.net/wp-content/uploads/2023/05/cropped-PurzelradioHeader.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-revisited",
+      "name": "Revisited",
+      "broadcaster": "independent",
+      "streamUrl": "https://revisited.stream.laut.fm/revisited",
+      "homepage": "https://laut.fm/revisited",
+      "country": "AT",
+      "tags": [
+        "classic rock",
+        "rock"
+      ],
+      "favicon": "https://assets.laut.fm/e837bb137d5e31a048d55632f3f84394?t=_120x120",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.7702,
+        14.3598
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "at-callshop-radio-wien",
+      "name": "Callshop Radio Wien",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.callshopradio.com/callshopradio-wien",
+      "homepage": "https://callshopradio.com/",
+      "country": "AT",
+      "tags": [
+        "ambient",
+        "electro",
+        "electronic",
+        "hip hop",
+        "house"
+      ],
+      "favicon": "https://cdn.sanity.io/images/0smxd0yv/production/e21c49aec89f19279ac0b5d37a283e0a5be838c1-500x500.svg?w=300&h=300&fm=png&fit=max&auto=format",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-super80s",
+      "name": "Super80s",
+      "broadcaster": "independent",
+      "streamUrl": "https://secureonair.krone.at/super80s.aac?aggregator=konsole-hp&1755065290412",
+      "homepage": "https://www.super80s.at/",
+      "country": "AT",
+      "tags": [
+        "80er",
+        "80s",
+        "pop"
+      ],
+      "favicon": "https://www.super80s.at/images/logo.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-halil-haydar-telci",
+      "name": "halil haydar telci",
+      "broadcaster": "independent",
+      "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/JOYTURK_ROCK_SC?/",
+      "homepage": "https://playerservices.streamtheworld.com/api/livestream-redirect/JOYTURK_ROCK_SC?/",
+      "country": "AT",
+      "favicon": "https://playerservices.streamtheworld.com/api/livestream-redirect/JOYTURK_ROCK_SC?/",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-air-radio",
+      "name": "AIR-Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streamsrv-airradio.kechit.eu/128",
+      "homepage": "https://air-radio.at/",
+      "country": "AT",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-infora-austria",
+      "name": "Infora Austria",
+      "broadcaster": "independent",
+      "streamUrl": "https://s35.derstream.net/inforadio.mp3",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "AT",
+      "favicon": "https://orf.at/app-infos/sound/logos/infoRadio.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-replayscape",
+      "name": "ReplayScape",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.replayscape.com:8443/128k.mp3",
+      "homepage": "https://replayscape.com/",
+      "country": "AT",
+      "favicon": "https://replayscape.com/pix/logo/171206a_simpler_full_0of12_zoom_tiny_blue.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-rtv-unirea-international",
+      "name": "RTV Unirea International",
+      "broadcaster": "independent",
+      "streamUrl": "https://s1.bcmsol.ro/8002/stream",
+      "homepage": "https://rtvunirea.com/",
+      "country": "AT",
+      "tags": [
+        "folk",
+        "oldies",
+        "pop",
+        "rock"
+      ],
+      "favicon": "https://rtvunirea.com/wp-content/uploads/2020/06/png.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        47.8291,
+        16.2403
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "at-radio-wurmchen",
+      "name": "Radio Würmchen",
+      "broadcaster": "independent",
+      "streamUrl": "https://vanessa-unreceptive-dia.ngrok-free.dev/stream",
+      "homepage": "https://vanessa-unreceptive-dia.ngrok-free.dev/",
+      "country": "AT",
+      "tags": [
+        "ai",
+        "ai-powered",
+        "experimental",
+        "news",
+        "pop",
+        "rock"
+      ],
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "at-rock-antenne-austria",
+      "name": "Rock Antenne (Austria)",
+      "broadcaster": "independent",
+      "streamUrl": "https://s6-webradio.webradio.de/rockantenne-oesterreich",
+      "homepage": "https://www.rockantenne.at/",
+      "country": "AT",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.191,
+        16.3876
+      ],
+      "status": "stream-only"
     }
   ]
 }

--- a/public/stations.json
+++ b/public/stations.json
@@ -45292,6 +45292,87 @@
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
+    },
+    {
+      "id": "ch-kontrafunk-aac-64",
+      "name": "Kontrafunk (AAC 64)",
+      "broadcaster": "independent",
+      "streamUrl": "https://s5.radio.co/sca4082ebb/low",
+      "homepage": "https://kontrafunk.radio/de/",
+      "country": "CH",
+      "tags": [
+        "conservative",
+        "news",
+        "politics",
+        "talk"
+      ],
+      "bitrate": 64,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-kontrafunk-mobil",
+      "name": "Kontrafunk (Mobil)",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.multhielemedia.de/listen/kontrafunk/mobil",
+      "homepage": "https://kontrafunk.radio/",
+      "country": "CH",
+      "tags": [
+        "news",
+        "opinion",
+        "talk"
+      ],
+      "bitrate": 64,
+      "codec": "AAC",
+      "geo": [
+        47.6688,
+        8.986
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-lounge-radio-com-swiss-made",
+      "name": "LOUNGE-RADIO.COM - swiss made",
+      "broadcaster": "independent",
+      "streamUrl": "https://player.streamhosting.ch/lounge64.aac",
+      "homepage": "https://lounge-radio.com/",
+      "country": "CH",
+      "tags": [
+        "lounge downtempo chillout ambient easy listening"
+      ],
+      "favicon": "https://lounge-radio.com/images/lounge-radio_logo.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "geo": [
+        47.4729,
+        8.3081
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-my105-x-mas-radio-aac",
+      "name": "my105 X-MAS Radio (AAC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream01.my105.ch/my105xmas-aac.mp3",
+      "homepage": "https://www.my105.ch/xmas",
+      "country": "CH",
+      "bitrate": 96,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "ch-radio-schlagerpark",
+      "name": "Radio Schlagerpark",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.schlagerpark.com/",
+      "homepage": "https://www.schlagerpark.com/",
+      "country": "CH",
+      "tags": [
+        "partyschlager",
+        "schlager"
+      ],
+      "codec": "OGG",
+      "status": "stream-only"
     }
   ]
 }


### PR DESCRIPTION
## Austria (AT) — full RB sweep

Imports all playable AT stations from the Radio Browser sweep that don't collide with existing curated rows.

_Stacked on `curate/ch-cleanup-2026-05-04` — merge CH first to avoid a YAML diff collision._

### Scan stats

- Total RB stations scanned: 330
- Playable (ok + ok-hls): 140
- Already curated (isCurated=true): excluded by analyzer
- Duplicates (duplicateOf≠null): excluded by analyzer
- After uuid-dedup filter (raw candidates): 117
- Name conflicts with existing YAML: 2 (Radio Vorarlberg, Radio Helsinki)
- URL conflicts with existing YAML: 9 (ORF HQ duplicates, Orange 94.0, Lounge.FM 100% Austria, Museumsradio AM 1476, Abdulbasit Abdulsamad)
- Intra-set dedup (lower-voted within candidates): 2 (Metal Radio, U1 Tirol)
- Stationuuid collision with existing curated row: 1 (Arabella wien = curated Radio Arabella Wien with slightly different URL form)
- **Imported: 103**

### Top stations by votes

| Name | Votes | Stream URL |
|---|---|---|
| FM4 \| ORF | 2,340 | `https://orf-live.ors-shoutcast.at/fm4-q1a` |
| Radio U1 Tirol | 1,165 | `https://live.u1-radio.at/` |
| Arabella Relax | 904 | `https://frontend.streams.arabella.at/arabella-relax?aggregator=arabella-playlistfile` |
| Arabella wien | 632 | _(removed — stationuuid collision with curated `at-arabella-wien`)_ |
| Eurodance-X-Press | 621 | `https://secureonair.krone.at/eurodance.aac` |
| Mountain Reggae Radio | 619 | `https://mountainreggaeradio.stream.laut.fm/mountainreggaeradio` |
| Arabella Austropop | 531 | `https://frontend.streams.arabella.at/arabella-austropop/stream/mp3?aggregator=arabella-playlistfile` |

### Skipped stations and reasons

- **2 name conflicts** — Radio Vorarlberg, Radio Helsinki already in catalog
- **9 URL conflicts** — multiple ORF stations at HQ quality already curated under different names, plus Orange 94.0, Lounge.FM 100% Austria, Museumsradio AM 1476, Abdulbasit Abdulsamad
- **2 intra-set dups** — Metal Radio and U1 Tirol each had a second lower-voted RB entry pointing to the same station; kept only the higher-voted one
- **1 stationuuid collision** — "Arabella wien" shares stationuuid `61866d6c...` with the existing curated `at-arabella-wien` row (the curated entry has a truncated stream URL that didn't trigger the URL-exact-match filter; the stationuuid check caught it at build time)

### Verification

- `npm run catalog` ✓ — 2565 stations published
- `npm run check-catalog` ✓ — all publishable stations match JSON, HTTPS-only
- `npm run check-duplicates` ✓ — 0 collisions
- `npm test -- --run` ✓ — 281 tests passed

### Notes

- All imports are `status: stream-only`. No promotion.
- No existing rows touched.