### PR TITLE
curate: GB sweep (~841 stations)

### DIFF
--- a/data/stations.yaml
+++ b/data/stations.yaml
@@ -36241,3 +36241,12211 @@
   stationuuid: 1659d626-b7db-48e0-82d7-d0d645bf43ae
   changeuuid: ee6f62b6-cc71-4f97-86ec-6e62e23cdb96
   reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-tmm-1
+  broadcaster: independent
+  name: TMM 1
+  streamUrl: https://listen-msmn.sharp-stream.com/nme1.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://cdn-profiles.tunein.com/s159857/images/logod.png
+  homepage: https://www.themusicmachine.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 9619e7d7-0601-11e8-ae97-52543be04c81
+  changeuuid: 584f10b8-4ea5-4692-9728-abdf0a0c279a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-heart-70s
+  broadcaster: independent
+  name: Heart 70s
+  streamUrl: https://media-ssl.musicradio.com/Heart70sMP3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.heart.co.uk/70s
+  country: GB
+  status: stream-only
+  stationuuid: e7205cd4-dc30-11e9-a8ba-52543be04c81
+  changeuuid: 0786366e-80e1-444f-a397-791746479373
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-heart-dance
+  broadcaster: independent
+  name: Heart Dance
+  streamUrl: https://media-ssl.musicradio.com/HeartDanceMP3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.heart.co.uk/assets_v4r/heart/img/favicon-196x196.png
+  homepage: https://www.heart.co.uk/dance
+  country: GB
+  status: stream-only
+  stationuuid: fa76f16f-dc31-11e9-a8ba-52543be04c81
+  changeuuid: 300a20c6-6807-4ebd-86af-53f9de78c60b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-tmm-2
+  broadcaster: independent
+  name: TMM 2
+  streamUrl: https://listen-msmn.sharp-stream.com/nme2.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://cdn-profiles.tunein.com/s155539/images/logod.png
+  homepage: https://www.themusicmachine.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 9619e894-0601-11e8-ae97-52543be04c81
+  changeuuid: 59e59348-0901-47d1-8438-4966a449e562
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-love-radio-only-love-songs-70s80s90s
+  broadcaster: independent
+  name: LOVE.radio Only Love Songs 70s80s90s
+  streamUrl: https://loveradio.streamingmedia.it/england
+  bitrate: 192
+  codec: AAC+
+  homepage: https://love.radio/
+  country: GB
+  status: stream-only
+  stationuuid: 6dea6c7d-9b22-4698-889f-e7c34203ee6a
+  changeuuid: 858b5e59-54fa-4b3e-8500-5895bc17caa0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bbc-news-hd-720p
+  broadcaster: independent
+  name: BBC News HD (720P)
+  streamUrl: https://vs-hls-push-ww-live.akamaized.net/x=4/i=urn:bbc:pips:service:bbc_news_channel_hd/t=3840/v=pv14/b=5070016/main.m3u8
+  codec: UNKNOWN
+  favicon: https://upload.wikimedia.org/wikipedia/en/thumb/2/24/BBC_News_HD_Logo.svg/2560px-BBC_News_HD_Logo.svg.png
+  homepage: https://bbc.co.uk/news
+  country: GB
+  status: stream-only
+  stationuuid: ea391ded-00f0-47e0-841c-d92663e11854
+  changeuuid: c93de57c-a2b4-4446-8582-93f1af247c0f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-exclusively-dire-straits
+  broadcaster: independent
+  name: Exclusively Dire Straits
+  streamUrl: https://streaming.exclusive.radio/er/direstraits/icecast.audio
+  codec: MP3
+  homepage: https://exclusive.radio/
+  country: GB
+  status: stream-only
+  stationuuid: 70ce5567-4d1e-4a07-baa5-f5f08ca4b2f6
+  changeuuid: 459b4533-b81f-43f6-88a6-c1c8ea832d18
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-virgin-radio-chilled
+  broadcaster: independent
+  name: Virgin Radio Chilled
+  streamUrl: https://radio.virginradio.co.uk/stream-chilled?aw_0_1st.platform=vr-web
+  bitrate: 128
+  codec: AAC
+  homepage: https://virginradio.co.uk/radioplayer/live/virginradio-player-chilled.html
+  country: GB
+  status: stream-only
+  stationuuid: 8e630042-ef66-4063-a403-7632117ef5c8
+  changeuuid: 7c69ba50-9bb0-4c81-82cb-37b079c0753d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-seva-novgorodsev
+  broadcaster: independent
+  name: Радио Сева (Radio Seva Novgorodsev)
+  streamUrl: https://seva.ru/radio/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://seva.ru/radio/radio.png
+  homepage: https://seva.ru/
+  country: GB
+  status: stream-only
+  stationuuid: 30820d12-0409-44b7-b5e8-edc594910d92
+  changeuuid: bd18d070-0a99-4eb7-99fd-00307e00acd1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-tmm-2-hq
+  broadcaster: independent
+  name: TMM 2 (HQ)
+  streamUrl: https://listen-msmn.sharp-stream.com/nme2high.mp3
+  bitrate: 256
+  codec: MP3
+  favicon: https://cdn-profiles.tunein.com/s155539/images/logod.png
+  homepage: https://www.themusicmachine.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 2c788192-ca75-42c9-ace6-866087380796
+  changeuuid: 04552a42-88c4-40a5-b960-caedcdde4c4d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-exclusively-supertramp
+  broadcaster: independent
+  name: Exclusively Supertramp
+  streamUrl: https://streaming.exclusive.radio/er/supertramp/icecast.audio
+  codec: MP3
+  homepage: https://exclusive.radio/
+  country: GB
+  status: stream-only
+  stationuuid: dfa6d153-83de-4112-bd36-2156720bdfc5
+  changeuuid: 98abcb49-eb6e-4274-b26a-1cde5a4270c9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-britcom-2-pumpkin-fm
+  broadcaster: independent
+  name: BritCom 2 - Pumpkin FM
+  streamUrl: https://cast2.asurahosting.com/proxy/britcom2/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://pumpkinfm.com/wp-content/uploads/2019/02/BritComTwo300x300.jpg
+  homepage: https://pumpkinfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: 47416a39-4289-47a9-8747-056843a60c0b
+  changeuuid: 1706648d-4568-4dc8-80ea-d8e319fe4d1e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-exclusively-ac-dc
+  broadcaster: independent
+  name: Exclusively AC/DC
+  streamUrl: https://nl4.mystreaming.net/er/acdc/icecast.audio
+  codec: MP3
+  homepage: https://play.exclusive.radio/
+  country: GB
+  status: stream-only
+  stationuuid: ba93ec29-66c9-4bee-8f71-b71481001c8e
+  changeuuid: f2442dde-8410-46ae-aaf4-1848309384b9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-sky-news-uk
+  broadcaster: independent
+  name: sky news UK
+  streamUrl: https://tunein.cdnstream1.com/3688_96.mp3?aw_0_1st.skey=1718490659&aw_0_1st.abtest=&aw_0_1st.stationId=s2583&aw_0_1st.premium=false&source=TuneIn&aw_0_1st.platform=tunein&aw_0_1st.genre_id=g255&aw_0_1st.class=talk&aw_0_1st.ads_partner_alias=ce.Other&aw_0_azn.planguage=en
+  bitrate: 96
+  codec: MP3
+  favicon: https://news.sky.com/resources/apple-touch-icon.png?v=2
+  homepage: https://news.sky.com/
+  country: GB
+  status: stream-only
+  stationuuid: 512e876e-806b-4a61-8a57-f15e39b64907
+  changeuuid: 12422947-d548-411a-948a-d6e03a7c5465
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-soul-radio-only-classic-soul
+  broadcaster: independent
+  name: SOUL RADIO Only Classic Soul
+  streamUrl: https://listen.soulradio.uk/uk
+  bitrate: 192
+  codec: AAC+
+  homepage: https://soulradio.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 9f61ef81-bf7d-4bc4-8135-3fc8be52dafb
+  changeuuid: 0f25cbfb-ab07-4ce5-9116-d677f8458500
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-teenage-kicks-radio
+  broadcaster: independent
+  name: Teenage Kicks Radio
+  streamUrl: https://onlineradiobox.com/json/fr/teenagekicks/play
+  bitrate: 128
+  codec: MP3
+  homepage: https://teenagekicksradio.blogspot.com/
+  country: GB
+  status: stream-only
+  stationuuid: c9aabff3-95d1-4f9e-8b29-6682f7e031e2
+  changeuuid: ecdb95ea-eb38-499d-a731-38a6a5a91eed
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-house-nation-uk
+  broadcaster: independent
+  name: House Nation UK
+  streamUrl: https://streaming.radio.co/s06bd9d805/listen
+  bitrate: 192
+  codec: MP3
+  favicon: https://static.mytuner.mobi/media/tvos_radios/aWa7xGKfBh.jpg
+  homepage: https://housenationuk.com/
+  country: GB
+  status: stream-only
+  stationuuid: 8c78482a-17db-4057-a7c7-8fa14b3c3ce9
+  changeuuid: 20bd64f0-e93c-49f6-85ac-89bfbfe55cf0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-strange-radio-pumpkin-fm
+  broadcaster: independent
+  name: Strange Radio - Pumpkin FM
+  streamUrl: https://cast2.asurahosting.com/proxy/strangeradio/stream
+  bitrate: 64
+  codec: MP3
+  homepage: https://pumpkinfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: dce75ec5-a0f8-4bba-bf4c-2827c871490c
+  changeuuid: d2f9e431-182b-40a0-ac61-4d468ff7b4a5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-x-classic-rock
+  broadcaster: independent
+  name: Radio X Classic Rock
+  streamUrl: https://media-ice.musicradio.com/RadioXClassicRockMP3
+  bitrate: 128
+  codec: MP3
+  favicon: https://i.imgur.com/eBIsjQw.jpg
+  homepage: https://www.radiox.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 83bb028f-9cd6-489d-a9e0-6dc0821a071b
+  changeuuid: b824bda2-26fd-4513-8afa-61d568a18977
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-britcom-1-british-comedy-radio-pumpkin-fm-otrn
+  broadcaster: independent
+  name: BritCom 1 - British Comedy Radio  (Pumpkin FM OTRN)
+  streamUrl: https://cast2.asurahosting.com/proxy/britcom1/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://pumpkinfm.com/wp-content/uploads/2019/02/BritComOne300x300.jpg
+  homepage: https://britishcomedyradio.org/
+  country: GB
+  status: stream-only
+  stationuuid: 8cf13f16-df99-4fd8-b152-ab8218563a36
+  changeuuid: bac9b434-9908-4bed-a06f-18914dc96d38
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-happy-hardcore
+  broadcaster: independent
+  name: Happy Hardcore
+  streamUrl: https://audio-edge-3mayu.fra.h.radiomast.io/73055724-1141-41e2-a69b-24a6ca96c8e7
+  bitrate: 256
+  codec: MP3
+  homepage: https://www.happyhardcore.com/
+  country: GB
+  status: stream-only
+  stationuuid: 21dbb37d-60a6-4ec2-b5c8-28b46fc2bfea
+  changeuuid: 12240e5b-cfe4-40ea-aebe-9f4259bf6fc5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-kniteforce-radio
+  broadcaster: independent
+  name: Kniteforce Radio
+  streamUrl: https://kniteforce.out.airtime.pro/kniteforce_a
+  bitrate: 192
+  codec: MP3
+  homepage: https://kniteforce-radio.com/
+  country: GB
+  status: stream-only
+  stationuuid: fba2054a-0812-4a8f-b9bf-ab0546c5cccd
+  changeuuid: 79687ae0-00e4-438d-9fe9-354ef2703db8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-slow-focus-nts
+  broadcaster: independent
+  name: "Slow Focus | NTS"
+  streamUrl: https://stream-mixtape-geo.ntslive.net/mixtape
+  codec: MP3
+  favicon: https://www.nts.live/apple-touch-icon.png?v=47re43rrzb
+  homepage: https://www.nts.live/infinite-mixtapes/slow-focus
+  country: GB
+  status: stream-only
+  stationuuid: d5468df4-e6d0-11e9-a96c-52543be04c81
+  changeuuid: b53980ab-1494-46a5-8558-f34a7d196d55
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-rokit-radio-science-fiction
+  broadcaster: independent
+  name: ROKit Radio Science Fiction
+  streamUrl: https://streaming05.liveboxstream.uk/proxy/roksta12/stream
+  bitrate: 48
+  codec: MP3
+  favicon: https://rokitradio.com/images/channels/scifi.jpg
+  homepage: https://rokitradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 68f52212-e3b0-479b-9da6-962a6c5e713d
+  changeuuid: cac3c984-961b-427f-a0bb-c39714bfc4a1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-britcom-3-british-comedy-radio-pumpkin-fm-otrn
+  broadcaster: independent
+  name: BritCom 3 - British Comedy Radio (Pumpkin FM OTRN)
+  streamUrl: https://cast2.asurahosting.com/proxy/britcom3/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://pumpkinfm.com/wp-content/uploads/2023/02/BritComThreeNew300x300-3.jpg
+  homepage: https://britishcomedyradio.org/
+  country: GB
+  status: stream-only
+  stationuuid: 37bf8039-77ed-4805-9030-c40d5cb2820a
+  changeuuid: 3333dc19-6fe0-4a5c-81b9-bff4fcd4c22c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-fun-kids
+  broadcaster: independent
+  name: Fun Kids
+  streamUrl: https://listen-funkids.sharp-stream.com/funkids.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.funkidslive.com/
+  country: GB
+  status: stream-only
+  stationuuid: ff871225-7731-45a1-aee0-9e8fa463dfc3
+  changeuuid: b1ccb0e1-ee4e-4627-82c0-7e14b7052ee2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hearme-classic-hard-rock
+  broadcaster: independent
+  name: HearMe - Classic Hard Rock
+  streamUrl: https://radio.hearme.fm:8250/stream
+  codec: MP3
+  homepage: https://hearme.fm/
+  country: GB
+  status: stream-only
+  stationuuid: 1f951feb-544e-447b-8143-8b9656a46cf2
+  changeuuid: 545c907c-b6ae-433a-9957-1041c6028540
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-uk-bass-radio
+  broadcaster: independent
+  name: UK Bass Radio
+  streamUrl: https://www.ukbassradio.com/stream
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.ukbassradio.com/wp-content/uploads/2021/03/cropped-thumbnail_ukbass-radio5.png
+  homepage: https://www.ukbassradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 29dc48c6-adf5-49bf-a9d7-dfde3e9cfc6d
+  changeuuid: 502878b0-3ced-4c86-aacb-5b3f2a14ec25
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-box-uk
+  broadcaster: independent
+  name: box uk
+  streamUrl: https://boxstream.danceradiouk.com/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://boxuk.danceradiouk.com/favicon.ico
+  homepage: https://boxuk.danceradiouk.com/
+  country: GB
+  status: stream-only
+  stationuuid: 7ae5f001-8112-4e6c-abf4-d069dc37e3a9
+  changeuuid: 6ac2900e-90c9-4ca3-9583-2bc1bbb91d3b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-now-70s
+  broadcaster: independent
+  name: Now 70s
+  streamUrl: https://lightning-now70s-samsungnz.amagi.tv/playlist.m3u8
+  bitrate: 1020
+  codec: AAC,H.264
+  favicon: https://upload.wikimedia.org/wikipedia/commons/c/cd/NOW_70s.png
+  homepage: https://nowmusic.com/
+  country: GB
+  status: stream-only
+  stationuuid: 6925c7e9-116b-42ab-9126-4c13c1b65baf
+  changeuuid: a300ab3c-ff31-4500-b2d6-fe90106d97f5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-capital-chill
+  broadcaster: independent
+  name: Capital Chill
+  streamUrl: https://media-ssl.musicradio.com/CapitalChill
+  bitrate: 48
+  codec: AAC
+  homepage: https://capitalchill.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: dfaf9dd9-6705-494d-bf96-ce7fbdbba021
+  changeuuid: 6997ef3c-7ab0-4465-b5aa-0af7b61db6d7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-rokit-radio-british-comedy-1
+  broadcaster: independent
+  name: "ROKit Radio : British Comedy 1"
+  streamUrl: https://streaming04.liveboxstream.uk/proxy/roksta14/stream
+  bitrate: 48
+  codec: MP3
+  favicon: https://rokitradio.com/images/channels/british_comedy_1.jpg
+  homepage: https://rokitradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: da52663e-bf3e-40aa-b863-28c1d12d6464
+  changeuuid: bca1e0d6-a8e2-4700-98a0-8592921ecd97
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-eric-clapton
+  broadcaster: independent
+  name: "Eric Clapton "
+  streamUrl: https://streaming.exclusive.radio/er/ericclapton/icecast.audio
+  codec: MP3
+  favicon: https://upload.wikimedia.org/wikipedia/commons/thumb/0/0a/Eric_Clapton_-_Royal_Albert_Hall_-_Wednesday_24th_May_2017_EricClaptonRAH240517-30_%2834987232355%29_%28cropped%29.jpg/1200px-Eric_Clapton_-_Royal_Albert_Hall_-_Wednesday_24th_May_2017_EricClaptonRAH240517-30_%2834987232355%29_%28cropped%29.jpg
+  homepage: https://tunein.com/artist/Eric-Clapton-m473626/
+  country: GB
+  status: stream-only
+  stationuuid: e70ca27e-0c1a-4045-8996-d754914b999d
+  changeuuid: 6e37cd7d-3101-431c-adff-85c13671f163
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-classic-fm-calm
+  broadcaster: independent
+  name: Classic FM Calm
+  streamUrl: https://media-ice.musicradio.com/ClassicFMCalmMP3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.classicfm.com/calm/
+  country: GB
+  status: stream-only
+  stationuuid: 2babf29a-811c-4a51-93c3-9f3531ef2e97
+  changeuuid: a4913661-8293-4b42-a897-22784d6f5a14
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-house-music-radio
+  broadcaster: independent
+  name: House Music Radio
+  streamUrl: https://uk4-vn.mixstream.net/8128/listen.mp3
+  bitrate: 320
+  codec: MP3
+  homepage: https://www.housemusicradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: c58c0009-ad0d-4ed5-a208-a8e797885a75
+  changeuuid: 481387cc-709a-4414-bbab-80403b863194
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-smooth-relax
+  broadcaster: independent
+  name: Smooth Relax
+  streamUrl: https://icecast.thisisdax.com/SmoothRelaxMP3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.smoothradio.com/relax/
+  country: GB
+  status: stream-only
+  stationuuid: 15a7162c-45a3-4bde-b864-aa7731c6dd87
+  changeuuid: 70049744-0c76-42c7-80b6-bff1e686433a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-diva-radio-funk-disco-music-paradise
+  broadcaster: independent
+  name: "Diva Radio - Funk & Disco Music Paradise"
+  streamUrl: https://stream.deevaradio.net:10443/divaradiofunk
+  bitrate: 192
+  codec: MP3
+  homepage: https://deevaradio.net/
+  country: GB
+  status: stream-only
+  stationuuid: 5c850da2-076b-43b5-aa38-91e72fac39f6
+  changeuuid: f86a5be5-5da3-4441-a8a8-9ccab61ce225
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-nation-60s
+  broadcaster: independent
+  name: Nation 60s
+  streamUrl: https://listen-nation.sharp-stream.com/nation60s.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: http://www.nationradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: dd4e349c-77df-43da-a97d-34234ab08a2f
+  changeuuid: bedd057f-81b0-4b18-a042-3c6f573ff623
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-100-hip-hop-nts
+  broadcaster: independent
+  name: "100% Hip Hop | NTS"
+  streamUrl: https://stream-mixtape-geo.ntslive.net/mixtape2
+  codec: MP3
+  homepage: https://www.nts.live/infinite-mixtapes/100-percent-hip-hop
+  country: GB
+  status: stream-only
+  stationuuid: afd853b3-e6d1-11e9-a96c-52543be04c81
+  changeuuid: f0f8f136-ab5a-4701-a6f9-f5ae309ae659
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-danceradiouk-dance-uk
+  broadcaster: independent
+  name: DanceRadioUK - Dance UK
+  streamUrl: https://dancestream.danceradiouk.com/stream/1/
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.danceradiouk.com/wp-content/uploads/2021/02/druk300-150x150.png
+  homepage: https://danceradiouk.com/
+  country: GB
+  status: stream-only
+  stationuuid: 30369d73-370f-4403-b5d5-39843a00fcec
+  changeuuid: 1aec7145-f48a-42ec-9566-17294261e95d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-naim-jazz-flac
+  broadcaster: independent
+  name: "Naim Jazz [flac]"
+  streamUrl: https://mscp3.live-streams.nl:8342/jazz-flac.flac
+  bitrate: 128
+  codec: OGG
+  favicon: https://www.naimaudio.com/build/assets/apple-touch-icon-2a4e35a0.png
+  homepage: https://www.naimaudio.com/new-naim-radio
+  country: GB
+  status: stream-only
+  stationuuid: fe6cd053-2fef-43e3-88af-8fac82591868
+  changeuuid: 7ca38ffe-624f-4e33-be66-c53dabf38259
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-kool-fm
+  broadcaster: independent
+  name: Kool FM
+  streamUrl: https://admin.stream.rinse.fm/proxy/kool/stream
+  bitrate: 128
+  codec: AAC+
+  favicon: https://pbs.twimg.com/profile_images/1638236080674578434/Hbww_nFm_400x400.jpg
+  homepage: https://rinse.fm/channels/kool/
+  country: GB
+  status: stream-only
+  stationuuid: 973c30a5-a178-4daf-89c7-272ec6c47456
+  changeuuid: 3e70a3df-7ab8-41dc-9ccd-68766ed8a1dc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-virgin-radio-anthems
+  broadcaster: independent
+  name: Virgin Radio Anthems
+  streamUrl: https://radio.virginradio.co.uk/stream-anthems
+  bitrate: 128
+  codec: AAC
+  homepage: https://virginradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 1a1ef3a9-0f99-11ea-a87e-52543be04c81
+  changeuuid: baf3bf4b-fb13-46f0-a703-f36d8f1410cd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-rokit-radio-british-comedy-2
+  broadcaster: independent
+  name: "ROKit Radio : British Comedy 2"
+  streamUrl: https://streaming05.liveboxstream.uk/proxy/jondreas/stream
+  bitrate: 48
+  codec: MP3
+  favicon: https://rokitradio.com/favicon.ico
+  homepage: https://rokitradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 99f4e5bf-e2a0-4386-b116-3ecd4e4de6b5
+  changeuuid: 78a1f015-f105-4b96-ae74-8a62e9d56abc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-classic-fm-hd
+  broadcaster: independent
+  name: Classic FM HD
+  streamUrl: https://ice-sov.musicradio.com/ClassicFMHD?hdauth=:2000000000:a290d4b39a16153061d4c743008b9fe8d424a7e5ec6469d40acf51fdcd336e80
+  bitrate: 192
+  codec: AAC
+  favicon: https://is1-ssl.mzstatic.com/image/thumb/Purple116/v4/bd/a7/bf/bda7bf4f-16e9-6b60-0d87-a39d432b505e/AppIcon-1x_U007emarketing-0-7-0-85-220.png/492x0w.webp
+  homepage: https://www.classicfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: bd1c441c-132a-4d48-a3f3-bdb386f4b09a
+  changeuuid: 91f37a09-67d6-4471-9251-6a9ff8f4a45b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-boom-radio-uk
+  broadcaster: independent
+  name: Boom Radio UK
+  streamUrl: https://listen-boomradio.sharp-stream.com/65_boom_radio_live_192
+  bitrate: 256
+  codec: AAC
+  favicon: https://mmo.aiircdn.com/460/5fb3bb6151ee4.png
+  homepage: https://www.boomradiouk.com/
+  country: GB
+  status: stream-only
+  stationuuid: 5ed77642-9f68-484a-8bbc-af00a4acc629
+  changeuuid: e22af6c9-b26c-459f-be06-d11177a00687
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-street-sounds-radio
+  broadcaster: independent
+  name: Street Sounds Radio
+  streamUrl: https://streaming.broadcastradio.com:10525/streetsd
+  codec: MP3
+  homepage: https://www.streetsoundsradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 5ed6b080-b967-4202-8bb5-96b4557aee5d
+  changeuuid: acbe3229-b63c-48d3-a247-a7c1ca42be48
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-45-radio
+  broadcaster: independent
+  name: "45 Radio"
+  streamUrl: https://stream1.themediasite.co.uk:7009/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.my45radio.co.uk/apple-touch-icon.png
+  homepage: https://www.my45radio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 1408a44f-4c34-49ac-a746-80715c2fea54
+  changeuuid: 71364805-0163-42d0-8b4a-dabb02a8da9a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bbc-for-australasia
+  broadcaster: independent
+  name: BBC for Australasia
+  streamUrl: https://stream.live.vc.bbcmedia.co.uk/bbc_world_service_australasia
+  bitrate: 56
+  codec: MP3
+  favicon: https://bbc.co.uk/favicon.ico
+  homepage: https://bbc.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: c0ba5cba-d388-4ecc-824e-734e767174e2
+  changeuuid: 16742ff4-bc46-4f22-bc2b-2810ec8ac969
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-smooth-country
+  broadcaster: independent
+  name: Smooth Country
+  streamUrl: https://media-ssl.musicradio.com/SmoothCountry
+  bitrate: 48
+  codec: AAC
+  favicon: https://www.smoothradio.com/assets_v4r/smooth/img/favicon-196x196.png
+  homepage: https://www.smoothradio.com/country/
+  country: GB
+  status: stream-only
+  stationuuid: 46f13c3e-823f-4f1e-ab82-5a7b145c337f
+  changeuuid: f5022d84-23e8-423a-8ef0-2c4ef7397c47
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hypedem-reggae-radio
+  broadcaster: independent
+  name: HypeDem Reggae Radio
+  streamUrl: https://mrwolfman2.radioca.st/;
+  bitrate: 128
+  codec: MP3
+  homepage: https://hypedem-radio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 353cb65a-3706-4e7c-8f91-d13eb2829557
+  changeuuid: f1f96f00-f12e-4365-a686-969ad1401525
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-london-music-radio
+  broadcaster: independent
+  name: London Music Radio
+  streamUrl: https://radiobossrelay.radioca.st/stream
+  bitrate: 320
+  codec: MP3
+  favicon: https://londonmusicradio.com/wp-content/uploads/2017/04/thumbnail_Logo2-2-copyY-copy-black-e1519168864488.jpg
+  homepage: https://londonmusicradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 61bdc00f-5a55-4e0b-a841-7747d66fa7dd
+  changeuuid: f8563276-db7b-4d39-a1e2-9b3dbe2e8298
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-kiss-uk
+  broadcaster: independent
+  name: KISS UK
+  streamUrl: https://live-kiss.sharp-stream.com/kiss100.mp3
+  bitrate: 112
+  codec: MP3
+  favicon: https://media.bauerradio.com/image/upload/c_crop,g_custom/v1678797505/brand_manager/stations/mahvph4fqjmnp4y8d6wt.png
+  homepage: https://kissfmuk.com/
+  country: GB
+  status: stream-only
+  stationuuid: 5984167a-b25e-4eec-a878-ff9253ee0c4a
+  changeuuid: 09b39b4f-05ce-4dea-a203-19c02a62d860
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-essex
+  broadcaster: independent
+  name: Radio Essex
+  streamUrl: https://stream.aiir.com/ujzy590c3stvv
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/339/67698698b4c61.png
+  homepage: https://www.radioessex.com/
+  country: GB
+  status: stream-only
+  stationuuid: b7925a87-ce5d-48f1-b0df-fb30d75aa2c4
+  changeuuid: 29e794e7-5131-41ca-b6d7-4fbe05293b84
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-rinse-uk
+  broadcaster: independent
+  name: Rinse UK
+  streamUrl: https://admin.stream.rinse.fm/proxy/rinse_uk/stream
+  bitrate: 128
+  codec: AAC+
+  favicon: https://i1.sndcdn.com/avatars-HFUM5iVBOYInWEED-oro7Vg-t200x200.jpg
+  homepage: https://www.rinse.fm/channels/uk/
+  country: GB
+  status: stream-only
+  stationuuid: 9c100db7-ba97-4e6f-821f-dba1ed08ad52
+  changeuuid: 661f694b-d0fb-4900-8201-b8acb8e9d8ec
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-classic-fm-movies
+  broadcaster: independent
+  name: Classic FM Movies
+  streamUrl: https://media-ice.musicradio.com/ClassicFMMoviesMP3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.classicfm.com/movies/
+  country: GB
+  status: stream-only
+  stationuuid: 7cc0c486-92cb-4509-9b93-775e41950ed3
+  changeuuid: 8b39f00a-eb56-4ddd-a76c-7dd1e09d150d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-intamixx-80s-90s-radio-uk
+  broadcaster: independent
+  name: Intamixx 80s 90s Radio UK
+  streamUrl: https://radio.intamixx.uk:8443/radio2
+  bitrate: 128
+  codec: MP3
+  favicon: https://80s.intamixx.uk/images/imc8090.jpg
+  homepage: https://80s.intamixx.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 8c45fcc8-a9fe-4e07-9a53-67b6a2a1fc76
+  changeuuid: b282f593-a91e-4b23-8b17-8d303fd40dd6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-cruiseone-radio
+  broadcaster: independent
+  name: CruiseOne Radio
+  streamUrl: https://solid24.streamupsolutions.com/proxy/cmxicxxx?mp=/256kbps
+  bitrate: 256
+  codec: MP3
+  favicon: https://i1.sndcdn.com/avatars-000037533466-mgfbsp-t500x500.jpg
+  homepage: https://cruiseoneradio.net/
+  country: GB
+  status: stream-only
+  stationuuid: 10edd1ec-192b-40ff-aaf2-645471d04dfb
+  changeuuid: f15ef263-3066-4b15-87d8-5f84f8ebba77
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-kicks-fm
+  broadcaster: independent
+  name: KICKS fm
+  streamUrl: https://s6.citrus3.com:8452/stream
+  bitrate: 160
+  codec: MP3
+  homepage: https://www.kicks.fm/
+  country: GB
+  status: stream-only
+  stationuuid: 58341289-63e4-4ef6-b760-09bbfd420659
+  changeuuid: 49595981-68b9-4f85-8742-7ecee9cdfffd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-expansions-nts
+  broadcaster: independent
+  name: "Expansions | NTS"
+  streamUrl: https://stream-mixtape-geo.ntslive.net/mixtape3
+  codec: MP3
+  favicon: https://www.nts.live/apple-touch-icon.png?v=47re43rrzb
+  homepage: https://www.nts.live/infinite-mixtapes/expansions
+  country: GB
+  status: stream-only
+  stationuuid: 7a6953ac-e6d1-11e9-a96c-52543be04c81
+  changeuuid: a8a443fb-2978-4060-ad74-2584ca66c3a4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-energy-fm-dance-music-radio
+  broadcaster: independent
+  name: Energy FM - Dance Music Radio
+  streamUrl: https://radio.streemlion.com:1875/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://cdn.onlineradiobox.com/img/logo/9/35209.v3.png
+  homepage: https://www.energyfm.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 14ed260e-abd1-401c-8cf0-7e4625f58dae
+  changeuuid: 195ce884-1a23-41b1-98c8-3528717fc8ec
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-1940s-radio-hs-pumpkin-fm
+  broadcaster: independent
+  name: "1940s Radio HS - Pumpkin FM"
+  streamUrl: https://cast2.asurahosting.com/proxy/1940sradio/stream
+  bitrate: 128
+  codec: MP3
+  homepage: https://pumpkinfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: dbb7ac2b-cda4-42ef-9e7a-18c62dade3f6
+  changeuuid: 01256fd7-c42c-46d4-9e06-db10a01b6274
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-davide-of-mimic
+  broadcaster: independent
+  name: Davide of MIMIC
+  streamUrl: https://streaming04.liveboxstream.uk/proxy/davideof?mp=/stream
+  bitrate: 320
+  codec: MP3
+  homepage: https://www.davideofmimic.com/
+  country: GB
+  status: stream-only
+  stationuuid: 86cbd3d9-dfce-4c62-830a-c92fe552d476
+  changeuuid: fba19669-2d7d-4c0e-8ba3-52d0667bc6a7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-classic-fm-essential-classical
+  broadcaster: independent
+  name: Classic FM Essential Classical
+  streamUrl: https://icecast.thisisdax.com/ClassicFM-M-Essential
+  bitrate: 48
+  codec: AAC
+  favicon: https://www.radio.de/images/broadcasts/a1/f8/126083/1/c300.png
+  homepage: https://www.classicfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: e847f0b7-4694-4d96-a56a-3bc9543c5705
+  changeuuid: 4c12011d-7c39-4dee-b6b9-f8edbc95b021
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-psychedelicized-radio
+  broadcaster: independent
+  name: Psychedelicized Radio
+  streamUrl: https://cast1.asurahosting.com/proxy/psychedelicized/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://cdn-radiotime-logos.tunein.com/s155704q.png
+  homepage: https://psychedelicized.com/
+  country: GB
+  status: stream-only
+  stationuuid: ded0682b-5b6b-4be7-a351-a03b765e91de
+  changeuuid: 1b1ec539-857e-4e85-b280-21f9f4a719d7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-dire-straits
+  broadcaster: independent
+  name: Dire Straits
+  streamUrl: https://stream.pcradio.ru/dire_straits-hi
+  codec: AAC
+  favicon: null
+  homepage: https://pcradio.ru/
+  country: GB
+  status: stream-only
+  stationuuid: e5d11c60-4d05-41cd-84dc-60ccf9445caf
+  changeuuid: 17d6c6ab-ed11-4d0c-aa41-232e08751141
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-gold-london
+  broadcaster: independent
+  name: Gold London
+  streamUrl: https://media-ssl.musicradio.com/Gold?isLoggedIn=false&dax_version=release_2019&dax_player=GlobalPlayer&dax_platform=Web&aisDelivery=streaming&listenerid=1612127423858_0.6253666805372976&aw_0_1st.playerid=GlobalPlayer&aw_0_1st.skey=1612127423&aw_0_req.userConsentV2=CPA5x3uPA5x3uAGABCENBLCgAAAAAAAAAATIAAAAAAAA.YAAAAAAAAAAA
+  bitrate: 48
+  codec: AAC
+  favicon: https://media-ssl.musicradio.com/favicon.ico
+  homepage: https://media-ssl.musicradio.com/Gold?isLoggedIn=false&dax_version=release_2019&dax_player=GlobalPlayer&dax_platform=Web&aisDelivery=streaming&listenerid=1612127423858_0.6253666805372976&aw_0_1st.playerid=GlobalPlayer&aw_0_1st.skey=1612127423&aw_0_req.userConsentV2=CPA5x3uPA5x3uAGABCENBLCgAAAAAAAAAATIAAAAAAAA.YAAAAAAAAAAA
+  country: GB
+  status: stream-only
+  stationuuid: 996a22a8-9bc1-48dc-8f08-e46b71dafc66
+  changeuuid: 803e5d19-f8a8-4e01-b2c1-dade9b23f57c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-greatest-hits-non-stop
+  broadcaster: independent
+  name: Greatest Hits Non-Stop
+  streamUrl: https://s8.myradiostream.com/58238//listen.mp3
+  bitrate: 160
+  codec: MP3
+  favicon: https://greatesthitsnonstop.com/wp-content/uploads/2020/02/GHNS_512-1.png
+  homepage: https://greatesthitsnonstop.com/
+  country: GB
+  status: stream-only
+  stationuuid: 291e80cf-fe08-42f6-ae95-7a1dfac2d5de
+  changeuuid: db70013c-bf1b-4455-80f2-95cbdf9d7be1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-reprezent-radio
+  broadcaster: independent
+  name: Reprezent Radio
+  streamUrl: https://radio.canstream.co.uk:8022/live.mp3
+  bitrate: 256
+  codec: MP3
+  favicon: https://cdn.prod.website-files.com/62bc4b9b51f455e9a386fdd1/62be3ea967ffbeb32ccfe453_android-chrome-256x256.png
+  homepage: https://www.reprezentradio.org.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 962d6d54-0601-11e8-ae97-52543be04c81
+  changeuuid: 44fd999c-f777-48d8-8bb7-d6b92f53055e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-naim-radio-320k-aac
+  broadcaster: independent
+  name: "Naim Radio [320k aac]"
+  streamUrl: https://mscp3.live-streams.nl:8362/high.aac
+  bitrate: 320
+  codec: AAC
+  favicon: https://www.naimaudio.com/build/assets/apple-touch-icon-2a4e35a0.png
+  homepage: https://www.naimaudio.com/radio/player
+  country: GB
+  status: stream-only
+  stationuuid: bc67e55c-26b9-4426-8412-8c16032694be
+  changeuuid: a0c1d1f9-bc16-438e-b486-c14b1fd72e0b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-box-uk-radio
+  broadcaster: independent
+  name: Box UK Radio
+  streamUrl: https://boxstream.danceradiouk.com/stream/1/stream.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.danceradiouk.com/players/files/images/albumart/13040-BoxUK-300.jpg
+  homepage: https://www.danceradiouk.com/
+  country: GB
+  status: stream-only
+  stationuuid: ce62430f-e971-48c3-b31c-ee55a2a81974
+  changeuuid: af817c5c-aa4f-435c-837a-516d109f68ee
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-classic-fm-video-game-music
+  broadcaster: independent
+  name: Classic FM Video Game Music
+  streamUrl: https://icecast.thisisdax.com/ClassicFM-M-Gaming
+  bitrate: 48
+  codec: AAC
+  favicon: https://www.classicfm.com/assets_v4r/classic/img/favicon-196x196.png
+  homepage: https://www.classicfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: 1cedf594-9460-47c9-ad66-1c3bda41901b
+  changeuuid: e59fdce7-0cdb-4724-b26c-618d6a8822a0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bbc-arabic
+  broadcaster: independent
+  name: "BBC Arabic "
+  streamUrl: https://stream.live.vc.bbcmedia.co.uk/bbc_arabic_radio
+  bitrate: 56
+  codec: MP3
+  favicon: null
+  homepage: https://stream.live.vc.bbcmedia.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: fd7898b9-e442-4824-a313-77f25cb59de1
+  changeuuid: 07972fb4-5076-444e-8956-afc2ca71a3d6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-birdsong-radio
+  broadcaster: independent
+  name: Birdsong Radio
+  streamUrl: https://a1.radio.co/s5c5da6a36/listen
+  codec: MP3
+  favicon: https://images.radio.co/station_logos/s5c5da6a36.20240717025356.png
+  homepage: https://www.birdsong.fm/
+  country: GB
+  status: stream-only
+  stationuuid: ceab5124-608a-4eb1-8149-d65829f9a9d7
+  changeuuid: 766f4f0a-a7fa-4196-aa6d-07a2212daf13
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-4-to-the-floor-nts
+  broadcaster: independent
+  name: "4 To The Floor | NTS"
+  streamUrl: https://stream-mixtape-geo.ntslive.net/mixtape5
+  codec: MP3
+  favicon: https://www.nts.live/apple-touch-icon.png?v=47re43rrzb
+  homepage: https://www.nts.live/infinite-mixtapes/4-to-the-floor
+  country: GB
+  status: stream-only
+  stationuuid: e231378a-e6d1-11e9-a96c-52543be04c81
+  changeuuid: 4b3645e0-91c2-4d01-a8a2-1b358a7f8be0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-truckstopradio
+  broadcaster: independent
+  name: TruckStopRadio
+  streamUrl: https://oreo.truckstopradio.co.uk/radio/8000/radio.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://truckstopradio.co.uk/favicon.ico
+  homepage: https://truckstopradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: bf9bf08f-836d-481f-8837-19e419363fd3
+  changeuuid: d11d4d3c-88d8-435c-bd19-b0769dafc2a5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-x
+  broadcaster: independent
+  name: Radio X
+  streamUrl: https://media-ssl.musicradio.com/RadioXLondonMP3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radiox.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: fc057e27-07f1-4556-bd31-bceb31d5eabd
+  changeuuid: 1324879f-f17e-4305-96a4-e0429e3c6190
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-the-english-909-radio
+  broadcaster: independent
+  name: The English 909 Radio
+  streamUrl: https://www.radioking.com/play/the-english-909
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.google.co.uk/search?q=the+english+909+radio+favicon&tbm=isch&ved=2ahUKEwjy5ois1dX6AhVYgc4BHX2PCx8Q2-cCegQIABAA&oq=the+english+909+radio+favicon&gs_lcp=CgNpbWcQAzoECCMQJ1CSB1jdRWC8SGgAcAB4AIABR4gBmASSAQE5mAEAoAEBqgELZ3dzLXdpei1pbWfAAQE&sclient=img&ei=jBBEY_LwF9iCur4P_Z6u-AE&authuser=0&bih=711&biw=1431&hl=en-GB#imgrc=BAdZB6F91SYoWM
+  homepage: https://english909.com/
+  country: GB
+  status: stream-only
+  stationuuid: b996ea20-7d49-4409-baa6-4d44989dc3d4
+  changeuuid: 69af3e1a-aba2-4640-b586-0bd06ff7ea88
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-rokit-radio-comedy-gold
+  broadcaster: independent
+  name: "ROKit Radio : Comedy Gold"
+  streamUrl: https://streaming06.liveboxstream.uk/proxy/rokstar8/stream
+  bitrate: 48
+  codec: MP3
+  favicon: https://rokitradio.com/images/channels/comedy_gold.jpg
+  homepage: https://rokitradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 4b6aebf2-0ced-4058-8e71-52c701359b93
+  changeuuid: 67a4c443-f8c2-4200-9df1-51a37a3d07bb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-just-house-music
+  broadcaster: independent
+  name: Just House Music
+  streamUrl: https://justhousemusic.radioca.st/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://cdn-profiles.tunein.com/s293430/images/logod.png?t=638095610890000000
+  homepage: https://justhousemusic.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: f9a4e918-7df8-42ba-862f-21828d7c9b09
+  changeuuid: e139fdad-ff60-4b11-95e2-e2df99aae93b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-england-pumpkin-fm
+  broadcaster: independent
+  name: Radio England - Pumpkin FM
+  streamUrl: https://cast2.asurahosting.com/proxy/radioengland/stream
+  bitrate: 64
+  codec: MP3
+  homepage: https://pumpkinfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: 0816371a-d5a5-439e-beb2-717d9cf7e689
+  changeuuid: 1c1f9041-daee-4d39-8756-b76fe431d5ac
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-dandelion-radio
+  broadcaster: independent
+  name: Dandelion Radio
+  streamUrl: https://solid41.streamupsolutions.com/proxy/bqbyzdhi?mp=/stream
+  bitrate: 128
+  codec: MP3
+  favicon: http://www.dandelionradio.com/favicon.ico
+  homepage: http://www.dandelionradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 961fe58c-0601-11e8-ae97-52543be04c81
+  changeuuid: ede017bd-104b-4f0b-a97a-28440178166b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-jfsr-jazz-funk-soul-radio
+  broadcaster: independent
+  name: JFSR - Jazz Funk Soul Radio
+  streamUrl: https://s2.radio.co/s22ae5a8a6/listen
+  bitrate: 320
+  codec: AAC
+  favicon: https://jfsr.co.uk/wp-content/uploads/2020/08/cropped-JFSR-Favicon-300x300.png
+  homepage: https://jfsr.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: e392aeac-2fb8-4f34-9543-6f4c8209d3a7
+  changeuuid: 616f5197-18a1-4c05-909b-554ceead7fd5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-totally-80s-radio
+  broadcaster: independent
+  name: Totally 80s Radio
+  streamUrl: https://ukstream.radiohost.co.uk/listen/totally_80s_radio/radio.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://lh3.googleusercontent.com/YJxyM8-pCOf0oai9UTisHiudRJ1ni2Xt3s7DdPYQKp_oMCuHBn75zpZMSpFd_CBt6PdCKjlOWk9ToqItZPzcrlcgtMXK_h0k=s500
+  homepage: https://www.totally80sradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 74b45490-b3ff-45a9-9087-d021f3fd7282
+  changeuuid: 2800b94a-da7e-42d5-a480-a4aa4111aaf0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-now-80s
+  broadcaster: independent
+  name: Now 80s
+  streamUrl: https://lightning-now80s-samsunguk.amagi.tv/playlist.m3u8
+  bitrate: 1020
+  codec: AAC,H.264
+  homepage: https://nowmusic.com/
+  country: GB
+  status: stream-only
+  stationuuid: fa6de722-63b8-443d-a39f-50e3b96e5009
+  changeuuid: 2fb704bf-6845-484c-8654-e073c9afcad5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-poolside-nts
+  broadcaster: independent
+  name: "Poolside | NTS"
+  streamUrl: https://stream-mixtape-geo.ntslive.net/mixtape4
+  codec: MP3
+  favicon: https://www.nts.live/favicon.ico
+  homepage: https://www.nts.live/infinite-mixtapes/poolside
+  country: GB
+  status: stream-only
+  stationuuid: 4f9dd235-e6d1-11e9-a96c-52543be04c81
+  changeuuid: 0109a5d6-13fa-4c96-8694-5d051f0b8a8f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-rokit-radio-classic-old-time-radio-shows
+  broadcaster: independent
+  name: "ROKit Radio : Classic Old Time Radio Shows"
+  streamUrl: https://streaming04.liveboxstream.uk/proxy/roksta18/stream
+  bitrate: 48
+  codec: MP3
+  favicon: https://rokitradio.com/images/channels/old_time_gold.jpg
+  homepage: https://rokitradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 68e826da-67e5-4df8-a179-9f105aa46f87
+  changeuuid: e188dbec-e8de-438e-8d91-e28cad114049
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-fsn-world-news
+  broadcaster: independent
+  name: FSN World News
+  streamUrl: https://www.fsnradionews.com/FSNNews/FSNWorldNews.mp3
+  codec: MP3
+  homepage: https://www.featurestorynews.com/
+  country: GB
+  status: stream-only
+  stationuuid: f0f9c15e-7b8a-49b5-8d3d-96563d8972e3
+  changeuuid: 16df0773-71df-4302-9f34-60cecc6e174c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-24-7-disco
+  broadcaster: independent
+  name: "24-7 Disco"
+  streamUrl: https://antares.dribbcast.com/proxy/s8190/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://24-7nicheradio.com/wp-content/uploads/2017/04/xDisco.jpg.pagespeed.ic.Z0Vjw3zxU-.webp
+  homepage: https://24-7nicheradio.com/audiogallery/24-7-disco/
+  country: GB
+  status: stream-only
+  stationuuid: 2816ef39-ba7d-42fc-9f81-443c386ac3dc
+  changeuuid: ce8a2465-59c6-452a-9d76-a02e36713682
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-tonic-ska-radio
+  broadcaster: independent
+  name: Tonic Ska Radio
+  streamUrl: https://eu10.fastcast4u.com/tonicska
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.tonicskaradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: cfe03119-0437-4b8d-b9fd-2bace1551bd1
+  changeuuid: f59a7395-d7ad-4560-8af2-49fe4bd8613c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-crime-incorporated-pumpkin-fm
+  broadcaster: independent
+  name: Crime Incorporated - Pumpkin FM
+  streamUrl: https://cast2.asurahosting.com/proxy/crimeinc/stream
+  bitrate: 64
+  codec: MP3
+  favicon: https://pumpkinfm.com/wp-content/uploads/2019/02/CrimeInc300x300.jpg
+  homepage: https://pumpkinfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: 07afab0b-d31a-4a1a-9e32-cc7f5bfbd53f
+  changeuuid: 052ead58-649e-4ce9-8cdf-c061a7ff113e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-aah-classical-radio-bach
+  broadcaster: independent
+  name: Aah Classical Radio - Bach
+  streamUrl: https://radio.hearme.fm:9040/stream
+  codec: MP3
+  favicon: http://img.sedoparking.com/templates/logos/sedo_logo.png
+  homepage: http://classical.aahradio.com/channel/bach/
+  country: GB
+  status: stream-only
+  stationuuid: 15dfa7b3-70f5-4dda-9eb3-daf62daae922
+  changeuuid: 86550aae-8f3a-47f9-a712-4d6e4f6774de
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-rokit-radio-adventure-stories
+  broadcaster: independent
+  name: "ROKit Radio : Adventure Stories"
+  streamUrl: https://streaming06.liveboxstream.uk/proxy/rokstar7/stream
+  bitrate: 48
+  codec: MP3
+  favicon: https://rokitradio.com/images/channels/adventure_stories.jpg
+  homepage: https://rokitradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 6d73fb63-8785-4e74-be33-8f55da6ae89f
+  changeuuid: 4c1a8af0-b4db-4c0b-90d8-9190ad098235
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-the-tube-nts
+  broadcaster: independent
+  name: "The Tube | NTS"
+  streamUrl: https://stream-mixtape-geo.ntslive.net/mixtape26
+  codec: MP3
+  favicon: https://www.nts.live/apple-touch-icon.png?v=47re43rrzb
+  homepage: https://www.nts.live/infinite-mixtapes/the-tube
+  country: GB
+  status: stream-only
+  stationuuid: cda70b2c-e8f0-4d05-9b74-dc26b0a187b1
+  changeuuid: 61fc089e-2a61-4d9a-b0d1-8a49d4743292
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-flashback-radio
+  broadcaster: independent
+  name: Flashback Radio
+  streamUrl: https://live.flashbackcentral.co.uk/radio/8000/apple
+  bitrate: 128
+  codec: AAC
+  favicon: https://irp.cdn-website.com/d8990fde/site_favicon_16_1654769166393.ico
+  homepage: https://www.flashbackradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: dca27db4-05db-4fc6-91fe-5d55992c2339
+  changeuuid: 38b72e67-219a-4ebc-a1d3-55b0183fb701
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-memory-lane-nts
+  broadcaster: independent
+  name: "Memory Lane | NTS"
+  streamUrl: https://stream-mixtape-geo.ntslive.net/mixtape6
+  codec: MP3
+  favicon: https://www.nts.live/favicon.ico
+  homepage: https://www.nts.live/infinite-mixtapes/memory-lane
+  country: GB
+  status: stream-only
+  stationuuid: 3c66c82a-e6d0-11e9-a96c-52543be04c81
+  changeuuid: 89d13ecf-55ae-44eb-8337-75295bf4d479
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-pink-floyd
+  broadcaster: independent
+  name: Pink Floyd
+  streamUrl: https://stream.pcradio.ru/Pink_Floyd-hi
+  codec: AAC
+  favicon: null
+  homepage: https://pcradio.ru/
+  country: GB
+  status: stream-only
+  stationuuid: 39c07f86-2d14-469a-994b-968de965e75a
+  changeuuid: b1dbddd6-7a52-4482-8d2e-5fff384acc2c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-tmm-1-hq
+  broadcaster: independent
+  name: TMM 1 (HQ)
+  streamUrl: https://listen-msmn.sharp-stream.com/nme1high.mp3
+  bitrate: 256
+  codec: MP3
+  favicon: https://cdn-profiles.tunein.com/s159857/images/logod.png
+  homepage: https://www.themusicmachine.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 6d55f9ad-5a50-4ac3-be1c-4abcbb68fd09
+  changeuuid: e41cca24-06ae-4311-8185-ae84d1d338f7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-actual-radio
+  broadcaster: independent
+  name: Actual Radio
+  streamUrl: https://securestreams.autopo.st:1174/;
+  bitrate: 128
+  codec: MP3
+  homepage: https://actualradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: d8d21c43-efbb-4d27-9abc-c0671e769d71
+  changeuuid: 49849f09-0835-4b01-95fa-9517e09f6347
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-subtle-radio
+  broadcaster: independent
+  name: Subtle Radio
+  streamUrl: https://subtle.out.airtime.pro/subtle_a
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.subtleradio.com/wp-content/uploads/2022/11/favicon.png
+  homepage: https://www.subtleradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 1dbdc89f-f0d1-4bf7-8922-266edeb912dd
+  changeuuid: d333ec2c-b64a-4277-a2e0-81d25bc26489
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-field-recordings-nts
+  broadcaster: independent
+  name: "Field Recordings | NTS"
+  streamUrl: https://stream-mixtape-geo.ntslive.net/mixtape23
+  codec: MP3
+  favicon: https://www.nts.live/apple-touch-icon.png?v=47re43rrzb
+  homepage: https://www.nts.live/infinite-mixtapes/field-recordings
+  country: GB
+  status: stream-only
+  stationuuid: 3fb45633-813e-4c6b-b262-e90c3846d10d
+  changeuuid: 6bf42c01-9b52-41b0-ad60-915c90a128cb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-soho-radio-london
+  broadcaster: independent
+  name: Soho Radio London
+  streamUrl: https://sohoradiomusic.doughunt.co.uk:8010/128mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://sohoradiolondon.com/wp-content/themes/sohoradio-jan-2023/build/images/favicons/sohoradio-192x192.jpg
+  homepage: https://sohoradiolondon.com/
+  country: GB
+  status: stream-only
+  stationuuid: 20bcbbc0-75b1-43ab-9919-6230ce0d8bba
+  changeuuid: 5c982868-d3cc-41db-be8e-ac8998ba8655
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-labyrinth-nts
+  broadcaster: independent
+  name: "Labyrinth | NTS"
+  streamUrl: https://stream-mixtape-geo.ntslive.net/mixtape31
+  codec: MP3
+  favicon: https://www.nts.live/apple-touch-icon.png?v=47re43rrzb
+  homepage: https://www.nts.live/infinite-mixtapes/labyrinth
+  country: GB
+  status: stream-only
+  stationuuid: 9391f9be-cbc1-4c84-8da5-cf7eebefaab2
+  changeuuid: 3f636f54-d44f-42ae-82be-96ea75a6ecf4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-the-voice-of-doom
+  broadcaster: independent
+  name: The Voice Of Doom
+  streamUrl: https://streaming.galaxywebsolutions.com:9046/stream
+  bitrate: 320
+  codec: AAC
+  homepage: https://www.thevoiceofdoom.com/
+  country: GB
+  status: stream-only
+  stationuuid: 94e61c2c-a6fb-4ff0-8b3d-1041a3e8e42e
+  changeuuid: 69a17e90-9f14-4cae-abec-82b4d53ed63b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-dnbradio-com
+  broadcaster: independent
+  name: DnBRadio.com
+  streamUrl: https://fw.dnbradio.com/dnbradio_main.mp3
+  bitrate: 320
+  codec: MP3
+  favicon: https://dnbradio.com/img/logotags.png
+  homepage: https://dnbradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 705c6f01-92b5-4766-9c6f-53540414b6c3
+  changeuuid: 4fe59181-2c9e-4d2a-9c55-eb3fa9ef3783
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-gen-x-radio
+  broadcaster: independent
+  name: Gen X Radio
+  streamUrl: https://s2.radio.co/sf25229e16/listen
+  bitrate: 320
+  codec: AAC
+  favicon: https://genxradio.co.uk/wp-content/uploads/2021/11/cropped-GenXAsset-9-192x192.png
+  homepage: https://genxradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 5df5fc8a-3259-4d29-988d-814ab6332ece
+  changeuuid: 2fdd1015-e56c-470d-bfc7-a3d714fccdd5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-house-fusion-radio-uk
+  broadcaster: independent
+  name: House Fusion Radio (UK)
+  streamUrl: https://housefusionradiouk.out.airtime.pro/housefusionradiouk_a
+  bitrate: 192
+  codec: MP3
+  favicon: https://d1di2lzuh97fh2.cloudfront.net/files/1j/1j3/1j3767.ico?ph=a9529f376f
+  homepage: https://house-fusion-radio5.webnode.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: b6d47672-aa01-4363-bd26-32f0e8d9570e
+  changeuuid: 529189a2-528e-4165-aea8-65f88f554d0f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-the-british-home-front-radio-service
+  broadcaster: independent
+  name: The British Home Front Radio Service
+  streamUrl: https://solid24.streamupsolutions.com/proxy/mmpplqiv?mp=/;type=mp3
+  bitrate: 128
+  codec: MP3
+  homepage: http://www.1940sukradio.co.uk/BHFR/
+  country: GB
+  status: stream-only
+  stationuuid: d53f641f-8321-4d46-b062-506ee653760b
+  changeuuid: f1cce0a8-d8bc-4cee-91c0-3ca60631ce71
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-heart-musicals
+  broadcaster: independent
+  name: Heart Musicals
+  streamUrl: https://media-ice.musicradio.com/HeartMusicalsMP3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.heart.co.uk/musicals/
+  country: GB
+  status: stream-only
+  stationuuid: 0ea2b325-307b-45d4-80ce-f948302b1366
+  changeuuid: 3ed8e67d-152d-4299-9cd0-c22448efa3ef
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-boogaloo-radio
+  broadcaster: independent
+  name: Boogaloo Radio
+  streamUrl: https://streams.radio.co/sb88c742f0/listen
+  bitrate: 192
+  codec: MP3
+  homepage: https://boogalooradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: df185514-161b-476d-a913-d2c2927033a8
+  changeuuid: e1673b42-93aa-4d6c-b3ae-131f21ea10e8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-easy-50s
+  broadcaster: independent
+  name: Easy 50s
+  streamUrl: https://streaming.exclusive.radio/uber/easy50/icecast.audio
+  codec: MP3
+  favicon: https://manager.uber.radio/static/uploads/station/45f6ba11-a495-4500-abae-41c0b999df6c.png
+  homepage: https://easy.radio/station/47/658
+  country: GB
+  status: stream-only
+  stationuuid: 634d8abf-8a2f-4e4e-ac85-58a4c4b831ca
+  changeuuid: 3d8962df-f918-4e19-b596-b77dac162f33
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-mi-soul
+  broadcaster: independent
+  name: "Mi-Soul "
+  streamUrl: https://listen-misoul.sharp-stream.com/462_mi_soul_128_mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://upload.wikimedia.org/wikipedia/en/thumb/c/cc/Mi-Soul_logo.png/220px-Mi-Soul_logo.png
+  homepage: https://mi-soul.com/
+  country: GB
+  status: stream-only
+  stationuuid: 67b7f9d7-2ead-4525-95de-b105b63d2451
+  changeuuid: e2e8d42d-4d88-4161-929e-5861a79185fc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-liquid-dnb
+  broadcaster: independent
+  name: Liquid DnB
+  streamUrl: https://antares.dribbcast.com/proxy/dave1/stream/
+  bitrate: 128
+  codec: MP3
+  homepage: https://liquid-dnb.com/
+  country: GB
+  status: stream-only
+  stationuuid: b8148b29-09d0-4aa1-8bfe-43d236260170
+  changeuuid: 3b56d0d8-29aa-477f-9647-345b1399697d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bbc-radio-one
+  broadcaster: independent
+  name: BBC Radio One
+  streamUrl: https://a.files.bbci.co.uk/ms6/live/3441A116-B12E-4D2F-ACA8-C1984642FA4B/audio/simulcast/hls/nonuk/audio_syndication_low_sbr_v1/aks/bbc_radio_one.m3u8
+  bitrate: 101
+  codec: AAC+
+  favicon: https://cdn-radiotime-logos.tunein.com/s24939q.png
+  homepage: http://www.bbc.co.uk/radio1
+  country: GB
+  status: stream-only
+  stationuuid: a1b40e7a-94fe-4199-bd8f-31a7ed074a53
+  changeuuid: 430146e7-5eff-4b5a-9638-efdaa06108c8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-funkuradio
+  broadcaster: independent
+  name: FunkURadio
+  streamUrl: https://furfmcou.radioca.st/stream
+  bitrate: 128
+  codec: MP3
+  homepage: http://www.funkuradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 3e841d56-72bc-4728-a8df-fa8389f0f974
+  changeuuid: d3d1542e-45b7-414b-95f8-1ccd58c0f738
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-american-gold-pumpkin-fm
+  broadcaster: independent
+  name: American Gold - Pumpkin FM
+  streamUrl: https://cast2.asurahosting.com/proxy/americangold/stream
+  bitrate: 64
+  codec: MP3
+  favicon: https://pumpkinfm.com/wp-content/uploads/2021/01/AmericanGold300x300.jpg
+  homepage: https://pumpkinfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: f422b275-d5e2-4702-8f75-43deed1c267b
+  changeuuid: fd8f191f-c14b-40f9-9266-c394f1988a2b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-diva-radio-disco
+  broadcaster: independent
+  name: Diva Radio Disco
+  streamUrl: https://stream.deevaradio.net:10443/divaradiodisco
+  bitrate: 192
+  codec: MP3
+  homepage: https://deevaradio.net/
+  country: GB
+  status: stream-only
+  stationuuid: ef93618c-686d-45fb-908e-8da696365f8b
+  changeuuid: 7eed6e42-4052-44dd-9bb6-f2f9691ab6f2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-dubplate-fm-dub-bass
+  broadcaster: independent
+  name: "Dubplate.fm Dub &Bass"
+  streamUrl: https://sc2.dubplate.fm/radio/8000/dubandbass/uhifi
+  bitrate: 256
+  codec: MP3
+  homepage: https://dubplate.fm/dub-and-bass-radio
+  country: GB
+  status: stream-only
+  stationuuid: 5a71d128-cb37-4d62-8b8b-a705e95ad2d8
+  changeuuid: aad8b21b-db62-4563-9567-21e28a3d0faa
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-neon-radio-80s-90s-pop-dance
+  broadcaster: independent
+  name: "Neon Radio - 80s & 90s Pop & Dance"
+  streamUrl: https://live.flashbackcentral.co.uk/radio/8050/tunein.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.neonradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 04bd267f-046a-4275-b7c5-c29f9e25efc9
+  changeuuid: e44dfd69-740f-4739-8481-cb7ade3f8ed6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-ozzy-osbourne
+  broadcaster: independent
+  name: Ozzy Osbourne
+  streamUrl: https://stream.pcradio.ru/ozzy_osbourne-hi
+  codec: AAC
+  favicon: null
+  homepage: https://pcradio.ru/
+  country: GB
+  status: stream-only
+  stationuuid: 2e79d453-28ec-45d2-b511-e9d5f8055f28
+  changeuuid: ef4d5e17-08a4-492a-9c11-0159a1b677a1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-heart-south-wales
+  broadcaster: independent
+  name: Heart South Wales
+  streamUrl: https://media-ssl.musicradio.com/HeartSouthWalesMP3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.heart.co.uk/assets_v4r/heart/img/favicon-196x196.png
+  homepage: https://www.heart.co.uk/southwales
+  country: GB
+  status: stream-only
+  stationuuid: 8b5d407b-dc32-11e9-a8ba-52543be04c81
+  changeuuid: 32b66766-5fe6-4e45-8f28-ad35b0016042
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-central-24
+  broadcaster: independent
+  name: Radio Central 24
+  streamUrl: https://casper.radioca.st/;
+  bitrate: 128
+  codec: MP3
+  favicon: http://radiocentral24.com/assets/images/transparent-121x64.png
+  homepage: http://radiocentral24.com/
+  country: GB
+  status: stream-only
+  stationuuid: bd24e3d2-3e2e-47c4-b0a2-73e551728f4c
+  changeuuid: ab1db302-82f7-47d3-8b84-61f36038c649
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-one-world-radio-tomorrowland-anthems
+  broadcaster: independent
+  name: One World Radio - Tomorrowland Anthems
+  streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/OWR_DAB.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.tomorrowland.com/home/apple-touch-icon.png
+  homepage: https://www.tomorrowland.com/home/radio
+  country: GB
+  status: stream-only
+  stationuuid: 5f3fa761-76be-4672-98fd-c5e71771834d
+  changeuuid: 8205726c-8269-4d3b-b83c-ec0a4f77cbda
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-total-soul-uk-192kb-mp3
+  broadcaster: independent
+  name: Total Soul (UK) 192kb mp3
+  streamUrl: https://onair7.xdevel.com/proxy/xautocloud_atvn_1069?mp=/;1/
+  bitrate: 192
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/440/66d2d8d6d54ea.png
+  homepage: https://www.totalsoul.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: afb31087-30b4-44c7-8469-b3526d8f3bb5
+  changeuuid: 5281feab-c507-4336-b4fc-fff1eabf7612
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-i-like-it-oldskool
+  broadcaster: independent
+  name: I Like It Oldskool
+  streamUrl: https://ilikeitoldskool.radioca.st/stream
+  bitrate: 320
+  codec: MP3
+  favicon: https://ilikeitoldskool.co.uk/favicon.ico
+  homepage: https://ilikeitoldskool.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: cc4928e9-f513-4c59-b42c-56097b881431
+  changeuuid: c4944f12-af26-4298-bc71-c3bdbcd63330
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-select-radio
+  broadcaster: independent
+  name: Select Radio
+  streamUrl: https://streaming05.liveboxstream.uk/proxy/selectr1/stream
+  bitrate: 128
+  codec: AAC+
+  favicon: https://selectradioapp.com/wp-content/uploads/2023/11/cropped-selecticon-180x180.png
+  homepage: https://selectradioapp.com/
+  country: GB
+  status: stream-only
+  stationuuid: ce9dced9-1160-450d-a81e-d2df3981e14e
+  changeuuid: 0307d013-6f90-4af8-a4d0-063af6ca5dc9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hot-radio
+  broadcaster: independent
+  name: Hot Radio
+  streamUrl: https://stream1.hippynet.co.uk/stream/hotradio/dorset
+  bitrate: 160
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/406/601068617960a.png
+  homepage: https://www.hot.radio/
+  country: GB
+  status: stream-only
+  stationuuid: 597d9f11-b953-4cae-8f8f-88ff846fe2e9
+  changeuuid: fd4490fe-6090-4762-b36b-01d0b4fb281f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-heart-xmas
+  broadcaster: independent
+  name: Heart Xmas
+  streamUrl: https://media-ssl.musicradio.com/HeartXmas
+  bitrate: 48
+  codec: AAC
+  country: GB
+  status: stream-only
+  stationuuid: 38c61264-4246-4ea1-a280-42a85d59ad25
+  changeuuid: d33cb22c-cd9f-40a0-a0c5-836c1c86cab3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-lite-radio
+  broadcaster: independent
+  name: Lite Radio
+  streamUrl: https://ais-sa2.cdnstream1.com/2382_128.mp3?rp_source=1&=&&___cb=212916936695709
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.literadio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: dcad0c3e-347d-41fb-b10a-3a37eae6dfed
+  changeuuid: c1bfeec3-0233-4d30-8844-4db1730553f3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-trancetechnic-radio
+  broadcaster: independent
+  name: "Trancetechnic Radio "
+  streamUrl: https://s11.ssl-stream.com/ssl/trancete?mp=/stream
+  bitrate: 128
+  codec: MP3
+  favicon: http://img.sedoparking.com/templates/logos/sedo_logo.png
+  homepage: http://www.trancetechnic.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 99d8fad1-51f0-44f3-943c-ee6b4a2864f4
+  changeuuid: b4c1bfb3-910f-4a7d-a965-528c7a6f034b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-easy-radio
+  broadcaster: independent
+  name: Easy Radio
+  streamUrl: https://listen-nation.sharp-stream.com/breezyradiouk.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.nationplayer.com/easy-radio-south/
+  country: GB
+  status: stream-only
+  stationuuid: 43e0dd7d-4d78-4355-9261-6b1f8042796a
+  changeuuid: 48be9943-7fe4-493f-bf24-7346ba56a3ea
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-kaos-sound-pink-floyd-radio
+  broadcaster: independent
+  name: KAOS Sound  - Pink Floyd Radio
+  streamUrl: https://s3.myradiostream.com/:59506/stream/1/
+  bitrate: 128
+  codec: MP3
+  favicon: https://cdn-profiles.tunein.com/s140303/images/logog.png?t=160685
+  homepage: https://kaos-sound.co.uk/mrsdocs/home.html
+  country: GB
+  status: stream-only
+  stationuuid: 0b7938b0-230f-4e3b-aea7-d5c3439969b9
+  changeuuid: 48b6d05a-82cb-4cb3-8f92-b30b0bcede12
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-netil-radio
+  broadcaster: independent
+  name: Netil Radio
+  streamUrl: https://netilradio.out.airtime.pro/netilradio_a
+  bitrate: 128
+  codec: MP3
+  homepage: http://netilradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 2a85a1c6-0cec-428a-a7df-126e4d8a90d9
+  changeuuid: ca341b21-16a2-4516-b1cb-120bdac5b3a4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-rokit-radio-classic-crime-and-suspense
+  broadcaster: independent
+  name: "ROKit Radio : Classic Crime and Suspense"
+  streamUrl: https://streaming04.liveboxstream.uk/proxy/roksta17/stream
+  bitrate: 48
+  codec: MP3
+  favicon: https://rokitradio.com/favicon.ico
+  homepage: https://rokitradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 02a7479c-dbbd-43f6-bbcf-70a3e0fcc481
+  changeuuid: 3336175a-d13e-413f-bdd7-2105cf65ed40
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-psychedelic-secret-radio
+  broadcaster: independent
+  name: Psychedelic Secret radio
+  streamUrl: https://solid48.streamupsolutions.com/proxy/bglsokon?mp=/=stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.psychedelicsecretsradio.com/favicon.ico
+  homepage: https://www.psychedelicsecretsradio.com/?m=1
+  country: GB
+  status: stream-only
+  stationuuid: d288325b-a5ed-42c4-820b-f7b99ab39bd1
+  changeuuid: ccc62068-6cdc-4494-bf58-a85af2334d55
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-x-90s
+  broadcaster: independent
+  name: Radio X 90s
+  streamUrl: https://media-ice.musicradio.com/RadioX90sMP3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radiox.co.uk/90s/
+  country: GB
+  status: stream-only
+  stationuuid: bf8c3fd8-80bb-46f3-929b-effac0a1c31f
+  changeuuid: 9b8dd89d-0147-4f57-b177-f5e2a91e5a04
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bfbs-beats
+  broadcaster: independent
+  name: BFBS Beats
+  streamUrl: https://edge-audio-01-cr.sharp-stream.com/ssvcbfbs20.aac?device=bfbs_beats
+  bitrate: 64
+  codec: AAC+
+  favicon: https://www.forces.net/themes/custom/forcesnet_2020/favicon.ico
+  homepage: https://www.forces.net/
+  country: GB
+  status: stream-only
+  stationuuid: eaddb63a-251a-11e8-91bf-52543be04c81
+  changeuuid: ba01fb10-7fba-4a41-945d-5d0e075352bc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-feelings-nts
+  broadcaster: independent
+  name: "Feelings | NTS"
+  streamUrl: https://stream-mixtape-geo.ntslive.net/mixtape27
+  codec: MP3
+  favicon: https://www.nts.live/apple-touch-icon.png?v=47re43rrzb
+  homepage: https://www.nts.live/infinite-mixtapes/feelings
+  country: GB
+  status: stream-only
+  stationuuid: 636a1133-b9d5-4412-9e8f-36c37f190176
+  changeuuid: d4d02648-11c2-44d8-bd9f-3784586c3ab3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-classic-fm-hall-of-fame
+  broadcaster: independent
+  name: Classic FM Hall of Fame
+  streamUrl: https://icecast.thisisdax.com/ClassicFM-M-HOF
+  bitrate: 48
+  codec: AAC
+  favicon: https://www.radio.de/images/broadcasts/a1/f8/126083/1/c300.png
+  homepage: https://www.classicfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: 2862466b-e997-4bc1-95d2-2ba51972a8ae
+  changeuuid: 50378baa-ae7c-4057-b116-47dd020cf92c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-nu-disco-funk-radio
+  broadcaster: independent
+  name: Nu Disco Funk Radio
+  streamUrl: https://my.radiolize.com/radio/8090/radio.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://uk.radio.net/300/nudiscofunkradio.jpeg?version=b5b29e74fa5bb43b3b8a3e9d27349a94
+  homepage: https://nu-disco-funk-radio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 05324cb6-8a7c-47a2-accb-5423f3d1e686
+  changeuuid: 125e47d2-46f0-4925-a6a1-5e4bad071c42
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-britasia-radio
+  broadcaster: independent
+  name: BritAsia Radio
+  streamUrl: https://s4.radio.co/sfefce156f/listen
+  bitrate: 320
+  codec: MP3
+  favicon: https://britasia.tv/wp-content/uploads/2021/01/britasia-radio-logo.jpg
+  homepage: https://britasia.tv/radio/
+  country: GB
+  status: stream-only
+  stationuuid: f2e9cd87-8f8c-4ebf-8479-eae9b2998168
+  changeuuid: 75bae926-a65c-4356-9caf-ea9d143e45ba
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-mystery-train-radio
+  broadcaster: independent
+  name: "Mystery Train Radio "
+  streamUrl: https://streamer.radio.co/sf662f27c0/listen
+  bitrate: 192
+  codec: AAC
+  homepage: https://www.mysterytrainradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 02da1082-5c2b-4db7-9465-a6f7ba25813b
+  changeuuid: a40dcc53-3079-4fcb-a2e4-593c03825b50
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-judas-priest
+  broadcaster: independent
+  name: Judas Priest
+  streamUrl: https://stream.pcradio.ru/judas_priest-hi
+  codec: AAC
+  favicon: null
+  homepage: https://pcradio.ru/
+  country: GB
+  status: stream-only
+  stationuuid: a1e4582c-af68-41f8-9785-77bd09f0a6b9
+  changeuuid: 1f7ed9ab-13b0-4c52-be51-d1636afd0f5f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-smooth-radio-suffolk
+  broadcaster: independent
+  name: Smooth Radio (Suffolk)
+  streamUrl: https://media-ssl.musicradio.com/SmoothSuffolk
+  bitrate: 48
+  codec: AAC
+  favicon: https://www.smoothradio.com/assets_v4r/smooth/img/favicon-196x196.png
+  homepage: https://www.smoothradio.com/suffolk/
+  country: GB
+  status: stream-only
+  stationuuid: f4928612-ed25-4c21-a852-0600deb0ff1e
+  changeuuid: 5eee99b2-73a4-4da3-8ebc-9a87989a3f18
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-led-zeppelin
+  broadcaster: independent
+  name: Led Zeppelin
+  streamUrl: https://stream.pcradio.ru/Led_Zeppelin-hi
+  codec: AAC
+  favicon: null
+  homepage: https://pcradio.ru/
+  country: GB
+  status: stream-only
+  stationuuid: 1d62a120-704a-4285-a574-c17f48b155f8
+  changeuuid: 76973c23-8790-4dd5-8dc6-0d9b415cccfe
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-smooth-christmas
+  broadcaster: independent
+  name: Smooth Christmas
+  streamUrl: https://media-ice.musicradio.com/SmoothXmasMP3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.smoothradio.com/news/christmas/
+  country: GB
+  status: stream-only
+  stationuuid: 052ee406-0369-44be-939d-a35d24f376c4
+  changeuuid: 1425474e-de06-475b-a1d3-820883a41581
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-boot-boy-radio
+  broadcaster: independent
+  name: Boot Boy Radio
+  streamUrl: https://streaming04.liveboxstream.uk/proxy/dwain?mp=/stream
+  bitrate: 192
+  codec: AAC+
+  favicon: https://bootboyradio.net/wp-content/uploads/2021/02/cropped-900logosquare-192x192.jpg
+  homepage: https://bootboyradio.net/
+  country: GB
+  status: stream-only
+  stationuuid: 9bc64606-6eb1-40bd-901e-aed7c510baa0
+  changeuuid: ec28cf6d-87e5-418f-9098-2fda2b3edd26
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-boom-light
+  broadcaster: independent
+  name: Boom Light
+  streamUrl: https://listen-boomradio.sharp-stream.com/65_boom_light_128_mp3
+  bitrate: 128
+  codec: MP3
+  country: GB
+  status: stream-only
+  stationuuid: 97826f0f-c91b-4e58-8c77-dc1a9ca1f519
+  changeuuid: 37d25fba-3a21-4583-9d12-8f631fa337ca
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-solar-radio
+  broadcaster: independent
+  name: Solar Radio
+  streamUrl: https://listen-msmn.sharp-stream.com/solarlow.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://solarradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 05a082a6-6b31-4515-939d-8896f69160ad
+  changeuuid: 4c0fb40e-b180-40f8-b9ab-8249de2b7301
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-twr-uk
+  broadcaster: independent
+  name: TWR UK
+  streamUrl: https://direct.sharp-stream.com/twruk.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.twr.org.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 7d2b22a8-a65b-11e9-a787-52543be04c81
+  changeuuid: f8ebb839-6a89-46dd-90ff-699e545d803c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-malvern-radio-international-pumpkin-fm
+  broadcaster: independent
+  name: Malvern Radio International - Pumpkin FM
+  streamUrl: https://cast2.asurahosting.com/proxy/radiomalvernint/stream
+  bitrate: 128
+  codec: MP3
+  homepage: https://pumpkinfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: a23a00e2-ca9b-4869-82ec-063d7303d98b
+  changeuuid: 4f7107e7-20a9-4182-9a1e-8c378c1ac372
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-gold-radio-uk
+  broadcaster: independent
+  name: Gold Radio UK
+  streamUrl: https://media-ice.musicradio.com/GoldMP3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.goldradio.com/?page=2
+  country: GB
+  status: stream-only
+  stationuuid: 9b3a5084-91ba-4d90-ac06-3e0ba8c50d67
+  changeuuid: 683b9b37-8408-4caa-a2ba-17c336d4a728
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-heart-fm-birmingham
+  broadcaster: independent
+  name: Heart FM (Birmingham)
+  streamUrl: https://media-ssl.musicradio.com/HeartWestMids?isLoggedIn=true&dax_version=release_4140&dax_player=GlobalPlayer&dax_platform=Web&delivery_type=streaming&aw_0_req.userConsentV2=CPytTYAPytTYAAGABCENATEoAP_AAAGAAAwIGMpF7D5VZWFC-OZ5YKsAMYhXQMCAIuQQCASAA-ABCAKQIIQGgmAQFASgBAAKAQAAIAJBAAIECAAQCQAAAAAAAACAAAAABAAIAAAAgAAAAAAIAAAGAAAAAAAIgAAAEAAAmAwAAIIAAADgkBkABAACwAKgAcAA8ACAAGQANAAeQBDAEQAJgATwAqgB-AEIAKUAW4AwwB7AD9AIGAVcAxQCkQF5hAAoADwASAA_AHOApsMABAU2IAAgAkFQAQAhjIAIAQx0BwABYAFQAOAAgABkADQAHkAQwBEACYAE8AKoAXQAxAB-AFGAKUAW4AwwBogD2AH6AQMAjoBVwCxAGKAReAvMcAOAAQAA8AC4AJAAcgA_AHOAQgAiIBFgCMgKQAU2AvohAIAAWAEMAJgAVQAxAClAKuAYogADAAQAOcAsRKAcAAgABYAHAAeABEACYAFUAMQAowBbgFXAMUAi8BeZIAIABcAHIA1ADMlIC4ACwAKgAcABAADIAGgAPIAhgCIAEwAJ4AUgAqgBiAD8AKMAUoAtwBogD9AI6AVcBF4C8ygA8AC4AJAAcgA_ADaANQAc4BFgCxAF1AMUAa8BSACmwF9A.YAAAAAAAAAAA&dax_listenerid=824C2FA8EC1A06EF990BEDF6BE300A70&gigya_id=aca49a64b4254a8ab5a088cd031e7efe&nlsid=1c499bb707f2fc48cfd210acda4433d0
+  bitrate: 48
+  codec: AAC
+  homepage: https://www.heart.co.uk/westmids/
+  country: GB
+  status: stream-only
+  stationuuid: ae60f33c-cdbe-4ff8-a416-01916d60bc98
+  changeuuid: f4806073-1a14-4c3e-92c6-8777a810d355
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-bloodstream
+  broadcaster: independent
+  name: Radio Bloodstream
+  streamUrl: https://uk1.internet-radio.com/proxy/bloodstream?mp=/stream
+  codec: MP3
+  favicon: https://www.radiobloodstream.com/favicon.ico
+  homepage: https://www.radiobloodstream.com/en/
+  country: GB
+  status: stream-only
+  stationuuid: 5f6f5a1e-4d61-4b5f-ab5c-74bcfd893ac4
+  changeuuid: fbbfbec1-4209-44ca-8e18-1fbfcffea489
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-monocle-radio
+  broadcaster: independent
+  name: Monocle Radio
+  streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/MONOCLE_24.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://pbs.twimg.com/profile_images/1641728752236281856/zeIa6wPU_400x400.jpg
+  homepage: https://monocle.com/radio/
+  country: GB
+  status: stream-only
+  stationuuid: c73b9eff-0ac5-4a43-b05a-346591c66675
+  changeuuid: 92dc58d7-e990-47aa-96e4-654da44a095b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-atlantic-252
+  broadcaster: independent
+  name: Atlantic 252
+  streamUrl: https://stream4.themediasite.co.uk:8042/
+  bitrate: 192
+  codec: MP3
+  favicon: https://play-lh.googleusercontent.com/kIp3BTHaetEyZcMXvOzQ41i15fTZkShTAhpmjS-643non9AxqB45R1--DyU1PbFV=w240-h480-rw
+  homepage: https://www.atlantic252radio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 4655694e-a599-4105-9298-55d590b30ac7
+  changeuuid: 887fdc65-1422-4034-a43e-8cec87bce5cf
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-24-7-blues-radio
+  broadcaster: independent
+  name: "24/7 Blues Radio"
+  streamUrl: https://ec3.yesstreaming.net:3685/stream
+  bitrate: 64
+  codec: MP3
+  favicon: https://www.247onlineradio.com/wp-content/uploads/2023/04/247-Blues-Radio.jpg
+  homepage: https://www.247onlineradio.com/24-7-online-radio-group-stations/24-7-blues-radio/
+  country: GB
+  status: stream-only
+  stationuuid: a648882e-b8d3-422a-9a79-307ccab8c406
+  changeuuid: 0b43b8b4-c3c4-4685-a498-976f001e1fbf
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-forest-gold
+  broadcaster: independent
+  name: Forest Gold
+  streamUrl: https://c2.prostream365.com:8000/live
+  bitrate: 128
+  codec: AAC
+  favicon: https://www.forestgoldradio.com/favicon.ico
+  homepage: https://www.forestgoldradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 1b599e3f-a35e-409a-82b2-dcaaf38d598e
+  changeuuid: 17a24972-9a53-4b89-b711-481ad0ad8190
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-news-radio-uk
+  broadcaster: independent
+  name: News Radio UK
+  streamUrl: https://stream.aiir.com/clcb6m0k9shvv
+  codec: AAC
+  favicon: https://newsradiouk.co.uk/wp-content/uploads/2022/06/Facebook-profile.png
+  homepage: https://newsradiouk.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: a0d298f1-ecfb-4faf-9fe0-5c59d9824131
+  changeuuid: ca9a9b21-23e4-4820-b87a-27d10ee747c2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-sheet-music-nts
+  broadcaster: independent
+  name: "Sheet Music | NTS"
+  streamUrl: https://stream-mixtape-geo.ntslive.net/mixtape35
+  codec: MP3
+  favicon: https://www.nts.live/apple-touch-icon.png?v=47re43rrzb
+  homepage: https://www.nts.live/infinite-mixtapes/sheet-music
+  country: GB
+  status: stream-only
+  stationuuid: 1e0ad463-0dbc-4913-b12d-7d0b7300882b
+  changeuuid: 06b3a8f2-1f22-47b1-b3c0-3c2ee539667f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-chocolate-radio
+  broadcaster: independent
+  name: Chocolate Radio
+  streamUrl: https://stream.radio.co/sa7336b687/listen?ver=712690
+  bitrate: 192
+  codec: AAC
+  homepage: https://chocolate-radio.com/
+  country: GB
+  status: stream-only
+  stationuuid: c2383b38-0b46-450e-8b9c-981e4b34c3aa
+  changeuuid: 5fed0fb0-718f-4dfc-9acb-042bbbaa1bd3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-nation-radio-wales
+  broadcaster: independent
+  name: Nation Radio Wales
+  streamUrl: https://edge-ads-05-gos2.sharp-stream.com/tcnationi.aac
+  bitrate: 48
+  codec: AAC+
+  homepage: https://nationradio.wales/
+  country: GB
+  status: stream-only
+  stationuuid: 9826efd7-b7bc-4469-926f-3dde50bb0bb5
+  changeuuid: b97d56a4-052a-4e4a-9c3e-1332aaa3f317
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-rockin50s-radio
+  broadcaster: independent
+  name: Rockin50s Radio
+  streamUrl: https://eu10.fastcast4u.com/rockin50s
+  bitrate: 128
+  codec: MP3
+  favicon: https://rockin50s.uk/images/site/site_logo2small.png
+  homepage: https://rockin50s.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 29e6919f-076d-4643-82df-a8bbaa6263a6
+  changeuuid: 5e765e97-2507-4d6a-ab34-5ae264984f78
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-uk-bass
+  broadcaster: independent
+  name: UK Bass
+  streamUrl: https://ukbassradio.com/stream
+  bitrate: 192
+  codec: MP3
+  homepage: https://ukbassradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 6e59a7ea-be41-4539-af11-ce78936d42d0
+  changeuuid: df50cbae-428b-4f3a-8997-b600e192c9f6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-dancefmlive-trance
+  broadcaster: independent
+  name: DanceFMLive Trance
+  streamUrl: https://broadcast.dancefmlive.com/radio/8010/radio.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.dancefmlive.com/wp-content/uploads/2021/02/trance.jpg
+  homepage: https://www.dancefmlive.com/
+  country: GB
+  status: stream-only
+  stationuuid: dcd3b0e9-a7bf-402e-8d0a-14f25af2d68c
+  changeuuid: d0e1b9f0-341c-4895-810d-63c2995c5d89
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-divine-radio-london
+  broadcaster: independent
+  name: Divine Radio London
+  streamUrl: https://uk2.internet-radio.com/proxy/divinestream?mp=/stream
+  bitrate: 64
+  codec: AAC+
+  homepage: https://www.divineradiolondon.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: b4491892-12f3-41b7-8252-5cd5e4cf61fb
+  changeuuid: 1eb2e997-e4b1-42e0-b9e9-a7e63886c9da
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-smooth-soul
+  broadcaster: independent
+  name: Smooth Soul
+  streamUrl: https://media-ice.musicradio.com/SmoothSoulMP3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.smoothradio.com/soul/
+  country: GB
+  status: stream-only
+  stationuuid: 866980e7-2ffb-4c3c-9bef-1195fb6f29d8
+  changeuuid: 8fc0b0ff-ddfc-4483-8285-ecf417c1853a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bolton-fm
+  broadcaster: independent
+  name: Bolton FM
+  streamUrl: https://radio.canstream.co.uk:8083/live.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.boltonfm.com/bfm_website_logos/BFM_Logos/BoltonFM-Logo-square.png
+  homepage: https://www.boltonfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: afe3f5a1-88b3-4a2d-b317-710c13d35689
+  changeuuid: d1b5376f-f4f9-4a7c-937a-06be3b644f3c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-sweat-nts
+  broadcaster: independent
+  name: "Sweat | NTS"
+  streamUrl: https://stream-mixtape-geo.ntslive.net/mixtape24
+  codec: MP3
+  favicon: https://www.nts.live/apple-touch-icon.png?v=47re43rrzb
+  homepage: https://www.nts.live/infinite-mixtapes/sweat
+  country: GB
+  status: stream-only
+  stationuuid: 7afce64a-1626-4391-9cad-cb6e664489a8
+  changeuuid: e097de17-5220-4b64-846c-171e7c8947dd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-dclm-radio
+  broadcaster: independent
+  name: DCLM Radio
+  streamUrl: https://airtime.dclm.org/radio/8000/live
+  bitrate: 64
+  codec: MP3
+  favicon: https://radio.dclm.org/assets/img/favicon.png
+  homepage: https://radio.dclm.org/
+  country: GB
+  status: stream-only
+  stationuuid: 78c2d08d-591c-482d-ad50-6939432fedc6
+  changeuuid: c8eae56e-afea-48f6-b49b-c13d54287346
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-5-rivers-radio
+  broadcaster: independent
+  name: "5 Rivers radio"
+  streamUrl: https://onlineradiobox.com/json/uk/5rivers/play?platform=web
+  bitrate: 320
+  codec: MP3
+  favicon: null
+  homepage: https://onlineradiobox.com/json/uk/5rivers/play?platform=web
+  country: GB
+  status: stream-only
+  stationuuid: 4ff45fd0-1ecb-4611-8d2d-38ff54dfcd54
+  changeuuid: a96d9c77-fb32-44b1-9cc5-87dc5217862b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bradford-asian-radio
+  broadcaster: independent
+  name: Bradford Asian Radio
+  streamUrl: https://cast1.asurahosting.com/proxy/bradford/stream
+  bitrate: 128
+  codec: MP3
+  favicon: null
+  homepage: https://cast1.asurahosting.com/proxy/bradford/stream
+  country: GB
+  status: stream-only
+  stationuuid: 77461b3b-d41e-4794-9884-6b9a2361ba70
+  changeuuid: ce12ebab-5cb9-4ddb-8f6c-70273fa9539f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-swu-fm
+  broadcaster: independent
+  name: SWU FM
+  streamUrl: https://admin.stream.rinse.fm/proxy/swu/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://rinse.fm/favicon.ico
+  homepage: https://rinse.fm/channels/swu/
+  country: GB
+  status: stream-only
+  stationuuid: fb156190-ade3-4f47-873a-2136cdc793d6
+  changeuuid: 1557094c-15ff-4475-99f1-d89bac25b481
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-brmb-radio
+  broadcaster: independent
+  name: BRMB Radio
+  streamUrl: https://radio.canstream.co.uk:8147/live.mp3
+  bitrate: 160
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/1111/64a34bf89acd7.png
+  homepage: https://www.brmbradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 44bf63a3-ff14-4248-923d-77291127475e
+  changeuuid: d9300be5-b33e-4f5d-932c-da591e38a073
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-resonance-104-4fm
+  broadcaster: independent
+  name: Resonance 104.4FM
+  streamUrl: https://stream.resonance.fm/resonance?rp_source=1&=&&___cb=309691324386261
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.resonancefm.com/assets/logo-a79206a34394173ba3e41d66a3388f4c.png
+  homepage: https://www.resonancefm.com/
+  country: GB
+  status: stream-only
+  stationuuid: fcb3ce76-8f7b-4949-897e-4158b67ed952
+  changeuuid: e4f5405f-2a08-4146-9e03-72d7cdcfbba4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-foundation-fm
+  broadcaster: independent
+  name: Foundation FM
+  streamUrl: https://streamer.radio.co/s0628bdd53/listen
+  bitrate: 192
+  codec: MP3
+  favicon: https://foundation.fm/images/favicon/favicon.ico
+  homepage: https://foundation.fm/
+  country: GB
+  status: stream-only
+  stationuuid: e8c409e9-ee6f-4670-84bf-02485247def0
+  changeuuid: 1054eb54-15df-47f7-8f5f-9c8f80d1141a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-maria-england
+  broadcaster: independent
+  name: Radio Maria England
+  streamUrl: https://dreamsiteradiocp5.com/proxy/rmengland?mp=/stream
+  bitrate: 48
+  codec: AAC+
+  homepage: https://radiomariaengland.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 095033f1-e833-4b6d-99c6-42efd5db789c
+  changeuuid: 8c79edf4-b96e-4051-82a0-45fbea7023de
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bloop-london-radio-channel-4-music-only-themed-s
+  broadcaster: independent
+  name: "Bloop London Radio (channel 4) - MUSIC ONLY THEMED STREAM.  NATURAL HIGH. DRENCHED IN GROOVES, AN ORGANIC JOURNEY OF BEATS DEDICATED TO MOVING YOUR ASS."
+  streamUrl: https://radio.canstream.co.uk:8058/live.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://blooplondon.com/favicon.ico
+  homepage: https://blooplondon.com/
+  country: GB
+  status: stream-only
+  stationuuid: dc67e4a5-1f90-456a-a8d5-f4a4a8dd5a4a
+  changeuuid: 638008eb-86a0-4a83-8c18-1df79952cb67
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-heart-00s
+  broadcaster: independent
+  name: Heart 00s
+  streamUrl: https://media-ssl.musicradio.com/Heart00sMP3
+  bitrate: 128
+  codec: MP3
+  homepage: https://media-ssl.musicradio.com/Heart00sMP3
+  country: GB
+  status: stream-only
+  stationuuid: ea5d9964-6b60-4f75-a95d-2bc5217d245b
+  changeuuid: 70447189-2bab-4073-94f3-7a7b829b7d9e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hearme-beethoven
+  broadcaster: independent
+  name: HearMe-Beethoven
+  streamUrl: https://radio.hearme.fm:9050/stream
+  codec: MP3
+  homepage: http://www.hearme.fm/
+  country: GB
+  status: stream-only
+  stationuuid: a2b45e00-4c11-4968-9fa8-180491247bf7
+  changeuuid: aedd9ec3-3c12-4770-a5a1-015f05cfb709
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hot-gold
+  broadcaster: independent
+  name: Hot Gold
+  streamUrl: https://stream1.hippynet.co.uk/stream/hotgold/dorset
+  bitrate: 160
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/406/61940c9fa5f84.png
+  homepage: https://www.hotgold.radio/
+  country: GB
+  status: stream-only
+  stationuuid: ea615435-d7b8-4957-903b-992acf3d58ca
+  changeuuid: fa2f320f-1877-42eb-8acf-506eab624dd1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-the-prodigy
+  broadcaster: independent
+  name: The Prodigy
+  streamUrl: https://stream.pcradio.ru/The_Prodigy-hi
+  codec: AAC
+  favicon: null
+  homepage: https://pcradio.ru/
+  country: GB
+  status: stream-only
+  stationuuid: 16584bf8-e3e5-447e-8fe1-dee16cc17268
+  changeuuid: e8facd55-922b-4124-9af1-94e22565256e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-ram-fm-80s-hit-radio
+  broadcaster: independent
+  name: Ram FM 80s Hit Radio
+  streamUrl: https://usa1-vn.mixstream.net/8084/listen.mp3
+  bitrate: 64
+  codec: AAC+
+  favicon: https://ramfm.org/favicon.ico
+  homepage: https://ramfm.org/
+  country: GB
+  status: stream-only
+  stationuuid: 36a14570-8c0d-4011-8d79-215dcf5abf8b
+  changeuuid: 1435e75e-73ad-4109-b2b3-171801692529
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-capital-fm-london
+  broadcaster: independent
+  name: Capital FM London
+  streamUrl: https://media-ssl.musicradio.com/CapitalMP3
+  bitrate: 128
+  codec: MP3
+  homepage: https://capitalfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: 038bfc04-cebb-4fc7-ac13-823b83c8a9d9
+  changeuuid: 1115c8cc-6cc1-43c5-a473-c43e30580451
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-rokit-radio-saturn-x-radio-shows
+  broadcaster: independent
+  name: "ROKit Radio : Saturn-X Radio Shows"
+  streamUrl: https://streaming05.liveboxstream.uk/proxy/jondre03/stream
+  bitrate: 48
+  codec: MP3
+  favicon: https://rokitradio.com/favicon.ico
+  homepage: https://rokitradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 12d06507-314e-49cd-85ee-2c454ea33421
+  changeuuid: a297a391-d073-4080-82da-32047e943560
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-totalrock-radio
+  broadcaster: independent
+  name: TotalRock Radio
+  streamUrl: https://s3.citrus3.com:8056/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://scontent.fcgk8-1.fna.fbcdn.net/v/t1.18169-9/11400985_1602513246663466_6035298720034077887_n.jpg?stp=cp0_dst-jpg_e15_fr_q65&_nc_cat=108&ccb=1-7&_nc_sid=7aed08&efg=eyJpIjoiYiJ9&_nc_eui2=AeEETQvQCq6lHutRRfK171iMKMnkfCxBQUgoyeR8LEFBSC8L74DpSPHz7DvwVuHvpZkIi6qJ0_1acvrVbfekHQL9&_nc_ohc=Oo7DzNH7oTMAX_ZluE8&tn=I4UqcoMHerbAkKms&_nc_ht=scontent.fcgk8-1.fna&oh=00_AfBCXINd2TGpeja3jEiHkpvCmVAH0sxg6_Q39XWj5iRvUA&oe=6407F56B
+  homepage: https://totalrock.com/
+  country: GB
+  status: stream-only
+  stationuuid: ee843b89-e69d-4a64-bb8f-0ed8da7a558a
+  changeuuid: b3331de2-4b47-4ef5-9ba2-c5290ec6807b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-asian-star-radio
+  broadcaster: independent
+  name: Asian Star Radio
+  streamUrl: https://radio.canstream.co.uk:9067/live.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: null
+  homepage: https://radio.canstream.co.uk:9067/live.mp3
+  country: GB
+  status: stream-only
+  stationuuid: 995c536d-b45f-4681-920b-3d4bd9661a1b
+  changeuuid: 0badf63e-7faf-4b41-9320-ff3b838563cd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-4tunesfm
+  broadcaster: independent
+  name: "4TunesFM"
+  streamUrl: https://c30.radioboss.fm:18274/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://assets.production.linktr.ee/profiles/_next/static/logo-assets/apple-icon-120x120.png
+  homepage: https://links.4tunefm.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 1be154bf-1aa6-4637-89d8-f394780479fc
+  changeuuid: f432b59f-1f77-4742-a67a-1adacf7293d2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-gb-news
+  broadcaster: independent
+  name: GB News
+  streamUrl: https://amg01076-lightningintern-gbnews-samsunguk-0lu52.amagi.tv/playlist/amg01076-lightningintern-gbnews-samsunguk/playlist.m3u8
+  bitrate: 1020
+  codec: AAC
+  homepage: https://superradio.cc/
+  country: GB
+  status: stream-only
+  stationuuid: 22eb42bb-ced7-4556-b902-e789d4411ff3
+  changeuuid: 0ac00d0a-3280-4d87-b34b-70c0a30766bb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-heart-fm
+  broadcaster: independent
+  name: Heart FM
+  streamUrl: https://media-ssl.musicradio.com/HeartUK
+  bitrate: 48
+  codec: AAC
+  favicon: https://cdn-profiles.tunein.com/s320841/images/logod.jpg?t=638651487420000000
+  homepage: https://www.heart.co.uk/london/radio/
+  country: GB
+  status: stream-only
+  stationuuid: 42679ed6-49cb-428e-9b74-94af62ad8a0a
+  changeuuid: 9aa60fed-b878-40bb-9965-8554962ff06b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hot-hits-uk-com
+  broadcaster: independent
+  name: Hot Hits UK.com
+  streamUrl: https://443-1.autopo.st/54/stream.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://hothitsuk.com/wp-content/uploads/2020/09/HHUK-3D-transparent-300-x-200.png
+  homepage: https://www.hothitsuk.com/
+  country: GB
+  status: stream-only
+  stationuuid: 5a7ddeac-be16-4090-a77b-b9ead4ed74db
+  changeuuid: 0f6c930a-7767-4e01-8a1c-ae297fe4b0ba
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-rokit-radio-american-classic-radio-shows
+  broadcaster: independent
+  name: "ROKit Radio : American Classic Radio Shows"
+  streamUrl: https://streaming05.liveboxstream.uk/proxy/jondre01/stream
+  bitrate: 48
+  codec: MP3
+  favicon: https://rokitradio.com/images/channels/american_classics.jpg
+  homepage: https://rokitradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 366dde91-14e4-4634-8d5b-ff70ccd97f3c
+  changeuuid: 767c296a-4bf6-4db8-93d4-05135193ea5a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-heart-80s
+  broadcaster: independent
+  name: Radio Heart 80s
+  streamUrl: https://ice-sov.musicradio.com/Heart80sMP3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.heart.co.uk/80s
+  country: GB
+  status: stream-only
+  stationuuid: 4054f742-9af5-4ef0-bca7-70366ad2dbaf
+  changeuuid: 35cc4022-1468-4075-9a9c-d7ba10383895
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-rafa-bible-radio-english
+  broadcaster: independent
+  name: Rafa Bible Radio English
+  streamUrl: https://gains.reviveradio.net/proxy/rafabibleradioeng?mp=/stream
+  bitrate: 128
+  codec: MP3
+  homepage: http://www.rafaradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 086b2f96-7453-45d8-b672-467cb54d8edf
+  changeuuid: 66cd91d0-cb91-4c6e-89fc-e412922284fc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-faza
+  broadcaster: independent
+  name: Radio Faza
+  streamUrl: https://radiocast.cr8tive-digital.com/radiofaza
+  bitrate: 128
+  codec: MP3
+  favicon: https://radiofaza.co.uk/favicon.ico
+  homepage: https://radiofaza.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 3101bfd5-5279-4fbb-864f-e742ac85cc55
+  changeuuid: 422bf2ae-c53b-4a32-abfd-2edf99c3d7c7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-smooth-80s
+  broadcaster: independent
+  name: Smooth 80s
+  streamUrl: https://media-ice.musicradio.com/Smooth80sMP3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.smoothradio.com/80s/
+  country: GB
+  status: stream-only
+  stationuuid: 96568036-4928-44ba-a54e-c4db0b5463f2
+  changeuuid: 28db5651-2cb2-430a-b7dd-d9cda0fc00d1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-sunrise-radio
+  broadcaster: independent
+  name: Sunrise Radio
+  streamUrl: https://direct.sharp-stream.com/sunriseradio.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.sunriseradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: d835e8dc-a3cd-490b-9881-fa5c7b1c2280
+  changeuuid: 096f5ebe-dda9-4921-9f46-6573c608572c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-calm-n-chill-radio
+  broadcaster: independent
+  name: Calm N Chill Radio
+  streamUrl: https://stream.zeno.fm/yvcddifycietv
+  codec: MP3
+  favicon: https://cloud-4shg5daq1-hack-club-bot.vercel.app/0calm_n_chill_radio_logo.png
+  homepage: https://theresmarty.pages.dev/
+  country: GB
+  status: stream-only
+  stationuuid: 108a36e8-75b9-4b4d-8893-1ea2bda3d0fa
+  changeuuid: 0ed66fc8-fb09-4fc8-8bbd-be92713e0a5f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-nazareth
+  broadcaster: independent
+  name: Nazareth
+  streamUrl: https://stream.pcradio.ru/Nazareth-hi
+  codec: AAC
+  favicon: null
+  homepage: https://pcradio.ru/
+  country: GB
+  status: stream-only
+  stationuuid: bab974f5-7ba2-4f4d-8dfb-9b462c5079fa
+  changeuuid: 83c5f6b5-b371-4a24-94cc-beede79d0cb2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-lyca-dil-se-radio
+  broadcaster: independent
+  name: Lyca Dil se radio
+  streamUrl: https://edge-ads-03-gos2.sharp-stream.com/1035.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: null
+  homepage: https://edge-ads-03-gos2.sharp-stream.com/1035.mp3
+  country: GB
+  status: stream-only
+  stationuuid: 1ddeb917-4826-4418-93f2-78aa8e4a5328
+  changeuuid: abca1fcc-c284-4bcd-8163-83a7cc5b4e1f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-old-skool-rave-tapes
+  broadcaster: independent
+  name: Old Skool Rave Tapes
+  streamUrl: https://azuracast.oldskoolravetapes.co.uk/listen/old_skool_rave_tapes/backup?refresh=1744812055358
+  bitrate: 96
+  codec: AAC
+  favicon: https://oldskoolravetapes.co.uk/wp-content/uploads/2023/02/Old-Skool-Rave-Tapes-New-512.jpg
+  homepage: https://oldskoolravetapes.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: e1a177e9-5947-46a4-8757-0415c9b106bc
+  changeuuid: 35ecd5bf-2cdc-4072-9f90-bd143aea8e96
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-24-7-edm-radio
+  broadcaster: independent
+  name: "24/7 EDM Radio"
+  streamUrl: https://ec6.yesstreaming.net:1455/stream
+  bitrate: 64
+  codec: MP3
+  favicon: https://www.247onlineradio.com/wp-content/uploads/2023/04/247-EDM-Radio.jpg
+  homepage: https://www.247onlineradio.com/24-7-edm-radio/
+  country: GB
+  status: stream-only
+  stationuuid: 917a434d-c9a0-4a68-9cc5-7def1ab1b957
+  changeuuid: 93027261-1dc5-48d4-8db7-8fdc61b8049f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-24-7-jazz-radio
+  broadcaster: independent
+  name: "24/7 Jazz Radio"
+  streamUrl: https://ec3.yesstreaming.net:3455/stream
+  bitrate: 64
+  codec: MP3
+  favicon: https://www.247onlineradio.com/wp-content/uploads/2020/02/247-Jazz-Radio.jpg
+  homepage: https://www.247onlineradio.com/24-7-jazz-radio/
+  country: GB
+  status: stream-only
+  stationuuid: 11c067d9-0f68-4773-9bc2-335072309c71
+  changeuuid: 47a1852a-b15e-4f33-9c18-02fda2b0e900
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-oldskool-uk
+  broadcaster: independent
+  name: Oldskool UK
+  streamUrl: https://usa10.fastcast4u.com:8880/
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.oldskool.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 6f8f7281-c0c9-48bd-955c-83f4729ec67c
+  changeuuid: 6eb4c526-676e-4975-bed3-9a4a6f350b26
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-now-rock
+  broadcaster: independent
+  name: Now Rock
+  streamUrl: https://lightning-now90s-samsungnz.amagi.tv/playlist.m3u8
+  bitrate: 1020
+  codec: AAC,H.264
+  homepage: https://nowmusic.com/
+  country: GB
+  status: stream-only
+  stationuuid: 524038f7-543b-4fed-91f9-8222adea4305
+  changeuuid: 1247ec9b-bbaa-41d1-a0e2-56713cfda065
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-the-beatles
+  broadcaster: independent
+  name: The Beatles
+  streamUrl: https://stream.pcradio.ru/The_Beatles-hi
+  codec: AAC
+  favicon: null
+  homepage: https://pcradio.ru/radio
+  country: GB
+  status: stream-only
+  stationuuid: 620bfdce-d62b-4b51-8125-3b6fde79a2b0
+  changeuuid: 891de09a-f637-4062-8eaa-0aa17e33f4b6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-80s-rhythm
+  broadcaster: independent
+  name: "80s Rhythm"
+  streamUrl: https://stream.mybroadbandradio.com/80srhythmhq/
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.80srhythm.com/
+  country: GB
+  status: stream-only
+  stationuuid: cab769d2-af4b-457c-b7e0-8d097ce872f1
+  changeuuid: 6f59e0d8-4042-427c-a66e-0df650210379
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-globl-funk-radio
+  broadcaster: independent
+  name: Globl Funk Radio
+  streamUrl: https://securestreams2.autopo.st:1148/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.globalfunkradio.com/favicon/128x128.png
+  homepage: https://www.globalfunkradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 88360635-3913-43c8-a72f-71a477fe3584
+  changeuuid: f5adab7d-a47d-4dad-9524-07f7a1428707
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-the-sounds-of-gta-nts
+  broadcaster: independent
+  name: "The Sounds of GTA | NTS"
+  streamUrl: https://stream-mixtape-geo.ntslive.net/mixtape33
+  codec: MP3
+  favicon: https://www.nts.live/favicon.ico
+  homepage: https://www.nts.live/infinite-mixtapes/the-sound-of-gta
+  country: GB
+  status: stream-only
+  stationuuid: ad8eab8a-6b18-4833-a13d-dad173aacc08
+  changeuuid: 6b43104a-b159-4406-a2f2-b65c979acfa1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bbc-radio-leeds
+  broadcaster: independent
+  name: BBC Radio Leeds
+  streamUrl: https://as-hls-ww-live.akamaized.net/pool_50115440/live/ww/bbc_radio_leeds/bbc_radio_leeds.isml/bbc_radio_leeds-audio%3d96000.norewind.m3u8
+  codec: UNKNOWN
+  favicon: https://sounds.files.bbci.co.uk/3.5.0/services/bbc_radio_leeds/blocks-colour_600x600.png
+  homepage: https://www.bbc.co.uk/schedules/p00fzl7w
+  country: GB
+  status: stream-only
+  stationuuid: 3c811494-8c26-4f97-b3da-5c0b7d49b6a0
+  changeuuid: d2d04146-0a70-4d5e-8a90-a481ba5c0d4a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bristol-sound-webradio
+  broadcaster: independent
+  name: Bristol Sound Webradio
+  streamUrl: https://thebristolsoundwebradio.stream.laut.fm/thebristolsoundwebradio
+  bitrate: 128
+  codec: MP3
+  favicon: https://64.media.tumblr.com/8d23b78c8346101f620e06d5ce5e7165/tumblr_pmqf9sPig21uq8z6lo1_r2_400.jpg
+  homepage: https://bristol-sound-webradio.tumblr.com/LISTEN
+  country: GB
+  status: stream-only
+  stationuuid: cdc4a71a-cb5f-4f05-8073-4ef3d72bfdf2
+  changeuuid: 1e47deef-d7e9-444c-9592-b346f9abbb02
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-venture-radio-pumpkin-fm
+  broadcaster: independent
+  name: Venture Radio - Pumpkin FM
+  streamUrl: https://cast2.asurahosting.com/proxy/ventureradio/stream
+  bitrate: 64
+  codec: MP3
+  favicon: https://pumpkinfm.com/wp-content/uploads/2019/02/VentureRadio300x300.jpg
+  homepage: https://pumpkinfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: 9d337e34-ff59-4933-be3e-16e21bea4318
+  changeuuid: 32308122-18a7-4a1b-9c53-6cf43a4a127a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-infrared-fm
+  broadcaster: independent
+  name: Infrared.fm
+  streamUrl: https://carol.epichosts.co.uk:8232/live.mp3
+  bitrate: 256
+  codec: MP3
+  favicon: http://infrared.fm/favicon.ico
+  homepage: http://infrared.fm/
+  country: GB
+  status: stream-only
+  stationuuid: 6a79ad48-3c95-472d-bdf0-850c1172cf69
+  changeuuid: d10573b5-82d1-4698-8720-7032ee88f235
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-revolution-radio-one
+  broadcaster: independent
+  name: Revolution Radio One
+  streamUrl: https://visual.shoutca.st/stream/revolutionone/stream
+  bitrate: 320
+  codec: AAC
+  favicon: https://static.wixstatic.com/media/a4f5c5_466d1b7b03424018be005a100fda1990%7emv2_d_1726_1562_s_2.png/v1/fill/w_180%2ch_180%2clg_1%2cusm_0.66_1.00_0.01/a4f5c5_466d1b7b03424018be005a100fda1990%7emv2_d_1726_1562_s_2.png
+  homepage: https://revolutionradio.online/revolutionone
+  country: GB
+  status: stream-only
+  stationuuid: 78290cd1-3301-4dd9-bc6a-999fcf70654b
+  changeuuid: e18bc30d-d4e8-4144-be9e-4672c03a8a3f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-deep-purple
+  broadcaster: independent
+  name: Deep Purple
+  streamUrl: https://stream.pcradio.ru/Deep_purple-hi
+  codec: AAC
+  favicon: null
+  homepage: https://pcradio.ru/
+  country: GB
+  status: stream-only
+  stationuuid: 53d055fb-9364-4d12-be68-f61d4c14c0b3
+  changeuuid: da1349e8-0fa2-44f2-96a3-e12c4871180a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hearme-60s-rock
+  broadcaster: independent
+  name: HearMe - 60s Rock
+  streamUrl: https://radio.hearme.fm:8230/stream
+  codec: MP3
+  homepage: https://hearme.fm/
+  country: GB
+  status: stream-only
+  stationuuid: dd24eb09-84cb-4d9e-aca4-4c2ed71e624d
+  changeuuid: 8678e808-b3b5-452b-a975-f0fdf1eee1fd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-xl-uk-radio
+  broadcaster: independent
+  name: "XL:UK Radio"
+  streamUrl: https://s3.radio.co/s113a5dc46/listen
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.xlukradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 124c45d7-57a9-46ed-8b93-83b306992126
+  changeuuid: 00cb2969-bf6f-47a5-811f-8a089bd9d265
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bbc-radio-nottingham
+  broadcaster: independent
+  name: BBC Radio Nottingham
+  streamUrl: https://a.files.bbci.co.uk/ms6/live/3441A116-B12E-4D2F-ACA8-C1984642FA4B/audio/simulcast/hls/nonuk/audio_syndication_low_sbr_v1/aks/bbc_radio_nottingham.m3u8
+  bitrate: 101
+  codec: AAC+
+  favicon: https://static.mytuner.mobi/media/tvos_radios/U3M5n4tQDu.png
+  homepage: https://www.radio-uk.co.uk/bbc-radio-nottingham
+  country: GB
+  status: stream-only
+  stationuuid: 3e0d94fa-114f-4135-88ac-28b084996929
+  changeuuid: 75c54d90-5930-4f13-ae67-9822a48b0ae3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-https-www-differentdrumz-co-uk
+  broadcaster: independent
+  name: "https://www.differentdrumz.co.uk/"
+  streamUrl: https://differentdrumz.radioca.st/stream%20;
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.differentdrumz.co.uk/wp-content/uploads/2016/02/Tune-In-Pic.png
+  homepage: https://www.differentdrumz.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: c0616d81-b9c1-4dfe-bfa2-8f6b486c6339
+  changeuuid: c8f852ae-c2ae-4d57-b759-35c07bf47617
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-the-pit-nts
+  broadcaster: independent
+  name: "The Pit | NTS"
+  streamUrl: https://stream-mixtape-geo.ntslive.net/mixtape34
+  codec: MP3
+  favicon: https://www.nts.live/favicon.ico
+  homepage: https://www.nts.live/infinite-mixtapes/the-pit
+  country: GB
+  status: stream-only
+  stationuuid: 2eb49b46-e056-4628-80c3-f63f685d22a4
+  changeuuid: 6d293761-83ad-4dda-93c1-cfe60e22d6c1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-classic-fm-music-for-pets
+  broadcaster: independent
+  name: Classic FM Music For Pets
+  streamUrl: https://media-ssl.musicradio.com/ClassicFM-M-Pets
+  bitrate: 48
+  codec: AAC
+  homepage: https://www.classicfm.com/lifestyle/pets/
+  country: GB
+  status: stream-only
+  stationuuid: 3485c69f-fc47-4081-aafd-ab77a24fdd7d
+  changeuuid: 45661f56-7807-4544-8efb-e1e6d7445d15
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-smooth-chill-focus
+  broadcaster: independent
+  name: Smooth Chill Focus
+  streamUrl: https://media-ssl.musicradio.com/SmoothChill-M-Concentration?
+  bitrate: 48
+  codec: AAC
+  homepage: https://www.radio-uk.co.uk/chill
+  country: GB
+  status: stream-only
+  stationuuid: a6491d20-4dff-491f-827e-af15b35df655
+  changeuuid: b30338b4-debe-4539-976b-012b386a913e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-dance-anthems-radio
+  broadcaster: independent
+  name: Dance Anthems Radio
+  streamUrl: https://stream3.themediasite.co.uk/stream/danceanthems
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.danceanthemsradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 9c099bc8-3bfa-46fc-90a8-6c7da95e6f3c
+  changeuuid: f641b074-30cf-4460-8b42-f3540c8e99e1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-love-soul-radio-london
+  broadcaster: independent
+  name: Love Soul Radio London
+  streamUrl: https://s1.citrus3.com:8018/stream
+  bitrate: 128
+  codec: AAC
+  favicon: https://static.thenounproject.com/png/128478-200.png
+  homepage: https://lovesoulradiolondon.org/
+  country: GB
+  status: stream-only
+  stationuuid: 7a2244bc-06e1-4307-99b1-4cdeaad2e8b3
+  changeuuid: ee9b2249-4639-40d5-abe9-26a8a2387fd3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-24-7-scifi-radio
+  broadcaster: independent
+  name: "24/7 SciFi Radio"
+  streamUrl: https://ec6.yesstreaming.net:1465/stream
+  bitrate: 64
+  codec: MP3
+  favicon: https://www.247onlineradio.com/wp-content/uploads/2023/04/2019-08-24-16.30.25-scaled.jpg
+  homepage: https://www.247onlineradio.com/24-7-online-radio-group-stations/24-7-scifi-radio/
+  country: GB
+  status: stream-only
+  stationuuid: 70bb22f0-8cd6-416f-ad17-54783844c7a4
+  changeuuid: 611be021-11f7-4401-ba88-7292e084d24f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-rainbow
+  broadcaster: independent
+  name: Rainbow
+  streamUrl: https://stream.pcradio.ru/Rainbow-hi
+  codec: AAC
+  favicon: null
+  homepage: https://pcradio.ru/
+  country: GB
+  status: stream-only
+  stationuuid: 2f15bbc2-be6f-459b-887b-01553272be62
+  changeuuid: 1f067083-90bb-4160-8a48-4a18efe64eae
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-itch-fm
+  broadcaster: independent
+  name: Itch.FM
+  streamUrl: https://streaming.radio.co/s264858a04/listen
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.itch.fm/
+  country: GB
+  status: stream-only
+  stationuuid: 6b957e67-a5ed-438a-b919-3d536d3d9019
+  changeuuid: 159933d0-1dd1-41c9-9311-2473e6f53ec6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-otaku-nts
+  broadcaster: independent
+  name: "Otaku | NTS"
+  streamUrl: https://stream-mixtape-geo.ntslive.net/mixtape36
+  codec: MP3
+  favicon: https://www.nts.live/favicon.ico
+  homepage: https://www.nts.live/infinite-mixtapes/otaku
+  country: GB
+  status: stream-only
+  stationuuid: 1047345d-6bf5-4d89-98d7-137eb552ddc6
+  changeuuid: 44797ab4-30a2-4f91-be39-0252155b626c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-dance-classics-uk
+  broadcaster: independent
+  name: Dance Classics UK
+  streamUrl: https://stream4.themediasite.co.uk/stream/danceclassics
+  bitrate: 192
+  codec: AAC
+  favicon: https://static2.mytuner.mobi/media/tvos_radios/ku8qxjlffvfr.png
+  homepage: http://www.danceclassics.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: b57cef96-d760-4d33-b743-46f0f1a4591b
+  changeuuid: 7e3009ce-6f5e-431c-9ea5-d62cc93e85e7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-dragon-radio
+  broadcaster: independent
+  name: Dragon Radio
+  streamUrl: https://listen-nation.sharp-stream.com/tcnationdigital.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.nationplayer.com/dragon-radio/
+  country: GB
+  status: stream-only
+  stationuuid: 339553b3-3e86-466e-b340-d0bd84353122
+  changeuuid: 29db4da4-54b6-44f7-b39a-69f7da314f0c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-malvern-radio-jrs-pumpkin-fm
+  broadcaster: independent
+  name: Malvern Radio JRS - Pumpkin FM
+  streamUrl: https://cast2.asurahosting.com/proxy/malvernradiojrs/stream
+  bitrate: 128
+  codec: MP3
+  homepage: https://pumpkinfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: 53c0f24f-7021-4349-a2e0-b63a40f2aed6
+  changeuuid: d128417e-37c5-4ff7-8560-1ffb0d611a8d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-playback-uk
+  broadcaster: independent
+  name: Playback UK
+  streamUrl: https://chilledstreaming.com:8650/mobile.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.playbackuk.com/wp-content/uploads/2021/01/cropped-pbuk-123-192x192.jpg
+  homepage: https://www.playbackuk.com/
+  country: GB
+  status: stream-only
+  stationuuid: 138e0496-c5f1-48a0-8cad-764fb23dfec9
+  changeuuid: 101b78ef-436b-4b10-b67b-febffd9e9d75
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-dance-90s
+  broadcaster: independent
+  name: RADIO DANCE 90s
+  streamUrl: https://radiodance.streamingmedia.it/uk.aac
+  bitrate: 320
+  codec: AAC+
+  favicon: https://www.radio.dance/logo_radiodance90s_512.png
+  homepage: https://www.radio.dance/
+  country: GB
+  status: stream-only
+  stationuuid: b712c71b-8dfd-4670-ba9e-33a1decea395
+  changeuuid: d274a88d-7bc1-46c3-8c56-a9037f46732a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-simulator-radio
+  broadcaster: independent
+  name: Simulator Radio
+  streamUrl: https://simulatorradio.stream/stream.mp3
+  bitrate: 320
+  codec: MP3
+  homepage: https://simulatorradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: f2a3a51f-e0cb-4b3a-b7dd-b7bc91f8ee3a
+  changeuuid: ed7ba5c2-06d8-4283-92f4-1780174773df
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-powerhouse-radio
+  broadcaster: independent
+  name: Powerhouse Radio
+  streamUrl: https://streaming.broadcastradio.com:11065/powerhouse
+  codec: MP3
+  homepage: https://powerhouseradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 4c67bfd4-c12e-4020-b294-cc41568f001e
+  changeuuid: d66cbdb1-8a22-4858-9a5c-76962fa68325
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-salaam-radio
+  broadcaster: independent
+  name: Salaam Radio
+  streamUrl: https://radio.canstream.co.uk:8005/live.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://storage.googleapis.com/salaamradio-live/landing-page/_ui/media/logo.png
+  homepage: https://www.salaamradio.co.uk/#
+  country: GB
+  status: stream-only
+  stationuuid: 7cae1159-a663-488a-952f-b98449b8ca51
+  changeuuid: cb11a469-bd25-43e6-80a0-f7fa9e486df2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-go-radio-glasgow
+  broadcaster: independent
+  name: Go Radio Glasgow
+  streamUrl: https://streaming.broadcastradio.com:8252/goradio
+  bitrate: 128
+  codec: MP3
+  favicon: https://thisisgo.co.uk/wp-content/uploads/2023/04/go-logo.png
+  homepage: https://thisisgo.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: f3d2adf5-822b-4e7d-928a-fe914ce4b8b1
+  changeuuid: 0ee58555-a766-4b43-bb0d-0c0f557e3e61
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-jazz-fm91
+  broadcaster: independent
+  name: JAZZ.FM91
+  streamUrl: https://jazzfm91.streamb.live/SB00009
+  bitrate: 131
+  codec: AAC
+  homepage: https://jazz.fm/
+  country: GB
+  status: stream-only
+  stationuuid: 64990fa2-2e54-4a32-a300-32b0232e11fc
+  changeuuid: c2be3ae0-4cb4-4db8-b288-d6c5df8775b6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-premier-christian-radio
+  broadcaster: independent
+  name: Premier Christian Radio
+  streamUrl: https://pcr.streamguys1.com/pcrnational-96k.aac
+  bitrate: 56
+  codec: AAC
+  favicon: https://www.premier.plus/images/common/logo-animated-50ms.gif
+  homepage: https://www.premier.plus/stations/premier-christian-radio
+  country: GB
+  status: stream-only
+  stationuuid: 87cbedde-e9ea-465b-87d8-3a72fcc4e3b5
+  changeuuid: 532b4ba5-cb7b-4212-91db-78ada02e443f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-xpression-fm-bollywood
+  broadcaster: independent
+  name: Xpression FM Bollywood
+  streamUrl: https://casper.radioca.st/
+  bitrate: 128
+  codec: MP3
+  favicon: null
+  homepage: https://casper.radioca.st/
+  country: GB
+  status: stream-only
+  stationuuid: b6622298-f0fd-4fbc-bdcf-f929da731642
+  changeuuid: f30c75fa-ede3-4f2f-a77f-ce3fc380d375
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-rustradio
+  broadcaster: independent
+  name: RustRadio
+  streamUrl: https://listen.rustradio.co.uk:8443/stream
+  bitrate: 320
+  codec: MP3
+  favicon: https://rustradio.co.uk/images/RRDefault.png
+  country: GB
+  status: stream-only
+  stationuuid: fe7013ef-1d5c-4966-9ad2-a68f36562325
+  changeuuid: ff70bdec-406e-4c40-bde2-5a8041142331
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-the-mix-radio-80s
+  broadcaster: independent
+  name: The Mix Radio 80s
+  streamUrl: https://tmr80s.radioca.st/stream
+  bitrate: 256
+  codec: MP3
+  favicon: https://static.mytuner.mobi/media/tvos_radios/390/the-mix-radio-80s.dd4413ea.png
+  homepage: https://www.themixradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 72fe5798-bf1e-4df9-b4d9-aa4712a189f4
+  changeuuid: e1cb12f8-4a91-4a44-b22b-354482ceb94f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-fred-film-radio-28-education
+  broadcaster: independent
+  name: Fred Film Radio-28 Education
+  streamUrl: https://s10.webradio-hosting.com/proxy/fredradioedu/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.fred.fm/wp-content/uploads/2014/12/Fred-Logo_trasp_-copia.png
+  homepage: https://www.fred.fm/
+  country: GB
+  status: stream-only
+  stationuuid: a9872d56-95ab-49d0-87a6-b740c0589c31
+  changeuuid: fb5acb6c-3206-48d4-91bb-46854000cdb2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-like-anthems
+  broadcaster: independent
+  name: Like Anthems
+  streamUrl: https://likeradiostream.com/likeanthemsaac
+  bitrate: 48
+  codec: AAC+
+  homepage: https://like.radio/
+  country: GB
+  status: stream-only
+  stationuuid: a9aa4326-cbf3-4dc7-9f97-c955d3c2c04d
+  changeuuid: b9d1ee1b-bdb3-49e2-9159-ed6d02573aab
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-smokie
+  broadcaster: independent
+  name: Smokie
+  streamUrl: https://stream.pcradio.ru/smokie-hi
+  codec: AAC
+  favicon: null
+  homepage: https://pcradio.ru/
+  country: GB
+  status: stream-only
+  stationuuid: dd100cfe-ec81-4aa5-929b-79f4bf47841c
+  changeuuid: 5b2a0ad0-1243-4961-ad4f-7095b7388e76
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-24-7-bossa-nova-radio
+  broadcaster: independent
+  name: "24/7 Bossa Nova Radio"
+  streamUrl: https://ec6.yesstreaming.net:1605/stream
+  bitrate: 64
+  codec: MP3
+  favicon: https://www.247onlineradio.com/wp-content/uploads/2023/04/247-Bossa-Nova-Radio.jpg
+  homepage: https://www.247onlineradio.com/24-7-online-radio-group-stations/24-7-bossa-nova-radio/
+  country: GB
+  status: stream-only
+  stationuuid: eda8b900-0ac5-4248-8499-fe23c729ad9c
+  changeuuid: 4e1e8e5a-70a2-4dca-9c79-102a92f72f8b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-fred-film-radio-english
+  broadcaster: independent
+  name: FRED FILM RADIO English
+  streamUrl: https://s10.webradio-hosting.com/proxy/fredradioen/stream
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.fred.fm/
+  country: GB
+  status: stream-only
+  stationuuid: 8a751974-b40c-4677-881d-8f0215a03c48
+  changeuuid: e1b7e04a-14ed-4a15-9ddd-064ea49b7425
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-progzilla-radio
+  broadcaster: independent
+  name: Progzilla_Radio
+  streamUrl: https://radio.progzilla.com/main
+  bitrate: 52
+  codec: AAC
+  favicon: http://www.progzilla.com/favicon.ico
+  homepage: http://www.progzilla.com/
+  country: GB
+  status: stream-only
+  stationuuid: 0c853606-cf48-43db-8e5e-3b6db2e7e678
+  changeuuid: a23e68ac-8344-47c3-88d2-a91c0de99f94
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-24-7-nature-radio
+  broadcaster: independent
+  name: "24/7 Nature Radio"
+  streamUrl: https://ec3.yesstreaming.net:3545/stream
+  bitrate: 64
+  codec: MP3
+  favicon: https://www.getmeradio.com/stations/247natureradio-4493/logos/512x512.png
+  homepage: https://www.247natureradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 8a4f4537-5231-4d3e-864e-e834ca2c4732
+  changeuuid: fddfa440-3215-4316-b778-b3e24f5e2cc3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-dance-uk
+  broadcaster: independent
+  name: Dance UK
+  streamUrl: https://dancestream.danceradiouk.com/stream/1/stream.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://danceradiouk.com/players/files/images/albumart/13040-DanceUK-300.jpg
+  homepage: https://www.danceradiouk.com/
+  country: GB
+  status: stream-only
+  stationuuid: 4f423b65-faae-4d46-992b-e865af169e9a
+  changeuuid: 8c2af463-20ce-481d-bf1c-1c0cf27c8ef5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-heart-wiltshire
+  broadcaster: independent
+  name: Heart Wiltshire
+  streamUrl: https://media-ssl.musicradio.com/HeartWiltshireMP3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.heart.co.uk/wiltshire/
+  country: GB
+  status: stream-only
+  stationuuid: 2b4cf5e1-0f29-4e0e-b04b-e743a79f729a
+  changeuuid: b0e5b8bd-9a88-4d2a-bdc8-acc94e24c8cb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-house-fm
+  broadcaster: independent
+  name: House FM
+  streamUrl: https://uksoutha.streaming.broadcast.radio:19920/housefm
+  bitrate: 128
+  codec: MP3
+  favicon: https://hse.fm/cdn/shop/files/logo_on_content_c7615023-6bff-4bf9-8841-9a9916b5a3b0_2500x.png?v=1615321261
+  homepage: https://hse.fm/
+  country: GB
+  status: stream-only
+  stationuuid: 1a421361-eb9f-40e9-9ab1-1a4ca39b90dd
+  changeuuid: d5c412c0-162e-432c-a732-8e9ffa97ee76
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-uk-health-radio
+  broadcaster: independent
+  name: UK Health Radio
+  streamUrl: https://streaming.radio.co/s8e535ff20/listen
+  bitrate: 128
+  codec: MP3
+  favicon: https://ukhealthradio.com/wp-content/themes/ukhealthradio_new/assets/img/ukhealthdario_logo.png
+  homepage: https://ukhealthradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: d019ccf6-722b-4828-817a-a56964ff2aab
+  changeuuid: ad816ef6-c6a6-4374-81cd-0fa72826904a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-capital-anthems
+  broadcaster: independent
+  name: Capital Anthems
+  streamUrl: https://media-ice.musicradio.com/CapitalAnthemsMP3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.capitalfm.com/anthems/
+  country: GB
+  status: stream-only
+  stationuuid: f0e3ae87-cdcd-4abe-bb25-7f1bc14e1ec2
+  changeuuid: 64564555-2e70-4aca-ad8c-e32e7aa58b20
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-easylistening-com
+  broadcaster: independent
+  name: EasyListening.com
+  streamUrl: https://easylistening.out.airtime.pro/easylistening_a
+  bitrate: 64
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/7c2261_da98addc261649d699647544ae301897~mv2.jpg/v1/fill/w_488,h_88,al_c,lg_1,q_80,enc_auto/7c2261_da98addc261649d699647544ae301897~mv2.jpg
+  homepage: https://www.easylistening.com/
+  country: GB
+  status: stream-only
+  stationuuid: 3b43bbfa-1562-41f8-9faf-7645e0215deb
+  changeuuid: 0c97c178-2174-470b-972f-fc6f2d7a8883
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-fred-film-radio-extra
+  broadcaster: independent
+  name: Fred Film Radio Extra
+  streamUrl: https://s10.webradio-hosting.com/proxy/fredradioec/stream
+  bitrate: 128
+  codec: MP3
+  homepage: http://www.fred.fm/
+  country: GB
+  status: stream-only
+  stationuuid: 71e40131-5d2f-44d0-ae14-40e22582c777
+  changeuuid: d78fc640-677b-4a88-92a9-7bfaf21a77e4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-intamixx-desi-radio-uk
+  broadcaster: independent
+  name: Intamixx Desi Radio UK
+  streamUrl: https://radio.intamixx.uk:8443/radio1
+  bitrate: 128
+  codec: MP3
+  favicon: https://radio.intamixx.uk/images/intamixx.jpg
+  homepage: https://radio.intamixx.uk/#hero
+  country: GB
+  status: stream-only
+  stationuuid: 9b59f5a2-6676-4276-a822-8461c7ba5d1b
+  changeuuid: 736dd99f-2615-45a5-8838-4848fa4dc40b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-totally-wired-radio
+  broadcaster: independent
+  name: Totally Wired Radio
+  streamUrl: https://totallywired.out.airtime.pro/totallywired_a
+  bitrate: 192
+  codec: MP3
+  favicon: https://totallywiredradio.com/radio/wp-content/uploads/2019/04/TWR-fb.png
+  homepage: https://totallywiredradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: a6f07bae-327a-4a76-bd1d-f305c1af35a1
+  changeuuid: 7e62c222-4021-44be-bd3e-f348e17dea7a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-great-yorkshire-radio
+  broadcaster: independent
+  name: Great Yorkshire Radio
+  streamUrl: https://stream1.superstreaming.co.uk/proxy/greatyorkshire/stream
+  bitrate: 192
+  codec: MP3
+  favicon: https://greatyorkshireradio.co.uk/images/GYRWEBLOGO.jpg
+  homepage: https://greatyorkshireradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 84a83085-ddf6-4113-8f7d-f7e87fd5011a
+  changeuuid: cc24490d-c11f-4678-b4cb-bb2b520e73f9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-ram-fm-80s-hit-radio-2
+  broadcaster: independent
+  name: RAM FM - 80s Hit Radio
+  streamUrl: https://cc6.beheerstream.com/proxy/ramfm?mp=/stream
+  bitrate: 320
+  codec: MP3
+  homepage: https://ramfm.org/
+  country: GB
+  status: stream-only
+  stationuuid: f36d78ce-98a7-43f1-8537-a36539ff7c04
+  changeuuid: 1e5e39ae-bcb7-45b8-989e-7a83b5888957
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-rap-house-infinite-mixtapes-nts
+  broadcaster: independent
+  name: "Rap House - Infinite Mixtapes | NTS"
+  streamUrl: https://stream-mixtape-geo.ntslive.net/mixtape22
+  codec: MP3
+  homepage: https://www.nts.live/infinite-mixtapes/rap-house
+  country: GB
+  status: stream-only
+  stationuuid: 4e5fc635-8d2a-4e80-b44f-d07315892705
+  changeuuid: 18b3097e-13fc-44ef-be4a-64b72fdafb4b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-planet-rock-where-rock-lives
+  broadcaster: independent
+  name: " PLANET ROCK: Where Rock Lives"
+  streamUrl: https://stream-mz.hellorayo.co.uk/planetrock.aac?direct=true&aw_0_1st.playerid=BMUK_Airable&aw_0_1st.skey=6778249992
+  bitrate: 47
+  codec: AAC+
+  favicon: https://cdn-profiles.tunein.com/s2377/images/logod.png
+  homepage: https://www.hellorayo.co.uk/planet-rock
+  country: GB
+  status: stream-only
+  stationuuid: dec031e0-4419-45d2-9f3e-76e91d876c40
+  changeuuid: f8191e12-58f1-4315-9208-90311bdb9ec0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-107-8-black-diamond-fm
+  broadcaster: independent
+  name: "107.8 Black Diamond FM"
+  streamUrl: https://icecast-s.bdfm.radio/blackdiamondfm?icecast
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.blackdiamondfm.com/favicon.ico
+  homepage: https://www.blackdiamondfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: ae9befe3-a2db-46be-9906-3383e3454d39
+  changeuuid: efe59af9-b0ec-47d4-875b-8e5a1b72e895
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-lcrfm-103-6-lincoln
+  broadcaster: independent
+  name: LCRFM 103.6 Lincoln
+  streamUrl: https://streaming.broadcast.radio/lincoln
+  codec: MP3
+  homepage: https://lcrlincoln.com/
+  country: GB
+  status: stream-only
+  stationuuid: 13b5607d-f44d-43db-b08d-b0bf7ebe3ca3
+  changeuuid: 53e9781f-e877-4698-a8ec-72b44a85acb1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-noods-radio
+  broadcaster: independent
+  name: "Noods Radio "
+  streamUrl: https://noods-radio.radiocult.fm/stream
+  bitrate: 192
+  codec: MP3
+  homepage: http://www.noodsradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 3f938990-dcbc-4931-be49-0ca558a0976e
+  changeuuid: 34674b78-999c-416b-8f1f-4ea3ae5b4fcd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-power-of-worship-radio
+  broadcaster: independent
+  name: Power of Worship Radio
+  streamUrl: https://fwd.autopo.st/powerofworshipradio?_=484910
+  codec: AAC
+  favicon: https://mmo.aiircdn.com/177/664992e2268f6.png
+  homepage: https://www.powerofworship.net/
+  country: GB
+  status: stream-only
+  stationuuid: 0566f8a8-8da3-422a-b623-b63bcc506acc
+  changeuuid: b6e85277-4043-4ece-912a-b03847edd5cb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-r5k-radio
+  broadcaster: independent
+  name: R5K Radio
+  streamUrl: https://stream.r5k.net/
+  bitrate: 320
+  codec: MP3
+  favicon: http://radio.r5k.uk/wp-content/uploads/2024/09/R-Black-Glow.png
+  homepage: https://r5k.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 0b5f4fba-344e-49c9-b23a-37e57a9aa242
+  changeuuid: 6a665e86-cf5a-4d01-8352-accd3768cacb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-riverside-radio
+  broadcaster: independent
+  name: Riverside Radio
+  streamUrl: https://streaming04.liveboxstream.uk/proxy/mtunstil?mp=/stream
+  bitrate: 64
+  codec: AAC+
+  homepage: https://riversideradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: ce89820e-1c1c-435b-a83e-0e1c3d7556a7
+  changeuuid: 87fe1edf-3632-4a20-9fc8-33bfb9e7ff3b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-capital-fm-birmingham
+  broadcaster: independent
+  name: Capital FM (Birmingham)
+  streamUrl: https://media-ice.musicradio.com/CapitalBirminghamMP3
+  bitrate: 128
+  codec: MP3
+  homepage: https://tunein.com/radio/Capital-Birmingham-1022-s25008/
+  country: GB
+  status: stream-only
+  stationuuid: 5514fe6a-b5da-4264-bc42-416cbd2bf42a
+  changeuuid: fbeca935-ad75-4af9-b027-c8e27743622f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hereme-2000s-pop
+  broadcaster: independent
+  name: Hereme 2000s pop
+  streamUrl: https://radio.hearme.fm:8040/stream
+  codec: MP3
+  homepage: https://hearme.fm/
+  country: GB
+  status: stream-only
+  stationuuid: bc1080a9-b10c-44f3-bf88-e879d146eff6
+  changeuuid: 6a32db9f-2203-4d10-85b4-800063649c04
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-one-world-radio
+  broadcaster: independent
+  name: One World Radio
+  streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/OWR_INTERNATIONAL.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: https://global.tomorrowland.com/
+  country: GB
+  status: stream-only
+  stationuuid: 35192ec4-e851-4ce3-a828-89992e99ba49
+  changeuuid: c0e37036-ec4b-4fe4-98a0-774c1f5c38ec
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-northsea-uk
+  broadcaster: independent
+  name: Radio Northsea UK
+  streamUrl: https://listentomystream.com:8008/;
+  bitrate: 320
+  codec: MP3
+  favicon: https://i1.sndcdn.com/artworks-000172944490-2m076q-t500x500.jpg
+  homepage: https://www.rniradio.net/
+  country: GB
+  status: stream-only
+  stationuuid: 1844f409-fab3-4f5e-b917-6e27d99d266b
+  changeuuid: 8c81d70b-f9a7-44e0-94f2-589d5c72889d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-24-7-lounge-radio
+  broadcaster: independent
+  name: "24/7 Lounge Radio"
+  streamUrl: https://ec3.yesstreaming.net:3665/stream
+  bitrate: 64
+  codec: MP3
+  favicon: https://www.247onlineradio.com/wp-content/uploads/2023/04/247-Lounge-Radio.jpg
+  homepage: https://www.247onlineradio.com/24-7-online-radio-group-stations/24-7-lounge-radio/
+  country: GB
+  status: stream-only
+  stationuuid: 4c9accd8-74c0-48b7-b42d-86ba204c0e24
+  changeuuid: 56acc964-3830-458e-beee-07cff2f5655b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-quantum-radio
+  broadcaster: independent
+  name: qUAntUm RaDio
+  streamUrl: https://radio.erb.pw/listen/subspace/radio.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://radio.erb.pw/public/subspace
+  country: GB
+  status: stream-only
+  stationuuid: e9465363-e12d-41fd-a68b-b50cbc19ee03
+  changeuuid: 1d7cba86-4560-4174-a03c-b9a4d83d1ad7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-taiyabah-masjid
+  broadcaster: independent
+  name: Taiyabah Masjid
+  streamUrl: https://taiyabahmbolton.radioca.st/stream
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.taiyabahmasjid.com/
+  country: GB
+  status: stream-only
+  stationuuid: f6bd573d-3fc2-490b-8cd5-7c5f8c840e78
+  changeuuid: 9e6f9d9b-d4fc-4fb2-8e25-c7deec612546
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-awaz-fm
+  broadcaster: independent
+  name: Awaz FM
+  streamUrl: https://uksoutha.streaming.broadcast.radio/awazfm?1709527674574=
+  codec: MP3
+  favicon: https://api.broadcast.radio/api/image/feb85d15-2e18-45a7-b50a-e35b957f7d5a.png?g=center&w=600&h=600&c=true
+  homepage: https://www.awazfm.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 8647c273-2831-4397-bef9-43111f85d7d7
+  changeuuid: 691d33ae-93e4-4d6e-b487-f86ff7491b5d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-crackers-radio
+  broadcaster: independent
+  name: Crackers Radio
+  streamUrl: https://crackersfresh.radioca.st/;
+  bitrate: 320
+  codec: MP3
+  homepage: https://www.crackersradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 76fca412-d9a9-43b2-bf32-a077e2082d90
+  changeuuid: 5394c398-6672-4a18-acec-e8ae9418a1a1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-xl-1296
+  broadcaster: independent
+  name: Radio XL 1296
+  streamUrl: https://xlradio.co.uk:8000/
+  bitrate: 128
+  codec: MP3
+  favicon: null
+  homepage: https://xlradio.co.uk:8000/
+  country: GB
+  status: stream-only
+  stationuuid: 0cb269e7-39ef-4904-b479-684791e744f1
+  changeuuid: 39bb7859-f1da-46d8-88e8-e2302abf7eb3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-97-country-fm
+  broadcaster: independent
+  name: "97 Country FM"
+  streamUrl: https://vistaradio.streamb.live/SB00040?=&&___cb=491767877535127
+  bitrate: 57
+  codec: AAC+
+  favicon: https://www.myprincegeorgenow.com/wp-content/uploads/2021/05/mynow-icon.png
+  homepage: https://www.myprincegeorgenow.com/on-air/countryfm/
+  country: GB
+  status: stream-only
+  stationuuid: 1ed64e91-ce3c-4f11-9090-d16b2d3fc32e
+  changeuuid: b06557b4-981f-48eb-b383-9f795fc1ead7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hearme-70s-rock
+  broadcaster: independent
+  name: HearMe - 70s Rock
+  streamUrl: https://radio.hearme.fm:8240/stream
+  codec: MP3
+  homepage: https://hearme.fm/
+  country: GB
+  status: stream-only
+  stationuuid: aecb407b-b446-4b3c-94f7-54a3ccbe4a91
+  changeuuid: 76551ff0-0cad-4f25-b21e-575944975208
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-regal-radio
+  broadcaster: independent
+  name: Regal Radio
+  streamUrl: https://stream.regalradio.net/stream.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.regalradio.net/apple-touch-icon.png
+  homepage: https://www.regalradio.net/
+  country: GB
+  status: stream-only
+  stationuuid: d9376b3c-0ada-4642-b042-504249f44d4a
+  changeuuid: 4fd2ca75-9903-497f-a8cf-363f73083c7c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-soulpower-radio-com
+  broadcaster: independent
+  name: SOULPOWER-RADIO.COM
+  streamUrl: https://s2.radio.co/sb0964023c/listen
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.enomcentral.com/favicon.ico?v=1731000855
+  homepage: https://soulpower-radio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 02b67015-c882-42f6-a986-63105ed6baab
+  changeuuid: a77c822e-c714-48be-84ee-21b9106ab542
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-masjid-e-salaam-bolton
+  broadcaster: independent
+  name: Masjid E Salaam Bolton
+  streamUrl: https://msalaambolton.radioca.st/Stream
+  bitrate: 56
+  codec: MP3
+  homepage: https://www.masjidesalaam.com/
+  country: GB
+  status: stream-only
+  stationuuid: eb20e6c3-e632-47c4-b405-3f549bbee456
+  changeuuid: abdbbbe0-008a-4963-95d7-4edaba6a593d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-sanskar-radio
+  broadcaster: independent
+  name: Sanskar Radio
+  streamUrl: https://radio.canstream.co.uk:8024/live.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: http://sanskarradio.com/wp-content/uploads/2018/10/logo-01.jpg
+  homepage: http://sanskarradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 28bd8ede-2eee-4b59-bdbd-1ed1e173f78b
+  changeuuid: 841ff3f0-1cbc-46d1-b8de-db0a236a43b1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-the-ambientscape-project
+  broadcaster: independent
+  name: The Ambientscape Project
+  streamUrl: https://listen.radioking.com/radio/504205/stream/561655
+  bitrate: 128
+  codec: MP3
+  favicon: https://lh3.googleusercontent.com/nl0-E_ry5_Nrnfl2EH1BfXZPxrajs0E4g1d6d2ApEAvm_6WUhnfGxWVPRV940ey0KuTLes7AddVA88dk1PlvRQw7gJPcuQ=s120
+  homepage: https://www.ambientscape.com/radio
+  country: GB
+  status: stream-only
+  stationuuid: c8107f2f-3b30-4631-ad1b-0b6c41f0f8a6
+  changeuuid: f41f51cd-0f13-40a2-8ece-4409311088d4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-big-l
+  broadcaster: independent
+  name: Big L
+  streamUrl: https://s2.streamer1.com/listen/bigl/biglTEST.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.bigl.co.uk/images/icon-2.png
+  homepage: https://www.bigl.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 30d35f4a-8df7-49d5-a4ae-ec9882358f06
+  changeuuid: 7f047548-2017-4857-b38a-2b3d598c7bae
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-do-you-radio
+  broadcaster: independent
+  name: Do You Radio
+  streamUrl: https://doyouworld.out.airtime.pro/doyouworld_a
+  bitrate: 128
+  codec: MP3
+  homepage: https://doyou.world/
+  country: GB
+  status: stream-only
+  stationuuid: 128d5561-8439-4e2a-9e6c-4e48ad4f0cc0
+  changeuuid: 3665592c-3239-40a3-bfbe-a382ad7b4471
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-fred-film-radio-entertainment
+  broadcaster: independent
+  name: Fred Film Radio Entertainment
+  streamUrl: https://s10.webradio-hosting.com/proxy/fredenter/stream
+  bitrate: 128
+  codec: MP3
+  favicon: http://www.fred.fm/favicon.ico
+  homepage: http://www.fred.fm/
+  country: GB
+  status: stream-only
+  stationuuid: 7c87afe9-384b-44ee-9b9e-af972fc507ab
+  changeuuid: 412c9c59-bdd4-47b0-aa00-4afe2f80e2b4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-shine-879
+  broadcaster: independent
+  name: Shine 879
+  streamUrl: https://s3.radio.co/sd4abfe69e/listen
+  bitrate: 128
+  codec: MP3
+  favicon: https://shinedab.com/favicon.ico
+  homepage: https://shinedab.com/
+  country: GB
+  status: stream-only
+  stationuuid: 877da38b-5657-47d6-81c1-e805e7400718
+  changeuuid: 9a37d0b6-b584-4311-80c2-db828c5134bc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-worldwide-fm
+  broadcaster: independent
+  name: Worldwide FM
+  streamUrl: https://worldwide-fm.radiocult.fm/stream
+  bitrate: 320
+  codec: MP3
+  favicon: https://scontent-fra5-2.xx.fbcdn.net/v/t39.30808-1/450237294_942043604601681_3306132891557988504_n.jpg?stp=dst-jpg_s200x200_tt6&_nc_cat=109&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=Ur-AWGYdJIEQ7kNvwHfsWWi&_nc_oc=Adn31I1juFGVfOprAsE1UsSz-7_H0ISFLok1gNrhmWqzfmlI6AbPJgNZB15dkduTEq4&_nc_zt=24&_nc_ht=scontent-fra5-2.xx&_nc_gid=60spXN55S49um4k8ceAfcA&oh=00_AfrO3IOBFCxwn4Bqxc2mOFTcigubLSqRjTY1N2cfbWsvxg&oe=696ED4DC
+  homepage: https://www.worldwidefm.net/
+  country: GB
+  status: stream-only
+  stationuuid: 1651c32f-55d8-4429-995d-872ea0dcf520
+  changeuuid: 782d83dd-17ad-4190-bd52-7499433de707
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-100-8-home-radio
+  broadcaster: independent
+  name: "100.8 Home Radio"
+  streamUrl: https://uksoutha.streaming.broadcast.radio/home?1721747577077=
+  codec: MP3
+  favicon: https://api.broadcast.radio/api/image/7ed6bffb-6808-4c08-8576-6132efe7bd78.png?g=center
+  homepage: https://www.homeradio.org/
+  country: GB
+  status: stream-only
+  stationuuid: 433bf375-2cd4-4018-99a0-ffc285ffb154
+  changeuuid: 5b78c351-d9f3-401f-9c41-6c97fb37a7e0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-jazz-london-radio
+  broadcaster: independent
+  name: Jazz London radio
+  streamUrl: https://radio.canstream.co.uk:8075/live.aac
+  bitrate: 64
+  codec: AAC
+  favicon: https://www.jazzlondonradio.com/images/favicon.ico
+  homepage: https://www.jazzlondonradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: a7d816c2-722f-4060-907d-b4c796482d87
+  changeuuid: 30220c72-08aa-4d96-8d3a-96cf3d4ae2aa
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-naim-classical
+  broadcaster: independent
+  name: Naim classical
+  streamUrl: https://mscp3.live-streams.nl:8252/class-flac.flac
+  bitrate: 128
+  codec: OGG
+  favicon: https://www.naimaudio.com/build/assets/apple-touch-icon-2a4e35a0.png
+  homepage: https://www.naimaudio.com/
+  country: GB
+  status: stream-only
+  stationuuid: b8cbbb93-dea3-47b9-be48-114b2f030667
+  changeuuid: ff359987-ab41-4397-96a8-b855f74a1701
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-isle-of-wight-radio
+  broadcaster: independent
+  name: Isle of Wight Radio
+  streamUrl: https://s2.xrad.io:9598/listen.mp3?=&&___cb=275280937051671
+  bitrate: 128
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/386/5ec2a4d8bc430.png
+  homepage: https://www.iwradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 74ab194b-5124-4bdc-8855-81e6bb6eb4d1
+  changeuuid: 369e37cf-3360-423c-8a45-b45c5329f475
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-rokit-radio-1940s-radio
+  broadcaster: independent
+  name: Rokit Radio 1940s Radio
+  streamUrl: https://streaming06.liveboxstream.uk/proxy/roksta13/stream
+  bitrate: 48
+  codec: MP3
+  favicon: https://www2.rokitradio.com/_next/image?url=%2Fimages%2Fchannels%2F1940s.jpg&w=128&q=75
+  homepage: https://www2.rokitradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: f40ed777-ea5c-45b0-a248-32393c656890
+  changeuuid: b0cdc82b-24fc-4df3-9e6f-67184c6d6e96
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-university-radio-york
+  broadcaster: independent
+  name: University Radio York
+  streamUrl: https://audio.ury.org.uk/live-high
+  bitrate: 192
+  codec: MP3
+  homepage: https://ury.org.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 22a01c34-8654-46fc-9c93-9d068e2e8730
+  changeuuid: 37ab231e-7e58-4b8c-b93a-95ca9d2854f1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-90s-2000s-more
+  broadcaster: independent
+  name: "90s 2000s & More"
+  streamUrl: https://lunar.citrus3.com:8162/stream
+  bitrate: 128
+  codec: AAC
+  favicon: https://lunar.citrus3.com:2020/pub/90s2000sandmore/background.jpg
+  homepage: https://lunar.citrus3.com:2020/public/90s2000sandmore
+  country: GB
+  status: stream-only
+  stationuuid: fb8ecb5b-51f9-410b-813f-6c125e020437
+  changeuuid: 6bd00f3c-493f-4210-84fa-05d6e91a6ebc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-golden-decades-radio
+  broadcaster: independent
+  name: Golden Decades Radio
+  streamUrl: https://streaming.live365.com/a99471
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.goldendecadesradio.net/favicin.ico
+  homepage: https://www.goldendecadesradio.net/
+  country: GB
+  status: stream-only
+  stationuuid: 329fecec-770f-4ec4-afdf-dfd25dcba6db
+  changeuuid: cab0035c-b6b9-40b2-bc3c-f72669124456
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hospital-radio-norwich
+  broadcaster: independent
+  name: Hospital Radio Norwich
+  streamUrl: https://hospita1.radioca.st/;
+  bitrate: 96
+  codec: MP3
+  homepage: https://hospitalradionorwich.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: ef43e14b-b8b6-41ac-8c64-a1fd08409783
+  changeuuid: 47b191e6-2fd8-4e06-ae63-6014d480f6a6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-real-roots-radio
+  broadcaster: independent
+  name: Real roots radio
+  streamUrl: https://streams.radio.co/s1df61e0af/listen
+  bitrate: 192
+  codec: MP3
+  homepage: https://realrootsradio.net/
+  country: GB
+  status: stream-only
+  stationuuid: 93b6eecb-d160-4fc6-8edc-e1c3d1f0613a
+  changeuuid: 0fae458d-6935-4504-b8f8-a51c66d0b124
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-sunshine-radio-online-uk
+  broadcaster: independent
+  name: Sunshine Radio Online UK
+  streamUrl: https://stream1.themediasite.co.uk/8036/stream
+  bitrate: 192
+  codec: MP3
+  homepage: https://sunshineradioonline.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: d4256d94-2dc8-4a3b-98a0-a4f6d580219f
+  changeuuid: d9b24401-5452-4135-bb40-8eee92e158f8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-this-is-the-coast
+  broadcaster: independent
+  name: This is the Coast
+  streamUrl: https://streaming.broadcastradio.com:10765/thisisthecoast
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/428/6192188de6d51.png
+  homepage: https://www.thisisthecoast.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: f198327c-97c7-4f13-8092-52fd115069d6
+  changeuuid: edc62a3e-d1a7-432b-a1e6-33145c16c9f6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-24-7-classical-radio
+  broadcaster: independent
+  name: "24/7 Classical Radio"
+  streamUrl: https://ec3.yesstreaming.net:3615/stream
+  bitrate: 64
+  codec: MP3
+  favicon: https://usercontent.one/wp/www.247onlineradio.com/wp-content/uploads/2019/10/Classical-Radio-logo.jpg
+  homepage: https://www.247onlineradio.com/classical-radio/
+  country: GB
+  status: stream-only
+  stationuuid: 651effd2-e319-46fe-9ff4-4acf17fb3165
+  changeuuid: d4171347-dc22-4d01-beda-996d9e099cde
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-belters-radio
+  broadcaster: independent
+  name: Belters Radio
+  streamUrl: https://uk2.internet-radio.com/proxy/belters?mp=/live
+  bitrate: 64
+  codec: MP3
+  favicon: https://seeded-session-images.scdn.co/v2/img/122/secondary/artist/6Q7SW1I96IGwqBDhIm55oj/en
+  homepage: https://www.belter-radio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 0d3c8b15-096e-4c87-ae3a-a429d2263c88
+  changeuuid: 6fc8ba97-82c2-4db5-988e-e721fc6aab2e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-original-106
+  broadcaster: independent
+  name: Original 106
+  streamUrl: https://listen-original.sharp-stream.com/original106.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/11/62090e452aff2.png
+  homepage: https://www.originalfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: 2b9745a6-9155-44f6-adfe-e62ff9361d7e
+  changeuuid: b88dcf3c-bf94-4b4b-b5b3-99a602477eba
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-the-buzz
+  broadcaster: independent
+  name: The Buzz
+  streamUrl: https://streaming05.liveboxstream.uk/proxy/kookyinc/stream
+  bitrate: 320
+  codec: MP3
+  favicon: https://media.licdn.com/dms/image/D5622AQGpwL9LyKlbdg/feedshare-shrink_800/0/1697466642566?e=2147483647&v=beta&t=aYyFGOmG4uUzv7nHS5wNnENGiObuOXs9dZ6gzAG6zrM
+  homepage: https://www.thisisthebuzz.com/
+  country: GB
+  status: stream-only
+  stationuuid: fb42e84d-7f35-41e8-b579-a3bbfbe94d75
+  changeuuid: d4c3a56b-7e22-4280-bd19-443eeffa830b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-aaja-radio-channel-2
+  broadcaster: independent
+  name: "Aaja Radio | Channel 2"
+  streamUrl: https://aaja-2.radiocult.fm/stream
+  bitrate: 192
+  codec: MP3
+  favicon: https://aajamusic.com/_nuxt/icons/icon_64x64.fafdcd.png
+  homepage: https://aajamusic.com/radio
+  country: GB
+  status: stream-only
+  stationuuid: ea6e4da5-087d-421c-95b6-5ccbedc58468
+  changeuuid: 85cdc845-c6eb-4d53-927c-fde1f7c262e2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-classical-radio-international
+  broadcaster: independent
+  name: CLASSICAL RADIO INTERNATIONAL
+  streamUrl: https://ec3.yesstreaming.net:3625/stream
+  bitrate: 64
+  codec: MP3
+  favicon: https://www.247onlineradio.com/wp-content/uploads/2019/01/Classical-Radio-logo.png
+  homepage: https://www.247onlineradio.com/classical-radio-international/
+  country: GB
+  status: stream-only
+  stationuuid: 0f3efc0c-1362-4ef5-a417-09699655dd6e
+  changeuuid: d0a937d3-460f-495e-ac3d-8ebfcd3efff4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-clyde-built-radio
+  broadcaster: independent
+  name: Clyde Built Radio
+  streamUrl: https://clydebuiltradio.out.airtime.pro/clydebuiltradio_a
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.clydebuiltradio.com/apple-touch-icon.png
+  homepage: https://www.clydebuiltradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: de8d7315-0779-4d4f-ba10-57260f51e194
+  changeuuid: 1e5da417-23c3-43e5-bc28-bd670ff000f8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-crucial-hip-hop-and-electro
+  broadcaster: independent
+  name: Crucial Hip Hop and Electro
+  streamUrl: https://uksoutha.streaming.broadcast.radio/crucial
+  codec: MP3
+  homepage: https://www.streetsoundsradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 30192e4e-48c4-4816-99e3-4112491a1d30
+  changeuuid: 37e313a4-ecff-49b4-8d50-438cf5850ba3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-dirty-radio-for-underworld-fans
+  broadcaster: independent
+  name: Dirty Radio for Underworld Fans
+  streamUrl: https://live.dirty.radio/stream
+  bitrate: 64
+  codec: AAC
+  homepage: https://dirty.radio/
+  country: GB
+  status: stream-only
+  stationuuid: 1a267e2e-69db-4fd8-ab27-cca867bbe59f
+  changeuuid: 2db61dce-61b2-4b00-bcc4-fbc6256e987a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-maritime-radio
+  broadcaster: independent
+  name: maritime radio
+  streamUrl: https://mediacp.nkpa.co.uk/stream/maritime%E2%80%8B/MRMP3
+  bitrate: 128
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/1353/65d08095711fe.png
+  homepage: https://www.maritimeradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 568f42b6-37d6-43f3-a0e2-e38f4d882c06
+  changeuuid: 2af43db5-1b30-477a-9524-6f1ad0599402
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-cdnx-radio
+  broadcaster: independent
+  name: CDNX Radio
+  streamUrl: https://streaming.cdnx.co.uk/proxy/cx128mp3?mp=/stream&=&&___cb=870564735813642
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.camdenmarket.com/journal/cdnx-radio
+  country: GB
+  status: stream-only
+  stationuuid: c67e3836-a66f-4786-a98e-b6dd91edfde2
+  changeuuid: af6b6499-147d-4d4f-b9b6-3c6123db2b5d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hearme-love-songs
+  broadcaster: independent
+  name: HearMe - Love songs
+  streamUrl: https://radio.hearme.fm:8140/stream
+  codec: MP3
+  homepage: https://hearme.fm/
+  country: GB
+  status: stream-only
+  stationuuid: f14fbd38-e6c0-4d9a-8d4d-b8f8f0c9fce6
+  changeuuid: ddb14a7e-2259-4ae6-8fa6-9a33953c9da7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-christmas
+  broadcaster: independent
+  name: Radio Christmas
+  streamUrl: https://streaming.radiochristmas.co.uk/RadioChristmas
+  bitrate: 256
+  codec: MP3
+  favicon: https://radiochristmas.co.uk/favicon.ico
+  homepage: https://radiochristmas.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 8555a8e5-6bc2-49bc-b08a-0cd7bcbb3beb
+  changeuuid: 6ace3acf-6244-4a85-8f0a-c44ffe419a72
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-resonance-extra
+  broadcaster: independent
+  name: Resonance Extra
+  streamUrl: https://stream.resonance.fm/resonance-extra
+  bitrate: 192
+  codec: MP3
+  favicon: https://extra.resonance.fm/favicon.ico
+  homepage: https://extra.resonance.fm/
+  country: GB
+  status: stream-only
+  stationuuid: d9e327ff-2c59-4145-83a9-67f7b33a1ab2
+  changeuuid: ca058a47-9f63-46f6-93ee-2353b44bc767
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-xtra-hot
+  broadcaster: independent
+  name: Xtra Hot
+  streamUrl: https://stream1.hippynet.co.uk/stream/xtrahot/live
+  bitrate: 160
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/406/63e29f650517e.png
+  homepage: https://www.xtrahot.radio/
+  country: GB
+  status: stream-only
+  stationuuid: ba26c3b2-80a4-42a4-8569-c5cf37d249e4
+  changeuuid: a1e36955-3975-4584-98c2-827090ca280e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-centreforce-883
+  broadcaster: independent
+  name: Centreforce 883
+  streamUrl: https://listen.centreforceradio.com/96
+  bitrate: 96
+  codec: MP3
+  homepage: https://www.centreforceradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 55495003-c899-48fe-a51a-12c4a381f0db
+  changeuuid: 1b5d46a9-e1b0-4da6-9d1c-8b8e98a1aa04
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-coffee-morning
+  broadcaster: independent
+  name: Coffee Morning
+  streamUrl: https://media-the.musicradio.com/Global-M-CoffeeMorning
+  bitrate: 48
+  codec: AAC
+  favicon: https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse4.mm.bing.net%2Fth%3Fid%3DOIP.urcOy5KLidgx_JRwHUewewAAAA%26pid%3DApi&f=1&ipt=52c4c14b37a85c76dcb3d11f83b678bf7eddd5574cb09cd4839d7e64110eb25d&ipo=images
+  homepage: https://global.com/global-player
+  country: GB
+  status: stream-only
+  stationuuid: ba60b138-3d74-4579-9f3f-e2c4eda58a80
+  changeuuid: c18df94b-f7fc-4e29-9660-2e3915f682b5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hardrock-hell
+  broadcaster: independent
+  name: Hardrock Hell
+  streamUrl: https://s3.radio.co/s1f74e2763/listen
+  bitrate: 192
+  codec: MP3
+  homepage: https://hardrockhellradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 2f281ed9-c336-4049-ab17-524f4bc81c0a
+  changeuuid: c9b832b9-aecb-4a30-8a3a-09e9c77d3444
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hearme-classic-rock
+  broadcaster: independent
+  name: HearMe - Classic Rock
+  streamUrl: https://radio.hearme.fm:8270/stream
+  codec: MP3
+  homepage: https://hearme.fm/
+  country: GB
+  status: stream-only
+  stationuuid: ca47a1f5-329a-45de-a0db-97eb6bce75ce
+  changeuuid: 018f363a-c795-4c27-80b2-b6e52b2591f7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-louder-than-war
+  broadcaster: independent
+  name: Louder Than War
+  streamUrl: https://s2.radio.co/sab795a38d/listen
+  bitrate: 128
+  codec: MP3
+  homepage: https://louderthanwar.com/
+  country: GB
+  status: stream-only
+  stationuuid: 43410501-8008-46a9-aaa2-f0372c023e64
+  changeuuid: 78252fe3-69c1-4561-8d2b-c93112d3f25f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-movedahouse
+  broadcaster: independent
+  name: MoveDaHouse
+  streamUrl: https://uk7.internet-radio.com/proxy/movedahouse?mp=//stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.movedahouse.com/wp-content/uploads/2018/01/mdh-172x172.jpg
+  homepage: https://www.movedahouse.com/
+  country: GB
+  status: stream-only
+  stationuuid: 568c844b-5a9c-4a37-a6bc-1a86f6093572
+  changeuuid: 35821de3-b250-43df-a01b-cc320c82927d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-smooth-bristol-and-bath
+  broadcaster: independent
+  name: Smooth Bristol and Bath
+  streamUrl: https://media-the.musicradio.com/SmoothBristolMP3
+  bitrate: 128
+  codec: MP3
+  favicon: http://www.smoothradio.com/assets_v4r/smooth/img/favicon-196x196.png
+  homepage: https://www.smoothradio.com/bristol/
+  country: GB
+  status: stream-only
+  stationuuid: 7942a5dc-9b99-40df-9e2b-c0940ee262cc
+  changeuuid: a2f34b0c-660f-4971-84f4-e4b7cef8754b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-jambo-radio
+  broadcaster: independent
+  name: "Jambo! Radio"
+  streamUrl: https://stream3.themediasite.co.uk:8130/stream
+  bitrate: 192
+  codec: MP3
+  favicon: https://jamboradio.co.uk/wp-content/uploads/2019/10/cropped-Jambo-Logo-1-192x192.png
+  homepage: https://jamboradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 54a67c4e-6e90-4741-aad2-958f7e1a1f73
+  changeuuid: 5c5cb846-07db-4f01-a55a-a166a2c03f9a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-power-ace-radio
+  broadcaster: independent
+  name: Power Ace Radio
+  streamUrl: https://music-station.live/radio/8030/radio.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.poweraceradio.com/favicon.ico
+  homepage: https://www.poweraceradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 68ec09af-5b30-46b4-acf1-71400cf95892
+  changeuuid: 55f9699e-5f3f-4d1e-be0b-203d34e4a9ef
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-rstv-dance
+  broadcaster: independent
+  name: RSTV Dance
+  streamUrl: https://radiozender.mpbnetwerken.nl/rstvdance.mp3
+  bitrate: 384
+  codec: AAC+
+  favicon: https://radiodns.mpbnl.nl/logos/rstv/dance.png
+  homepage: https://dance.rstvnetworks.com/
+  country: GB
+  status: stream-only
+  stationuuid: 863baf3f-c9c6-4f00-810b-acf4e9d8031a
+  changeuuid: b71176fc-4ca9-4c36-8fa6-674bf28f933f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-aaja-radio-channel-1
+  broadcaster: independent
+  name: "Aaja Radio | Channel 1"
+  streamUrl: https://aaja.radiocult.fm/stream
+  bitrate: 192
+  codec: MP3
+  favicon: https://aajamusic.com/_nuxt/icons/icon_64x64.fafdcd.png
+  homepage: https://aajamusic.com/radio
+  country: GB
+  status: stream-only
+  stationuuid: 7811e960-53ef-4e2c-a739-e2dff567ae86
+  changeuuid: 9a91c57e-9a2a-4ce7-a0fd-dcec4c6ab8b7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bikers-hangout-radio
+  broadcaster: independent
+  name: Bikers Hangout Radio
+  streamUrl: https://stream.radio.co/s803057ca0/listen
+  bitrate: 192
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/21bad3_49d2ec0019f24f83bffacbce6787fd0a%7emv2.png/v1/fill/w_180%2ch_180%2clg_1%2cusm_0.66_1.00_0.01/21bad3_49d2ec0019f24f83bffacbce6787fd0a%7emv2.png
+  homepage: https://www.bikershangout.co.uk/bikers-hangout-radio
+  country: GB
+  status: stream-only
+  stationuuid: fd819a4b-e016-444c-86bd-c6db40ce6eba
+  changeuuid: a3966273-8248-410e-921b-27abcd1a7425
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bluesradio-uk
+  broadcaster: independent
+  name: BluesRadio UK
+  streamUrl: https://streaming06.liveboxstream.uk/proxy/david125/stream
+  bitrate: 128
+  codec: MP3
+  homepage: http://www.bluesradio.co.uk/index.php
+  country: GB
+  status: stream-only
+  stationuuid: ecf8275b-bbe8-4035-a8b0-aa04d90a51dc
+  changeuuid: 48f256b1-72a5-4d70-91aa-0975d1549b1f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bar-latina-radio
+  broadcaster: independent
+  name: Bar Latina Radio
+  streamUrl: https://s2.citrus3.com:2000/stream/barlatinaradio
+  bitrate: 320
+  codec: MP3
+  homepage: https://www.barlatina.com/
+  country: GB
+  status: stream-only
+  stationuuid: adfd10cf-ec13-482e-98c7-ba32a8b33879
+  changeuuid: b07fd123-a402-4710-8bb3-3030883e1886
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-black-metal-radio
+  broadcaster: independent
+  name: Black Metal Radio
+  streamUrl: https://das-edge16-live365-dal02.cdnstream.com/a05584
+  bitrate: 192
+  codec: MP3
+  homepage: https://live365.com/station/BLACK-METAL-RADIO-a05584
+  country: GB
+  status: stream-only
+  stationuuid: 117587c0-b66a-437f-b76a-85adcfd146e9
+  changeuuid: e907afc2-e5cb-4e9d-ae9b-fc1d0b41347a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-naim-radio
+  broadcaster: independent
+  name: Naim Radio
+  streamUrl: https://mscp3.live-streams.nl:8362/flac.flac
+  bitrate: 160
+  codec: OGG
+  favicon: https://www.naimaudio.com/build/assets/apple-touch-icon-2a4e35a0.png
+  homepage: https://www.naimaudio.com/
+  country: GB
+  status: stream-only
+  stationuuid: d233c573-3902-444d-8cb0-70eef9142481
+  changeuuid: 83fd5198-c9f1-4a3e-b863-be13f832a89d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-big-beat-brighton
+  broadcaster: independent
+  name: Big Beat Brighton
+  streamUrl: https://s4.citrus3.com:8366/stream
+  bitrate: 256
+  codec: AAC
+  homepage: https://big-beat-brighton.ueniweb.com/
+  country: GB
+  status: stream-only
+  stationuuid: 0e9bf834-78ab-4202-9c32-6fbe35a9b996
+  changeuuid: 29114937-3b6d-4380-ad96-6d64db288402
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-brown-noise-radio
+  broadcaster: independent
+  name: Brown Noise Radio
+  streamUrl: https://uk1.internet-radio.com/proxy/brownnoise?mp=/stream;
+  bitrate: 64
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/996eee_494ede18f9684a0898e0fc38dc06869b%7Emv2.jpg/v1/fill/w_180%2Ch_180%2Clg_1%2Cusm_0.66_1.00_0.01/996eee_494ede18f9684a0898e0fc38dc06869b%7Emv2.jpg
+  homepage: https://www.brownnoiseradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: bb074b4a-c9cc-4811-8282-171ac9bc114f
+  changeuuid: 1fde3e76-4478-4475-a18d-0941f248bac2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-heart-10s
+  broadcaster: independent
+  name: Heart 10s
+  streamUrl: https://media-ice.musicradio.com/Heart10sMP3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.heart.co.uk/10s/
+  country: GB
+  status: stream-only
+  stationuuid: f45705b5-0410-46a7-bf0e-cbb83d4315d2
+  changeuuid: 9599401d-97d7-4a5b-a575-c365ccb70f6a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-majestic-jukebox-radio
+  broadcaster: independent
+  name: Majestic Jukebox Radio
+  streamUrl: https://uk3.internet-radio.com/proxy/majesticjukebox/live
+  bitrate: 16
+  codec: AAC+
+  favicon: https://static.wixstatic.com/media/83e446_a77f5ab906b7455689b82789c523e616~mv2.jpg/v1/fit/w_2500,h_1330,al_c/83e446_a77f5ab906b7455689b82789c523e616~mv2.jpg
+  homepage: https://www.majesticjukeboxradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 01cf48e3-25aa-4bf7-b6d7-563da99b95ac
+  changeuuid: 2fec48e2-4a0d-49c0-9a23-f2138d099fd4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-x-chilled
+  broadcaster: independent
+  name: Radio X Chilled
+  streamUrl: https://media-ice.musicradio.com/RadioXChilledMP3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radiox.co.uk/chilled/
+  country: GB
+  status: stream-only
+  stationuuid: c58bbc71-ad5d-4b92-bb4b-dd85e9d3c411
+  changeuuid: a94a1451-d438-49f0-ab37-24c0769b5556
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-sabotage
+  broadcaster: independent
+  name: Sabotage
+  streamUrl: https://listen.radioking.com/radio/634/stream/2282
+  bitrate: 128
+  codec: MP3
+  favicon: https://t4.ftcdn.net/jpg/04/69/34/51/360_F_469345184_YlmdPahjiPXs133mjIZf98YgZ5g8ZFSN.jpg
+  homepage: https://welove.radio/radio/sabotage/
+  country: GB
+  status: stream-only
+  stationuuid: fa951073-c9af-4216-b41e-899cb34feeb2
+  changeuuid: bc9ae266-2b5d-43c1-8612-936c4a0c4d35
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-60-north-radio
+  broadcaster: independent
+  name: "60 North Radio"
+  streamUrl: https://cdn1.zetcast.net/stream
+  bitrate: 320
+  codec: MP3
+  favicon: https://60north.radio/wp-content/uploads/2020/06/60n-radio-app-icon-108x108-1.jpeg
+  homepage: https://60north.radio/
+  country: GB
+  status: stream-only
+  stationuuid: fe4c2870-703c-4802-b2f6-a95664be32ff
+  changeuuid: f4fa1fa7-f946-412d-8f36-4bb5b1975435
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-dance-revolution
+  broadcaster: independent
+  name: Dance Revolution
+  streamUrl: https://s5.radio.co/s89dcf578d/listen
+  bitrate: 192
+  codec: MP3
+  favicon: http://dancerevradio.com/wp-content/uploads/2024/01/asset-10360-1.jpg
+  homepage: https://dancerevradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: b1d72676-8870-47da-91db-a88357b64c51
+  changeuuid: ffd09def-c3cd-425e-8085-b8463faec51f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-ekr-retro-rock
+  broadcaster: independent
+  name: EKR Retro Rock
+  streamUrl: https://streaming06.liveboxstream.uk/proxy/eastken4?mp=/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://ekrdigital.com/wp-content/themes/ekr-digital-radio/img/icons/retro-rock_180.png
+  homepage: https://ekrdigital.com/retro-rock/
+  country: GB
+  status: stream-only
+  stationuuid: fbc76c8d-fb4b-4e0d-9bac-f70a5bdbb909
+  changeuuid: 074aebd7-c574-4d9e-8b5c-1470f0bf6b46
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-electric-lion-radio-london
+  broadcaster: independent
+  name: Electric Lion Radio London
+  streamUrl: https://streaming04.liveboxstream.uk/proxy/electric?mp=/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://electriclionradio.com/resources/Electric%20Lion.jpg
+  homepage: https://electriclionradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 5de724c6-2781-446f-9d33-3b3d6e5c4130
+  changeuuid: 1656c235-1142-445c-aa8d-481f6b736468
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hearme-trance
+  broadcaster: independent
+  name: HearMe - trance
+  streamUrl: https://radio.hearme.fm:8100/stream
+  codec: MP3
+  homepage: https://hearme.fm/
+  country: GB
+  status: stream-only
+  stationuuid: 457a05d0-bad4-4fb3-80e2-481eb359113c
+  changeuuid: 63195550-37bc-4587-8ac5-ab82b5363145
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-intamixx
+  broadcaster: independent
+  name: Intamixx
+  streamUrl: https://intamixx.no-ip.com:8002/;
+  bitrate: 128
+  codec: MP3
+  favicon: https://radio.intamixx.uk/favicon.ico
+  homepage: https://radio.intamixx.uk/
+  country: GB
+  status: stream-only
+  stationuuid: b95e64c8-724a-4d3f-9df3-3df697b6700f
+  changeuuid: 6447e7e9-e30e-4c8b-a228-e41a08a170b6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-nostalgia-central
+  broadcaster: independent
+  name: Nostalgia Central
+  streamUrl: https://s5.radio.co/s6211fbeed/listen
+  bitrate: 192
+  codec: MP3
+  favicon: http://ncradio.com/wp-content/uploads/2024/08/nclogo.png
+  homepage: https://ncradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 490068a8-e5f9-40eb-8374-53bce3fecd4d
+  changeuuid: ba7fbe51-69fb-482a-8a57-0c24e6521d98
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-xtra-dance
+  broadcaster: independent
+  name: Radio Xtra Dance
+  streamUrl: https://c30.radioboss.fm:8613/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://radioxtra.co.uk/wp-content/uploads/2023/07/xTRA-DANCE-B-150x150-1.jpg
+  homepage: https://radioxtra.co.uk/xtra-dance/
+  country: GB
+  status: stream-only
+  stationuuid: fad87733-40e7-4e8e-9e10-93e9b250e8cb
+  changeuuid: 62b3c937-185d-4256-b17c-a4652b2e51eb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-soul-roots-radio
+  broadcaster: independent
+  name: Soul Roots Radio
+  streamUrl: https://streams.radio.co/sbdfc075c0/listen
+  bitrate: 192
+  codec: MP3
+  favicon: https://soulrootsradio.com/wp-content/uploads/2022/08/Soul-Roots-Header-Logo.png
+  homepage: https://soulrootsradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 2e4a7e87-2d9d-4e64-9e74-6a46bc4a627c
+  changeuuid: 13e64713-cf25-477b-9ca6-04cbfa15d938
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-ace-cafe-radio
+  broadcaster: independent
+  name: Ace Cafe Radio
+  streamUrl: https://listen.radioking.com/radio/69079/stream/106852
+  bitrate: 128
+  codec: MP3
+  homepage: https://acecafe.com/ace-cafe-radio/
+  country: GB
+  status: stream-only
+  stationuuid: 866e0a53-836e-4e07-8c10-aa044e8b61e5
+  changeuuid: 86aa73fa-eb74-4f0d-8a2d-de1f8f182bfd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-get-ready-to-rock
+  broadcaster: independent
+  name: Get Ready to Rock
+  streamUrl: https://streamer.radio.co/s24ae1285c/listen
+  bitrate: 128
+  codec: MP3
+  homepage: http://getreadytorockradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 687da7eb-816b-4865-ba51-240ba2573f55
+  changeuuid: dccd51b1-f552-4e6c-9441-3110da1c85d6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-healthcare-now-radio
+  broadcaster: independent
+  name: Healthcare Now Radio
+  streamUrl: https://healthcarenowradio.out.airtime.pro/healthcarenowradio_a
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.healthcarenowradio.com/wp-content/uploads/2017/12/HCNR-websiteheader-636.png
+  homepage: https://www.healthcarenowradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 78b769e1-2e66-476a-b564-f78921bf3fb3
+  changeuuid: 20fd37ae-f525-4f57-819b-1032f22bad6f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-sd-radio
+  broadcaster: independent
+  name: SD Radio
+  streamUrl: https://mystation.micast.media/radio/8020/radio.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://sdradiouk.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 4d8c78c0-a08d-481b-979a-ec1295af876e
+  changeuuid: 57292a6a-c06f-43f8-b4bf-3764d452ce04
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-ambur-radio
+  broadcaster: independent
+  name: Ambur Radio
+  streamUrl: https://radio.garden/api/ara/content/listen/FEBrvDEk/channel.mp3?1743950367875
+  bitrate: 128
+  codec: MP3
+  favicon: https://amburfm.co.uk/wp-content/uploads/2020/04/logo-ambur-original-composite-cropped.jpg.pagespeed.ce.wm1b2kWhy7.jpg
+  homepage: https://amburfm.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 8a0234a7-8e04-44f2-9dea-9026f8bdfb11
+  changeuuid: 019797a8-a7b5-4787-b522-bbdc495c79a8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-box-radio-dreamscapes
+  broadcaster: independent
+  name: Box radio dreamscapes
+  streamUrl: https://boxradio-edge-00.streamafrica.net/dreamscapes
+  codec: MP3
+  homepage: https://boxradio.net/opendata
+  country: GB
+  status: stream-only
+  stationuuid: 4d84f432-e22d-42c3-b23c-2c93f242146b
+  changeuuid: 88d8cfdc-e2ae-4fee-a462-d8f90339029f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-ehfm
+  broadcaster: independent
+  name: EHFM
+  streamUrl: https://ehfm.out.airtime.pro/ehfm_a
+  bitrate: 192
+  codec: MP3
+  favicon: https://static.mytuner.mobi/media/tvos_radios/lbvlm87gg7bp.png
+  homepage: https://www.ehfm.live/
+  country: GB
+  status: stream-only
+  stationuuid: 57c21dab-3c40-4ca6-b49b-8755bd7a3dcd
+  changeuuid: acd84655-502f-43ae-a219-9945955e73c9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-fresh-fm-radio-london
+  broadcaster: independent
+  name: Fresh Fm Radio London
+  streamUrl: https://eu4.fastcast4u.com/proxy/blacka?mp=/1
+  bitrate: 128
+  codec: MP3
+  homepage: https://freshfmradiolondon.com/
+  country: GB
+  status: stream-only
+  stationuuid: b5699b26-274e-4451-9c1f-cc307b642793
+  changeuuid: ddac1c5d-6d6c-4c9f-ad39-aa886cf07384
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-gaydio-london
+  broadcaster: independent
+  name: Gaydio London
+  streamUrl: https://listen-gaydio.sharp-stream.com/472_gaydio_london_128_mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/20/664f572bc2e7c.png
+  homepage: https://www.gaydio.co.uk/london/
+  country: GB
+  status: stream-only
+  stationuuid: 50f21d6e-02a0-476c-8361-cfa6e8509add
+  changeuuid: d0fd32be-dcb3-4ca6-ac89-37cb2107126e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-heart-love
+  broadcaster: independent
+  name: Heart Love
+  streamUrl: https://media-ice.musicradio.com/HeartLoveMP3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.heart.co.uk/love/
+  country: GB
+  status: stream-only
+  stationuuid: 0e7652b3-70d7-41d9-92a1-fc9badb346a6
+  changeuuid: 1ebe8a69-891c-4a8a-bd38-8681b4e306f1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-pure-beat-radio
+  broadcaster: independent
+  name: Pure Beat Radio
+  streamUrl: https://cast6.asurahosting.com/proxy/purebeat/stream
+  bitrate: 320
+  codec: MP3
+  favicon: http://purebeatradio.co.uk/gallery/favicons/favicon-120x120.png
+  homepage: http://purebeatradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: aeb74f1d-3bc7-470a-b141-fe5781dab116
+  changeuuid: d030d6d4-d408-4d30-a4d1-3e2ef3d86bbb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-24-7-cafe-radio
+  broadcaster: independent
+  name: "24/7 Cafe Radio"
+  streamUrl: https://ec6.yesstreaming.net:1555/stream
+  bitrate: 64
+  codec: MP3
+  favicon: https://www.247caferadio.com/wp-content/uploads/2020/11/cropped-247-Cafe-Radio.jpg
+  homepage: https://www.247caferadio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 265f18a1-be20-487e-8d6f-9a8146f6c63b
+  changeuuid: 8e9eab8d-77db-4974-b7ee-cedce02a162f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-dejavufm
+  broadcaster: independent
+  name: dejavufm
+  streamUrl: https://dejavufm.radioca.st/;
+  bitrate: 320
+  codec: MP3
+  favicon: https://i2.wp.com/dejavufm.com/wp-content/uploads/deja-pic-logo-.jpg?fit=600%2C600&ssl=1
+  homepage: https://dejavufm.com/
+  country: GB
+  status: stream-only
+  stationuuid: 706f58ed-0a92-48dc-a45e-4cb811d68e5d
+  changeuuid: ec524c43-539e-41c5-8228-d86ee9b7a6a9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-energy-fm-classic-dance-and-the-best-new-music
+  broadcaster: independent
+  name: ENERGY FM - classic dance and the best new music
+  streamUrl: https://s1.myradiostream.com/8838/listen.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.energyfm.co.uk/favicon.ico
+  homepage: https://www.energyfm.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: a6c51c25-270f-4796-9189-01d94149287b
+  changeuuid: debbeae3-6b4c-4e6a-92ca-fb66d7687c84
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-funky-corner-radio-uk
+  broadcaster: independent
+  name: Funky Corner Radio UK
+  streamUrl: https://ais-sa2.cdnstream1.com/2447_192.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: https://funkycorner.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 2c4ee091-6461-4e95-a982-06ad8995f1f7
+  changeuuid: c4a058ca-c1da-4175-b685-8521e16270c5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-soul-rhythms-radio-uk
+  broadcaster: independent
+  name: Soul Rhythms Radio UK
+  streamUrl: https://a7.asurahosting.com:8230/radio.mp3
+  bitrate: 320
+  codec: MP3
+  favicon: https://soulrhythmsradio.com/wp-content/uploads/2023/12/SRR-LOGOTHIS_ONE.jpg
+  homepage: https://soulrhythmsradio.com/home/
+  country: GB
+  status: stream-only
+  stationuuid: a933e805-8c3b-4842-b41f-05617340f68e
+  changeuuid: fd8f429b-7ebd-4417-8fcd-46af96fe4204
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-switch-fm-london
+  broadcaster: independent
+  name: Switch FM London
+  streamUrl: https://stream.switchfm.co.uk/listen/switchfm/switchfm.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://switchfm.co.uk/assets/img/favicon.ico
+  homepage: https://switchfm.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 6cb3c224-1fea-4b83-831c-34b691059dc1
+  changeuuid: 5de1ff37-452d-452e-8e37-17706452f8d7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-teamsport-radio
+  broadcaster: independent
+  name: Teamsport Radio
+  streamUrl: https://uksouth1.juiceboxradio.com/tsradionational
+  bitrate: 96
+  codec: AAC+
+  homepage: http://teamsportradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 98ef30cd-0bef-49aa-8a54-af4ffc4780f1
+  changeuuid: 6c3dde39-1f98-4e34-9f3b-89b7d35d25f1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-80s-zoom
+  broadcaster: independent
+  name: "80s Zoom"
+  streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/SAM03AAC226_SC.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTzUFC8MX_VPOLHcB32vggZZhwC928NeErEyQ&s.jpg
+  homepage: http://www.80szoom.com/
+  country: GB
+  status: stream-only
+  stationuuid: 5ba5ce07-cb82-46ef-874a-7c9613bf2abf
+  changeuuid: 0570107d-65e2-4aec-b9b9-86e17c53e98e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bloop-london-radio-live4
+  broadcaster: independent
+  name: Bloop London Radio - live4
+  streamUrl: https://radio.canstream.co.uk:8058/live4.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://blooplondon.com/favicon.ico
+  homepage: https://blooplondon.com/
+  country: GB
+  status: stream-only
+  stationuuid: d38c7d24-a8b5-4148-a3ef-0a64b2988ca8
+  changeuuid: 69fbcacb-16f0-4e8e-8e07-7607ab4fff32
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-d3ep-radio
+  broadcaster: independent
+  name: D3EP Radio
+  streamUrl: https://cast.d3ep.com:8008/192?v=1726246823
+  bitrate: 192
+  codec: MP3
+  favicon: https://d3ep.com/assets/images/topbar-logo.png
+  homepage: https://d3ep.com/
+  country: GB
+  status: stream-only
+  stationuuid: d210ac34-0fee-4586-b9d6-24b84e2c0c4e
+  changeuuid: efef6687-fbd1-4bda-9a9f-de53178d4cca
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-heart-bristol
+  broadcaster: independent
+  name: Heart Bristol
+  streamUrl: https://media-ssl.musicradio.com/HeartBristol?
+  bitrate: 48
+  codec: AAC
+  favicon: https://www.heart.co.uk/assets_v4r/dist/combined/img/logos/bristol.png
+  homepage: https://www.heart.co.uk/bristol/
+  country: GB
+  status: stream-only
+  stationuuid: 599d579a-5554-45ff-8787-e811f88a6d8b
+  changeuuid: 09165c2e-539f-4d8f-8e3f-c4ed72cb6d54
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-point-blank-fm
+  broadcaster: independent
+  name: Point Blank FM
+  streamUrl: https://pointblankradio.co.uk/stream.mp3?latency=high
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.pointblankradio.com/wp-content/uploads/2022/11/Primary-logo.png
+  homepage: https://www.pointblankradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 9957dc39-7c25-499c-8a9c-5ce871924316
+  changeuuid: 4673049e-3e83-4538-85e6-2a5cf8e83736
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-scifi-radio
+  broadcaster: independent
+  name: SCIFI.radio
+  streamUrl: https://station.kryptonradio.com:8080/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://i0.wp.com/scifi.radio/wp-content/uploads/2021/02/cropped-scifiradio-b-512x512-1.png?fit=180%2C180&ssl=1
+  homepage: http://scifi.radio/
+  country: GB
+  status: stream-only
+  stationuuid: 092bb25d-5416-49f4-a994-e49271fcff0e
+  changeuuid: 0f1718c2-2e35-4b9c-bc12-e48b9fb76bf5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-cbn-television
+  broadcaster: independent
+  name: CBN-Television
+  streamUrl: https://5790d294af2dc.streamlock.net/CBNVI/CBNVI/playlist.m3u8
+  bitrate: 2032
+  codec: AAC,H.264
+  favicon: https://static.wixstatic.com/media/a79bb4_69234cd7684d43fa85e3b8d0c18fe9ee~mv2.png/v1/fill/w_167,h_57,al_c,lg_1,q_85,enc_auto/a79bb4_69234cd7684d43fa85e3b8d0c18fe9ee~mv2.png
+  homepage: https://www.cbnvirginislands.com/cbn-tv
+  country: GB
+  status: stream-only
+  stationuuid: 7c335c13-2325-4659-9b1a-4a0d31e3c61f
+  changeuuid: 5eb02c22-a501-44fa-9752-0ce3441c93a6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-london-soul-radio
+  broadcaster: independent
+  name: London Soul Radio
+  streamUrl: https://londonsoulradio.out.airtime.pro/londonsoulradio_a
+  bitrate: 128
+  codec: MP3
+  favicon: https://cdn-profiles.tunein.com/s137728/images/logod.jpg?t=637190405260000000
+  homepage: https://www.thesouloflondonradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 4b137d96-506f-4b0e-ad9f-744fd29a865d
+  changeuuid: 7cd44fd5-2c7f-4ec1-b0b3-a246275655ca
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-moon-phase-radio
+  broadcaster: independent
+  name: Moon Phase Radio
+  streamUrl: https://dc1.serverse.com/proxy/dnutqhxl/stream
+  bitrate: 192
+  codec: MP3
+  homepage: http://moonphaseradio.uk/
+  country: GB
+  status: stream-only
+  stationuuid: fb75959e-29e7-4d50-9cb2-b8b10891d5ab
+  changeuuid: f893c575-ddf2-464e-9165-71bd76de9f3e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-queen
+  broadcaster: independent
+  name: Queen
+  streamUrl: https://stream.pcradio.ru/Queen-hi
+  codec: AAC
+  favicon: null
+  homepage: https://pcradio.ru/
+  country: GB
+  status: stream-only
+  stationuuid: f97e38e9-b0e8-459e-ac37-1983f83a75da
+  changeuuid: 541c73e0-84ee-4234-a99e-47f7cd860a39
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-fred-film-radio-27-industry
+  broadcaster: independent
+  name: Fred Film Radio-27 INDUSTRY
+  streamUrl: https://s10.webradio-hosting.com/proxy/fredradioind/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.fred.fm/wp-content/uploads/2014/12/Fred-Logo_trasp_-copia.png
+  homepage: https://www.fred.fm/
+  country: GB
+  status: stream-only
+  stationuuid: addba89c-d7f5-4467-889e-97e5675cce8c
+  changeuuid: 3dd5bfd2-d9a8-4ae1-9b0f-86f439ce6794
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-greatest-hits-radio
+  broadcaster: independent
+  name: Greatest Hits Radio
+  streamUrl: https://stream-mz.hellorayo.co.uk/net2westmidlands.aac?aw_0_1st.skey=1602676850&direct=true&rp_source=1
+  bitrate: 48
+  codec: AAC+
+  favicon: https://assets.planetradio.co.uk/img/ConfigWebHeaderLogoSVGImageUrl/381.svg?ver=1545132394
+  homepage: https://www.hellorayo.co.uk/greatest-hits/west-midlands
+  country: GB
+  status: stream-only
+  stationuuid: 1bfae443-4fa5-45ed-92a5-8aecd6a70756
+  changeuuid: 9947a32e-28d6-4479-be0b-56f1927e2917
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hearme-2020s-pop-music
+  broadcaster: independent
+  name: HearMe - 2020s Pop Music
+  streamUrl: https://radio.hearme.fm:8000/stream
+  codec: MP3
+  homepage: https://hearme.fm/
+  country: GB
+  status: stream-only
+  stationuuid: ba9841e1-4178-49df-9333-db5d443c7046
+  changeuuid: b669a06f-17c6-4698-af77-dc3ef7bf4e5d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-x-00s
+  broadcaster: independent
+  name: Radio X 00s
+  streamUrl: https://media-ice.musicradio.com/RadioX00sMP3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radiox.co.uk/00s/
+  country: GB
+  status: stream-only
+  stationuuid: 1406b2e7-76db-4b1e-890a-af7a76f839e5
+  changeuuid: e423b33d-a99a-4e78-9c21-f2a16f4916bb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radiohead
+  broadcaster: independent
+  name: Radiohead
+  streamUrl: https://stream.pcradio.ru/radiohead-hi
+  codec: AAC
+  favicon: null
+  homepage: https://pcradio.ru/
+  country: GB
+  status: stream-only
+  stationuuid: 3c7f3361-f72f-4ff5-ad1d-9af563f95584
+  changeuuid: b1633f71-25c1-4942-96e1-fb3b75f3a2c9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-replay-news-english-news-radio-every-5-minutes
+  broadcaster: independent
+  name: REPLAY NEWS - English           News radio every 5 minutes
+  streamUrl: https://replaynewsen.ice.infomaniak.ch/replaynewsen-128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.publicsante.com/BIENVENU/LOGO%20REPLAY%20NEWS-EN.png
+  homepage: https://www.replaynews.net/
+  country: GB
+  status: stream-only
+  stationuuid: 6802b74c-71ba-453b-935f-beb2c03a952c
+  changeuuid: a74c7dba-8e2f-4a23-ae91-e145db40c47a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-sab-radio-folkestone-uk
+  broadcaster: independent
+  name: SAB RADIO FOLKESTONE UK
+  streamUrl: https://spectrum.radioca.st/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://shepwayspectrumarts.co.uk/favicon.ico
+  homepage: https://shepwayspectrumarts.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 5796e0f8-6fef-4efe-b0bb-9fe421401135
+  changeuuid: 06f7880e-e145-45d0-ab07-6c9263ca8cd5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-sam-fm-hampshire
+  broadcaster: independent
+  name: SAM FM Hampshire
+  streamUrl: https://listen-nation.sharp-stream.com/samfmhampshire.aac
+  bitrate: 48
+  codec: AAC+
+  favicon: https://hellorayo.co.uk/tesla/static/favicons/rayo/favicon.svg
+  homepage: https://hellorayo.co.uk/greatest-hits/
+  country: GB
+  status: stream-only
+  stationuuid: 93f0757d-7dcb-440c-ab30-274f0c6e5425
+  changeuuid: 001c46d0-6373-43fd-bd0d-2e4420481cb9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-ujima-radio
+  broadcaster: independent
+  name: Ujima Radio
+  streamUrl: https://radio.canstream.co.uk:8037/live.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.ujimaradio.com/favicon.ico
+  homepage: https://radio.canstream.co.uk:8037/live.mp3
+  country: GB
+  status: stream-only
+  stationuuid: 23687a64-3d15-44ab-a45c-e0114719b277
+  changeuuid: 7dfbe053-688d-4806-8df7-f21cb88c7848
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-beyond-radio
+  broadcaster: independent
+  name: Beyond Radio
+  streamUrl: https://stream.beyondradio.co.uk/radio/8000/high
+  bitrate: 192
+  codec: AAC
+  favicon: https://mmo.aiircdn.com/458/61aa613685fdd.png
+  homepage: https://www.beyondradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 3ce2d8da-aa4f-458c-8316-601ad5375981
+  changeuuid: 0d2492c4-d41d-4389-8e50-43ac58c73b15
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-box-office-radio
+  broadcaster: independent
+  name: Box Office Radio
+  streamUrl: https://s2.citrus3.com:8400/stream
+  bitrate: 256
+  codec: MP3
+  favicon: https://raw.githubusercontent.com/AusIPTV/IPTVLogos/master/Box_Office_Radio.png
+  homepage: https://boxofficeradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 0bf68865-449b-4190-a11c-597a4a47c0e9
+  changeuuid: 19ed9884-ab93-448d-b3ed-912973bad3df
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-british-tamil-radio
+  broadcaster: independent
+  name: British Tamil Radio
+  streamUrl: https://hello.citrus3.com:8188/stream
+  bitrate: 128
+  codec: AAC
+  favicon: https://www.bitronline.com/wp-content/uploads/2023/12/cropped-logo_radio_main-1-300x300.png
+  homepage: https://www.bitronline.com/
+  country: GB
+  status: stream-only
+  stationuuid: 1e64ded1-bc95-479c-8f67-e98ad15010ad
+  changeuuid: c3a64798-f884-41d8-b6b9-77e04ab75cdf
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-chunt-fm
+  broadcaster: independent
+  name: Chunt FM
+  streamUrl: https://fm.chunt.org/stream
+  bitrate: 320
+  codec: MP3
+  favicon: https://chunt.org/images/logo_fishe_calm_256.png
+  homepage: https://chunt.org/
+  country: GB
+  status: stream-only
+  stationuuid: 02ec5302-9dc4-42f7-9801-2278c06c1073
+  changeuuid: 231f4145-cdb7-4d3c-8ccb-62efb45d302a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hearme-1990s-pop-music
+  broadcaster: independent
+  name: HearMe - 1990s pop music
+  streamUrl: https://radio.hearme.fm:8050/stream
+  codec: MP3
+  homepage: https://hearme.fm/
+  country: GB
+  status: stream-only
+  stationuuid: 72acc195-c972-464b-96ae-d90f4d117e4b
+  changeuuid: 2bef1584-aa85-4734-8db3-535b1ce4fa9a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-heckington-living-community-radio
+  broadcaster: independent
+  name: Heckington Living Community Radio
+  streamUrl: https://streaming.live365.com/a52107
+  bitrate: 128
+  codec: MP3
+  homepage: http://www.heckingtonliving.co.uk/heckington-living-community-radio/
+  country: GB
+  status: stream-only
+  stationuuid: b459a3de-39f9-4179-9ce2-19e9e74c8d94
+  changeuuid: 7f3744e0-eebc-4cb1-9c13-f1966df5daed
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-jazz-radio-international
+  broadcaster: independent
+  name: JAZZ RADIO INTERNATIONAL
+  streamUrl: https://ec3.yesstreaming.net:1815/stream
+  bitrate: 64
+  codec: MP3
+  favicon: https://www.247onlineradio.com/wp-content/uploads/2015/07/JIR-logo.jpg
+  homepage: https://www.247onlineradio.com/jazz-radio-international/
+  country: GB
+  status: stream-only
+  stationuuid: 5d2e1109-82a9-40dd-8f90-25dfb0cbf01c
+  changeuuid: 1bcab309-8162-4d8a-b614-de227950c189
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-laser-558
+  broadcaster: independent
+  name: Laser 558
+  streamUrl: https://s6.autopo.st/proxy/stfkrnfr?mp=/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://i0.wp.com/laser558.live/wp-content/uploads/2023/06/cropped-820eb3aa2e08a58fcf16db6aebbbdcb4_2000x.png?fit=180%2c180&#038;ssl=1
+  homepage: https://laser558.live/
+  country: GB
+  status: stream-only
+  stationuuid: 09b323c7-3130-490b-b3cc-0521a24634ff
+  changeuuid: 4b64dd14-9dba-4fde-b953-0b01086c8c80
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-nation-classic-hits
+  broadcaster: independent
+  name: Nation Classic Hits
+  streamUrl: https://listen-nation.sharp-stream.com/nationparty.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.nationplayer.com/nation-classic-hits/
+  country: GB
+  status: stream-only
+  stationuuid: 9d082320-7f24-4189-9d1e-19eb89a32018
+  changeuuid: a2fdd064-9488-4392-a631-5ba5b50a4598
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-angel-radio
+  broadcaster: independent
+  name: Angel Radio
+  streamUrl: https://edge.clrmedia.co.uk/angel_hb
+  bitrate: 96
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/d58553_797ec55eb22b47f38dd7203577e49e5e%7emv2.png/v1/fill/w_180%2ch_180%2clg_1%2cusm_0.66_1.00_0.01/d58553_797ec55eb22b47f38dd7203577e49e5e%7emv2.png
+  homepage: https://www.angelradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: fb441035-d115-444b-b57c-2a97adb6e681
+  changeuuid: 5b0d5118-5b6d-459a-9e32-e2e5fb3fcb9c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hearme-classic-eurodisco
+  broadcaster: independent
+  name: HearMe - Classic EuroDisco
+  streamUrl: https://radio.hearme.fm:9810/stream
+  codec: MP3
+  favicon: https://hearme.fm/wp-content/uploads/2024/06/2024-Redrafted-Transparent-Box-No-Text-1-1024x1024.png
+  homepage: https://hearme.fm/radio/classic-eurodisco/
+  country: GB
+  status: stream-only
+  stationuuid: f6fd2828-5e3a-4ae4-85d1-86e34a85a3c2
+  changeuuid: 3e33a31d-45e0-4b92-9ee9-d159de3158fa
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hot-fm-uk
+  broadcaster: independent
+  name: Hot FM UK
+  streamUrl: https://hotfmuk.radioca.st/;
+  bitrate: 128
+  codec: MP3
+  favicon: https://static.mytuner.mobi/media/tvos_radios/3tbgbthvw26v.webp
+  homepage: https://www.hotfm.org.uk/
+  country: GB
+  status: stream-only
+  stationuuid: da5e3f19-fced-4436-b276-0e6a0db39b59
+  changeuuid: 8f48dc01-e7d5-49e4-84e3-fd416b8cbccf
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-mellow-mountain-radio
+  broadcaster: independent
+  name: Mellow Mountain Radio
+  streamUrl: https://owncast.mellowmountainradio.com/hls/stream.m3u8
+  bitrate: 1108
+  codec: AAC,H.264
+  favicon: https://irp.cdn-website.com/5e4cb10b/site_favicon_16_1715929040005.ico
+  homepage: https://www.mellowmountainradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 58834354-1bc1-426d-9b93-a5eecff8a80b
+  changeuuid: 5095cfb0-691b-4017-ab95-dcb6fcd05d1e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-north-manchester-fm
+  broadcaster: independent
+  name: North Manchester FM
+  streamUrl: https://radio.canstream.co.uk:8061/live.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://northmanchester.fm/wp-content/uploads/2011/08/nmfm10661.jpg
+  homepage: https://northmanchester.fm/
+  country: GB
+  status: stream-only
+  stationuuid: a553dcde-0b66-4c2d-a860-1b1e1e0aa887
+  changeuuid: cc11ab95-dea5-49db-8edb-2d2187f4e4ac
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-poprockradiouk
+  broadcaster: independent
+  name: PopRockRadioUK
+  streamUrl: https://popradiouk.out.airtime.pro/popradiouk_a
+  bitrate: 64
+  codec: MP3
+  country: GB
+  status: stream-only
+  stationuuid: dc27386e-ca42-4caa-b014-f7a4318f8b6f
+  changeuuid: f47df7d7-6cce-4248-abf8-dbd9e032fdb4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-stones-live-the-24-7-maidstone-united-radio-stat
+  broadcaster: independent
+  name: "Stones Live! - The 24/7 Maidstone United Radio Station"
+  streamUrl: https://uk5.internet-radio.com/proxy/stoneslive?mp=/stream;
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.stoneslive.com/wp-content/uploads/2015/07/julystoneslive.png
+  homepage: https://www.stoneslive.com/
+  country: GB
+  status: stream-only
+  stationuuid: 49c326d1-0058-40e7-b627-208b7800ff3c
+  changeuuid: 900f746e-a399-43cd-ab4e-77ddfd96868b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-the-christmas-station
+  broadcaster: independent
+  name: The Christmas Station
+  streamUrl: https://stream.radio.co/s63541ce9b/listen
+  bitrate: 64
+  codec: AAC
+  favicon: https://thechristmasstation.org/images/stationlogo.webp
+  homepage: https://thechristmasstation.org/
+  country: GB
+  status: stream-only
+  stationuuid: ca900cf9-e425-469b-b8cc-06a179f1f240
+  changeuuid: 49bdcc68-3289-4c91-94b6-07f158f83cde
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-wey-valley
+  broadcaster: independent
+  name: Wey Valley
+  streamUrl: https://stream.readyformed.com:8443/wey1
+  bitrate: 64
+  codec: AAC+
+  favicon: https://www.weyvalleyradio.uk/favicon.ico
+  homepage: https://www.weyvalleyradio.uk/l
+  country: GB
+  status: stream-only
+  stationuuid: e5daba4f-428e-11e9-aa55-52543be04c81
+  changeuuid: 2a9c14c8-b852-4d5d-900b-c5d96337080c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-kisstory-non-stop-old-skool-anthems
+  broadcaster: independent
+  name: " KISSTORY: Non-Stop Old Skool & Anthems"
+  streamUrl: https://live-bauerkiss.sharp-stream.com/kisstory.aac?direct=true&aw_0_1st.playerid=BMUK_Airable&aw_0_1st.skey=6778249992
+  bitrate: 48
+  codec: AAC+
+  favicon: https://cdn-profiles.tunein.com/s77960/images/logod.png
+  homepage: https://www.hellorayo.co.uk/kisstory
+  country: GB
+  status: stream-only
+  stationuuid: 53733e08-7728-40ee-b968-59e71f0281b6
+  changeuuid: 9f1a18d0-fda1-498a-8b86-c3c2cdd9d54a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-24-7-london-radio-royalty-free-music
+  broadcaster: independent
+  name: "24/7 London Radio - Royalty Free Music"
+  streamUrl: https://ec3.yesstreaming.net:3645/stream
+  bitrate: 64
+  codec: MP3
+  favicon: https://usercontent.one/wp/www.247londonradio.com/wp-content/uploads/2020/02/cropped-247-london-Radio-Logo.jpg
+  homepage: https://www.247londonradio.com/royalty-free-music/
+  country: GB
+  status: stream-only
+  stationuuid: df0fb96e-4a82-44c7-af2b-d4a08cf55145
+  changeuuid: f6b56f78-04b2-4f23-b2a0-dff1505cf638
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-cj-carlos
+  broadcaster: independent
+  name: CJ Carlos
+  streamUrl: https://s3.radio.co/sf2bda8390/listen
+  bitrate: 192
+  codec: AAC
+  homepage: https://cjcarlosevents.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 88a2e73d-2dcd-4f66-85b1-d3ca91916218
+  changeuuid: 9c9902cd-f144-41f5-ba00-4fbaf7162506
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-gamingnow-radio
+  broadcaster: independent
+  name: GamingNow Radio
+  streamUrl: https://media01.gamingnow.net:8010/
+  bitrate: 256
+  codec: MP3
+  homepage: https://gamingnow.net/radio/
+  country: GB
+  status: stream-only
+  stationuuid: d19b61de-a1d8-4ade-8111-96f054897a14
+  changeuuid: c02e6236-38c8-4e06-9aa7-65e77ee9d9c2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-in2beats
+  broadcaster: independent
+  name: in2Beats
+  streamUrl: https://in2radio.co.uk/IN2MP3
+  bitrate: 192
+  codec: MP3
+  homepage: https://in2beats.com/
+  country: GB
+  status: stream-only
+  stationuuid: 64d7e167-a7e7-4a8f-b2b0-4fc19efa6099
+  changeuuid: f5255018-64f4-4c9b-af59-899977228255
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-laser-558-classic
+  broadcaster: independent
+  name: Laser 558 Classic
+  streamUrl: https://s6.autopo.st/proxy/neffjohd?mp=/stream
+  bitrate: 128
+  codec: MP3
+  homepage: https://laser558.live/
+  country: GB
+  status: stream-only
+  stationuuid: 25171269-205c-4872-8a1a-ccaa705fe8f8
+  changeuuid: 7f5ce6a3-f548-4742-ae54-1d56f0a0e357
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-ribblefm
+  broadcaster: independent
+  name: RibbleFM
+  streamUrl: https://uksouth.streaming.broadcast.radio/ribblefm
+  codec: MP3
+  favicon: https://ribblefm.com/wp-content/uploads/2023/02/ribblefm-logo.webp
+  homepage: https://ribblefm.com/
+  country: GB
+  status: stream-only
+  stationuuid: a17fbf18-ea95-4baf-aebd-4aba1ef1dd34
+  changeuuid: 917f0067-2472-48a6-ac8d-26c365ddb6a6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-starpoint-radio
+  broadcaster: independent
+  name: Starpoint Radio
+  streamUrl: https://stream2.hippynet.co.uk/stream/starpointradiohigh
+  bitrate: 192
+  codec: MP3
+  homepage: http://www.starpointradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: f226bc65-686a-49f1-b82c-6743612197ba
+  changeuuid: b4dfad64-4e41-4265-bcd4-b8ec7bffa68e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-uk-national-radio
+  broadcaster: independent
+  name: UK National Radio
+  streamUrl: https://das-edge14-live365-dal02.cdnstream.com/a80402
+  bitrate: 192
+  codec: MP3
+  favicon: https://media.live365.com/download/119460ab-eb43-4fca-a482-eadc9c4d9ef0.png
+  homepage: https://www.uknationalradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 38441808-02e0-4d04-88ae-4e67bee3fdf4
+  changeuuid: f7740d80-0d4d-4e59-b5de-bc11c55bf103
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-1btn
+  broadcaster: independent
+  name: "1BTN"
+  streamUrl: https://edge.clrmedia.co.uk/obfm_mp3
+  codec: MP3
+  homepage: https://1btn.fm/
+  country: GB
+  status: stream-only
+  stationuuid: 5c353e67-3f33-45b7-8a7f-eb4571907c4e
+  changeuuid: 90b896e6-0c5a-4ba5-b396-247cd29256e0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-24-7-restaurant-radio
+  broadcaster: independent
+  name: "24/7 Restaurant Radio"
+  streamUrl: https://ec6.yesstreaming.net:1655/stream
+  bitrate: 64
+  codec: MP3
+  favicon: https://usercontent.one/wp/www.247restaurantradio.com/wp-content/uploads/2021/04/cropped-247-Restaurant-Radio.jpg
+  homepage: https://www.247restaurantradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 2412aaa9-4a0e-48a5-b22f-245801bf064d
+  changeuuid: 46d341c0-11a2-4686-a9a8-ae83810cc1c7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-alpha-wave-radio
+  broadcaster: independent
+  name: Alpha Wave Radio
+  streamUrl: https://listentomystream.com:8068/stream
+  bitrate: 320
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/a8d0cc_272a834a431540a6a4bc2c9a7f652ec0~mv2.png/v1/fill/w_123,h_123,al_c,q_85,usm_0.66_1.00_0.01,enc_auto/Bright%20Blue.png
+  homepage: https://www.alphawaveradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: d275f459-7fb1-49a5-952c-1637718f0878
+  changeuuid: 1f2467fb-0392-4c7f-8cd9-1fddbe505006
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bbc-radio-tees
+  broadcaster: independent
+  name: BBC Radio Tees
+  streamUrl: https://a.files.bbci.co.uk/ms6/live/3441A116-B12E-4D2F-ACA8-C1984642FA4B/audio/simulcast/hls/nonuk/pc_hd_abr_v2/aks/bbc_tees.m3u8
+  bitrate: 101
+  codec: AAC+
+  favicon: https://static.files.bbci.co.uk/sounds/web/sounds-web/img/sounds-apple-touch-icon.ead169771d.png
+  homepage: https://www.bbc.co.uk/radiotees/
+  country: GB
+  status: stream-only
+  stationuuid: 47ee32eb-3d2b-4dc8-bb60-825ee57db0ed
+  changeuuid: 166c2b1f-f8d0-4480-9fff-5c07add88308
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-beware-the-radio
+  broadcaster: independent
+  name: "Beware! The Radio"
+  streamUrl: https://bewaretheradio.out.airtime.pro/bewaretheradio_a
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.bewaretheradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 7271f78c-519b-4fbc-b034-1a3213e0dbb3
+  changeuuid: fcc5c593-6b8a-4c23-a7eb-f83b4975f1dc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-fred-film-radio-mandarin
+  broadcaster: independent
+  name: FRED FILM RADIO Mandarin
+  streamUrl: https://s10.webradio-hosting.com/proxy/fredradiocn/stream/1/
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.fred.fm/wp-content/uploads/2014/12/Fred-Logo_trasp_-copia.png
+  homepage: https://www.fred.fm/
+  country: GB
+  status: stream-only
+  stationuuid: ac0d34c3-748d-4d2f-aa42-7cfb07145ef8
+  changeuuid: 58ac4297-cc98-4794-a00b-6d82775953f6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hearme-2010s-pop-music
+  broadcaster: independent
+  name: HearMe 2010s pop music
+  streamUrl: https://radio.hearme.fm:8030/stream
+  codec: MP3
+  homepage: https://hearme.fm/
+  country: GB
+  status: stream-only
+  stationuuid: af98071e-f1c2-4ca3-8120-1d68cf53661e
+  changeuuid: 27dea5af-bd91-4f86-a766-6e3b75918585
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-ostm-radio
+  broadcaster: independent
+  name: OSTM Radio
+  streamUrl: https://stream.zeno.fm/1vx25xbdmzzuv
+  codec: MP3
+  favicon: https://www.ostm.co.uk/img/favicon.ico
+  homepage: https://www.ostm.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: a6d8473d-e8fe-47e5-b05a-edcdf4c18934
+  changeuuid: 1d5d27e1-c82e-4f69-b9ac-550335ebcf86
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-capital-nottinghamshire
+  broadcaster: independent
+  name: Capital (Nottinghamshire)
+  streamUrl: https://media-ice.musicradio.com/CapitalNottinghamshireMP3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.capitalfm.com/assets_v4r/capital/img/favicon-196x196.png
+  homepage: https://www.capitalfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: 49d8ced8-12e6-40b3-a099-327bb146b946
+  changeuuid: af884f5b-8181-4f4e-88cd-d0259f3b0987
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-caravan-radio
+  broadcaster: independent
+  name: Caravan Radio
+  streamUrl: https://stream4.themediasite.co.uk:8044/stream?_=456752
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.caravanradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 064d9bd9-7246-462c-a544-bb91ce1e14e9
+  changeuuid: 77b4d4de-2d73-418c-8ba2-26903544d7ca
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-cosmic-fuzz-fm
+  broadcaster: independent
+  name: COSMIC FUZZ FM
+  streamUrl: https://26343.live.streamtheworld.com/SAM04AAC335_SC
+  bitrate: 320
+  codec: MP3
+  favicon: https://img1.wsimg.com/isteam/ip/a07df4e6-3874-46a7-b088-6a4e68a6123b/blob-6f3a7d7.png/:/cr=t:0%25,l:0%25,w:100%25,h:100%25/rs=w:806,h:403
+  homepage: https://cosmicfuzzfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: 274319b9-6662-465b-8016-c6fae9b14adb
+  changeuuid: 62f84619-7075-4edb-84e2-822a2b8394f2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-galaxy-of-stars
+  broadcaster: independent
+  name: "Galaxy of Stars "
+  streamUrl: https://media-ssl.musicradio.com/Global-M-GalaxyStars
+  bitrate: 48
+  codec: AAC
+  favicon: https://images.globalplayer.com/images/595200?width=450&signature=8QhLiiKoeaxJMt_Zc6w4S9Wekz0=
+  homepage: https://www.globalplayer.com/playlists/2SWmn/
+  country: GB
+  status: stream-only
+  stationuuid: 8005a59e-7245-4872-8e84-aced12f6f7c2
+  changeuuid: 1cffa0ce-aa90-41a1-9b31-8d2075107866
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-magic-classical
+  broadcaster: independent
+  name: Magic Classical
+  streamUrl: https://stream-mz.hellorayo.co.uk/scala.aac
+  bitrate: 48
+  codec: AAC+
+  homepage: https://www.hellorayo.co.uk/magic-classical
+  country: GB
+  status: stream-only
+  stationuuid: d18943f2-7c18-4e1d-8cf2-9ce1c5616f86
+  changeuuid: acc833af-5bcb-411f-aef5-edf645ef7573
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-ssradio
+  broadcaster: independent
+  name: SSRadio
+  streamUrl: https://ssradiol.radioca.st/listen.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://ssradio.com/wp-content/themes/ssradio/images/ssrDeepLogo.gif
+  homepage: https://ssradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 0753f1cf-8812-4133-a586-cec763884ba7
+  changeuuid: c64beda1-9d76-4fab-8e65-5741c30c3eeb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-the-people-s-radio-a-star-citizen-community-radi
+  broadcaster: independent
+  name: "The People's Radio - A Star Citizen Community Radio Station"
+  streamUrl: https://us1.streamingpulse.com/ssl/7058
+  bitrate: 320
+  codec: MP3
+  favicon: https://us7.streamingpulse.com/4232/tmp/images/logo.1632318369.png
+  homepage: https://thepeoplesradio.space/
+  country: GB
+  status: stream-only
+  stationuuid: 4ea91a6e-3b76-437e-8e5f-8e2d73d5ab39
+  changeuuid: 7edf0edf-3d3f-4d3e-ab1d-cad4abfebe6f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-winchester-radio
+  broadcaster: independent
+  name: Winchester Radio
+  streamUrl: https://winchest.radioca.st/stream?rp_source=1&=&&___cb=427101946874329
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.hampshirehospitals.nhs.uk/application/files/5715/9741/0233/WinchRadio-portrait250x109.png
+  homepage: http://winchester.radio/
+  country: GB
+  status: stream-only
+  stationuuid: 3361523d-d9c9-4908-ae39-84997ee09ea2
+  changeuuid: c9047f75-b7b6-4235-ad8e-547ee3cd86c6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-virgin-radio-uk-rock-n-roll-radio-from-the-top-o
+  broadcaster: independent
+  name: " VIRGIN RADIO UK: Rock‘n’Roll Radio From The Top Of The Tower"
+  streamUrl: https://virgin.live.stream.broadcasting.news/stream
+  bitrate: 128
+  codec: AAC
+  favicon: https://cdn-profiles.tunein.com/s266113/images/logod.png
+  homepage: https://virginradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 723e042f-3c2f-4562-b8fa-3f9a8d31cf3e
+  changeuuid: 52ad9798-438b-4fd3-bdfc-3fa3b0a06dc1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-24-7-seawaves-radio
+  broadcaster: independent
+  name: "24/7 Seawaves Radio"
+  streamUrl: https://ec6.yesstreaming.net:1505/stream
+  bitrate: 64
+  codec: MP3
+  favicon: https://www.247natureradio.com/wp-content/uploads/2021/09/247-Seawaves-Radio.jpg
+  homepage: https://www.247natureradio.com/24-7-seawaves-radio/
+  country: GB
+  status: stream-only
+  stationuuid: 04c6c260-eafc-419c-b374-f061080bfd81
+  changeuuid: 2c82e42e-a971-4499-9da5-9e27d3bb8029
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-big-barn-radio
+  broadcaster: independent
+  name: BIG BARN RADIO
+  streamUrl: https://s2.radio.co/s04214ea9a/listen
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.wix.com/favicon.ico
+  homepage: https://bigbarnradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 1ec70ece-e320-40f3-bc96-95f57f0ebf5a
+  changeuuid: eedad89a-2660-4c1b-b226-28d7a671b26d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-broradio
+  broadcaster: independent
+  name: broradio
+  streamUrl: https://streaming.broadcastradio.com:8422/brorad?=&&___cb=380218828489260
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.broradio.fm/
+  country: GB
+  status: stream-only
+  stationuuid: 8787051e-b4f7-4748-b70d-300532da5164
+  changeuuid: ce17dccb-c045-4e10-802c-8b08aadca165
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-burgess-hill-radio
+  broadcaster: independent
+  name: Burgess Hill Radio
+  streamUrl: https://streaming.broadcastradio.com:9312/burgesshillradio
+  codec: MP3
+  homepage: https://www.burgesshillradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 5b33e248-4dff-44c4-b3ce-e4eabf3d8d09
+  changeuuid: 8a382297-e6c8-449b-b8f0-ac09761e32c6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-heritage-chart-radio
+  broadcaster: independent
+  name: Heritage Chart Radio
+  streamUrl: https://s4.radio.co/sd5b175766/listen
+  bitrate: 320
+  codec: MP3
+  homepage: https://www.heritagechart.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 405ac58a-0ea5-4c5e-b158-0d750e871ea0
+  changeuuid: 1769cc17-0d05-48ca-8ae5-9c6614d34147
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-jingle-ark-jingle-jukebox
+  broadcaster: independent
+  name: Jingle Ark Jingle Jukebox
+  streamUrl: https://stream.zeno.fm/6q0ftbdzk2zuv
+  codec: MP3
+  favicon: https://zeno.fm/static/icons/apple-icon-120x120.png
+  homepage: https://zeno.fm/radio/jingle-ark-classics/
+  country: GB
+  status: stream-only
+  stationuuid: b55b73c6-20b6-4fd4-a86f-1f653d81dcf7
+  changeuuid: 948cf13a-d8cc-4702-8adc-99643a75eab3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-music-galaxy-radio
+  broadcaster: independent
+  name: Music Galaxy Radio
+  streamUrl: https://eu10.fastcast4u.com/themusi2
+  bitrate: 128
+  codec: MP3
+  favicon: https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRl5H_571Uc9TPjudUTSRXY6Kme_1deY38X0r8gWVmn1YclbOUPbBC3exlC4gEOZEs05r0&usqp=CAU
+  homepage: https://www.themusicgalaxyradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: a0beeffe-2cb5-43f0-bec0-cee8ea861dfe
+  changeuuid: 26d3333f-54fe-439d-a180-eae7f129ab83
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-retro-mix-radio
+  broadcaster: independent
+  name: Retro Mix Radio
+  streamUrl: https://stream.retromixradio.co.uk/radio48
+  bitrate: 48
+  codec: AAC+
+  homepage: https://www.retromixradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: fe3689b2-bf07-4e8c-92a8-8f491164e2b2
+  changeuuid: 7720f398-fe7e-49be-8949-baa368ae85f4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-sheppey-fm-92-2
+  broadcaster: independent
+  name: Sheppey FM 92.2
+  streamUrl: https://streaming05.liveboxstream.uk/proxy/sheppeyf?mp=/stream
+  bitrate: 256
+  codec: MP3
+  homepage: https://sheppeyfm.org.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 76e001af-8740-4da8-93cc-5eb83016050e
+  changeuuid: 83f8dcc5-ce7d-41f0-9a8f-84cb47fd0125
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-your-hits-digital
+  broadcaster: independent
+  name: Your Hits Digital
+  streamUrl: https://stream-yourhitsdigital.creativedork.com/
+  bitrate: 64
+  codec: AAC+
+  homepage: https://www.yourhitsdigital.com/
+  country: GB
+  status: stream-only
+  stationuuid: cce4d842-89f1-404d-b32b-8ba4f63bba40
+  changeuuid: 2edda94c-7295-47d5-a86d-5890bf81d62d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-242-radio
+  broadcaster: independent
+  name: "242 Radio"
+  streamUrl: https://uk7.internet-radio.com/proxy/242radio?mp=/stream&1705137844878
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.242radio.com/index_htm_files/17903@2x.jpg
+  homepage: https://www.242radio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 7790d186-8111-4c34-9d8f-ffdafa68732b
+  changeuuid: 778a3892-d07d-42c9-9682-f264916fa32d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-apocalypse-radio
+  broadcaster: independent
+  name: Apocalypse Radio
+  streamUrl: https://radiopanel.scoobynetworks.uk:10990/stream?type=http&nocache=28
+  bitrate: 320
+  codec: AAC+
+  homepage: https://apocalypse-radio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: df11295d-b998-4af0-b9b2-6f67b7615bbe
+  changeuuid: bbf5e69d-9500-4108-a223-02741d9a579c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bfbs-uk
+  broadcaster: independent
+  name: BFBS UK
+  streamUrl: https://listen-ssvcbfbs.sharp-stream.com/ssvcbfbs1.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://radio.bfbs.com/icons/icon-512x512.png?v=0afec91a27aaa6d57f2b000c6fbe8cac
+  homepage: https://radio.bfbs.com/stations/bfbs-uk
+  country: GB
+  status: stream-only
+  stationuuid: 5fb0e4b7-d7dd-4177-8521-3186746fd06e
+  changeuuid: a8fe9921-d08c-4883-a6e6-4ebdc3254976
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bloomberg-uk
+  broadcaster: independent
+  name: Bloomberg UK
+  streamUrl: https://bloomberg-live-prod-us-east-1.s3.amazonaws.com/rad/Channel-RAD-AWS-virginia-1/Source-RadUK-96-1_live.m3u8
+  codec: UNKNOWN
+  favicon: https://www.bloomberg.com/favicon.ico
+  homepage: https://www.bloomberg.com/audio
+  country: GB
+  status: stream-only
+  stationuuid: 24f61d87-4a36-4db7-b80a-df96755e9b7f
+  changeuuid: b9c3c34b-c19f-4bdc-b885-1428b22ea6be
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-frisk-guilty-pleasures
+  broadcaster: independent
+  name: Frisk Guilty Pleasures
+  streamUrl: https://www.friskradio.com:8443/stream31
+  codec: AAC
+  favicon: https://management.friskradio.com:7000/stations/logo?id=6
+  homepage: https://www.friskradio.com/?station=6#station-select-panel
+  country: GB
+  status: stream-only
+  stationuuid: 40adec4e-ed1e-4a28-b7ea-417d5bf6d7eb
+  changeuuid: f685ab39-76a7-496e-ab3a-863ed86f7d75
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-inverness-hospital-radio
+  broadcaster: independent
+  name: Inverness Hospital Radio
+  streamUrl: https://uksoutha.streaming.broadcast.radio/invernesshr?1699799769753=
+  codec: MP3
+  homepage: https://www.invernesshospitalradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 8af6269e-5a11-4ca3-bb57-9306fa0a7a34
+  changeuuid: b17aaf20-3c58-4859-abbe-79265bf4d3f2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-nation-xmas
+  broadcaster: independent
+  name: Nation Xmas
+  streamUrl: https://listen-nation.sharp-stream.com/nationxmas.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.nationplayer.com/nation-xmas/
+  country: GB
+  status: stream-only
+  stationuuid: 36733cfe-2acf-46ee-bd04-d243bc76cb80
+  changeuuid: fbebf74f-31f5-484f-b75c-1398301a80f6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-ocean-youth-radio
+  broadcaster: independent
+  name: Ocean Youth Radio
+  streamUrl: https://stream.radio.co/s7bb9c4fc8/low
+  bitrate: 64
+  codec: MP3
+  favicon: https://images.squarespace-cdn.com/content/v1/63b306b5c427c63f7ac443bb/a113998f-ade6-40ba-9e52-0ee49b945a1d/02_OYLogoWhite.png?format=1500w
+  homepage: https://www.oceanyouth.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 407a84ec-091c-4741-ad11-36698c83698b
+  changeuuid: 6e4db4af-8d11-45bb-a62b-081018ecadb2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-groovy
+  broadcaster: independent
+  name: Radio Groovy
+  streamUrl: https://stream.radio.co/s560edbdb7/listen
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radiogroovy.com/
+  country: GB
+  status: stream-only
+  stationuuid: d2243a22-f0a8-4f65-852f-ffbf58df7ee8
+  changeuuid: f19c9d01-0609-4fb2-988f-437204f56cc0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-101-8-wcr-fm
+  broadcaster: independent
+  name: "101.8 WCR FM"
+  streamUrl: https://stream3.themediasite.co.uk:8312/stream?_=580911
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.wcrfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: 7acde6d6-84b1-46dd-81bc-4fc8f1e4b6b0
+  changeuuid: fad87b4e-d319-4ee8-b724-a04f8616dbb6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-24-7-country-walks-radio
+  broadcaster: independent
+  name: "24/7 Country Walks Radio"
+  streamUrl: https://ec6.yesstreaming.net:1585/stream
+  bitrate: 64
+  codec: MP3
+  favicon: https://www.247onlineradio.com/wp-content/uploads/2023/04/247-Country-Walks.jpg
+  homepage: https://www.247onlineradio.com/24-7-online-radio-group-stations/24-7-country-walks-radio/
+  country: GB
+  status: stream-only
+  stationuuid: 9db7f22c-3997-40e6-a039-c045069ec42f
+  changeuuid: c77b3f5c-c5d8-48f2-932d-227a46e4196f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-crystal-107-4-fm
+  broadcaster: independent
+  name: Crystal 107.4 FM
+  streamUrl: https://crystalfm-radiohosting2.radioca.st/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.crystalfm.co.uk/index_htm_files/favicon.ico
+  homepage: https://www.crystalfm.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 70b27d48-d503-422a-b023-69b45b7759c7
+  changeuuid: 5c4be0ca-7784-420b-87fc-554d3d26fee4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-liverpool-live-radio
+  broadcaster: independent
+  name: Liverpool Live Radio
+  streamUrl: https://stream.aiir.com/xbmvsamvpnluv
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/417/5f8022222baf6.png
+  homepage: https://www.liverpoolliveradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 0c669041-51b8-4110-8c3f-8eee1ca15e68
+  changeuuid: 9fa6af1b-7423-4d4d-8f01-e22c9b1e86be
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-mechanical-music-radio
+  broadcaster: independent
+  name: Mechanical Music Radio
+  streamUrl: https://global.citrus3.com:2020/stream/mechanicalmusicradio
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.mechanicalmusicradio.co.uk/uploads/1/1/3/3/1133045/google-play-store-featured-section.png
+  homepage: https://www.mechanicalmusicradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: d9c58c54-f96a-4881-aa56-6150094252c0
+  changeuuid: 6fb811d3-6a94-4905-b2ea-360df252e64e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-buena-vida
+  broadcaster: independent
+  name: Radio Buena Vida
+  streamUrl: https://s4.radio.co/s69b281ac0/listen
+  bitrate: 192
+  codec: MP3
+  favicon: https://buenavida.co.uk/wp-content/uploads/2022/08/Small-logo-for-Soundcloud.jpg
+  homepage: https://buenavida.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 3bee72bd-0de4-448e-ae23-2e962923643f
+  changeuuid: 8952b4f6-48dc-4009-9481-4aad5129575f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-newark
+  broadcaster: independent
+  name: Radio Newark
+  streamUrl: https://streamer.radionewark.com/
+  bitrate: 64
+  codec: MP3
+  favicon: https://radionewark.org/images/favicon/apple-touch-icon.png
+  homepage: https://radionewark.org/
+  country: GB
+  status: stream-only
+  stationuuid: a07d5f19-88c6-4054-b3cd-60d31b93d569
+  changeuuid: 9e03f4f6-f08c-4678-89b0-46fc378e61f2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-sabras-radio
+  broadcaster: independent
+  name: Sabras Radio
+  streamUrl: https://radio.canstream.co.uk:8025/live.mp3?_=596083
+  bitrate: 128
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/232/6460ea059133d.png
+  homepage: https://www.sabrasradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 3c4f2b35-946b-4ce7-adda-13256d058512
+  changeuuid: ce12e9a9-ba64-494d-9aed-d6223509e08f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-24-7-spa-radio
+  broadcaster: independent
+  name: "24/7 Spa Radio"
+  streamUrl: https://ec6.yesstreaming.net:2915/stream
+  bitrate: 64
+  codec: MP3
+  favicon: https://usercontent.one/wp/www.247sparadio.com/wp-content/uploads/2021/04/cropped-247-Spa-Radio.jpg
+  homepage: https://www.247sparadio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 5b691932-daa8-44f0-a9d8-2533c2a28585
+  changeuuid: 344a7632-c237-4fea-935c-dee621f04cf9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-95-6-brfm
+  broadcaster: independent
+  name: "95.6 BRFM"
+  streamUrl: https://mediacp.nkpa.co.uk/stream/Brfm/BrfmMP3
+  bitrate: 128
+  codec: AAC
+  homepage: https://brfm.net/
+  country: GB
+  status: stream-only
+  stationuuid: 0a26cd0b-c61c-41ee-a4ad-9b4bde46da71
+  changeuuid: a1917b87-c01c-4ebd-8804-400425cb3abe
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-banita-maxx-radio
+  broadcaster: independent
+  name: Banita Maxx Radio
+  streamUrl: https://stream.zeno.fm/z5artz4g2wzuv
+  codec: MP3
+  homepage: https://banitamaxx.pl/
+  country: GB
+  status: stream-only
+  stationuuid: 22bc86f2-6572-4a85-ab55-74e92c3ad50f
+  changeuuid: 78c95a7e-f742-46c6-8888-9153cfc3f047
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-dance-radio-uk
+  broadcaster: independent
+  name: Dance Radio UK
+  streamUrl: https://dancestream.danceradiouk.com/
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.danceradiouk.com/
+  country: GB
+  status: stream-only
+  stationuuid: 0a525f49-59dc-463a-ad3a-904d707da6e0
+  changeuuid: 06b06b63-3312-472d-a25c-0e0b94426f2b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-fenland-youth-radio
+  broadcaster: independent
+  name: Fenland Youth Radio
+  streamUrl: https://streaming.broadcastradio.com:10445/youngtech
+  codec: UNKNOWN
+  favicon: https://irp.cdn-website.com/546fca48/site_favicon_16_1630357525872.ico
+  homepage: https://www.fenlandyouthradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: f9de3e59-bc15-4ec5-82af-788374a4f90a
+  changeuuid: e9a74638-a62f-4ec0-a34d-46915b89e6b1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-forest-fm
+  broadcaster: independent
+  name: Forest FM
+  streamUrl: https://radio.canstream.co.uk:8146/live.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://forestfm.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 7aa9c305-b5c2-4410-9605-ff8b1fe2fbed
+  changeuuid: 49d31121-a75b-4777-b285-436fde065fb7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-iconicextra
+  broadcaster: independent
+  name: IconicExtra
+  streamUrl: https://ukbeatz.radioca.st/stream
+  bitrate: 320
+  codec: MP3
+  favicon: https://www.iconicextra.com/wp-content/uploads/2020/06/cropped-logo_redo1cl-180x180.png
+  homepage: https://www.iconicextra.com/
+  country: GB
+  status: stream-only
+  stationuuid: 428d41dc-2879-47b2-91fc-eee02b5dfa84
+  changeuuid: 76ce20a5-96bf-4532-b239-9dd461e121ce
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-insanity-radio
+  broadcaster: independent
+  name: Insanity Radio
+  streamUrl: https://stream.cor.insanityradio.com/insanity.flac
+  codec: OGG
+  homepage: https://insanityradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 03c2017f-2ba2-4338-af52-5a1f5e67aa46
+  changeuuid: 7daa047e-d68b-424b-855b-daf72f24483b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-mix-92-6
+  broadcaster: independent
+  name: Mix 92.6
+  streamUrl: https://stream4.hippynet.co.uk/stream/8012/stream
+  codec: MP3
+  favicon: https://mix926.com/favicon.ico
+  homepage: https://mix926.com/
+  country: GB
+  status: stream-only
+  stationuuid: a82450a3-11b1-4054-812e-8e27e78e96e0
+  changeuuid: 66fb162a-6939-4f4d-8b9d-11ee05bfadcd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-music-box-radio
+  broadcaster: independent
+  name: Music Box Radio
+  streamUrl: https://uk5.internet-radio.com/proxy/musicboxradio?mp=/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.musicboxradio.co.uk/apple-touch-icon.png
+  homepage: https://www.musicboxradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: cd6a9b24-b02b-4d6a-82cf-74479f003fd6
+  changeuuid: 5ca21691-3dc0-4296-858e-cddf9188bff6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-nr1-drum-and-bass-radio
+  broadcaster: independent
+  name: NR1 Drum and Bass Radio
+  streamUrl: https://radio.listen-nr1dnb.com/listen/nr1_dnb_radio/radio.mp3
+  bitrate: 320
+  codec: MP3
+  favicon: https://listen.nr1dnb.com/icons/icon-512.png
+  homepage: https://listen.nr1dnb.com/
+  country: GB
+  status: stream-only
+  stationuuid: 52243a80-7713-4392-89c0-f3bde610993b
+  changeuuid: fb8de010-1592-470a-a17a-17eb2e643d9f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-powerstream
+  broadcaster: independent
+  name: PowerStream
+  streamUrl: https://my.powerstream.live/1985/stream
+  bitrate: 320
+  codec: MP3
+  favicon: https://dj-stream.com/favicon.ico
+  homepage: https://dj-stream.com/
+  country: GB
+  status: stream-only
+  stationuuid: d78d0c42-03c7-42a3-a5ac-f13aede07fcf
+  changeuuid: 8860d1fc-44da-4487-b56b-2ab38014ece4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-west-middlesex
+  broadcaster: independent
+  name: Radio West Middlesex
+  streamUrl: https://uk6.internet-radio.com/proxy/radiowestmiddlesex?mp=/stream;
+  bitrate: 128
+  codec: MP3
+  favicon: http://radiowestmiddlesex.org.uk/wordpress/wp-content/themes/RWMTheme4/images/page.jpg
+  homepage: http://radiowestmiddlesex.org.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 09709427-073f-48f0-96a0-be2e49851dba
+  changeuuid: 02d00d0b-887a-4dd0-b6bf-bcd1d0bdf88e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-thornbury-radio
+  broadcaster: independent
+  name: Thornbury Radio
+  streamUrl: https://s42.myradiostream.com/29400/listen.mp3?_=135900
+  bitrate: 192
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/222/5f4659d5167b4.png
+  homepage: https://www.thornbury.radio/
+  country: GB
+  status: stream-only
+  stationuuid: f08c35c9-489d-4934-81b8-50b707b16d83
+  changeuuid: 31f67cab-1b5e-40ab-aee5-f031263e74be
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-vintage-radio-birkenhead
+  broadcaster: independent
+  name: Vintage Radio birkenhead
+  streamUrl: https://streaming04.liveboxstream.uk/proxy/vintager/stream
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.vintageradio.org.uk/#
+  country: GB
+  status: stream-only
+  stationuuid: 4289ab0a-083c-45be-a044-d0e5e612cae2
+  changeuuid: 44a7ebbe-b2bf-428e-a3b6-1d6362776561
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-voices
+  broadcaster: independent
+  name: Voices
+  streamUrl: https://voicesradio.out.airtime.pro/voicesradio_a
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.voicesradio.co.uk/favicon.ico
+  homepage: https://www.voicesradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 66bf1eb0-9125-4e6c-a83a-4cb928493c0d
+  changeuuid: e1560e08-eb41-4bfa-a9cf-e7b47a688775
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-we-get-lifted-radio-wglr-192k-mp3
+  broadcaster: independent
+  name: We Get Lifted Radio (WGLR) 192k mp3
+  streamUrl: https://s3.radio.co/sa80d22794/listen
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.wegetliftedradio.com/wp-content/uploads/2020/03/cropped-WGLR-HEADER-1-1-1-600x343.png
+  homepage: https://wegetliftedradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 36c5b127-92df-447f-add6-02e91acbc238
+  changeuuid: ecc885b1-76c5-4ecd-af41-5f5b44e6266e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-britcom-4
+  broadcaster: independent
+  name: Britcom 4
+  streamUrl: https://cast2.asurahosting.com/proxy/britcom4/stream.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://pumpkinfm.com/wp-content/uploads/2022/03/pfmnewlogoSmall.jpg
+  homepage: https://pumpkinfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: 45daead0-5c3f-44f4-8bb3-177596bcf8ab
+  changeuuid: 25d9b55a-0ef2-467b-bf93-3e8b01bc3a12
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-cam-fm-97-2
+  broadcaster: independent
+  name: Cam FM 97.2
+  streamUrl: https://stream.camfm.co.uk/camfm
+  codec: MP3
+  favicon: https://www.camfm.co.uk/media/images/default_thumb.png
+  homepage: https://www.camfm.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: bdbb1fe5-0542-4a68-8b39-2556703d35f7
+  changeuuid: a1a7addb-2f14-4b22-907b-5b4d949d0405
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-fantasy-radio-devizes
+  broadcaster: independent
+  name: Fantasy Radio (Devizes)
+  streamUrl: https://server.fantasyradio.co.uk/fantasyradio
+  bitrate: 256
+  codec: MP3
+  favicon: https://www.fantasyradio.co.uk/files/9414/1236/5176/fbthumb.png
+  homepage: https://www.fantasyradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: c41b8b47-87e9-4c33-a4c0-f890c488a81a
+  changeuuid: f0839370-4ee1-44eb-bd51-241caf4d6b49
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-island-time-infinite-mixtapes-nts
+  broadcaster: independent
+  name: "Island Time - Infinite Mixtapes | NTS"
+  streamUrl: https://stream-mixtape-geo.ntslive.net/mixtape21
+  codec: MP3
+  homepage: https://www.nts.live/infinite-mixtapes/island-time
+  country: GB
+  status: stream-only
+  stationuuid: 94b2330d-3c81-4a2c-ad0f-a6c36f506edb
+  changeuuid: da5cf0f6-a686-4569-afe2-4b16bb983520
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-kennet-radio
+  broadcaster: independent
+  name: Kennet Radio
+  streamUrl: https://stream.kennetradio.com/64.aac
+  bitrate: 48
+  codec: AAC
+  favicon: https://kennetradio.com/wp-content/uploads/2021/05/kr_square_150.png
+  homepage: https://kennetradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 9029e03c-1645-49eb-bb36-de7a8161e6ad
+  changeuuid: 47ddbff3-42fa-415c-9d6c-3890c329af43
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-mkfm
+  broadcaster: independent
+  name: MKFM
+  streamUrl: https://mkfmradioplayer2.radioca.st/;stream.nsv?=&&___cb=838498533391580
+  bitrate: 128
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/171/6367c3f242240.png
+  homepage: https://www.mkfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: c39a0882-25ec-44c0-aede-80eef1dd2c32
+  changeuuid: d691e08a-ad21-49cf-8868-434711dc3ab7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-northwich
+  broadcaster: independent
+  name: Radio Northwich
+  streamUrl: https://stream.radio.co/s98163f694/listen
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radionorthwich.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 230d7f4c-1369-44f7-9d92-cee399912a1a
+  changeuuid: 4b1aa653-f4cf-473a-aae9-988dfa9ac4e6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-reform-radio
+  broadcaster: independent
+  name: Reform Radio
+  streamUrl: https://testform.out.airtime.pro/testform_a
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.reformradio.co.uk/favicon.ico
+  homepage: https://www.reformradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: cac4c694-99b2-40eb-8957-6361e7d3768e
+  changeuuid: 4b50f920-5ded-4645-8bf2-e55328a97786
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-smash-hits-radio-retro
+  broadcaster: independent
+  name: Smash hits radio retro
+  streamUrl: https://s3.radio.co/s802363087/listen
+  bitrate: 192
+  codec: MP3
+  homepage: https://s3.radio.co/s802363087/listen
+  country: GB
+  status: stream-only
+  stationuuid: c5553730-ed5c-4844-b62b-de559dbf08b7
+  changeuuid: bcd1c1b0-22fc-44c0-a390-a2e9fec11d47
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-sunny-g-community-radio
+  broadcaster: independent
+  name: Sunny G Community Radio
+  streamUrl: https://streaming06.liveboxstream.uk/proxy/gary1?mp=/stream
+  bitrate: 320
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/3455a1_7e4ecdcdcf7344fe88ca9633cc48aae4~mv2.png/v1/fill/w_315,h_315,al_c,lg_1,q_85,enc_auto/Sunny_G_logo%20(no%20background).png
+  homepage: https://www.sunnyg.org/
+  country: GB
+  status: stream-only
+  stationuuid: 7c320ee5-99f4-405b-8f68-30f64d38b28c
+  changeuuid: 6b60c390-a397-4e2e-8710-b3c82fb2dbd6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-york-hospital-radio
+  broadcaster: independent
+  name: York Hospital Radio
+  streamUrl: https://stream1.superstreaming.co.uk/proxy/yorkhospradio/stream
+  bitrate: 192
+  codec: MP3
+  favicon: https://yorkhospitalradio.com/wp-content/uploads/2024/01/cropped-yhr-site-logo-180x180.png
+  homepage: http://www.yorkhospitalradio.com/#
+  country: GB
+  status: stream-only
+  stationuuid: 4ac56f28-e3c9-4c7d-87b2-408458047cfc
+  changeuuid: 1c3ba7e4-08f3-4d0b-a119-5a5fc2f12377
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-kiss-the-best-vibes-energy
+  broadcaster: independent
+  name: " KISS - The Best Vibes & Energy"
+  streamUrl: https://live-bauerkiss.sharp-stream.com/kissnational.aac?direct=true&aw_0_1st.skey=1602676850&rp_source=1&=&&___cb=60456375243858
+  bitrate: 47
+  codec: AAC+
+  favicon: https://cdn-profiles.tunein.com/s6004/images/logod.png
+  homepage: https://www.hellorayo.co.uk/kiss
+  country: GB
+  status: stream-only
+  stationuuid: 0f1a8621-d35a-4073-83d3-7ee14207a9a9
+  changeuuid: 284c3e77-5b9b-49ed-a990-d2cd84fe7560
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-kiss-dance-the-biggest-dance-anthems-24-7
+  broadcaster: independent
+  name: " KISS DANCE: The Biggest Dance Anthems 24/7"
+  streamUrl: https://stream-kiss.hellorayo.co.uk/kissdance.aac?direct=true&aw_0_1st.skey=1602676850&rp_source=1&=&&___cb=60456375243858
+  bitrate: 127
+  codec: AAC
+  favicon: https://cdn-profiles.tunein.com/s321341/images/logod.png
+  homepage: https://www.hellorayo.co.uk/kiss-dance
+  country: GB
+  status: stream-only
+  stationuuid: 9c8f6141-f8e8-4779-bfed-5a79e14ed4dd
+  changeuuid: 3ec5d910-d1d0-417d-9c38-3cdaab3b6b22
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-100-whatever-westcountry
+  broadcaster: independent
+  name: "100% Whatever Westcountry"
+  streamUrl: https://dh1-sanityradio.radioca.st/stream
+  codec: MP3
+  favicon: https://whateverwestcountry.com/wp-content/uploads/2020/06/WHATEVER-WEST-GRN.png
+  homepage: https://whateverwestcountry.com/
+  country: GB
+  status: stream-only
+  stationuuid: 46ec3fff-4ebd-4c37-bbec-183771cd15e2
+  changeuuid: 92a55edc-6082-4cfc-8617-a067b940a38a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-academy-fm-folkestone
+  broadcaster: independent
+  name: Academy FM Folkestone
+  streamUrl: https://s2.xrad.io:9480/;stream/1
+  bitrate: 48
+  codec: AAC+
+  favicon: https://static.wixstatic.com/media/2a383b_fd22a81897514de18547bdf81eb202de~mv2.png/v1/fill/w_84,h_75,al_c,q_85,usm_0.66_1.00_0.01,enc_auto/Wordpress%20Transparent.png
+  homepage: https://www.radiofolkestone.com/
+  country: GB
+  status: stream-only
+  stationuuid: f9358d0f-770f-49e7-b8bd-06437ef808fb
+  changeuuid: 966d17df-db97-472f-8e70-98d137ef5856
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bhbn-radio
+  broadcaster: independent
+  name: BHBN Radio
+  streamUrl: https://uksoutha.streaming.broadcast.radio/stream/9400/BHBN?1699801420380=
+  bitrate: 64
+  codec: MP3
+  homepage: https://www.bhbn.net/
+  country: GB
+  status: stream-only
+  stationuuid: 9c97de3d-f160-48a9-83e0-0b71f5f3a90d
+  changeuuid: 4f87233c-789c-48ea-ac83-562aa91dd90b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-brooklands-radio
+  broadcaster: independent
+  name: Brooklands Radio
+  streamUrl: https://stream4.hippynet.co.uk/stream/brooklandsradio
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.brooklandsradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 44bbf65f-e461-4cf7-af03-dc835ddb1710
+  changeuuid: b75be62e-f7ff-4b78-8458-3743ecd67189
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-caresound-radio
+  broadcaster: independent
+  name: CareSound Radio
+  streamUrl: https://streaming.broadcast.radio/perth?1699803359553=
+  bitrate: 128
+  codec: MP3
+  favicon: https://caresound.radio/wp-content/uploads/CSR-Full-Colour-Round-Gradient-150px.png
+  homepage: https://caresound.radio/
+  country: GB
+  status: stream-only
+  stationuuid: 9d492832-5ea5-439e-b882-8eea969dbdad
+  changeuuid: d1c5889e-b76c-400b-b77e-955f1155f715
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-clubland-radio-uk
+  broadcaster: independent
+  name: Clubland Radio UK
+  streamUrl: https://s2.radio.co/sf1cecf191/listen
+  bitrate: 192
+  codec: MP3
+  favicon: https://cdn.onlineradiobox.com/img/l/3/33563.v13.png
+  homepage: https://clublandradiouk.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 2fb1e538-17d9-4fa4-8b3d-7b42dd80be41
+  changeuuid: 82b55ad7-d313-4a3b-ab9b-e4e9013a07ea
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-def-leppard
+  broadcaster: independent
+  name: Def Leppard
+  streamUrl: https://stream.pcradio.ru/def_leppard-hi
+  codec: AAC
+  favicon: null
+  homepage: https://pcradio.ru/
+  country: GB
+  status: stream-only
+  stationuuid: a7dd8e74-c836-4844-bd59-d44cac395952
+  changeuuid: 087fa495-1166-4339-b746-fa5387c3d4c9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-dnbradio-atmospheric
+  broadcaster: independent
+  name: DnBRadio Atmospheric
+  streamUrl: https://azura.drmnbss.org/listen/plushrecs/radio.mp3
+  bitrate: 320
+  codec: MP3
+  favicon: https://www.google.com/s2/favicons?sz=256&domain_url=https%3A%2F%2Fdnbradio.com%2F%3Fchannel%3Dplushrecs%26autoplay%3D0
+  homepage: https://dnbradio.com/?channel=plushrecs&autoplay=0
+  country: GB
+  status: stream-only
+  stationuuid: 0415274f-7dae-4410-8b2a-ed5913ba23fa
+  changeuuid: 9910a265-78fe-4cef-8c1b-be2ecc0acf63
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-frisk-radio-uk
+  broadcaster: independent
+  name: Frisk Radio UK
+  streamUrl: https://www.friskradio.com:8443/stream11
+  codec: AAC
+  favicon: https://management.friskradio.com:7000/stations/logo?id=1
+  homepage: https://www.friskradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 0c956e74-2e2a-49c6-b760-50a1c9a89f60
+  changeuuid: b90d5cde-d06c-4237-9bde-f77d901c676c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-grampian-hospital-radio
+  broadcaster: independent
+  name: Grampian Hospital Radio
+  streamUrl: https://uksoutha.streaming.broadcast.radio/ghr?1699804401378=
+  codec: MP3
+  homepage: https://www.grampianhospitalradio.org/
+  country: GB
+  status: stream-only
+  stationuuid: 5ec5b4d7-218c-4e83-8f50-14e72dbacd51
+  changeuuid: c618edb9-26f7-4d63-8401-3c0cb34e298d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-greatest-hits-radio-60s
+  broadcaster: independent
+  name: Greatest Hits Radio 60s
+  streamUrl: https://stream-al.hellorayo.co.uk/ghr60s.aac?aw_0_1st.skey=1602676850&direct=true&rp_source=1
+  bitrate: 48
+  codec: AAC+
+  favicon: https://media.bauerradio.com/image/upload/c_crop,g_custom/v1725015216/brand_manager/stations/pqnbvpmvgj7jnsopgpix.svg
+  homepage: https://www.hellorayo.co.uk/greatest-hits-60s
+  country: GB
+  status: stream-only
+  stationuuid: b2ad284d-bef1-4f68-8bbd-14195092ea5f
+  changeuuid: a5832174-e265-47de-a820-8248357f2048
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hwd-hospital-radio
+  broadcaster: independent
+  name: HWD Hospital Radio
+  streamUrl: https://streaming04.liveboxstream.uk/proxy/hwdhospi?mp=/stream
+  bitrate: 112
+  codec: AAC+
+  favicon: https://www.hwdhospitalradio.com/images/logo.png
+  homepage: https://www.hwdhospitalradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 98c34a8e-7971-45ed-b109-293e671d837d
+  changeuuid: d431c6b8-7dc4-4e7f-8a39-f9115a1d0915
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-one-world-radio-daybreak-session
+  broadcaster: independent
+  name: One World Radio - Daybreak Session
+  streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/OWR_DAYBREAK_ADP.aac
+  bitrate: 256
+  codec: AAC+
+  favicon: https://www.tomorrowland.com/home/apple-touch-icon.png
+  homepage: https://www.tomorrowland.com/home/radio
+  country: GB
+  status: stream-only
+  stationuuid: b29999a4-e837-4c61-b35d-2e20ad4f18ca
+  changeuuid: fc6f7aae-8e6e-4bf2-a1a2-2bf886ed6725
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-pure-radio
+  broadcaster: independent
+  name: Pure Radio
+  streamUrl: https://kathy.torontocast.com:4825/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://listentopure.uk/wp-content/uploads/2023/02/cropped-cropped-pure-logo-23-150.png
+  homepage: https://listentopure.uk/
+  country: GB
+  status: stream-only
+  stationuuid: d8f7834a-c176-402a-863e-5e6fbc918cee
+  changeuuid: 2e4d9c23-d19d-47fd-8220-c05f5bf20280
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-rominimal-radio
+  broadcaster: independent
+  name: ROminimal Radio
+  streamUrl: https://r4.rominimal.club/listen/rominimal.club/radio2.m4a
+  bitrate: 320
+  codec: AAC
+  favicon: https://rominimal.club/images/logo.png
+  homepage: https://rominimal.club/
+  country: GB
+  status: stream-only
+  stationuuid: 277d2d2f-92c7-4d64-837d-d7ac364cc027
+  changeuuid: 1bb01ccd-a945-4929-9500-7534c1ddb764
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-soar-sound
+  broadcaster: independent
+  name: Soar Sound
+  streamUrl: https://icecast.maxxwave.co.uk/soarsound
+  bitrate: 128
+  codec: AAC
+  favicon: https://i0.wp.com/www.soarsound.uk/wp-content/uploads/2024/03/cropped-SoarLogoFinal-Favicon-e1710351771330.png?fit=150%2C146&ssl=1
+  homepage: https://www.soarsound.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 3a54dd03-fe07-4907-9990-86fdc1184c0d
+  changeuuid: 2d1e8c18-f8de-492e-8a08-84f56ccd610b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-white-cliffs-radio
+  broadcaster: independent
+  name: White Cliffs Radio
+  streamUrl: https://listen.whitecliffsradio.co.uk/
+  codec: MP3
+  favicon: https://images.whitecliffsradio.co.uk/wcr_logo_new_r.webp
+  homepage: https://www.whitecliffsradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 5560f0c8-e50b-4cba-8cdb-07b964724adc
+  changeuuid: 548f0903-6169-4451-a1c2-77a3970c98b4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-wrexham-premier-radio
+  broadcaster: independent
+  name: Wrexham Premier Radio
+  streamUrl: https://uksoutha.streaming.broadcast.radio/premier?1709519917408=
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.premier-radio.co.uk/favicon.ico
+  homepage: https://www.premier-radio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 06bfd450-ddd1-4564-b104-0075489e6495
+  changeuuid: f89003a8-ebcf-4072-a55b-978a01079d60
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bcfm-93-2
+  broadcaster: independent
+  name: BCfm 93.2
+  streamUrl: https://bcfmradiomain.radioca.st/live.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.bcfmradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 31db87e1-58da-4141-bd92-cf0da3257c25
+  changeuuid: e36e956f-b06f-4724-8cd9-9a14cad1214a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-belfast-89
+  broadcaster: independent
+  name: Belfast 89
+  streamUrl: https://streaming.broadcast.radio/belfastfm
+  codec: MP3
+  homepage: https://www.belfast89.com/
+  country: GB
+  status: stream-only
+  stationuuid: adac65c9-8672-46f3-9784-506d43c045eb
+  changeuuid: 912f1276-194e-497e-a9b4-c4bdf4a3f982
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bouncy-vibes-radio
+  broadcaster: independent
+  name: Bouncy Vibes Radio
+  streamUrl: https://bouncy-host.co.uk/radio/8000/radio.mp3
+  bitrate: 320
+  codec: MP3
+  favicon: https://bouncy-vibes.co.uk/images/favicon.ico
+  homepage: https://bouncy-vibes.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 14ce05ef-34d7-49e0-8c78-e38935d81345
+  changeuuid: bd1def97-0536-46ed-8b23-f71e9b4fb9f8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-drama-radio
+  broadcaster: independent
+  name: Drama Radio
+  streamUrl: https://streaming06.liveboxstream.uk/proxy/roksta10/stream
+  bitrate: 48
+  codec: MP3
+  favicon: https://www2.rokitradio.com/_next/image?url=%2Fimages%2Fchannels%2Fdrama.jpg&w=128&q=75
+  homepage: https://www2.rokitradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 0f32ba45-efc8-4672-8add-1defc72bfd87
+  changeuuid: c17300af-9bf1-4035-8eec-c6477b2d259b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-heart-west-midlands
+  broadcaster: independent
+  name: Heart West Midlands
+  streamUrl: https://media-ice.musicradio.com/HeartWestMidsMP3
+  bitrate: 128
+  codec: MP3
+  favicon: http://www.heart.co.uk/assets_v4r/heart/img/favicon-196x196.png
+  homepage: https://www.heart.co.uk/westmids/
+  country: GB
+  status: stream-only
+  stationuuid: cd272f35-7183-48b8-92c7-366d5734bcbd
+  changeuuid: ffb15524-d18a-42f1-bb5d-944d1d303394
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-lazy-gold
+  broadcaster: independent
+  name: Lazy Gold
+  streamUrl: https://stream-lazyradio.creativedork.com/
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.lazygold.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 4ed32c27-aa84-4ff2-9a6e-0481878f0894
+  changeuuid: 08f8674a-76cd-499d-bbd7-a52eee254bf7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-memory-lane-radio
+  broadcaster: independent
+  name: Memory Lane Radio
+  streamUrl: https://memorylaneradio.radioca.st/;
+  bitrate: 192
+  codec: MP3
+  homepage: https://memorylaneradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 255ad4f9-990e-4090-85ed-203702b6dc51
+  changeuuid: 6254a4a1-024b-4140-90b1-e350d6480184
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-pure-west-radio
+  broadcaster: independent
+  name: Pure West Radio
+  streamUrl: https://uksoutha.streaming.broadcast.radio/stream/8580/purewest
+  bitrate: 256
+  codec: MP3
+  favicon: https://www.purewestradio.com/media/jjvja3hb/pure-west-radio-450x450.png
+  homepage: https://www.purewestradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 4dfee959-414e-4790-9c69-8f07937aaab6
+  changeuuid: 2a008376-5191-4438-aaa1-feb411694875
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-red-rose-radio
+  broadcaster: independent
+  name: Red Rose Radio
+  streamUrl: https://listen.red-roseradio.co.uk:8008/stream?_=520468
+  bitrate: 192
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/1552/6680100859da1.png
+  homepage: https://www.redroseradio.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 39065863-b3e0-4eb3-ae28-0cc4f6e26622
+  changeuuid: 278ac239-758e-4f6c-bcfd-32ca9b224738
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-sister-midnight-fm
+  broadcaster: independent
+  name: Sister Midnight FM
+  streamUrl: https://stream.radio.co/s35e4926a1/listen
+  bitrate: 128
+  codec: MP3
+  favicon: https://radio.sistermidnight.org/favicons/apple-touch-icon.png
+  homepage: https://radio.sistermidnight.org/
+  country: GB
+  status: stream-only
+  stationuuid: 75a1072f-3e3a-4c8f-b3e3-dc23386da6ba
+  changeuuid: 4dc51578-ce0b-452d-872f-119a21f37a74
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-soul-connexion-radio
+  broadcaster: independent
+  name: Soul Connexion Radio
+  streamUrl: https://stream.soulconnexionradio.com/1045
+  bitrate: 320
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/1cdeb2_d480bb8158f4469284f543e790063616%7Emv2.jpg/v1/fill/w_192%2Ch_192%2Clg_1%2Cusm_0.66_1.00_0.01/1cdeb2_d480bb8158f4469284f543e790063616%7Emv2.jpg
+  homepage: https://www.soulconnexionradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 7de072cb-08fe-471f-bb59-672d7a76079e
+  changeuuid: 4f0cf509-3bda-4fba-ad47-151ec983211e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-24-7-online-radio
+  broadcaster: independent
+  name: "24/7 Online Radio"
+  streamUrl: https://ec3.yesstreaming.net:3585/stream
+  bitrate: 64
+  codec: MP3
+  favicon: https://usercontent.one/wp/www.247onlineradio.com/wp-content/uploads/2020/02/247-Online-Radio-Station-Logo.jpg
+  homepage: https://www.247onlineradio.com/24-7-online-radio/
+  country: GB
+  status: stream-only
+  stationuuid: 4a1111a1-1f2a-4ede-8ef1-0c78caa0d142
+  changeuuid: ca47255a-13e0-4c39-b792-52905917b787
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-deal-radio
+  broadcaster: independent
+  name: Deal Radio
+  streamUrl: https://s2.radio.co/sa44aa697f/listen
+  bitrate: 128
+  codec: MP3
+  favicon: https://dev.dealradio.co.uk/wp-content/uploads/2020/06/Small-redblue.png
+  homepage: https://www.dealradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 17c8f661-9cbd-459e-97f5-aa24331747ae
+  changeuuid: 790a9f47-3679-43f8-86b6-0cc3b5fb6277
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-greatest-hits-radio-80s
+  broadcaster: independent
+  name: Greatest Hits Radio 80s
+  streamUrl: https://stream-al.hellorayo.co.uk/ghr80s.aac?aw_0_1st.skey=1602676850&direct=true&rp_source=1
+  bitrate: 47
+  codec: AAC+
+  favicon: https://media.bauerradio.com/image/upload/c_crop,g_custom/v1741162714/brand_manager/stations/tmeuw7bt9gwnbkuxpjab.png
+  homepage: https://www.hellorayo.co.uk/greatest-hits-radio-80s
+  country: GB
+  status: stream-only
+  stationuuid: 4cb7a690-b0cc-4259-8aac-4674c69da10e
+  changeuuid: 75d7a5fe-7057-414a-b7b0-c5959abbd72e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-margate-radio
+  broadcaster: independent
+  name: Margate Radio
+  streamUrl: https://margate-radio.radiocult.fm/stream
+  bitrate: 192
+  codec: MP3
+  favicon: https://images.squarespace-cdn.com/content/v1/55dccc18e4b080417ce5fafa/1585823097541-KVKK0PO2RTI5SZC6YLWF/MargateRadio_White_72dpi.png?format=1500w
+  homepage: https://margateradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: c23448e9-2bb5-48e1-9436-61fc13d79558
+  changeuuid: 4e5dd5cd-b278-4ee2-a742-b51b425afe05
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-midlands-radio
+  broadcaster: independent
+  name: Midlands Radio
+  streamUrl: https://stream-153.zeno.fm/2mn7tdzkug0uv
+  codec: AAC
+  favicon: https://static.mytuner.mobi/media/tvos_radios/CXYgFMyE7u.jpg
+  homepage: https://www.radio-uk.co.uk/midlands-radio-80s
+  country: GB
+  status: stream-only
+  stationuuid: f6622cbc-f029-4249-be56-dc839759a8ed
+  changeuuid: 5a5b5a4d-6f83-4039-9415-8bedca65f777
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-now-radio-80s
+  broadcaster: independent
+  name: NOW Radio 80s
+  streamUrl: https://stream.zeno.fm/ihij6rdighvtv
+  codec: MP3
+  favicon: https://www.mynowradio.co.uk/wp-content/uploads/2023/12/NOW-Radio-90s-1-scaled.jpg
+  homepage: https://www.mynowradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 810e8186-243d-4c9b-9487-c187ce32a7db
+  changeuuid: 445a66fe-0e28-4dad-8883-afabb9aec138
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-jupiter
+  broadcaster: independent
+  name: Radio Jupiter
+  streamUrl: https://s10.myradiostream.com/:7946/listen.mp3?nocache=1686498616
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.radiojupiter.studio/
+  country: GB
+  status: stream-only
+  stationuuid: 0615faee-8fb9-4681-96bf-df7928b3ab34
+  changeuuid: d91b0049-08b2-45dc-bf75-e31d2adeecb9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio2funky
+  broadcaster: independent
+  name: Radio2Funky
+  streamUrl: https://s6.citrus3.com:8006/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://radio2funky.co.uk/wp-content/uploads/2023/04/DAB-logo-new.png
+  homepage: https://radio2funky.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: c99ce535-30a0-4cf5-8399-68d550c5b50f
+  changeuuid: 20aa0cb5-7c65-4bba-b6bf-e4fa3f761cc1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-rainbow-radio-wales
+  broadcaster: independent
+  name: Rainbow Radio Wales
+  streamUrl: https://stream.zeno.fm/dtbgwan9sd0uv
+  codec: MP3
+  favicon: http://rainbowradio.uk/wp-content/uploads/2024/07/7h5TKbvAqe__1_-removebg-preview.png
+  homepage: https://rainbowradio.uk/
+  country: GB
+  status: stream-only
+  stationuuid: a6851e7a-d14a-42f9-88ec-549560426b23
+  changeuuid: d59cc166-2089-4624-8cf3-a08b7063e0df
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-southampton-hospital-radio
+  broadcaster: independent
+  name: Southampton Hospital Radio
+  streamUrl: https://s6.autopo.st/proxy/shrinternet?mp=/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.sohba.org/static/35df7ec86d.android-icon-192x192.png
+  homepage: https://www.sohba.org/
+  country: GB
+  status: stream-only
+  stationuuid: 91446e27-de4f-4641-844b-ad1f79249ff9
+  changeuuid: 47b29c63-bc83-4f35-9270-6e595d7a8e39
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-yo1-radio
+  broadcaster: independent
+  name: Yo1 Radio
+  streamUrl: https://stream1.themediasite.co.uk:8026/;?_=215164
+  bitrate: 192
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/706/6311ef9a56ac6.png
+  homepage: https://www.yo1radio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 68872342-3b4f-4cff-8bef-82e17ccacb2b
+  changeuuid: f1d8c882-b5bf-4d01-9a5b-098c86481409
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-kisstory-r-b-the-hottest-r-b-tracks-from-kisstor
+  broadcaster: independent
+  name: " KISSTORY R&B: The Hottest R&B tracks from KISSTORY"
+  streamUrl: https://live-bauerkiss.sharp-stream.com/kisstoryrb.aac?direct=true&aw_0_1st.playerid=BMUK_Airable&aw_0_1st.skey=6778249992
+  bitrate: 127
+  codec: AAC
+  favicon: https://cdn-profiles.tunein.com/s333201/images/logod.png
+  homepage: https://www.hellorayo.co.uk/kisstory-rnb
+  country: GB
+  status: stream-only
+  stationuuid: 19b250fe-9027-4caf-b6ea-33022f0b6392
+  changeuuid: d1915f1a-6fba-4f78-b79c-1195ecbfc72c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-air-gay-radio
+  broadcaster: independent
+  name: Air Gay Radio
+  streamUrl: https://ecmanager.pro-fhi.net:2655/stream
+  bitrate: 64
+  codec: AAC
+  favicon: https://www.airgayradio.net/wp-content/uploads/2020/06/qr-code.png
+  homepage: https://www.airgayradio.net/
+  country: GB
+  status: stream-only
+  stationuuid: 30590797-ad95-4c3e-98d6-93f76419032b
+  changeuuid: 9068aad1-e0d1-4c68-865c-bed19d9bacf6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-amber-radio
+  broadcaster: independent
+  name: Amber Radio
+  streamUrl: https://stream3.themediasite.co.uk:8240/listen.mp3?sid=3
+  bitrate: 128
+  codec: MP3
+  favicon: https://amber.radio/wp-content/uploads/2022/12/Amber-Radio-Logo-Assets_Original-Clear-Background.png
+  homepage: https://amber.radio/
+  country: GB
+  status: stream-only
+  stationuuid: 7b50bebb-b3a8-486c-a614-09c00429e2a1
+  changeuuid: a292e04f-83ee-461a-be7e-249a39fb958b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-armagh-city-radio
+  broadcaster: independent
+  name: Armagh City Radio
+  streamUrl: https://acrlive.radioca.st/stream?type=http&nocache=1702573713796
+  bitrate: 192
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/3bc95e_9e8eb3dcdc8c4162b6516cc4f1a781c6~mv2.png/v1/fill/w_522,h_530,al_c,q_85,usm_0.66_1.00_0.01,enc_auto/A-only-PNG.png
+  homepage: https://www.armaghcityradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: fd7c34c2-ff27-41c7-bf42-fd9c79aeeb80
+  changeuuid: 2bbe16c5-074f-45a7-9f1d-eb736c0fb99a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-aycliffe-radio
+  broadcaster: independent
+  name: Aycliffe Radio
+  streamUrl: https://solid41.streamupsolutions.com/proxy/catidbxp?mp=/;type=mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.ayclifferadio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 40da6b0f-d5a1-43f1-a57b-a66061b74292
+  changeuuid: 45c7f467-03ea-431c-a177-ff46d5231830
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-countryline-radio
+  broadcaster: independent
+  name: CountryLine Radio
+  streamUrl: https://listen-chriscountry.sharp-stream.com/chriscountry.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.countryline.radio/
+  country: GB
+  status: stream-only
+  stationuuid: 4e7766f3-dcd1-48a1-b721-e38f10f8d7ac
+  changeuuid: 07a6241c-bf82-4fdc-9eeb-2e183ed8e233
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-edge-1
+  broadcaster: independent
+  name: Edge 1
+  streamUrl: https://stream.aiir.com/8dhvgxm1kbvuv
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/703/666adc84d05bb.png
+  homepage: https://edgeradio.co.uk/edge1
+  country: GB
+  status: stream-only
+  stationuuid: de34afcd-c217-4114-a264-cd67a7176561
+  changeuuid: 2d42b6b5-9ad7-4488-b2cf-c81d14458888
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hifi-prime
+  broadcaster: independent
+  name: HiFi Prime
+  streamUrl: https://stream.cloudrad.io/5913/8160
+  bitrate: 128
+  codec: MP3
+  favicon: http://hifiradio.net/wp-content/uploads/2023/09/prime-crop.png
+  homepage: https://hifiradio.net/
+  country: GB
+  status: stream-only
+  stationuuid: bf22dc25-7408-47dd-bd9d-9eca530accf7
+  changeuuid: 75506a43-cf86-41d6-bc48-eed20de780ab
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hospital-radio-chelmsford
+  broadcaster: independent
+  name: Hospital Radio Chelmsford
+  streamUrl: https://solid55.streamupsolutions.com/proxy/mmbdfslu?mp=//stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://lirp.cdn-website.com/b164d775/dms3rep/multi/opt/IMG_0007-432w.jpg
+  homepage: https://www.hrc.org.uk/
+  country: GB
+  status: stream-only
+  stationuuid: f5f0f217-b134-498c-a583-f116dc241b79
+  changeuuid: fbfe7477-6f77-475e-93cd-cbe43854cd44
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hospital-radio-plymouth
+  broadcaster: independent
+  name: Hospital Radio Plymouth
+  streamUrl: https://hospitalradioplymouth.radioca.st/stream
+  bitrate: 128
+  codec: AAC
+  favicon: https://www.hospitalradioplymouth.org.uk/wp-content/uploads/2020/06/HRP-LogoNEWTRANS-100px-e1630450570740.png
+  homepage: https://www.hospitalradioplymouth.org.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 602b0dd5-37e8-4071-b27d-f36bce8ae3cb
+  changeuuid: 677e0672-9c65-4f52-ba50-b7ba019abb73
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-juice-liverpool
+  broadcaster: independent
+  name: Juice Liverpool
+  streamUrl: https://uksouth1.juiceboxradio.com/JuiceLiverpool
+  bitrate: 96
+  codec: AAC+
+  favicon: https://juiceliverpool.co.uk/assets/img/favicons/favicon-196x196.png
+  homepage: https://juiceliverpool.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: be847566-03e9-4d48-89b2-4c479e418464
+  changeuuid: aa0163c0-e7db-43b5-b97d-f2849874faef
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-kaos-sound
+  broadcaster: independent
+  name: Kaos Sound
+  streamUrl: https://s3.myradiostream.com:59506/stream
+  bitrate: 128
+  codec: MP3
+  homepage: https://kaos-sound.co.uk/mrsdocs/home.html
+  country: GB
+  status: stream-only
+  stationuuid: abded711-acf7-412a-bac3-b0436723bee0
+  changeuuid: 29ce77a3-1496-41f0-8c95-e684e82cdf94
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-lyca-gold-2
+  broadcaster: independent
+  name: Lyca Gold 2
+  streamUrl: https://listen-lycaradio.sharp-stream.com/lyca_gold_2.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://lycaradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: c4bb8fe8-0d8a-436b-9a79-24ac3e453177
+  changeuuid: e915c688-abd1-43ca-8a45-7903ad386111
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-mdog-radio
+  broadcaster: independent
+  name: Mdog Radio
+  streamUrl: https://stream2.hippynet.co.uk/stream/8212
+  bitrate: 320
+  codec: MP3
+  homepage: https://www.facebook.com/people/Mdog-Radio/100083286139973/
+  country: GB
+  status: stream-only
+  stationuuid: 2c849e24-23db-458a-addb-5df866c55fdb
+  changeuuid: 0fae8ce5-8bf8-4bf6-a1c1-9d6ee8f6c9d8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-neon-radio
+  broadcaster: independent
+  name: Neon Radio
+  streamUrl: https://live.flashbackcentral.co.uk/radio/8050/radio.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://images.leadconnectorhq.com/image/f_webp/q_80/r_480/u_https://assets.cdn.filesafe.space/dCZ3DwdyoW0OEpmHJlYP/media/66bb37b0e49a8129bd748aa2.png
+  homepage: https://www.neonradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 89c8bcec-e11f-4afb-aa98-e7ebeb5ebe68
+  changeuuid: fafe853a-0f34-4030-a7db-36b8726ef9c6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-northants-1
+  broadcaster: independent
+  name: Northants 1
+  streamUrl: https://solid41.streamupsolutions.com/proxy/svdkgaiq/stream?icecast
+  bitrate: 128
+  codec: MP3
+  favicon: https://northants1.co.uk/wp-content/uploads/2022/12/Northants-_1_-Symbol-Red.png
+  homepage: https://northants1.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 5f477a20-3eda-441d-881f-20f2e96c263a
+  changeuuid: 8cbcd418-ccee-409d-be01-3f6d1cc48277
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-park-radio
+  broadcaster: independent
+  name: Park Radio
+  streamUrl: https://s32.myradiostream.com/18756/listen.mp3
+  bitrate: 96
+  codec: MP3
+  favicon: null
+  homepage: https://parkradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 9a5fe43a-3a44-48a6-8b3f-be24071d4671
+  changeuuid: 5cff8b38-e4fa-450e-af00-d2a7baba78eb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-waters
+  broadcaster: independent
+  name: Radio Waters
+  streamUrl: https://uk5.internet-radio.com/proxy/radiowaters/stream
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.radiowaters.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: a12ac2ec-0539-4baa-b313-a119ef7a64b1
+  changeuuid: b9f96d45-0cf2-4417-8288-61f9bc1e059f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-rhubarb-radio
+  broadcaster: independent
+  name: Rhubarb Radio
+  streamUrl: https://securestreams2.autopo.st:1234/stream#.mp3?1702339792481
+  bitrate: 160
+  codec: MP3
+  homepage: https://www.rhubarbradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 48683066-a5a0-48be-805e-76ab6ffc15c6
+  changeuuid: c9875a99-a6c5-4f2f-8acc-ba24b3c1e5a8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-university-radio-falmer
+  broadcaster: independent
+  name: University Radio Falmer
+  streamUrl: https://listen-urfonline.sharp-stream.com/urfonline.mp3?nocache=0.1868666957825399
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.urfonline.com/favicon-256x256.png
+  homepage: https://www.urfonline.com/
+  country: GB
+  status: stream-only
+  stationuuid: f1be343e-84cb-48a5-b959-b7a851780586
+  changeuuid: a0d9e51e-5672-468e-8ec2-eef63014e071
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-zero-radio
+  broadcaster: independent
+  name: Zero Radio
+  streamUrl: https://uk7.internet-radio.com/proxy/0radio?mp=%2Flive&1731415265701
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.zeroradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 163517fc-1e28-4b02-a2d1-b3569b52dc3f
+  changeuuid: 153760d0-1c30-4657-aad0-5a697d04ab19
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bailrigg-fm
+  broadcaster: independent
+  name: Bailrigg FM
+  streamUrl: https://stream.bailriggfm.co.uk/listen/bfm/128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://bailriggfm.co.uk/wp-content/uploads/2020/06/cropped-Bailrigg-Mini-Logo-red-background-192x192.png
+  homepage: https://bailriggfm.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 96cbf714-1017-4ccf-9489-420a3ac6ca66
+  changeuuid: 356ea828-b5b2-4af8-9635-cc223a16503b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-derby-sound
+  broadcaster: independent
+  name: Derby Sound
+  streamUrl: https://uk7.internet-radio.com/proxy/in2derbyradio?mp=%2Fstream%3B
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.derbysound.org.uk/favicon.ico
+  homepage: https://www.derbysound.org.uk/
+  country: GB
+  status: stream-only
+  stationuuid: f854fb44-bf01-4049-ab58-6d5c9a1560a3
+  changeuuid: 7f3986f5-1f37-4516-81e4-c87db6fc86cc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-frisk-radio
+  broadcaster: independent
+  name: FRISK Radio
+  streamUrl: https://www.friskradio.com:8443/stream1
+  codec: AAC
+  favicon: https://www.friskradio.com/application/assets/images/favicon/64.png
+  homepage: https://www.friskradio.com/#station-select-panel
+  country: GB
+  status: stream-only
+  stationuuid: 2a038c93-626c-406a-9a85-d6c202f99a95
+  changeuuid: 8f13ae27-afcd-47b9-a15f-00fd13486954
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hearme-00s-rock
+  broadcaster: independent
+  name: HearMe - 00s rock
+  streamUrl: https://radio.hearme.fm:8130/stream
+  codec: MP3
+  favicon: https://hearme.fm/favicon.ico
+  homepage: https://hearme.fm/
+  country: GB
+  status: stream-only
+  stationuuid: 4c460069-0c47-4836-88a0-b08a3dfb9cf1
+  changeuuid: 8be81af1-d19c-4833-bae0-a143422f3705
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hearme-80s-rock
+  broadcaster: independent
+  name: Hearme - 80s rock
+  streamUrl: https://radio.hearme.fm:8310/stream
+  codec: MP3
+  homepage: https://hearme.fm/
+  country: GB
+  status: stream-only
+  stationuuid: b85932a8-c036-40c1-a3ae-fb5728f6fe91
+  changeuuid: 046a72df-9d12-4a67-8d66-911e381bf67f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hospital-radio-glamorgan
+  broadcaster: independent
+  name: Hospital Radio Glamorgan
+  streamUrl: https://streaming.broadcastradio.com:8002/glamorg?1725024804656=
+  bitrate: 128
+  codec: MP3
+  favicon: https://api.broadcast.radio/api/image/d57d29e6-9c41-4875-8cc9-952e32e08310.png?g=center
+  homepage: https://www.radioglamorgan.com/
+  country: GB
+  status: stream-only
+  stationuuid: 5e297a51-9d6f-4b8a-9903-90e2c770936a
+  changeuuid: c5723301-c22a-4eed-bf2d-65584ab629a2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-leeds-student-radio
+  broadcaster: independent
+  name: Leeds Student Radio
+  streamUrl: https://s2.radio.co/seb5cdba5b/listen
+  bitrate: 128
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/316c00_def14e5b8c604227b2fa666a3a15fa2d~mv2.png/v1/fill/w_105,h_107,al_c,q_85,usm_0.66_1.00_0.01,enc_auto/LSR%20Logo.png
+  homepage: https://www.thisislsr.com/
+  country: GB
+  status: stream-only
+  stationuuid: 42341185-03db-43cb-b64f-e70ae941d854
+  changeuuid: 04148efd-cd4e-4335-a7a9-797763244371
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-alty
+  broadcaster: independent
+  name: Radio Alty
+  streamUrl: https://streams.radio.co/s4d51ef3bf/listen
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.radioalty.co.uk/uploads/1/3/1/5/131514373/published/radio-alty-rgb-master-logo-transparent-bkground.png?1702248957
+  homepage: https://www.radioalty.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 505164d1-e17c-4e85-baff-38056f92fe62
+  changeuuid: aaf73de9-7331-4581-a49c-63adcd736a46
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-cherwell
+  broadcaster: independent
+  name: Radio Cherwell
+  streamUrl: https://uk6.internet-radio.com/proxy/cherwell?mp=/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://radiocherwell.com/wp-content/uploads/2019/05/RC_LOGO_RGB-150x115.png
+  homepage: https://radiocherwell.com/
+  country: GB
+  status: stream-only
+  stationuuid: 79ffdb88-78df-4493-afec-3735a5de1bd8
+  changeuuid: fc5feda5-7e3c-4da3-a12a-442fa59fa50b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-redhill-mp3
+  broadcaster: independent
+  name: Radio Redhill mp3
+  streamUrl: https://radioredhill.uk/stream/live.mp3
+  bitrate: 160
+  codec: MP3
+  favicon: https://radioredhill.uk/favicon.png
+  homepage: https://radioredhill.uk/
+  country: GB
+  status: stream-only
+  stationuuid: b1e98910-091c-4f6a-9462-9bfc7b072c9e
+  changeuuid: c9ae600c-b42e-4716-ad70-986b069aaf9f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-rare-groove-radio
+  broadcaster: independent
+  name: Rare Groove Radio
+  streamUrl: https://a9.asurahosting.com:7950/radio.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://assets.zyrosite.com/cdn-cgi/image/format=auto,w=268,fit=crop,q=95/Yyv7QeD1ZgiXyg7m/rgr-logo-YNqrVzg7QMF85M1n.png
+  homepage: https://raregrooveradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 867acea5-228c-459e-a431-9a3e95e3fda0
+  changeuuid: 66e7a98f-111c-4a00-bfa4-69d987d2106c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-satsang-radio
+  broadcaster: independent
+  name: Satsang Radio
+  streamUrl: https://icecast.maxxwave.co.uk/satsang
+  bitrate: 80
+  codec: AAC
+  favicon: https://images.squarespace-cdn.com/content/v1/6801621b014aea65690810ca/e422d15b-d3ab-43d3-97d7-8695fe43a7df/Screenshot+2025-07-30+at+22.34.52.png?format=1500w
+  homepage: https://satsangradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 41a5ddc2-d737-41d0-a4f6-8652d701329d
+  changeuuid: af24bb6e-e2c0-485b-bca1-cf1f13ee4d22
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-stirling-community-radio
+  broadcaster: independent
+  name: Stirling Community Radio
+  streamUrl: https://streaming.broadcastradio.com:11855/castlesound?8852
+  bitrate: 128
+  codec: MP3
+  favicon: https://stirlingcommunity.radio/images/radio/player/logo-1715587272.webp
+  homepage: https://stirlingcommunity.radio/
+  country: GB
+  status: stream-only
+  stationuuid: e499f1e5-5502-4f53-8a0c-7737e591a6be
+  changeuuid: b5020028-82d8-4980-995b-fa3799bf5b54
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-the-big-top-40-show-sundays-4-7pm
+  broadcaster: independent
+  name: The Big Top 40 Show (SUNDAYS 4 - 7PM)
+  streamUrl: https://icecast.thisisdax.com/BigTop40
+  bitrate: 48
+  codec: AAC
+  favicon: https://www.bigtop40.com/assets_v4r/bigtop40/img/logos/large.png
+  homepage: https://www.bigtop40.com/
+  country: GB
+  status: stream-only
+  stationuuid: 74e8b53d-10ac-4879-b27b-c93c4955ed1d
+  changeuuid: bbd083e6-1a5d-47af-9308-e440afb0b67a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-time-2-chill-radio
+  broadcaster: independent
+  name: Time 2 Chill Radio
+  streamUrl: https://ec6.yesstreaming.net:3615/stream
+  bitrate: 320
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/55ed4f_f43016b1c5784b71b344cd4504914340~mv2.png/v1/crop/x_0,y_342,w_1920,h_1376/fill/w_548,h_396,al_c,q_85,usm_0.66_1.00_0.01,enc_avif,quality_auto/hammock-icon_edited.png
+  homepage: https://www.time2chill.co.uk/radio
+  country: GB
+  status: stream-only
+  stationuuid: b7126702-9470-4eb5-99a5-11b8d00abf15
+  changeuuid: bbab21ee-60ab-451d-a4f7-2b77875020cf
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-trust-am-hospital-radio
+  broadcaster: independent
+  name: Trust AM Hospital Radio
+  streamUrl: https://streaming.galaxywebsolutions.com:9034/stream
+  bitrate: 128
+  codec: MP3
+  homepage: https://trustam.com/
+  country: GB
+  status: stream-only
+  stationuuid: d7b4b5e4-c330-4979-aec3-310393e220c1
+  changeuuid: 51785026-9600-4a10-9ff6-79e7721f038a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-wave-community-radio
+  broadcaster: independent
+  name: Wave Community Radio
+  streamUrl: https://streaming06.liveboxstream.uk/proxy/piraten1?mp=/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://wavewsm.co.uk/wp-content/uploads/2023/06/cropped-wavelogo-1.png
+  homepage: https://wavewsm.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 49049538-3414-4266-a694-dff2a49ec494
+  changeuuid: a2e005ce-93b1-4694-83c2-98bf229d836c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-95-6-b-radio
+  broadcaster: independent
+  name: "95.6 B Radio"
+  streamUrl: https://stream.aiir.com/t4k624qg11kuv?_=802765
+  codec: AAC
+  favicon: https://mmo.aiircdn.com/347/62b4dc758ba9d.jpg
+  homepage: https://www.bradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 28c077ac-49c6-48db-9f42-7cd2ff90570c
+  changeuuid: 29483ab9-4313-456b-a2ea-ba45499d9002
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bedrock-radio
+  broadcaster: independent
+  name: Bedrock Radio
+  streamUrl: https://s40.myradiostream.com:16652/bedrockradio
+  bitrate: 128
+  codec: MP3
+  favicon: https://i0.wp.com/www.bedrockradio.org.uk/wp-content/uploads/2019/06/alternate-logo-white.png?resize=300%2C135&ssl=1
+  homepage: https://www.bedrockradio.org.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 08e5af4b-0473-4c11-942d-f447490a9ce5
+  changeuuid: 76a2db8a-23b3-491b-b101-0d97fdcca9fe
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-blastfm-indie-radio-station
+  broadcaster: independent
+  name: BlastFM Indie Radio Station
+  streamUrl: https://blast-indie-radio.com:8000/live
+  bitrate: 256
+  codec: MP3
+  favicon: https://blastfmsocial.media/upload/photos/2019/08/e1Yzi7QNBg2Lw32vvghN_30_e2c846377ca16726ad65724674b98d3e_avatar.jpg?cache=0
+  homepage: https://blastfmsocial.media/BlastIndie
+  country: GB
+  status: stream-only
+  stationuuid: 82896fe3-f810-4e21-9209-90b120fc1ff1
+  changeuuid: 83a7029a-c74e-4227-9b42-9e06f030fa19
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-care-radio
+  broadcaster: independent
+  name: Care Radio
+  streamUrl: https://listen-careradio.sharp-stream.com/120_care_radio_128_mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/590/620694edbfb9e.jpg
+  homepage: https://www.careradio.org/
+  country: GB
+  status: stream-only
+  stationuuid: d3624951-3f7d-4959-b273-1392cf7fac8e
+  changeuuid: 7ae5994f-9713-422b-b036-700d03cfddfe
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-central-radio-north-west
+  broadcaster: independent
+  name: Central Radio North West
+  streamUrl: https://stream.central.radio/listen/web/high
+  bitrate: 128
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/778/673b04861e76c.png
+  homepage: https://www.central.radio/
+  country: GB
+  status: stream-only
+  stationuuid: 1e1fd495-149a-4f03-b43d-a830d92d1ed5
+  changeuuid: 1904a93f-2106-4df1-bb00-2eac17125cf7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-delite-radio
+  broadcaster: independent
+  name: Delite Radio
+  streamUrl: https://stream.deliteonline.com/live320
+  bitrate: 512
+  codec: AAC
+  favicon: http://www.deliteradio.com/upload/players/62fb755a427c40.95586069.jpg
+  homepage: http://www.deliteradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: ed9d6856-e938-4a7d-ba6f-aa5f5b53baa0
+  changeuuid: 42bfbdbb-09e0-4adc-a09f-9f348a371256
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-gems-top-40
+  broadcaster: independent
+  name: GEMS  TOP 40
+  streamUrl: https://stream.gemsradio.net:8000/;
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.gemsradio.net/wp-content/uploads/2021/10/cropped-Gems-Radio-icon-180x180.jpg
+  homepage: https://www.gemsradio.net/
+  country: GB
+  status: stream-only
+  stationuuid: eacbe68c-6c72-4882-910d-789616f21733
+  changeuuid: 4ecab968-5a6a-4aa1-b78f-d338ff959f4e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-glitterbeam-italia
+  broadcaster: independent
+  name: GlitterBeam Italia
+  streamUrl: https://quincy.torontocast.com:1740/stream
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.glitterbeam.net/
+  country: GB
+  status: stream-only
+  stationuuid: 34791e71-bdcd-4a11-9c7d-e486a90ea049
+  changeuuid: 86e5a336-54dd-437b-8b1c-78d36f0b0bc4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-glitterbeam-radio
+  broadcaster: independent
+  name: GlitterBeam Radio
+  streamUrl: https://ukwesta.streaming.broadcast.radio:17810/glitterbeam
+  bitrate: 128
+  codec: MP3
+  favicon: https://usercontent.one/wp/www.glitterbeam.co.uk/wp-content/uploads/2023/09/GBRECSMALL4.png
+  homepage: https://www.glitterbeam.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 1343d0f5-15fc-491b-8351-7bd8c7919300
+  changeuuid: 17b657af-9d5d-49e9-a8da-f85ad9eba933
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-global-pride
+  broadcaster: independent
+  name: Global Pride
+  streamUrl: https://media-sov.musicradio.com/Global-M-Pride
+  bitrate: 48
+  codec: AAC
+  favicon: https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse2.mm.bing.net%2Fth%3Fid%3DOIP.cmoF-nf5byb4GKWOVoVefAAAAA%26pid%3DApi&f=1&ipt=fb8665bb588c291de9ed9bd2765e62613792e1203899f9a45f639d973e894cf7&ipo=images
+  homepage: https://global.com/global-player
+  country: GB
+  status: stream-only
+  stationuuid: 410493e6-e279-4347-8884-702aabc0defb
+  changeuuid: 68126196-9bac-4452-80fe-c0137f3a4035
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-great-driffield-radio
+  broadcaster: independent
+  name: Great Driffield Radio
+  streamUrl: https://stream1.superstreaming.co.uk/proxy/greatdriffield/stream?rp_source=1&=&&___cb=720015281299521
+  bitrate: 192
+  codec: MP3
+  favicon: https://greatdriffieldradio.co.uk/wp-content/uploads/2023/12/gdr-150x150.jpg
+  homepage: https://greatdriffieldradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 87a03289-05fe-4e07-8116-7a60b1408237
+  changeuuid: bad15d9e-f0ec-448e-8a74-119a12251abc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-greatest-hits-radio-70s
+  broadcaster: independent
+  name: Greatest Hits Radio 70s
+  streamUrl: https://stream-al.hellorayo.co.uk/ghr70s.aac?aw_0_1st.skey=1602676850&direct=true&rp_source=1
+  bitrate: 47
+  codec: AAC+
+  favicon: https://media.bauerradio.com/image/upload/c_crop,g_custom/v1742817230/brand_manager/stations/vpgvlb3s5roqkyo6cxvf.svg
+  homepage: https://www.hellorayo.co.uk/greatest-hits-radio-70s
+  country: GB
+  status: stream-only
+  stationuuid: 4c6d43e7-b474-440f-be56-d899dd0e757e
+  changeuuid: a035af27-1331-4e5a-819e-4955931fcd97
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-mad-wasp-radio
+  broadcaster: independent
+  name: Mad Wasp Radio
+  streamUrl: https://streaming.radio.co/s8a8d7b49a/listen
+  bitrate: 128
+  codec: MP3
+  favicon: https://pbs.twimg.com/profile_images/1684130478981279744/QqiJhxb9_400x400.jpg
+  homepage: https://madwaspradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 6bd8806e-a450-4e8b-ad59-6d85469821eb
+  changeuuid: 579aee96-ca71-466e-8f85-f6d601781d2e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-mixx-radio-preston
+  broadcaster: independent
+  name: mixx radio preston
+  streamUrl: https://stream-hitsradio.creativedork.com/
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.liveradio.uk/files/images/482949/resized/180x172c/mixx_radio_preston.jpg
+  homepage: https://hitsradio.radioplayer.airsuite.studio/
+  country: GB
+  status: stream-only
+  stationuuid: 6a67b337-da57-4a02-9d08-cd609cf1f727
+  changeuuid: 1711970d-06e0-455f-ae67-860c626d512c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-only-old-skool-radio
+  broadcaster: independent
+  name: Only Old Skool Radio
+  streamUrl: https://listentomystream.com:8036/;?type=http&nocache=107036
+  bitrate: 320
+  codec: MP3
+  favicon: https://onlyoldskoolradio.com/wp-content/uploads/2020/06/cropped-icon1-32x32.png
+  homepage: https://onlyoldskoolradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 113eb10f-4258-44b9-8506-85d406729b28
+  changeuuid: 6683eb81-1c70-4664-8645-64636016b537
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-newquay
+  broadcaster: independent
+  name: Radio Newquay
+  streamUrl: https://s46.myradiostream.com/8816/listen.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://mm.aiircdn.com/479/5b9a5e36391cd.png
+  homepage: https://www.radionewquay.com/
+  country: GB
+  status: stream-only
+  stationuuid: b39e9c3e-596c-4d8d-9bd1-bf823c09ec8b
+  changeuuid: 14bb10f3-4e07-4499-b3fa-a360720685bb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-ninesprings
+  broadcaster: independent
+  name: Radio Ninesprings
+  streamUrl: https://stream.radioninesprings.com/ninesprings-high?_=293441
+  bitrate: 256
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/494/603669b913ade.png
+  homepage: https://www.radioninesprings.com/
+  country: GB
+  status: stream-only
+  stationuuid: 059f3e10-d7bf-4f29-a001-39d853d042cb
+  changeuuid: 21448dd2-c1ad-431f-a009-096d017026b8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-radio
+  broadcaster: independent
+  name: Radio Radio
+  streamUrl: https://c16.radioboss.fm:18014/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://radioradio.fm/grafika/logo1a.png
+  homepage: https://radioradio.fm/
+  country: GB
+  status: stream-only
+  stationuuid: 033b3a5b-93cc-46d2-b7f4-0c381fb800e8
+  changeuuid: 71f03cd7-5bf2-4a1f-8a99-1465b8e3c86e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-rudy
+  broadcaster: independent
+  name: Radio Rudy
+  streamUrl: https://stream-55.zeno.fm/21y1sqfvkm0uv
+  codec: MP3
+  favicon: https://zeno.fm/favicon.ico
+  homepage: https://zeno.fm/radio/radio-rudy/
+  country: GB
+  status: stream-only
+  stationuuid: 5948322a-0634-46e2-97ab-37ae02ff1980
+  changeuuid: 121422aa-1ddb-4d65-9fe8-5f082f9526e5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radiosega-he-aac-v2
+  broadcaster: independent
+  name: RadioSEGA (HE-AAC v2)
+  streamUrl: https://icecast.radiosega.net/live
+  bitrate: 256
+  codec: AAC+
+  favicon: https://www.radiosega.net/_images/template/siteHeader-newlogo_hover.png
+  homepage: https://www.radiosega.net/
+  country: GB
+  status: stream-only
+  stationuuid: b9ee66ff-d196-4bfd-b4b2-2ad87657e2f9
+  changeuuid: 7400daf0-a3a9-4aa1-99ad-a02af2e3bd2a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-retro-soul-radio
+  broadcaster: independent
+  name: Retro Soul Radio
+  streamUrl: https://streaming.galaxywebsolutions.com/stream/retrosoul
+  bitrate: 128
+  codec: MP3
+  favicon: https://static-media.streema.com/media/cache/cf/d9/cfd9303c27dd71c35a2370766d4d1309.jpg
+  homepage: https://www.retrosoulradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 0de4d5eb-53ce-46fa-a20c-73b8300f9c58
+  changeuuid: 63435768-ed19-47c5-bd09-0397f7e809f2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-salisbury-radio
+  broadcaster: independent
+  name: Salisbury Radio
+  streamUrl: https://securestreams6.autopo.st:2139/stream.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://salisburyradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 7d24ec3a-c37a-4a7a-99b3-1e0991ff8041
+  changeuuid: eb9d33c1-5350-4cf6-a1bb-03f17ae5f903
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-vixen-101
+  broadcaster: independent
+  name: Vixen 101
+  streamUrl: https://s33.myradiostream.com:15184/;?type=http
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.vixen101.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 05741225-4a5e-4a61-b90b-30b3ddcf9e78
+  changeuuid: 3fc2f18e-d4f5-43c0-b42c-52e51c8edf69
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-weekend-offender-radio
+  broadcaster: independent
+  name: Weekend Offender Radio
+  streamUrl: https://uk2.internet-radio.com/proxy/weekendoffender?mp=/stream;
+  bitrate: 128
+  codec: MP3
+  favicon: https://weekendoffender.com/cdn/shop/files/android-chrome-512x512.png?crop=center&height=32&v=1699368215&width=32
+  homepage: https://weekendoffender.com/
+  country: GB
+  status: stream-only
+  stationuuid: 2cea2982-7bd7-457f-a599-fc90b5aeea79
+  changeuuid: 98b7ae5d-95ac-4862-9633-714bdde7ecd9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-west-kent-radio
+  broadcaster: independent
+  name: West Kent Radio
+  streamUrl: https://ukwesta.streaming.broadcast.radio/wkcr
+  bitrate: 170
+  codec: MP3
+  favicon: https://www.westkentradio.co.uk/favicon.png
+  homepage: https://www.westkentradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 4dea201f-598f-4794-a25d-5a71058a5ca1
+  changeuuid: 21a4fdb9-2d36-493e-a7d2-a8ce5c411b46
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-xenfm
+  broadcaster: independent
+  name: XenFM
+  streamUrl: https://radio.xenfm.com/listen/xenfm/radio.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://xenfm.com/wp-content/uploads/2020/05/cropped-PythiaArsenicEye.png
+  homepage: https://xenfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: 16c600b5-0e48-4ace-b9bb-5bfc39a757d6
+  changeuuid: b9684799-f420-4c15-aaa0-0f034a9c7217
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-alfred
+  broadcaster: independent
+  name: Alfred
+  streamUrl: https://stream2.hippynet.co.uk:8204/stream
+  bitrate: 160
+  codec: MP3
+  homepage: https://thisisalfred.com/
+  country: GB
+  status: stream-only
+  stationuuid: 0f5816c2-022d-444e-a08f-cfe571a20f7a
+  changeuuid: 5236ca28-30ae-4ed9-95b5-3b772937c270
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-arena-radio
+  broadcaster: independent
+  name: Arena Radio
+  streamUrl: https://stream3.themediasite.co.uk:8318/stream
+  bitrate: 192
+  codec: MP3
+  favicon: https://public-rf-upload.minhawebradio.net/250716/logo/d7351a69a8b11013d475908bf2f562ba.png
+  homepage: http://arenaradio.live/
+  country: GB
+  status: stream-only
+  stationuuid: d72509cc-1ed8-4b2b-84a7-46edbdc22d78
+  changeuuid: 9cddc334-16ad-4af1-883c-3082a3e95f0b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bfbs-aldershot
+  broadcaster: independent
+  name: BFBS Aldershot
+  streamUrl: https://listen-ssvcbfbs.sharp-stream.com/ssvcbfbs13.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://radio.bfbs.com/icons/icon-512x512.png?v=0afec91a27aaa6d57f2b000c6fbe8cac
+  homepage: https://radio.bfbs.com/stations/bfbs-aldershot
+  country: GB
+  status: stream-only
+  stationuuid: 0e3d37da-f614-4998-9e1a-ca7274e4d37e
+  changeuuid: 6f72eac1-82ff-41b4-9ff0-4abdaa7fedd0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-black-country-radio
+  broadcaster: independent
+  name: Black Country Radio
+  streamUrl: https://listen-blackcountryradio.sharp-stream.com/blackcountryradio.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.blackcountryradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 4633eabd-28ea-4a8a-a324-0a45ba184d93
+  changeuuid: 1900e05c-9b1a-4b59-8928-c962614f65e0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-brap-fm
+  broadcaster: independent
+  name: Brap.FM
+  streamUrl: https://radio.brap.fm:8000/radio.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.brap.fm/
+  country: GB
+  status: stream-only
+  stationuuid: 47101fd9-3716-4954-9733-adf9b5091812
+  changeuuid: 3acffda1-5e0a-479a-a37e-21603674d226
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-crop-radio
+  broadcaster: independent
+  name: CROP Radio
+  streamUrl: https://s3.radio.co/sb713b671e/listen
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.cropradio.live/images/favicons/apple-touch-icon.png
+  homepage: https://www.cropradio.live/
+  country: GB
+  status: stream-only
+  stationuuid: 8880fed6-295b-4257-89e3-a7c75034780b
+  changeuuid: f11ad245-68a5-4a02-8da1-4dedfb47d72a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-cutters-choice
+  broadcaster: independent
+  name: Cutters Choice
+  streamUrl: https://cutters-choice-radio.radiocult.fm/stream
+  bitrate: 320
+  codec: MP3
+  homepage: https://www.cutterschoiceradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 70cf8648-f02a-40a1-a285-228369a4fae7
+  changeuuid: 9cca1fe5-353c-4897-94a4-ee7d68ddaebc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-dundee-radio-club
+  broadcaster: independent
+  name: Dundee Radio Club
+  streamUrl: https://dundee-radio-club.radiocult.fm/stream
+  bitrate: 320
+  codec: MP3
+  homepage: https://dundeeradio.club/
+  country: GB
+  status: stream-only
+  stationuuid: 721286a0-1886-4a06-92e3-2f5be0451ebb
+  changeuuid: 99a216df-4b22-47cc-9142-66b6cc082185
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-flex-fm-101-4
+  broadcaster: independent
+  name: Flex FM 101.4
+  streamUrl: https://a2.asurahosting.com:7400/radio.mp3
+  bitrate: 320
+  codec: MP3
+  favicon: https://upload.wikimedia.org/wikipedia/en/4/40/Flex_FM_London_logo.png
+  homepage: https://flexfm.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 0a885695-4f50-4676-8fab-0e7dff0e4fa9
+  changeuuid: aec33f1f-05af-4faa-baa7-59e0fe1ce43e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-fresh-soundz-radio
+  broadcaster: independent
+  name: Fresh Soundz Radio
+  streamUrl: https://solid48.streamupsolutions.com/proxy/neivwtxt/stream/
+  bitrate: 320
+  codec: MP3
+  favicon: https://static.mytuner.mobi/media/tvos_radios/626/soundz-radio-uk.426d8b6f.jpg
+  homepage: https://www.freshsoundzradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 023bfe22-8ced-42b2-9a6f-f205487b5858
+  changeuuid: 921915b2-bb16-48f1-9b4d-55589f0b1d40
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-frisky-radio-chill
+  broadcaster: independent
+  name: Frisky Radio Chill
+  streamUrl: https://stream.chill.friskyradio.com/
+  bitrate: 96
+  codec: MP3
+  homepage: http://friskyradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: fce5f166-670f-4e51-b8d8-9145110e1435
+  changeuuid: 0532ab5f-a24d-4dcc-890a-97a37764a4c9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-frisky-radio-deep
+  broadcaster: independent
+  name: Frisky Radio Deep
+  streamUrl: https://stream.deep.friskyradio.com/
+  bitrate: 96
+  codec: MP3
+  homepage: http://friskyradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 1e5d470b-7605-4d36-9734-4d34f9f2ebab
+  changeuuid: 53c96069-9ead-4915-9bc9-84feed525038
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-genx-radio
+  broadcaster: independent
+  name: GenX Radio
+  streamUrl: https://s2.radio.co/sf25229e16/low
+  bitrate: 64
+  codec: AAC
+  favicon: https://genxradio.co.uk/wp-content/uploads/2021/11/GenXAsset-3.png
+  homepage: https://genxradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 4519a42f-b4c0-4856-aa49-3a497af7de9a
+  changeuuid: 0f0cd65c-18ea-4218-921c-b64f32877e11
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-gold-dust-radio
+  broadcaster: independent
+  name: Gold Dust Radio
+  streamUrl: https://gold-dust-radio.radiocult.fm/stream
+  bitrate: 192
+  codec: MP3
+  favicon: https://images.squarespace-cdn.com/content/v1/5c80edb83560c31af710d6cc/1610290067018-YNK9FQE7ZGF56JE26AK6/gd-landscape-rgb-2.png?format=1500w
+  homepage: https://www.golddusthub.com/
+  country: GB
+  status: stream-only
+  stationuuid: a4611629-e7ac-4bea-8fda-625c695c1656
+  changeuuid: 91fe7884-ab6b-4874-b4f1-269703b51891
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-gwh
+  broadcaster: independent
+  name: GWH
+  streamUrl: https://carina.streamerr.co/stream/swindonhr
+  bitrate: 128
+  codec: MP3
+  country: GB
+  status: stream-only
+  stationuuid: 4ce780ba-f267-4016-b5ba-7762a3d98cd3
+  changeuuid: 0a5789fb-7c12-4d12-a6bd-639300b6bab4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hbsa-hospital-radio
+  broadcaster: independent
+  name: HBSA Hospital Radio
+  streamUrl: https://solid24.streamupsolutions.com/proxy/zzjcamth?mp=/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://hbsaradio.com/wp-content/themes/topofthehour/images/logo.png
+  homepage: https://hbsaradio.com/#
+  country: GB
+  status: stream-only
+  stationuuid: 220d73f5-268b-45da-b74c-4e9d599ca349
+  changeuuid: e90f6245-f792-48a5-96e6-59fad16cd6de
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-heaven-and-heaven-radio
+  broadcaster: independent
+  name: Heaven and Heaven radio
+  streamUrl: https://eu10.fastcast4u.com:1500/
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.heavenandheavenradio.org/apple-touch-icon.png?v=1721674313144
+  homepage: https://www.heavenandheavenradio.org/
+  country: GB
+  status: stream-only
+  stationuuid: 4c536c2b-8fa7-4a14-baa3-82aed93975ec
+  changeuuid: 957ad0e7-983d-4f5c-85c7-639632c7f915
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hospital-radio-colchester
+  broadcaster: independent
+  name: Hospital Radio Colchester
+  streamUrl: https://streaming.broadcastradio.com:10905/hrcolchester
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/2aa317_7b0e1ad2c28944858946b7a57ede4ab1.png/v1/fill/w_172,h_153,al_c,lg_1,q_85,enc_auto/2aa317_7b0e1ad2c28944858946b7a57ede4ab1.png
+  homepage: https://www.hrcolchester.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 8daf0a5c-fb3f-4f79-ac1b-5fd71be7d662
+  changeuuid: 7db21d63-64a5-4ba3-bb46-0e3ead7fb34e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-incapable-staircase
+  broadcaster: independent
+  name: Incapable Staircase
+  streamUrl: https://streams.radio.co/s436782ce6/listen
+  bitrate: 128
+  codec: MP3
+  favicon: https://incapablestaircase.com/wp-content/uploads/2024/08/favicon.png
+  homepage: https://www.incapablestaircase.com/
+  country: GB
+  status: stream-only
+  stationuuid: 41fe5c28-d87a-4e71-8a37-87e91597e94d
+  changeuuid: dd5a4757-98d2-4a85-8eab-524329db5d12
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-kizzfm-uk-90-9
+  broadcaster: independent
+  name: KizzFM UK 90.9
+  streamUrl: https://azura.kizzfmuk90-9.com/listen/kizzfmuk/radio.mp3?1689855016244
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.kizzfmuk90-9.com/
+  country: GB
+  status: stream-only
+  stationuuid: 1db0f955-aefa-4535-9811-748d1ee9db73
+  changeuuid: a7af9736-1af2-4075-b402-809de4555cbb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-lofi-hiphop-chillsky
+  broadcaster: independent
+  name: Lofi hiphop - chillsky
+  streamUrl: https://chill.radioca.st/stream
+  bitrate: 128
+  codec: MP3
+  homepage: https://chillsky.com/
+  country: GB
+  status: stream-only
+  stationuuid: 72f7fc65-a1ec-4e13-93f4-639363d2ff9a
+  changeuuid: cf60d3d8-04b1-4cea-93d6-004adf7d1608
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-london-romanian-radio
+  broadcaster: independent
+  name: London Romanian Radio
+  streamUrl: https://play.lrradio.uk/
+  bitrate: 64
+  codec: AAC
+  favicon: https://lrradio.uk/img/logo.png
+  homepage: https://lrradio.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 76c14813-a09a-480d-85c5-44ae3c6eda54
+  changeuuid: f40925d8-3c29-4464-82cb-aaff2a9f8ce3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-loose-fm
+  broadcaster: independent
+  name: Loose FM
+  streamUrl: https://loosefm.radiocult.fm/stream
+  bitrate: 320
+  codec: MP3
+  favicon: https://www.google.com/s2/favicons?sz=256&domain_url=https%3A%2F%2Fwww.loose.fm%2F
+  homepage: https://www.loose.fm/
+  country: GB
+  status: stream-only
+  stationuuid: 073b7b41-31c8-4f69-92e0-64ec9548af31
+  changeuuid: 8906fdc4-aef2-41bc-a245-49a85cdd5d60
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-mystery-radio
+  broadcaster: independent
+  name: Mystery Radio
+  streamUrl: https://streaming06.liveboxstream.uk/proxy/rokstar9/stream
+  bitrate: 48
+  codec: MP3
+  favicon: https://www2.rokitradio.com/_next/image?url=%2Fimages%2Fchannels%2Fmystery.jpg&w=128&q=75
+  homepage: https://www2.rokitradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 4f3ccf20-cc5a-465d-ba2e-0ecaa75fb5f2
+  changeuuid: 31a5a62a-69cc-405c-81da-9435171fc6d8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-p4ppp-radio
+  broadcaster: independent
+  name: P4PPP Radio
+  streamUrl: https://stream.zeno.fm/hgc7mcknqpuuv
+  codec: AAC
+  favicon: https://zeno.fm/_next/image/?url=https%3A%2F%2Fimages.zeno.fm%2F27b-9YErzi8ANXvNMuOlFjdfMRu1P7AJXYaBWpmPZN0%2Frs%3Afit%3A240%3A240%2Fg%3Ace%3A0%3A0%2FaHR0cHM6Ly9zdHJlYW0tdG9vbHMuemVub21lZGlhLmNvbS9jb250ZW50L3N0YXRpb25zLzYzZGMzZmRmLTQwYTgtNDFkMS04MzZiLWYyMzgwODdhMTAyMC9pbWFnZS8_dXBkYXRlZD0xNzE3MDYyMzY1MDAw.webp&w=1920&q=100
+  homepage: https://zeno.fm/radio/p4ppp-radio/
+  country: GB
+  status: stream-only
+  stationuuid: 67d1d138-6318-48d3-80c0-e3e9949298b6
+  changeuuid: e1f5fb43-28a8-4b28-947f-80ac8d4ece35
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-cardiff
+  broadcaster: independent
+  name: "Radio Cardiff "
+  streamUrl: https://radiocardiff.radioca.st/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://firebasestorage.googleapis.com/v0/b/radiogalaxy-580f4.appspot.com/o/images%2FIMG_20240909_115752423.jpg?alt=media&token=b344b077-73bc-46dd-9b59-eb196ff15d0f
+  homepage: https://radiocardiff.org/
+  country: GB
+  status: stream-only
+  stationuuid: 6706d898-f7c6-42ad-9e1b-4d473985eca4
+  changeuuid: c9454048-614d-459a-80cb-0c9961420ad9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-grapevine
+  broadcaster: independent
+  name: Radio Grapevine
+  streamUrl: https://streaming06.liveboxstream.uk/proxy/radiogra?mp=/stream
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radiograpevine.com/
+  country: GB
+  status: stream-only
+  stationuuid: 956c474b-36d2-4692-bb8e-b430b35ecc27
+  changeuuid: 3ba9db96-89d7-4b10-a2a6-e384966d2cb0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-seerah
+  broadcaster: independent
+  name: Radio Seerah
+  streamUrl: https://icecast.maxxwave.co.uk/radioseerah
+  bitrate: 80
+  codec: AAC
+  favicon: https://cloud-1de12d.becdn.net/media/iW=274&iH=274&oX=0&oY=0&cW=274&cH=274/0c0eff783969b0e0df546d2b6ec9ca8a/MainLOGO.jpg
+  homepage: https://www.radioseerah.com/
+  country: GB
+  status: stream-only
+  stationuuid: a92b5960-0802-45b4-a286-ae1a9151938e
+  changeuuid: 5e3794da-7b74-4b3a-ac28-a10b4781a139
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-utsav
+  broadcaster: independent
+  name: Radio UTSAV
+  streamUrl: https://icecast.maxxwave.co.uk/utsav
+  bitrate: 80
+  codec: AAC
+  favicon: https://radioutsav.com/wp-content/uploads/2024/09/PHOTO-2024-09-01-11-54-35.jpg
+  homepage: https://radioutsav.com/
+  country: GB
+  status: stream-only
+  stationuuid: cd0c14ff-11b3-47af-8dd3-955e789ecdb4
+  changeuuid: 0d6519b4-af8a-47a9-99b7-99e1ee0a5ad9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radionev-24x7-hit-music-lounge
+  broadcaster: independent
+  name: RadioNev (24x7 hit music lounge)
+  streamUrl: https://a7.asurahosting.com/listen/radionev/radio.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.radionev.com/sitepad-data/uploads/2024/11/512.png
+  homepage: https://www.radionev.com/
+  country: GB
+  status: stream-only
+  stationuuid: 18db4772-1f7d-43ef-9fdf-c50fdbe97a78
+  changeuuid: e529fb57-6b2f-4ede-8009-782acb361c0b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-roch-valley-radio
+  broadcaster: independent
+  name: Roch Valley Radio
+  streamUrl: https://rochvalley.radioca.st/stream?_=723854
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/572/615a03a7cb961.jpg
+  homepage: https://www.rochvalleyradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 9eccde5d-20a7-4d42-a8cf-7edc0aef3473
+  changeuuid: d151a5f9-7c35-4fff-9cdb-3298b66c1ce4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-rotherham-radio
+  broadcaster: independent
+  name: Rotherham Radio
+  streamUrl: https://stream3.themediasite.co.uk:8004/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://play-lh.googleusercontent.com/RcFfsJQvuWz-6ZhsTb7jOjwA6dSS0uy8h926Tgxnn4qDez7qEnBINiU9kqyc_qSvA4Q=w240-h480-rw
+  homepage: https://www.rotherhamradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 25ed3119-2ddc-407e-8f96-227a4dcf40a7
+  changeuuid: 49cd647a-078f-4158-a1c7-b45b791cc753
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-stoke-mandeville-hospital-radio
+  broadcaster: independent
+  name: Stoke Mandeville Hospital Radio
+  streamUrl: https://ukwesta.streaming.broadcast.radio/stoke?1692976686054=
+  codec: MP3
+  favicon: https://www.smhr.co.uk/favicon.ico
+  homepage: https://www.smhr.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 8c52d075-f7a5-4963-a922-09c5fa47272f
+  changeuuid: 00e9f762-e23d-4207-8783-78a1071df05d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-the-richie-allen-show
+  broadcaster: independent
+  name: The Richie Allen Show
+  streamUrl: https://ukwesta.streaming.broadcast.radio/therichieallenshow
+  codec: MP3
+  homepage: https://richieallen.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 35a2aa8b-a8c6-41c3-95fe-2e0857223095
+  changeuuid: 48cffd2c-8378-49e0-80bc-93d3fc7bb24d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-vintage-radio-wirral
+  broadcaster: independent
+  name: Vintage Radio Wirral
+  streamUrl: https://streaming04.liveboxstream.uk/proxy/vintager?mp=/stream
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.vintageradio.org.uk/sitepad-data/uploads/2024/11/WhatsApp-Image-2024-10-09-at-16.44.13_8902e262.jpg
+  homepage: https://www.vintageradio.org.uk/
+  country: GB
+  status: stream-only
+  stationuuid: bbd26799-7129-4620-9e46-49677e3fe320
+  changeuuid: 55bfe336-46a3-47cc-bdde-6a732f8008b5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-beat-geeks-radio
+  broadcaster: independent
+  name: Beat Geeks Radio
+  streamUrl: https://broadcast.shoutstream.co.uk:8050/stream
+  bitrate: 128
+  codec: AAC+
+  favicon: https://img1.wsimg.com/isteam/ip/bae4931a-2ea8-4815-9a46-4271f6de2b79/logo%20large.png/:/rs=w:400,h:400,cg:true,m/cr=w:400,h:400/qt=q:95
+  homepage: https://beatgeeksradio.com/#5f139bdd-e5cd-420c-a57c-c7075e626746
+  country: GB
+  status: stream-only
+  stationuuid: 8b219ccf-914c-4822-ad96-245f7e0a7c63
+  changeuuid: b4af40c7-2008-41da-9f6d-66fac0efd54c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-beat-route-radio
+  broadcaster: independent
+  name: Beat Route Radio
+  streamUrl: https://beatrouteradio.radioca.st/autodj
+  bitrate: 128
+  codec: MP3
+  favicon: https://firebasestorage.googleapis.com/v0/b/radiogalaxy-580f4.appspot.com/o/images%2FIMG_20240909_160637684.jpg?alt=media&token=e0d32581-2089-4058-9d80-01279c52b1cc
+  homepage: https://beatrouteradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: beae5ddc-ed22-4c5a-bbfa-cbf0815b794b
+  changeuuid: 6e51621b-8261-4ed3-80c4-db879e815044
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-blue-in-green-radio
+  broadcaster: independent
+  name: "Blue-in-Green:RADIO"
+  streamUrl: https://stream.radio.co/s9e1625f13/listen
+  bitrate: 128
+  codec: MP3
+  favicon: http://4.bp.blogspot.com/-aeCJDMfXnVM/WKWDZV4LOuI/AAAAAAAABxI/QPsmN8EWUBgPXVlN3hE9Q2EyypmA9WWfQCK4B/s400/BinGRadio%2BBW.png
+  homepage: http://www.blueingreenradio.com/?m=1
+  country: GB
+  status: stream-only
+  stationuuid: 0fb72765-2bab-4242-b635-ac8bae673676
+  changeuuid: 450ad6d3-e218-401b-9635-5197300bcf1c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-capital-xtra-reloaded
+  broadcaster: independent
+  name: Capital Xtra Reloaded
+  streamUrl: https://media-ice.musicradio.com/CapitalXTRAReloadedMP3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.capitalxtra.com/reloaded/
+  country: GB
+  status: stream-only
+  stationuuid: 10ceb226-550d-41ce-84e9-df7f33729c84
+  changeuuid: 63f5ebe1-8674-4d1e-a360-3b84fda5b292
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-charlie-mason-radio
+  broadcaster: independent
+  name: Charlie Mason Radio
+  streamUrl: https://s9.reliastream.com/proxy/charlie1/stream
+  bitrate: 320
+  codec: MP3
+  homepage: https://charliemasonradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: aaa2710d-6598-4691-8cf8-a73c1c023a8a
+  changeuuid: 2c0f018c-c418-4104-8d2d-1f7faf96192d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-colin-mogagabe
+  broadcaster: independent
+  name: Colin Mogagabe
+  streamUrl: https://music-station.live/listen/crw_radio/radio.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.music-station.live/static/uploads/crw_radio/album_art.1721666882.png
+  homepage: https://music-station.live/public/crw_radio
+  country: GB
+  status: stream-only
+  stationuuid: b059116f-12b9-4ecb-9a6c-4195f5c141c2
+  changeuuid: cd868afe-3467-4efb-a6e3-424ee61d4452
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-conquest-hospital-radio
+  broadcaster: independent
+  name: Conquest Hospital Radio
+  streamUrl: https://chrconquest.radioca.st/radio.mp3
+  bitrate: 160
+  codec: MP3
+  favicon: https://conquesthospitalradio.co.uk/wp-content/uploads/2021/07/950291C2-2ECB-460D-A667-30F09D405480.jpeg
+  homepage: https://conquesthospitalradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 6b595df4-22e1-4731-b820-6a9ace4e99f5
+  changeuuid: a5447740-64c1-42a1-8871-5984a32b4b68
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-crmk
+  broadcaster: independent
+  name: CRMK
+  streamUrl: https://stream.radio.co/sdfcc41b7a/listen
+  bitrate: 192
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/2f38db_822606c0d74d443cbca64a25e47899b5~mv2.png/v1/fill/w_109,h_109,al_c,q_85,usm_0.66_1.00_0.01,enc_auto/Untitled.png
+  homepage: https://www.crmk.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: a58bf7d6-ae56-4c62-8613-a1d45dc5fab3
+  changeuuid: 005ddfe0-7982-49fe-bb44-be210a7794c6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-deephouse-fm
+  broadcaster: independent
+  name: deephouse.fm
+  streamUrl: https://altair.streamerr.co:8124/stream
+  bitrate: 192
+  codec: MP3
+  favicon: https://deephouse.fm/wp-content/uploads/2025/12/Deep-House-FM-Logo.jpg
+  homepage: https://deephouse.fm/
+  country: GB
+  status: stream-only
+  stationuuid: b55bdebb-54b5-4fdf-9078-d750612fcda1
+  changeuuid: 0f6bbb52-1e86-4fcb-acbb-44a6814c84a5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-doncaster-radio
+  broadcaster: independent
+  name: Doncaster Radio
+  streamUrl: https://stream1.themediasite.co.uk:8008/stream
+  bitrate: 192
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/493/64b694df58f95.png
+  homepage: https://www.doncasterradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 37618117-b106-45e1-9a62-a7c385ee580b
+  changeuuid: 0cff368b-ed50-4420-b1e0-aac194ca5257
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-drystone-radio
+  broadcaster: independent
+  name: Drystone Radio
+  streamUrl: https://uksoutha.streaming.broadcast.radio/drystoneradio?1724596500437=
+  codec: MP3
+  homepage: https://www.drystoneradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: b137a456-40e1-46fa-b840-482fc100d10a
+  changeuuid: 6f22b398-6306-4ec5-b719-6e98f90a3eca
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-eden-fm-107-5
+  broadcaster: independent
+  name: Eden Fm 107.5
+  streamUrl: https://eu4.fastcast4u.com/proxy/edenfmlt?mp=/1
+  bitrate: 128
+  codec: AAC+
+  favicon: https://fastcast4u.com/player/edenfmlt/_user/logo/e/edenfmlt/ch0.jpg
+  homepage: http://www.edenfm.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 13e826d0-62ac-478e-9447-2c35a1b94bff
+  changeuuid: 877eff34-0e1e-4fdc-b4ed-d45f746042ff
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-fishnet-radio
+  broadcaster: independent
+  name: Fishnet Radio
+  streamUrl: https://stream.radio.co/s74e130a62/listen
+  bitrate: 192
+  codec: MP3
+  favicon: https://static.mytuner.mobi/media/tvos_radios/151/fishnet-radio.6ea1e90b.png
+  homepage: https://www.fishnetradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 5efbf78b-7543-4405-9ade-f2561735f807
+  changeuuid: f42c40ca-633a-48e6-829f-f273db91e693
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-fix-radio
+  broadcaster: independent
+  name: Fix Radio
+  streamUrl: https://n06a-eu.rcs.revma.com/gnys6kxst8tvv
+  codec: AAC
+  favicon: https://mmo.aiircdn.com/203/623068c8b2091.png
+  homepage: https://www.fixradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: f1beb3ef-0410-47ef-a137-0430b1f8beb6
+  changeuuid: 6e7a995a-6712-47d2-a585-c684f9e764b6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-fosse-107
+  broadcaster: independent
+  name: Fosse 107
+  streamUrl: https://icecast.maxxwave.co.uk/fossehinckleyhq
+  bitrate: 80
+  codec: AAC
+  favicon: https://mm.aiircdn.com/375/59372c77cd002.png
+  homepage: https://www.fosse107.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 39a42811-79fe-44ed-a4cc-392ef2a6d774
+  changeuuid: 1a5d6672-3dee-42f6-9272-d6d45ce68fb3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-frisk-radio-groove-northeast
+  broadcaster: independent
+  name: frisk radio groove northeast
+  streamUrl: https://www.friskradio.com:8443/stream21
+  codec: AAC
+  homepage: https://www.friskradio.com/?station=4un
+  country: GB
+  status: stream-only
+  stationuuid: de8dea11-4dc3-48df-b229-44b0bed9f921
+  changeuuid: 13680e0d-c6f0-4e4b-b1c9-76898eb8033d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hailsham-fm
+  broadcaster: independent
+  name: Hailsham FM
+  streamUrl: https://s21.myradiostream.com/:10716/listen.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.hailshamfm.com/wp-content/uploads/2021/03/Hailsham-95.9FM-logo-NO-STRAP.png
+  homepage: https://www.hailshamfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: 0637f4cc-4c57-4ccf-80b3-1aeda062c197
+  changeuuid: 762b5481-d2f7-4244-b429-b6477e6d84c5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hearme-movie-soundtracks-radio
+  broadcaster: independent
+  name: "Hearme Movie Soundtracks Radio "
+  streamUrl: https://radio.hearme.fm:8074/stream
+  codec: MP3
+  favicon: https://hearme.fm/wp-content/uploads/2024/06/2024-Redrafted-Transparent-Box-No-Text-1-1024x1024.png
+  homepage: https://hearme.fm/radio/movie-soundtracks/
+  country: GB
+  status: stream-only
+  stationuuid: da9a3558-135c-466c-a8bc-4eca5433ff0c
+  changeuuid: 4c13cda0-9e51-4d0e-bd28-4522b81d8edc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-johnstone-sound
+  broadcaster: independent
+  name: Johnstone Sound
+  streamUrl: https://stream1.themediasite.co.uk:8084/;
+  bitrate: 320
+  codec: MP3
+  homepage: https://johnstonesound.com/
+  country: GB
+  status: stream-only
+  stationuuid: 0a87202d-0fdd-40f5-8a15-bedc48bb9ed4
+  changeuuid: 94fc7147-2577-428b-8ee8-ae1327dd1f91
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-konflict-radio
+  broadcaster: independent
+  name: Konflict Radio
+  streamUrl: https://uk3.internet-radio.com/proxy/konflictradio?mp=/stream
+  bitrate: 320
+  codec: MP3
+  favicon: https://konflict-radio.com/images/krlogo.png
+  homepage: https://konflict-radio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 07fc81e9-58e4-4097-90e4-e4022712d984
+  changeuuid: ad40e826-f510-4388-888d-bc2d2b7fdb8a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-mersey-radio
+  broadcaster: independent
+  name: Mersey Radio
+  streamUrl: https://stream.shoutcastservices.com/proxy/merseyradio/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://merseyradio.co.uk/wp-content/uploads/2023/03/cropped-logo.png
+  homepage: https://merseyradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: a38650f3-7691-4a5e-9475-0d549d3679b5
+  changeuuid: f5ae74dc-f148-4a36-ae9b-9e148098de15
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-mid-downs-radio
+  broadcaster: independent
+  name: Mid Downs Radio
+  streamUrl: https://listen-mdr.sharp-stream.com/mdr.mp3
+  bitrate: 65
+  codec: MP3
+  homepage: https://www.mdr.org.uk/
+  country: GB
+  status: stream-only
+  stationuuid: de4ca30c-690a-4ac4-b123-fdbf0655349d
+  changeuuid: 9e9e15ac-b508-49bc-ae98-1214d11b65f1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-ocean-city-radio
+  broadcaster: independent
+  name: Ocean City Radio
+  streamUrl: https://s3.radio.co/se9877d32a/listen#.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://oceancityradio.co.uk/favicon.ico
+  homepage: https://oceancityradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: d14f6873-f99f-4b41-8194-fd46e27d6f66
+  changeuuid: a9bf42a9-1f7f-400c-a0a2-80822288236c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-outreach-dance
+  broadcaster: independent
+  name: Outreach Dance
+  streamUrl: https://live.ukrp.tv/outreachdance.aac
+  bitrate: 32
+  codec: AAC
+  homepage: https://www.outreachdance.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: aaaf4c25-8173-4838-82a3-e2300e5cf58d
+  changeuuid: a0b26a7d-5e15-490d-8eba-001acfdd78a3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-overton-radio
+  broadcaster: independent
+  name: Overton Radio
+  streamUrl: https://securestreams6.autopo.st:2506/stream
+  bitrate: 192
+  codec: MP3
+  favicon: https://overtonradio.com/wp-content/uploads/2023/07/1-1-1024x1024.png
+  homepage: https://www.overtonradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 7d701a61-820a-4c19-988f-421e7ffd78d7
+  changeuuid: 375b78d8-3364-4789-bba6-0c55460dfb0d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-enrg
+  broadcaster: independent
+  name: Radio ENRG
+  streamUrl: https://edge.mixlr.com/channel/xssdg
+  codec: MP3
+  favicon: https://i0.wp.com/radioenrg.com/wp-content/uploads/2020/06/radio-enrg-triangle-black-10.png
+  homepage: https://radioenrg.com/
+  country: GB
+  status: stream-only
+  stationuuid: 065a9594-4b93-4dad-a65b-cdb55adf9f0f
+  changeuuid: bcfd63fc-6db0-42e9-99c7-3e3cc1333a78
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-leyland
+  broadcaster: independent
+  name: Radio Leyland
+  streamUrl: https://streaming06.liveboxstream.uk/proxy/leyland2?mp=/stream
+  bitrate: 128
+  codec: MP3
+  homepage: https://radioleyland.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 53d6f35f-debd-479d-aa7c-61ccbf30ab54
+  changeuuid: 34c9a20b-2f87-41a6-9e1e-1d077e1bbd1c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-warneford
+  broadcaster: independent
+  name: Radio Warneford
+  streamUrl: https://uk7.internet-radio.com/proxy/radiowarneford?mp=/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.radiowarneford.com/wp-content/uploads/2023/11/rw-logo-2023-50th-400.png
+  homepage: https://www.radiowarneford.com/
+  country: GB
+  status: stream-only
+  stationuuid: 6b8928ad-5b12-4949-a552-959d4be265d4
+  changeuuid: 4cc06dbd-8548-4d32-a161-fd4415d466a4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-rother-radio-rotherham-sheffield
+  broadcaster: independent
+  name: "Rother Radio (Rotherham & Sheffield)"
+  streamUrl: https://streaming06.liveboxstream.uk/proxy/hitmusic?mp=/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://static.mytuner.mobi/media/tvos_radios/594/rother-radio.cc31313e.png
+  homepage: https://www.rotherradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: c68edb9c-dbc8-409d-891e-400ece56c982
+  changeuuid: c1fe57f4-2fd0-46f1-85fd-3292d3d9936b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-rustfm
+  broadcaster: independent
+  name: RustFM
+  streamUrl: https://listen.rustfm.com/listen/rustfm/radio.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://rustfm.com/assets/images/logo_wr.png
+  homepage: https://rustfm.com/#home
+  country: GB
+  status: stream-only
+  stationuuid: 47d46a2f-7bf6-4c7e-a776-b4a788047911
+  changeuuid: 7a32eafb-85dc-418a-a8c6-26d1a4ee25d4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-soundart-radio
+  broadcaster: independent
+  name: Soundart Radio
+  streamUrl: https://radio.canstream.co.uk:8134/live.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.soundartradio.org.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 161201f8-ae58-4f44-806b-4f8c8b90c853
+  changeuuid: 223111c6-6de7-4a66-b0bd-68f392f79d44
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-storm-radio
+  broadcaster: independent
+  name: Storm Radio
+  streamUrl: https://streaming.radio.co/s6df48fd88/listen
+  bitrate: 192
+  codec: MP3
+  favicon: https://img1.wsimg.com/isteam/ip/73788d98-eb15-4545-b89e-02e21d7c3eb9/STORM%20HEADER%20NEW%20A11.jpg/:/rs=w:902,h:273
+  homepage: https://stormfm.uk/home
+  country: GB
+  status: stream-only
+  stationuuid: 25c33875-d263-40c4-a4b4-79bcd0afa8a1
+  changeuuid: 960d0373-e156-4852-a955-0225bd986fd4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-the-sound-lab
+  broadcaster: independent
+  name: The Sound Lab
+  streamUrl: https://s4.radio.co/s0fc46103b/listen
+  bitrate: 192
+  codec: MP3
+  favicon: https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSa6ZgnMpbK8OK1EtUIYciHuysU3-zw2_NdOsB053eHdXnyMpkK9N2JYvHFRVdfsVnggKs&usqp=CAU
+  homepage: https://www.thesoundlabuk.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 9aea8bfd-f3ca-4829-b51d-bd440739c547
+  changeuuid: 21c2bdd2-3b0e-4295-bee6-c54d06f0f14d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-urban-all-in-1-radio
+  broadcaster: independent
+  name: Urban All In 1 Radio
+  streamUrl: https://stream.urbanallin1radio.co.uk/radio.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: https://urbanallin1radio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: e637a363-bc10-466b-960e-21ee86a9ecf0
+  changeuuid: 66ca0a70-a6dd-49cf-a5fe-95c24fcb7d19
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-capital-the-uk-s-no-1-hit-music-station
+  broadcaster: independent
+  name: " CAPITAL - The UK's No.1 Hit Music Station"
+  streamUrl: https://media-ssl.musicradio.com/CapitalUK
+  bitrate: 48
+  codec: AAC
+  favicon: https://cdn-profiles.tunein.com/s241396/images/logod.jpg
+  homepage: https://www.capitalfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: 4ad5bdc7-01e5-47c9-a1f9-751671b4707e
+  changeuuid: 96da73cc-8600-451b-a552-27626cbf5f64
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-capital-dance-the-uk-s-official-dance-station
+  broadcaster: independent
+  name: " CAPITAL DANCE: The UK's Official Dance Station"
+  streamUrl: https://media-ssl.musicradio.com/CapitalDance
+  bitrate: 48
+  codec: AAC
+  favicon: https://cdn-profiles.tunein.com/s309497/images/logod.jpg
+  homepage: https://www.capitaldance.com/
+  country: GB
+  status: stream-only
+  stationuuid: 5d50b9af-852d-43eb-89dd-b9b934e3f551
+  changeuuid: 9a218de4-7693-4ffd-9c06-741070295b02
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-kiss-xtra-black-music-culture
+  broadcaster: independent
+  name: " KISS XTRA: Black Music & Culture"
+  streamUrl: https://live-bauerkiss.sharp-stream.com/kissfresh.aac?direct=true&aw_0_1st.skey=1602676850&rp_source=1&=&&___cb=60456375243858
+  bitrate: 47
+  codec: AAC+
+  favicon: https://cdn-profiles.tunein.com/s198663/images/logod.png
+  homepage: https://www.hellorayo.co.uk/kiss-xtra
+  country: GB
+  status: stream-only
+  stationuuid: abb48ea5-7aaf-460c-bf04-7fe3b7f10bb7
+  changeuuid: bfceeb0d-0762-4309-8016-fae15ae42ac0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-96-3-seahaven-fm
+  broadcaster: independent
+  name: "96.3 Seahaven FM"
+  streamUrl: https://stream1.hippynet.co.uk:8107/stream?_=526570
+  bitrate: 170
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/892/63854c57a853f.png
+  homepage: https://www.seahavenfm.radio/
+  country: GB
+  status: stream-only
+  stationuuid: 042bb509-22e7-4eb8-9d7b-d69caf2ae57d
+  changeuuid: 5a82993c-d175-4856-91f8-105206480363
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-ajk-radio
+  broadcaster: independent
+  name: AJK Radio
+  streamUrl: https://solid41.streamupsolutions.com/proxy/wzbznkee/stream
+  bitrate: 320
+  codec: MP3
+  homepage: https://ajkradio.net/
+  country: GB
+  status: stream-only
+  stationuuid: ac8f3667-da06-449f-b876-e96b0e35b9d5
+  changeuuid: edd07e72-52ac-44a6-b6c1-a8e0bb3ad7a9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-arystation-beyond-reality
+  broadcaster: independent
+  name: AryStation - Beyond Reality
+  streamUrl: https://a11.asurahosting.com:8740/radio.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: https://radio.metachitect.com/
+  country: GB
+  status: stream-only
+  stationuuid: f9c3a3e4-06c9-4082-bb8f-c195a8837789
+  changeuuid: cde14b2a-4082-4cba-8d92-6e9527165f41
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bbc-cwr
+  broadcaster: independent
+  name: BBC CWR
+  streamUrl: https://as-hls-ww-live.akamaized.net/pool_79805333/live/ww/bbc_radio_coventry_warwickshire/bbc_radio_coventry_warwickshire.isml/bbc_radio_coventry_warwickshire-audio%3d96000.norewind.m3u8
+  codec: UNKNOWN
+  favicon: https://sounds.files.bbci.co.uk/3.9.4/networks/bbc_radio_coventry_warwickshire/colour_default.svg
+  homepage: https://www.bbc.co.uk/sounds/play/live/bbc_radio_coventry_warwickshire
+  country: GB
+  status: stream-only
+  stationuuid: 6c2699fb-de31-443d-b1a7-4249f45f4fc0
+  changeuuid: 770d0d1c-753a-4084-a0bc-708cefb1b8e3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bbc-radio-cambridge
+  broadcaster: independent
+  name: BBC Radio Cambridge
+  streamUrl: https://as-hls-ww-live.akamaized.net/pool_21074581/live/ww/bbc_radio_cambridge/bbc_radio_cambridge.isml/dash/bbc_radio_cambridge-audio%3d96000.norewind.m3u8
+  codec: UNKNOWN
+  favicon: https://sounds.files.bbci.co.uk/3.9.4/networks/bbc_radio_cambridge/colour_default.svg
+  homepage: https://www.bbc.co.uk/sounds/play/live/bbc_radio_cambridge
+  country: GB
+  status: stream-only
+  stationuuid: 69af9796-8391-4f32-bb58-ddc0a7673014
+  changeuuid: f431597d-e4e5-4b2b-b696-a8867c0d9b83
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-brown-student-community-radio
+  broadcaster: independent
+  name: "BROWN STUDENT & COMMUNITY RADIO"
+  streamUrl: https://listen.bsrlive.com/bsrmp3?1729748097161
+  bitrate: 128
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/39c7bc_eb82f27fe4d8402986e669cdbca13c4d~mv2.png/v1/fill/w_84,h_69,al_c,q_85,usm_0.66_1.00_0.01,enc_auto/39c7bc_eb82f27fe4d8402986e669cdbca13c4d~mv2.png
+  homepage: https://www.bsrlive.com/
+  country: GB
+  status: stream-only
+  stationuuid: f9ce7fb0-8db1-4cec-ba5b-6403ee483985
+  changeuuid: 94e95716-5b6b-4004-93c6-17085806901f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-cannock-chase-radio-fm
+  broadcaster: independent
+  name: Cannock Chase Radio FM
+  streamUrl: https://streaming.broadcast.radio/cannockchase?1712410831388=
+  codec: MP3
+  favicon: https://i0.wp.com/www.cannockchaseradio.co.uk/wp-content/uploads/2020/11/mobile-app-VER2.png?fit=1820%2C1120&ssl=1
+  homepage: https://www.cannockchaseradio.co.uk/#
+  country: GB
+  status: stream-only
+  stationuuid: 18da8249-0f65-4a29-b7aa-61239c7c44f5
+  changeuuid: ca72216a-92bf-467a-9acf-40fb8c17d920
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-celtic-music-radio
+  broadcaster: independent
+  name: Celtic Music Radio
+  streamUrl: https://uksoutha.streaming.broadcast.radio/celtic
+  codec: MP3
+  favicon: https://www.celticmusicradio.net/wp-content/uploads/2021/03/cropped-CMR-Logo-New-Ross-New-again-morse-correct.jpg
+  homepage: https://www.celticmusicradio.net/
+  country: GB
+  status: stream-only
+  stationuuid: 39e5d255-c3ad-4f81-9957-a1ceb59a3488
+  changeuuid: 89a98268-af26-469f-bd07-2a2a2c97f4cd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-crystal-love-radio
+  broadcaster: independent
+  name: Crystal Love Radio
+  streamUrl: https://betelgeuse.nucast.co.uk:8034/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://crystalloveradio.com/wp-content/uploads/2022/08/Crystallove-favi.jpg
+  homepage: https://crystalloveradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 39803846-5236-4951-b0e9-0f89fca438ab
+  changeuuid: 428b857a-324a-4760-8a6c-8799be5c9ead
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-daz-in-the-hat-radio
+  broadcaster: independent
+  name: Daz In The Hat Radio
+  streamUrl: https://s5.radio.co/s367c77774/listen
+  bitrate: 128
+  codec: MP3
+  favicon: https://assets.zyrosite.com/cdn-cgi/image/format=auto,w=238,fit=crop,q=95/Y4LlnV0PrgfegPw5/daz-in-the-hat-edited-logo-m2Wb7PBjx2ie7lwk.jpg
+  homepage: https://dazinthehat.com/
+  country: GB
+  status: stream-only
+  stationuuid: e6a82efc-59e5-42e8-bdce-ab0363596626
+  changeuuid: 1a8c93a8-6662-4c58-977d-7f4804da409c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-dean-radio
+  broadcaster: independent
+  name: Dean Radio
+  streamUrl: https://radio.forestmedia.co.uk/deanradio
+  bitrate: 128
+  codec: MP3
+  favicon: https://deanradio.co.uk/favicon.ico
+  homepage: https://deanradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: e2c6b5eb-08af-48b6-9f80-59f3ce14b6f6
+  changeuuid: a2f7d165-41f5-477c-aa96-7979d197f4cd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-dune-radio
+  broadcaster: independent
+  name: Dune Radio
+  streamUrl: https://stream.aiir.com/3phqulqckaguv?_=981158
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/192/649d16201b02a.png
+  homepage: https://www.duneradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 6597d969-eff4-424d-b2d5-37b25fd10285
+  changeuuid: 894586ff-6bdf-49c8-927e-3b9d32dbf335
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-first-radio-bounce-northeast
+  broadcaster: independent
+  name: "First radio bounce northeast "
+  streamUrl: https://www.friskradio.com:8443/stream41
+  codec: AAC
+  homepage: https://www.friskradio.com/?station=7
+  country: GB
+  status: stream-only
+  stationuuid: 67e86bb1-0f24-4bad-9ab8-007187c03ef0
+  changeuuid: 7a401e35-6b9a-498c-a180-ae31486ed3d0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-fuse-fm
+  broadcaster: independent
+  name: Fuse FM
+  streamUrl: https://streaming.radio.co/s53051f118/low
+  bitrate: 64
+  codec: MP3
+  favicon: https://fusefm.co.uk/wp-content/themes/yootheme/cache/1f/Logo-Transparent-1fa9e60d.webp
+  homepage: https://fusefm.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 243bae90-3218-4eab-897d-061d0e07e056
+  changeuuid: 6969502b-a44f-4bba-b34e-d4c1207ef8ba
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-global-breakfast-radio
+  broadcaster: independent
+  name: Global Breakfast Radio
+  streamUrl: https://globalbreakfastradio.com:8443/stream
+  codec: MP3
+  favicon: https://www.globalbreakfastradio.com/images/global-breakfast-radio.png
+  homepage: https://www.globalbreakfastradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 1b59e89b-7028-4710-8909-c6fe662adac1
+  changeuuid: b609b462-f24a-4742-b5a7-b72379e7c551
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hits-hull-east-york
+  broadcaster: independent
+  name: "Hits hull & East York"
+  streamUrl: https://listen-nation.sharp-stream.com/hull.mp3?aw_0_1st.playerid=BMUK_html5
+  bitrate: 128
+  codec: MP3
+  homepage: https://hellorayo.co.uk/hits-radio/
+  country: GB
+  status: stream-only
+  stationuuid: 3e41c90a-171f-4a17-a1c0-3516aa898d4a
+  changeuuid: 361ce3d6-40a1-4606-b0a8-3511075b48b7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-homemade-radio
+  broadcaster: independent
+  name: Homemade Radio
+  streamUrl: https://homemaderadio-brianager.radioca.st/;
+  bitrate: 320
+  codec: MP3
+  favicon: https://static.vecteezy.com/system/resources/thumbnails/001/933/723/small/radio-online-neon-signs-style-text-free-vector.jpg
+  homepage: https://homemade-radio.com/
+  country: GB
+  status: stream-only
+  stationuuid: acc196b2-0ad5-4024-840a-79283d590cf2
+  changeuuid: d07de684-2acd-4b32-8c09-8e3bfae488ba
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-house-radio-net
+  broadcaster: independent
+  name: House Radio Net
+  streamUrl: https://server.houseradio.net:8000/stream
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.houseradio.net/
+  country: GB
+  status: stream-only
+  stationuuid: 2e66059f-7c92-43bf-bbbf-6d92372e8d22
+  changeuuid: 7e2614bc-3df6-4c2b-9ef6-29c949a9ae81
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-keep-106
+  broadcaster: independent
+  name: KeeP 106
+  streamUrl: https://solid9.streamupsolutions.com/proxy/djcohrzp?mp=/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://keep106.com/wp-content/uploads/2020/02/imageedit_5_8575205827.png
+  homepage: https://keep106.com/
+  country: GB
+  status: stream-only
+  stationuuid: da5266f1-558a-4a5b-9911-d21b43e21c9c
+  changeuuid: 2c0f1faa-cf49-4160-86ae-3d558aef114d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-kfm-radio
+  broadcaster: independent
+  name: KFM Radio
+  streamUrl: https://s2.radio.co/s367e90f45/listen
+  bitrate: 128
+  codec: MP3
+  favicon: https://i0.wp.com/kfmradio.co.uk/wp-content/uploads/2022/09/KFM-logob-200.png?fit=200102&amp;ssl=1
+  homepage: https://kfmradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 35431197-daf1-4347-a71b-1aacf49336fd
+  changeuuid: edd791f4-b49c-4286-a57c-95c2a918bfae
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-lincs-sound
+  broadcaster: independent
+  name: Lincs Sound
+  streamUrl: https://stream.aiir.com/ubrzdpuap28vv
+  codec: AAC
+  favicon: https://mmo.aiircdn.com/2033/6861243b23677.jpg
+  homepage: https://www.lincssound.com/
+  country: GB
+  status: stream-only
+  stationuuid: 620a1ecc-3aae-47e9-bda8-63e263e9d552
+  changeuuid: 1382320d-98ac-4e37-b132-25b2d8373e17
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-love-will-save-the-day
+  broadcaster: independent
+  name: Love Will Save The Day
+  streamUrl: https://lovewillsavetheday.out.airtime.pro/lovewillsavetheday_a
+  bitrate: 128
+  codec: MP3
+  homepage: https://lovewillsavetheday.fm/
+  country: GB
+  status: stream-only
+  stationuuid: e9e6e838-a649-4b03-b955-0cf42be7c696
+  changeuuid: f84f1b14-b573-4906-88c8-3da9714b5f75
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-lushstarr-radio
+  broadcaster: independent
+  name: LushStarr Radio
+  streamUrl: https://cdn.voscast.com/resources/?key=5d34553745888466d26fc1cc83166d78&c=wmp
+  codec: UNKNOWN
+  favicon: https://compiled.ams3.cdn.digitaloceanspaces.com/profile_images/0FDEUXEQompwot5vyQTaBHD1y4M50wpAv2Pd9osJ.jpg
+  homepage: http://www.lushstarr.com/
+  country: GB
+  status: stream-only
+  stationuuid: f17a4cbf-132c-4370-8537-ef5b5cf77c79
+  changeuuid: 338859f7-2e91-42a5-890a-0fefac0d4511
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-mode-radio-london
+  broadcaster: independent
+  name: Mode Radio London
+  streamUrl: https://mode-london.radiocult.fm/stream
+  bitrate: 320
+  codec: MP3
+  homepage: https://mode.london/
+  country: GB
+  status: stream-only
+  stationuuid: 1aeda665-088f-45b1-abb4-f18c195bf24f
+  changeuuid: b77f474c-7b5e-4e8f-9366-b5a390c0fd69
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-only-hits-radio
+  broadcaster: independent
+  name: Only Hits Radio
+  streamUrl: https://stream4.themediasite.co.uk:8210/stream?_=328882
+  bitrate: 192
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/2016/68090c0a5a354.png
+  homepage: https://www.onlyhitsradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: c3a7c298-2af6-4bd9-a103-82876753178e
+  changeuuid: d09ad8c2-73c0-4106-b9e7-dee980e12152
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-prodigies-radio
+  broadcaster: independent
+  name: Prodigies Radio
+  streamUrl: https://polaris.nucast.co.uk:7580/stream
+  bitrate: 320
+  codec: MP3
+  homepage: https://polaris.nucast.co.uk/custom-player/7580#
+  country: GB
+  status: stream-only
+  stationuuid: d8f83528-d24c-4931-a45e-3e84900f6571
+  changeuuid: c03ebbe4-e4ec-40c1-964e-8068ab1ce1ac
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-frimley-park
+  broadcaster: independent
+  name: Radio Frimley Park
+  streamUrl: https://frimleypark.radioca.st/stream?icy=http
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.radiofrimleypark.co.uk/icons/favicon-256.png
+  homepage: https://www.radiofrimleypark.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 60d706f1-4d4e-48b8-b51e-e967eb8ff50c
+  changeuuid: 33f1d37a-2533-4423-8c10-8697a4ca58d4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-horton
+  broadcaster: independent
+  name: Radio Horton
+  streamUrl: https://radiohorton.radioca.st/;
+  bitrate: 128
+  codec: MP3
+  homepage: https://radiohorton.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 9894afea-8272-4be6-bc85-845913d54753
+  changeuuid: da3dfd6c-e5d8-4e5e-9a0b-7fa9f0b770da
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-north-angus
+  broadcaster: independent
+  name: Radio North Angus
+  streamUrl: https://uk3-vn.mixstream.net/8192/listen.mp3
+  bitrate: 48
+  codec: MP3
+  favicon: https://radionorthangus.co.uk/wp-content/uploads/2024/02/resize-homer.bk_.png-150x150.webp
+  homepage: https://radionorthangus.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 48a5cfff-edb9-4537-a686-526620663428
+  changeuuid: d884ba0e-c2d4-4c80-a73d-4208ed7f1c93
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-northumberland
+  broadcaster: independent
+  name: Radio Northumberland
+  streamUrl: https://northumberland.radioca.st/;
+  bitrate: 128
+  codec: MP3
+  favicon: https://cdn.instant.audio/images/logos/internetradiouk-com/northumberland.png
+  homepage: https://radionorthumberland.com/
+  country: GB
+  status: stream-only
+  stationuuid: 7e02f816-5237-48c2-850b-e4ba63a09181
+  changeuuid: eaa8a939-441c-46e5-966d-a0b8dee6fccb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-scarborough
+  broadcaster: independent
+  name: Radio Scarborough
+  streamUrl: https://s3.radio.co/s201b7a9d0/listen
+  bitrate: 64
+  codec: MP3
+  favicon: https://radioscarborough.com/wp-content/uploads/2023/01/cropped-Site-Icon-Final-32x32.png
+  homepage: https://radioscarborough.com/
+  country: GB
+  status: stream-only
+  stationuuid: 38b1773b-00f9-4add-98e7-d235ac6dd909
+  changeuuid: 4edde119-def8-49c7-bde2-648e7397a525
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-seahaven-fm-eastbourne
+  broadcaster: independent
+  name: Seahaven FM - Eastbourne
+  streamUrl: https://stream4.hippynet.co.uk:8002/stream?_=201701
+  bitrate: 170
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/892/63c550fe44a02.png
+  homepage: https://www.seahavenfm.radio/
+  country: GB
+  status: stream-only
+  stationuuid: 1717822e-1c1b-45ac-8054-286e33c47508
+  changeuuid: f5dd77f9-a87a-4860-9481-3ca8ebc2549f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-sine-fm
+  broadcaster: independent
+  name: Sine FM
+  streamUrl: https://uksoutha.streaming.broadcast.radio/sinefm?1716196689781=
+  codec: MP3
+  favicon: https://www.sinefm.com/wp-content/uploads/2019/11/sine-fm-logo-new-800.png
+  homepage: https://www.sinefm.com/
+  country: GB
+  status: stream-only
+  stationuuid: 89c3a2f7-4fe9-43b1-b078-d361dc0efd2a
+  changeuuid: e1f78ccb-b82e-449f-8a85-eccadf598653
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-skylab-radio
+  broadcaster: independent
+  name: Skylab Radio
+  streamUrl: https://uksoutha.streaming.broadcast.radio:29690/skylab-radio-limited
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/c558e3_a1b2627549444e919504fa15988a9f57~mv2.png/v1/fill/w_198,h_184,al_c,q_85,usm_0.66_1.00_0.01,enc_avif,quality_auto/c558e3_a1b2627549444e919504fa15988a9f57~mv2.png
+  homepage: https://uksoutha.streaming.broadcast.radio:29690/skylab-radio-limited
+  country: GB
+  status: stream-only
+  stationuuid: 24273571-703e-4373-b715-d7e7680d7599
+  changeuuid: 33062efc-d027-4e67-b07e-5f4d906f54ca
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-smooth-west-midlands
+  broadcaster: independent
+  name: Smooth West Midlands
+  streamUrl: https://media-ice.musicradio.com/SmoothWestMidsMP3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.smoothradio.com/westmids/assets_v4r/smooth/img/favicon32x32.png
+  homepage: https://www.smoothradio.com/westmids/
+  country: GB
+  status: stream-only
+  stationuuid: 82c9c402-34f2-42c9-8c85-2fc390f78f1c
+  changeuuid: 046f6672-1ee8-4aa7-b1bc-f183cff1206d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-source-fm
+  broadcaster: independent
+  name: Source FM
+  streamUrl: https://radio.canstream.co.uk:8144/live.mp3?1724162896961=
+  bitrate: 110
+  codec: MP3
+  favicon: https://api.broadcast.radio/api/image/d3661645-0ece-409b-b583-8d74b59c4bee.png?g=center&w=600&h=600&c=true
+  homepage: https://www.thesourcefm.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 6ab88aab-c71d-4008-81a3-ff3579f7e86e
+  changeuuid: faef1ef6-d096-415a-afa0-e01fd681f05b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-stu-allan-radio
+  broadcaster: independent
+  name: Stu Allan Radio
+  streamUrl: https://stream.stuallan.com/stream1
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.stuallan.com/
+  country: GB
+  status: stream-only
+  stationuuid: dde42b52-9dec-49ff-b49f-8dbf59085393
+  changeuuid: 68b9ff68-864a-4631-95d0-00e90dd05231
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-w-b-r-we-black-radio
+  broadcaster: independent
+  name: W.B.R. We Black Radio
+  streamUrl: https://s4.radio.co/safcfabd03/listen
+  bitrate: 192
+  codec: AAC
+  favicon: https://weblackradio.org/images/1534de6bf1609559b708e82ef57c76b2.png
+  homepage: https://weblackradio.org/
+  country: GB
+  status: stream-only
+  stationuuid: 37a34dcc-3cb0-4d58-a0ee-cb90aa1dd901
+  changeuuid: 8285840c-c1a0-453f-b6c6-a8eccf489919
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-banitamaxxradio
+  broadcaster: independent
+  name: BanitaMaxxRadio
+  streamUrl: https://ssl-1.radiohost.pl:9454/stream192
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.banitamaxx.pl/
+  country: GB
+  status: stream-only
+  stationuuid: e5ab1040-0166-4601-9463-11757da92006
+  changeuuid: 7e623f98-e2e2-498c-a714-7e4ea12a2be5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bath-sound
+  broadcaster: independent
+  name: Bath Sound
+  streamUrl: https://uksoutha.streaming.broadcast.radio/bathhr
+  codec: MP3
+  favicon: https://bathsound.radio/imgs/bs.png
+  homepage: https://bathsound.radio/
+  country: GB
+  status: stream-only
+  stationuuid: bc93004d-2fbd-4594-b82a-a45b79530d49
+  changeuuid: 23995508-6243-4fc2-8a87-998ccc61dab9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bbc-essex
+  broadcaster: independent
+  name: BBC Essex
+  streamUrl: https://as-hls-ww-live.akamaized.net/pool_23657270/live/ww/bbc_radio_essex/bbc_radio_essex.isml/bbc_radio_essex-audio%3d96000.norewind.m3u8
+  codec: UNKNOWN
+  favicon: https://sounds.files.bbci.co.uk/3.9.4/networks/bbc_radio_essex/colour_default.svg
+  homepage: https://www.bbc.co.uk/sounds/play/live/bbc_radio_essex
+  country: GB
+  status: stream-only
+  stationuuid: 2219b9dd-7385-4e3e-ab8b-2c76a2bce90e
+  changeuuid: f383d93f-d3bf-4227-a256-4d397e2aabd9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-blastfm-internet-radio-station
+  broadcaster: independent
+  name: BlastFM Internet Radio Station
+  streamUrl: https://blastfm.net:8000/live
+  bitrate: 320
+  codec: MP3
+  favicon: https://blastfmsocial.media/stations/logo/blastfm.jpg
+  homepage: https://blastfmsocial.media/BlastFMRadio
+  country: GB
+  status: stream-only
+  stationuuid: 094d7d86-e509-4f20-a4d4-ece206c1bca2
+  changeuuid: b78f797f-07c0-491f-b073-fcb6b9f611db
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-chiltern-voice-fm
+  broadcaster: independent
+  name: Chiltern Voice FM
+  streamUrl: https://radio.entertainmenttechnologies.co.uk:8020/chilternvoice.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.chilternvoice.fm/wp-content/uploads/2024/02/Chiltern-Voice-Header-Logo-340x156-1.png
+  homepage: https://www.chilternvoice.fm/
+  country: GB
+  status: stream-only
+  stationuuid: 86982463-f289-4336-af13-9bf77a151196
+  changeuuid: 9aaecfcc-785d-43f7-ba9a-40be08bf97e6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-chon-98-1
+  broadcaster: independent
+  name: CHON 98.1
+  streamUrl: https://stream.chonfm.com:8042/stream
+  bitrate: 73
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/209/5fd529540c0f8.gif
+  homepage: https://www.chonfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: f263c982-81c9-49a1-bfee-9966907600ae
+  changeuuid: 6ac7dd99-44d9-4109-aee1-9850762110d8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-country-gospel-radio
+  broadcaster: independent
+  name: Country Gospel Radio
+  streamUrl: https://solid24.streamupsolutions.com/proxy/agtzpadc/stream
+  bitrate: 128
+  codec: MP3
+  homepage: https://countrygospelradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: c82c3825-934e-44a6-bbb6-df26d1b463ab
+  changeuuid: 02d665d7-404d-4873-a376-acf96ec9ef02
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-east-point-radio
+  broadcaster: independent
+  name: East Point Radio
+  streamUrl: https://streaming.radio.co/s3c76b154e/listen
+  bitrate: 128
+  codec: MP3
+  favicon: https://cdn.onlineradiobox.com/img/l/7/64737.v7.png
+  homepage: https://eastpointradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: effe5195-2465-4f05-a985-6bb1139feae5
+  changeuuid: 0c332535-dcb5-412b-a636-dafbf42d338b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-essex-radio
+  broadcaster: independent
+  name: Essex Radio
+  streamUrl: https://stream.essex.radio:8060/radio.mp3
+  bitrate: 128
+  codec: AAC
+  favicon: https://essex.radio/logo.png
+  homepage: https://essex.radio/
+  country: GB
+  status: stream-only
+  stationuuid: ec33435b-edb1-414b-8b77-6130d8980685
+  changeuuid: 05f9af57-fadb-4d5c-8af0-7e1464b6f387
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-fcr-plymouth
+  broadcaster: independent
+  name: FCR Plymouth
+  streamUrl: https://streams.radio.co/sde86bbbbf/low
+  bitrate: 64
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/0ff480_674875e451e6439dba6219a3aad51f2b%7Emv2.png/v1/fill/w_180%2Ch_180%2Clg_1%2Cusm_0.66_1.00_0.01/0ff480_674875e451e6439dba6219a3aad51f2b%7Emv2.png
+  homepage: https://www.fcradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 5e3c552a-4be6-4092-bcd4-c8d38fcd791e
+  changeuuid: 13032fff-0186-4dcd-a1a0-39b614b15049
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-frisky-radio
+  broadcaster: independent
+  name: Frisky Radio
+  streamUrl: https://stream.frisky.friskyradio.com/
+  bitrate: 96
+  codec: MP3
+  homepage: http://friskyradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 82107bab-3030-4aca-b0e0-6ccf82d7f965
+  changeuuid: 3c3559f2-bb11-42bd-bf23-217ca00caa41
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-frome-fm
+  broadcaster: independent
+  name: Frome FM
+  streamUrl: https://icecast2.bargus.co.uk:8001/fromefm.mp3
+  bitrate: 120
+  codec: MP3
+  favicon: https://cdn.prod.website-files.com/65c3a3799d14b21f3710d0b4/66827a1d55ff35d4200e0849_FromeFMIcon-256.png
+  homepage: https://www.frome.fm/
+  country: GB
+  status: stream-only
+  stationuuid: 7af80d4e-1137-4617-9afc-cd1faa624852
+  changeuuid: 581364a4-a352-40ae-8c8c-cb5bcb0045e4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-green-radio
+  broadcaster: independent
+  name: Green Radio
+  streamUrl: https://gains.reviveradio.net/proxy/greenradio?mp=/stream
+  bitrate: 256
+  codec: MP3
+  homepage: https://greenradiolive.com/
+  country: GB
+  status: stream-only
+  stationuuid: 090a5ec5-11a5-4b36-8a87-edb2bd4f55e7
+  changeuuid: 19be10f2-167a-4e05-9f4c-c65b3949349b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-halesowen-town
+  broadcaster: independent
+  name: Halesowen Town
+  streamUrl: https://s3.radio.co/s75a8968ca/listen
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radiohalesowentown.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 0ec08342-14de-456f-b702-4708973fbb82
+  changeuuid: 4c74c462-d44a-4bef-b400-b61c8b83174c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hereford-fc
+  broadcaster: independent
+  name: Hereford FC
+  streamUrl: https://stream.radio.co/s025ead1b9/listen
+  bitrate: 96
+  codec: MP3
+  favicon: https://www.herefordfc.co.uk/wp-content/uploads/2015/05/RADIO-HEREFORD-FC.png
+  homepage: https://www.herefordfc.co.uk/radio-hereford-fc/
+  country: GB
+  status: stream-only
+  stationuuid: f74496eb-561a-496b-aa23-e83340a290c8
+  changeuuid: a74a0925-fb18-4cce-9d4c-0ded0277ec48
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hits-radio-uk
+  broadcaster: independent
+  name: Hits Radio UK
+  streamUrl: https://stream-al.hellorayo.co.uk/key.aac?aw_0_1st.skey=1602676850&direct=true&rp_source=1
+  bitrate: 47
+  codec: AAC+
+  homepage: https://www.hellorayo.co.uk/hits-radio
+  country: GB
+  status: stream-only
+  stationuuid: 0f8f58d2-07e3-4ddb-af14-918a3e90369a
+  changeuuid: cc8eae61-b0e2-4ef9-8a38-f70be2b0df4c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-jorvik-radio
+  broadcaster: independent
+  name: Jorvik Radio
+  streamUrl: https://uksoutha.streaming.broadcast.radio:24780/jorvikradio?_=21939
+  bitrate: 320
+  codec: AAC
+  favicon: https://mmo.aiircdn.com/533/661fa1000a560.png
+  homepage: https://www.jorvikradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: e6b8ff04-31c5-4062-a466-fd67a8630345
+  changeuuid: 1e24029d-1b3d-47eb-8995-d7144c83e3cf
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-keep-the-faith-internet-radio
+  broadcaster: independent
+  name: Keep The Faith Internet Radio
+  streamUrl: https://mars.streamerr.co/8060/stream
+  bitrate: 320
+  codec: MP3
+  homepage: https://keepthefaithinternetradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: c7633ceb-f221-4750-a020-83f8116ac631
+  changeuuid: bb7d9ad4-0044-4050-9120-b7f8e08219c1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-line-out-radio
+  broadcaster: independent
+  name: Line Out Radio
+  streamUrl: https://play.radioking.io/line-out-radio
+  bitrate: 128
+  codec: MP3
+  favicon: http://lineoutradio.com/wp-content/uploads/2021/06/LINEOUTLOGO-e1623077715840.png
+  homepage: http://lineoutradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 2278ce5d-e587-409a-8fd9-a64b8b67d78b
+  changeuuid: ad49140b-cc22-4e34-b5ed-3a165890a172
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-london-house-radio-ldn-house-radio
+  broadcaster: independent
+  name: London House Radio (LDN House Radio)
+  streamUrl: https://stream.ldnhouseradio.net/listen/live/radio.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://ldnhouseradio.net/wp-content/uploads/2024/06/cropped-logo-round-500-favicon-1-180x180.png
+  homepage: https://ldnhouseradio.net/
+  country: GB
+  status: stream-only
+  stationuuid: 732b0e4d-575e-4bd0-9fc8-a4e9eefa5087
+  changeuuid: 144e1c22-25ef-4e87-abc3-da20ee0bc2b9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-luna-radio-reborn-mp3
+  broadcaster: independent
+  name: Luna Radio Reborn (mp3)
+  streamUrl: https://luna.ponyvillefm.com/listen/lunaradio/radio.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: http://luna.ponyvillefm.com/api/station/lunaradio/art/f3b23e8f636f5abd2dafbafb
+  homepage: https://luna.ponyvillefm.com/public/lunaradio
+  country: GB
+  status: stream-only
+  stationuuid: 29476414-c26c-4e2e-92a9-82fe10d6e64b
+  changeuuid: 9ed05375-68ba-4f53-b8be-4a73590f6c93
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-m4d-radio-mix
+  broadcaster: independent
+  name: M4D Radio Mix
+  streamUrl: https://s2.radio.co/s07cd038f1/listen
+  bitrate: 192
+  codec: MP3
+  favicon: https://m4dradio.com/wp-content/uploads/2020/05/cropped-m4dradiologo.png
+  homepage: https://m4dradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 65d9541a-ce23-4c29-a8ba-b03fcc36b390
+  changeuuid: 91c450e7-ca06-4c64-a4db-30d6f3a8bfb1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-meridian-fm-107
+  broadcaster: independent
+  name: Meridian FM 107
+  streamUrl: https://uksoutha.streaming.broadcast.radio/meridianfm
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.meridianfm.com/favicon.ico?i=423
+  homepage: https://www.meridianfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: 5710512c-33f0-4f8d-900d-8a435291fd17
+  changeuuid: deba5f0e-fcc8-496d-a1d2-b966d5dee97f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-morley-radio
+  broadcaster: independent
+  name: Morley Radio
+  streamUrl: https://s2.radio.co/sb0e9a4581/low
+  bitrate: 64
+  codec: AAC
+  homepage: https://morleyradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 625c8b79-6fc0-40c3-a3a1-d5e4440923fc
+  changeuuid: 906574b0-a4b1-42be-892b-421e15bd7642
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-oc-radio
+  broadcaster: independent
+  name: OC Radio
+  streamUrl: https://stream.digilinkconnect.co.uk:2020/stream/oldhamcollegeradio
+  bitrate: 192
+  codec: AAC
+  homepage: https://www.oldham.ac.uk/college-life/oc-radio/
+  country: GB
+  status: stream-only
+  stationuuid: a3c00e6b-90f5-4451-a50e-34938c9a9ba8
+  changeuuid: bd90faf6-02ec-437f-a743-2b50b04e795e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-osn-fm
+  broadcaster: independent
+  name: OSN.fm
+  streamUrl: https://stream.stuallan.com/stream2
+  bitrate: 128
+  codec: MP3
+  favicon: http://osn.fm/img/OSN-Radio-PNG.png
+  homepage: https://osn.fm/
+  country: GB
+  status: stream-only
+  stationuuid: abb88853-2058-4abf-879a-9f1a75fb077b
+  changeuuid: 9d5c74df-495b-45c0-9d72-d43f3f841304
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-panacea-radio
+  broadcaster: independent
+  name: Panacea Radio
+  streamUrl: https://stream-15.aiir.com/kqwcuxfxcwhtv?zt=eyJhbGciOiJIUzI1NiJ9.eyJzdHJlYW0iOiJrcXdjdXhmeGN3aHR2IiwiaG9zdCI6InN0cmVhbS0xNS5haWlyLmNvbSIsInJ0dGwiOjUsImp0aSI6IjVkMTNteVlIU0FXNE5STXpWNEdZeFEiLCJpYXQiOjE3Njg2MDczMzksImV4cCI6MTc2ODYwNzM5OX0.IvvTX4vVuMyuvTvxJQTRNTahLXGSgOeVK3c4JGax0ds
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/515/64c0e1942de5b.jpg
+  homepage: https://www.panacearadio.net/
+  country: GB
+  status: stream-only
+  stationuuid: 467645a7-06bc-4762-9b2a-128cc9bfb081
+  changeuuid: 207a3f81-8348-486b-819c-c6404df01696
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-persian-vibe-radio
+  broadcaster: independent
+  name: Persian Vibe Radio
+  streamUrl: https://radio.aydayazdani.com/stream
+  bitrate: 192
+  codec: MP3
+  favicon: https://radio.aydayazdani.com/assets/img/pvr-logo.png
+  homepage: https://radio.aydayazdani.com/
+  country: GB
+  status: stream-only
+  stationuuid: e55150cf-f6bd-44ea-9f66-0a00dc88c8f0
+  changeuuid: edef9c50-d859-4c30-80e4-d1319ee0c6f3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-phasefm
+  broadcaster: independent
+  name: PhaseFM
+  streamUrl: https://azuracast.clubhits.uk/listen/phasefm/radio.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://phasefm.co.uk/wp-content/uploads/2025/07/clubhitsuk-variety-mix-mytuner-logo.png
+  homepage: https://phasefm.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: bf450fc3-a276-432c-95c5-98e295cc79a9
+  changeuuid: 03cd7bbe-0ecc-4c5b-ae70-4b194c699c78
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-prince-bishops-hospital-radio
+  broadcaster: independent
+  name: Prince Bishops Hospital Radio
+  streamUrl: https://pbhr.radioca.st/stream
+  bitrate: 48
+  codec: AAC
+  favicon: https://www.pbhr.org.uk/wp-content/uploads/2017/01/logo-mic.png
+  homepage: https://www.pbhr.org.uk/#
+  country: GB
+  status: stream-only
+  stationuuid: 6b563d41-f29d-4639-9731-63fd3811b291
+  changeuuid: 62f46dfb-e596-4c61-9b7d-6d2450d5b4eb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-bronglais
+  broadcaster: independent
+  name: Radio Bronglais
+  streamUrl: https://stream.radiobronglais.cymru/stream?ver=92941
+  bitrate: 128
+  codec: MP3
+  homepage: https://radiobronglais.cymru/
+  country: GB
+  status: stream-only
+  stationuuid: c8855dde-af56-4d94-9940-0c43ef867054
+  changeuuid: 99b8ff2d-97ab-434f-ab8f-14d717c73a49
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-hartlepool
+  broadcaster: independent
+  name: Radio Hartlepool
+  streamUrl: https://server.radiohartlepool.co.uk:8443/hartlepool-mp3
+  bitrate: 64
+  codec: MP3
+  favicon: https://radiohartlepool.co.uk/wp-content/uploads/2023/01/cropped-RHlogo.jpg
+  homepage: https://radiohartlepool.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: ec89e9a0-0d5e-48f6-b735-8d256c400dc6
+  changeuuid: c5a8a888-985e-4092-a396-efc64eb73c53
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-wigwam
+  broadcaster: independent
+  name: Radio Wigwam
+  streamUrl: https://streaming.broadcast.radio/radio-wigwam
+  codec: MP3
+  favicon: https://radiowigwam.co.uk/wp-content/uploads/2024/08/wiwamnewdark.jpg.webp
+  homepage: https://radiowigwam.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: b876aaf5-bd27-4576-927c-802acd73b4ae
+  changeuuid: 99206212-07e7-4962-889b-a64619d6e675
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-wimborne
+  broadcaster: independent
+  name: Radio Wimborne
+  streamUrl: https://radio.canstream.co.uk:8057/live.mp3
+  bitrate: 320
+  codec: MP3
+  homepage: https://www.radiowimborne.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: acf8c0e5-ca3c-4b95-a4f2-ce5b49d5a0d9
+  changeuuid: f6adf3fc-b2c6-49cd-a93f-792fc5798976
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-woking
+  broadcaster: independent
+  name: Radio Woking
+  streamUrl: https://radiowoking.radioca.st/stream?rp_source=1&=&&___cb=821829812672569
+  bitrate: 192
+  codec: MP3
+  favicon: http://www.radiowoking.co.uk/wp-content/uploads/2014/05/radiowokingwebhead7new75x360.gif
+  homepage: https://www.radiowoking.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 51d08647-970d-4b50-851a-36a7db5e7ddd
+  changeuuid: 2f1138c0-97f4-49a8-aad6-0ac9a2a785b8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radiorosak
+  broadcaster: independent
+  name: RADIOROSAK
+  streamUrl: https://stream.rcast.net/68127
+  bitrate: 48
+  codec: AAC+
+  homepage: http://radiorosak.com/
+  country: GB
+  status: stream-only
+  stationuuid: 11464b95-3766-44c6-bfdc-4d75ae8e9a5c
+  changeuuid: a55b1c8e-6cd9-4caf-ae14-241503e8e5da
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-ramsgate-radio
+  broadcaster: independent
+  name: Ramsgate Radio
+  streamUrl: https://play.radioking.io/ramsgate-radio1/610934
+  bitrate: 192
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/d883a7_649474a2c070450396a7c3d08a5ce624%7Emv2.png/v1/fill/w_180%2Ch_180%2Clg_1%2Cusm_0.66_1.00_0.01/d883a7_649474a2c070450396a7c3d08a5ce624%7Emv2.png
+  homepage: https://www.ramsgateradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 77076065-4635-4dff-b388-eebe413436b7
+  changeuuid: c7c5f1e4-a540-43cd-984e-e6c571795bda
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-shine-radio
+  broadcaster: independent
+  name: Shine Radio
+  streamUrl: https://listen-petersfield.sharp-stream.com/petersfield.aac
+  bitrate: 96
+  codec: AAC+
+  favicon: https://shineradio.uk/wp-content/uploads/2020/08/shine_logo_primary_d_rgb_01_crop.jpg
+  homepage: https://shineradio.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 351f1709-0c4f-4058-baf1-b63114f75a4d
+  changeuuid: 2ad282e4-dbc7-4560-8864-9462135d0cab
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-smooth-grooving-radio
+  broadcaster: independent
+  name: Smooth Grooving Radio
+  streamUrl: https://sgr.lucasmultimedia.com/stream.ogg
+  bitrate: 128
+  codec: MP3
+  favicon: http://smoothgrooving.com/favicon-1.ico
+  homepage: http://smoothgrooving.com/
+  country: GB
+  status: stream-only
+  stationuuid: 2180fcff-befa-4ab1-bd30-93176bf16355
+  changeuuid: 6b56c14e-fd13-45fe-8268-7f41707b0f49
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-somervalley-fm
+  broadcaster: independent
+  name: Somervalley fm
+  streamUrl: https://stream4.hippynet.co.uk:8014/stream
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.somervalleyfm.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 72ce8ddd-2376-403e-ad7b-1ec618b1a2d1
+  changeuuid: c1135e0c-a130-4a3a-9234-0b0544d5a79a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-southern-roots-radio
+  broadcaster: independent
+  name: Southern Roots Radio
+  streamUrl: https://uksoutha.streaming.broadcast.radio/southern-roots-radio.mp3
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/4a71bd_d0a57c5ed62c4a8fbaee7ce942611b60~mv2.png/v1/fill/w_242,h_242,al_c,q_85,usm_0.66_1.00_0.01,enc_avif,quality_auto/1000022871-Photoroom.png
+  homepage: https://www.southern-roots.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: a5609ff9-523f-4a65-970d-98a0ec729b5e
+  changeuuid: 00bddb73-1570-4a03-8024-5b38f947586e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-spotlight-radio
+  broadcaster: independent
+  name: Spotlight Radio
+  streamUrl: https://stream1.hippynet.co.uk:8075/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://l5.tm-web-01.co.uk/img/fav/favicon-1024-167.png
+  homepage: https://www.spotlightradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 8031b69b-b4e3-402f-bcec-8ee985f29299
+  changeuuid: 14b6efb4-f93c-442d-a81e-25a41ffa87c6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-subcity-radio
+  broadcaster: independent
+  name: Subcity Radio
+  streamUrl: https://stream.subcity.org/listen
+  bitrate: 320
+  codec: MP3
+  favicon: https://f4.bcbits.com/img/a1309017338_10.jpg
+  homepage: https://www.subcity.org/
+  country: GB
+  status: stream-only
+  stationuuid: 2a5af2b2-dc8a-4d1a-91b9-a491022b5f59
+  changeuuid: d8a36509-1417-45a2-8bdb-2166abf752c4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-teenbuzz-radio
+  broadcaster: independent
+  name: Teenbuzz Radio
+  streamUrl: https://streaming.broadcast.radio/teenbuzzradio?1744351024052=
+  codec: MP3
+  favicon: https://teenbuzzradio.com/wp-content/uploads/2020/06/logo.png
+  homepage: https://teenbuzzradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 1d7eb550-4f76-4ad5-a7bc-95b69ef33ce3
+  changeuuid: b4221e7e-e23f-441a-b2f1-b247b2d72110
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-the-gates-radio-station
+  broadcaster: independent
+  name: The Gates Radio Station
+  streamUrl: https://thegatesradio.co.uk/listen/the_gates_radio_station/radio.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.thegates.bolton.sch.uk/images/favicon_2.ico
+  homepage: https://www.thegates.bolton.sch.uk/page/the-gates-radio/135355
+  country: GB
+  status: stream-only
+  stationuuid: b6c8bda6-6827-4564-8544-5d995d44a837
+  changeuuid: 091d219c-fd96-41fb-a467-0bb8264fb792
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-the-void-underground-music-radio
+  broadcaster: independent
+  name: The Void – Underground Music Radio
+  streamUrl: https://thevoidrad.io/stream320
+  bitrate: 128
+  codec: AAC
+  favicon: https://thevoidrad.io/favicon.ico
+  homepage: https://thevoidrad.io/
+  country: GB
+  status: stream-only
+  stationuuid: 690e7bc2-b96c-400c-951d-d1226a9e7103
+  changeuuid: eb78bff6-8fcd-42b2-a164-9d4495820bed
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-ugnjamz
+  broadcaster: independent
+  name: ugnjamz
+  streamUrl: https://streaming.live365.com/a27539
+  bitrate: 128
+  codec: MP3
+  favicon: https://ugnjamz.com/wp-content/uploads/2020/06/UGN-LOGO.png
+  homepage: https://ugnjamz.com/
+  country: GB
+  status: stream-only
+  stationuuid: 5029176e-8a24-4c75-bdff-37030400251e
+  changeuuid: d1f7ac9e-ae82-4996-ae54-50b7ea512994
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-venture-radio
+  broadcaster: independent
+  name: Venture Radio
+  streamUrl: https://streamz.anytek.co.uk/proxy/tracla00
+  bitrate: 128
+  codec: MP3
+  favicon: https://is1-ssl.mzstatic.com/image/thumb/Music211/v4/03/b0/e2/03b0e211-be78-5e79-815b-dc2961e40f40/13UABIM53820.rgb.jpg/600x600bb.jpg
+  homepage: https://www.ventureradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: fc52f984-2e93-40e0-ace2-2de4a6c851a5
+  changeuuid: c1ee3800-2626-4d9d-9c9b-73ffbb071fff
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-6-towns-radio
+  broadcaster: independent
+  name: "6 Towns Radio"
+  streamUrl: https://stream-14.aiir.com/z7drhoivbpbuv?zt=eyJhbGciOiJIUzI1NiJ9.eyJzdHJlYW0iOiJ6N2RyaG9pdmJwYnV2IiwiaG9zdCI6InN0cmVhbS0xNC5haWlyLmNvbSIsInJ0dGwiOjUsImp0aSI6IjhROHpmZWlKVE1hWi1pdnUxdGRtVXciLCJpYXQiOjE3NjkwMzIxOTcsImV4cCI6MTc2OTAzMjI1N30.Lw7Duueb_YYvm7nI82EU1lRAlrd9NHH1ahB4WANmiaU
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/1209/656101b604916.png
+  homepage: https://www.6towns.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: fc8ba7fc-045b-4d48-abbd-e0ca8af95ae9
+  changeuuid: 5b8e15bd-55a7-49b6-9cad-5cd0cf0bf2f6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bbc-radio-berkshire
+  broadcaster: independent
+  name: BBC Radio Berkshire
+  streamUrl: https://as-hls-ww-live.akamaized.net/pool_64162474/live/ww/bbc_radio_berkshire/bbc_radio_berkshire.isml/dash/bbc_radio_berkshire-audio%3d96000.norewind.m3u8
+  codec: UNKNOWN
+  favicon: https://sounds.files.bbci.co.uk/3.9.4/networks/bbc_radio_berkshire/colour_default.svg
+  homepage: https://www.bbc.co.uk/sounds/play/live/bbc_radio_berkshire
+  country: GB
+  status: stream-only
+  stationuuid: a7ef6a83-6f6a-4d43-9862-f7fc6da34868
+  changeuuid: 12c38b98-0c9f-4192-96a3-dc8a02b26da9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bbc-radio-bristol
+  broadcaster: independent
+  name: BBC Radio Bristol
+  streamUrl: https://as-hls-ww-live.akamaized.net/pool_41858929/live/ww/bbc_radio_bristol/bbc_radio_bristol.isml/dash/bbc_radio_bristol-audio%3d96000.norewind.m3u8
+  codec: UNKNOWN
+  favicon: https://sounds.files.bbci.co.uk/3.9.4/networks/bbc_radio_bristol/colour_default.svg
+  homepage: https://www.bbc.co.uk/sounds/play/live/bbc_radio_bristol
+  country: GB
+  status: stream-only
+  stationuuid: 6fcd453e-eea0-4c84-abb5-4f7a2f5967a1
+  changeuuid: 865ac1d6-8717-416c-b7a1-8378948cf61b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bbc-radio-hereford-and-worcester
+  broadcaster: independent
+  name: BBC Radio Hereford and Worcester
+  streamUrl: https://as-hls-ww-live.akamaized.net/pool_80112859/live/ww/bbc_radio_hereford_worcester/bbc_radio_hereford_worcester.isml/bbc_radio_hereford_worcester-audio%3d96000.norewind.m3u8
+  codec: UNKNOWN
+  favicon: https://sounds.files.bbci.co.uk/3.9.4/networks/bbc_radio_hereford_worcester/colour_default.svg
+  homepage: https://www.bbc.co.uk/sounds/play/live/bbc_radio_hereford_worcester
+  country: GB
+  status: stream-only
+  stationuuid: 5e27d6db-bb84-44d4-a5de-9f79a35cb3fd
+  changeuuid: a8e13aee-63ec-43f6-8b61-4a5b58aaf454
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bombshell-radio
+  broadcaster: independent
+  name: Bombshell Radio
+  streamUrl: https://s8.ssl-stream.com:1175/stream
+  bitrate: 192
+  codec: MP3
+  favicon: https://bombshellradio.com/wp-content/uploads/2025/03/originalFile-bombshell-radio-1-2-370x370.jpg
+  homepage: https://bombshellradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 0ec6e73e-3e92-4b30-bad9-5368855a19f4
+  changeuuid: d7f3d488-415d-4889-bf42-2cb9e0420afb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-broadland-radio
+  broadcaster: independent
+  name: Broadland Radio
+  streamUrl: https://arqiva-broadlandradio-live-a.edge.audiocdn.com/10002_128mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://static.mytuner.mobi/media/tvos_radios/401/broadland.8c715f56.png
+  homepage: https://broadlandradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 6db3261f-5e04-4ba8-b373-8bf4371a52f8
+  changeuuid: 6c2c6d15-05fa-49bb-8bbb-33ee86ffdafc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bucks-radio
+  broadcaster: independent
+  name: Bucks Radio
+  streamUrl: https://n01.radiojar.com/f6mru9artg0uv?_=745309&rj-tok=AAABihJa1SMABODPIDh9C1t79A&rj-ttl=5
+  codec: MP3
+  homepage: https://www.bucks.radio/
+  country: GB
+  status: stream-only
+  stationuuid: e7a31f94-a0f0-4579-b05c-1788b4412b6f
+  changeuuid: 86c49a68-d909-481e-9b10-5ad1c7a23eb0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-burton-radio
+  broadcaster: independent
+  name: Burton Radio
+  streamUrl: https://s9.citrus3.com:8370/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://images.squarespace-cdn.com/content/v1/6589f8f0f6168a1963a4d06a/19ba74fd-da8c-4021-a0a5-f6f52489492c/BR-512.png?format=1500w
+  homepage: https://www.burtonradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: ee6bf032-02b8-4e47-a9bb-5eea57e102ce
+  changeuuid: 86d72a1e-eab1-48b4-b65f-51ff353cde17
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-cheesy-fm
+  broadcaster: independent
+  name: Cheesy FM
+  streamUrl: https://n27a-eu.rcs.revma.com/8ebhfmak44uvv?rj-ttl=5&rj-tok=AAABnbAucYoA8uoxbTFltYIAvg
+  codec: AAC
+  favicon: https://mmo.aiircdn.com/520/61a8cce0e4cbb.jpg
+  homepage: https://www.cheesyfm.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 967986ba-926e-4e9f-87d5-d59bc8a2b2ce
+  changeuuid: fe917c28-5ae1-47df-afd6-a2dbe0dd434d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-dales-radio
+  broadcaster: independent
+  name: Dales Radio
+  streamUrl: https://stream3.themediasite.co.uk:8364/stream?_=690543
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.dalesradio.co/
+  country: GB
+  status: stream-only
+  stationuuid: fbc03689-d06e-4e98-8e9e-cda2e5b16f6d
+  changeuuid: 20ffe501-3f4c-4cb9-bcef-dbaddf1b925e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-drums-radio
+  broadcaster: independent
+  name: Drums Radio
+  streamUrl: https://streams.radio.co/sa75718856/listen
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.drumsradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 2e6c9977-2894-48d2-96ba-433f297d458f
+  changeuuid: ec6b94b1-1775-4ec9-9c23-c88e7da4c9b0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-forest-one
+  broadcaster: independent
+  name: Forest One
+  streamUrl: https://c2.prostream365.com:8010/live
+  bitrate: 128
+  codec: AAC
+  favicon: https://static.mytuner.mobi/media/tvos_radios/469/forest-one.fee679cd.png
+  homepage: https://www.forestradiouk.com/forestone
+  country: GB
+  status: stream-only
+  stationuuid: 5dff8400-38f8-4500-bac7-f65fa9b364d2
+  changeuuid: c084e011-0ea9-4203-a898-3a5a654478b0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-frisky-radio-classics
+  broadcaster: independent
+  name: Frisky Radio Classics
+  streamUrl: https://stream.classics.friskyradio.com/
+  bitrate: 96
+  codec: MP3
+  homepage: http://friskyradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: c30c3ab0-3729-4e82-8f15-d60ad4b22015
+  changeuuid: 796bec5c-3266-4aec-bd01-80eb76d04063
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-genesis-radio-birmingham
+  broadcaster: independent
+  name: Genesis Radio Birmingham
+  streamUrl: https://cast5.my-control-panel.com/proxy/grb/stream
+  bitrate: 128
+  codec: MP3
+  homepage: https://genesisradiobirmingham.com/
+  country: GB
+  status: stream-only
+  stationuuid: 69b2e14a-da22-41f8-bc09-1d31e79c3bd5
+  changeuuid: 29899099-408b-4a2f-84b6-26cad1c6f9a9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-goodnight-sweetheart-radio
+  broadcaster: independent
+  name: Goodnight Sweetheart Radio
+  streamUrl: https://a3.asurahosting.com/listen/goodnight_sweetheart_radio/radio.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: https://a3.my-control-panel.com/station/648
+  country: GB
+  status: stream-only
+  stationuuid: ee787566-73fd-4e5a-95d0-6f41cab6560e
+  changeuuid: 60adee7d-ae8e-4178-b40e-360592aceb02
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-groove-genie-radio
+  broadcaster: independent
+  name: Groove Genie Radio
+  streamUrl: https://groove-genie.co.uk/listen/groove_genie_radio/radio.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://i0.wp.com/groovegenieradio.com/wp-content/uploads/2023/05/Groove-Genie-Radio-Logo-512x512-1.png?resize=370%2C370&ssl=1
+  homepage: https://groovegenieradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 3bd72187-1567-4125-a80c-e206ce33fc62
+  changeuuid: dfa296e6-575c-4afb-a036-3fab6f334721
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-high-peak-1
+  broadcaster: independent
+  name: High Peak 1
+  streamUrl: https://stream3.themediasite.co.uk:8260/stream
+  bitrate: 192
+  codec: MP3
+  favicon: https://highpeak1.co.uk/wp-content/uploads/2024/03/LogoJpg-370x370.jpg
+  homepage: https://highpeak1.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 62de15bc-c199-46fc-8c9b-9b3e20be9f73
+  changeuuid: 0c0f260c-1534-4575-b323-0ec38351e8bf
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hits-radio-london
+  broadcaster: independent
+  name: Hits Radio London
+  streamUrl: https://stream-mz.hellorayo.co.uk/net1london.aac?aw_0_1st.skey=1602676850&direct=true&rp_source=1
+  bitrate: 47
+  codec: AAC+
+  favicon: https://media.bauerradio.com/image/upload/c_crop,g_custom/v1713275588/brand_manager/stations/nbcsqhgitwccojxtwfxn.svg
+  homepage: https://www.hellorayo.co.uk/hits-radio/london
+  country: GB
+  status: stream-only
+  stationuuid: ab6eb0b5-2b70-4412-b226-478945fb5edc
+  changeuuid: b5900e1e-eec7-48b1-9782-adbbe3473ee8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-inside-the-gates-radio
+  broadcaster: independent
+  name: Inside The Gates Radio
+  streamUrl: https://s2.radio.co/s98e7a2900/listen
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.insidethegatesradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 192df41d-f2bd-49ee-b68a-a8485c791992
+  changeuuid: 99d17217-5cfd-4ed8-929d-220f1e7189c8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-itisnow-radio
+  broadcaster: independent
+  name: itisnow Radio
+  streamUrl: https://stream.radio.co/sc41e33712/listen
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.itisnowradio.com/uploads/1/4/5/0/145020825/logo-web.jpg
+  homepage: https://www.itisnowradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 48a01798-4b20-41c5-b2c6-312e74cf6d79
+  changeuuid: c7b5adeb-cbb7-41fa-8c64-6bb0631f772a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-kic-radio
+  broadcaster: independent
+  name: KIC Radio
+  streamUrl: https://stream.aiir.com/nbgvn4hgyrxuv
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/1333/692847fae5e8f.jpg
+  homepage: https://www.kicradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: bea75dee-0290-4e7d-aaa7-138ea7d5d75c
+  changeuuid: b91cbf12-99ba-4877-b1bc-d7519efc6b37
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-laser-gold
+  broadcaster: independent
+  name: Laser Gold
+  streamUrl: https://stream1.hippynet.co.uk:8067/stream
+  bitrate: 128
+  codec: AAC
+  favicon: https://primary.jwwb.nl/public/t/a/i/temp-dozjcpvcaeqpdalqxwlr/205-high.jpg?enable-io=true&crop=1%3A1&width=816
+  homepage: https://www.laserinternational.co.uk/laser-gold
+  country: GB
+  status: stream-only
+  stationuuid: fc39e429-4066-40ae-a799-2e0ab159a69a
+  changeuuid: 37c55fac-de1f-46f4-9c2d-fb142d7977dc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-mix-fm-glasgow
+  broadcaster: independent
+  name: Mix FM - Glasgow
+  streamUrl: https://radio.mixfmonline.com:8443/listen/mix_fm/radio.aac
+  bitrate: 64
+  codec: AAC
+  favicon: https://www.mixfm.pro/wp-content/uploads/2024/06/NEW-LOGO-768x186.png
+  homepage: https://www.mixfmglasgow.com/
+  country: GB
+  status: stream-only
+  stationuuid: ef40f745-b4a2-4df1-a78d-3fe907430882
+  changeuuid: d2fe08eb-85fe-48da-a4bd-500358260e90
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-mondo-radio
+  broadcaster: independent
+  name: Mondo Radio
+  streamUrl: https://streamer.radio.co/s1afcca186/listen
+  bitrate: 96
+  codec: MP3
+  favicon: https://images.squarespace-cdn.com/content/v1/648cf7010ac2fb3561bc2154/5b5a7df2-8c59-49fa-9b71-dca00edfe7ff/favicon.ico?format=100w
+  homepage: https://www.mondo.radio/
+  country: GB
+  status: stream-only
+  stationuuid: 7c093cab-e41d-4981-84ae-5647b9aa5c06
+  changeuuid: 0694914e-7e0d-4c99-a832-b3658b657007
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-motorsport-radio
+  broadcaster: independent
+  name: Motorsport Radio
+  streamUrl: https://streaming.radio.co/sd88832e85/listen
+  bitrate: 128
+  codec: MP3
+  favicon: https://motorsport.radio/wp-content/uploads/2020/05/iTunes-Cover-512px.png
+  homepage: https://motorsport.radio/nowplaying/
+  country: GB
+  status: stream-only
+  stationuuid: cb6da657-0784-4106-a2bc-4842728198bc
+  changeuuid: 74bc4f13-5829-41bb-b6e2-60d03cbfb2c8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-nufc-talk-radio
+  broadcaster: independent
+  name: NUFC Talk Radio
+  streamUrl: https://s4.radio.co/s35505f6df/listen
+  bitrate: 96
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/a2c77b_e4f745f8472e4e36aed9b628816b6e6e~mv2.jpg/v1/fill/w_2500,h_2500,al_c/a2c77b_e4f745f8472e4e36aed9b628816b6e6e~mv2.jpg
+  homepage: https://www.nufctalkradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 88855c97-001d-45fd-b04f-e74a81f61c2a
+  changeuuid: 69f41461-2c70-4bc3-b848-fb370fa044e9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-orryy-live
+  broadcaster: independent
+  name: Orryy Live
+  streamUrl: https://radio.orryy.com/live
+  codec: MP3
+  favicon: https://orryy.com/assets/logo.png
+  homepage: https://orryy.com/live
+  country: GB
+  status: stream-only
+  stationuuid: fed9199c-92ab-44ec-ba15-4ebc77dc9caa
+  changeuuid: 5da07a8e-fbd4-4b8e-b698-45ccc7ccfa1b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-osn-radio-plus
+  broadcaster: independent
+  name: OSN Radio Plus
+  streamUrl: https://stream.stuallan.com/stream3
+  bitrate: 128
+  codec: MP3
+  homepage: https://osn.fm/
+  country: GB
+  status: stream-only
+  stationuuid: bfd46092-629c-475c-830b-ab7b307e816b
+  changeuuid: cd28896a-6e02-4679-962d-1d643f405b85
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-past-perfect-radio
+  broadcaster: independent
+  name: Past Perfect Radio
+  streamUrl: https://s2.xrad.io:9646/;stream/1
+  bitrate: 48
+  codec: AAC+
+  favicon: https://www.pastperfect.com/wp-content/uploads/2023/07/Past-Perfect-Radio-e1688392518104-768x473.png
+  homepage: https://www.pastperfect.com/
+  country: GB
+  status: stream-only
+  stationuuid: f4abf99b-3e7c-4e66-bdfd-f9cf9742ed17
+  changeuuid: 110764d2-cbd1-466b-82c4-51cfba930064
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-premier-gospel
+  broadcaster: independent
+  name: Premier Gospel
+  streamUrl: https://pcr.streamguys1.com/pgospel-96k.aac
+  bitrate: 56
+  codec: AAC
+  homepage: https://www.premier.plus/stations/premier-gospel
+  country: GB
+  status: stream-only
+  stationuuid: 9c39b69f-32df-40c3-8738-07035ca546d2
+  changeuuid: b7522c1a-af40-46d7-b7f0-72c4ec5b2471
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-premier-praise
+  broadcaster: independent
+  name: Premier Praise
+  streamUrl: https://pcr.streamguys1.com/ppeace-96k.aac
+  bitrate: 56
+  codec: AAC
+  homepage: https://www.premier.plus/stations/premier-peace
+  country: GB
+  status: stream-only
+  stationuuid: 140295df-e043-42e0-a80d-ebe848713063
+  changeuuid: c3a41296-7996-42a8-a5ee-0dc6e1cb1891
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-quality-radio
+  broadcaster: independent
+  name: Quality Radio
+  streamUrl: https://uksoutha.streaming.broadcast.radio/quality_FM
+  codec: MP3
+  favicon: https://qualityradio.uk/wp-content/uploads/2022/08/qar-logo-e1661895864614.png
+  homepage: https://qualityradio.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 1c257712-e943-4792-8b56-0ed44a4db316
+  changeuuid: 548426d6-3173-4951-9898-bfa6e12f0184
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-hillingdon
+  broadcaster: independent
+  name: Radio Hillingdon
+  streamUrl: https://streaming.broadcast.radio/hrhillingdonaac?1699805800701=
+  bitrate: 128
+  codec: AAC
+  favicon: https://www.radiohillingdon.com/images/Listen%20Live%20Button%202023.png
+  homepage: https://www.radiohillingdon.com/
+  country: GB
+  status: stream-only
+  stationuuid: 1a751f04-4eeb-412a-a6c6-a1ab58decbe6
+  changeuuid: 0065ecfc-cf84-4a8a-bc7f-eb796ef876a4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-lear
+  broadcaster: independent
+  name: Radio LEAR
+  streamUrl: https://icecast.maxxwave.co.uk/lear
+  bitrate: 80
+  codec: AAC
+  favicon: https://img-284.media.info/i/bg/7/7941-1759585321.webp
+  homepage: https://radiolear.uk/
+  country: GB
+  status: stream-only
+  stationuuid: a3ee6eff-a7cf-4250-948d-99935c2457d7
+  changeuuid: 2db771a2-6133-4561-a862-224476fa1283
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-wester-ross
+  broadcaster: independent
+  name: Radio Wester Ross
+  streamUrl: https://stream.rcs.revma.com/96z3d1qs5bcwv
+  codec: MP3
+  favicon: https://www.radiowesterross.scot/application/files/3917/0852/2702/favicon.ico
+  homepage: https://www.radiowesterross.scot/
+  country: GB
+  status: stream-only
+  stationuuid: d61ddebb-dd6f-40d8-8ce8-bcb6642397c2
+  changeuuid: 0772bae4-7c10-4599-b89d-c38949c9a612
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-xtra
+  broadcaster: independent
+  name: Radio Xtra
+  streamUrl: https://n18a-eu.rcs.revma.com/nye22yatz42vv?rj-ttl=5&rj-tok=AAABm86No4cAj3cUwHekQ5GQLQ
+  codec: MP3
+  favicon: https://radioxtra.co.uk/wp-content/uploads/2023/07/Radio-XTRA-2.svg
+  homepage: https://radioxtra.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 9554c047-5c51-4ce5-a6bb-eb65d61bb228
+  changeuuid: 3dfcb425-30bd-467f-8598-2160b3ec358d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radiowave
+  broadcaster: independent
+  name: RadioWave
+  streamUrl: https://1.radiowave.eu/listen/test/aacHQ
+  bitrate: 320
+  codec: AAC
+  favicon: https://radiowave.eu/static/uploads/browser_icon/192.1743030143.png
+  homepage: https://radiowave.eu/public/test
+  country: GB
+  status: stream-only
+  stationuuid: 8bdfe6a8-fd46-4c2f-bb73-b730bb95a30f
+  changeuuid: e26f3d70-b574-4ddc-89ba-4b6a097ecb5d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-reiver-fm-scottish-borders-radio
+  broadcaster: independent
+  name: "Reiver FM – Scottish Borders Radio "
+  streamUrl: https://s10.myradiostream.com/35820/listen.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: https://reiverfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: 9ae16b8c-40fc-4c62-939c-9d4c2fb8be37
+  changeuuid: 2429469d-de01-4b57-88bb-b36afd646cd7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-rutland-and-stamford-sound
+  broadcaster: independent
+  name: Rutland and Stamford Sound
+  streamUrl: https://stream.aiir.com/lqeblzjduoduv
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/500/6035405e0d05a.png
+  homepage: https://www.rutlandandstamfordsound.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: a383a5b1-5a8c-4178-9885-ea527b3cdcce
+  changeuuid: 98bbf302-395e-43ff-be78-8ba55fee80dd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-slim-radio
+  broadcaster: independent
+  name: Slim Radio
+  streamUrl: https://a2.asurahosting.com:6260/radio.mp3
+  bitrate: 320
+  codec: MP3
+  favicon: https://www.slimradio.co.uk
+  homepage: http://www.slimradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 6a2fe382-636f-4423-b30c-ba51d2388c3a
+  changeuuid: 810f3c1c-91fa-4a21-90c2-0418e0e838c5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-spark-fm
+  broadcaster: independent
+  name: Spark FM
+  streamUrl: https://stream1.hippynet.co.uk:8117/live.mp3
+  bitrate: 320
+  codec: MP3
+  homepage: https://www.sparksunderland.com/
+  country: GB
+  status: stream-only
+  stationuuid: a0a6e01e-c70e-4ddd-b274-766e99424716
+  changeuuid: 995cf6a5-6c10-4fd7-8cc3-8f2e9a2309ae
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-td1-radio
+  broadcaster: independent
+  name: TD1 Radio
+  streamUrl: https://streaming.mbc.scot/listen/td1_radio/radio.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.td1radio.scot/
+  country: GB
+  status: stream-only
+  stationuuid: d15ad933-7ee3-40d2-8b8c-01b6ff675e3e
+  changeuuid: b081a056-3770-4b81-8131-00d50f335eda
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-the-cat-107-9
+  broadcaster: independent
+  name: The Cat 107.9
+  streamUrl: https://uksoutha.streaming.broadcast.radio/thecatcloud?1769875744264=
+  codec: MP3
+  favicon: https://thecat.radio/favicon.ico?i=5365
+  homepage: https://thecat.radio/
+  country: GB
+  status: stream-only
+  stationuuid: 1a5bf21a-e67a-44ee-82ea-b9ac2376ef2b
+  changeuuid: 1878d7c0-aae9-4b76-95c5-a8eba5cda147
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-triphop-radio
+  broadcaster: independent
+  name: TripHop.Radio
+  streamUrl: https://live.triphop.radio/
+  bitrate: 128
+  codec: MP3
+  favicon: https://pages.register.radio/uploads/triphop-radio-69d395851f50d.png
+  homepage: https://www.triphop.radio/
+  country: GB
+  status: stream-only
+  stationuuid: 72612036-9d94-46a7-b0ff-7a1061a62867
+  changeuuid: 2d969a48-2afe-46a6-affe-5d76099986c1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-truck-beat-fm
+  broadcaster: independent
+  name: Truck Beat FM
+  streamUrl: https://streamer.radio.co/s895c9762a/listen
+  bitrate: 128
+  codec: MP3
+  homepage: https://truck-beat-fm.github.io/Truck-Beat-FM-radio/index.html
+  country: GB
+  status: stream-only
+  stationuuid: 8fcb2319-f3b7-4766-9d7f-e9d8642c2440
+  changeuuid: d1fc5632-3c94-44e1-8b2a-b941c2bd6b35
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-vdub-radio
+  broadcaster: independent
+  name: VDub Radio
+  streamUrl: https://s2.radio.co/s6fb3318ac/listen
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.vdubradio.com/uploads/1/2/3/2/123248749/new-2024-aerial-line-x-1200_orig.jpg
+  homepage: https://www.vdubradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 73c0d87f-a547-47f7-a6fd-0a2738558db8
+  changeuuid: a142065b-5af0-4b99-8b2c-00ddb8af33b2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-vibe-1
+  broadcaster: independent
+  name: Vibe 1
+  streamUrl: https://stream3.themediasite.co.uk:8106/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQX-73EE6UPXYWRfGsZ6WkesAy6ef2fwE3pSA&s
+  homepage: https://www.vibe1.uk/
+  country: GB
+  status: stream-only
+  stationuuid: f81b8923-98cc-437d-94ee-7d50dd1b91bd
+  changeuuid: 85a4e6b0-f927-4f37-af8e-937d69f46ec2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-weald-radio
+  broadcaster: independent
+  name: Weald Radio
+  streamUrl: https://uksoutha.streaming.broadcast.radio/oastradio
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/2225/687d0e4b722ce.jpg
+  homepage: https://www.wealdradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 10f6f8f2-00c8-48d3-ada4-f7bd2298a8bb
+  changeuuid: 56452f82-e799-44cf-b595-db62e67e21de
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-word-central-radio
+  broadcaster: independent
+  name: Word Central Radio
+  streamUrl: https://play.radioking.io/word-central-radio/707122
+  bitrate: 192
+  codec: MP3
+  favicon: https://image.radioking.io/radios/643897/logo/1cf1f955-b76c-4d78-a4ea-5af7c21909c5.jpeg
+  homepage: https://wordcentralradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 53f2d51f-01b8-4f11-b6ad-8f5f1d76856a
+  changeuuid: e425f4bb-5f6b-4e0a-8c8e-1941f7f862b3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-2day-mix-radio
+  broadcaster: independent
+  name: "2day mix radio"
+  streamUrl: https://2day.2daymixradio.org:8000/radio.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: https://2daymixradio.org/
+  country: GB
+  status: stream-only
+  stationuuid: c67374fe-b34a-479f-a644-b97d410026fb
+  changeuuid: 847fb7f3-b67b-4b0f-9b0a-c4ef53cef0b4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-arp-radio
+  broadcaster: independent
+  name: ARP Radio
+  streamUrl: https://arpradio.com:8443/listen/arp_radio/arp.mp3
+  bitrate: 320
+  codec: MP3
+  homepage: https://arpradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 2dd9ec68-b0e7-47c8-bc52-86579a8de0af
+  changeuuid: 8c1226b7-4477-4cad-b534-17d80bdbd38f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-ashdown-radio
+  broadcaster: independent
+  name: Ashdown Radio
+  streamUrl: https://streaming.broadcast.radio/uckfieldfmmp3?_=365639
+  bitrate: 128
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/592/61d2dbf595ad9.png
+  homepage: https://www.ashdownradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 24afa5b0-9e7f-4264-b139-9a9c72bf6950
+  changeuuid: c40c7e2c-b94e-44f4-a5fd-7fc61d38e3ab
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bexhill-radio
+  broadcaster: independent
+  name: Bexhill Radio
+  streamUrl: https://a13.asurahosting.com/listen/bexhill_radio/radio.mp3
+  bitrate: 320
+  codec: MP3
+  favicon: https://bexhillradio.com/wp-content/uploads/2025/11/PHOTO-2025-08-04-19-38-26.jpg
+  homepage: https://bexhillradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: e3eb1f35-9f15-4a06-ae06-14786eccd01a
+  changeuuid: bc30ace8-cddb-4297-b999-a8a1744ace1d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bounce-nation-radio
+  broadcaster: independent
+  name: Bounce Nation Radio
+  streamUrl: https://stream.stuallan.com/stream4
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.stuallan.com/
+  country: GB
+  status: stream-only
+  stationuuid: 47aaaaf4-0549-46e5-bd20-75b3c8b7702d
+  changeuuid: 6fb2a0db-cad9-41c9-9351-0bcf5c351e69
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bournemouth-one
+  broadcaster: independent
+  name: Bournemouth One
+  streamUrl: https://n10a-eu.rcs.revma.com/bq0p6qbnpucwv?rj-ttl=5&rj-tok=AAABm8kwEu0ATCenU6Ba4CGEmg
+  codec: AAC
+  favicon: https://mmo.aiircdn.com/743/6773b4fd7db3a.png
+  homepage: https://www.bournemouthone.com/
+  country: GB
+  status: stream-only
+  stationuuid: 3976ed63-6e97-458e-acc5-29d0bb55c0ff
+  changeuuid: b1db0f38-c9a5-41b0-a2af-755c1484cf35
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-branchfm
+  broadcaster: independent
+  name: BranchFM
+  streamUrl: https://s11.ssl-stream.com/ssl/branchfm?mp=%2Fstream&rp_source=1&=&&___cb=797689455893916
+  bitrate: 192
+  codec: MP3
+  homepage: https://branchfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: 451a9871-c303-446b-9f7e-21d16b9af29a
+  changeuuid: f89b3aab-a323-4ff6-af41-f6a77a71322d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-castle-radio
+  broadcaster: independent
+  name: Castle Radio
+  streamUrl: https://c36.radioboss.fm:8114/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.castleradio.co.uk/set1.png
+  homepage: https://www.castleradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: c98ba9c4-27ed-4996-b8ff-cf704ba273f2
+  changeuuid: cda31509-84cc-4b5f-8bba-9bc0692e4926
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-central-radio
+  broadcaster: independent
+  name: Central Radio
+  streamUrl: https://n33a-eu.rcs.revma.com/aehah7wnpp3vv
+  codec: AAC
+  favicon: https://mmo.aiircdn.com/778/673b04861e76c.png
+  homepage: http://www.central.radio/
+  country: GB
+  status: stream-only
+  stationuuid: eae9e199-dd68-403d-ada3-76726324e654
+  changeuuid: 8ae97c07-ac0b-4f4c-b7b0-ca809fbddc98
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-crucial-sounds-radio
+  broadcaster: independent
+  name: crucial sounds radio
+  streamUrl: https://usa19.fastcast4u.com:9420/stream
+  bitrate: 320
+  codec: MP3
+  homepage: https://crucialsoundsradio.uk/
+  country: GB
+  status: stream-only
+  stationuuid: dc90eff0-4100-45df-923a-0d6e97f407a1
+  changeuuid: abd2c51b-ec5b-4be4-ba3e-fc384580ded3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-da-hub-radio
+  broadcaster: independent
+  name: Da Hub Radio
+  streamUrl: https://stream.dahubradio.co.uk:8848/stream
+  bitrate: 128
+  codec: MP3
+  homepage: https://dahubradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 56e2e57d-0ee3-4865-822c-f37335bdf058
+  changeuuid: cbedb433-3774-4670-ba38-a2ae6f8ddad8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-dork-radio
+  broadcaster: independent
+  name: Dork Radio
+  streamUrl: https://s2.radio.co/s3e57f0675/listen
+  bitrate: 192
+  codec: MP3
+  favicon: https://readdork.com/wp-content/uploads/2025/02/dork_logo_new_nearblack-768x185.webp
+  homepage: https://readdork.com/
+  country: GB
+  status: stream-only
+  stationuuid: 03738ed0-5d6c-45ef-b232-6c09e8c7aba7
+  changeuuid: 2a4c21e7-c973-474b-be74-f3d2a9e58c25
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-eava-fm
+  broadcaster: independent
+  name: EAVA FM
+  streamUrl: https://radio.canstream.co.uk:8000/eavafm.mp3
+  bitrate: 96
+  codec: MP3
+  favicon: https://www.eavafm.com/wp-content/uploads/2021/12/eava_logo_Clear_3400.png
+  homepage: https://www.eavafm.com/
+  country: GB
+  status: stream-only
+  stationuuid: 4808310d-bc75-4a05-a2b1-de9e5eaced99
+  changeuuid: f2be796c-4374-4333-aa6e-0c923cb304c6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-electric-circus
+  broadcaster: independent
+  name: electric circus
+  streamUrl: https://a5.asurahosting.com:7990/radio.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.electriccircus.uk/wp-content/uploads/go-x/u/3c3ed3c4-f457-43f2-b909-fbee7590e08b/image-384x304.jpg
+  homepage: https://www.electriccircus.uk/radio/
+  country: GB
+  status: stream-only
+  stationuuid: 9218802f-1977-430b-b95c-439d1554dc41
+  changeuuid: c9bbbdea-f6be-4154-b790-df6ae19f5a3b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hfm-102-3
+  broadcaster: independent
+  name: HFM 102.3
+  streamUrl: https://listen-harboroughfm.sharp-stream.com/harboroughfm.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://harboroughfm.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 78742a2b-17c8-4105-9525-be7d06d42024
+  changeuuid: 2a55797e-3b88-4a86-b949-57e6411a5521
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hgv1-radio
+  broadcaster: independent
+  name: HGV1 Radio
+  streamUrl: https://stream4.themediasite.co.uk/stream/hgv1-main
+  bitrate: 192
+  codec: MP3
+  homepage: https://hgvradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 5c919eac-d2af-4766-a883-d7871a6c09f8
+  changeuuid: 201859d7-4a8b-4e2a-a058-61164a9deb4f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-huntingdon-community-radio-hcr-fm
+  broadcaster: independent
+  name: Huntingdon Community Radio - HCR FM
+  streamUrl: https://listen.streamaudio.co/proxy/hcr/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.hcrfm.co.uk/favicon.ico
+  homepage: https://www.hcrfm.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: c077bae1-df52-4aa0-a7e6-67f5ab14528d
+  changeuuid: e3472ecd-8282-4661-ba1e-9eb900666766
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-indie-soul-radio
+  broadcaster: independent
+  name: Indie Soul Radio
+  streamUrl: https://s2.citrus3.com:8404/stream
+  bitrate: 128
+  codec: AAC
+  homepage: https://www.indiesoulradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: ccf3396a-40e3-4541-887a-89f5b1f879ee
+  changeuuid: 0ae61f30-9210-49cd-90de-fc7dbe2f53e7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-kick-radio
+  broadcaster: independent
+  name: KICK RADIO
+  streamUrl: https://cast4.my-control-panel.com/proxy/edp/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.kickradio.co.uk/public/themes/default/assets/favicon.ico
+  homepage: https://www.kickradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 2388821a-0d0b-4f09-ae2c-6f6fe3bc06b3
+  changeuuid: 097e866a-09d6-4577-95da-a6d46a8a0867
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-laser-dance
+  broadcaster: independent
+  name: Laser Dance
+  streamUrl: https://stream.airwavebroadcast.com:8010/laserdancehq
+  bitrate: 128
+  codec: AAC
+  favicon: https://primary.jwwb.nl/public/t/a/i/temp-dozjcpvcaeqpdalqxwlr/315-high.jpg?enable-io=true&width=1252
+  homepage: https://www.laserinternational.co.uk/laser-dance
+  country: GB
+  status: stream-only
+  stationuuid: 436a5a1d-d267-4893-b036-c59df79043fd
+  changeuuid: 5c09d18c-5e84-45fe-a03f-cdf2616fec08
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-laser-hot-hits
+  broadcaster: independent
+  name: Laser Hot Hits
+  streamUrl: https://stream.airwavebroadcast.com:8040/laserhq
+  bitrate: 256
+  codec: MP3
+  favicon: https://primary.jwwb.nl/public/t/a/i/temp-dozjcpvcaeqpdalqxwlr/225-high.png?enable-io=true&width=816
+  homepage: https://www.laserinternational.co.uk/laser-hot-hits-international
+  country: GB
+  status: stream-only
+  stationuuid: 1b3d1f50-f8dd-4ebd-9faf-cae04788b218
+  changeuuid: cba24311-7608-42d6-ae7b-ede45b9137c8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-love-da-beat-radio
+  broadcaster: independent
+  name: Love Da Beat Radio
+  streamUrl: https://love-da-beat-radio-cf8d1146.radiocult.fm/stream
+  bitrate: 160
+  codec: MP3
+  homepage: https://www.lovedabeatradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: bb2d8310-f52c-4848-ad93-0bbb1b0b915b
+  changeuuid: fafcff7a-c41b-41de-bdb9-3c8a2621631d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-lyme-out-live
+  broadcaster: independent
+  name: lyme out live
+  streamUrl: https://centova87.shoutcastservices.com/proxy/lymeout/stream
+  bitrate: 128
+  codec: MP3
+  favicon: null
+  homepage: https://centova87.shoutcastservices.com/proxy/lymeout/stream
+  country: GB
+  status: stream-only
+  stationuuid: 5e0b938c-94b8-41e8-a408-1b4f46119461
+  changeuuid: 27bc7bcd-6f7c-414a-bfa3-03bec986b875
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-mearns-fm
+  broadcaster: independent
+  name: Mearns FM
+  streamUrl: https://stream2.hippynet.co.uk:8002/lowquality
+  bitrate: 96
+  codec: MP3
+  favicon: https://www.mearnsfm.org.uk/wp-content/uploads/2020/06/imageedit_5_7574751306.png
+  homepage: https://www.mearnsfm.org.uk/
+  country: GB
+  status: stream-only
+  stationuuid: a83511ac-92ad-4879-b1ff-6dd9a4c2c78b
+  changeuuid: 2ff12e1b-b6e9-4f22-8aa2-11aaf9eb0e84
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-nitro-fm
+  broadcaster: independent
+  name: nitro-FM
+  streamUrl: https://radio.nitro-server.uk/listen/nitrohost/radio.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: https://radio.nitro-server.uk/listen/nitrohost/
+  country: GB
+  status: stream-only
+  stationuuid: fc0d1031-cca4-4c23-9408-c0ec7690a8b0
+  changeuuid: 763f481e-cd3d-4bf9-8fad-8d82e8989721
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-outreach-radio
+  broadcaster: independent
+  name: Outreach Radio
+  streamUrl: https://live.ukrp.tv/outreachradio.aac
+  bitrate: 32
+  codec: AAC
+  favicon: https://cdn.outreachradio.co.uk/wp-content/uploads/2020/11/cropped-logo_website.jpg
+  homepage: https://www.outreachradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: de298f25-06ef-4114-8043-fa0dd75ff8c8
+  changeuuid: 671ff294-4510-4d7a-a0ea-5707f2006baa
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-piestream
+  broadcaster: independent
+  name: Piestream
+  streamUrl: https://radio.psymusic.co.uk/listen/piestream/hifi.mp3
+  bitrate: 320
+  codec: AAC
+  favicon: https://psymusic.co.uk/images/alien-head32.png
+  homepage: https://www.psymusic.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 3903eac2-5061-45e5-89a3-8a7ec183e8e4
+  changeuuid: 18b5bd28-ebf8-4197-bd3b-a631bd5fdf0e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-polish-radio-london
+  broadcaster: independent
+  name: Polish Radio London
+  streamUrl: https://n19a-eu.rcs.revma.com/prfmwmwy768uv?rj-ttl=5&rj-tok=AAABnQg2ZmsA5RX2yPMR7AlE5w
+  codec: AAC
+  homepage: https://prl24.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 9d3e2fad-cae9-48cb-90f1-11c7bef8a8ab
+  changeuuid: c5dec87f-7c16-4497-9dd2-609cfd94bb83
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-camarthenshire
+  broadcaster: independent
+  name: Radio Camarthenshire
+  streamUrl: https://listen-nation.sharp-stream.com/tccarmarthenshire.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://upload.wikimedia.org/wikipedia/commons/thumb/a/ac/Radiocarmar.png/250px-Radiocarmar.png
+  homepage: https://www.nationplayer.com/radio-carmarthenshire/
+  country: GB
+  status: stream-only
+  stationuuid: 5bd70f6e-b7a5-4f3b-ab52-0ac20f7e9624
+  changeuuid: 70745837-8d1a-46ba-909f-2dce9e277ed7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-victory
+  broadcaster: independent
+  name: Radio Victory
+  streamUrl: https://stream3.themediasite.co.uk:8380/stream
+  bitrate: 256
+  codec: MP3
+  homepage: https://radiovictory.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 956ed88f-2766-4f6a-9bf0-f3a9b697ca34
+  changeuuid: 6999f498-f764-4c80-8cdd-7475281f9625
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radiowave-eu
+  broadcaster: independent
+  name: Radiowave.eu
+  streamUrl: https://radiowave.eu/hls/test/live.m3u8
+  bitrate: 211
+  codec: AAC
+  favicon: https://radiowave.eu/static/uploads/browser_icon/192.1743030143.png
+  homepage: https://radiowave.eu/
+  country: GB
+  status: stream-only
+  stationuuid: b2f27b98-05c5-45a2-a457-54cae21c406a
+  changeuuid: 5eb820b7-b9e1-4d79-96f8-3667595f5ae4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-raiders-radio
+  broadcaster: independent
+  name: Raiders Radio
+  streamUrl: https://s2.citrus3.com:8464/stream
+  bitrate: 128
+  codec: AAC
+  favicon: https://raidersradio.co.uk/favicon.png
+  homepage: https://raidersradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 8e46e90a-9bbc-4d47-a82a-61dfb14a57ef
+  changeuuid: 15ce1a48-8e8f-4f58-a644-b4e044cfb129
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-retrobyte-radio
+  broadcaster: independent
+  name: RetroByte Radio
+  streamUrl: https://retrobytesradio.radioca.st/stream
+  bitrate: 320
+  codec: MP3
+  homepage: https://www.retrobyteradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: f3d2c5ca-970f-43e9-aab9-e1bc7b74041d
+  changeuuid: a480c506-b944-4488-8d1f-77d2a42a89fc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-rtm-fm
+  broadcaster: independent
+  name: RTM.FM
+  streamUrl: https://streams.radio.co/s3d2f05f8f/listen
+  bitrate: 128
+  codec: MP3
+  favicon: https://rtm.fm/favicon.png
+  homepage: https://rtm.fm/
+  country: GB
+  status: stream-only
+  stationuuid: a0a43edc-544d-47b2-8980-2ab7c946c2e8
+  changeuuid: 71371581-dfce-4a54-926f-d7074ccbe0ae
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-selecta-radio-uk
+  broadcaster: independent
+  name: Selecta Radio UK
+  streamUrl: https://streaming.live365.com/a40232
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.selectaradiouk.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 38c91628-48d5-4768-b975-3383493f5284
+  changeuuid: 5a1bda14-1bdd-45f3-8fb8-ba3a599e7b5d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-sle-radio-one
+  broadcaster: independent
+  name: SLE RADIO ONE
+  streamUrl: https://sleradiogroup.com/listen/sle_radio_1/sleone.mp3
+  bitrate: 256
+  codec: AAC
+  favicon: https://sleradio.com/station1.png
+  homepage: https://sleradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 982ee37b-0dd5-4acb-94e6-bc2575e38893
+  changeuuid: 1e8a7b6b-ef8a-4712-9bf5-07a27ab26b1e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-sle-radio-rave
+  broadcaster: independent
+  name: SLE RADIO RAVE
+  streamUrl: https://sleradiogroup.com/listen/sle_radio_rave/radio.mp3
+  bitrate: 256
+  codec: MP3
+  favicon: https://sleradio.com/station-rave.png
+  homepage: https://sleradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 09a754eb-863e-4299-9ee7-eef21c5eff74
+  changeuuid: 2a7ed47f-ace8-496d-b958-d9c1d1bcf878
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-smooth-tyne-wear
+  broadcaster: independent
+  name: "Smooth Tyne & Wear"
+  streamUrl: https://media-ice.musicradio.com/SmoothNorthEastNMP3
+  bitrate: 128
+  codec: MP3
+  favicon: http://www.smoothradio.com/assets_v4r/smooth/img/favicon-196x196.png
+  homepage: https://www.smoothradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: da2ecfd9-4e07-45c3-be0a-999e01487e54
+  changeuuid: 34764d79-d16c-4925-bffd-1f9c2aa50b12
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-toby-s-tunes
+  broadcaster: independent
+  name: "Toby's Tunes"
+  streamUrl: https://stream.aiir.com/he5hocuryqbvv
+  codec: AAC
+  homepage: https://classichits.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: b3574205-b8ad-41ea-aad8-1dd6cbbef903
+  changeuuid: c4f4c90d-f898-4e67-b989-1b3ec80484ba
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-toohotradio-net
+  broadcaster: independent
+  name: TooHotRadio.net
+  streamUrl: https://stream.toohotradio.net/128
+  bitrate: 128
+  codec: MP3
+  favicon: https://toohotradio.net/resize/toohot2.png?w=180
+  homepage: https://toohotradio.net/#
+  country: GB
+  status: stream-only
+  stationuuid: b6fa0be8-846a-4279-80b2-c39d2e4d6e17
+  changeuuid: f0963878-a4f6-4e5d-9221-2075875573e4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-ttns
+  broadcaster: independent
+  name: TTNS
+  streamUrl: https://listen.thethursdaynightshow.com/live
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.thethursdaynightshow.com/
+  country: GB
+  status: stream-only
+  stationuuid: e925e09e-623a-4dff-b7b4-99de76089dba
+  changeuuid: 7040fef5-1c6f-4a35-9c36-a784e9afa430
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-tuneskool-radio
+  broadcaster: independent
+  name: Tuneskool Radio
+  streamUrl: https://c18.radioboss.fm:8423/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://tuneskoolradio.co.uk/wp-content/uploads/2024/01/Tune_school_radio-768x384.jpg
+  homepage: https://tuneskoolradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 63e45e24-fc7e-4d69-bcaa-6c3e9b7fc342
+  changeuuid: 86cd1f0a-46c7-4552-b9d5-fba8eb840dae
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-xpression-fm
+  broadcaster: independent
+  name: Xpression FM
+  streamUrl: https://streaming.broadcastradio.com:10855/xpression
+  bitrate: 128
+  codec: MP3
+  favicon: http://www.xpression.fm/uploads/3/7/0/6/37062627/image-removebg-preview.png
+  homepage: http://www.xpression.fm/
+  country: GB
+  status: stream-only
+  stationuuid: 7a89ade9-cae3-4a36-ae1b-5ce7a497b63d
+  changeuuid: acfab051-b6a2-4a37-9d85-f08d1190e6fa
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-zack-fm
+  broadcaster: independent
+  name: Zack FM
+  streamUrl: https://s2.streamer1.com/listen/zackfm/zackTEST.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.zackfm.com/templates/joomla3_005/images/logo.png
+  homepage: https://www.zackfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: 7df157a2-7a65-4dea-9278-af66f9d8292c
+  changeuuid: 41226e84-b7ac-44ba-b7b8-1a9e4e67cf44
+  reviewedAt: "2026-05-04"

--- a/public/stations.json
+++ b/public/stations.json
@@ -47008,6 +47008,12777 @@
         16.3876
       ],
       "status": "stream-only"
+    },
+    {
+      "id": "gb-tmm-1",
+      "name": "TMM 1",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-msmn.sharp-stream.com/nme1.mp3",
+      "homepage": "https://www.themusicmachine.co.uk/",
+      "country": "GB",
+      "tags": [
+        "alternative",
+        "alternative rock",
+        "garage",
+        "indie",
+        "indie pop",
+        "indie rock"
+      ],
+      "favicon": "https://cdn-profiles.tunein.com/s159857/images/logod.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-heart-70s",
+      "name": "Heart 70s",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ssl.musicradio.com/Heart70sMP3",
+      "homepage": "https://www.heart.co.uk/70s",
+      "country": "GB",
+      "tags": [
+        "70s",
+        "national",
+        "pop",
+        "public radio",
+        "variety"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-heart-dance",
+      "name": "Heart Dance",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ssl.musicradio.com/HeartDanceMP3",
+      "homepage": "https://www.heart.co.uk/dance",
+      "country": "GB",
+      "tags": [
+        "dance",
+        "national",
+        "pop",
+        "public radio",
+        "variety"
+      ],
+      "favicon": "https://www.heart.co.uk/assets_v4r/heart/img/favicon-196x196.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-tmm-2",
+      "name": "TMM 2",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-msmn.sharp-stream.com/nme2.mp3",
+      "homepage": "https://www.themusicmachine.co.uk/",
+      "country": "GB",
+      "tags": [
+        "alternative",
+        "hiphop",
+        "electronic"
+      ],
+      "favicon": "https://cdn-profiles.tunein.com/s155539/images/logod.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-love-radio-only-love-songs-70s80s90s",
+      "name": "LOVE.radio Only Love Songs 70s80s90s",
+      "broadcaster": "independent",
+      "streamUrl": "https://loveradio.streamingmedia.it/england",
+      "homepage": "https://love.radio/",
+      "country": "GB",
+      "tags": [
+        "love",
+        "love songs",
+        "lovesongs",
+        "romantic"
+      ],
+      "bitrate": 192,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bbc-news-hd-720p",
+      "name": "BBC News HD (720P)",
+      "broadcaster": "independent",
+      "streamUrl": "https://vs-hls-push-ww-live.akamaized.net/x=4/i=urn:bbc:pips:service:bbc_news_channel_hd/t=3840/v=pv14/b=5070016/main.m3u8",
+      "homepage": "https://bbc.co.uk/news",
+      "country": "GB",
+      "tags": [
+        "england",
+        "english",
+        "london",
+        "news",
+        "uk",
+        "world news"
+      ],
+      "favicon": "https://upload.wikimedia.org/wikipedia/en/thumb/2/24/BBC_News_HD_Logo.svg/2560px-BBC_News_HD_Logo.svg.png",
+      "codec": "UNKNOWN",
+      "geo": [
+        51.5007,
+        -0.1246
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-exclusively-dire-straits",
+      "name": "Exclusively Dire Straits",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.exclusive.radio/er/direstraits/icecast.audio",
+      "homepage": "https://exclusive.radio/",
+      "country": "GB",
+      "tags": [
+        "rock"
+      ],
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-virgin-radio-chilled",
+      "name": "Virgin Radio Chilled",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.virginradio.co.uk/stream-chilled?aw_0_1st.platform=vr-web",
+      "homepage": "https://virginradio.co.uk/radioplayer/live/virginradio-player-chilled.html",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-seva-novgorodsev",
+      "name": "Радио Сева (Radio Seva Novgorodsev)",
+      "broadcaster": "independent",
+      "streamUrl": "https://seva.ru/radio/stream",
+      "homepage": "https://seva.ru/",
+      "country": "GB",
+      "tags": [
+        "music",
+        "rock",
+        "talk",
+        "музыка",
+        "разговорное",
+        "рок"
+      ],
+      "favicon": "https://seva.ru/radio/radio.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-tmm-2-hq",
+      "name": "TMM 2 (HQ)",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-msmn.sharp-stream.com/nme2high.mp3",
+      "homepage": "https://www.themusicmachine.co.uk/",
+      "country": "GB",
+      "tags": [
+        "alternative",
+        "hiphop",
+        "electronic"
+      ],
+      "favicon": "https://cdn-profiles.tunein.com/s155539/images/logod.png",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-exclusively-supertramp",
+      "name": "Exclusively Supertramp",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.exclusive.radio/er/supertramp/icecast.audio",
+      "homepage": "https://exclusive.radio/",
+      "country": "GB",
+      "tags": [
+        "rock"
+      ],
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-britcom-2-pumpkin-fm",
+      "name": "BritCom 2 - Pumpkin FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast2.asurahosting.com/proxy/britcom2/stream",
+      "homepage": "https://pumpkinfm.com/",
+      "country": "GB",
+      "tags": [
+        "british comedy",
+        "comedy",
+        "old time radio"
+      ],
+      "favicon": "https://pumpkinfm.com/wp-content/uploads/2019/02/BritComTwo300x300.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-exclusively-ac-dc",
+      "name": "Exclusively AC/DC",
+      "broadcaster": "independent",
+      "streamUrl": "https://nl4.mystreaming.net/er/acdc/icecast.audio",
+      "homepage": "https://play.exclusive.radio/",
+      "country": "GB",
+      "tags": [
+        "classic rock"
+      ],
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-sky-news-uk",
+      "name": "sky news UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://tunein.cdnstream1.com/3688_96.mp3?aw_0_1st.skey=1718490659&aw_0_1st.abtest=&aw_0_1st.stationId=s2583&aw_0_1st.premium=false&source=TuneIn&aw_0_1st.platform=tunein&aw_0_1st.genre_id=g255&aw_0_1st.class=talk&aw_0_1st.ads_partner_alias=ce.Other&aw_0_azn.planguage=en",
+      "homepage": "https://news.sky.com/",
+      "country": "GB",
+      "favicon": "https://news.sky.com/resources/apple-touch-icon.png?v=2",
+      "bitrate": 96,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-soul-radio-only-classic-soul",
+      "name": "SOUL RADIO Only Classic Soul",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.soulradio.uk/uk",
+      "homepage": "https://soulradio.uk/",
+      "country": "GB",
+      "tags": [
+        "50s",
+        "60s",
+        "70s",
+        "classic soul",
+        "oldies",
+        "soul"
+      ],
+      "bitrate": 192,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-teenage-kicks-radio",
+      "name": "Teenage Kicks Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://onlineradiobox.com/json/fr/teenagekicks/play",
+      "homepage": "https://teenagekicksradio.blogspot.com/",
+      "country": "GB",
+      "tags": [
+        "new wave",
+        "pop and electronic music from the late 70s and the 80s",
+        "punk"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-house-nation-uk",
+      "name": "House Nation UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.radio.co/s06bd9d805/listen",
+      "homepage": "https://housenationuk.com/",
+      "country": "GB",
+      "tags": [
+        "house"
+      ],
+      "favicon": "https://static.mytuner.mobi/media/tvos_radios/aWa7xGKfBh.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-strange-radio-pumpkin-fm",
+      "name": "Strange Radio - Pumpkin FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast2.asurahosting.com/proxy/strangeradio/stream",
+      "homepage": "https://pumpkinfm.com/",
+      "country": "GB",
+      "tags": [
+        "horror stories",
+        "mystery",
+        "sci-fi",
+        "science fiction",
+        "scifi",
+        "space"
+      ],
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-x-classic-rock",
+      "name": "Radio X Classic Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ice.musicradio.com/RadioXClassicRockMP3",
+      "homepage": "https://www.radiox.co.uk/",
+      "country": "GB",
+      "tags": [
+        "classic rock",
+        "rock"
+      ],
+      "favicon": "https://i.imgur.com/eBIsjQw.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-britcom-1-british-comedy-radio-pumpkin-fm-otrn",
+      "name": "BritCom 1 - British Comedy Radio  (Pumpkin FM OTRN)",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast2.asurahosting.com/proxy/britcom1/stream",
+      "homepage": "https://britishcomedyradio.org/",
+      "country": "GB",
+      "favicon": "https://pumpkinfm.com/wp-content/uploads/2019/02/BritComOne300x300.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-happy-hardcore",
+      "name": "Happy Hardcore",
+      "broadcaster": "independent",
+      "streamUrl": "https://audio-edge-3mayu.fra.h.radiomast.io/73055724-1141-41e2-a69b-24a6ca96c8e7",
+      "homepage": "https://www.happyhardcore.com/",
+      "country": "GB",
+      "tags": [
+        "dj mixes",
+        "electronic",
+        "hardcore",
+        "oldskool hardcore"
+      ],
+      "bitrate": 256,
+      "codec": "MP3",
+      "geo": [
+        51.4814,
+        -0.3186
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-kniteforce-radio",
+      "name": "Kniteforce Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://kniteforce.out.airtime.pro/kniteforce_a",
+      "homepage": "https://kniteforce-radio.com/",
+      "country": "GB",
+      "tags": [
+        "drum & bass",
+        "hardcore",
+        "jungle"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-slow-focus-nts",
+      "name": "Slow Focus | NTS",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-mixtape-geo.ntslive.net/mixtape",
+      "homepage": "https://www.nts.live/infinite-mixtapes/slow-focus",
+      "country": "GB",
+      "tags": [
+        "ambient",
+        "drone",
+        "relaxing"
+      ],
+      "favicon": "https://www.nts.live/apple-touch-icon.png?v=47re43rrzb",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-rokit-radio-science-fiction",
+      "name": "ROKit Radio Science Fiction",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming05.liveboxstream.uk/proxy/roksta12/stream",
+      "homepage": "https://rokitradio.com/",
+      "country": "GB",
+      "tags": [
+        "action",
+        "drama",
+        "old time radio",
+        "otr",
+        "radio shows",
+        "science fiction"
+      ],
+      "favicon": "https://rokitradio.com/images/channels/scifi.jpg",
+      "bitrate": 48,
+      "codec": "MP3",
+      "geo": [
+        51.5069,
+        -0.1225
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-britcom-3-british-comedy-radio-pumpkin-fm-otrn",
+      "name": "BritCom 3 - British Comedy Radio (Pumpkin FM OTRN)",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast2.asurahosting.com/proxy/britcom3/stream",
+      "homepage": "https://britishcomedyradio.org/",
+      "country": "GB",
+      "favicon": "https://pumpkinfm.com/wp-content/uploads/2023/02/BritComThreeNew300x300-3.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-fun-kids",
+      "name": "Fun Kids",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-funkids.sharp-stream.com/funkids.mp3",
+      "homepage": "https://www.funkidslive.com/",
+      "country": "GB",
+      "tags": [
+        "kids"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.5197,
+        -0.1173
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hearme-classic-hard-rock",
+      "name": "HearMe - Classic Hard Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.hearme.fm:8250/stream",
+      "homepage": "https://hearme.fm/",
+      "country": "GB",
+      "tags": [
+        "classic hard rock"
+      ],
+      "codec": "MP3",
+      "geo": [
+        53.5403,
+        -1.0547
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-uk-bass-radio",
+      "name": "UK Bass Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.ukbassradio.com/stream",
+      "homepage": "https://www.ukbassradio.com/",
+      "country": "GB",
+      "tags": [
+        "breakbeat hardcore",
+        "drum and bass",
+        "drumfunk",
+        "dubstep",
+        "garage",
+        "hardcore"
+      ],
+      "favicon": "https://www.ukbassradio.com/wp-content/uploads/2021/03/cropped-thumbnail_ukbass-radio5.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-box-uk",
+      "name": "box uk",
+      "broadcaster": "independent",
+      "streamUrl": "https://boxstream.danceradiouk.com/stream",
+      "homepage": "https://boxuk.danceradiouk.com/",
+      "country": "GB",
+      "favicon": "https://boxuk.danceradiouk.com/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-now-70s",
+      "name": "Now 70s",
+      "broadcaster": "independent",
+      "streamUrl": "https://lightning-now70s-samsungnz.amagi.tv/playlist.m3u8",
+      "homepage": "https://nowmusic.com/",
+      "country": "GB",
+      "tags": [
+        "1970s",
+        "70s",
+        "classic hits",
+        "retro"
+      ],
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/c/cd/NOW_70s.png",
+      "bitrate": 1020,
+      "codec": "AAC,H.264",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-capital-chill",
+      "name": "Capital Chill",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ssl.musicradio.com/CapitalChill",
+      "homepage": "https://capitalchill.co.uk/",
+      "country": "GB",
+      "tags": [
+        "chill",
+        "chilled"
+      ],
+      "bitrate": 48,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-rokit-radio-british-comedy-1",
+      "name": "ROKit Radio : British Comedy 1",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming04.liveboxstream.uk/proxy/roksta14/stream",
+      "homepage": "https://rokitradio.com/",
+      "country": "GB",
+      "tags": [
+        "comedy",
+        "old time radio",
+        "otr",
+        "radio shows",
+        "u.k. comedy"
+      ],
+      "favicon": "https://rokitradio.com/images/channels/british_comedy_1.jpg",
+      "bitrate": 48,
+      "codec": "MP3",
+      "geo": [
+        51.5068,
+        -0.1228
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-eric-clapton",
+      "name": "Eric Clapton ",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.exclusive.radio/er/ericclapton/icecast.audio",
+      "homepage": "https://tunein.com/artist/Eric-Clapton-m473626/",
+      "country": "GB",
+      "tags": [
+        "international"
+      ],
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0a/Eric_Clapton_-_Royal_Albert_Hall_-_Wednesday_24th_May_2017_EricClaptonRAH240517-30_%2834987232355%29_%28cropped%29.jpg/1200px-Eric_Clapton_-_Royal_Albert_Hall_-_Wednesday_24th_May_2017_EricClaptonRAH240517-30_%2834987232355%29_%28cropped%29.jpg",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-classic-fm-calm",
+      "name": "Classic FM Calm",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ice.musicradio.com/ClassicFMCalmMP3",
+      "homepage": "https://www.classicfm.com/calm/",
+      "country": "GB",
+      "tags": [
+        "classical",
+        "romantic"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-house-music-radio",
+      "name": "House Music Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://uk4-vn.mixstream.net/8128/listen.mp3",
+      "homepage": "https://www.housemusicradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "deep house",
+        "house"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-smooth-relax",
+      "name": "Smooth Relax",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.thisisdax.com/SmoothRelaxMP3",
+      "homepage": "https://www.smoothradio.com/relax/",
+      "country": "GB",
+      "tags": [
+        "easy listening",
+        "relaxing"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-diva-radio-funk-disco-music-paradise",
+      "name": "Diva Radio - Funk & Disco Music Paradise",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.deevaradio.net:10443/divaradiofunk",
+      "homepage": "https://deevaradio.net/",
+      "country": "GB",
+      "tags": [
+        "boogie",
+        "disco",
+        "funk",
+        "r'n'b",
+        "rap",
+        "soul"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.3366,
+        -0.0293
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-nation-60s",
+      "name": "Nation 60s",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-nation.sharp-stream.com/nation60s.mp3",
+      "homepage": "http://www.nationradio.com/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-100-hip-hop-nts",
+      "name": "100% Hip Hop | NTS",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-mixtape-geo.ntslive.net/mixtape2",
+      "homepage": "https://www.nts.live/infinite-mixtapes/100-percent-hip-hop",
+      "country": "GB",
+      "tags": [
+        "hip-hop"
+      ],
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-danceradiouk-dance-uk",
+      "name": "DanceRadioUK - Dance UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://dancestream.danceradiouk.com/stream/1/",
+      "homepage": "https://danceradiouk.com/",
+      "country": "GB",
+      "tags": [
+        "dance"
+      ],
+      "favicon": "https://www.danceradiouk.com/wp-content/uploads/2021/02/druk300-150x150.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-naim-jazz-flac",
+      "name": "Naim Jazz [flac]",
+      "broadcaster": "independent",
+      "streamUrl": "https://mscp3.live-streams.nl:8342/jazz-flac.flac",
+      "homepage": "https://www.naimaudio.com/new-naim-radio",
+      "country": "GB",
+      "favicon": "https://www.naimaudio.com/build/assets/apple-touch-icon-2a4e35a0.png",
+      "bitrate": 128,
+      "codec": "OGG",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-kool-fm",
+      "name": "Kool FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://admin.stream.rinse.fm/proxy/kool/stream",
+      "homepage": "https://rinse.fm/channels/kool/",
+      "country": "GB",
+      "tags": [
+        "breakbeat",
+        "dancefloor",
+        "drum and bass",
+        "jump up",
+        "jungle",
+        "jungle hardcore"
+      ],
+      "favicon": "https://pbs.twimg.com/profile_images/1638236080674578434/Hbww_nFm_400x400.jpg",
+      "bitrate": 128,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-virgin-radio-anthems",
+      "name": "Virgin Radio Anthems",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.virginradio.co.uk/stream-anthems",
+      "homepage": "https://virginradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "anthems",
+        "national"
+      ],
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-rokit-radio-british-comedy-2",
+      "name": "ROKit Radio : British Comedy 2",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming05.liveboxstream.uk/proxy/jondreas/stream",
+      "homepage": "https://rokitradio.com/",
+      "country": "GB",
+      "tags": [
+        "comedy",
+        "old time radio",
+        "otr",
+        "radio shows",
+        "u.k. comedy"
+      ],
+      "favicon": "https://rokitradio.com/favicon.ico",
+      "bitrate": 48,
+      "codec": "MP3",
+      "geo": [
+        51.5071,
+        -0.1228
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-classic-fm-hd",
+      "name": "Classic FM HD",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice-sov.musicradio.com/ClassicFMHD?hdauth=:2000000000:a290d4b39a16153061d4c743008b9fe8d424a7e5ec6469d40acf51fdcd336e80",
+      "homepage": "https://www.classicfm.com/",
+      "country": "GB",
+      "tags": [
+        "classical"
+      ],
+      "favicon": "https://is1-ssl.mzstatic.com/image/thumb/Purple116/v4/bd/a7/bf/bda7bf4f-16e9-6b60-0d87-a39d432b505e/AppIcon-1x_U007emarketing-0-7-0-85-220.png/492x0w.webp",
+      "bitrate": 192,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-boom-radio-uk",
+      "name": "Boom Radio UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-boomradio.sharp-stream.com/65_boom_radio_live_192",
+      "homepage": "https://www.boomradiouk.com/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/460/5fb3bb6151ee4.png",
+      "bitrate": 256,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-street-sounds-radio",
+      "name": "Street Sounds Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.broadcastradio.com:10525/streetsd",
+      "homepage": "https://www.streetsoundsradio.com/",
+      "country": "GB",
+      "tags": [
+        "funk",
+        "jazz"
+      ],
+      "codec": "MP3",
+      "geo": [
+        51.7192,
+        0.4757
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-45-radio",
+      "name": "45 Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream1.themediasite.co.uk:7009/stream",
+      "homepage": "https://www.my45radio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "60s",
+        "70s",
+        "80s",
+        "90s"
+      ],
+      "favicon": "https://www.my45radio.co.uk/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bbc-for-australasia",
+      "name": "BBC for Australasia",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.live.vc.bbcmedia.co.uk/bbc_world_service_australasia",
+      "homepage": "https://bbc.co.uk/",
+      "country": "GB",
+      "tags": [
+        "news"
+      ],
+      "favicon": "https://bbc.co.uk/favicon.ico",
+      "bitrate": 56,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-smooth-country",
+      "name": "Smooth Country",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ssl.musicradio.com/SmoothCountry",
+      "homepage": "https://www.smoothradio.com/country/",
+      "country": "GB",
+      "tags": [
+        "country",
+        "country music"
+      ],
+      "favicon": "https://www.smoothradio.com/assets_v4r/smooth/img/favicon-196x196.png",
+      "bitrate": 48,
+      "codec": "AAC",
+      "geo": [
+        51.5306,
+        -0.022
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hypedem-reggae-radio",
+      "name": "HypeDem Reggae Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://mrwolfman2.radioca.st/;",
+      "homepage": "https://hypedem-radio.com/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-london-music-radio",
+      "name": "London Music Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiobossrelay.radioca.st/stream",
+      "homepage": "https://londonmusicradio.com/",
+      "country": "GB",
+      "favicon": "https://londonmusicradio.com/wp-content/uploads/2017/04/thumbnail_Logo2-2-copyY-copy-black-e1519168864488.jpg",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-kiss-uk",
+      "name": "KISS UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://live-kiss.sharp-stream.com/kiss100.mp3",
+      "homepage": "https://kissfmuk.com/",
+      "country": "GB",
+      "tags": [
+        "bauer radio",
+        "kiss",
+        "kiss fm",
+        "pop"
+      ],
+      "favicon": "https://media.bauerradio.com/image/upload/c_crop,g_custom/v1678797505/brand_manager/stations/mahvph4fqjmnp4y8d6wt.png",
+      "bitrate": 112,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-essex",
+      "name": "Radio Essex",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.aiir.com/ujzy590c3stvv",
+      "homepage": "https://www.radioessex.com/",
+      "country": "GB",
+      "tags": [
+        "contemporary hits radio",
+        "pop",
+        "top 40 hits"
+      ],
+      "favicon": "https://mmo.aiircdn.com/339/67698698b4c61.png",
+      "codec": "MP3",
+      "geo": [
+        51.5408,
+        0.6908
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-rinse-uk",
+      "name": "Rinse UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://admin.stream.rinse.fm/proxy/rinse_uk/stream",
+      "homepage": "https://www.rinse.fm/channels/uk/",
+      "country": "GB",
+      "tags": [
+        "dance music",
+        "dubstep",
+        "garage",
+        "grime",
+        "house",
+        "jungle"
+      ],
+      "favicon": "https://i1.sndcdn.com/avatars-HFUM5iVBOYInWEED-oro7Vg-t200x200.jpg",
+      "bitrate": 128,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-classic-fm-movies",
+      "name": "Classic FM Movies",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ice.musicradio.com/ClassicFMMoviesMP3",
+      "homepage": "https://www.classicfm.com/movies/",
+      "country": "GB",
+      "tags": [
+        "classical",
+        "film score",
+        "movies"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-intamixx-80s-90s-radio-uk",
+      "name": "Intamixx 80s 90s Radio UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.intamixx.uk:8443/radio2",
+      "homepage": "https://80s.intamixx.uk/",
+      "country": "GB",
+      "tags": [
+        "80s",
+        "90s",
+        "dance",
+        "drum and bass",
+        "electronic",
+        "funk"
+      ],
+      "favicon": "https://80s.intamixx.uk/images/imc8090.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.1788,
+        -0.3079
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-cruiseone-radio",
+      "name": "CruiseOne Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://solid24.streamupsolutions.com/proxy/cmxicxxx?mp=/256kbps",
+      "homepage": "https://cruiseoneradio.net/",
+      "country": "GB",
+      "tags": [
+        "electronic",
+        "indie",
+        "indie rock",
+        "pop",
+        "rock"
+      ],
+      "favicon": "https://i1.sndcdn.com/avatars-000037533466-mgfbsp-t500x500.jpg",
+      "bitrate": 256,
+      "codec": "MP3",
+      "geo": [
+        51.4552,
+        -2.5931
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-kicks-fm",
+      "name": "KICKS fm",
+      "broadcaster": "independent",
+      "streamUrl": "https://s6.citrus3.com:8452/stream",
+      "homepage": "https://www.kicks.fm/",
+      "country": "GB",
+      "tags": [
+        "general"
+      ],
+      "bitrate": 160,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-expansions-nts",
+      "name": "Expansions | NTS",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-mixtape-geo.ntslive.net/mixtape3",
+      "homepage": "https://www.nts.live/infinite-mixtapes/expansions",
+      "country": "GB",
+      "tags": [
+        "jazz"
+      ],
+      "favicon": "https://www.nts.live/apple-touch-icon.png?v=47re43rrzb",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-energy-fm-dance-music-radio",
+      "name": "Energy FM - Dance Music Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.streemlion.com:1875/stream",
+      "homepage": "https://www.energyfm.co.uk/",
+      "country": "GB",
+      "tags": [
+        "dance",
+        "house",
+        "trance"
+      ],
+      "favicon": "https://cdn.onlineradiobox.com/img/logo/9/35209.v3.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-1940s-radio-hs-pumpkin-fm",
+      "name": "1940s Radio HS - Pumpkin FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast2.asurahosting.com/proxy/1940sradio/stream",
+      "homepage": "https://pumpkinfm.com/",
+      "country": "GB",
+      "tags": [
+        "1930s",
+        "1940s",
+        "1950s",
+        "40s",
+        "50s",
+        "big band"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-davide-of-mimic",
+      "name": "Davide of MIMIC",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming04.liveboxstream.uk/proxy/davideof?mp=/stream",
+      "homepage": "https://www.davideofmimic.com/",
+      "country": "GB",
+      "tags": [
+        "classical"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-classic-fm-essential-classical",
+      "name": "Classic FM Essential Classical",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.thisisdax.com/ClassicFM-M-Essential",
+      "homepage": "https://www.classicfm.com/",
+      "country": "GB",
+      "tags": [
+        "classical"
+      ],
+      "favicon": "https://www.radio.de/images/broadcasts/a1/f8/126083/1/c300.png",
+      "bitrate": 48,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-psychedelicized-radio",
+      "name": "Psychedelicized Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast1.asurahosting.com/proxy/psychedelicized/stream",
+      "homepage": "https://psychedelicized.com/",
+      "country": "GB",
+      "tags": [
+        "psychedelic rock"
+      ],
+      "favicon": "https://cdn-radiotime-logos.tunein.com/s155704q.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-dire-straits",
+      "name": "Dire Straits",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.pcradio.ru/dire_straits-hi",
+      "homepage": "https://pcradio.ru/",
+      "country": "GB",
+      "tags": [
+        "discography"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-gold-london",
+      "name": "Gold London",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ssl.musicradio.com/Gold?isLoggedIn=false&dax_version=release_2019&dax_player=GlobalPlayer&dax_platform=Web&aisDelivery=streaming&listenerid=1612127423858_0.6253666805372976&aw_0_1st.playerid=GlobalPlayer&aw_0_1st.skey=1612127423&aw_0_req.userConsentV2=CPA5x3uPA5x3uAGABCENBLCgAAAAAAAAAATIAAAAAAAA.YAAAAAAAAAAA",
+      "homepage": "https://media-ssl.musicradio.com/Gold?isLoggedIn=false&dax_version=release_2019&dax_player=GlobalPlayer&dax_platform=Web&aisDelivery=streaming&listenerid=1612127423858_0.6253666805372976&aw_0_1st.playerid=GlobalPlayer&aw_0_1st.skey=1612127423&aw_0_req.userConsentV2=CPA5x3uPA5x3uAGABCENBLCgAAAAAAAAAATIAAAAAAAA.YAAAAAAAAAAA",
+      "country": "GB",
+      "favicon": "https://media-ssl.musicradio.com/favicon.ico",
+      "bitrate": 48,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-greatest-hits-non-stop",
+      "name": "Greatest Hits Non-Stop",
+      "broadcaster": "independent",
+      "streamUrl": "https://s8.myradiostream.com/58238//listen.mp3",
+      "homepage": "https://greatesthitsnonstop.com/",
+      "country": "GB",
+      "favicon": "https://greatesthitsnonstop.com/wp-content/uploads/2020/02/GHNS_512-1.png",
+      "bitrate": 160,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-reprezent-radio",
+      "name": "Reprezent Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.canstream.co.uk:8022/live.mp3",
+      "homepage": "https://www.reprezentradio.org.uk/",
+      "country": "GB",
+      "tags": [
+        "music",
+        "grime",
+        "hiphop",
+        "electronic"
+      ],
+      "favicon": "https://cdn.prod.website-files.com/62bc4b9b51f455e9a386fdd1/62be3ea967ffbeb32ccfe453_android-chrome-256x256.png",
+      "bitrate": 256,
+      "codec": "MP3",
+      "geo": [
+        51.4634,
+        -0.1123
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-naim-radio-320k-aac",
+      "name": "Naim Radio [320k aac]",
+      "broadcaster": "independent",
+      "streamUrl": "https://mscp3.live-streams.nl:8362/high.aac",
+      "homepage": "https://www.naimaudio.com/radio/player",
+      "country": "GB",
+      "favicon": "https://www.naimaudio.com/build/assets/apple-touch-icon-2a4e35a0.png",
+      "bitrate": 320,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-box-uk-radio",
+      "name": "Box UK Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://boxstream.danceradiouk.com/stream/1/stream.mp3",
+      "homepage": "https://www.danceradiouk.com/",
+      "country": "GB",
+      "favicon": "https://www.danceradiouk.com/players/files/images/albumart/13040-BoxUK-300.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-classic-fm-video-game-music",
+      "name": "Classic FM Video Game Music",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.thisisdax.com/ClassicFM-M-Gaming",
+      "homepage": "https://www.classicfm.com/",
+      "country": "GB",
+      "tags": [
+        "classical"
+      ],
+      "favicon": "https://www.classicfm.com/assets_v4r/classic/img/favicon-196x196.png",
+      "bitrate": 48,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bbc-arabic",
+      "name": "BBC Arabic ",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.live.vc.bbcmedia.co.uk/bbc_arabic_radio",
+      "homepage": "https://stream.live.vc.bbcmedia.co.uk/",
+      "country": "GB",
+      "tags": [
+        "news"
+      ],
+      "bitrate": 56,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-birdsong-radio",
+      "name": "Birdsong Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://a1.radio.co/s5c5da6a36/listen",
+      "homepage": "https://www.birdsong.fm/",
+      "country": "GB",
+      "favicon": "https://images.radio.co/station_logos/s5c5da6a36.20240717025356.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-4-to-the-floor-nts",
+      "name": "4 To The Floor | NTS",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-mixtape-geo.ntslive.net/mixtape5",
+      "homepage": "https://www.nts.live/infinite-mixtapes/4-to-the-floor",
+      "country": "GB",
+      "tags": [
+        "disco",
+        "house",
+        "techno"
+      ],
+      "favicon": "https://www.nts.live/apple-touch-icon.png?v=47re43rrzb",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-truckstopradio",
+      "name": "TruckStopRadio",
+      "broadcaster": "independent",
+      "streamUrl": "https://oreo.truckstopradio.co.uk/radio/8000/radio.mp3",
+      "homepage": "https://truckstopradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://truckstopradio.co.uk/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-x",
+      "name": "Radio X",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ssl.musicradio.com/RadioXLondonMP3",
+      "homepage": "https://www.radiox.co.uk/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-the-english-909-radio",
+      "name": "The English 909 Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.radioking.com/play/the-english-909",
+      "homepage": "https://english909.com/",
+      "country": "GB",
+      "favicon": "https://www.google.co.uk/search?q=the+english+909+radio+favicon&tbm=isch&ved=2ahUKEwjy5ois1dX6AhVYgc4BHX2PCx8Q2-cCegQIABAA&oq=the+english+909+radio+favicon&gs_lcp=CgNpbWcQAzoECCMQJ1CSB1jdRWC8SGgAcAB4AIABR4gBmASSAQE5mAEAoAEBqgELZ3dzLXdpei1pbWfAAQE&sclient=img&ei=jBBEY_LwF9iCur4P_Z6u-AE&authuser=0&bih=711&biw=1431&hl=en-GB#imgrc=BAdZB6F91SYoWM",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-rokit-radio-comedy-gold",
+      "name": "ROKit Radio : Comedy Gold",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming06.liveboxstream.uk/proxy/rokstar8/stream",
+      "homepage": "https://rokitradio.com/",
+      "country": "GB",
+      "tags": [
+        "comedy",
+        "old time radio",
+        "otr",
+        "radio shows"
+      ],
+      "favicon": "https://rokitradio.com/images/channels/comedy_gold.jpg",
+      "bitrate": 48,
+      "codec": "MP3",
+      "geo": [
+        51.507,
+        -0.1228
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-just-house-music",
+      "name": "Just House Music",
+      "broadcaster": "independent",
+      "streamUrl": "https://justhousemusic.radioca.st/stream",
+      "homepage": "https://justhousemusic.co.uk/",
+      "country": "GB",
+      "favicon": "https://cdn-profiles.tunein.com/s293430/images/logod.png?t=638095610890000000",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.4964,
+        -0.1305
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-england-pumpkin-fm",
+      "name": "Radio England - Pumpkin FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast2.asurahosting.com/proxy/radioengland/stream",
+      "homepage": "https://pumpkinfm.com/",
+      "country": "GB",
+      "tags": [
+        "1940s",
+        "1950s",
+        "40s",
+        "50s",
+        "british comedy",
+        "comedy"
+      ],
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-dandelion-radio",
+      "name": "Dandelion Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://solid41.streamupsolutions.com/proxy/bqbyzdhi?mp=/stream",
+      "homepage": "http://www.dandelionradio.com/",
+      "country": "GB",
+      "tags": [
+        "alternative",
+        "indie",
+        "eclectic",
+        "john peel"
+      ],
+      "favicon": "http://www.dandelionradio.com/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-jfsr-jazz-funk-soul-radio",
+      "name": "JFSR - Jazz Funk Soul Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.radio.co/s22ae5a8a6/listen",
+      "homepage": "https://jfsr.co.uk/",
+      "country": "GB",
+      "tags": [
+        "funk",
+        "jazz",
+        "soul"
+      ],
+      "favicon": "https://jfsr.co.uk/wp-content/uploads/2020/08/cropped-JFSR-Favicon-300x300.png",
+      "bitrate": 320,
+      "codec": "AAC",
+      "geo": [
+        55.0985,
+        -2.9443
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-totally-80s-radio",
+      "name": "Totally 80s Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ukstream.radiohost.co.uk/listen/totally_80s_radio/radio.mp3",
+      "homepage": "https://www.totally80sradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://lh3.googleusercontent.com/YJxyM8-pCOf0oai9UTisHiudRJ1ni2Xt3s7DdPYQKp_oMCuHBn75zpZMSpFd_CBt6PdCKjlOWk9ToqItZPzcrlcgtMXK_h0k=s500",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-now-80s",
+      "name": "Now 80s",
+      "broadcaster": "independent",
+      "streamUrl": "https://lightning-now80s-samsunguk.amagi.tv/playlist.m3u8",
+      "homepage": "https://nowmusic.com/",
+      "country": "GB",
+      "tags": [
+        "1980s",
+        "80s",
+        "classic hits",
+        "retro"
+      ],
+      "bitrate": 1020,
+      "codec": "AAC,H.264",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-poolside-nts",
+      "name": "Poolside | NTS",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-mixtape-geo.ntslive.net/mixtape4",
+      "homepage": "https://www.nts.live/infinite-mixtapes/poolside",
+      "country": "GB",
+      "tags": [
+        "poolside",
+        "soul"
+      ],
+      "favicon": "https://www.nts.live/favicon.ico",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-rokit-radio-classic-old-time-radio-shows",
+      "name": "ROKit Radio : Classic Old Time Radio Shows",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming04.liveboxstream.uk/proxy/roksta18/stream",
+      "homepage": "https://rokitradio.com/",
+      "country": "GB",
+      "tags": [
+        "comedy",
+        "drama",
+        "old time radio",
+        "otr",
+        "radio shows",
+        "sitcom"
+      ],
+      "favicon": "https://rokitradio.com/images/channels/old_time_gold.jpg",
+      "bitrate": 48,
+      "codec": "MP3",
+      "geo": [
+        51.5074,
+        -0.1244
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-fsn-world-news",
+      "name": "FSN World News",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.fsnradionews.com/FSNNews/FSNWorldNews.mp3",
+      "homepage": "https://www.featurestorynews.com/",
+      "country": "GB",
+      "tags": [
+        "news",
+        "world news"
+      ],
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-24-7-disco",
+      "name": "24-7 Disco",
+      "broadcaster": "independent",
+      "streamUrl": "https://antares.dribbcast.com/proxy/s8190/stream",
+      "homepage": "https://24-7nicheradio.com/audiogallery/24-7-disco/",
+      "country": "GB",
+      "favicon": "https://24-7nicheradio.com/wp-content/uploads/2017/04/xDisco.jpg.pagespeed.ic.Z0Vjw3zxU-.webp",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-tonic-ska-radio",
+      "name": "Tonic Ska Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://eu10.fastcast4u.com/tonicska",
+      "homepage": "https://www.tonicskaradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "ska"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.5074,
+        -0.1276
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-crime-incorporated-pumpkin-fm",
+      "name": "Crime Incorporated - Pumpkin FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast2.asurahosting.com/proxy/crimeinc/stream",
+      "homepage": "https://pumpkinfm.com/",
+      "country": "GB",
+      "tags": [
+        "crime",
+        "detective",
+        "mystery",
+        "old time radio",
+        "police",
+        "suspense"
+      ],
+      "favicon": "https://pumpkinfm.com/wp-content/uploads/2019/02/CrimeInc300x300.jpg",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-aah-classical-radio-bach",
+      "name": "Aah Classical Radio - Bach",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.hearme.fm:9040/stream",
+      "homepage": "http://classical.aahradio.com/channel/bach/",
+      "country": "GB",
+      "tags": [
+        "classical"
+      ],
+      "favicon": "http://img.sedoparking.com/templates/logos/sedo_logo.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-rokit-radio-adventure-stories",
+      "name": "ROKit Radio : Adventure Stories",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming06.liveboxstream.uk/proxy/rokstar7/stream",
+      "homepage": "https://rokitradio.com/",
+      "country": "GB",
+      "tags": [
+        "adventure",
+        "old time radio",
+        "otr",
+        "radio shows"
+      ],
+      "favicon": "https://rokitradio.com/images/channels/adventure_stories.jpg",
+      "bitrate": 48,
+      "codec": "MP3",
+      "geo": [
+        51.5075,
+        -0.1239
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-the-tube-nts",
+      "name": "The Tube | NTS",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-mixtape-geo.ntslive.net/mixtape26",
+      "homepage": "https://www.nts.live/infinite-mixtapes/the-tube",
+      "country": "GB",
+      "tags": [
+        "avant-garde",
+        "industrial",
+        "minimal wave",
+        "post-punk"
+      ],
+      "favicon": "https://www.nts.live/apple-touch-icon.png?v=47re43rrzb",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-flashback-radio",
+      "name": "Flashback Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.flashbackcentral.co.uk/radio/8000/apple",
+      "homepage": "https://www.flashbackradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "00s",
+        "90s",
+        "dance",
+        "pop",
+        "rock"
+      ],
+      "favicon": "https://irp.cdn-website.com/d8990fde/site_favicon_16_1654769166393.ico",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-memory-lane-nts",
+      "name": "Memory Lane | NTS",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-mixtape-geo.ntslive.net/mixtape6",
+      "homepage": "https://www.nts.live/infinite-mixtapes/memory-lane",
+      "country": "GB",
+      "tags": [
+        "garage rock",
+        "psychedelic",
+        "soul"
+      ],
+      "favicon": "https://www.nts.live/favicon.ico",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-pink-floyd",
+      "name": "Pink Floyd",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.pcradio.ru/Pink_Floyd-hi",
+      "homepage": "https://pcradio.ru/",
+      "country": "GB",
+      "tags": [
+        "discography"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-tmm-1-hq",
+      "name": "TMM 1 (HQ)",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-msmn.sharp-stream.com/nme1high.mp3",
+      "homepage": "https://www.themusicmachine.co.uk/",
+      "country": "GB",
+      "tags": [
+        "alternative",
+        "alternative rock",
+        "garage",
+        "indie",
+        "indie pop",
+        "indie rock"
+      ],
+      "favicon": "https://cdn-profiles.tunein.com/s159857/images/logod.png",
+      "bitrate": 256,
+      "codec": "MP3",
+      "geo": [
+        51.5015,
+        -0.1305
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-actual-radio",
+      "name": "Actual Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://securestreams.autopo.st:1174/;",
+      "homepage": "https://actualradio.com/",
+      "country": "GB",
+      "tags": [
+        "80s",
+        "classic hits",
+        "oldies"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-subtle-radio",
+      "name": "Subtle Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://subtle.out.airtime.pro/subtle_a",
+      "homepage": "https://www.subtleradio.com/",
+      "country": "GB",
+      "tags": [
+        "community radio",
+        "music",
+        "variety"
+      ],
+      "favicon": "https://www.subtleradio.com/wp-content/uploads/2022/11/favicon.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-field-recordings-nts",
+      "name": "Field Recordings | NTS",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-mixtape-geo.ntslive.net/mixtape23",
+      "homepage": "https://www.nts.live/infinite-mixtapes/field-recordings",
+      "country": "GB",
+      "tags": [
+        "field recording"
+      ],
+      "favicon": "https://www.nts.live/apple-touch-icon.png?v=47re43rrzb",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-soho-radio-london",
+      "name": "Soho Radio London",
+      "broadcaster": "independent",
+      "streamUrl": "https://sohoradiomusic.doughunt.co.uk:8010/128mp3",
+      "homepage": "https://sohoradiolondon.com/",
+      "country": "GB",
+      "tags": [
+        "culture",
+        "eclectic",
+        "variety"
+      ],
+      "favicon": "https://sohoradiolondon.com/wp-content/themes/sohoradio-jan-2023/build/images/favicons/sohoradio-192x192.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-labyrinth-nts",
+      "name": "Labyrinth | NTS",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-mixtape-geo.ntslive.net/mixtape31",
+      "homepage": "https://www.nts.live/infinite-mixtapes/labyrinth",
+      "country": "GB",
+      "tags": [
+        "breaks",
+        "techno"
+      ],
+      "favicon": "https://www.nts.live/apple-touch-icon.png?v=47re43rrzb",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-the-voice-of-doom",
+      "name": "The Voice Of Doom",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.galaxywebsolutions.com:9046/stream",
+      "homepage": "https://www.thevoiceofdoom.com/",
+      "country": "GB",
+      "tags": [
+        "death metal",
+        "doom metal",
+        "gothic metal",
+        "metal",
+        "symphonic metal"
+      ],
+      "bitrate": 320,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-dnbradio-com",
+      "name": "DnBRadio.com",
+      "broadcaster": "independent",
+      "streamUrl": "https://fw.dnbradio.com/dnbradio_main.mp3",
+      "homepage": "https://dnbradio.com/",
+      "country": "GB",
+      "favicon": "https://dnbradio.com/img/logotags.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-gen-x-radio",
+      "name": "Gen X Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.radio.co/sf25229e16/listen",
+      "homepage": "https://genxradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "00s",
+        "10s",
+        "20s",
+        "60s",
+        "70s",
+        "80s"
+      ],
+      "favicon": "https://genxradio.co.uk/wp-content/uploads/2021/11/cropped-GenXAsset-9-192x192.png",
+      "bitrate": 320,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-house-fusion-radio-uk",
+      "name": "House Fusion Radio (UK)",
+      "broadcaster": "independent",
+      "streamUrl": "https://housefusionradiouk.out.airtime.pro/housefusionradiouk_a",
+      "homepage": "https://house-fusion-radio5.webnode.co.uk/",
+      "country": "GB",
+      "tags": [
+        "chillout",
+        "deep",
+        "disco",
+        "funky",
+        "house",
+        "old skool"
+      ],
+      "favicon": "https://d1di2lzuh97fh2.cloudfront.net/files/1j/1j3/1j3767.ico?ph=a9529f376f",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-the-british-home-front-radio-service",
+      "name": "The British Home Front Radio Service",
+      "broadcaster": "independent",
+      "streamUrl": "https://solid24.streamupsolutions.com/proxy/mmpplqiv?mp=/;type=mp3",
+      "homepage": "http://www.1940sukradio.co.uk/BHFR/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-heart-musicals",
+      "name": "Heart Musicals",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ice.musicradio.com/HeartMusicalsMP3",
+      "homepage": "https://www.heart.co.uk/musicals/",
+      "country": "GB",
+      "tags": [
+        "movies",
+        "musicals"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-boogaloo-radio",
+      "name": "Boogaloo Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streams.radio.co/sb88c742f0/listen",
+      "homepage": "https://boogalooradio.com/",
+      "country": "GB",
+      "tags": [
+        "brit pop",
+        "indie rock"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.5764,
+        -0.1436
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-easy-50s",
+      "name": "Easy 50s",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.exclusive.radio/uber/easy50/icecast.audio",
+      "homepage": "https://easy.radio/station/47/658",
+      "country": "GB",
+      "favicon": "https://manager.uber.radio/static/uploads/station/45f6ba11-a495-4500-abae-41c0b999df6c.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-mi-soul",
+      "name": "Mi-Soul ",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-misoul.sharp-stream.com/462_mi_soul_128_mp3",
+      "homepage": "https://mi-soul.com/",
+      "country": "GB",
+      "favicon": "https://upload.wikimedia.org/wikipedia/en/thumb/c/cc/Mi-Soul_logo.png/220px-Mi-Soul_logo.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-liquid-dnb",
+      "name": "Liquid DnB",
+      "broadcaster": "independent",
+      "streamUrl": "https://antares.dribbcast.com/proxy/dave1/stream/",
+      "homepage": "https://liquid-dnb.com/",
+      "country": "GB",
+      "tags": [
+        "dnb",
+        "liquid dnb"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bbc-radio-one",
+      "name": "BBC Radio One",
+      "broadcaster": "independent",
+      "streamUrl": "https://a.files.bbci.co.uk/ms6/live/3441A116-B12E-4D2F-ACA8-C1984642FA4B/audio/simulcast/hls/nonuk/audio_syndication_low_sbr_v1/aks/bbc_radio_one.m3u8",
+      "homepage": "http://www.bbc.co.uk/radio1",
+      "country": "GB",
+      "favicon": "https://cdn-radiotime-logos.tunein.com/s24939q.png",
+      "bitrate": 101,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-funkuradio",
+      "name": "FunkURadio",
+      "broadcaster": "independent",
+      "streamUrl": "https://furfmcou.radioca.st/stream",
+      "homepage": "http://www.funkuradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "70s",
+        "80s",
+        "disco",
+        "funk",
+        "jazz",
+        "rare groove"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-american-gold-pumpkin-fm",
+      "name": "American Gold - Pumpkin FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast2.asurahosting.com/proxy/americangold/stream",
+      "homepage": "https://pumpkinfm.com/",
+      "country": "GB",
+      "tags": [
+        "1940s",
+        "1950s",
+        "1960s",
+        "american",
+        "cabaret",
+        "old time radio"
+      ],
+      "favicon": "https://pumpkinfm.com/wp-content/uploads/2021/01/AmericanGold300x300.jpg",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-diva-radio-disco",
+      "name": "Diva Radio Disco",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.deevaradio.net:10443/divaradiodisco",
+      "homepage": "https://deevaradio.net/",
+      "country": "GB",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.5032,
+        -0.0787
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-dubplate-fm-dub-bass",
+      "name": "Dubplate.fm Dub &Bass",
+      "broadcaster": "independent",
+      "streamUrl": "https://sc2.dubplate.fm/radio/8000/dubandbass/uhifi",
+      "homepage": "https://dubplate.fm/dub-and-bass-radio",
+      "country": "GB",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-neon-radio-80s-90s-pop-dance",
+      "name": "Neon Radio - 80s & 90s Pop & Dance",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.flashbackcentral.co.uk/radio/8050/tunein.mp3",
+      "homepage": "https://www.neonradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "hits 80s",
+        "hits 90s",
+        "pop music"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-ozzy-osbourne",
+      "name": "Ozzy Osbourne",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.pcradio.ru/ozzy_osbourne-hi",
+      "homepage": "https://pcradio.ru/",
+      "country": "GB",
+      "tags": [
+        "discography"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-heart-south-wales",
+      "name": "Heart South Wales",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ssl.musicradio.com/HeartSouthWalesMP3",
+      "homepage": "https://www.heart.co.uk/southwales",
+      "country": "GB",
+      "tags": [
+        "adult contemporary",
+        "pop",
+        "public radio",
+        "south wales",
+        "variety"
+      ],
+      "favicon": "https://www.heart.co.uk/assets_v4r/heart/img/favicon-196x196.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-central-24",
+      "name": "Radio Central 24",
+      "broadcaster": "independent",
+      "streamUrl": "https://casper.radioca.st/;",
+      "homepage": "http://radiocentral24.com/",
+      "country": "GB",
+      "tags": [
+        "bhangra",
+        "bollywood",
+        "pakistani"
+      ],
+      "favicon": "http://radiocentral24.com/assets/images/transparent-121x64.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-one-world-radio-tomorrowland-anthems",
+      "name": "One World Radio - Tomorrowland Anthems",
+      "broadcaster": "independent",
+      "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/OWR_DAB.mp3",
+      "homepage": "https://www.tomorrowland.com/home/radio",
+      "country": "GB",
+      "tags": [
+        "dance",
+        "edm",
+        "electronic"
+      ],
+      "favicon": "https://www.tomorrowland.com/home/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-total-soul-uk-192kb-mp3",
+      "name": "Total Soul (UK) 192kb mp3",
+      "broadcaster": "independent",
+      "streamUrl": "https://onair7.xdevel.com/proxy/xautocloud_atvn_1069?mp=/;1/",
+      "homepage": "https://www.totalsoul.co.uk/",
+      "country": "GB",
+      "tags": [
+        "80's",
+        "disco",
+        "soul"
+      ],
+      "favicon": "https://mmo.aiircdn.com/440/66d2d8d6d54ea.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-i-like-it-oldskool",
+      "name": "I Like It Oldskool",
+      "broadcaster": "independent",
+      "streamUrl": "https://ilikeitoldskool.radioca.st/stream",
+      "homepage": "https://ilikeitoldskool.co.uk/",
+      "country": "GB",
+      "tags": [
+        "dance",
+        "hardcore",
+        "house",
+        "jungle",
+        "uk garage"
+      ],
+      "favicon": "https://ilikeitoldskool.co.uk/favicon.ico",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-select-radio",
+      "name": "Select Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming05.liveboxstream.uk/proxy/selectr1/stream",
+      "homepage": "https://selectradioapp.com/",
+      "country": "GB",
+      "favicon": "https://selectradioapp.com/wp-content/uploads/2023/11/cropped-selecticon-180x180.png",
+      "bitrate": 128,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hot-radio",
+      "name": "Hot Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream1.hippynet.co.uk/stream/hotradio/dorset",
+      "homepage": "https://www.hot.radio/",
+      "country": "GB",
+      "tags": [
+        "00s",
+        "2000s",
+        "2010s",
+        "2020s",
+        "bournemouth",
+        "community"
+      ],
+      "favicon": "https://mmo.aiircdn.com/406/601068617960a.png",
+      "bitrate": 160,
+      "codec": "MP3",
+      "geo": [
+        50.737,
+        -1.9505
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-heart-xmas",
+      "name": "Heart Xmas",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ssl.musicradio.com/HeartXmas",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "GB",
+      "tags": [
+        "international"
+      ],
+      "bitrate": 48,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-lite-radio",
+      "name": "Lite Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ais-sa2.cdnstream1.com/2382_128.mp3?rp_source=1&=&&___cb=212916936695709",
+      "homepage": "https://www.literadio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "soft adult contemporary"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-trancetechnic-radio",
+      "name": "Trancetechnic Radio ",
+      "broadcaster": "independent",
+      "streamUrl": "https://s11.ssl-stream.com/ssl/trancete?mp=/stream",
+      "homepage": "http://www.trancetechnic.uk/",
+      "country": "GB",
+      "tags": [
+        "acid house",
+        "techno",
+        "trance",
+        "trancetechnic",
+        "trancetechnic radio"
+      ],
+      "favicon": "http://img.sedoparking.com/templates/logos/sedo_logo.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-easy-radio",
+      "name": "Easy Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-nation.sharp-stream.com/breezyradiouk.mp3",
+      "homepage": "https://www.nationplayer.com/easy-radio-south/",
+      "country": "GB",
+      "tags": [
+        "easy",
+        "easy listening"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-kaos-sound-pink-floyd-radio",
+      "name": "KAOS Sound  - Pink Floyd Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s3.myradiostream.com/:59506/stream/1/",
+      "homepage": "https://kaos-sound.co.uk/mrsdocs/home.html",
+      "country": "GB",
+      "tags": [
+        "classic rock",
+        "rock"
+      ],
+      "favicon": "https://cdn-profiles.tunein.com/s140303/images/logog.png?t=160685",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-netil-radio",
+      "name": "Netil Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://netilradio.out.airtime.pro/netilradio_a",
+      "homepage": "http://netilradio.com/",
+      "country": "GB",
+      "tags": [
+        "ambient",
+        "beats",
+        "breaks",
+        "disco",
+        "electro",
+        "electronic"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-rokit-radio-classic-crime-and-suspense",
+      "name": "ROKit Radio : Classic Crime and Suspense",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming04.liveboxstream.uk/proxy/roksta17/stream",
+      "homepage": "https://rokitradio.com/",
+      "country": "GB",
+      "tags": [
+        "crime",
+        "old time radio",
+        "otr",
+        "radio shows",
+        "suspense"
+      ],
+      "favicon": "https://rokitradio.com/favicon.ico",
+      "bitrate": 48,
+      "codec": "MP3",
+      "geo": [
+        51.5075,
+        -0.1221
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-psychedelic-secret-radio",
+      "name": "Psychedelic Secret radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://solid48.streamupsolutions.com/proxy/bglsokon?mp=/=stream",
+      "homepage": "https://www.psychedelicsecretsradio.com/?m=1",
+      "country": "GB",
+      "favicon": "https://www.psychedelicsecretsradio.com/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-x-90s",
+      "name": "Radio X 90s",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ice.musicradio.com/RadioX90sMP3",
+      "homepage": "https://www.radiox.co.uk/90s/",
+      "country": "GB",
+      "tags": [
+        "90s",
+        "alternative",
+        "indie rock"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bfbs-beats",
+      "name": "BFBS Beats",
+      "broadcaster": "independent",
+      "streamUrl": "https://edge-audio-01-cr.sharp-stream.com/ssvcbfbs20.aac?device=bfbs_beats",
+      "homepage": "https://www.forces.net/",
+      "country": "GB",
+      "tags": [
+        "beats",
+        "bfbs",
+        "charts",
+        "electro",
+        "hits",
+        "pop dance"
+      ],
+      "favicon": "https://www.forces.net/themes/custom/forcesnet_2020/favicon.ico",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-feelings-nts",
+      "name": "Feelings | NTS",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-mixtape-geo.ntslive.net/mixtape27",
+      "homepage": "https://www.nts.live/infinite-mixtapes/feelings",
+      "country": "GB",
+      "tags": [
+        "boogie",
+        "disco",
+        "doo-wop",
+        "gospel",
+        "soul"
+      ],
+      "favicon": "https://www.nts.live/apple-touch-icon.png?v=47re43rrzb",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-classic-fm-hall-of-fame",
+      "name": "Classic FM Hall of Fame",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.thisisdax.com/ClassicFM-M-HOF",
+      "homepage": "https://www.classicfm.com/",
+      "country": "GB",
+      "tags": [
+        "classical"
+      ],
+      "favicon": "https://www.radio.de/images/broadcasts/a1/f8/126083/1/c300.png",
+      "bitrate": 48,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-nu-disco-funk-radio",
+      "name": "Nu Disco Funk Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://my.radiolize.com/radio/8090/radio.mp3",
+      "homepage": "https://nu-disco-funk-radio.com/",
+      "country": "GB",
+      "tags": [
+        "deep house",
+        "disco",
+        "electric",
+        "funk"
+      ],
+      "favicon": "https://uk.radio.net/300/nudiscofunkradio.jpeg?version=b5b29e74fa5bb43b3b8a3e9d27349a94",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-britasia-radio",
+      "name": "BritAsia Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s4.radio.co/sfefce156f/listen",
+      "homepage": "https://britasia.tv/radio/",
+      "country": "GB",
+      "favicon": "https://britasia.tv/wp-content/uploads/2021/01/britasia-radio-logo.jpg",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-mystery-train-radio",
+      "name": "Mystery Train Radio ",
+      "broadcaster": "independent",
+      "streamUrl": "https://streamer.radio.co/sf662f27c0/listen",
+      "homepage": "https://www.mysterytrainradio.com/",
+      "country": "GB",
+      "tags": [
+        "americana",
+        "blues",
+        "eclectic",
+        "folk",
+        "indie",
+        "rock"
+      ],
+      "bitrate": 192,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-judas-priest",
+      "name": "Judas Priest",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.pcradio.ru/judas_priest-hi",
+      "homepage": "https://pcradio.ru/",
+      "country": "GB",
+      "tags": [
+        "discography"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-smooth-radio-suffolk",
+      "name": "Smooth Radio (Suffolk)",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ssl.musicradio.com/SmoothSuffolk",
+      "homepage": "https://www.smoothradio.com/suffolk/",
+      "country": "GB",
+      "tags": [
+        "adult contemporary",
+        "chill",
+        "chillout",
+        "oldies",
+        "smooth"
+      ],
+      "favicon": "https://www.smoothradio.com/assets_v4r/smooth/img/favicon-196x196.png",
+      "bitrate": 48,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-led-zeppelin",
+      "name": "Led Zeppelin",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.pcradio.ru/Led_Zeppelin-hi",
+      "homepage": "https://pcradio.ru/",
+      "country": "GB",
+      "tags": [
+        "discography"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-smooth-christmas",
+      "name": "Smooth Christmas",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ice.musicradio.com/SmoothXmasMP3",
+      "homepage": "https://www.smoothradio.com/news/christmas/",
+      "country": "GB",
+      "tags": [
+        "christmas music"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-boot-boy-radio",
+      "name": "Boot Boy Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming04.liveboxstream.uk/proxy/dwain?mp=/stream",
+      "homepage": "https://bootboyradio.net/",
+      "country": "GB",
+      "tags": [
+        "punk",
+        "reggae",
+        "ska",
+        "soul"
+      ],
+      "favicon": "https://bootboyradio.net/wp-content/uploads/2021/02/cropped-900logosquare-192x192.jpg",
+      "bitrate": 192,
+      "codec": "AAC+",
+      "geo": [
+        52.4785,
+        1.7551
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-boom-light",
+      "name": "Boom Light",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-boomradio.sharp-stream.com/65_boom_light_128_mp3",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "GB",
+      "tags": [
+        "decades"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-solar-radio",
+      "name": "Solar Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-msmn.sharp-stream.com/solarlow.mp3",
+      "homepage": "https://solarradio.com/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-twr-uk",
+      "name": "TWR UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://direct.sharp-stream.com/twruk.mp3",
+      "homepage": "https://www.twr.org.uk/",
+      "country": "GB",
+      "tags": [
+        "christian"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-malvern-radio-international-pumpkin-fm",
+      "name": "Malvern Radio International - Pumpkin FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast2.asurahosting.com/proxy/radiomalvernint/stream",
+      "homepage": "https://pumpkinfm.com/",
+      "country": "GB",
+      "tags": [
+        "classical baroque",
+        "classical music",
+        "opera",
+        "symphony"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        52.1074,
+        -2.3384
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-gold-radio-uk",
+      "name": "Gold Radio UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ice.musicradio.com/GoldMP3",
+      "homepage": "https://www.goldradio.com/?page=2",
+      "country": "GB",
+      "tags": [
+        "golden oldies",
+        "pop"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-heart-fm-birmingham",
+      "name": "Heart FM (Birmingham)",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ssl.musicradio.com/HeartWestMids?isLoggedIn=true&dax_version=release_4140&dax_player=GlobalPlayer&dax_platform=Web&delivery_type=streaming&aw_0_req.userConsentV2=CPytTYAPytTYAAGABCENATEoAP_AAAGAAAwIGMpF7D5VZWFC-OZ5YKsAMYhXQMCAIuQQCASAA-ABCAKQIIQGgmAQFASgBAAKAQAAIAJBAAIECAAQCQAAAAAAAACAAAAABAAIAAAAgAAAAAAIAAAGAAAAAAAIgAAAEAAAmAwAAIIAAADgkBkABAACwAKgAcAA8ACAAGQANAAeQBDAEQAJgATwAqgB-AEIAKUAW4AwwB7AD9AIGAVcAxQCkQF5hAAoADwASAA_AHOApsMABAU2IAAgAkFQAQAhjIAIAQx0BwABYAFQAOAAgABkADQAHkAQwBEACYAE8AKoAXQAxAB-AFGAKUAW4AwwBogD2AH6AQMAjoBVwCxAGKAReAvMcAOAAQAA8AC4AJAAcgA_AHOAQgAiIBFgCMgKQAU2AvohAIAAWAEMAJgAVQAxAClAKuAYogADAAQAOcAsRKAcAAgABYAHAAeABEACYAFUAMQAowBbgFXAMUAi8BeZIAIABcAHIA1ADMlIC4ACwAKgAcABAADIAGgAPIAhgCIAEwAJ4AUgAqgBiAD8AKMAUoAtwBogD9AI6AVcBF4C8ygA8AC4AJAAcgA_ADaANQAc4BFgCxAF1AMUAa8BSACmwF9A.YAAAAAAAAAAA&dax_listenerid=824C2FA8EC1A06EF990BEDF6BE300A70&gigya_id=aca49a64b4254a8ab5a088cd031e7efe&nlsid=1c499bb707f2fc48cfd210acda4433d0",
+      "homepage": "https://www.heart.co.uk/westmids/",
+      "country": "GB",
+      "bitrate": 48,
+      "codec": "AAC",
+      "geo": [
+        52.4881,
+        -1.8492
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-bloodstream",
+      "name": "Radio Bloodstream",
+      "broadcaster": "independent",
+      "streamUrl": "https://uk1.internet-radio.com/proxy/bloodstream?mp=/stream",
+      "homepage": "https://www.radiobloodstream.com/en/",
+      "country": "GB",
+      "tags": [
+        "hard rock",
+        "heavy metal",
+        "rock"
+      ],
+      "favicon": "https://www.radiobloodstream.com/favicon.ico",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-monocle-radio",
+      "name": "Monocle Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/MONOCLE_24.mp3",
+      "homepage": "https://monocle.com/radio/",
+      "country": "GB",
+      "tags": [
+        "culture",
+        "design",
+        "entrepreneurship",
+        "global",
+        "live shows",
+        "news"
+      ],
+      "favicon": "https://pbs.twimg.com/profile_images/1641728752236281856/zeIa6wPU_400x400.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-atlantic-252",
+      "name": "Atlantic 252",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream4.themediasite.co.uk:8042/",
+      "homepage": "https://www.atlantic252radio.com/",
+      "country": "GB",
+      "tags": [
+        "90s",
+        "dance",
+        "hits",
+        "pop"
+      ],
+      "favicon": "https://play-lh.googleusercontent.com/kIp3BTHaetEyZcMXvOzQ41i15fTZkShTAhpmjS-643non9AxqB45R1--DyU1PbFV=w240-h480-rw",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-24-7-blues-radio",
+      "name": "24/7 Blues Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ec3.yesstreaming.net:3685/stream",
+      "homepage": "https://www.247onlineradio.com/24-7-online-radio-group-stations/24-7-blues-radio/",
+      "country": "GB",
+      "tags": [
+        "blues"
+      ],
+      "favicon": "https://www.247onlineradio.com/wp-content/uploads/2023/04/247-Blues-Radio.jpg",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-forest-gold",
+      "name": "Forest Gold",
+      "broadcaster": "independent",
+      "streamUrl": "https://c2.prostream365.com:8000/live",
+      "homepage": "https://www.forestgoldradio.com/",
+      "country": "GB",
+      "tags": [
+        "classic hits",
+        "golden oldies",
+        "goldies",
+        "oldies"
+      ],
+      "favicon": "https://www.forestgoldradio.com/favicon.ico",
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        51.6978,
+        0.1099
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-news-radio-uk",
+      "name": "News Radio UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.aiir.com/clcb6m0k9shvv",
+      "homepage": "https://newsradiouk.co.uk/",
+      "country": "GB",
+      "tags": [
+        "information",
+        "news",
+        "talk"
+      ],
+      "favicon": "https://newsradiouk.co.uk/wp-content/uploads/2022/06/Facebook-profile.png",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-sheet-music-nts",
+      "name": "Sheet Music | NTS",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-mixtape-geo.ntslive.net/mixtape35",
+      "homepage": "https://www.nts.live/infinite-mixtapes/sheet-music",
+      "country": "GB",
+      "tags": [
+        "classical"
+      ],
+      "favicon": "https://www.nts.live/apple-touch-icon.png?v=47re43rrzb",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-chocolate-radio",
+      "name": "Chocolate Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radio.co/sa7336b687/listen?ver=712690",
+      "homepage": "https://chocolate-radio.com/",
+      "country": "GB",
+      "tags": [
+        "r&b/urban"
+      ],
+      "bitrate": 192,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-nation-radio-wales",
+      "name": "Nation Radio Wales",
+      "broadcaster": "independent",
+      "streamUrl": "https://edge-ads-05-gos2.sharp-stream.com/tcnationi.aac",
+      "homepage": "https://nationradio.wales/",
+      "country": "GB",
+      "tags": [
+        "contemporary"
+      ],
+      "bitrate": 48,
+      "codec": "AAC+",
+      "geo": [
+        51.482,
+        -3.1771
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-rockin50s-radio",
+      "name": "Rockin50s Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://eu10.fastcast4u.com/rockin50s",
+      "homepage": "https://rockin50s.uk/",
+      "country": "GB",
+      "favicon": "https://rockin50s.uk/images/site/site_logo2small.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-uk-bass",
+      "name": "UK Bass",
+      "broadcaster": "independent",
+      "streamUrl": "https://ukbassradio.com/stream",
+      "homepage": "https://ukbassradio.com/",
+      "country": "GB",
+      "tags": [
+        "drum and bass",
+        "neurofunk",
+        "uk bass"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-dancefmlive-trance",
+      "name": "DanceFMLive Trance",
+      "broadcaster": "independent",
+      "streamUrl": "https://broadcast.dancefmlive.com/radio/8010/radio.mp3",
+      "homepage": "https://www.dancefmlive.com/",
+      "country": "GB",
+      "tags": [
+        "trance"
+      ],
+      "favicon": "https://www.dancefmlive.com/wp-content/uploads/2021/02/trance.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-divine-radio-london",
+      "name": "Divine Radio London",
+      "broadcaster": "independent",
+      "streamUrl": "https://uk2.internet-radio.com/proxy/divinestream?mp=/stream",
+      "homepage": "https://www.divineradiolondon.co.uk/",
+      "country": "GB",
+      "tags": [
+        "dj mixes",
+        "electronic",
+        "underground"
+      ],
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-smooth-soul",
+      "name": "Smooth Soul",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ice.musicradio.com/SmoothSoulMP3",
+      "homepage": "https://www.smoothradio.com/soul/",
+      "country": "GB",
+      "tags": [
+        "motown",
+        "soul"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bolton-fm",
+      "name": "Bolton FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.canstream.co.uk:8083/live.mp3",
+      "homepage": "https://www.boltonfm.com/",
+      "country": "GB",
+      "tags": [
+        "community",
+        "local"
+      ],
+      "favicon": "https://www.boltonfm.com/bfm_website_logos/BFM_Logos/BoltonFM-Logo-square.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        53.5765,
+        -2.4324
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-sweat-nts",
+      "name": "Sweat | NTS",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-mixtape-geo.ntslive.net/mixtape24",
+      "homepage": "https://www.nts.live/infinite-mixtapes/sweat",
+      "country": "GB",
+      "tags": [
+        "party"
+      ],
+      "favicon": "https://www.nts.live/apple-touch-icon.png?v=47re43rrzb",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-dclm-radio",
+      "name": "DCLM Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://airtime.dclm.org/radio/8000/live",
+      "homepage": "https://radio.dclm.org/",
+      "country": "GB",
+      "favicon": "https://radio.dclm.org/assets/img/favicon.png",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-5-rivers-radio",
+      "name": "5 Rivers radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://onlineradiobox.com/json/uk/5rivers/play?platform=web",
+      "homepage": "https://onlineradiobox.com/json/uk/5rivers/play?platform=web",
+      "country": "GB",
+      "tags": [
+        "music"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bradford-asian-radio",
+      "name": "Bradford Asian Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast1.asurahosting.com/proxy/bradford/stream",
+      "homepage": "https://cast1.asurahosting.com/proxy/bradford/stream",
+      "country": "GB",
+      "tags": [
+        "music"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-swu-fm",
+      "name": "SWU FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://admin.stream.rinse.fm/proxy/swu/stream",
+      "homepage": "https://rinse.fm/channels/swu/",
+      "country": "GB",
+      "tags": [
+        "dnb",
+        "drum and bass",
+        "house",
+        "jungle",
+        "mixed",
+        "techno"
+      ],
+      "favicon": "https://rinse.fm/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.4409,
+        -2.6003
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-brmb-radio",
+      "name": "BRMB Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.canstream.co.uk:8147/live.mp3",
+      "homepage": "https://www.brmbradio.com/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/1111/64a34bf89acd7.png",
+      "bitrate": 160,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-resonance-104-4fm",
+      "name": "Resonance 104.4FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.resonance.fm/resonance?rp_source=1&=&&___cb=309691324386261",
+      "homepage": "https://www.resonancefm.com/",
+      "country": "GB",
+      "favicon": "https://www.resonancefm.com/assets/logo-a79206a34394173ba3e41d66a3388f4c.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-foundation-fm",
+      "name": "Foundation FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://streamer.radio.co/s0628bdd53/listen",
+      "homepage": "https://foundation.fm/",
+      "country": "GB",
+      "tags": [
+        "community radio",
+        "electronic",
+        "hip-hop",
+        "indie",
+        "jazz"
+      ],
+      "favicon": "https://foundation.fm/images/favicon/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-maria-england",
+      "name": "Radio Maria England",
+      "broadcaster": "independent",
+      "streamUrl": "https://dreamsiteradiocp5.com/proxy/rmengland?mp=/stream",
+      "homepage": "https://radiomariaengland.uk/",
+      "country": "GB",
+      "tags": [
+        "religious"
+      ],
+      "bitrate": 48,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bloop-london-radio-channel-4-music-only-themed-s",
+      "name": "Bloop London Radio (channel 4) - MUSIC ONLY THEMED STREAM.  NATURAL HIGH. DRENCHED IN GROOVES, AN ORGANIC JOURNEY OF BEATS DEDICATED TO MOVING YOUR ASS.",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.canstream.co.uk:8058/live.mp3",
+      "homepage": "https://blooplondon.com/",
+      "country": "GB",
+      "tags": [
+        "electronic",
+        "grooves"
+      ],
+      "favicon": "https://blooplondon.com/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-heart-00s",
+      "name": "Heart 00s",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ssl.musicradio.com/Heart00sMP3",
+      "homepage": "https://media-ssl.musicradio.com/Heart00sMP3",
+      "country": "GB",
+      "tags": [
+        "pop"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hearme-beethoven",
+      "name": "HearMe-Beethoven",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.hearme.fm:9050/stream",
+      "homepage": "http://www.hearme.fm/",
+      "country": "GB",
+      "tags": [
+        "classical"
+      ],
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hot-gold",
+      "name": "Hot Gold",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream1.hippynet.co.uk/stream/hotgold/dorset",
+      "homepage": "https://www.hotgold.radio/",
+      "country": "GB",
+      "tags": [
+        "70s",
+        "80s",
+        "90s",
+        "bournemouth",
+        "community",
+        "community radio"
+      ],
+      "favicon": "https://mmo.aiircdn.com/406/61940c9fa5f84.png",
+      "bitrate": 160,
+      "codec": "MP3",
+      "geo": [
+        50.737,
+        -1.9505
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-the-prodigy",
+      "name": "The Prodigy",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.pcradio.ru/The_Prodigy-hi",
+      "homepage": "https://pcradio.ru/",
+      "country": "GB",
+      "tags": [
+        "discography"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-ram-fm-80s-hit-radio",
+      "name": "Ram FM 80s Hit Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://usa1-vn.mixstream.net/8084/listen.mp3",
+      "homepage": "https://ramfm.org/",
+      "country": "GB",
+      "tags": [
+        "70s",
+        "80s",
+        "90s",
+        "eighties"
+      ],
+      "favicon": "https://ramfm.org/favicon.ico",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-capital-fm-london",
+      "name": "Capital FM London",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ssl.musicradio.com/CapitalMP3",
+      "homepage": "https://capitalfm.com/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-rokit-radio-saturn-x-radio-shows",
+      "name": "ROKit Radio : Saturn-X Radio Shows",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming05.liveboxstream.uk/proxy/jondre03/stream",
+      "homepage": "https://rokitradio.com/",
+      "country": "GB",
+      "tags": [
+        "adventure",
+        "old time radio",
+        "otr",
+        "radio shows",
+        "science fiction",
+        "scifi"
+      ],
+      "favicon": "https://rokitradio.com/favicon.ico",
+      "bitrate": 48,
+      "codec": "MP3",
+      "geo": [
+        51.507,
+        -0.1227
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-totalrock-radio",
+      "name": "TotalRock Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s3.citrus3.com:8056/stream",
+      "homepage": "https://totalrock.com/",
+      "country": "GB",
+      "tags": [
+        "metal",
+        "music",
+        "rock"
+      ],
+      "favicon": "https://scontent.fcgk8-1.fna.fbcdn.net/v/t1.18169-9/11400985_1602513246663466_6035298720034077887_n.jpg?stp=cp0_dst-jpg_e15_fr_q65&_nc_cat=108&ccb=1-7&_nc_sid=7aed08&efg=eyJpIjoiYiJ9&_nc_eui2=AeEETQvQCq6lHutRRfK171iMKMnkfCxBQUgoyeR8LEFBSC8L74DpSPHz7DvwVuHvpZkIi6qJ0_1acvrVbfekHQL9&_nc_ohc=Oo7DzNH7oTMAX_ZluE8&tn=I4UqcoMHerbAkKms&_nc_ht=scontent.fcgk8-1.fna&oh=00_AfBCXINd2TGpeja3jEiHkpvCmVAH0sxg6_Q39XWj5iRvUA&oe=6407F56B",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-asian-star-radio",
+      "name": "Asian Star Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.canstream.co.uk:9067/live.mp3",
+      "homepage": "https://radio.canstream.co.uk:9067/live.mp3",
+      "country": "GB",
+      "tags": [
+        "music"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-4tunesfm",
+      "name": "4TunesFM",
+      "broadcaster": "independent",
+      "streamUrl": "https://c30.radioboss.fm:18274/stream",
+      "homepage": "https://links.4tunefm.co.uk/",
+      "country": "GB",
+      "tags": [
+        "jazz",
+        "reggae"
+      ],
+      "favicon": "https://assets.production.linktr.ee/profiles/_next/static/logo-assets/apple-icon-120x120.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.4042,
+        -0.0853
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-gb-news",
+      "name": "GB News",
+      "broadcaster": "independent",
+      "streamUrl": "https://amg01076-lightningintern-gbnews-samsunguk-0lu52.amagi.tv/playlist/amg01076-lightningintern-gbnews-samsunguk/playlist.m3u8",
+      "homepage": "https://superradio.cc/",
+      "country": "GB",
+      "tags": [
+        "gbn",
+        "news",
+        "tv"
+      ],
+      "bitrate": 1020,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-heart-fm",
+      "name": "Heart FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ssl.musicradio.com/HeartUK",
+      "homepage": "https://www.heart.co.uk/london/radio/",
+      "country": "GB",
+      "favicon": "https://cdn-profiles.tunein.com/s320841/images/logod.jpg?t=638651487420000000",
+      "bitrate": 48,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hot-hits-uk-com",
+      "name": "Hot Hits UK.com",
+      "broadcaster": "independent",
+      "streamUrl": "https://443-1.autopo.st/54/stream.mp3",
+      "homepage": "https://www.hothitsuk.com/",
+      "country": "GB",
+      "tags": [
+        "contemporary hits",
+        "dance music",
+        "edm",
+        "top40"
+      ],
+      "favicon": "https://hothitsuk.com/wp-content/uploads/2020/09/HHUK-3D-transparent-300-x-200.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.5043,
+        -0.1099
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-rokit-radio-american-classic-radio-shows",
+      "name": "ROKit Radio : American Classic Radio Shows",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming05.liveboxstream.uk/proxy/jondre01/stream",
+      "homepage": "https://rokitradio.com/",
+      "country": "GB",
+      "tags": [
+        "old time radio",
+        "otr",
+        "radio show"
+      ],
+      "favicon": "https://rokitradio.com/images/channels/american_classics.jpg",
+      "bitrate": 48,
+      "codec": "MP3",
+      "geo": [
+        51.5074,
+        -0.1221
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-heart-80s",
+      "name": "Radio Heart 80s",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice-sov.musicradio.com/Heart80sMP3",
+      "homepage": "https://www.heart.co.uk/80s",
+      "country": "GB",
+      "tags": [
+        "80s",
+        "classic hits",
+        "oldies"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-rafa-bible-radio-english",
+      "name": "Rafa Bible Radio English",
+      "broadcaster": "independent",
+      "streamUrl": "https://gains.reviveradio.net/proxy/rafabibleradioeng?mp=/stream",
+      "homepage": "http://www.rafaradio.com/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-faza",
+      "name": "Radio Faza",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiocast.cr8tive-digital.com/radiofaza",
+      "homepage": "https://radiofaza.co.uk/",
+      "country": "GB",
+      "favicon": "https://radiofaza.co.uk/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-smooth-80s",
+      "name": "Smooth 80s",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ice.musicradio.com/Smooth80sMP3",
+      "homepage": "https://www.smoothradio.com/80s/",
+      "country": "GB",
+      "tags": [
+        "80s"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-sunrise-radio",
+      "name": "Sunrise Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://direct.sharp-stream.com/sunriseradio.mp3",
+      "homepage": "https://www.sunriseradio.com/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-calm-n-chill-radio",
+      "name": "Calm N Chill Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.zeno.fm/yvcddifycietv",
+      "homepage": "https://theresmarty.pages.dev/",
+      "country": "GB",
+      "tags": [
+        "calm",
+        "chill",
+        "sleep",
+        "relax"
+      ],
+      "favicon": "https://cloud-4shg5daq1-hack-club-bot.vercel.app/0calm_n_chill_radio_logo.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-nazareth",
+      "name": "Nazareth",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.pcradio.ru/Nazareth-hi",
+      "homepage": "https://pcradio.ru/",
+      "country": "GB",
+      "tags": [
+        "discography"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-lyca-dil-se-radio",
+      "name": "Lyca Dil se radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://edge-ads-03-gos2.sharp-stream.com/1035.mp3",
+      "homepage": "https://edge-ads-03-gos2.sharp-stream.com/1035.mp3",
+      "country": "GB",
+      "tags": [
+        "music"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-old-skool-rave-tapes",
+      "name": "Old Skool Rave Tapes",
+      "broadcaster": "independent",
+      "streamUrl": "https://azuracast.oldskoolravetapes.co.uk/listen/old_skool_rave_tapes/backup?refresh=1744812055358",
+      "homepage": "https://oldskoolravetapes.co.uk/",
+      "country": "GB",
+      "tags": [
+        "old skool"
+      ],
+      "favicon": "https://oldskoolravetapes.co.uk/wp-content/uploads/2023/02/Old-Skool-Rave-Tapes-New-512.jpg",
+      "bitrate": 96,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-24-7-edm-radio",
+      "name": "24/7 EDM Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ec6.yesstreaming.net:1455/stream",
+      "homepage": "https://www.247onlineradio.com/24-7-edm-radio/",
+      "country": "GB",
+      "tags": [
+        "edm",
+        "electronic dance music"
+      ],
+      "favicon": "https://www.247onlineradio.com/wp-content/uploads/2023/04/247-EDM-Radio.jpg",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-24-7-jazz-radio",
+      "name": "24/7 Jazz Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ec3.yesstreaming.net:3455/stream",
+      "homepage": "https://www.247onlineradio.com/24-7-jazz-radio/",
+      "country": "GB",
+      "tags": [
+        "jazz"
+      ],
+      "favicon": "https://www.247onlineradio.com/wp-content/uploads/2020/02/247-Jazz-Radio.jpg",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-oldskool-uk",
+      "name": "Oldskool UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://usa10.fastcast4u.com:8880/",
+      "homepage": "https://www.oldskool.uk/",
+      "country": "GB",
+      "tags": [
+        "dnb",
+        "hardcore",
+        "house",
+        "jungle",
+        "rave",
+        "techno"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-now-rock",
+      "name": "Now Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://lightning-now90s-samsungnz.amagi.tv/playlist.m3u8",
+      "homepage": "https://nowmusic.com/",
+      "country": "GB",
+      "tags": [
+        "alternative rock",
+        "classic rock",
+        "pop rock",
+        "rock"
+      ],
+      "bitrate": 1020,
+      "codec": "AAC,H.264",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-the-beatles",
+      "name": "The Beatles",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.pcradio.ru/The_Beatles-hi",
+      "homepage": "https://pcradio.ru/radio",
+      "country": "GB",
+      "tags": [
+        "discography"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-80s-rhythm",
+      "name": "80s Rhythm",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.mybroadbandradio.com/80srhythmhq/",
+      "homepage": "https://www.80srhythm.com/",
+      "country": "GB",
+      "tags": [
+        "80s",
+        "dance",
+        "new wave",
+        "pop",
+        "rock"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-globl-funk-radio",
+      "name": "Globl Funk Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://securestreams2.autopo.st:1148/stream",
+      "homepage": "https://www.globalfunkradio.com/",
+      "country": "GB",
+      "tags": [
+        "bass",
+        "disco",
+        "electro",
+        "funk",
+        "hip-hop"
+      ],
+      "favicon": "https://www.globalfunkradio.com/favicon/128x128.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-the-sounds-of-gta-nts",
+      "name": "The Sounds of GTA | NTS",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-mixtape-geo.ntslive.net/mixtape33",
+      "homepage": "https://www.nts.live/infinite-mixtapes/the-sound-of-gta",
+      "country": "GB",
+      "tags": [
+        "videogames"
+      ],
+      "favicon": "https://www.nts.live/favicon.ico",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bbc-radio-leeds",
+      "name": "BBC Radio Leeds",
+      "broadcaster": "independent",
+      "streamUrl": "https://as-hls-ww-live.akamaized.net/pool_50115440/live/ww/bbc_radio_leeds/bbc_radio_leeds.isml/bbc_radio_leeds-audio%3d96000.norewind.m3u8",
+      "homepage": "https://www.bbc.co.uk/schedules/p00fzl7w",
+      "country": "GB",
+      "tags": [
+        "various"
+      ],
+      "favicon": "https://sounds.files.bbci.co.uk/3.5.0/services/bbc_radio_leeds/blocks-colour_600x600.png",
+      "codec": "UNKNOWN",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bristol-sound-webradio",
+      "name": "Bristol Sound Webradio",
+      "broadcaster": "independent",
+      "streamUrl": "https://thebristolsoundwebradio.stream.laut.fm/thebristolsoundwebradio",
+      "homepage": "https://bristol-sound-webradio.tumblr.com/LISTEN",
+      "country": "GB",
+      "tags": [
+        "bristol",
+        "chillout",
+        "downtempo",
+        "trip-hop",
+        "triphop"
+      ],
+      "favicon": "https://64.media.tumblr.com/8d23b78c8346101f620e06d5ce5e7165/tumblr_pmqf9sPig21uq8z6lo1_r2_400.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-venture-radio-pumpkin-fm",
+      "name": "Venture Radio - Pumpkin FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast2.asurahosting.com/proxy/ventureradio/stream",
+      "homepage": "https://pumpkinfm.com/",
+      "country": "GB",
+      "tags": [
+        "adventure",
+        "cowboys",
+        "gunfighter",
+        "gunslingers",
+        "indians",
+        "westerns"
+      ],
+      "favicon": "https://pumpkinfm.com/wp-content/uploads/2019/02/VentureRadio300x300.jpg",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-infrared-fm",
+      "name": "Infrared.fm",
+      "broadcaster": "independent",
+      "streamUrl": "https://carol.epichosts.co.uk:8232/live.mp3",
+      "homepage": "http://infrared.fm/",
+      "country": "GB",
+      "tags": [
+        "breaks",
+        "drum & bass",
+        "hardcore",
+        "jungle"
+      ],
+      "favicon": "http://infrared.fm/favicon.ico",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-revolution-radio-one",
+      "name": "Revolution Radio One",
+      "broadcaster": "independent",
+      "streamUrl": "https://visual.shoutca.st/stream/revolutionone/stream",
+      "homepage": "https://revolutionradio.online/revolutionone",
+      "country": "GB",
+      "tags": [
+        "rock"
+      ],
+      "favicon": "https://static.wixstatic.com/media/a4f5c5_466d1b7b03424018be005a100fda1990%7emv2_d_1726_1562_s_2.png/v1/fill/w_180%2ch_180%2clg_1%2cusm_0.66_1.00_0.01/a4f5c5_466d1b7b03424018be005a100fda1990%7emv2_d_1726_1562_s_2.png",
+      "bitrate": 320,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-deep-purple",
+      "name": "Deep Purple",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.pcradio.ru/Deep_purple-hi",
+      "homepage": "https://pcradio.ru/",
+      "country": "GB",
+      "tags": [
+        "discography"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hearme-60s-rock",
+      "name": "HearMe - 60s Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.hearme.fm:8230/stream",
+      "homepage": "https://hearme.fm/",
+      "country": "GB",
+      "tags": [
+        "60s rock",
+        "60’s rock"
+      ],
+      "codec": "MP3",
+      "geo": [
+        54.3678,
+        -3.1641
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-xl-uk-radio",
+      "name": "XL:UK Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s3.radio.co/s113a5dc46/listen",
+      "homepage": "https://www.xlukradio.com/",
+      "country": "GB",
+      "tags": [
+        "afrobeat",
+        "asian urban hits",
+        "bhangra",
+        "bollywood",
+        "dance",
+        "dance hall"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.6185,
+        -3.943
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bbc-radio-nottingham",
+      "name": "BBC Radio Nottingham",
+      "broadcaster": "independent",
+      "streamUrl": "https://a.files.bbci.co.uk/ms6/live/3441A116-B12E-4D2F-ACA8-C1984642FA4B/audio/simulcast/hls/nonuk/audio_syndication_low_sbr_v1/aks/bbc_radio_nottingham.m3u8",
+      "homepage": "https://www.radio-uk.co.uk/bbc-radio-nottingham",
+      "country": "GB",
+      "favicon": "https://static.mytuner.mobi/media/tvos_radios/U3M5n4tQDu.png",
+      "bitrate": 101,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-https-www-differentdrumz-co-uk",
+      "name": "https://www.differentdrumz.co.uk/",
+      "broadcaster": "independent",
+      "streamUrl": "https://differentdrumz.radioca.st/stream%20;",
+      "homepage": "https://www.differentdrumz.co.uk/",
+      "country": "GB",
+      "favicon": "https://www.differentdrumz.co.uk/wp-content/uploads/2016/02/Tune-In-Pic.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-the-pit-nts",
+      "name": "The Pit | NTS",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-mixtape-geo.ntslive.net/mixtape34",
+      "homepage": "https://www.nts.live/infinite-mixtapes/the-pit",
+      "country": "GB",
+      "tags": [
+        "black metal",
+        "metal",
+        "thrash metal"
+      ],
+      "favicon": "https://www.nts.live/favicon.ico",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-classic-fm-music-for-pets",
+      "name": "Classic FM Music For Pets",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ssl.musicradio.com/ClassicFM-M-Pets",
+      "homepage": "https://www.classicfm.com/lifestyle/pets/",
+      "country": "GB",
+      "tags": [
+        "classic"
+      ],
+      "bitrate": 48,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-smooth-chill-focus",
+      "name": "Smooth Chill Focus",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ssl.musicradio.com/SmoothChill-M-Concentration?",
+      "homepage": "https://www.radio-uk.co.uk/chill",
+      "country": "GB",
+      "bitrate": 48,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-dance-anthems-radio",
+      "name": "Dance Anthems Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream3.themediasite.co.uk/stream/danceanthems",
+      "homepage": "https://www.danceanthemsradio.com/",
+      "country": "GB",
+      "tags": [
+        "00s",
+        "90s",
+        "anthems",
+        "dance",
+        "old skool"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-love-soul-radio-london",
+      "name": "Love Soul Radio London",
+      "broadcaster": "independent",
+      "streamUrl": "https://s1.citrus3.com:8018/stream",
+      "homepage": "https://lovesoulradiolondon.org/",
+      "country": "GB",
+      "favicon": "https://static.thenounproject.com/png/128478-200.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-24-7-scifi-radio",
+      "name": "24/7 SciFi Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ec6.yesstreaming.net:1465/stream",
+      "homepage": "https://www.247onlineradio.com/24-7-online-radio-group-stations/24-7-scifi-radio/",
+      "country": "GB",
+      "tags": [
+        "ambient",
+        "new age",
+        "sci-fi"
+      ],
+      "favicon": "https://www.247onlineradio.com/wp-content/uploads/2023/04/2019-08-24-16.30.25-scaled.jpg",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-rainbow",
+      "name": "Rainbow",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.pcradio.ru/Rainbow-hi",
+      "homepage": "https://pcradio.ru/",
+      "country": "GB",
+      "tags": [
+        "discography"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-itch-fm",
+      "name": "Itch.FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.radio.co/s264858a04/listen",
+      "homepage": "https://www.itch.fm/",
+      "country": "GB",
+      "tags": [
+        "hiphop"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-otaku-nts",
+      "name": "Otaku | NTS",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-mixtape-geo.ntslive.net/mixtape36",
+      "homepage": "https://www.nts.live/infinite-mixtapes/otaku",
+      "country": "GB",
+      "tags": [
+        "anime",
+        "soundtracks",
+        "videogame music"
+      ],
+      "favicon": "https://www.nts.live/favicon.ico",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-dance-classics-uk",
+      "name": "Dance Classics UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream4.themediasite.co.uk/stream/danceclassics",
+      "homepage": "http://www.danceclassics.co.uk/",
+      "country": "GB",
+      "tags": [
+        "90s",
+        "dance"
+      ],
+      "favicon": "https://static2.mytuner.mobi/media/tvos_radios/ku8qxjlffvfr.png",
+      "bitrate": 192,
+      "codec": "AAC",
+      "geo": [
+        51.7016,
+        -3.0409
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-dragon-radio",
+      "name": "Dragon Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-nation.sharp-stream.com/tcnationdigital.mp3",
+      "homepage": "https://www.nationplayer.com/dragon-radio/",
+      "country": "GB",
+      "tags": [
+        "pop"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.4586,
+        -3.4464
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-malvern-radio-jrs-pumpkin-fm",
+      "name": "Malvern Radio JRS - Pumpkin FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast2.asurahosting.com/proxy/malvernradiojrs/stream",
+      "homepage": "https://pumpkinfm.com/",
+      "country": "GB",
+      "tags": [
+        "big band",
+        "jazz",
+        "ragtime",
+        "swing"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        52.1157,
+        -2.3284
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-playback-uk",
+      "name": "Playback UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://chilledstreaming.com:8650/mobile.mp3",
+      "homepage": "https://www.playbackuk.com/",
+      "country": "GB",
+      "tags": [
+        "dnb",
+        "house",
+        "jungle",
+        "uk garage"
+      ],
+      "favicon": "https://www.playbackuk.com/wp-content/uploads/2021/01/cropped-pbuk-123-192x192.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-dance-90s",
+      "name": "RADIO DANCE 90s",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiodance.streamingmedia.it/uk.aac",
+      "homepage": "https://www.radio.dance/",
+      "country": "GB",
+      "favicon": "https://www.radio.dance/logo_radiodance90s_512.png",
+      "bitrate": 320,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-simulator-radio",
+      "name": "Simulator Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://simulatorradio.stream/stream.mp3",
+      "homepage": "https://simulatorradio.com/",
+      "country": "GB",
+      "tags": [
+        "commercial free",
+        "community",
+        "gaming",
+        "top 40"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-powerhouse-radio",
+      "name": "Powerhouse Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.broadcastradio.com:11065/powerhouse",
+      "homepage": "https://powerhouseradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "christian",
+        "christian contemporary",
+        "christian praise&worship"
+      ],
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-salaam-radio",
+      "name": "Salaam Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.canstream.co.uk:8005/live.mp3",
+      "homepage": "https://www.salaamradio.co.uk/#",
+      "country": "GB",
+      "favicon": "https://storage.googleapis.com/salaamradio-live/landing-page/_ui/media/logo.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-go-radio-glasgow",
+      "name": "Go Radio Glasgow",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.broadcastradio.com:8252/goradio",
+      "homepage": "https://thisisgo.co.uk/",
+      "country": "GB",
+      "favicon": "https://thisisgo.co.uk/wp-content/uploads/2023/04/go-logo.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-jazz-fm91",
+      "name": "JAZZ.FM91",
+      "broadcaster": "independent",
+      "streamUrl": "https://jazzfm91.streamb.live/SB00009",
+      "homepage": "https://jazz.fm/",
+      "country": "GB",
+      "tags": [
+        "jazz"
+      ],
+      "bitrate": 131,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-premier-christian-radio",
+      "name": "Premier Christian Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://pcr.streamguys1.com/pcrnational-96k.aac",
+      "homepage": "https://www.premier.plus/stations/premier-christian-radio",
+      "country": "GB",
+      "favicon": "https://www.premier.plus/images/common/logo-animated-50ms.gif",
+      "bitrate": 56,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-xpression-fm-bollywood",
+      "name": "Xpression FM Bollywood",
+      "broadcaster": "independent",
+      "streamUrl": "https://casper.radioca.st/",
+      "homepage": "https://casper.radioca.st/",
+      "country": "GB",
+      "tags": [
+        "music"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-rustradio",
+      "name": "RustRadio",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.rustradio.co.uk:8443/stream",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "GB",
+      "tags": [
+        "metal"
+      ],
+      "favicon": "https://rustradio.co.uk/images/RRDefault.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        51.685,
+        -4.182
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-the-mix-radio-80s",
+      "name": "The Mix Radio 80s",
+      "broadcaster": "independent",
+      "streamUrl": "https://tmr80s.radioca.st/stream",
+      "homepage": "https://www.themixradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "1980s",
+        "80s",
+        "classic rock",
+        "pop",
+        "pop music",
+        "pop rock"
+      ],
+      "favicon": "https://static.mytuner.mobi/media/tvos_radios/390/the-mix-radio-80s.dd4413ea.png",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-fred-film-radio-28-education",
+      "name": "Fred Film Radio-28 Education",
+      "broadcaster": "independent",
+      "streamUrl": "https://s10.webradio-hosting.com/proxy/fredradioedu/stream",
+      "homepage": "https://www.fred.fm/",
+      "country": "GB",
+      "tags": [
+        "culture",
+        "film"
+      ],
+      "favicon": "https://www.fred.fm/wp-content/uploads/2014/12/Fred-Logo_trasp_-copia.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-like-anthems",
+      "name": "Like Anthems",
+      "broadcaster": "independent",
+      "streamUrl": "https://likeradiostream.com/likeanthemsaac",
+      "homepage": "https://like.radio/",
+      "country": "GB",
+      "tags": [
+        "00s",
+        "90s",
+        "dance",
+        "pop"
+      ],
+      "bitrate": 48,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-smokie",
+      "name": "Smokie",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.pcradio.ru/smokie-hi",
+      "homepage": "https://pcradio.ru/",
+      "country": "GB",
+      "tags": [
+        "discography"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-24-7-bossa-nova-radio",
+      "name": "24/7 Bossa Nova Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ec6.yesstreaming.net:1605/stream",
+      "homepage": "https://www.247onlineradio.com/24-7-online-radio-group-stations/24-7-bossa-nova-radio/",
+      "country": "GB",
+      "tags": [
+        "bossa nova",
+        "smooth jazz"
+      ],
+      "favicon": "https://www.247onlineradio.com/wp-content/uploads/2023/04/247-Bossa-Nova-Radio.jpg",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-fred-film-radio-english",
+      "name": "FRED FILM RADIO English",
+      "broadcaster": "independent",
+      "streamUrl": "https://s10.webradio-hosting.com/proxy/fredradioen/stream",
+      "homepage": "https://www.fred.fm/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-progzilla-radio",
+      "name": "Progzilla_Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.progzilla.com/main",
+      "homepage": "http://www.progzilla.com/",
+      "country": "GB",
+      "tags": [
+        "progressive rock"
+      ],
+      "favicon": "http://www.progzilla.com/favicon.ico",
+      "bitrate": 52,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-24-7-nature-radio",
+      "name": "24/7 Nature Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ec3.yesstreaming.net:3545/stream",
+      "homepage": "https://www.247natureradio.com/",
+      "country": "GB",
+      "tags": [
+        "environment",
+        "nature"
+      ],
+      "favicon": "https://www.getmeradio.com/stations/247natureradio-4493/logos/512x512.png",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-dance-uk",
+      "name": "Dance UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://dancestream.danceradiouk.com/stream/1/stream.mp3",
+      "homepage": "https://www.danceradiouk.com/",
+      "country": "GB",
+      "favicon": "https://danceradiouk.com/players/files/images/albumart/13040-DanceUK-300.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-heart-wiltshire",
+      "name": "Heart Wiltshire",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ssl.musicradio.com/HeartWiltshireMP3",
+      "homepage": "https://www.heart.co.uk/wiltshire/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-house-fm",
+      "name": "House FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://uksoutha.streaming.broadcast.radio:19920/housefm",
+      "homepage": "https://hse.fm/",
+      "country": "GB",
+      "tags": [
+        "deep house",
+        "house",
+        "soulful house"
+      ],
+      "favicon": "https://hse.fm/cdn/shop/files/logo_on_content_c7615023-6bff-4bf9-8841-9a9916b5a3b0_2500x.png?v=1615321261",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.4916,
+        -0.1346
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-uk-health-radio",
+      "name": "UK Health Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.radio.co/s8e535ff20/listen",
+      "homepage": "https://ukhealthradio.com/",
+      "country": "GB",
+      "favicon": "https://ukhealthradio.com/wp-content/themes/ukhealthradio_new/assets/img/ukhealthdario_logo.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-capital-anthems",
+      "name": "Capital Anthems",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ice.musicradio.com/CapitalAnthemsMP3",
+      "homepage": "https://www.capitalfm.com/anthems/",
+      "country": "GB",
+      "tags": [
+        "adult contemporary",
+        "anthems",
+        "pop"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-easylistening-com",
+      "name": "EasyListening.com",
+      "broadcaster": "independent",
+      "streamUrl": "https://easylistening.out.airtime.pro/easylistening_a",
+      "homepage": "https://www.easylistening.com/",
+      "country": "GB",
+      "favicon": "https://static.wixstatic.com/media/7c2261_da98addc261649d699647544ae301897~mv2.jpg/v1/fill/w_488,h_88,al_c,lg_1,q_80,enc_auto/7c2261_da98addc261649d699647544ae301897~mv2.jpg",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-fred-film-radio-extra",
+      "name": "Fred Film Radio Extra",
+      "broadcaster": "independent",
+      "streamUrl": "https://s10.webradio-hosting.com/proxy/fredradioec/stream",
+      "homepage": "http://www.fred.fm/",
+      "country": "GB",
+      "tags": [
+        "culture",
+        "film",
+        "movie"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-intamixx-desi-radio-uk",
+      "name": "Intamixx Desi Radio UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.intamixx.uk:8443/radio1",
+      "homepage": "https://radio.intamixx.uk/#hero",
+      "country": "GB",
+      "favicon": "https://radio.intamixx.uk/images/intamixx.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-totally-wired-radio",
+      "name": "Totally Wired Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://totallywired.out.airtime.pro/totallywired_a",
+      "homepage": "https://totallywiredradio.com/",
+      "country": "GB",
+      "tags": [
+        "adult contemporary",
+        "jazz",
+        "soul"
+      ],
+      "favicon": "https://totallywiredradio.com/radio/wp-content/uploads/2019/04/TWR-fb.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-great-yorkshire-radio",
+      "name": "Great Yorkshire Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream1.superstreaming.co.uk/proxy/greatyorkshire/stream",
+      "homepage": "https://greatyorkshireradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://greatyorkshireradio.co.uk/images/GYRWEBLOGO.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-ram-fm-80s-hit-radio-2",
+      "name": "RAM FM - 80s Hit Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://cc6.beheerstream.com/proxy/ramfm?mp=/stream",
+      "homepage": "https://ramfm.org/",
+      "country": "GB",
+      "tags": [
+        "80s"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-rap-house-infinite-mixtapes-nts",
+      "name": "Rap House - Infinite Mixtapes | NTS",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-mixtape-geo.ntslive.net/mixtape22",
+      "homepage": "https://www.nts.live/infinite-mixtapes/rap-house",
+      "country": "GB",
+      "tags": [
+        "drill",
+        "rap",
+        "trap"
+      ],
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-planet-rock-where-rock-lives",
+      "name": " PLANET ROCK: Where Rock Lives",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-mz.hellorayo.co.uk/planetrock.aac?direct=true&aw_0_1st.playerid=BMUK_Airable&aw_0_1st.skey=6778249992",
+      "homepage": "https://www.hellorayo.co.uk/planet-rock",
+      "country": "GB",
+      "tags": [
+        "bauer radio",
+        "classic rock",
+        "dab",
+        "digital radio",
+        "england",
+        "europe"
+      ],
+      "favicon": "https://cdn-profiles.tunein.com/s2377/images/logod.png",
+      "bitrate": 47,
+      "codec": "AAC+",
+      "geo": [
+        51.5085,
+        -0.1284
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-107-8-black-diamond-fm",
+      "name": "107.8 Black Diamond FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast-s.bdfm.radio/blackdiamondfm?icecast",
+      "homepage": "https://www.blackdiamondfm.com/",
+      "country": "GB",
+      "tags": [
+        "107.8",
+        "107.8 fm",
+        "country",
+        "music",
+        "regge",
+        "reggeton"
+      ],
+      "favicon": "https://www.blackdiamondfm.com/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-lcrfm-103-6-lincoln",
+      "name": "LCRFM 103.6 Lincoln",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.broadcast.radio/lincoln",
+      "homepage": "https://lcrlincoln.com/",
+      "country": "GB",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-noods-radio",
+      "name": "Noods Radio ",
+      "broadcaster": "independent",
+      "streamUrl": "https://noods-radio.radiocult.fm/stream",
+      "homepage": "http://www.noodsradio.com/",
+      "country": "GB",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-power-of-worship-radio",
+      "name": "Power of Worship Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://fwd.autopo.st/powerofworshipradio?_=484910",
+      "homepage": "https://www.powerofworship.net/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/177/664992e2268f6.png",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-r5k-radio",
+      "name": "R5K Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.r5k.net/",
+      "homepage": "https://r5k.uk/",
+      "country": "GB",
+      "tags": [
+        "edm"
+      ],
+      "favicon": "http://radio.r5k.uk/wp-content/uploads/2024/09/R-Black-Glow.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-riverside-radio",
+      "name": "Riverside Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming04.liveboxstream.uk/proxy/mtunstil?mp=/stream",
+      "homepage": "https://riversideradio.com/",
+      "country": "GB",
+      "tags": [
+        "arts",
+        "culture",
+        "local radio",
+        "music news",
+        "variety"
+      ],
+      "bitrate": 64,
+      "codec": "AAC+",
+      "geo": [
+        51.4744,
+        -0.1529
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-capital-fm-birmingham",
+      "name": "Capital FM (Birmingham)",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ice.musicradio.com/CapitalBirminghamMP3",
+      "homepage": "https://tunein.com/radio/Capital-Birmingham-1022-s25008/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        52.4654,
+        -1.8828
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hereme-2000s-pop",
+      "name": "Hereme 2000s pop",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.hearme.fm:8040/stream",
+      "homepage": "https://hearme.fm/",
+      "country": "GB",
+      "tags": [
+        "2000's",
+        "pop",
+        "pop music"
+      ],
+      "codec": "MP3",
+      "geo": [
+        52.6964,
+        -2.8125
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-one-world-radio",
+      "name": "One World Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/OWR_INTERNATIONAL.mp3",
+      "homepage": "https://global.tomorrowland.com/",
+      "country": "GB",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-northsea-uk",
+      "name": "Radio Northsea UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://listentomystream.com:8008/;",
+      "homepage": "https://www.rniradio.net/",
+      "country": "GB",
+      "tags": [
+        "60s",
+        "70s",
+        "80s",
+        "90s",
+        "offshore",
+        "pop"
+      ],
+      "favicon": "https://i1.sndcdn.com/artworks-000172944490-2m076q-t500x500.jpg",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-24-7-lounge-radio",
+      "name": "24/7 Lounge Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ec3.yesstreaming.net:3665/stream",
+      "homepage": "https://www.247onlineradio.com/24-7-online-radio-group-stations/24-7-lounge-radio/",
+      "country": "GB",
+      "tags": [
+        "blues",
+        "chillout",
+        "jazz",
+        "lounge"
+      ],
+      "favicon": "https://www.247onlineradio.com/wp-content/uploads/2023/04/247-Lounge-Radio.jpg",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-quantum-radio",
+      "name": "qUAntUm RaDio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.erb.pw/listen/subspace/radio.mp3",
+      "homepage": "https://radio.erb.pw/public/subspace",
+      "country": "GB",
+      "tags": [
+        "chiptune",
+        "chiptunes"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-taiyabah-masjid",
+      "name": "Taiyabah Masjid",
+      "broadcaster": "independent",
+      "streamUrl": "https://taiyabahmbolton.radioca.st/stream",
+      "homepage": "https://www.taiyabahmasjid.com/",
+      "country": "GB",
+      "tags": [
+        "islamic",
+        "masjid",
+        "mosque",
+        "religion",
+        "religious"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        53.592,
+        -2.4314
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-awaz-fm",
+      "name": "Awaz FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://uksoutha.streaming.broadcast.radio/awazfm?1709527674574=",
+      "homepage": "https://www.awazfm.co.uk/",
+      "country": "GB",
+      "favicon": "https://api.broadcast.radio/api/image/feb85d15-2e18-45a7-b50a-e35b957f7d5a.png?g=center&w=600&h=600&c=true",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-crackers-radio",
+      "name": "Crackers Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://crackersfresh.radioca.st/;",
+      "homepage": "https://www.crackersradio.com/",
+      "country": "GB",
+      "tags": [
+        "disco & jazz",
+        "funk",
+        "soul"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        51.4238,
+        0.0591
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-xl-1296",
+      "name": "Radio XL 1296",
+      "broadcaster": "independent",
+      "streamUrl": "https://xlradio.co.uk:8000/",
+      "homepage": "https://xlradio.co.uk:8000/",
+      "country": "GB",
+      "tags": [
+        "music"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-97-country-fm",
+      "name": "97 Country FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://vistaradio.streamb.live/SB00040?=&&___cb=491767877535127",
+      "homepage": "https://www.myprincegeorgenow.com/on-air/countryfm/",
+      "country": "GB",
+      "favicon": "https://www.myprincegeorgenow.com/wp-content/uploads/2021/05/mynow-icon.png",
+      "bitrate": 57,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hearme-70s-rock",
+      "name": "HearMe - 70s Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.hearme.fm:8240/stream",
+      "homepage": "https://hearme.fm/",
+      "country": "GB",
+      "tags": [
+        "70s rock",
+        "70’s rock"
+      ],
+      "codec": "MP3",
+      "geo": [
+        52.2682,
+        -0.7031
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-regal-radio",
+      "name": "Regal Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.regalradio.net/stream.mp3",
+      "homepage": "https://www.regalradio.net/",
+      "country": "GB",
+      "tags": [
+        "blues",
+        "community radio",
+        "interview",
+        "local music",
+        "local radio",
+        "music"
+      ],
+      "favicon": "https://www.regalradio.net/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-soulpower-radio-com",
+      "name": "SOULPOWER-RADIO.COM",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.radio.co/sb0964023c/listen",
+      "homepage": "https://soulpower-radio.com/",
+      "country": "GB",
+      "tags": [
+        "funk",
+        "jazz",
+        "soul"
+      ],
+      "favicon": "https://www.enomcentral.com/favicon.ico?v=1731000855",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        52.5333,
+        -1.6211
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-masjid-e-salaam-bolton",
+      "name": "Masjid E Salaam Bolton",
+      "broadcaster": "independent",
+      "streamUrl": "https://msalaambolton.radioca.st/Stream",
+      "homepage": "https://www.masjidesalaam.com/",
+      "country": "GB",
+      "bitrate": 56,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-sanskar-radio",
+      "name": "Sanskar Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.canstream.co.uk:8024/live.mp3",
+      "homepage": "http://sanskarradio.com/",
+      "country": "GB",
+      "favicon": "http://sanskarradio.com/wp-content/uploads/2018/10/logo-01.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-the-ambientscape-project",
+      "name": "The Ambientscape Project",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/504205/stream/561655",
+      "homepage": "https://www.ambientscape.com/radio",
+      "country": "GB",
+      "favicon": "https://lh3.googleusercontent.com/nl0-E_ry5_Nrnfl2EH1BfXZPxrajs0E4g1d6d2ApEAvm_6WUhnfGxWVPRV940ey0KuTLes7AddVA88dk1PlvRQw7gJPcuQ=s120",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-big-l",
+      "name": "Big L",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.streamer1.com/listen/bigl/biglTEST.mp3",
+      "homepage": "https://www.bigl.co.uk/",
+      "country": "GB",
+      "favicon": "https://www.bigl.co.uk/images/icon-2.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-do-you-radio",
+      "name": "Do You Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://doyouworld.out.airtime.pro/doyouworld_a",
+      "homepage": "https://doyou.world/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-fred-film-radio-entertainment",
+      "name": "Fred Film Radio Entertainment",
+      "broadcaster": "independent",
+      "streamUrl": "https://s10.webradio-hosting.com/proxy/fredenter/stream",
+      "homepage": "http://www.fred.fm/",
+      "country": "GB",
+      "tags": [
+        "culture",
+        "film",
+        "movie"
+      ],
+      "favicon": "http://www.fred.fm/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-shine-879",
+      "name": "Shine 879",
+      "broadcaster": "independent",
+      "streamUrl": "https://s3.radio.co/sd4abfe69e/listen",
+      "homepage": "https://shinedab.com/",
+      "country": "GB",
+      "tags": [
+        "dance",
+        "house",
+        "uk garage"
+      ],
+      "favicon": "https://shinedab.com/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-worldwide-fm",
+      "name": "Worldwide FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://worldwide-fm.radiocult.fm/stream",
+      "homepage": "https://www.worldwidefm.net/",
+      "country": "GB",
+      "tags": [
+        "electronica",
+        "jazz",
+        "progressive",
+        "underground music",
+        "world music"
+      ],
+      "favicon": "https://scontent-fra5-2.xx.fbcdn.net/v/t39.30808-1/450237294_942043604601681_3306132891557988504_n.jpg?stp=dst-jpg_s200x200_tt6&_nc_cat=109&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=Ur-AWGYdJIEQ7kNvwHfsWWi&_nc_oc=Adn31I1juFGVfOprAsE1UsSz-7_H0ISFLok1gNrhmWqzfmlI6AbPJgNZB15dkduTEq4&_nc_zt=24&_nc_ht=scontent-fra5-2.xx&_nc_gid=60spXN55S49um4k8ceAfcA&oh=00_AfrO3IOBFCxwn4Bqxc2mOFTcigubLSqRjTY1N2cfbWsvxg&oe=696ED4DC",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-100-8-home-radio",
+      "name": "100.8 Home Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://uksoutha.streaming.broadcast.radio/home?1721747577077=",
+      "homepage": "https://www.homeradio.org/",
+      "country": "GB",
+      "favicon": "https://api.broadcast.radio/api/image/7ed6bffb-6808-4c08-8576-6132efe7bd78.png?g=center",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-jazz-london-radio",
+      "name": "Jazz London radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.canstream.co.uk:8075/live.aac",
+      "homepage": "https://www.jazzlondonradio.com/",
+      "country": "GB",
+      "tags": [
+        "jazz"
+      ],
+      "favicon": "https://www.jazzlondonradio.com/images/favicon.ico",
+      "bitrate": 64,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-naim-classical",
+      "name": "Naim classical",
+      "broadcaster": "independent",
+      "streamUrl": "https://mscp3.live-streams.nl:8252/class-flac.flac",
+      "homepage": "https://www.naimaudio.com/",
+      "country": "GB",
+      "favicon": "https://www.naimaudio.com/build/assets/apple-touch-icon-2a4e35a0.png",
+      "bitrate": 128,
+      "codec": "OGG",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-isle-of-wight-radio",
+      "name": "Isle of Wight Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.xrad.io:9598/listen.mp3?=&&___cb=275280937051671",
+      "homepage": "https://www.iwradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/386/5ec2a4d8bc430.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-rokit-radio-1940s-radio",
+      "name": "Rokit Radio 1940s Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming06.liveboxstream.uk/proxy/roksta13/stream",
+      "homepage": "https://www2.rokitradio.com/",
+      "country": "GB",
+      "favicon": "https://www2.rokitradio.com/_next/image?url=%2Fimages%2Fchannels%2F1940s.jpg&w=128&q=75",
+      "bitrate": 48,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-university-radio-york",
+      "name": "University Radio York",
+      "broadcaster": "independent",
+      "streamUrl": "https://audio.ury.org.uk/live-high",
+      "homepage": "https://ury.org.uk/",
+      "country": "GB",
+      "tags": [
+        "student radio"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-90s-2000s-more",
+      "name": "90s 2000s & More",
+      "broadcaster": "independent",
+      "streamUrl": "https://lunar.citrus3.com:8162/stream",
+      "homepage": "https://lunar.citrus3.com:2020/public/90s2000sandmore",
+      "country": "GB",
+      "tags": [
+        "00s",
+        "10s",
+        "80s",
+        "90s",
+        "hits",
+        "pop"
+      ],
+      "favicon": "https://lunar.citrus3.com:2020/pub/90s2000sandmore/background.jpg",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-golden-decades-radio",
+      "name": "Golden Decades Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.live365.com/a99471",
+      "homepage": "https://www.goldendecadesradio.net/",
+      "country": "GB",
+      "tags": [
+        "70s",
+        "80s",
+        "90s",
+        "pop",
+        "rock"
+      ],
+      "favicon": "https://www.goldendecadesradio.net/favicin.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        54.8945,
+        -2.9357
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hospital-radio-norwich",
+      "name": "Hospital Radio Norwich",
+      "broadcaster": "independent",
+      "streamUrl": "https://hospita1.radioca.st/;",
+      "homepage": "https://hospitalradionorwich.co.uk/",
+      "country": "GB",
+      "tags": [
+        "classical",
+        "comedy",
+        "country",
+        "eighties",
+        "fifties",
+        "folk"
+      ],
+      "bitrate": 96,
+      "codec": "MP3",
+      "geo": [
+        52.6158,
+        1.2183
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-real-roots-radio",
+      "name": "Real roots radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streams.radio.co/s1df61e0af/listen",
+      "homepage": "https://realrootsradio.net/",
+      "country": "GB",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-sunshine-radio-online-uk",
+      "name": "Sunshine Radio Online UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream1.themediasite.co.uk/8036/stream",
+      "homepage": "https://sunshineradioonline.co.uk/",
+      "country": "GB",
+      "tags": [
+        "music"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-this-is-the-coast",
+      "name": "This is the Coast",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.broadcastradio.com:10765/thisisthecoast",
+      "homepage": "https://www.thisisthecoast.co.uk/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/428/6192188de6d51.png",
+      "codec": "MP3",
+      "geo": [
+        54.2797,
+        -0.3936
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-24-7-classical-radio",
+      "name": "24/7 Classical Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ec3.yesstreaming.net:3615/stream",
+      "homepage": "https://www.247onlineradio.com/classical-radio/",
+      "country": "GB",
+      "favicon": "https://usercontent.one/wp/www.247onlineradio.com/wp-content/uploads/2019/10/Classical-Radio-logo.jpg",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-belters-radio",
+      "name": "Belters Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://uk2.internet-radio.com/proxy/belters?mp=/live",
+      "homepage": "https://www.belter-radio.com/",
+      "country": "GB",
+      "tags": [
+        "alternative",
+        "indie rock"
+      ],
+      "favicon": "https://seeded-session-images.scdn.co/v2/img/122/secondary/artist/6Q7SW1I96IGwqBDhIm55oj/en",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-original-106",
+      "name": "Original 106",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-original.sharp-stream.com/original106.mp3",
+      "homepage": "https://www.originalfm.com/",
+      "country": "GB",
+      "tags": [
+        "adult contemporary",
+        "pop music",
+        "top 40"
+      ],
+      "favicon": "https://mmo.aiircdn.com/11/62090e452aff2.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        57.1464,
+        -2.0956
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-the-buzz",
+      "name": "The Buzz",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming05.liveboxstream.uk/proxy/kookyinc/stream",
+      "homepage": "https://www.thisisthebuzz.com/",
+      "country": "GB",
+      "tags": [
+        "80s",
+        "90s",
+        "pop",
+        "rock"
+      ],
+      "favicon": "https://media.licdn.com/dms/image/D5622AQGpwL9LyKlbdg/feedshare-shrink_800/0/1697466642566?e=2147483647&v=beta&t=aYyFGOmG4uUzv7nHS5wNnENGiObuOXs9dZ6gzAG6zrM",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-aaja-radio-channel-2",
+      "name": "Aaja Radio | Channel 2",
+      "broadcaster": "independent",
+      "streamUrl": "https://aaja-2.radiocult.fm/stream",
+      "homepage": "https://aajamusic.com/radio",
+      "country": "GB",
+      "tags": [
+        "music",
+        "variety",
+        "eclectic"
+      ],
+      "favicon": "https://aajamusic.com/_nuxt/icons/icon_64x64.fafdcd.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.4761,
+        -0.0226
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-classical-radio-international",
+      "name": "CLASSICAL RADIO INTERNATIONAL",
+      "broadcaster": "independent",
+      "streamUrl": "https://ec3.yesstreaming.net:3625/stream",
+      "homepage": "https://www.247onlineradio.com/classical-radio-international/",
+      "country": "GB",
+      "tags": [
+        "classical music"
+      ],
+      "favicon": "https://www.247onlineradio.com/wp-content/uploads/2019/01/Classical-Radio-logo.png",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-clyde-built-radio",
+      "name": "Clyde Built Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://clydebuiltradio.out.airtime.pro/clydebuiltradio_a",
+      "homepage": "https://www.clydebuiltradio.com/",
+      "country": "GB",
+      "tags": [
+        "arts",
+        "community radio",
+        "culture",
+        "local music",
+        "music",
+        "non-profit"
+      ],
+      "favicon": "https://www.clydebuiltradio.com/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-crucial-hip-hop-and-electro",
+      "name": "Crucial Hip Hop and Electro",
+      "broadcaster": "independent",
+      "streamUrl": "https://uksoutha.streaming.broadcast.radio/crucial",
+      "homepage": "https://www.streetsoundsradio.com/",
+      "country": "GB",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-dirty-radio-for-underworld-fans",
+      "name": "Dirty Radio for Underworld Fans",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.dirty.radio/stream",
+      "homepage": "https://dirty.radio/",
+      "country": "GB",
+      "tags": [
+        "electronica",
+        "house",
+        "idm"
+      ],
+      "bitrate": 64,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-maritime-radio",
+      "name": "maritime radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://mediacp.nkpa.co.uk/stream/maritime%E2%80%8B/MRMP3",
+      "homepage": "https://www.maritimeradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/1353/65d08095711fe.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-cdnx-radio",
+      "name": "CDNX Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.cdnx.co.uk/proxy/cx128mp3?mp=/stream&=&&___cb=870564735813642",
+      "homepage": "https://www.camdenmarket.com/journal/cdnx-radio",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.5398,
+        -0.1362
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hearme-love-songs",
+      "name": "HearMe - Love songs",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.hearme.fm:8140/stream",
+      "homepage": "https://hearme.fm/",
+      "country": "GB",
+      "tags": [
+        "love songs"
+      ],
+      "codec": "MP3",
+      "geo": [
+        52.2682,
+        0.3516
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-christmas",
+      "name": "Radio Christmas",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.radiochristmas.co.uk/RadioChristmas",
+      "homepage": "https://radiochristmas.co.uk/",
+      "country": "GB",
+      "favicon": "https://radiochristmas.co.uk/favicon.ico",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-resonance-extra",
+      "name": "Resonance Extra",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.resonance.fm/resonance-extra",
+      "homepage": "https://extra.resonance.fm/",
+      "country": "GB",
+      "favicon": "https://extra.resonance.fm/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-xtra-hot",
+      "name": "Xtra Hot",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream1.hippynet.co.uk/stream/xtrahot/live",
+      "homepage": "https://www.xtrahot.radio/",
+      "country": "GB",
+      "tags": [
+        "bournemouth",
+        "community",
+        "community radio",
+        "dorset",
+        "funk",
+        "garage"
+      ],
+      "favicon": "https://mmo.aiircdn.com/406/63e29f650517e.png",
+      "bitrate": 160,
+      "codec": "MP3",
+      "geo": [
+        50.737,
+        -1.9505
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-centreforce-883",
+      "name": "Centreforce 883",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.centreforceradio.com/96",
+      "homepage": "https://www.centreforceradio.com/",
+      "country": "GB",
+      "bitrate": 96,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-coffee-morning",
+      "name": "Coffee Morning",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-the.musicradio.com/Global-M-CoffeeMorning",
+      "homepage": "https://global.com/global-player",
+      "country": "GB",
+      "tags": [
+        "global",
+        "heart",
+        "live playlist",
+        "media-the",
+        "smooth",
+        "uk"
+      ],
+      "favicon": "https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse4.mm.bing.net%2Fth%3Fid%3DOIP.urcOy5KLidgx_JRwHUewewAAAA%26pid%3DApi&f=1&ipt=52c4c14b37a85c76dcb3d11f83b678bf7eddd5574cb09cd4839d7e64110eb25d&ipo=images",
+      "bitrate": 48,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hardrock-hell",
+      "name": "Hardrock Hell",
+      "broadcaster": "independent",
+      "streamUrl": "https://s3.radio.co/s1f74e2763/listen",
+      "homepage": "https://hardrockhellradio.com/",
+      "country": "GB",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        52.6311,
+        1.2909
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hearme-classic-rock",
+      "name": "HearMe - Classic Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.hearme.fm:8270/stream",
+      "homepage": "https://hearme.fm/",
+      "country": "GB",
+      "tags": [
+        "classic rock"
+      ],
+      "codec": "MP3",
+      "geo": [
+        50.9584,
+        -1.4062
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-louder-than-war",
+      "name": "Louder Than War",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.radio.co/sab795a38d/listen",
+      "homepage": "https://louderthanwar.com/",
+      "country": "GB",
+      "tags": [
+        "punk postpunk"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-movedahouse",
+      "name": "MoveDaHouse",
+      "broadcaster": "independent",
+      "streamUrl": "https://uk7.internet-radio.com/proxy/movedahouse?mp=//stream",
+      "homepage": "https://www.movedahouse.com/",
+      "country": "GB",
+      "favicon": "https://www.movedahouse.com/wp-content/uploads/2018/01/mdh-172x172.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-smooth-bristol-and-bath",
+      "name": "Smooth Bristol and Bath",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-the.musicradio.com/SmoothBristolMP3",
+      "homepage": "https://www.smoothradio.com/bristol/",
+      "country": "GB",
+      "tags": [
+        "smooth"
+      ],
+      "favicon": "http://www.smoothradio.com/assets_v4r/smooth/img/favicon-196x196.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-jambo-radio",
+      "name": "Jambo! Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream3.themediasite.co.uk:8130/stream",
+      "homepage": "https://jamboradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://jamboradio.co.uk/wp-content/uploads/2019/10/cropped-Jambo-Logo-1-192x192.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-power-ace-radio",
+      "name": "Power Ace Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://music-station.live/radio/8030/radio.mp3",
+      "homepage": "https://www.poweraceradio.com/",
+      "country": "GB",
+      "tags": [
+        "afrobeats",
+        "easy listening",
+        "jazz",
+        "reggae",
+        "reggaetón",
+        "soul"
+      ],
+      "favicon": "https://www.poweraceradio.com/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-rstv-dance",
+      "name": "RSTV Dance",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiozender.mpbnetwerken.nl/rstvdance.mp3",
+      "homepage": "https://dance.rstvnetworks.com/",
+      "country": "GB",
+      "tags": [
+        "dance music"
+      ],
+      "favicon": "https://radiodns.mpbnl.nl/logos/rstv/dance.png",
+      "bitrate": 384,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-aaja-radio-channel-1",
+      "name": "Aaja Radio | Channel 1",
+      "broadcaster": "independent",
+      "streamUrl": "https://aaja.radiocult.fm/stream",
+      "homepage": "https://aajamusic.com/radio",
+      "country": "GB",
+      "tags": [
+        "music",
+        "variety",
+        "eclectic"
+      ],
+      "favicon": "https://aajamusic.com/_nuxt/icons/icon_64x64.fafdcd.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.4761,
+        -0.0226
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bikers-hangout-radio",
+      "name": "Bikers Hangout Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radio.co/s803057ca0/listen",
+      "homepage": "https://www.bikershangout.co.uk/bikers-hangout-radio",
+      "country": "GB",
+      "favicon": "https://static.wixstatic.com/media/21bad3_49d2ec0019f24f83bffacbce6787fd0a%7emv2.png/v1/fill/w_180%2ch_180%2clg_1%2cusm_0.66_1.00_0.01/21bad3_49d2ec0019f24f83bffacbce6787fd0a%7emv2.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bluesradio-uk",
+      "name": "BluesRadio UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming06.liveboxstream.uk/proxy/david125/stream",
+      "homepage": "http://www.bluesradio.co.uk/index.php",
+      "country": "GB",
+      "tags": [
+        "blues"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bar-latina-radio",
+      "name": "Bar Latina Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.citrus3.com:2000/stream/barlatinaradio",
+      "homepage": "https://www.barlatina.com/",
+      "country": "GB",
+      "tags": [
+        "bachata",
+        "kizomba",
+        "latin",
+        "regaeton",
+        "salsa"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        51.5135,
+        -0.1346
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-black-metal-radio",
+      "name": "Black Metal Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://das-edge16-live365-dal02.cdnstream.com/a05584",
+      "homepage": "https://live365.com/station/BLACK-METAL-RADIO-a05584",
+      "country": "GB",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-naim-radio",
+      "name": "Naim Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://mscp3.live-streams.nl:8362/flac.flac",
+      "homepage": "https://www.naimaudio.com/",
+      "country": "GB",
+      "tags": [
+        "various"
+      ],
+      "favicon": "https://www.naimaudio.com/build/assets/apple-touch-icon-2a4e35a0.png",
+      "bitrate": 160,
+      "codec": "OGG",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-big-beat-brighton",
+      "name": "Big Beat Brighton",
+      "broadcaster": "independent",
+      "streamUrl": "https://s4.citrus3.com:8366/stream",
+      "homepage": "https://big-beat-brighton.ueniweb.com/",
+      "country": "GB",
+      "tags": [
+        "classic hits",
+        "oldies",
+        "pop"
+      ],
+      "bitrate": 256,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-brown-noise-radio",
+      "name": "Brown Noise Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://uk1.internet-radio.com/proxy/brownnoise?mp=/stream;",
+      "homepage": "https://www.brownnoiseradio.com/",
+      "country": "GB",
+      "favicon": "https://static.wixstatic.com/media/996eee_494ede18f9684a0898e0fc38dc06869b%7Emv2.jpg/v1/fill/w_180%2Ch_180%2Clg_1%2Cusm_0.66_1.00_0.01/996eee_494ede18f9684a0898e0fc38dc06869b%7Emv2.jpg",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-heart-10s",
+      "name": "Heart 10s",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ice.musicradio.com/Heart10sMP3",
+      "homepage": "https://www.heart.co.uk/10s/",
+      "country": "GB",
+      "tags": [
+        "10s",
+        "2010s",
+        "adult contemporary"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-majestic-jukebox-radio",
+      "name": "Majestic Jukebox Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://uk3.internet-radio.com/proxy/majesticjukebox/live",
+      "homepage": "https://www.majesticjukeboxradio.com/",
+      "country": "GB",
+      "tags": [
+        "60s",
+        "70s",
+        "oldies",
+        "rocknroll"
+      ],
+      "favicon": "https://static.wixstatic.com/media/83e446_a77f5ab906b7455689b82789c523e616~mv2.jpg/v1/fit/w_2500,h_1330,al_c/83e446_a77f5ab906b7455689b82789c523e616~mv2.jpg",
+      "bitrate": 16,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-x-chilled",
+      "name": "Radio X Chilled",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ice.musicradio.com/RadioXChilledMP3",
+      "homepage": "https://www.radiox.co.uk/chilled/",
+      "country": "GB",
+      "tags": [
+        "alternative",
+        "chilled",
+        "indie rock"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-sabotage",
+      "name": "Sabotage",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/634/stream/2282",
+      "homepage": "https://welove.radio/radio/sabotage/",
+      "country": "GB",
+      "tags": [
+        "alternative indie rock"
+      ],
+      "favicon": "https://t4.ftcdn.net/jpg/04/69/34/51/360_F_469345184_YlmdPahjiPXs133mjIZf98YgZ5g8ZFSN.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-60-north-radio",
+      "name": "60 North Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://cdn1.zetcast.net/stream",
+      "homepage": "https://60north.radio/",
+      "country": "GB",
+      "favicon": "https://60north.radio/wp-content/uploads/2020/06/60n-radio-app-icon-108x108-1.jpeg",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-dance-revolution",
+      "name": "Dance Revolution",
+      "broadcaster": "independent",
+      "streamUrl": "https://s5.radio.co/s89dcf578d/listen",
+      "homepage": "https://dancerevradio.com/",
+      "country": "GB",
+      "favicon": "http://dancerevradio.com/wp-content/uploads/2024/01/asset-10360-1.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-ekr-retro-rock",
+      "name": "EKR Retro Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming06.liveboxstream.uk/proxy/eastken4?mp=/stream",
+      "homepage": "https://ekrdigital.com/retro-rock/",
+      "country": "GB",
+      "tags": [
+        "70s",
+        "80s",
+        "retro",
+        "rock"
+      ],
+      "favicon": "https://ekrdigital.com/wp-content/themes/ekr-digital-radio/img/icons/retro-rock_180.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-electric-lion-radio-london",
+      "name": "Electric Lion Radio London",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming04.liveboxstream.uk/proxy/electric?mp=/stream",
+      "homepage": "https://electriclionradio.com/",
+      "country": "GB",
+      "favicon": "https://electriclionradio.com/resources/Electric%20Lion.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hearme-trance",
+      "name": "HearMe - trance",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.hearme.fm:8100/stream",
+      "homepage": "https://hearme.fm/",
+      "country": "GB",
+      "tags": [
+        "trance"
+      ],
+      "codec": "MP3",
+      "geo": [
+        53.9561,
+        -1.7578
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-intamixx",
+      "name": "Intamixx",
+      "broadcaster": "independent",
+      "streamUrl": "https://intamixx.no-ip.com:8002/;",
+      "homepage": "https://radio.intamixx.uk/",
+      "country": "GB",
+      "tags": [
+        "bhangra",
+        "desi"
+      ],
+      "favicon": "https://radio.intamixx.uk/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-nostalgia-central",
+      "name": "Nostalgia Central",
+      "broadcaster": "independent",
+      "streamUrl": "https://s5.radio.co/s6211fbeed/listen",
+      "homepage": "https://ncradio.com/",
+      "country": "GB",
+      "tags": [
+        "1950s",
+        "1960s",
+        "1970s",
+        "1980s",
+        "1990s",
+        "nostalgic"
+      ],
+      "favicon": "http://ncradio.com/wp-content/uploads/2024/08/nclogo.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        53.0614,
+        -5.2515
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-xtra-dance",
+      "name": "Radio Xtra Dance",
+      "broadcaster": "independent",
+      "streamUrl": "https://c30.radioboss.fm:8613/stream",
+      "homepage": "https://radioxtra.co.uk/xtra-dance/",
+      "country": "GB",
+      "tags": [
+        "00s dance",
+        "10s dance",
+        "90s dance",
+        "commercial free",
+        "dance music",
+        "news free"
+      ],
+      "favicon": "https://radioxtra.co.uk/wp-content/uploads/2023/07/xTRA-DANCE-B-150x150-1.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-soul-roots-radio",
+      "name": "Soul Roots Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streams.radio.co/sbdfc075c0/listen",
+      "homepage": "https://soulrootsradio.com/",
+      "country": "GB",
+      "favicon": "https://soulrootsradio.com/wp-content/uploads/2022/08/Soul-Roots-Header-Logo.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-ace-cafe-radio",
+      "name": "Ace Cafe Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/69079/stream/106852",
+      "homepage": "https://acecafe.com/ace-cafe-radio/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.8584,
+        0.0875
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-get-ready-to-rock",
+      "name": "Get Ready to Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://streamer.radio.co/s24ae1285c/listen",
+      "homepage": "http://getreadytorockradio.com/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-healthcare-now-radio",
+      "name": "Healthcare Now Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://healthcarenowradio.out.airtime.pro/healthcarenowradio_a",
+      "homepage": "https://www.healthcarenowradio.com/",
+      "country": "GB",
+      "favicon": "https://www.healthcarenowradio.com/wp-content/uploads/2017/12/HCNR-websiteheader-636.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-sd-radio",
+      "name": "SD Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://mystation.micast.media/radio/8020/radio.mp3",
+      "homepage": "https://sdradiouk.co.uk/",
+      "country": "GB",
+      "tags": [
+        "dance",
+        "dnb",
+        "drum and bass",
+        "grime",
+        "hip hop",
+        "house"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        53.702,
+        -1.7857
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-ambur-radio",
+      "name": "Ambur Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.garden/api/ara/content/listen/FEBrvDEk/channel.mp3?1743950367875",
+      "homepage": "https://amburfm.co.uk/",
+      "country": "GB",
+      "favicon": "https://amburfm.co.uk/wp-content/uploads/2020/04/logo-ambur-original-composite-cropped.jpg.pagespeed.ce.wm1b2kWhy7.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-box-radio-dreamscapes",
+      "name": "Box radio dreamscapes",
+      "broadcaster": "independent",
+      "streamUrl": "https://boxradio-edge-00.streamafrica.net/dreamscapes",
+      "homepage": "https://boxradio.net/opendata",
+      "country": "GB",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-ehfm",
+      "name": "EHFM",
+      "broadcaster": "independent",
+      "streamUrl": "https://ehfm.out.airtime.pro/ehfm_a",
+      "homepage": "https://www.ehfm.live/",
+      "country": "GB",
+      "tags": [
+        "community radio",
+        "edinburgh"
+      ],
+      "favicon": "https://static.mytuner.mobi/media/tvos_radios/lbvlm87gg7bp.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-fresh-fm-radio-london",
+      "name": "Fresh Fm Radio London",
+      "broadcaster": "independent",
+      "streamUrl": "https://eu4.fastcast4u.com/proxy/blacka?mp=/1",
+      "homepage": "https://freshfmradiolondon.com/",
+      "country": "GB",
+      "tags": [
+        "dub",
+        "lovers rock reggae",
+        "reggae",
+        "roots",
+        "uk"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.5024,
+        -0.1154
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-gaydio-london",
+      "name": "Gaydio London",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-gaydio.sharp-stream.com/472_gaydio_london_128_mp3",
+      "homepage": "https://www.gaydio.co.uk/london/",
+      "country": "GB",
+      "tags": [
+        "chat",
+        "gaydio",
+        "pop music"
+      ],
+      "favicon": "https://mmo.aiircdn.com/20/664f572bc2e7c.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.5063,
+        -0.1286
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-heart-love",
+      "name": "Heart Love",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ice.musicradio.com/HeartLoveMP3",
+      "homepage": "https://www.heart.co.uk/love/",
+      "country": "GB",
+      "tags": [
+        "adult contemporary",
+        "love songs",
+        "middle of the road"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-pure-beat-radio",
+      "name": "Pure Beat Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast6.asurahosting.com/proxy/purebeat/stream",
+      "homepage": "http://purebeatradio.co.uk/",
+      "country": "GB",
+      "favicon": "http://purebeatradio.co.uk/gallery/favicons/favicon-120x120.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-24-7-cafe-radio",
+      "name": "24/7 Cafe Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ec6.yesstreaming.net:1555/stream",
+      "homepage": "https://www.247caferadio.com/",
+      "country": "GB",
+      "favicon": "https://www.247caferadio.com/wp-content/uploads/2020/11/cropped-247-Cafe-Radio.jpg",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-dejavufm",
+      "name": "dejavufm",
+      "broadcaster": "independent",
+      "streamUrl": "https://dejavufm.radioca.st/;",
+      "homepage": "https://dejavufm.com/",
+      "country": "GB",
+      "tags": [
+        "underground"
+      ],
+      "favicon": "https://i2.wp.com/dejavufm.com/wp-content/uploads/deja-pic-logo-.jpg?fit=600%2C600&ssl=1",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-energy-fm-classic-dance-and-the-best-new-music",
+      "name": "ENERGY FM - classic dance and the best new music",
+      "broadcaster": "independent",
+      "streamUrl": "https://s1.myradiostream.com/8838/listen.mp3",
+      "homepage": "https://www.energyfm.co.uk/",
+      "country": "GB",
+      "favicon": "https://www.energyfm.co.uk/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-funky-corner-radio-uk",
+      "name": "Funky Corner Radio UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://ais-sa2.cdnstream1.com/2447_192.mp3",
+      "homepage": "https://funkycorner.uk/",
+      "country": "GB",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-soul-rhythms-radio-uk",
+      "name": "Soul Rhythms Radio UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://a7.asurahosting.com:8230/radio.mp3",
+      "homepage": "https://soulrhythmsradio.com/home/",
+      "country": "GB",
+      "tags": [
+        "afrobeats",
+        "alternative / indie",
+        "classic jazz",
+        "disco",
+        "funk",
+        "funky house"
+      ],
+      "favicon": "https://soulrhythmsradio.com/wp-content/uploads/2023/12/SRR-LOGOTHIS_ONE.jpg",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        51.4964,
+        -0.1514
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-switch-fm-london",
+      "name": "Switch FM London",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.switchfm.co.uk/listen/switchfm/switchfm.mp3",
+      "homepage": "https://switchfm.co.uk/",
+      "country": "GB",
+      "favicon": "https://switchfm.co.uk/assets/img/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-teamsport-radio",
+      "name": "Teamsport Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://uksouth1.juiceboxradio.com/tsradionational",
+      "homepage": "http://teamsportradio.com/",
+      "country": "GB",
+      "bitrate": 96,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-80s-zoom",
+      "name": "80s Zoom",
+      "broadcaster": "independent",
+      "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/SAM03AAC226_SC.mp3",
+      "homepage": "http://www.80szoom.com/",
+      "country": "GB",
+      "tags": [
+        "128 kbit/s",
+        "192kbps",
+        "1980s",
+        "24/7",
+        "256 kbit/s",
+        "256 kbps"
+      ],
+      "favicon": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTzUFC8MX_VPOLHcB32vggZZhwC928NeErEyQ&s.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.5307,
+        -0.1223
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bloop-london-radio-live4",
+      "name": "Bloop London Radio - live4",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.canstream.co.uk:8058/live4.mp3",
+      "homepage": "https://blooplondon.com/",
+      "country": "GB",
+      "tags": [
+        "electronic"
+      ],
+      "favicon": "https://blooplondon.com/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-d3ep-radio",
+      "name": "D3EP Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast.d3ep.com:8008/192?v=1726246823",
+      "homepage": "https://d3ep.com/",
+      "country": "GB",
+      "favicon": "https://d3ep.com/assets/images/topbar-logo.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.9153,
+        -1.7853
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-heart-bristol",
+      "name": "Heart Bristol",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ssl.musicradio.com/HeartBristol?",
+      "homepage": "https://www.heart.co.uk/bristol/",
+      "country": "GB",
+      "tags": [
+        "pop music"
+      ],
+      "favicon": "https://www.heart.co.uk/assets_v4r/dist/combined/img/logos/bristol.png",
+      "bitrate": 48,
+      "codec": "AAC",
+      "geo": [
+        51.451,
+        -2.5828
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-point-blank-fm",
+      "name": "Point Blank FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://pointblankradio.co.uk/stream.mp3?latency=high",
+      "homepage": "https://www.pointblankradio.com/",
+      "country": "GB",
+      "favicon": "https://www.pointblankradio.com/wp-content/uploads/2022/11/Primary-logo.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-scifi-radio",
+      "name": "SCIFI.radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://station.kryptonradio.com:8080/stream",
+      "homepage": "http://scifi.radio/",
+      "country": "GB",
+      "favicon": "https://i0.wp.com/scifi.radio/wp-content/uploads/2021/02/cropped-scifiradio-b-512x512-1.png?fit=180%2C180&ssl=1",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-cbn-television",
+      "name": "CBN-Television",
+      "broadcaster": "independent",
+      "streamUrl": "https://5790d294af2dc.streamlock.net/CBNVI/CBNVI/playlist.m3u8",
+      "homepage": "https://www.cbnvirginislands.com/cbn-tv",
+      "country": "GB",
+      "favicon": "https://static.wixstatic.com/media/a79bb4_69234cd7684d43fa85e3b8d0c18fe9ee~mv2.png/v1/fill/w_167,h_57,al_c,lg_1,q_85,enc_auto/a79bb4_69234cd7684d43fa85e3b8d0c18fe9ee~mv2.png",
+      "bitrate": 2032,
+      "codec": "AAC,H.264",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-london-soul-radio",
+      "name": "London Soul Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://londonsoulradio.out.airtime.pro/londonsoulradio_a",
+      "homepage": "https://www.thesouloflondonradio.com/",
+      "country": "GB",
+      "favicon": "https://cdn-profiles.tunein.com/s137728/images/logod.jpg?t=637190405260000000",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-moon-phase-radio",
+      "name": "Moon Phase Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://dc1.serverse.com/proxy/dnutqhxl/stream",
+      "homepage": "http://moonphaseradio.uk/",
+      "country": "GB",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-queen",
+      "name": "Queen",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.pcradio.ru/Queen-hi",
+      "homepage": "https://pcradio.ru/",
+      "country": "GB",
+      "tags": [
+        "discography"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-fred-film-radio-27-industry",
+      "name": "Fred Film Radio-27 INDUSTRY",
+      "broadcaster": "independent",
+      "streamUrl": "https://s10.webradio-hosting.com/proxy/fredradioind/stream",
+      "homepage": "https://www.fred.fm/",
+      "country": "GB",
+      "tags": [
+        "film"
+      ],
+      "favicon": "https://www.fred.fm/wp-content/uploads/2014/12/Fred-Logo_trasp_-copia.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-greatest-hits-radio",
+      "name": "Greatest Hits Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-mz.hellorayo.co.uk/net2westmidlands.aac?aw_0_1st.skey=1602676850&direct=true&rp_source=1",
+      "homepage": "https://www.hellorayo.co.uk/greatest-hits/west-midlands",
+      "country": "GB",
+      "favicon": "https://assets.planetradio.co.uk/img/ConfigWebHeaderLogoSVGImageUrl/381.svg?ver=1545132394",
+      "bitrate": 48,
+      "codec": "AAC+",
+      "geo": [
+        52.2785,
+        -1.7069
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hearme-2020s-pop-music",
+      "name": "HearMe - 2020s Pop Music",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.hearme.fm:8000/stream",
+      "homepage": "https://hearme.fm/",
+      "country": "GB",
+      "tags": [
+        "2020s pop music"
+      ],
+      "codec": "MP3",
+      "geo": [
+        53.1204,
+        -2.4609
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-x-00s",
+      "name": "Radio X 00s",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ice.musicradio.com/RadioX00sMP3",
+      "homepage": "https://www.radiox.co.uk/00s/",
+      "country": "GB",
+      "tags": [
+        "00s",
+        "2000s",
+        "alternative",
+        "indie rock"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radiohead",
+      "name": "Radiohead",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.pcradio.ru/radiohead-hi",
+      "homepage": "https://pcradio.ru/",
+      "country": "GB",
+      "tags": [
+        "discography"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-replay-news-english-news-radio-every-5-minutes",
+      "name": "REPLAY NEWS - English           News radio every 5 minutes",
+      "broadcaster": "independent",
+      "streamUrl": "https://replaynewsen.ice.infomaniak.ch/replaynewsen-128.mp3",
+      "homepage": "https://www.replaynews.net/",
+      "country": "GB",
+      "tags": [
+        "information",
+        "news"
+      ],
+      "favicon": "https://www.publicsante.com/BIENVENU/LOGO%20REPLAY%20NEWS-EN.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-sab-radio-folkestone-uk",
+      "name": "SAB RADIO FOLKESTONE UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://spectrum.radioca.st/stream",
+      "homepage": "https://shepwayspectrumarts.co.uk/",
+      "country": "GB",
+      "tags": [
+        "other",
+        "special"
+      ],
+      "favicon": "https://shepwayspectrumarts.co.uk/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-sam-fm-hampshire",
+      "name": "SAM FM Hampshire",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-nation.sharp-stream.com/samfmhampshire.aac",
+      "homepage": "https://hellorayo.co.uk/greatest-hits/",
+      "country": "GB",
+      "tags": [
+        "32 kbps",
+        "aac",
+        "classic hits"
+      ],
+      "favicon": "https://hellorayo.co.uk/tesla/static/favicons/rayo/favicon.svg",
+      "bitrate": 48,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-ujima-radio",
+      "name": "Ujima Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.canstream.co.uk:8037/live.mp3",
+      "homepage": "https://radio.canstream.co.uk:8037/live.mp3",
+      "country": "GB",
+      "tags": [
+        "african music",
+        "blues",
+        "caribbean music",
+        "community radio",
+        "local talk",
+        "political talk"
+      ],
+      "favicon": "https://www.ujimaradio.com/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.4572,
+        -2.5925
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-beyond-radio",
+      "name": "Beyond Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.beyondradio.co.uk/radio/8000/high",
+      "homepage": "https://www.beyondradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/458/61aa613685fdd.png",
+      "bitrate": 192,
+      "codec": "AAC",
+      "geo": [
+        54.0339,
+        -2.7914
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-box-office-radio",
+      "name": "Box Office Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.citrus3.com:8400/stream",
+      "homepage": "https://boxofficeradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "broadway",
+        "film music",
+        "musical",
+        "musicals",
+        "showtunes",
+        "soundtrack"
+      ],
+      "favicon": "https://raw.githubusercontent.com/AusIPTV/IPTVLogos/master/Box_Office_Radio.png",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-british-tamil-radio",
+      "name": "British Tamil Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://hello.citrus3.com:8188/stream",
+      "homepage": "https://www.bitronline.com/",
+      "country": "GB",
+      "favicon": "https://www.bitronline.com/wp-content/uploads/2023/12/cropped-logo_radio_main-1-300x300.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-chunt-fm",
+      "name": "Chunt FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://fm.chunt.org/stream",
+      "homepage": "https://chunt.org/",
+      "country": "GB",
+      "tags": [
+        "ambient",
+        "disco",
+        "drum and bass",
+        "house",
+        "jungle",
+        "soul"
+      ],
+      "favicon": "https://chunt.org/images/logo_fishe_calm_256.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hearme-1990s-pop-music",
+      "name": "HearMe - 1990s pop music",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.hearme.fm:8050/stream",
+      "homepage": "https://hearme.fm/",
+      "country": "GB",
+      "tags": [
+        "1990s",
+        "pop",
+        "pop music"
+      ],
+      "codec": "MP3",
+      "geo": [
+        52.4828,
+        -0.7031
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-heckington-living-community-radio",
+      "name": "Heckington Living Community Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.live365.com/a52107",
+      "homepage": "http://www.heckingtonliving.co.uk/heckington-living-community-radio/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        52.9818,
+        -0.2998
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-jazz-radio-international",
+      "name": "JAZZ RADIO INTERNATIONAL",
+      "broadcaster": "independent",
+      "streamUrl": "https://ec3.yesstreaming.net:1815/stream",
+      "homepage": "https://www.247onlineradio.com/jazz-radio-international/",
+      "country": "GB",
+      "tags": [
+        "jazz"
+      ],
+      "favicon": "https://www.247onlineradio.com/wp-content/uploads/2015/07/JIR-logo.jpg",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-laser-558",
+      "name": "Laser 558",
+      "broadcaster": "independent",
+      "streamUrl": "https://s6.autopo.st/proxy/stfkrnfr?mp=/stream",
+      "homepage": "https://laser558.live/",
+      "country": "GB",
+      "tags": [
+        "80s"
+      ],
+      "favicon": "https://i0.wp.com/laser558.live/wp-content/uploads/2023/06/cropped-820eb3aa2e08a58fcf16db6aebbbdcb4_2000x.png?fit=180%2c180&#038;ssl=1",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-nation-classic-hits",
+      "name": "Nation Classic Hits",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-nation.sharp-stream.com/nationparty.mp3",
+      "homepage": "https://www.nationplayer.com/nation-classic-hits/",
+      "country": "GB",
+      "tags": [
+        "adult contemporary",
+        "classic hits",
+        "oldies"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-angel-radio",
+      "name": "Angel Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://edge.clrmedia.co.uk/angel_hb",
+      "homepage": "https://www.angelradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://static.wixstatic.com/media/d58553_797ec55eb22b47f38dd7203577e49e5e%7emv2.png/v1/fill/w_180%2ch_180%2clg_1%2cusm_0.66_1.00_0.01/d58553_797ec55eb22b47f38dd7203577e49e5e%7emv2.png",
+      "bitrate": 96,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hearme-classic-eurodisco",
+      "name": "HearMe - Classic EuroDisco",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.hearme.fm:9810/stream",
+      "homepage": "https://hearme.fm/radio/classic-eurodisco/",
+      "country": "GB",
+      "favicon": "https://hearme.fm/wp-content/uploads/2024/06/2024-Redrafted-Transparent-Box-No-Text-1-1024x1024.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hot-fm-uk",
+      "name": "Hot FM UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://hotfmuk.radioca.st/;",
+      "homepage": "https://www.hotfm.org.uk/",
+      "country": "GB",
+      "tags": [
+        "music 70s 80s 90s",
+        "pop"
+      ],
+      "favicon": "https://static.mytuner.mobi/media/tvos_radios/3tbgbthvw26v.webp",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-mellow-mountain-radio",
+      "name": "Mellow Mountain Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://owncast.mellowmountainradio.com/hls/stream.m3u8",
+      "homepage": "https://www.mellowmountainradio.com/",
+      "country": "GB",
+      "favicon": "https://irp.cdn-website.com/5e4cb10b/site_favicon_16_1715929040005.ico",
+      "bitrate": 1108,
+      "codec": "AAC,H.264",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-north-manchester-fm",
+      "name": "North Manchester FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.canstream.co.uk:8061/live.mp3",
+      "homepage": "https://northmanchester.fm/",
+      "country": "GB",
+      "tags": [
+        "community"
+      ],
+      "favicon": "https://northmanchester.fm/wp-content/uploads/2011/08/nmfm10661.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-poprockradiouk",
+      "name": "PopRockRadioUK",
+      "broadcaster": "independent",
+      "streamUrl": "https://popradiouk.out.airtime.pro/popradiouk_a",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "GB",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-stones-live-the-24-7-maidstone-united-radio-stat",
+      "name": "Stones Live! - The 24/7 Maidstone United Radio Station",
+      "broadcaster": "independent",
+      "streamUrl": "https://uk5.internet-radio.com/proxy/stoneslive?mp=/stream;",
+      "homepage": "https://www.stoneslive.com/",
+      "country": "GB",
+      "favicon": "https://www.stoneslive.com/wp-content/uploads/2015/07/julystoneslive.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-the-christmas-station",
+      "name": "The Christmas Station",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radio.co/s63541ce9b/listen",
+      "homepage": "https://thechristmasstation.org/",
+      "country": "GB",
+      "favicon": "https://thechristmasstation.org/images/stationlogo.webp",
+      "bitrate": 64,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-wey-valley",
+      "name": "Wey Valley",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.readyformed.com:8443/wey1",
+      "homepage": "https://www.weyvalleyradio.uk/l",
+      "country": "GB",
+      "tags": [
+        "easy listening",
+        "pop"
+      ],
+      "favicon": "https://www.weyvalleyradio.uk/favicon.ico",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-kisstory-non-stop-old-skool-anthems",
+      "name": " KISSTORY: Non-Stop Old Skool & Anthems",
+      "broadcaster": "independent",
+      "streamUrl": "https://live-bauerkiss.sharp-stream.com/kisstory.aac?direct=true&aw_0_1st.playerid=BMUK_Airable&aw_0_1st.skey=6778249992",
+      "homepage": "https://www.hellorayo.co.uk/kisstory",
+      "country": "GB",
+      "tags": [
+        "anthems",
+        "bauer radio",
+        "classics",
+        "dance anthems",
+        "dance classics",
+        "england"
+      ],
+      "favicon": "https://cdn-profiles.tunein.com/s77960/images/logod.png",
+      "bitrate": 48,
+      "codec": "AAC+",
+      "geo": [
+        51.5082,
+        -0.1285
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-24-7-london-radio-royalty-free-music",
+      "name": "24/7 London Radio - Royalty Free Music",
+      "broadcaster": "independent",
+      "streamUrl": "https://ec3.yesstreaming.net:3645/stream",
+      "homepage": "https://www.247londonradio.com/royalty-free-music/",
+      "country": "GB",
+      "tags": [
+        "24/7",
+        "free",
+        "london",
+        "royalty free"
+      ],
+      "favicon": "https://usercontent.one/wp/www.247londonradio.com/wp-content/uploads/2020/02/cropped-247-london-Radio-Logo.jpg",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-cj-carlos",
+      "name": "CJ Carlos",
+      "broadcaster": "independent",
+      "streamUrl": "https://s3.radio.co/sf2bda8390/listen",
+      "homepage": "https://cjcarlosevents.co.uk/",
+      "country": "GB",
+      "tags": [
+        "r&b/urban"
+      ],
+      "bitrate": 192,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-gamingnow-radio",
+      "name": "GamingNow Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://media01.gamingnow.net:8010/",
+      "homepage": "https://gamingnow.net/radio/",
+      "country": "GB",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-in2beats",
+      "name": "in2Beats",
+      "broadcaster": "independent",
+      "streamUrl": "https://in2radio.co.uk/IN2MP3",
+      "homepage": "https://in2beats.com/",
+      "country": "GB",
+      "tags": [
+        "classic soul"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-laser-558-classic",
+      "name": "Laser 558 Classic",
+      "broadcaster": "independent",
+      "streamUrl": "https://s6.autopo.st/proxy/neffjohd?mp=/stream",
+      "homepage": "https://laser558.live/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-ribblefm",
+      "name": "RibbleFM",
+      "broadcaster": "independent",
+      "streamUrl": "https://uksouth.streaming.broadcast.radio/ribblefm",
+      "homepage": "https://ribblefm.com/",
+      "country": "GB",
+      "favicon": "https://ribblefm.com/wp-content/uploads/2023/02/ribblefm-logo.webp",
+      "codec": "MP3",
+      "geo": [
+        53.8506,
+        -2.3758
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-starpoint-radio",
+      "name": "Starpoint Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream2.hippynet.co.uk/stream/starpointradiohigh",
+      "homepage": "http://www.starpointradio.com/",
+      "country": "GB",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-uk-national-radio",
+      "name": "UK National Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://das-edge14-live365-dal02.cdnstream.com/a80402",
+      "homepage": "https://www.uknationalradio.com/",
+      "country": "GB",
+      "tags": [
+        "00s",
+        "10s",
+        "60s",
+        "70s",
+        "80s",
+        "90s"
+      ],
+      "favicon": "https://media.live365.com/download/119460ab-eb43-4fca-a482-eadc9c4d9ef0.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-1btn",
+      "name": "1BTN",
+      "broadcaster": "independent",
+      "streamUrl": "https://edge.clrmedia.co.uk/obfm_mp3",
+      "homepage": "https://1btn.fm/",
+      "country": "GB",
+      "tags": [
+        "electronic",
+        "funk",
+        "house",
+        "reggae",
+        "soul"
+      ],
+      "codec": "MP3",
+      "geo": [
+        50.8262,
+        -0.1611
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-24-7-restaurant-radio",
+      "name": "24/7 Restaurant Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ec6.yesstreaming.net:1655/stream",
+      "homepage": "https://www.247restaurantradio.com/",
+      "country": "GB",
+      "favicon": "https://usercontent.one/wp/www.247restaurantradio.com/wp-content/uploads/2021/04/cropped-247-Restaurant-Radio.jpg",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-alpha-wave-radio",
+      "name": "Alpha Wave Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://listentomystream.com:8068/stream",
+      "homepage": "https://www.alphawaveradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://static.wixstatic.com/media/a8d0cc_272a834a431540a6a4bc2c9a7f652ec0~mv2.png/v1/fill/w_123,h_123,al_c,q_85,usm_0.66_1.00_0.01,enc_auto/Bright%20Blue.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bbc-radio-tees",
+      "name": "BBC Radio Tees",
+      "broadcaster": "independent",
+      "streamUrl": "https://a.files.bbci.co.uk/ms6/live/3441A116-B12E-4D2F-ACA8-C1984642FA4B/audio/simulcast/hls/nonuk/pc_hd_abr_v2/aks/bbc_tees.m3u8",
+      "homepage": "https://www.bbc.co.uk/radiotees/",
+      "country": "GB",
+      "favicon": "https://static.files.bbci.co.uk/sounds/web/sounds-web/img/sounds-apple-touch-icon.ead169771d.png",
+      "bitrate": 101,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-beware-the-radio",
+      "name": "Beware! The Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://bewaretheradio.out.airtime.pro/bewaretheradio_a",
+      "homepage": "https://www.bewaretheradio.com/",
+      "country": "GB",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-fred-film-radio-mandarin",
+      "name": "FRED FILM RADIO Mandarin",
+      "broadcaster": "independent",
+      "streamUrl": "https://s10.webradio-hosting.com/proxy/fredradiocn/stream/1/",
+      "homepage": "https://www.fred.fm/",
+      "country": "GB",
+      "favicon": "https://www.fred.fm/wp-content/uploads/2014/12/Fred-Logo_trasp_-copia.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hearme-2010s-pop-music",
+      "name": "HearMe 2010s pop music",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.hearme.fm:8030/stream",
+      "homepage": "https://hearme.fm/",
+      "country": "GB",
+      "codec": "MP3",
+      "geo": [
+        52.6964,
+        -2.4609
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-ostm-radio",
+      "name": "OSTM Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.zeno.fm/1vx25xbdmzzuv",
+      "homepage": "https://www.ostm.co.uk/",
+      "country": "GB",
+      "tags": [
+        "alternative",
+        "alternative rock",
+        "indie",
+        "indie rock",
+        "rock"
+      ],
+      "favicon": "https://www.ostm.co.uk/img/favicon.ico",
+      "codec": "MP3",
+      "geo": [
+        53.4726,
+        -2.2996
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-capital-nottinghamshire",
+      "name": "Capital (Nottinghamshire)",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ice.musicradio.com/CapitalNottinghamshireMP3",
+      "homepage": "https://www.capitalfm.com/",
+      "country": "GB",
+      "tags": [
+        "top 40"
+      ],
+      "favicon": "https://www.capitalfm.com/assets_v4r/capital/img/favicon-196x196.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-caravan-radio",
+      "name": "Caravan Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream4.themediasite.co.uk:8044/stream?_=456752",
+      "homepage": "https://www.caravanradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "pop",
+        "rock"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-cosmic-fuzz-fm",
+      "name": "COSMIC FUZZ FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://26343.live.streamtheworld.com/SAM04AAC335_SC",
+      "homepage": "https://cosmicfuzzfm.com/",
+      "country": "GB",
+      "favicon": "https://img1.wsimg.com/isteam/ip/a07df4e6-3874-46a7-b088-6a4e68a6123b/blob-6f3a7d7.png/:/cr=t:0%25,l:0%25,w:100%25,h:100%25/rs=w:806,h:403",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-galaxy-of-stars",
+      "name": "Galaxy of Stars ",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ssl.musicradio.com/Global-M-GalaxyStars",
+      "homepage": "https://www.globalplayer.com/playlists/2SWmn/",
+      "country": "GB",
+      "tags": [
+        "dance",
+        "urban"
+      ],
+      "favicon": "https://images.globalplayer.com/images/595200?width=450&signature=8QhLiiKoeaxJMt_Zc6w4S9Wekz0=",
+      "bitrate": 48,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-magic-classical",
+      "name": "Magic Classical",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-mz.hellorayo.co.uk/scala.aac",
+      "homepage": "https://www.hellorayo.co.uk/magic-classical",
+      "country": "GB",
+      "tags": [
+        "classical music"
+      ],
+      "bitrate": 48,
+      "codec": "AAC+",
+      "geo": [
+        51.4786,
+        -0.1978
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-ssradio",
+      "name": "SSRadio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ssradiol.radioca.st/listen.mp3",
+      "homepage": "https://ssradio.com/",
+      "country": "GB",
+      "tags": [
+        "deep house",
+        "funky house",
+        "house",
+        "soulful house"
+      ],
+      "favicon": "https://ssradio.com/wp-content/themes/ssradio/images/ssrDeepLogo.gif",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-the-people-s-radio-a-star-citizen-community-radi",
+      "name": "The People's Radio - A Star Citizen Community Radio Station",
+      "broadcaster": "independent",
+      "streamUrl": "https://us1.streamingpulse.com/ssl/7058",
+      "homepage": "https://thepeoplesradio.space/",
+      "country": "GB",
+      "favicon": "https://us7.streamingpulse.com/4232/tmp/images/logo.1632318369.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-winchester-radio",
+      "name": "Winchester Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://winchest.radioca.st/stream?rp_source=1&=&&___cb=427101946874329",
+      "homepage": "http://winchester.radio/",
+      "country": "GB",
+      "favicon": "https://www.hampshirehospitals.nhs.uk/application/files/5715/9741/0233/WinchRadio-portrait250x109.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-virgin-radio-uk-rock-n-roll-radio-from-the-top-o",
+      "name": " VIRGIN RADIO UK: Rock‘n’Roll Radio From The Top Of The Tower",
+      "broadcaster": "independent",
+      "streamUrl": "https://virgin.live.stream.broadcasting.news/stream",
+      "homepage": "https://virginradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "dab",
+        "digital radio",
+        "england",
+        "english",
+        "europe",
+        "london"
+      ],
+      "favicon": "https://cdn-profiles.tunein.com/s266113/images/logod.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        51.5072,
+        -0.1269
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-24-7-seawaves-radio",
+      "name": "24/7 Seawaves Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ec6.yesstreaming.net:1505/stream",
+      "homepage": "https://www.247natureradio.com/24-7-seawaves-radio/",
+      "country": "GB",
+      "tags": [
+        "meditation",
+        "nature",
+        "relaxation",
+        "seawaves"
+      ],
+      "favicon": "https://www.247natureradio.com/wp-content/uploads/2021/09/247-Seawaves-Radio.jpg",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-big-barn-radio",
+      "name": "BIG BARN RADIO",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.radio.co/s04214ea9a/listen",
+      "homepage": "https://bigbarnradio.com/",
+      "country": "GB",
+      "tags": [
+        "pop"
+      ],
+      "favicon": "https://www.wix.com/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-broradio",
+      "name": "broradio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.broadcastradio.com:8422/brorad?=&&___cb=380218828489260",
+      "homepage": "https://www.broradio.fm/",
+      "country": "GB",
+      "tags": [
+        "community radio",
+        "local news",
+        "music",
+        "welsh language"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-burgess-hill-radio",
+      "name": "Burgess Hill Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.broadcastradio.com:9312/burgesshillradio",
+      "homepage": "https://www.burgesshillradio.co.uk/",
+      "country": "GB",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-heritage-chart-radio",
+      "name": "Heritage Chart Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s4.radio.co/sd5b175766/listen",
+      "homepage": "https://www.heritagechart.co.uk/",
+      "country": "GB",
+      "tags": [
+        "heritage"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-jingle-ark-jingle-jukebox",
+      "name": "Jingle Ark Jingle Jukebox",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.zeno.fm/6q0ftbdzk2zuv",
+      "homepage": "https://zeno.fm/radio/jingle-ark-classics/",
+      "country": "GB",
+      "favicon": "https://zeno.fm/static/icons/apple-icon-120x120.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-music-galaxy-radio",
+      "name": "Music Galaxy Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://eu10.fastcast4u.com/themusi2",
+      "homepage": "https://www.themusicgalaxyradio.com/",
+      "country": "GB",
+      "tags": [
+        "country",
+        "djs",
+        "funk",
+        "hip-hop",
+        "jazz",
+        "reggae"
+      ],
+      "favicon": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRl5H_571Uc9TPjudUTSRXY6Kme_1deY38X0r8gWVmn1YclbOUPbBC3exlC4gEOZEs05r0&usqp=CAU",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-retro-mix-radio",
+      "name": "Retro Mix Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.retromixradio.co.uk/radio48",
+      "homepage": "https://www.retromixradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "70s",
+        "80s",
+        "90s"
+      ],
+      "bitrate": 48,
+      "codec": "AAC+",
+      "geo": [
+        51.5754,
+        0.4752
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-sheppey-fm-92-2",
+      "name": "Sheppey FM 92.2",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming05.liveboxstream.uk/proxy/sheppeyf?mp=/stream",
+      "homepage": "https://sheppeyfm.org.uk/",
+      "country": "GB",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-your-hits-digital",
+      "name": "Your Hits Digital",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-yourhitsdigital.creativedork.com/",
+      "homepage": "https://www.yourhitsdigital.com/",
+      "country": "GB",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-242-radio",
+      "name": "242 Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://uk7.internet-radio.com/proxy/242radio?mp=/stream&1705137844878",
+      "homepage": "https://www.242radio.com/",
+      "country": "GB",
+      "favicon": "https://www.242radio.com/index_htm_files/17903@2x.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-apocalypse-radio",
+      "name": "Apocalypse Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiopanel.scoobynetworks.uk:10990/stream?type=http&nocache=28",
+      "homepage": "https://apocalypse-radio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "dance",
+        "dj remix",
+        "house",
+        "techno",
+        "trance"
+      ],
+      "bitrate": 320,
+      "codec": "AAC+",
+      "geo": [
+        52.4426,
+        -1.8402
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bfbs-uk",
+      "name": "BFBS UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-ssvcbfbs.sharp-stream.com/ssvcbfbs1.aac",
+      "homepage": "https://radio.bfbs.com/stations/bfbs-uk",
+      "country": "GB",
+      "favicon": "https://radio.bfbs.com/icons/icon-512x512.png?v=0afec91a27aaa6d57f2b000c6fbe8cac",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bloomberg-uk",
+      "name": "Bloomberg UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://bloomberg-live-prod-us-east-1.s3.amazonaws.com/rad/Channel-RAD-AWS-virginia-1/Source-RadUK-96-1_live.m3u8",
+      "homepage": "https://www.bloomberg.com/audio",
+      "country": "GB",
+      "tags": [
+        "business",
+        "news",
+        "ridwan",
+        "talk",
+        "world news"
+      ],
+      "favicon": "https://www.bloomberg.com/favicon.ico",
+      "codec": "UNKNOWN",
+      "geo": [
+        52.0957,
+        -0.4216
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-frisk-guilty-pleasures",
+      "name": "Frisk Guilty Pleasures",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.friskradio.com:8443/stream31",
+      "homepage": "https://www.friskradio.com/?station=6#station-select-panel",
+      "country": "GB",
+      "favicon": "https://management.friskradio.com:7000/stations/logo?id=6",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-inverness-hospital-radio",
+      "name": "Inverness Hospital Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://uksoutha.streaming.broadcast.radio/invernesshr?1699799769753=",
+      "homepage": "https://www.invernesshospitalradio.co.uk/",
+      "country": "GB",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-nation-xmas",
+      "name": "Nation Xmas",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-nation.sharp-stream.com/nationxmas.mp3",
+      "homepage": "https://www.nationplayer.com/nation-xmas/",
+      "country": "GB",
+      "tags": [
+        "christmas",
+        "christmas music",
+        "christmas songs"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-ocean-youth-radio",
+      "name": "Ocean Youth Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radio.co/s7bb9c4fc8/low",
+      "homepage": "https://www.oceanyouth.co.uk/",
+      "country": "GB",
+      "favicon": "https://images.squarespace-cdn.com/content/v1/63b306b5c427c63f7ac443bb/a113998f-ade6-40ba-9e52-0ee49b945a1d/02_OYLogoWhite.png?format=1500w",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-groovy",
+      "name": "Radio Groovy",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radio.co/s560edbdb7/listen",
+      "homepage": "https://www.radiogroovy.com/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-101-8-wcr-fm",
+      "name": "101.8 WCR FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream3.themediasite.co.uk:8312/stream?_=580911",
+      "homepage": "https://www.wcrfm.com/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        52.5833,
+        -2.1296
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-24-7-country-walks-radio",
+      "name": "24/7 Country Walks Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ec6.yesstreaming.net:1585/stream",
+      "homepage": "https://www.247onlineradio.com/24-7-online-radio-group-stations/24-7-country-walks-radio/",
+      "country": "GB",
+      "tags": [
+        "environnement",
+        "meditation",
+        "nature",
+        "relaxation"
+      ],
+      "favicon": "https://www.247onlineradio.com/wp-content/uploads/2023/04/247-Country-Walks.jpg",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-crystal-107-4-fm",
+      "name": "Crystal 107.4 FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://crystalfm-radiohosting2.radioca.st/stream",
+      "homepage": "https://www.crystalfm.co.uk/",
+      "country": "GB",
+      "tags": [
+        "cultural",
+        "eclectic programming",
+        "folk music"
+      ],
+      "favicon": "https://www.crystalfm.co.uk/index_htm_files/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-liverpool-live-radio",
+      "name": "Liverpool Live Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.aiir.com/xbmvsamvpnluv",
+      "homepage": "https://www.liverpoolliveradio.com/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/417/5f8022222baf6.png",
+      "codec": "MP3",
+      "geo": [
+        53.3954,
+        -2.9825
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-mechanical-music-radio",
+      "name": "Mechanical Music Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://global.citrus3.com:2020/stream/mechanicalmusicradio",
+      "homepage": "https://www.mechanicalmusicradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://www.mechanicalmusicradio.co.uk/uploads/1/1/3/3/1133045/google-play-store-featured-section.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-buena-vida",
+      "name": "Radio Buena Vida",
+      "broadcaster": "independent",
+      "streamUrl": "https://s4.radio.co/s69b281ac0/listen",
+      "homepage": "https://buenavida.co.uk/",
+      "country": "GB",
+      "tags": [
+        "community radio",
+        "music"
+      ],
+      "favicon": "https://buenavida.co.uk/wp-content/uploads/2022/08/Small-logo-for-Soundcloud.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        55.8341,
+        -4.2655
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-newark",
+      "name": "Radio Newark",
+      "broadcaster": "independent",
+      "streamUrl": "https://streamer.radionewark.com/",
+      "homepage": "https://radionewark.org/",
+      "country": "GB",
+      "favicon": "https://radionewark.org/images/favicon/apple-touch-icon.png",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-sabras-radio",
+      "name": "Sabras Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.canstream.co.uk:8025/live.mp3?_=596083",
+      "homepage": "https://www.sabrasradio.com/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/232/6460ea059133d.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-24-7-spa-radio",
+      "name": "24/7 Spa Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ec6.yesstreaming.net:2915/stream",
+      "homepage": "https://www.247sparadio.com/",
+      "country": "GB",
+      "favicon": "https://usercontent.one/wp/www.247sparadio.com/wp-content/uploads/2021/04/cropped-247-Spa-Radio.jpg",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-95-6-brfm",
+      "name": "95.6 BRFM",
+      "broadcaster": "independent",
+      "streamUrl": "https://mediacp.nkpa.co.uk/stream/Brfm/BrfmMP3",
+      "homepage": "https://brfm.net/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-banita-maxx-radio",
+      "name": "Banita Maxx Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.zeno.fm/z5artz4g2wzuv",
+      "homepage": "https://banitamaxx.pl/",
+      "country": "GB",
+      "tags": [
+        "edm",
+        "hardstyle",
+        "polish",
+        "trance"
+      ],
+      "codec": "MP3",
+      "geo": [
+        51.6829,
+        -0.4036
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-dance-radio-uk",
+      "name": "Dance Radio UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://dancestream.danceradiouk.com/",
+      "homepage": "https://www.danceradiouk.com/",
+      "country": "GB",
+      "tags": [
+        "80's",
+        "pop",
+        "top-40"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-fenland-youth-radio",
+      "name": "Fenland Youth Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.broadcastradio.com:10445/youngtech",
+      "homepage": "https://www.fenlandyouthradio.com/",
+      "country": "GB",
+      "tags": [
+        "community"
+      ],
+      "favicon": "https://irp.cdn-website.com/546fca48/site_favicon_16_1630357525872.ico",
+      "codec": "UNKNOWN",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-forest-fm",
+      "name": "Forest FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.canstream.co.uk:8146/live.mp3",
+      "homepage": "https://forestfm.co.uk/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-iconicextra",
+      "name": "IconicExtra",
+      "broadcaster": "independent",
+      "streamUrl": "https://ukbeatz.radioca.st/stream",
+      "homepage": "https://www.iconicextra.com/",
+      "country": "GB",
+      "favicon": "https://www.iconicextra.com/wp-content/uploads/2020/06/cropped-logo_redo1cl-180x180.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-insanity-radio",
+      "name": "Insanity Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.cor.insanityradio.com/insanity.flac",
+      "homepage": "https://insanityradio.com/",
+      "country": "GB",
+      "codec": "OGG",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-mix-92-6",
+      "name": "Mix 92.6",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream4.hippynet.co.uk/stream/8012/stream",
+      "homepage": "https://mix926.com/",
+      "country": "GB",
+      "tags": [
+        "community radio"
+      ],
+      "favicon": "https://mix926.com/favicon.ico",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-music-box-radio",
+      "name": "Music Box Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://uk5.internet-radio.com/proxy/musicboxradio?mp=/stream",
+      "homepage": "https://www.musicboxradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "community radio",
+        "eclectic",
+        "music"
+      ],
+      "favicon": "https://www.musicboxradio.co.uk/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-nr1-drum-and-bass-radio",
+      "name": "NR1 Drum and Bass Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.listen-nr1dnb.com/listen/nr1_dnb_radio/radio.mp3",
+      "homepage": "https://listen.nr1dnb.com/",
+      "country": "GB",
+      "tags": [
+        "dnb",
+        "drum and bass",
+        "electronic",
+        "jungle"
+      ],
+      "favicon": "https://listen.nr1dnb.com/icons/icon-512.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-powerstream",
+      "name": "PowerStream",
+      "broadcaster": "independent",
+      "streamUrl": "https://my.powerstream.live/1985/stream",
+      "homepage": "https://dj-stream.com/",
+      "country": "GB",
+      "favicon": "https://dj-stream.com/favicon.ico",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-west-middlesex",
+      "name": "Radio West Middlesex",
+      "broadcaster": "independent",
+      "streamUrl": "https://uk6.internet-radio.com/proxy/radiowestmiddlesex?mp=/stream;",
+      "homepage": "http://radiowestmiddlesex.org.uk/",
+      "country": "GB",
+      "favicon": "http://radiowestmiddlesex.org.uk/wordpress/wp-content/themes/RWMTheme4/images/page.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-thornbury-radio",
+      "name": "Thornbury Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s42.myradiostream.com/29400/listen.mp3?_=135900",
+      "homepage": "https://www.thornbury.radio/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/222/5f4659d5167b4.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-vintage-radio-birkenhead",
+      "name": "Vintage Radio birkenhead",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming04.liveboxstream.uk/proxy/vintager/stream",
+      "homepage": "https://www.vintageradio.org.uk/#",
+      "country": "GB",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-voices",
+      "name": "Voices",
+      "broadcaster": "independent",
+      "streamUrl": "https://voicesradio.out.airtime.pro/voicesradio_a",
+      "homepage": "https://www.voicesradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://www.voicesradio.co.uk/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.5361,
+        -0.1261
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-we-get-lifted-radio-wglr-192k-mp3",
+      "name": "We Get Lifted Radio (WGLR) 192k mp3",
+      "broadcaster": "independent",
+      "streamUrl": "https://s3.radio.co/sa80d22794/listen",
+      "homepage": "https://wegetliftedradio.com/",
+      "country": "GB",
+      "tags": [
+        "deep house",
+        "deep techno",
+        "edm",
+        "tech house"
+      ],
+      "favicon": "https://www.wegetliftedradio.com/wp-content/uploads/2020/03/cropped-WGLR-HEADER-1-1-1-600x343.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-britcom-4",
+      "name": "Britcom 4",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast2.asurahosting.com/proxy/britcom4/stream.mp3",
+      "homepage": "https://pumpkinfm.com/",
+      "country": "GB",
+      "tags": [
+        "comedy"
+      ],
+      "favicon": "https://pumpkinfm.com/wp-content/uploads/2022/03/pfmnewlogoSmall.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-cam-fm-97-2",
+      "name": "Cam FM 97.2",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.camfm.co.uk/camfm",
+      "homepage": "https://www.camfm.co.uk/",
+      "country": "GB",
+      "favicon": "https://www.camfm.co.uk/media/images/default_thumb.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-fantasy-radio-devizes",
+      "name": "Fantasy Radio (Devizes)",
+      "broadcaster": "independent",
+      "streamUrl": "https://server.fantasyradio.co.uk/fantasyradio",
+      "homepage": "https://www.fantasyradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "classic hits",
+        "community radio",
+        "hot adult contemporary",
+        "local radio"
+      ],
+      "favicon": "https://www.fantasyradio.co.uk/files/9414/1236/5176/fbthumb.png",
+      "bitrate": 256,
+      "codec": "MP3",
+      "geo": [
+        51.3525,
+        -1.996
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-island-time-infinite-mixtapes-nts",
+      "name": "Island Time - Infinite Mixtapes | NTS",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-mixtape-geo.ntslive.net/mixtape21",
+      "homepage": "https://www.nts.live/infinite-mixtapes/island-time",
+      "country": "GB",
+      "tags": [
+        "dub",
+        "reggae"
+      ],
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-kennet-radio",
+      "name": "Kennet Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.kennetradio.com/64.aac",
+      "homepage": "https://kennetradio.com/",
+      "country": "GB",
+      "favicon": "https://kennetradio.com/wp-content/uploads/2021/05/kr_square_150.png",
+      "bitrate": 48,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-mkfm",
+      "name": "MKFM",
+      "broadcaster": "independent",
+      "streamUrl": "https://mkfmradioplayer2.radioca.st/;stream.nsv?=&&___cb=838498533391580",
+      "homepage": "https://www.mkfm.com/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/171/6367c3f242240.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-northwich",
+      "name": "Radio Northwich",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radio.co/s98163f694/listen",
+      "homepage": "https://www.radionorthwich.co.uk/",
+      "country": "GB",
+      "tags": [
+        "local information",
+        "local music",
+        "local news",
+        "local programming",
+        "local radio",
+        "local talk"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        53.2627,
+        -2.5116
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-reform-radio",
+      "name": "Reform Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://testform.out.airtime.pro/testform_a",
+      "homepage": "https://www.reformradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "music",
+        "variety"
+      ],
+      "favicon": "https://www.reformradio.co.uk/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        53.4781,
+        -2.2565
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-smash-hits-radio-retro",
+      "name": "Smash hits radio retro",
+      "broadcaster": "independent",
+      "streamUrl": "https://s3.radio.co/s802363087/listen",
+      "homepage": "https://s3.radio.co/s802363087/listen",
+      "country": "GB",
+      "tags": [
+        "retro hits"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        -35.8329,
+        11.5342
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-sunny-g-community-radio",
+      "name": "Sunny G Community Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming06.liveboxstream.uk/proxy/gary1?mp=/stream",
+      "homepage": "https://www.sunnyg.org/",
+      "country": "GB",
+      "tags": [
+        "community"
+      ],
+      "favicon": "https://static.wixstatic.com/media/3455a1_7e4ecdcdcf7344fe88ca9633cc48aae4~mv2.png/v1/fill/w_315,h_315,al_c,lg_1,q_85,enc_auto/Sunny_G_logo%20(no%20background).png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        55.8595,
+        -4.2576
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-york-hospital-radio",
+      "name": "York Hospital Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream1.superstreaming.co.uk/proxy/yorkhospradio/stream",
+      "homepage": "http://www.yorkhospitalradio.com/#",
+      "country": "GB",
+      "favicon": "https://yorkhospitalradio.com/wp-content/uploads/2024/01/cropped-yhr-site-logo-180x180.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-kiss-the-best-vibes-energy",
+      "name": " KISS - The Best Vibes & Energy",
+      "broadcaster": "independent",
+      "streamUrl": "https://live-bauerkiss.sharp-stream.com/kissnational.aac?direct=true&aw_0_1st.skey=1602676850&rp_source=1&=&&___cb=60456375243858",
+      "homepage": "https://www.hellorayo.co.uk/kiss",
+      "country": "GB",
+      "tags": [
+        "dab",
+        "dance",
+        "dance music",
+        "digital radio",
+        "edm",
+        "england"
+      ],
+      "favicon": "https://cdn-profiles.tunein.com/s6004/images/logod.png",
+      "bitrate": 47,
+      "codec": "AAC+",
+      "geo": [
+        51.5078,
+        -0.1265
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-kiss-dance-the-biggest-dance-anthems-24-7",
+      "name": " KISS DANCE: The Biggest Dance Anthems 24/7",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-kiss.hellorayo.co.uk/kissdance.aac?direct=true&aw_0_1st.skey=1602676850&rp_source=1&=&&___cb=60456375243858",
+      "homepage": "https://www.hellorayo.co.uk/kiss-dance",
+      "country": "GB",
+      "tags": [
+        "anthems",
+        "bauer radio",
+        "club dance",
+        "dab",
+        "dab+",
+        "dance"
+      ],
+      "favicon": "https://cdn-profiles.tunein.com/s321341/images/logod.png",
+      "bitrate": 127,
+      "codec": "AAC",
+      "geo": [
+        51.5078,
+        -0.1275
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-100-whatever-westcountry",
+      "name": "100% Whatever Westcountry",
+      "broadcaster": "independent",
+      "streamUrl": "https://dh1-sanityradio.radioca.st/stream",
+      "homepage": "https://whateverwestcountry.com/",
+      "country": "GB",
+      "favicon": "https://whateverwestcountry.com/wp-content/uploads/2020/06/WHATEVER-WEST-GRN.png",
+      "codec": "MP3",
+      "geo": [
+        51.3272,
+        -2.958
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-academy-fm-folkestone",
+      "name": "Academy FM Folkestone",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.xrad.io:9480/;stream/1",
+      "homepage": "https://www.radiofolkestone.com/",
+      "country": "GB",
+      "favicon": "https://static.wixstatic.com/media/2a383b_fd22a81897514de18547bdf81eb202de~mv2.png/v1/fill/w_84,h_75,al_c,q_85,usm_0.66_1.00_0.01,enc_auto/Wordpress%20Transparent.png",
+      "bitrate": 48,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bhbn-radio",
+      "name": "BHBN Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://uksoutha.streaming.broadcast.radio/stream/9400/BHBN?1699801420380=",
+      "homepage": "https://www.bhbn.net/",
+      "country": "GB",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-brooklands-radio",
+      "name": "Brooklands Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream4.hippynet.co.uk/stream/brooklandsradio",
+      "homepage": "https://www.brooklandsradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "community radio",
+        "local news",
+        "local talk",
+        "pop music"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.3721,
+        -0.4602
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-caresound-radio",
+      "name": "CareSound Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.broadcast.radio/perth?1699803359553=",
+      "homepage": "https://caresound.radio/",
+      "country": "GB",
+      "favicon": "https://caresound.radio/wp-content/uploads/CSR-Full-Colour-Round-Gradient-150px.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-clubland-radio-uk",
+      "name": "Clubland Radio UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.radio.co/sf1cecf191/listen",
+      "homepage": "https://clublandradiouk.co.uk/",
+      "country": "GB",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/3/33563.v13.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-def-leppard",
+      "name": "Def Leppard",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.pcradio.ru/def_leppard-hi",
+      "homepage": "https://pcradio.ru/",
+      "country": "GB",
+      "tags": [
+        "discography"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-dnbradio-atmospheric",
+      "name": "DnBRadio Atmospheric",
+      "broadcaster": "independent",
+      "streamUrl": "https://azura.drmnbss.org/listen/plushrecs/radio.mp3",
+      "homepage": "https://dnbradio.com/?channel=plushrecs&autoplay=0",
+      "country": "GB",
+      "favicon": "https://www.google.com/s2/favicons?sz=256&domain_url=https%3A%2F%2Fdnbradio.com%2F%3Fchannel%3Dplushrecs%26autoplay%3D0",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-frisk-radio-uk",
+      "name": "Frisk Radio UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.friskradio.com:8443/stream11",
+      "homepage": "https://www.friskradio.com/",
+      "country": "GB",
+      "tags": [
+        "dance",
+        "deep house",
+        "pop"
+      ],
+      "favicon": "https://management.friskradio.com:7000/stations/logo?id=1",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-grampian-hospital-radio",
+      "name": "Grampian Hospital Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://uksoutha.streaming.broadcast.radio/ghr?1699804401378=",
+      "homepage": "https://www.grampianhospitalradio.org/",
+      "country": "GB",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-greatest-hits-radio-60s",
+      "name": "Greatest Hits Radio 60s",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-al.hellorayo.co.uk/ghr60s.aac?aw_0_1st.skey=1602676850&direct=true&rp_source=1",
+      "homepage": "https://www.hellorayo.co.uk/greatest-hits-60s",
+      "country": "GB",
+      "tags": [
+        "greatest hits"
+      ],
+      "favicon": "https://media.bauerradio.com/image/upload/c_crop,g_custom/v1725015216/brand_manager/stations/pqnbvpmvgj7jnsopgpix.svg",
+      "bitrate": 48,
+      "codec": "AAC+",
+      "geo": [
+        50.9613,
+        0.1162
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hwd-hospital-radio",
+      "name": "HWD Hospital Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming04.liveboxstream.uk/proxy/hwdhospi?mp=/stream",
+      "homepage": "https://www.hwdhospitalradio.com/",
+      "country": "GB",
+      "favicon": "https://www.hwdhospitalradio.com/images/logo.png",
+      "bitrate": 112,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-one-world-radio-daybreak-session",
+      "name": "One World Radio - Daybreak Session",
+      "broadcaster": "independent",
+      "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/OWR_DAYBREAK_ADP.aac",
+      "homepage": "https://www.tomorrowland.com/home/radio",
+      "country": "GB",
+      "favicon": "https://www.tomorrowland.com/home/apple-touch-icon.png",
+      "bitrate": 256,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-pure-radio",
+      "name": "Pure Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://kathy.torontocast.com:4825/stream",
+      "homepage": "https://listentopure.uk/",
+      "country": "GB",
+      "tags": [
+        "adult alternative",
+        "britpop",
+        "rock"
+      ],
+      "favicon": "https://listentopure.uk/wp-content/uploads/2023/02/cropped-cropped-pure-logo-23-150.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-rominimal-radio",
+      "name": "ROminimal Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://r4.rominimal.club/listen/rominimal.club/radio2.m4a",
+      "homepage": "https://rominimal.club/",
+      "country": "GB",
+      "tags": [
+        "deep minimal",
+        "electronic",
+        "microhouse",
+        "minimal techno",
+        "minimal techno mixes",
+        "rominimal"
+      ],
+      "favicon": "https://rominimal.club/images/logo.png",
+      "bitrate": 320,
+      "codec": "AAC",
+      "geo": [
+        51.5074,
+        -0.1278
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-soar-sound",
+      "name": "Soar Sound",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.maxxwave.co.uk/soarsound",
+      "homepage": "https://www.soarsound.uk/",
+      "country": "GB",
+      "favicon": "https://i0.wp.com/www.soarsound.uk/wp-content/uploads/2024/03/cropped-SoarLogoFinal-Favicon-e1710351771330.png?fit=150%2C146&ssl=1",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-white-cliffs-radio",
+      "name": "White Cliffs Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.whitecliffsradio.co.uk/",
+      "homepage": "https://www.whitecliffsradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://images.whitecliffsradio.co.uk/wcr_logo_new_r.webp",
+      "codec": "MP3",
+      "geo": [
+        51.1251,
+        1.3134
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-wrexham-premier-radio",
+      "name": "Wrexham Premier Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://uksoutha.streaming.broadcast.radio/premier?1709519917408=",
+      "homepage": "https://www.premier-radio.co.uk/",
+      "country": "GB",
+      "favicon": "https://www.premier-radio.co.uk/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bcfm-93-2",
+      "name": "BCfm 93.2",
+      "broadcaster": "independent",
+      "streamUrl": "https://bcfmradiomain.radioca.st/live.mp3",
+      "homepage": "https://www.bcfmradio.com/",
+      "country": "GB",
+      "tags": [
+        "bristol",
+        "rock"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.4445,
+        -2.5856
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-belfast-89",
+      "name": "Belfast 89",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.broadcast.radio/belfastfm",
+      "homepage": "https://www.belfast89.com/",
+      "country": "GB",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bouncy-vibes-radio",
+      "name": "Bouncy Vibes Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://bouncy-host.co.uk/radio/8000/radio.mp3",
+      "homepage": "https://bouncy-vibes.co.uk/",
+      "country": "GB",
+      "favicon": "https://bouncy-vibes.co.uk/images/favicon.ico",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-drama-radio",
+      "name": "Drama Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming06.liveboxstream.uk/proxy/roksta10/stream",
+      "homepage": "https://www2.rokitradio.com/",
+      "country": "GB",
+      "favicon": "https://www2.rokitradio.com/_next/image?url=%2Fimages%2Fchannels%2Fdrama.jpg&w=128&q=75",
+      "bitrate": 48,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-heart-west-midlands",
+      "name": "Heart West Midlands",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ice.musicradio.com/HeartWestMidsMP3",
+      "homepage": "https://www.heart.co.uk/westmids/",
+      "country": "GB",
+      "tags": [
+        "pop",
+        "rock"
+      ],
+      "favicon": "http://www.heart.co.uk/assets_v4r/heart/img/favicon-196x196.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-lazy-gold",
+      "name": "Lazy Gold",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-lazyradio.creativedork.com/",
+      "homepage": "https://www.lazygold.co.uk/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-memory-lane-radio",
+      "name": "Memory Lane Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://memorylaneradio.radioca.st/;",
+      "homepage": "https://memorylaneradio.co.uk/",
+      "country": "GB",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-pure-west-radio",
+      "name": "Pure West Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://uksoutha.streaming.broadcast.radio/stream/8580/purewest",
+      "homepage": "https://www.purewestradio.com/",
+      "country": "GB",
+      "tags": [
+        "local radio",
+        "pop",
+        "pop music",
+        "south wales"
+      ],
+      "favicon": "https://www.purewestradio.com/media/jjvja3hb/pure-west-radio-450x450.png",
+      "bitrate": 256,
+      "codec": "MP3",
+      "geo": [
+        51.8014,
+        -4.9721
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-red-rose-radio",
+      "name": "Red Rose Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.red-roseradio.co.uk:8008/stream?_=520468",
+      "homepage": "https://www.redroseradio.uk/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/1552/6680100859da1.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-sister-midnight-fm",
+      "name": "Sister Midnight FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radio.co/s35e4926a1/listen",
+      "homepage": "https://radio.sistermidnight.org/",
+      "country": "GB",
+      "tags": [
+        "music",
+        "non-commercial",
+        "variety"
+      ],
+      "favicon": "https://radio.sistermidnight.org/favicons/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-soul-connexion-radio",
+      "name": "Soul Connexion Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.soulconnexionradio.com/1045",
+      "homepage": "https://www.soulconnexionradio.com/",
+      "country": "GB",
+      "tags": [
+        "classic soul",
+        "disco",
+        "funk",
+        "jazz-funk",
+        "modern soul",
+        "nu disco"
+      ],
+      "favicon": "https://static.wixstatic.com/media/1cdeb2_d480bb8158f4469284f543e790063616%7Emv2.jpg/v1/fill/w_192%2Ch_192%2Clg_1%2Cusm_0.66_1.00_0.01/1cdeb2_d480bb8158f4469284f543e790063616%7Emv2.jpg",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-24-7-online-radio",
+      "name": "24/7 Online Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ec3.yesstreaming.net:3585/stream",
+      "homepage": "https://www.247onlineradio.com/24-7-online-radio/",
+      "country": "GB",
+      "tags": [
+        "chillout",
+        "easy listening",
+        "independent artists",
+        "lounge"
+      ],
+      "favicon": "https://usercontent.one/wp/www.247onlineradio.com/wp-content/uploads/2020/02/247-Online-Radio-Station-Logo.jpg",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-deal-radio",
+      "name": "Deal Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.radio.co/sa44aa697f/listen",
+      "homepage": "https://www.dealradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "eclectic"
+      ],
+      "favicon": "https://dev.dealradio.co.uk/wp-content/uploads/2020/06/Small-redblue.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-greatest-hits-radio-80s",
+      "name": "Greatest Hits Radio 80s",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-al.hellorayo.co.uk/ghr80s.aac?aw_0_1st.skey=1602676850&direct=true&rp_source=1",
+      "homepage": "https://www.hellorayo.co.uk/greatest-hits-radio-80s",
+      "country": "GB",
+      "tags": [
+        "80s",
+        "greatest hits"
+      ],
+      "favicon": "https://media.bauerradio.com/image/upload/c_crop,g_custom/v1741162714/brand_manager/stations/tmeuw7bt9gwnbkuxpjab.png",
+      "bitrate": 47,
+      "codec": "AAC+",
+      "geo": [
+        51.2725,
+        -0.173
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-margate-radio",
+      "name": "Margate Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://margate-radio.radiocult.fm/stream",
+      "homepage": "https://margateradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://images.squarespace-cdn.com/content/v1/55dccc18e4b080417ce5fafa/1585823097541-KVKK0PO2RTI5SZC6YLWF/MargateRadio_White_72dpi.png?format=1500w",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-midlands-radio",
+      "name": "Midlands Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-153.zeno.fm/2mn7tdzkug0uv",
+      "homepage": "https://www.radio-uk.co.uk/midlands-radio-80s",
+      "country": "GB",
+      "tags": [
+        "1980s",
+        "pop"
+      ],
+      "favicon": "https://static.mytuner.mobi/media/tvos_radios/CXYgFMyE7u.jpg",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-now-radio-80s",
+      "name": "NOW Radio 80s",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.zeno.fm/ihij6rdighvtv",
+      "homepage": "https://www.mynowradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "80's",
+        "80s"
+      ],
+      "favicon": "https://www.mynowradio.co.uk/wp-content/uploads/2023/12/NOW-Radio-90s-1-scaled.jpg",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-jupiter",
+      "name": "Radio Jupiter",
+      "broadcaster": "independent",
+      "streamUrl": "https://s10.myradiostream.com/:7946/listen.mp3?nocache=1686498616",
+      "homepage": "https://www.radiojupiter.studio/",
+      "country": "GB",
+      "tags": [
+        "adult contemporary",
+        "pop",
+        "rock"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.2748,
+        1.1623
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio2funky",
+      "name": "Radio2Funky",
+      "broadcaster": "independent",
+      "streamUrl": "https://s6.citrus3.com:8006/stream",
+      "homepage": "https://radio2funky.co.uk/",
+      "country": "GB",
+      "favicon": "https://radio2funky.co.uk/wp-content/uploads/2023/04/DAB-logo-new.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-rainbow-radio-wales",
+      "name": "Rainbow Radio Wales",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.zeno.fm/dtbgwan9sd0uv",
+      "homepage": "https://rainbowradio.uk/",
+      "country": "GB",
+      "favicon": "http://rainbowradio.uk/wp-content/uploads/2024/07/7h5TKbvAqe__1_-removebg-preview.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-southampton-hospital-radio",
+      "name": "Southampton Hospital Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s6.autopo.st/proxy/shrinternet?mp=/stream",
+      "homepage": "https://www.sohba.org/",
+      "country": "GB",
+      "favicon": "https://www.sohba.org/static/35df7ec86d.android-icon-192x192.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-yo1-radio",
+      "name": "Yo1 Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream1.themediasite.co.uk:8026/;?_=215164",
+      "homepage": "https://www.yo1radio.co.uk/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/706/6311ef9a56ac6.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-kisstory-r-b-the-hottest-r-b-tracks-from-kisstor",
+      "name": " KISSTORY R&B: The Hottest R&B tracks from KISSTORY",
+      "broadcaster": "independent",
+      "streamUrl": "https://live-bauerkiss.sharp-stream.com/kisstoryrb.aac?direct=true&aw_0_1st.playerid=BMUK_Airable&aw_0_1st.skey=6778249992",
+      "homepage": "https://www.hellorayo.co.uk/kisstory-rnb",
+      "country": "GB",
+      "tags": [
+        "anthems",
+        "bauer radio",
+        "black music",
+        "classics",
+        "england",
+        "europe"
+      ],
+      "favicon": "https://cdn-profiles.tunein.com/s333201/images/logod.png",
+      "bitrate": 127,
+      "codec": "AAC",
+      "geo": [
+        51.5095,
+        -0.1281
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-air-gay-radio",
+      "name": "Air Gay Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ecmanager.pro-fhi.net:2655/stream",
+      "homepage": "https://www.airgayradio.net/",
+      "country": "GB",
+      "favicon": "https://www.airgayradio.net/wp-content/uploads/2020/06/qr-code.png",
+      "bitrate": 64,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-amber-radio",
+      "name": "Amber Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream3.themediasite.co.uk:8240/listen.mp3?sid=3",
+      "homepage": "https://amber.radio/",
+      "country": "GB",
+      "favicon": "https://amber.radio/wp-content/uploads/2022/12/Amber-Radio-Logo-Assets_Original-Clear-Background.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-armagh-city-radio",
+      "name": "Armagh City Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://acrlive.radioca.st/stream?type=http&nocache=1702573713796",
+      "homepage": "https://www.armaghcityradio.com/",
+      "country": "GB",
+      "favicon": "https://static.wixstatic.com/media/3bc95e_9e8eb3dcdc8c4162b6516cc4f1a781c6~mv2.png/v1/fill/w_522,h_530,al_c,q_85,usm_0.66_1.00_0.01,enc_auto/A-only-PNG.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-aycliffe-radio",
+      "name": "Aycliffe Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://solid41.streamupsolutions.com/proxy/catidbxp?mp=/;type=mp3",
+      "homepage": "https://www.ayclifferadio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "local radio"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-countryline-radio",
+      "name": "CountryLine Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-chriscountry.sharp-stream.com/chriscountry.mp3",
+      "homepage": "https://www.countryline.radio/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-edge-1",
+      "name": "Edge 1",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.aiir.com/8dhvgxm1kbvuv",
+      "homepage": "https://edgeradio.co.uk/edge1",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/703/666adc84d05bb.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hifi-prime",
+      "name": "HiFi Prime",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.cloudrad.io/5913/8160",
+      "homepage": "https://hifiradio.net/",
+      "country": "GB",
+      "favicon": "http://hifiradio.net/wp-content/uploads/2023/09/prime-crop.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hospital-radio-chelmsford",
+      "name": "Hospital Radio Chelmsford",
+      "broadcaster": "independent",
+      "streamUrl": "https://solid55.streamupsolutions.com/proxy/mmbdfslu?mp=//stream",
+      "homepage": "https://www.hrc.org.uk/",
+      "country": "GB",
+      "favicon": "https://lirp.cdn-website.com/b164d775/dms3rep/multi/opt/IMG_0007-432w.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hospital-radio-plymouth",
+      "name": "Hospital Radio Plymouth",
+      "broadcaster": "independent",
+      "streamUrl": "https://hospitalradioplymouth.radioca.st/stream",
+      "homepage": "https://www.hospitalradioplymouth.org.uk/",
+      "country": "GB",
+      "favicon": "https://www.hospitalradioplymouth.org.uk/wp-content/uploads/2020/06/HRP-LogoNEWTRANS-100px-e1630450570740.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-juice-liverpool",
+      "name": "Juice Liverpool",
+      "broadcaster": "independent",
+      "streamUrl": "https://uksouth1.juiceboxradio.com/JuiceLiverpool",
+      "homepage": "https://juiceliverpool.co.uk/",
+      "country": "GB",
+      "favicon": "https://juiceliverpool.co.uk/assets/img/favicons/favicon-196x196.png",
+      "bitrate": 96,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-kaos-sound",
+      "name": "Kaos Sound",
+      "broadcaster": "independent",
+      "streamUrl": "https://s3.myradiostream.com:59506/stream",
+      "homepage": "https://kaos-sound.co.uk/mrsdocs/home.html",
+      "country": "GB",
+      "tags": [
+        "rock"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-lyca-gold-2",
+      "name": "Lyca Gold 2",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-lycaradio.sharp-stream.com/lyca_gold_2.mp3",
+      "homepage": "https://lycaradio.com/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-mdog-radio",
+      "name": "Mdog Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream2.hippynet.co.uk/stream/8212",
+      "homepage": "https://www.facebook.com/people/Mdog-Radio/100083286139973/",
+      "country": "GB",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        54.5682,
+        -5.9354
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-neon-radio",
+      "name": "Neon Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.flashbackcentral.co.uk/radio/8050/radio.mp3",
+      "homepage": "https://www.neonradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://images.leadconnectorhq.com/image/f_webp/q_80/r_480/u_https://assets.cdn.filesafe.space/dCZ3DwdyoW0OEpmHJlYP/media/66bb37b0e49a8129bd748aa2.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-northants-1",
+      "name": "Northants 1",
+      "broadcaster": "independent",
+      "streamUrl": "https://solid41.streamupsolutions.com/proxy/svdkgaiq/stream?icecast",
+      "homepage": "https://northants1.co.uk/",
+      "country": "GB",
+      "tags": [
+        "00's",
+        "10's",
+        "20's",
+        "chart",
+        "hit music",
+        "pop"
+      ],
+      "favicon": "https://northants1.co.uk/wp-content/uploads/2022/12/Northants-_1_-Symbol-Red.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        52.3946,
+        -0.7299
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-park-radio",
+      "name": "Park Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s32.myradiostream.com/18756/listen.mp3",
+      "homepage": "https://parkradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "community",
+        "diss",
+        "radio"
+      ],
+      "bitrate": 96,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-waters",
+      "name": "Radio Waters",
+      "broadcaster": "independent",
+      "streamUrl": "https://uk5.internet-radio.com/proxy/radiowaters/stream",
+      "homepage": "https://www.radiowaters.co.uk/",
+      "country": "GB",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-rhubarb-radio",
+      "name": "Rhubarb Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://securestreams2.autopo.st:1234/stream#.mp3?1702339792481",
+      "homepage": "https://www.rhubarbradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "local radio",
+        "music",
+        "pop music"
+      ],
+      "bitrate": 160,
+      "codec": "MP3",
+      "geo": [
+        53.6879,
+        -1.5768
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-university-radio-falmer",
+      "name": "University Radio Falmer",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-urfonline.sharp-stream.com/urfonline.mp3?nocache=0.1868666957825399",
+      "homepage": "https://www.urfonline.com/",
+      "country": "GB",
+      "tags": [
+        "music",
+        "talk",
+        "university",
+        "university radio"
+      ],
+      "favicon": "https://www.urfonline.com/favicon-256x256.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.8644,
+        -0.0885
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-zero-radio",
+      "name": "Zero Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://uk7.internet-radio.com/proxy/0radio?mp=%2Flive&1731415265701",
+      "homepage": "https://www.zeroradio.co.uk/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bailrigg-fm",
+      "name": "Bailrigg FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.bailriggfm.co.uk/listen/bfm/128.mp3",
+      "homepage": "https://bailriggfm.co.uk/",
+      "country": "GB",
+      "favicon": "https://bailriggfm.co.uk/wp-content/uploads/2020/06/cropped-Bailrigg-Mini-Logo-red-background-192x192.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-derby-sound",
+      "name": "Derby Sound",
+      "broadcaster": "independent",
+      "streamUrl": "https://uk7.internet-radio.com/proxy/in2derbyradio?mp=%2Fstream%3B",
+      "homepage": "https://www.derbysound.org.uk/",
+      "country": "GB",
+      "favicon": "https://www.derbysound.org.uk/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-frisk-radio",
+      "name": "FRISK Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.friskradio.com:8443/stream1",
+      "homepage": "https://www.friskradio.com/#station-select-panel",
+      "country": "GB",
+      "favicon": "https://www.friskradio.com/application/assets/images/favicon/64.png",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hearme-00s-rock",
+      "name": "HearMe - 00s rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.hearme.fm:8130/stream",
+      "homepage": "https://hearme.fm/",
+      "country": "GB",
+      "tags": [
+        "00s rock",
+        "00’s rock"
+      ],
+      "favicon": "https://hearme.fm/favicon.ico",
+      "codec": "MP3",
+      "geo": [
+        54.5721,
+        -2.8125
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hearme-80s-rock",
+      "name": "Hearme - 80s rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.hearme.fm:8310/stream",
+      "homepage": "https://hearme.fm/",
+      "country": "GB",
+      "tags": [
+        "80d rock",
+        "80’s rock"
+      ],
+      "codec": "MP3",
+      "geo": [
+        52.6964,
+        -2.4609
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hospital-radio-glamorgan",
+      "name": "Hospital Radio Glamorgan",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.broadcastradio.com:8002/glamorg?1725024804656=",
+      "homepage": "https://www.radioglamorgan.com/",
+      "country": "GB",
+      "favicon": "https://api.broadcast.radio/api/image/d57d29e6-9c41-4875-8cc9-952e32e08310.png?g=center",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-leeds-student-radio",
+      "name": "Leeds Student Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.radio.co/seb5cdba5b/listen",
+      "homepage": "https://www.thisislsr.com/",
+      "country": "GB",
+      "favicon": "https://static.wixstatic.com/media/316c00_def14e5b8c604227b2fa666a3a15fa2d~mv2.png/v1/fill/w_105,h_107,al_c,q_85,usm_0.66_1.00_0.01,enc_auto/LSR%20Logo.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-alty",
+      "name": "Radio Alty",
+      "broadcaster": "independent",
+      "streamUrl": "https://streams.radio.co/s4d51ef3bf/listen",
+      "homepage": "https://www.radioalty.co.uk/",
+      "country": "GB",
+      "favicon": "https://www.radioalty.co.uk/uploads/1/3/1/5/131514373/published/radio-alty-rgb-master-logo-transparent-bkground.png?1702248957",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        53.384,
+        -2.3545
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-cherwell",
+      "name": "Radio Cherwell",
+      "broadcaster": "independent",
+      "streamUrl": "https://uk6.internet-radio.com/proxy/cherwell?mp=/stream",
+      "homepage": "https://radiocherwell.com/",
+      "country": "GB",
+      "favicon": "https://radiocherwell.com/wp-content/uploads/2019/05/RC_LOGO_RGB-150x115.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-redhill-mp3",
+      "name": "Radio Redhill mp3",
+      "broadcaster": "independent",
+      "streamUrl": "https://radioredhill.uk/stream/live.mp3",
+      "homepage": "https://radioredhill.uk/",
+      "country": "GB",
+      "favicon": "https://radioredhill.uk/favicon.png",
+      "bitrate": 160,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-rare-groove-radio",
+      "name": "Rare Groove Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://a9.asurahosting.com:7950/radio.mp3",
+      "homepage": "https://raregrooveradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://assets.zyrosite.com/cdn-cgi/image/format=auto,w=268,fit=crop,q=95/Yyv7QeD1ZgiXyg7m/rgr-logo-YNqrVzg7QMF85M1n.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-satsang-radio",
+      "name": "Satsang Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.maxxwave.co.uk/satsang",
+      "homepage": "https://satsangradio.com/",
+      "country": "GB",
+      "favicon": "https://images.squarespace-cdn.com/content/v1/6801621b014aea65690810ca/e422d15b-d3ab-43d3-97d7-8695fe43a7df/Screenshot+2025-07-30+at+22.34.52.png?format=1500w",
+      "bitrate": 80,
+      "codec": "AAC",
+      "geo": [
+        52.645,
+        -1.1219
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-stirling-community-radio",
+      "name": "Stirling Community Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.broadcastradio.com:11855/castlesound?8852",
+      "homepage": "https://stirlingcommunity.radio/",
+      "country": "GB",
+      "favicon": "https://stirlingcommunity.radio/images/radio/player/logo-1715587272.webp",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-the-big-top-40-show-sundays-4-7pm",
+      "name": "The Big Top 40 Show (SUNDAYS 4 - 7PM)",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.thisisdax.com/BigTop40",
+      "homepage": "https://www.bigtop40.com/",
+      "country": "GB",
+      "tags": [
+        "music",
+        "pop"
+      ],
+      "favicon": "https://www.bigtop40.com/assets_v4r/bigtop40/img/logos/large.png",
+      "bitrate": 48,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-time-2-chill-radio",
+      "name": "Time 2 Chill Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ec6.yesstreaming.net:3615/stream",
+      "homepage": "https://www.time2chill.co.uk/radio",
+      "country": "GB",
+      "tags": [
+        "chillout",
+        "downtempo",
+        "lounge",
+        "new age"
+      ],
+      "favicon": "https://static.wixstatic.com/media/55ed4f_f43016b1c5784b71b344cd4504914340~mv2.png/v1/crop/x_0,y_342,w_1920,h_1376/fill/w_548,h_396,al_c,q_85,usm_0.66_1.00_0.01,enc_avif,quality_auto/hammock-icon_edited.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        53.3111,
+        0.2864
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-trust-am-hospital-radio",
+      "name": "Trust AM Hospital Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.galaxywebsolutions.com:9034/stream",
+      "homepage": "https://trustam.com/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-wave-community-radio",
+      "name": "Wave Community Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming06.liveboxstream.uk/proxy/piraten1?mp=/stream",
+      "homepage": "https://wavewsm.co.uk/",
+      "country": "GB",
+      "favicon": "https://wavewsm.co.uk/wp-content/uploads/2023/06/cropped-wavelogo-1.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-95-6-b-radio",
+      "name": "95.6 B Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.aiir.com/t4k624qg11kuv?_=802765",
+      "homepage": "https://www.bradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/347/62b4dc758ba9d.jpg",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bedrock-radio",
+      "name": "Bedrock Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s40.myradiostream.com:16652/bedrockradio",
+      "homepage": "https://www.bedrockradio.org.uk/",
+      "country": "GB",
+      "favicon": "https://i0.wp.com/www.bedrockradio.org.uk/wp-content/uploads/2019/06/alternate-logo-white.png?resize=300%2C135&ssl=1",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-blastfm-indie-radio-station",
+      "name": "BlastFM Indie Radio Station",
+      "broadcaster": "independent",
+      "streamUrl": "https://blast-indie-radio.com:8000/live",
+      "homepage": "https://blastfmsocial.media/BlastIndie",
+      "country": "GB",
+      "favicon": "https://blastfmsocial.media/upload/photos/2019/08/e1Yzi7QNBg2Lw32vvghN_30_e2c846377ca16726ad65724674b98d3e_avatar.jpg?cache=0",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-care-radio",
+      "name": "Care Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-careradio.sharp-stream.com/120_care_radio_128_mp3",
+      "homepage": "https://www.careradio.org/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/590/620694edbfb9e.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-central-radio-north-west",
+      "name": "Central Radio North West",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.central.radio/listen/web/high",
+      "homepage": "https://www.central.radio/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/778/673b04861e76c.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        53.7354,
+        -2.6807
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-delite-radio",
+      "name": "Delite Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.deliteonline.com/live320",
+      "homepage": "http://www.deliteradio.com/",
+      "country": "GB",
+      "favicon": "http://www.deliteradio.com/upload/players/62fb755a427c40.95586069.jpg",
+      "bitrate": 512,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-gems-top-40",
+      "name": "GEMS  TOP 40",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.gemsradio.net:8000/;",
+      "homepage": "https://www.gemsradio.net/",
+      "country": "GB",
+      "favicon": "https://www.gemsradio.net/wp-content/uploads/2021/10/cropped-Gems-Radio-icon-180x180.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-glitterbeam-italia",
+      "name": "GlitterBeam Italia",
+      "broadcaster": "independent",
+      "streamUrl": "https://quincy.torontocast.com:1740/stream",
+      "homepage": "https://www.glitterbeam.net/",
+      "country": "GB",
+      "tags": [
+        "lgbt",
+        "lgbtqia+",
+        "pop"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-glitterbeam-radio",
+      "name": "GlitterBeam Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ukwesta.streaming.broadcast.radio:17810/glitterbeam",
+      "homepage": "https://www.glitterbeam.co.uk/",
+      "country": "GB",
+      "favicon": "https://usercontent.one/wp/www.glitterbeam.co.uk/wp-content/uploads/2023/09/GBRECSMALL4.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-global-pride",
+      "name": "Global Pride",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-sov.musicradio.com/Global-M-Pride",
+      "homepage": "https://global.com/global-player",
+      "country": "GB",
+      "tags": [
+        "global",
+        "heart",
+        "media-sov",
+        "pride",
+        "uk"
+      ],
+      "favicon": "https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse2.mm.bing.net%2Fth%3Fid%3DOIP.cmoF-nf5byb4GKWOVoVefAAAAA%26pid%3DApi&f=1&ipt=fb8665bb588c291de9ed9bd2765e62613792e1203899f9a45f639d973e894cf7&ipo=images",
+      "bitrate": 48,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-great-driffield-radio",
+      "name": "Great Driffield Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream1.superstreaming.co.uk/proxy/greatdriffield/stream?rp_source=1&=&&___cb=720015281299521",
+      "homepage": "https://greatdriffieldradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://greatdriffieldradio.co.uk/wp-content/uploads/2023/12/gdr-150x150.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-greatest-hits-radio-70s",
+      "name": "Greatest Hits Radio 70s",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-al.hellorayo.co.uk/ghr70s.aac?aw_0_1st.skey=1602676850&direct=true&rp_source=1",
+      "homepage": "https://www.hellorayo.co.uk/greatest-hits-radio-70s",
+      "country": "GB",
+      "tags": [
+        "70s"
+      ],
+      "favicon": "https://media.bauerradio.com/image/upload/c_crop,g_custom/v1742817230/brand_manager/stations/vpgvlb3s5roqkyo6cxvf.svg",
+      "bitrate": 47,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-mad-wasp-radio",
+      "name": "Mad Wasp Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.radio.co/s8a8d7b49a/listen",
+      "homepage": "https://madwaspradio.com/",
+      "country": "GB",
+      "tags": [
+        "alternative",
+        "eclectic",
+        "freeform"
+      ],
+      "favicon": "https://pbs.twimg.com/profile_images/1684130478981279744/QqiJhxb9_400x400.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.4609,
+        -0.126
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-mixx-radio-preston",
+      "name": "mixx radio preston",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-hitsradio.creativedork.com/",
+      "homepage": "https://hitsradio.radioplayer.airsuite.studio/",
+      "country": "GB",
+      "favicon": "https://www.liveradio.uk/files/images/482949/resized/180x172c/mixx_radio_preston.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-only-old-skool-radio",
+      "name": "Only Old Skool Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://listentomystream.com:8036/;?type=http&nocache=107036",
+      "homepage": "https://onlyoldskoolradio.com/",
+      "country": "GB",
+      "favicon": "https://onlyoldskoolradio.com/wp-content/uploads/2020/06/cropped-icon1-32x32.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-newquay",
+      "name": "Radio Newquay",
+      "broadcaster": "independent",
+      "streamUrl": "https://s46.myradiostream.com/8816/listen.mp3",
+      "homepage": "https://www.radionewquay.com/",
+      "country": "GB",
+      "favicon": "https://mm.aiircdn.com/479/5b9a5e36391cd.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-ninesprings",
+      "name": "Radio Ninesprings",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radioninesprings.com/ninesprings-high?_=293441",
+      "homepage": "https://www.radioninesprings.com/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/494/603669b913ade.png",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-radio",
+      "name": "Radio Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://c16.radioboss.fm:18014/stream",
+      "homepage": "https://radioradio.fm/",
+      "country": "GB",
+      "tags": [
+        "pop",
+        "rock"
+      ],
+      "favicon": "https://radioradio.fm/grafika/logo1a.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-rudy",
+      "name": "Radio Rudy",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-55.zeno.fm/21y1sqfvkm0uv",
+      "homepage": "https://zeno.fm/radio/radio-rudy/",
+      "country": "GB",
+      "favicon": "https://zeno.fm/favicon.ico",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radiosega-he-aac-v2",
+      "name": "RadioSEGA (HE-AAC v2)",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.radiosega.net/live",
+      "homepage": "https://www.radiosega.net/",
+      "country": "GB",
+      "tags": [
+        "video game music"
+      ],
+      "favicon": "https://www.radiosega.net/_images/template/siteHeader-newlogo_hover.png",
+      "bitrate": 256,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-retro-soul-radio",
+      "name": "Retro Soul Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.galaxywebsolutions.com/stream/retrosoul",
+      "homepage": "https://www.retrosoulradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "disco",
+        "funk",
+        "jazz",
+        "soul"
+      ],
+      "favicon": "https://static-media.streema.com/media/cache/cf/d9/cfd9303c27dd71c35a2370766d4d1309.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-salisbury-radio",
+      "name": "Salisbury Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://securestreams6.autopo.st:2139/stream.mp3",
+      "homepage": "https://salisburyradio.co.uk/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-vixen-101",
+      "name": "Vixen 101",
+      "broadcaster": "independent",
+      "streamUrl": "https://s33.myradiostream.com:15184/;?type=http",
+      "homepage": "https://www.vixen101.co.uk/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-weekend-offender-radio",
+      "name": "Weekend Offender Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://uk2.internet-radio.com/proxy/weekendoffender?mp=/stream;",
+      "homepage": "https://weekendoffender.com/",
+      "country": "GB",
+      "favicon": "https://weekendoffender.com/cdn/shop/files/android-chrome-512x512.png?crop=center&height=32&v=1699368215&width=32",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-west-kent-radio",
+      "name": "West Kent Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ukwesta.streaming.broadcast.radio/wkcr",
+      "homepage": "https://www.westkentradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://www.westkentradio.co.uk/favicon.png",
+      "bitrate": 170,
+      "codec": "MP3",
+      "geo": [
+        51.1381,
+        0.2656
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-xenfm",
+      "name": "XenFM",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.xenfm.com/listen/xenfm/radio.mp3",
+      "homepage": "https://xenfm.com/",
+      "country": "GB",
+      "tags": [
+        "dnb",
+        "drum & bass",
+        "dubstep",
+        "edm",
+        "liquid",
+        "melodic"
+      ],
+      "favicon": "https://xenfm.com/wp-content/uploads/2020/05/cropped-PythiaArsenicEye.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.832,
+        -0.1428
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-alfred",
+      "name": "Alfred",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream2.hippynet.co.uk:8204/stream",
+      "homepage": "https://thisisalfred.com/",
+      "country": "GB",
+      "tags": [
+        "community news"
+      ],
+      "bitrate": 160,
+      "codec": "MP3",
+      "geo": [
+        51.0079,
+        -2.1927
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-arena-radio",
+      "name": "Arena Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream3.themediasite.co.uk:8318/stream",
+      "homepage": "http://arenaradio.live/",
+      "country": "GB",
+      "favicon": "https://public-rf-upload.minhawebradio.net/250716/logo/d7351a69a8b11013d475908bf2f562ba.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bfbs-aldershot",
+      "name": "BFBS Aldershot",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-ssvcbfbs.sharp-stream.com/ssvcbfbs13.aac",
+      "homepage": "https://radio.bfbs.com/stations/bfbs-aldershot",
+      "country": "GB",
+      "favicon": "https://radio.bfbs.com/icons/icon-512x512.png?v=0afec91a27aaa6d57f2b000c6fbe8cac",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-black-country-radio",
+      "name": "Black Country Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-blackcountryradio.sharp-stream.com/blackcountryradio.mp3",
+      "homepage": "https://www.blackcountryradio.co.uk/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-brap-fm",
+      "name": "Brap.FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.brap.fm:8000/radio.mp3",
+      "homepage": "https://www.brap.fm/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-crop-radio",
+      "name": "CROP Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s3.radio.co/sb713b671e/listen",
+      "homepage": "https://www.cropradio.live/",
+      "country": "GB",
+      "tags": [
+        "community radio",
+        "music",
+        "underground",
+        "variety"
+      ],
+      "favicon": "https://www.cropradio.live/images/favicons/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-cutters-choice",
+      "name": "Cutters Choice",
+      "broadcaster": "independent",
+      "streamUrl": "https://cutters-choice-radio.radiocult.fm/stream",
+      "homepage": "https://www.cutterschoiceradio.com/",
+      "country": "GB",
+      "tags": [
+        "dance",
+        "electronic",
+        "indie",
+        "ska"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-dundee-radio-club",
+      "name": "Dundee Radio Club",
+      "broadcaster": "independent",
+      "streamUrl": "https://dundee-radio-club.radiocult.fm/stream",
+      "homepage": "https://dundeeradio.club/",
+      "country": "GB",
+      "tags": [
+        "community radio",
+        "field recordings",
+        "music",
+        "podcasts",
+        "soundscape"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        56.4615,
+        -2.9701
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-flex-fm-101-4",
+      "name": "Flex FM 101.4",
+      "broadcaster": "independent",
+      "streamUrl": "https://a2.asurahosting.com:7400/radio.mp3",
+      "homepage": "https://flexfm.co.uk/",
+      "country": "GB",
+      "tags": [
+        "dance",
+        "drum and bass",
+        "edm",
+        "garage",
+        "uk"
+      ],
+      "favicon": "https://upload.wikimedia.org/wikipedia/en/4/40/Flex_FM_London_logo.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-fresh-soundz-radio",
+      "name": "Fresh Soundz Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://solid48.streamupsolutions.com/proxy/neivwtxt/stream/",
+      "homepage": "https://www.freshsoundzradio.com/",
+      "country": "GB",
+      "tags": [
+        "dj",
+        "house"
+      ],
+      "favicon": "https://static.mytuner.mobi/media/tvos_radios/626/soundz-radio-uk.426d8b6f.jpg",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-frisky-radio-chill",
+      "name": "Frisky Radio Chill",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.chill.friskyradio.com/",
+      "homepage": "http://friskyradio.com/",
+      "country": "GB",
+      "bitrate": 96,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-frisky-radio-deep",
+      "name": "Frisky Radio Deep",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.deep.friskyradio.com/",
+      "homepage": "http://friskyradio.com/",
+      "country": "GB",
+      "bitrate": 96,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-genx-radio",
+      "name": "GenX Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.radio.co/sf25229e16/low",
+      "homepage": "https://genxradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://genxradio.co.uk/wp-content/uploads/2021/11/GenXAsset-3.png",
+      "bitrate": 64,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-gold-dust-radio",
+      "name": "Gold Dust Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://gold-dust-radio.radiocult.fm/stream",
+      "homepage": "https://www.golddusthub.com/",
+      "country": "GB",
+      "favicon": "https://images.squarespace-cdn.com/content/v1/5c80edb83560c31af710d6cc/1610290067018-YNK9FQE7ZGF56JE26AK6/gd-landscape-rgb-2.png?format=1500w",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-gwh",
+      "name": "GWH",
+      "broadcaster": "independent",
+      "streamUrl": "https://carina.streamerr.co/stream/swindonhr",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hbsa-hospital-radio",
+      "name": "HBSA Hospital Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://solid24.streamupsolutions.com/proxy/zzjcamth?mp=/stream",
+      "homepage": "https://hbsaradio.com/#",
+      "country": "GB",
+      "favicon": "https://hbsaradio.com/wp-content/themes/topofthehour/images/logo.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-heaven-and-heaven-radio",
+      "name": "Heaven and Heaven radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://eu10.fastcast4u.com:1500/",
+      "homepage": "https://www.heavenandheavenradio.org/",
+      "country": "GB",
+      "favicon": "https://www.heavenandheavenradio.org/apple-touch-icon.png?v=1721674313144",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hospital-radio-colchester",
+      "name": "Hospital Radio Colchester",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.broadcastradio.com:10905/hrcolchester",
+      "homepage": "https://www.hrcolchester.co.uk/",
+      "country": "GB",
+      "favicon": "https://static.wixstatic.com/media/2aa317_7b0e1ad2c28944858946b7a57ede4ab1.png/v1/fill/w_172,h_153,al_c,lg_1,q_85,enc_auto/2aa317_7b0e1ad2c28944858946b7a57ede4ab1.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-incapable-staircase",
+      "name": "Incapable Staircase",
+      "broadcaster": "independent",
+      "streamUrl": "https://streams.radio.co/s436782ce6/listen",
+      "homepage": "https://www.incapablestaircase.com/",
+      "country": "GB",
+      "tags": [
+        "ambient",
+        "disco",
+        "djs",
+        "funk",
+        "indie"
+      ],
+      "favicon": "https://incapablestaircase.com/wp-content/uploads/2024/08/favicon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-kizzfm-uk-90-9",
+      "name": "KizzFM UK 90.9",
+      "broadcaster": "independent",
+      "streamUrl": "https://azura.kizzfmuk90-9.com/listen/kizzfmuk/radio.mp3?1689855016244",
+      "homepage": "https://www.kizzfmuk90-9.com/",
+      "country": "GB",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-lofi-hiphop-chillsky",
+      "name": "Lofi hiphop - chillsky",
+      "broadcaster": "independent",
+      "streamUrl": "https://chill.radioca.st/stream",
+      "homepage": "https://chillsky.com/",
+      "country": "GB",
+      "tags": [
+        "beats",
+        "chillout",
+        "lofi hip hop"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.5136,
+        -0.1237
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-london-romanian-radio",
+      "name": "London Romanian Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://play.lrradio.uk/",
+      "homepage": "https://lrradio.uk/",
+      "country": "GB",
+      "tags": [
+        "hot ac",
+        "pop",
+        "top 40"
+      ],
+      "favicon": "https://lrradio.uk/img/logo.png",
+      "bitrate": 64,
+      "codec": "AAC",
+      "geo": [
+        51.5708,
+        -0.2455
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-loose-fm",
+      "name": "Loose FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://loosefm.radiocult.fm/stream",
+      "homepage": "https://www.loose.fm/",
+      "country": "GB",
+      "tags": [
+        "eclectic",
+        "electronic",
+        "experimental"
+      ],
+      "favicon": "https://www.google.com/s2/favicons?sz=256&domain_url=https%3A%2F%2Fwww.loose.fm%2F",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        51.4995,
+        0.0062
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-mystery-radio",
+      "name": "Mystery Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming06.liveboxstream.uk/proxy/rokstar9/stream",
+      "homepage": "https://www2.rokitradio.com/",
+      "country": "GB",
+      "favicon": "https://www2.rokitradio.com/_next/image?url=%2Fimages%2Fchannels%2Fmystery.jpg&w=128&q=75",
+      "bitrate": 48,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-p4ppp-radio",
+      "name": "P4PPP Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.zeno.fm/hgc7mcknqpuuv",
+      "homepage": "https://zeno.fm/radio/p4ppp-radio/",
+      "country": "GB",
+      "tags": [
+        "digital health",
+        "health",
+        "peace",
+        "people",
+        "planet"
+      ],
+      "favicon": "https://zeno.fm/_next/image/?url=https%3A%2F%2Fimages.zeno.fm%2F27b-9YErzi8ANXvNMuOlFjdfMRu1P7AJXYaBWpmPZN0%2Frs%3Afit%3A240%3A240%2Fg%3Ace%3A0%3A0%2FaHR0cHM6Ly9zdHJlYW0tdG9vbHMuemVub21lZGlhLmNvbS9jb250ZW50L3N0YXRpb25zLzYzZGMzZmRmLTQwYTgtNDFkMS04MzZiLWYyMzgwODdhMTAyMC9pbWFnZS8_dXBkYXRlZD0xNzE3MDYyMzY1MDAw.webp&w=1920&q=100",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-cardiff",
+      "name": "Radio Cardiff ",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiocardiff.radioca.st/stream",
+      "homepage": "https://radiocardiff.org/",
+      "country": "GB",
+      "favicon": "https://firebasestorage.googleapis.com/v0/b/radiogalaxy-580f4.appspot.com/o/images%2FIMG_20240909_115752423.jpg?alt=media&token=b344b077-73bc-46dd-9b59-eb196ff15d0f",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-grapevine",
+      "name": "Radio Grapevine",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming06.liveboxstream.uk/proxy/radiogra?mp=/stream",
+      "homepage": "https://www.radiograpevine.com/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-seerah",
+      "name": "Radio Seerah",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.maxxwave.co.uk/radioseerah",
+      "homepage": "https://www.radioseerah.com/",
+      "country": "GB",
+      "favicon": "https://cloud-1de12d.becdn.net/media/iW=274&iH=274&oX=0&oY=0&cW=274&cH=274/0c0eff783969b0e0df546d2b6ec9ca8a/MainLOGO.jpg",
+      "bitrate": 80,
+      "codec": "AAC",
+      "geo": [
+        52.6341,
+        -1.1133
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-utsav",
+      "name": "Radio UTSAV",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.maxxwave.co.uk/utsav",
+      "homepage": "https://radioutsav.com/",
+      "country": "GB",
+      "favicon": "https://radioutsav.com/wp-content/uploads/2024/09/PHOTO-2024-09-01-11-54-35.jpg",
+      "bitrate": 80,
+      "codec": "AAC",
+      "geo": [
+        52.6562,
+        -1.1181
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radionev-24x7-hit-music-lounge",
+      "name": "RadioNev (24x7 hit music lounge)",
+      "broadcaster": "independent",
+      "streamUrl": "https://a7.asurahosting.com/listen/radionev/radio.mp3",
+      "homepage": "https://www.radionev.com/",
+      "country": "GB",
+      "favicon": "https://www.radionev.com/sitepad-data/uploads/2024/11/512.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-roch-valley-radio",
+      "name": "Roch Valley Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://rochvalley.radioca.st/stream?_=723854",
+      "homepage": "https://www.rochvalleyradio.com/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/572/615a03a7cb961.jpg",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-rotherham-radio",
+      "name": "Rotherham Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream3.themediasite.co.uk:8004/stream",
+      "homepage": "https://www.rotherhamradio.com/",
+      "country": "GB",
+      "favicon": "https://play-lh.googleusercontent.com/RcFfsJQvuWz-6ZhsTb7jOjwA6dSS0uy8h926Tgxnn4qDez7qEnBINiU9kqyc_qSvA4Q=w240-h480-rw",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        53.3795,
+        -1.5138
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-stoke-mandeville-hospital-radio",
+      "name": "Stoke Mandeville Hospital Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ukwesta.streaming.broadcast.radio/stoke?1692976686054=",
+      "homepage": "https://www.smhr.co.uk/",
+      "country": "GB",
+      "tags": [
+        "hospital radio"
+      ],
+      "favicon": "https://www.smhr.co.uk/favicon.ico",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-the-richie-allen-show",
+      "name": "The Richie Allen Show",
+      "broadcaster": "independent",
+      "streamUrl": "https://ukwesta.streaming.broadcast.radio/therichieallenshow",
+      "homepage": "https://richieallen.co.uk/",
+      "country": "GB",
+      "codec": "MP3",
+      "geo": [
+        53.5078,
+        -2.3043
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-vintage-radio-wirral",
+      "name": "Vintage Radio Wirral",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming04.liveboxstream.uk/proxy/vintager?mp=/stream",
+      "homepage": "https://www.vintageradio.org.uk/",
+      "country": "GB",
+      "favicon": "https://www.vintageradio.org.uk/sitepad-data/uploads/2024/11/WhatsApp-Image-2024-10-09-at-16.44.13_8902e262.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-beat-geeks-radio",
+      "name": "Beat Geeks Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://broadcast.shoutstream.co.uk:8050/stream",
+      "homepage": "https://beatgeeksradio.com/#5f139bdd-e5cd-420c-a57c-c7075e626746",
+      "country": "GB",
+      "favicon": "https://img1.wsimg.com/isteam/ip/bae4931a-2ea8-4815-9a46-4271f6de2b79/logo%20large.png/:/rs=w:400,h:400,cg:true,m/cr=w:400,h:400/qt=q:95",
+      "bitrate": 128,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-beat-route-radio",
+      "name": "Beat Route Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://beatrouteradio.radioca.st/autodj",
+      "homepage": "https://beatrouteradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://firebasestorage.googleapis.com/v0/b/radiogalaxy-580f4.appspot.com/o/images%2FIMG_20240909_160637684.jpg?alt=media&token=e0d32581-2089-4058-9d80-01279c52b1cc",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-blue-in-green-radio",
+      "name": "Blue-in-Green:RADIO",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radio.co/s9e1625f13/listen",
+      "homepage": "http://www.blueingreenradio.com/?m=1",
+      "country": "GB",
+      "favicon": "http://4.bp.blogspot.com/-aeCJDMfXnVM/WKWDZV4LOuI/AAAAAAAABxI/QPsmN8EWUBgPXVlN3hE9Q2EyypmA9WWfQCK4B/s400/BinGRadio%2BBW.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-capital-xtra-reloaded",
+      "name": "Capital Xtra Reloaded",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ice.musicradio.com/CapitalXTRAReloadedMP3",
+      "homepage": "https://www.capitalxtra.com/reloaded/",
+      "country": "GB",
+      "tags": [
+        "non-stop old skool & anthems"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.5102,
+        -0.1286
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-charlie-mason-radio",
+      "name": "Charlie Mason Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s9.reliastream.com/proxy/charlie1/stream",
+      "homepage": "https://charliemasonradio.com/",
+      "country": "GB",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-colin-mogagabe",
+      "name": "Colin Mogagabe",
+      "broadcaster": "independent",
+      "streamUrl": "https://music-station.live/listen/crw_radio/radio.mp3",
+      "homepage": "https://music-station.live/public/crw_radio",
+      "country": "GB",
+      "favicon": "https://www.music-station.live/static/uploads/crw_radio/album_art.1721666882.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.3814,
+        0.5224
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-conquest-hospital-radio",
+      "name": "Conquest Hospital Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://chrconquest.radioca.st/radio.mp3",
+      "homepage": "https://conquesthospitalradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://conquesthospitalradio.co.uk/wp-content/uploads/2021/07/950291C2-2ECB-460D-A667-30F09D405480.jpeg",
+      "bitrate": 160,
+      "codec": "MP3",
+      "geo": [
+        50.8549,
+        0.5811
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-crmk",
+      "name": "CRMK",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radio.co/sdfcc41b7a/listen",
+      "homepage": "https://www.crmk.co.uk/",
+      "country": "GB",
+      "tags": [
+        "pop"
+      ],
+      "favicon": "https://static.wixstatic.com/media/2f38db_822606c0d74d443cbca64a25e47899b5~mv2.png/v1/fill/w_109,h_109,al_c,q_85,usm_0.66_1.00_0.01,enc_auto/Untitled.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        52.0809,
+        -0.7229
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-deephouse-fm",
+      "name": "deephouse.fm",
+      "broadcaster": "independent",
+      "streamUrl": "https://altair.streamerr.co:8124/stream",
+      "homepage": "https://deephouse.fm/",
+      "country": "GB",
+      "tags": [
+        "deep house",
+        "house"
+      ],
+      "favicon": "https://deephouse.fm/wp-content/uploads/2025/12/Deep-House-FM-Logo.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-doncaster-radio",
+      "name": "Doncaster Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream1.themediasite.co.uk:8008/stream",
+      "homepage": "https://www.doncasterradio.com/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/493/64b694df58f95.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-drystone-radio",
+      "name": "Drystone Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://uksoutha.streaming.broadcast.radio/drystoneradio?1724596500437=",
+      "homepage": "https://www.drystoneradio.com/",
+      "country": "GB",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-eden-fm-107-5",
+      "name": "Eden Fm 107.5",
+      "broadcaster": "independent",
+      "streamUrl": "https://eu4.fastcast4u.com/proxy/edenfmlt?mp=/1",
+      "homepage": "http://www.edenfm.co.uk/",
+      "country": "GB",
+      "favicon": "https://fastcast4u.com/player/edenfmlt/_user/logo/e/edenfmlt/ch0.jpg",
+      "bitrate": 128,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-fishnet-radio",
+      "name": "Fishnet Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radio.co/s74e130a62/listen",
+      "homepage": "https://www.fishnetradio.com/",
+      "country": "GB",
+      "tags": [
+        "alternative",
+        "soul"
+      ],
+      "favicon": "https://static.mytuner.mobi/media/tvos_radios/151/fishnet-radio.6ea1e90b.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-fix-radio",
+      "name": "Fix Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://n06a-eu.rcs.revma.com/gnys6kxst8tvv",
+      "homepage": "https://www.fixradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/203/623068c8b2091.png",
+      "codec": "AAC",
+      "geo": [
+        51.4862,
+        -0.1188
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-fosse-107",
+      "name": "Fosse 107",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.maxxwave.co.uk/fossehinckleyhq",
+      "homepage": "https://www.fosse107.co.uk/",
+      "country": "GB",
+      "tags": [
+        "80s",
+        "90s",
+        "local news",
+        "news",
+        "rock"
+      ],
+      "favicon": "https://mm.aiircdn.com/375/59372c77cd002.png",
+      "bitrate": 80,
+      "codec": "AAC",
+      "geo": [
+        52.5408,
+        -1.376
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-frisk-radio-groove-northeast",
+      "name": "frisk radio groove northeast",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.friskradio.com:8443/stream21",
+      "homepage": "https://www.friskradio.com/?station=4un",
+      "country": "GB",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hailsham-fm",
+      "name": "Hailsham FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://s21.myradiostream.com/:10716/listen.mp3",
+      "homepage": "https://www.hailshamfm.com/",
+      "country": "GB",
+      "tags": [
+        "local radio"
+      ],
+      "favicon": "https://www.hailshamfm.com/wp-content/uploads/2021/03/Hailsham-95.9FM-logo-NO-STRAP.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.8628,
+        0.2595
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hearme-movie-soundtracks-radio",
+      "name": "Hearme Movie Soundtracks Radio ",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.hearme.fm:8074/stream",
+      "homepage": "https://hearme.fm/radio/movie-soundtracks/",
+      "country": "GB",
+      "tags": [
+        "soundtracks"
+      ],
+      "favicon": "https://hearme.fm/wp-content/uploads/2024/06/2024-Redrafted-Transparent-Box-No-Text-1-1024x1024.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-johnstone-sound",
+      "name": "Johnstone Sound",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream1.themediasite.co.uk:8084/;",
+      "homepage": "https://johnstonesound.com/",
+      "country": "GB",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        55.8359,
+        -4.5085
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-konflict-radio",
+      "name": "Konflict Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://uk3.internet-radio.com/proxy/konflictradio?mp=/stream",
+      "homepage": "https://konflict-radio.com/",
+      "country": "GB",
+      "tags": [
+        "dnb"
+      ],
+      "favicon": "https://konflict-radio.com/images/krlogo.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-mersey-radio",
+      "name": "Mersey Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.shoutcastservices.com/proxy/merseyradio/stream",
+      "homepage": "https://merseyradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://merseyradio.co.uk/wp-content/uploads/2023/03/cropped-logo.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-mid-downs-radio",
+      "name": "Mid Downs Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-mdr.sharp-stream.com/mdr.mp3",
+      "homepage": "https://www.mdr.org.uk/",
+      "country": "GB",
+      "tags": [
+        "hospital radio"
+      ],
+      "bitrate": 65,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-ocean-city-radio",
+      "name": "Ocean City Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s3.radio.co/se9877d32a/listen#.mp3",
+      "homepage": "https://oceancityradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "various"
+      ],
+      "favicon": "https://oceancityradio.co.uk/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-outreach-dance",
+      "name": "Outreach Dance",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.ukrp.tv/outreachdance.aac",
+      "homepage": "https://www.outreachdance.co.uk/",
+      "country": "GB",
+      "bitrate": 32,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-overton-radio",
+      "name": "Overton Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://securestreams6.autopo.st:2506/stream",
+      "homepage": "https://www.overtonradio.com/",
+      "country": "GB",
+      "favicon": "https://overtonradio.com/wp-content/uploads/2023/07/1-1-1024x1024.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-enrg",
+      "name": "Radio ENRG",
+      "broadcaster": "independent",
+      "streamUrl": "https://edge.mixlr.com/channel/xssdg",
+      "homepage": "https://radioenrg.com/",
+      "country": "GB",
+      "tags": [
+        "alternative",
+        "edinburgh",
+        "pop",
+        "rock",
+        "sport",
+        "student"
+      ],
+      "favicon": "https://i0.wp.com/radioenrg.com/wp-content/uploads/2020/06/radio-enrg-triangle-black-10.png",
+      "codec": "MP3",
+      "geo": [
+        55.9334,
+        -3.214
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-leyland",
+      "name": "Radio Leyland",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming06.liveboxstream.uk/proxy/leyland2?mp=/stream",
+      "homepage": "https://radioleyland.co.uk/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        53.6902,
+        -2.6987
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-warneford",
+      "name": "Radio Warneford",
+      "broadcaster": "independent",
+      "streamUrl": "https://uk7.internet-radio.com/proxy/radiowarneford?mp=/stream",
+      "homepage": "https://www.radiowarneford.com/",
+      "country": "GB",
+      "favicon": "https://www.radiowarneford.com/wp-content/uploads/2023/11/rw-logo-2023-50th-400.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-rother-radio-rotherham-sheffield",
+      "name": "Rother Radio (Rotherham & Sheffield)",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming06.liveboxstream.uk/proxy/hitmusic?mp=/stream",
+      "homepage": "https://www.rotherradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://static.mytuner.mobi/media/tvos_radios/594/rother-radio.cc31313e.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        53.3794,
+        -1.5138
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-rustfm",
+      "name": "RustFM",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.rustfm.com/listen/rustfm/radio.mp3",
+      "homepage": "https://rustfm.com/#home",
+      "country": "GB",
+      "favicon": "https://rustfm.com/assets/images/logo_wr.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-soundart-radio",
+      "name": "Soundart Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.canstream.co.uk:8134/live.mp3",
+      "homepage": "https://www.soundartradio.org.uk/",
+      "country": "GB",
+      "tags": [
+        "diy",
+        "experimental",
+        "experimental electronic music",
+        "field recordings",
+        "soundart"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-storm-radio",
+      "name": "Storm Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.radio.co/s6df48fd88/listen",
+      "homepage": "https://stormfm.uk/home",
+      "country": "GB",
+      "favicon": "https://img1.wsimg.com/isteam/ip/73788d98-eb15-4545-b89e-02e21d7c3eb9/STORM%20HEADER%20NEW%20A11.jpg/:/rs=w:902,h:273",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-the-sound-lab",
+      "name": "The Sound Lab",
+      "broadcaster": "independent",
+      "streamUrl": "https://s4.radio.co/s0fc46103b/listen",
+      "homepage": "https://www.thesoundlabuk.co.uk/",
+      "country": "GB",
+      "tags": [
+        "indie",
+        "pop"
+      ],
+      "favicon": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSa6ZgnMpbK8OK1EtUIYciHuysU3-zw2_NdOsB053eHdXnyMpkK9N2JYvHFRVdfsVnggKs&usqp=CAU",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-urban-all-in-1-radio",
+      "name": "Urban All In 1 Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.urbanallin1radio.co.uk/radio.mp3",
+      "homepage": "https://urbanallin1radio.co.uk/",
+      "country": "GB",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-capital-the-uk-s-no-1-hit-music-station",
+      "name": " CAPITAL - The UK's No.1 Hit Music Station",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ssl.musicradio.com/CapitalUK",
+      "homepage": "https://www.capitalfm.com/",
+      "country": "GB",
+      "tags": [
+        "capital",
+        "capital fm",
+        "contemporary hits radio",
+        "dab+",
+        "england",
+        "entertainment"
+      ],
+      "favicon": "https://cdn-profiles.tunein.com/s241396/images/logod.jpg",
+      "bitrate": 48,
+      "codec": "AAC",
+      "geo": [
+        51.5089,
+        -0.1272
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-capital-dance-the-uk-s-official-dance-station",
+      "name": " CAPITAL DANCE: The UK's Official Dance Station",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ssl.musicradio.com/CapitalDance",
+      "homepage": "https://www.capitaldance.com/",
+      "country": "GB",
+      "tags": [
+        "capital",
+        "capital dance",
+        "dab+",
+        "dance",
+        "dance music",
+        "edm"
+      ],
+      "favicon": "https://cdn-profiles.tunein.com/s309497/images/logod.jpg",
+      "bitrate": 48,
+      "codec": "AAC",
+      "geo": [
+        51.5082,
+        -0.1281
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-kiss-xtra-black-music-culture",
+      "name": " KISS XTRA: Black Music & Culture",
+      "broadcaster": "independent",
+      "streamUrl": "https://live-bauerkiss.sharp-stream.com/kissfresh.aac?direct=true&aw_0_1st.skey=1602676850&rp_source=1&=&&___cb=60456375243858",
+      "homepage": "https://www.hellorayo.co.uk/kiss-xtra",
+      "country": "GB",
+      "tags": [
+        "bauer radio",
+        "contemporary r&b",
+        "dab",
+        "digital radio",
+        "england",
+        "entertainment"
+      ],
+      "favicon": "https://cdn-profiles.tunein.com/s198663/images/logod.png",
+      "bitrate": 47,
+      "codec": "AAC+",
+      "geo": [
+        51.5082,
+        -0.1275
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-96-3-seahaven-fm",
+      "name": "96.3 Seahaven FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream1.hippynet.co.uk:8107/stream?_=526570",
+      "homepage": "https://www.seahavenfm.radio/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/892/63854c57a853f.png",
+      "bitrate": 170,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-ajk-radio",
+      "name": "AJK Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://solid41.streamupsolutions.com/proxy/wzbznkee/stream",
+      "homepage": "https://ajkradio.net/",
+      "country": "GB",
+      "tags": [
+        "eclectic"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-arystation-beyond-reality",
+      "name": "AryStation - Beyond Reality",
+      "broadcaster": "independent",
+      "streamUrl": "https://a11.asurahosting.com:8740/radio.mp3",
+      "homepage": "https://radio.metachitect.com/",
+      "country": "GB",
+      "tags": [
+        "all genres",
+        "country",
+        "hardstyle",
+        "hiphop",
+        "jazz",
+        "podcasts"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bbc-cwr",
+      "name": "BBC CWR",
+      "broadcaster": "independent",
+      "streamUrl": "https://as-hls-ww-live.akamaized.net/pool_79805333/live/ww/bbc_radio_coventry_warwickshire/bbc_radio_coventry_warwickshire.isml/bbc_radio_coventry_warwickshire-audio%3d96000.norewind.m3u8",
+      "homepage": "https://www.bbc.co.uk/sounds/play/live/bbc_radio_coventry_warwickshire",
+      "country": "GB",
+      "favicon": "https://sounds.files.bbci.co.uk/3.9.4/networks/bbc_radio_coventry_warwickshire/colour_default.svg",
+      "codec": "UNKNOWN",
+      "geo": [
+        52.4124,
+        -1.509
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bbc-radio-cambridge",
+      "name": "BBC Radio Cambridge",
+      "broadcaster": "independent",
+      "streamUrl": "https://as-hls-ww-live.akamaized.net/pool_21074581/live/ww/bbc_radio_cambridge/bbc_radio_cambridge.isml/dash/bbc_radio_cambridge-audio%3d96000.norewind.m3u8",
+      "homepage": "https://www.bbc.co.uk/sounds/play/live/bbc_radio_cambridge",
+      "country": "GB",
+      "tags": [
+        "cambridge"
+      ],
+      "favicon": "https://sounds.files.bbci.co.uk/3.9.4/networks/bbc_radio_cambridge/colour_default.svg",
+      "codec": "UNKNOWN",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-brown-student-community-radio",
+      "name": "BROWN STUDENT & COMMUNITY RADIO",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.bsrlive.com/bsrmp3?1729748097161",
+      "homepage": "https://www.bsrlive.com/",
+      "country": "GB",
+      "favicon": "https://static.wixstatic.com/media/39c7bc_eb82f27fe4d8402986e669cdbca13c4d~mv2.png/v1/fill/w_84,h_69,al_c,q_85,usm_0.66_1.00_0.01,enc_auto/39c7bc_eb82f27fe4d8402986e669cdbca13c4d~mv2.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-cannock-chase-radio-fm",
+      "name": "Cannock Chase Radio FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.broadcast.radio/cannockchase?1712410831388=",
+      "homepage": "https://www.cannockchaseradio.co.uk/#",
+      "country": "GB",
+      "favicon": "https://i0.wp.com/www.cannockchaseradio.co.uk/wp-content/uploads/2020/11/mobile-app-VER2.png?fit=1820%2C1120&ssl=1",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-celtic-music-radio",
+      "name": "Celtic Music Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://uksoutha.streaming.broadcast.radio/celtic",
+      "homepage": "https://www.celticmusicradio.net/",
+      "country": "GB",
+      "tags": [
+        "americana",
+        "celtic",
+        "community",
+        "contemporary folk",
+        "listener supported",
+        "roots"
+      ],
+      "favicon": "https://www.celticmusicradio.net/wp-content/uploads/2021/03/cropped-CMR-Logo-New-Ross-New-again-morse-correct.jpg",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-crystal-love-radio",
+      "name": "Crystal Love Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://betelgeuse.nucast.co.uk:8034/stream",
+      "homepage": "https://crystalloveradio.com/",
+      "country": "GB",
+      "favicon": "https://crystalloveradio.com/wp-content/uploads/2022/08/Crystallove-favi.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-daz-in-the-hat-radio",
+      "name": "Daz In The Hat Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s5.radio.co/s367c77774/listen",
+      "homepage": "https://dazinthehat.com/",
+      "country": "GB",
+      "favicon": "https://assets.zyrosite.com/cdn-cgi/image/format=auto,w=238,fit=crop,q=95/Y4LlnV0PrgfegPw5/daz-in-the-hat-edited-logo-m2Wb7PBjx2ie7lwk.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-dean-radio",
+      "name": "Dean Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.forestmedia.co.uk/deanradio",
+      "homepage": "https://deanradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "local radio",
+        "pop",
+        "pop music"
+      ],
+      "favicon": "https://deanradio.co.uk/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.825,
+        -2.5012
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-dune-radio",
+      "name": "Dune Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.aiir.com/3phqulqckaguv?_=981158",
+      "homepage": "https://www.duneradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/192/649d16201b02a.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-first-radio-bounce-northeast",
+      "name": "First radio bounce northeast ",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.friskradio.com:8443/stream41",
+      "homepage": "https://www.friskradio.com/?station=7",
+      "country": "GB",
+      "tags": [
+        "club dance"
+      ],
+      "codec": "AAC",
+      "geo": [
+        54.826,
+        -1.5381
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-fuse-fm",
+      "name": "Fuse FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.radio.co/s53051f118/low",
+      "homepage": "https://fusefm.co.uk/",
+      "country": "GB",
+      "favicon": "https://fusefm.co.uk/wp-content/themes/yootheme/cache/1f/Logo-Transparent-1fa9e60d.webp",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-global-breakfast-radio",
+      "name": "Global Breakfast Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://globalbreakfastradio.com:8443/stream",
+      "homepage": "https://www.globalbreakfastradio.com/",
+      "country": "GB",
+      "favicon": "https://www.globalbreakfastradio.com/images/global-breakfast-radio.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hits-hull-east-york",
+      "name": "Hits hull & East York",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-nation.sharp-stream.com/hull.mp3?aw_0_1st.playerid=BMUK_html5",
+      "homepage": "https://hellorayo.co.uk/hits-radio/",
+      "country": "GB",
+      "tags": [
+        "pop music"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        53.1204,
+        -3.8672
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-homemade-radio",
+      "name": "Homemade Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://homemaderadio-brianager.radioca.st/;",
+      "homepage": "https://homemade-radio.com/",
+      "country": "GB",
+      "tags": [
+        "adult contemporary",
+        "blues",
+        "classic rock",
+        "indie",
+        "rock"
+      ],
+      "favicon": "https://static.vecteezy.com/system/resources/thumbnails/001/933/723/small/radio-online-neon-signs-style-text-free-vector.jpg",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-house-radio-net",
+      "name": "House Radio Net",
+      "broadcaster": "independent",
+      "streamUrl": "https://server.houseradio.net:8000/stream",
+      "homepage": "https://www.houseradio.net/",
+      "country": "GB",
+      "tags": [
+        "club",
+        "dance",
+        "deep house",
+        "electronic",
+        "house",
+        "progressive house"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.5047,
+        -0.1051
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-keep-106",
+      "name": "KeeP 106",
+      "broadcaster": "independent",
+      "streamUrl": "https://solid9.streamupsolutions.com/proxy/djcohrzp?mp=/stream",
+      "homepage": "https://keep106.com/",
+      "country": "GB",
+      "favicon": "https://keep106.com/wp-content/uploads/2020/02/imageedit_5_8575205827.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-kfm-radio",
+      "name": "KFM Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.radio.co/s367e90f45/listen",
+      "homepage": "https://kfmradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "multi"
+      ],
+      "favicon": "https://i0.wp.com/kfmradio.co.uk/wp-content/uploads/2022/09/KFM-logob-200.png?fit=200102&amp;ssl=1",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        53.4084,
+        -2.1612
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-lincs-sound",
+      "name": "Lincs Sound",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.aiir.com/ubrzdpuap28vv",
+      "homepage": "https://www.lincssound.com/",
+      "country": "GB",
+      "tags": [
+        "classic hits",
+        "hot adult contemporary",
+        "pop",
+        "top hits"
+      ],
+      "favicon": "https://mmo.aiircdn.com/2033/6861243b23677.jpg",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-love-will-save-the-day",
+      "name": "Love Will Save The Day",
+      "broadcaster": "independent",
+      "streamUrl": "https://lovewillsavetheday.out.airtime.pro/lovewillsavetheday_a",
+      "homepage": "https://lovewillsavetheday.fm/",
+      "country": "GB",
+      "tags": [
+        "house"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-lushstarr-radio",
+      "name": "LushStarr Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://cdn.voscast.com/resources/?key=5d34553745888466d26fc1cc83166d78&c=wmp",
+      "homepage": "http://www.lushstarr.com/",
+      "country": "GB",
+      "favicon": "https://compiled.ams3.cdn.digitaloceanspaces.com/profile_images/0FDEUXEQompwot5vyQTaBHD1y4M50wpAv2Pd9osJ.jpg",
+      "codec": "UNKNOWN",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-mode-radio-london",
+      "name": "Mode Radio London",
+      "broadcaster": "independent",
+      "streamUrl": "https://mode-london.radiocult.fm/stream",
+      "homepage": "https://mode.london/",
+      "country": "GB",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-only-hits-radio",
+      "name": "Only Hits Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream4.themediasite.co.uk:8210/stream?_=328882",
+      "homepage": "https://www.onlyhitsradio.com/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/2016/68090c0a5a354.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-prodigies-radio",
+      "name": "Prodigies Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://polaris.nucast.co.uk:7580/stream",
+      "homepage": "https://polaris.nucast.co.uk/custom-player/7580#",
+      "country": "GB",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-frimley-park",
+      "name": "Radio Frimley Park",
+      "broadcaster": "independent",
+      "streamUrl": "https://frimleypark.radioca.st/stream?icy=http",
+      "homepage": "https://www.radiofrimleypark.co.uk/",
+      "country": "GB",
+      "favicon": "https://www.radiofrimleypark.co.uk/icons/favicon-256.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-horton",
+      "name": "Radio Horton",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiohorton.radioca.st/;",
+      "homepage": "https://radiohorton.co.uk/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-north-angus",
+      "name": "Radio North Angus",
+      "broadcaster": "independent",
+      "streamUrl": "https://uk3-vn.mixstream.net/8192/listen.mp3",
+      "homepage": "https://radionorthangus.co.uk/",
+      "country": "GB",
+      "favicon": "https://radionorthangus.co.uk/wp-content/uploads/2024/02/resize-homer.bk_.png-150x150.webp",
+      "bitrate": 48,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-northumberland",
+      "name": "Radio Northumberland",
+      "broadcaster": "independent",
+      "streamUrl": "https://northumberland.radioca.st/;",
+      "homepage": "https://radionorthumberland.com/",
+      "country": "GB",
+      "favicon": "https://cdn.instant.audio/images/logos/internetradiouk-com/northumberland.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-scarborough",
+      "name": "Radio Scarborough",
+      "broadcaster": "independent",
+      "streamUrl": "https://s3.radio.co/s201b7a9d0/listen",
+      "homepage": "https://radioscarborough.com/",
+      "country": "GB",
+      "tags": [
+        "community radio"
+      ],
+      "favicon": "https://radioscarborough.com/wp-content/uploads/2023/01/cropped-Site-Icon-Final-32x32.png",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-seahaven-fm-eastbourne",
+      "name": "Seahaven FM - Eastbourne",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream4.hippynet.co.uk:8002/stream?_=201701",
+      "homepage": "https://www.seahavenfm.radio/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/892/63c550fe44a02.png",
+      "bitrate": 170,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-sine-fm",
+      "name": "Sine FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://uksoutha.streaming.broadcast.radio/sinefm?1716196689781=",
+      "homepage": "https://www.sinefm.com/",
+      "country": "GB",
+      "favicon": "https://www.sinefm.com/wp-content/uploads/2019/11/sine-fm-logo-new-800.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-skylab-radio",
+      "name": "Skylab Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://uksoutha.streaming.broadcast.radio:29690/skylab-radio-limited",
+      "homepage": "https://uksoutha.streaming.broadcast.radio:29690/skylab-radio-limited",
+      "country": "GB",
+      "favicon": "https://static.wixstatic.com/media/c558e3_a1b2627549444e919504fa15988a9f57~mv2.png/v1/fill/w_198,h_184,al_c,q_85,usm_0.66_1.00_0.01,enc_avif,quality_auto/c558e3_a1b2627549444e919504fa15988a9f57~mv2.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-smooth-west-midlands",
+      "name": "Smooth West Midlands",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ice.musicradio.com/SmoothWestMidsMP3",
+      "homepage": "https://www.smoothradio.com/westmids/",
+      "country": "GB",
+      "favicon": "https://www.smoothradio.com/westmids/assets_v4r/smooth/img/favicon32x32.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-source-fm",
+      "name": "Source FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.canstream.co.uk:8144/live.mp3?1724162896961=",
+      "homepage": "https://www.thesourcefm.co.uk/",
+      "country": "GB",
+      "favicon": "https://api.broadcast.radio/api/image/d3661645-0ece-409b-b583-8d74b59c4bee.png?g=center&w=600&h=600&c=true",
+      "bitrate": 110,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-stu-allan-radio",
+      "name": "Stu Allan Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.stuallan.com/stream1",
+      "homepage": "https://www.stuallan.com/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-w-b-r-we-black-radio",
+      "name": "W.B.R. We Black Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s4.radio.co/safcfabd03/listen",
+      "homepage": "https://weblackradio.org/",
+      "country": "GB",
+      "favicon": "https://weblackradio.org/images/1534de6bf1609559b708e82ef57c76b2.png",
+      "bitrate": 192,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-banitamaxxradio",
+      "name": "BanitaMaxxRadio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ssl-1.radiohost.pl:9454/stream192",
+      "homepage": "https://www.banitamaxx.pl/",
+      "country": "GB",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bath-sound",
+      "name": "Bath Sound",
+      "broadcaster": "independent",
+      "streamUrl": "https://uksoutha.streaming.broadcast.radio/bathhr",
+      "homepage": "https://bathsound.radio/",
+      "country": "GB",
+      "favicon": "https://bathsound.radio/imgs/bs.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bbc-essex",
+      "name": "BBC Essex",
+      "broadcaster": "independent",
+      "streamUrl": "https://as-hls-ww-live.akamaized.net/pool_23657270/live/ww/bbc_radio_essex/bbc_radio_essex.isml/bbc_radio_essex-audio%3d96000.norewind.m3u8",
+      "homepage": "https://www.bbc.co.uk/sounds/play/live/bbc_radio_essex",
+      "country": "GB",
+      "favicon": "https://sounds.files.bbci.co.uk/3.9.4/networks/bbc_radio_essex/colour_default.svg",
+      "codec": "UNKNOWN",
+      "geo": [
+        51.5846,
+        0.7835
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-blastfm-internet-radio-station",
+      "name": "BlastFM Internet Radio Station",
+      "broadcaster": "independent",
+      "streamUrl": "https://blastfm.net:8000/live",
+      "homepage": "https://blastfmsocial.media/BlastFMRadio",
+      "country": "GB",
+      "favicon": "https://blastfmsocial.media/stations/logo/blastfm.jpg",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-chiltern-voice-fm",
+      "name": "Chiltern Voice FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.entertainmenttechnologies.co.uk:8020/chilternvoice.mp3",
+      "homepage": "https://www.chilternvoice.fm/",
+      "country": "GB",
+      "favicon": "https://www.chilternvoice.fm/wp-content/uploads/2024/02/Chiltern-Voice-Header-Logo-340x156-1.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-chon-98-1",
+      "name": "CHON 98.1",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.chonfm.com:8042/stream",
+      "homepage": "https://www.chonfm.com/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/209/5fd529540c0f8.gif",
+      "bitrate": 73,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-country-gospel-radio",
+      "name": "Country Gospel Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://solid24.streamupsolutions.com/proxy/agtzpadc/stream",
+      "homepage": "https://countrygospelradio.com/",
+      "country": "GB",
+      "tags": [
+        "bluegrass gospel",
+        "christian",
+        "country",
+        "country gospel",
+        "southern gospel"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-east-point-radio",
+      "name": "East Point Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.radio.co/s3c76b154e/listen",
+      "homepage": "https://eastpointradio.com/",
+      "country": "GB",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/7/64737.v7.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-essex-radio",
+      "name": "Essex Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.essex.radio:8060/radio.mp3",
+      "homepage": "https://essex.radio/",
+      "country": "GB",
+      "favicon": "https://essex.radio/logo.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-fcr-plymouth",
+      "name": "FCR Plymouth",
+      "broadcaster": "independent",
+      "streamUrl": "https://streams.radio.co/sde86bbbbf/low",
+      "homepage": "https://www.fcradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://static.wixstatic.com/media/0ff480_674875e451e6439dba6219a3aad51f2b%7Emv2.png/v1/fill/w_180%2Ch_180%2Clg_1%2Cusm_0.66_1.00_0.01/0ff480_674875e451e6439dba6219a3aad51f2b%7Emv2.png",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-frisky-radio",
+      "name": "Frisky Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.frisky.friskyradio.com/",
+      "homepage": "http://friskyradio.com/",
+      "country": "GB",
+      "bitrate": 96,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-frome-fm",
+      "name": "Frome FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast2.bargus.co.uk:8001/fromefm.mp3",
+      "homepage": "https://www.frome.fm/",
+      "country": "GB",
+      "favicon": "https://cdn.prod.website-files.com/65c3a3799d14b21f3710d0b4/66827a1d55ff35d4200e0849_FromeFMIcon-256.png",
+      "bitrate": 120,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-green-radio",
+      "name": "Green Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://gains.reviveradio.net/proxy/greenradio?mp=/stream",
+      "homepage": "https://greenradiolive.com/",
+      "country": "GB",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-halesowen-town",
+      "name": "Halesowen Town",
+      "broadcaster": "independent",
+      "streamUrl": "https://s3.radio.co/s75a8968ca/listen",
+      "homepage": "https://www.radiohalesowentown.co.uk/",
+      "country": "GB",
+      "tags": [
+        "sport"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hereford-fc",
+      "name": "Hereford FC",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radio.co/s025ead1b9/listen",
+      "homepage": "https://www.herefordfc.co.uk/radio-hereford-fc/",
+      "country": "GB",
+      "tags": [
+        "edgar street",
+        "hereford fc",
+        "hereford united",
+        "the bulls"
+      ],
+      "favicon": "https://www.herefordfc.co.uk/wp-content/uploads/2015/05/RADIO-HEREFORD-FC.png",
+      "bitrate": 96,
+      "codec": "MP3",
+      "geo": [
+        52.0606,
+        -2.7179
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hits-radio-uk",
+      "name": "Hits Radio UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-al.hellorayo.co.uk/key.aac?aw_0_1st.skey=1602676850&direct=true&rp_source=1",
+      "homepage": "https://www.hellorayo.co.uk/hits-radio",
+      "country": "GB",
+      "bitrate": 47,
+      "codec": "AAC+",
+      "geo": [
+        53.8288,
+        -2.3455
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-jorvik-radio",
+      "name": "Jorvik Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://uksoutha.streaming.broadcast.radio:24780/jorvikradio?_=21939",
+      "homepage": "https://www.jorvikradio.com/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/533/661fa1000a560.png",
+      "bitrate": 320,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-keep-the-faith-internet-radio",
+      "name": "Keep The Faith Internet Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://mars.streamerr.co/8060/stream",
+      "homepage": "https://keepthefaithinternetradio.co.uk/",
+      "country": "GB",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-line-out-radio",
+      "name": "Line Out Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://play.radioking.io/line-out-radio",
+      "homepage": "http://lineoutradio.com/",
+      "country": "GB",
+      "favicon": "http://lineoutradio.com/wp-content/uploads/2021/06/LINEOUTLOGO-e1623077715840.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-london-house-radio-ldn-house-radio",
+      "name": "London House Radio (LDN House Radio)",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.ldnhouseradio.net/listen/live/radio.mp3",
+      "homepage": "https://ldnhouseradio.net/",
+      "country": "GB",
+      "favicon": "https://ldnhouseradio.net/wp-content/uploads/2024/06/cropped-logo-round-500-favicon-1-180x180.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-luna-radio-reborn-mp3",
+      "name": "Luna Radio Reborn (mp3)",
+      "broadcaster": "independent",
+      "streamUrl": "https://luna.ponyvillefm.com/listen/lunaradio/radio.mp3",
+      "homepage": "https://luna.ponyvillefm.com/public/lunaradio",
+      "country": "GB",
+      "favicon": "http://luna.ponyvillefm.com/api/station/lunaradio/art/f3b23e8f636f5abd2dafbafb",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-m4d-radio-mix",
+      "name": "M4D Radio Mix",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.radio.co/s07cd038f1/listen",
+      "homepage": "https://m4dradio.com/",
+      "country": "GB",
+      "favicon": "https://m4dradio.com/wp-content/uploads/2020/05/cropped-m4dradiologo.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-meridian-fm-107",
+      "name": "Meridian FM 107",
+      "broadcaster": "independent",
+      "streamUrl": "https://uksoutha.streaming.broadcast.radio/meridianfm",
+      "homepage": "https://www.meridianfm.com/",
+      "country": "GB",
+      "tags": [
+        "community radio"
+      ],
+      "favicon": "https://www.meridianfm.com/favicon.ico?i=423",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-morley-radio",
+      "name": "Morley Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.radio.co/sb0e9a4581/low",
+      "homepage": "https://morleyradio.co.uk/",
+      "country": "GB",
+      "bitrate": 64,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-oc-radio",
+      "name": "OC Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.digilinkconnect.co.uk:2020/stream/oldhamcollegeradio",
+      "homepage": "https://www.oldham.ac.uk/college-life/oc-radio/",
+      "country": "GB",
+      "tags": [
+        "chart",
+        "dance",
+        "hiphop",
+        "indie",
+        "mainstream",
+        "pop"
+      ],
+      "bitrate": 192,
+      "codec": "AAC",
+      "geo": [
+        53.5424,
+        -2.1208
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-osn-fm",
+      "name": "OSN.fm",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.stuallan.com/stream2",
+      "homepage": "https://osn.fm/",
+      "country": "GB",
+      "favicon": "http://osn.fm/img/OSN-Radio-PNG.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-panacea-radio",
+      "name": "Panacea Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-15.aiir.com/kqwcuxfxcwhtv?zt=eyJhbGciOiJIUzI1NiJ9.eyJzdHJlYW0iOiJrcXdjdXhmeGN3aHR2IiwiaG9zdCI6InN0cmVhbS0xNS5haWlyLmNvbSIsInJ0dGwiOjUsImp0aSI6IjVkMTNteVlIU0FXNE5STXpWNEdZeFEiLCJpYXQiOjE3Njg2MDczMzksImV4cCI6MTc2ODYwNzM5OX0.IvvTX4vVuMyuvTvxJQTRNTahLXGSgOeVK3c4JGax0ds",
+      "homepage": "https://www.panacearadio.net/",
+      "country": "GB",
+      "tags": [
+        "funk",
+        "groove",
+        "soul"
+      ],
+      "favicon": "https://mmo.aiircdn.com/515/64c0e1942de5b.jpg",
+      "codec": "MP3",
+      "geo": [
+        53.3845,
+        -2.5905
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-persian-vibe-radio",
+      "name": "Persian Vibe Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.aydayazdani.com/stream",
+      "homepage": "https://radio.aydayazdani.com/",
+      "country": "GB",
+      "tags": [
+        "chill",
+        "farsi music",
+        "farsi pop",
+        "iranian music",
+        "persian music",
+        "persian pop"
+      ],
+      "favicon": "https://radio.aydayazdani.com/assets/img/pvr-logo.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.5074,
+        -0.1278
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-phasefm",
+      "name": "PhaseFM",
+      "broadcaster": "independent",
+      "streamUrl": "https://azuracast.clubhits.uk/listen/phasefm/radio.mp3",
+      "homepage": "https://phasefm.co.uk/",
+      "country": "GB",
+      "favicon": "https://phasefm.co.uk/wp-content/uploads/2025/07/clubhitsuk-variety-mix-mytuner-logo.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-prince-bishops-hospital-radio",
+      "name": "Prince Bishops Hospital Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://pbhr.radioca.st/stream",
+      "homepage": "https://www.pbhr.org.uk/#",
+      "country": "GB",
+      "favicon": "https://www.pbhr.org.uk/wp-content/uploads/2017/01/logo-mic.png",
+      "bitrate": 48,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-bronglais",
+      "name": "Radio Bronglais",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radiobronglais.cymru/stream?ver=92941",
+      "homepage": "https://radiobronglais.cymru/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-hartlepool",
+      "name": "Radio Hartlepool",
+      "broadcaster": "independent",
+      "streamUrl": "https://server.radiohartlepool.co.uk:8443/hartlepool-mp3",
+      "homepage": "https://radiohartlepool.co.uk/",
+      "country": "GB",
+      "favicon": "https://radiohartlepool.co.uk/wp-content/uploads/2023/01/cropped-RHlogo.jpg",
+      "bitrate": 64,
+      "codec": "MP3",
+      "geo": [
+        54.684,
+        -1.2148
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-wigwam",
+      "name": "Radio Wigwam",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.broadcast.radio/radio-wigwam",
+      "homepage": "https://radiowigwam.co.uk/",
+      "country": "GB",
+      "tags": [
+        "indie rock"
+      ],
+      "favicon": "https://radiowigwam.co.uk/wp-content/uploads/2024/08/wiwamnewdark.jpg.webp",
+      "codec": "MP3",
+      "geo": [
+        51.4808,
+        -3.1792
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-wimborne",
+      "name": "Radio Wimborne",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.canstream.co.uk:8057/live.mp3",
+      "homepage": "https://www.radiowimborne.co.uk/",
+      "country": "GB",
+      "tags": [
+        "community radio station"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        50.8014,
+        -1.9863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-woking",
+      "name": "Radio Woking",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiowoking.radioca.st/stream?rp_source=1&=&&___cb=821829812672569",
+      "homepage": "https://www.radiowoking.co.uk/",
+      "country": "GB",
+      "favicon": "http://www.radiowoking.co.uk/wp-content/uploads/2014/05/radiowokingwebhead7new75x360.gif",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radiorosak",
+      "name": "RADIOROSAK",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rcast.net/68127",
+      "homepage": "http://radiorosak.com/",
+      "country": "GB",
+      "bitrate": 48,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-ramsgate-radio",
+      "name": "Ramsgate Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://play.radioking.io/ramsgate-radio1/610934",
+      "homepage": "https://www.ramsgateradio.com/",
+      "country": "GB",
+      "favicon": "https://static.wixstatic.com/media/d883a7_649474a2c070450396a7c3d08a5ce624%7Emv2.png/v1/fill/w_180%2Ch_180%2Clg_1%2Cusm_0.66_1.00_0.01/d883a7_649474a2c070450396a7c3d08a5ce624%7Emv2.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-shine-radio",
+      "name": "Shine Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-petersfield.sharp-stream.com/petersfield.aac",
+      "homepage": "https://shineradio.uk/",
+      "country": "GB",
+      "favicon": "https://shineradio.uk/wp-content/uploads/2020/08/shine_logo_primary_d_rgb_01_crop.jpg",
+      "bitrate": 96,
+      "codec": "AAC+",
+      "geo": [
+        51.0045,
+        -0.9343
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-smooth-grooving-radio",
+      "name": "Smooth Grooving Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://sgr.lucasmultimedia.com/stream.ogg",
+      "homepage": "http://smoothgrooving.com/",
+      "country": "GB",
+      "favicon": "http://smoothgrooving.com/favicon-1.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-somervalley-fm",
+      "name": "Somervalley fm",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream4.hippynet.co.uk:8014/stream",
+      "homepage": "https://www.somervalleyfm.co.uk/",
+      "country": "GB",
+      "tags": [
+        "community radio",
+        "local station",
+        "north east somerset"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.2844,
+        -2.4851
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-southern-roots-radio",
+      "name": "Southern Roots Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://uksoutha.streaming.broadcast.radio/southern-roots-radio.mp3",
+      "homepage": "https://www.southern-roots.co.uk/",
+      "country": "GB",
+      "tags": [
+        "country"
+      ],
+      "favicon": "https://static.wixstatic.com/media/4a71bd_d0a57c5ed62c4a8fbaee7ce942611b60~mv2.png/v1/fill/w_242,h_242,al_c,q_85,usm_0.66_1.00_0.01,enc_avif,quality_auto/1000022871-Photoroom.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-spotlight-radio",
+      "name": "Spotlight Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream1.hippynet.co.uk:8075/stream",
+      "homepage": "https://www.spotlightradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://l5.tm-web-01.co.uk/img/fav/favicon-1024-167.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-subcity-radio",
+      "name": "Subcity Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.subcity.org/listen",
+      "homepage": "https://www.subcity.org/",
+      "country": "GB",
+      "tags": [
+        "freeform",
+        "independent",
+        "university"
+      ],
+      "favicon": "https://f4.bcbits.com/img/a1309017338_10.jpg",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-teenbuzz-radio",
+      "name": "Teenbuzz Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.broadcast.radio/teenbuzzradio?1744351024052=",
+      "homepage": "https://teenbuzzradio.com/",
+      "country": "GB",
+      "favicon": "https://teenbuzzradio.com/wp-content/uploads/2020/06/logo.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-the-gates-radio-station",
+      "name": "The Gates Radio Station",
+      "broadcaster": "independent",
+      "streamUrl": "https://thegatesradio.co.uk/listen/the_gates_radio_station/radio.mp3",
+      "homepage": "https://www.thegates.bolton.sch.uk/page/the-gates-radio/135355",
+      "country": "GB",
+      "favicon": "https://www.thegates.bolton.sch.uk/images/favicon_2.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-the-void-underground-music-radio",
+      "name": "The Void – Underground Music Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://thevoidrad.io/stream320",
+      "homepage": "https://thevoidrad.io/",
+      "country": "GB",
+      "tags": [
+        "dub techno",
+        "microhouse",
+        "minimal",
+        "rominimal"
+      ],
+      "favicon": "https://thevoidrad.io/favicon.ico",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-ugnjamz",
+      "name": "ugnjamz",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.live365.com/a27539",
+      "homepage": "https://ugnjamz.com/",
+      "country": "GB",
+      "tags": [
+        "christian rap",
+        "hip hop",
+        "rap",
+        "ridwan",
+        "urban gospel"
+      ],
+      "favicon": "https://ugnjamz.com/wp-content/uploads/2020/06/UGN-LOGO.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-venture-radio",
+      "name": "Venture Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streamz.anytek.co.uk/proxy/tracla00",
+      "homepage": "https://www.ventureradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "1980s",
+        "80's",
+        "80s",
+        "oldies"
+      ],
+      "favicon": "https://is1-ssl.mzstatic.com/image/thumb/Music211/v4/03/b0/e2/03b0e211-be78-5e79-815b-dc2961e40f40/13UABIM53820.rgb.jpg/600x600bb.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-6-towns-radio",
+      "name": "6 Towns Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-14.aiir.com/z7drhoivbpbuv?zt=eyJhbGciOiJIUzI1NiJ9.eyJzdHJlYW0iOiJ6N2RyaG9pdmJwYnV2IiwiaG9zdCI6InN0cmVhbS0xNC5haWlyLmNvbSIsInJ0dGwiOjUsImp0aSI6IjhROHpmZWlKVE1hWi1pdnUxdGRtVXciLCJpYXQiOjE3NjkwMzIxOTcsImV4cCI6MTc2OTAzMjI1N30.Lw7Duueb_YYvm7nI82EU1lRAlrd9NHH1ahB4WANmiaU",
+      "homepage": "https://www.6towns.co.uk/",
+      "country": "GB",
+      "tags": [
+        "adult contemporary",
+        "classic hits",
+        "local radio",
+        "pop"
+      ],
+      "favicon": "https://mmo.aiircdn.com/1209/656101b604916.png",
+      "codec": "MP3",
+      "geo": [
+        53.0588,
+        -2.2068
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bbc-radio-berkshire",
+      "name": "BBC Radio Berkshire",
+      "broadcaster": "independent",
+      "streamUrl": "https://as-hls-ww-live.akamaized.net/pool_64162474/live/ww/bbc_radio_berkshire/bbc_radio_berkshire.isml/dash/bbc_radio_berkshire-audio%3d96000.norewind.m3u8",
+      "homepage": "https://www.bbc.co.uk/sounds/play/live/bbc_radio_berkshire",
+      "country": "GB",
+      "tags": [
+        "bbc",
+        "berkshire"
+      ],
+      "favicon": "https://sounds.files.bbci.co.uk/3.9.4/networks/bbc_radio_berkshire/colour_default.svg",
+      "codec": "UNKNOWN",
+      "geo": [
+        51.9727,
+        -0.729
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bbc-radio-bristol",
+      "name": "BBC Radio Bristol",
+      "broadcaster": "independent",
+      "streamUrl": "https://as-hls-ww-live.akamaized.net/pool_41858929/live/ww/bbc_radio_bristol/bbc_radio_bristol.isml/dash/bbc_radio_bristol-audio%3d96000.norewind.m3u8",
+      "homepage": "https://www.bbc.co.uk/sounds/play/live/bbc_radio_bristol",
+      "country": "GB",
+      "tags": [
+        "bbc",
+        "bristol"
+      ],
+      "favicon": "https://sounds.files.bbci.co.uk/3.9.4/networks/bbc_radio_bristol/colour_default.svg",
+      "codec": "UNKNOWN",
+      "geo": [
+        52.0437,
+        -2.0636
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bbc-radio-hereford-and-worcester",
+      "name": "BBC Radio Hereford and Worcester",
+      "broadcaster": "independent",
+      "streamUrl": "https://as-hls-ww-live.akamaized.net/pool_80112859/live/ww/bbc_radio_hereford_worcester/bbc_radio_hereford_worcester.isml/bbc_radio_hereford_worcester-audio%3d96000.norewind.m3u8",
+      "homepage": "https://www.bbc.co.uk/sounds/play/live/bbc_radio_hereford_worcester",
+      "country": "GB",
+      "favicon": "https://sounds.files.bbci.co.uk/3.9.4/networks/bbc_radio_hereford_worcester/colour_default.svg",
+      "codec": "UNKNOWN",
+      "geo": [
+        52.1072,
+        -2.4442
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bombshell-radio",
+      "name": "Bombshell Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s8.ssl-stream.com:1175/stream",
+      "homepage": "https://bombshellradio.com/",
+      "country": "GB",
+      "favicon": "https://bombshellradio.com/wp-content/uploads/2025/03/originalFile-bombshell-radio-1-2-370x370.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-broadland-radio",
+      "name": "Broadland Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://arqiva-broadlandradio-live-a.edge.audiocdn.com/10002_128mp3",
+      "homepage": "https://broadlandradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "classic hits",
+        "hits",
+        "hot adult contemporary",
+        "pop"
+      ],
+      "favicon": "https://static.mytuner.mobi/media/tvos_radios/401/broadland.8c715f56.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bucks-radio",
+      "name": "Bucks Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://n01.radiojar.com/f6mru9artg0uv?_=745309&rj-tok=AAABihJa1SMABODPIDh9C1t79A&rj-ttl=5",
+      "homepage": "https://www.bucks.radio/",
+      "country": "GB",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-burton-radio",
+      "name": "Burton Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s9.citrus3.com:8370/stream",
+      "homepage": "https://www.burtonradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://images.squarespace-cdn.com/content/v1/6589f8f0f6168a1963a4d06a/19ba74fd-da8c-4021-a0a5-f6f52489492c/BR-512.png?format=1500w",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-cheesy-fm",
+      "name": "Cheesy FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://n27a-eu.rcs.revma.com/8ebhfmak44uvv?rj-ttl=5&rj-tok=AAABnbAucYoA8uoxbTFltYIAvg",
+      "homepage": "https://www.cheesyfm.co.uk/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/520/61a8cce0e4cbb.jpg",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-dales-radio",
+      "name": "Dales Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream3.themediasite.co.uk:8364/stream?_=690543",
+      "homepage": "https://www.dalesradio.co/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-drums-radio",
+      "name": "Drums Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streams.radio.co/sa75718856/listen",
+      "homepage": "https://www.drumsradio.com/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-forest-one",
+      "name": "Forest One",
+      "broadcaster": "independent",
+      "streamUrl": "https://c2.prostream365.com:8010/live",
+      "homepage": "https://www.forestradiouk.com/forestone",
+      "country": "GB",
+      "favicon": "https://static.mytuner.mobi/media/tvos_radios/469/forest-one.fee679cd.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        51.7061,
+        0.1227
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-frisky-radio-classics",
+      "name": "Frisky Radio Classics",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.classics.friskyradio.com/",
+      "homepage": "http://friskyradio.com/",
+      "country": "GB",
+      "bitrate": 96,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-genesis-radio-birmingham",
+      "name": "Genesis Radio Birmingham",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast5.my-control-panel.com/proxy/grb/stream",
+      "homepage": "https://genesisradiobirmingham.com/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        52.4792,
+        -1.8994
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-goodnight-sweetheart-radio",
+      "name": "Goodnight Sweetheart Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://a3.asurahosting.com/listen/goodnight_sweetheart_radio/radio.mp3",
+      "homepage": "https://a3.my-control-panel.com/station/648",
+      "country": "GB",
+      "tags": [
+        "1990s hits",
+        "music from the 1940s"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-groove-genie-radio",
+      "name": "Groove Genie Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://groove-genie.co.uk/listen/groove_genie_radio/radio.mp3",
+      "homepage": "https://groovegenieradio.com/",
+      "country": "GB",
+      "favicon": "https://i0.wp.com/groovegenieradio.com/wp-content/uploads/2023/05/Groove-Genie-Radio-Logo-512x512-1.png?resize=370%2C370&ssl=1",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-high-peak-1",
+      "name": "High Peak 1",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream3.themediasite.co.uk:8260/stream",
+      "homepage": "https://highpeak1.co.uk/",
+      "country": "GB",
+      "favicon": "https://highpeak1.co.uk/wp-content/uploads/2024/03/LogoJpg-370x370.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hits-radio-london",
+      "name": "Hits Radio London",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-mz.hellorayo.co.uk/net1london.aac?aw_0_1st.skey=1602676850&direct=true&rp_source=1",
+      "homepage": "https://www.hellorayo.co.uk/hits-radio/london",
+      "country": "GB",
+      "favicon": "https://media.bauerradio.com/image/upload/c_crop,g_custom/v1713275588/brand_manager/stations/nbcsqhgitwccojxtwfxn.svg",
+      "bitrate": 47,
+      "codec": "AAC+",
+      "geo": [
+        51.2556,
+        -0.148
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-inside-the-gates-radio",
+      "name": "Inside The Gates Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.radio.co/s98e7a2900/listen",
+      "homepage": "https://www.insidethegatesradio.com/",
+      "country": "GB",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-itisnow-radio",
+      "name": "itisnow Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radio.co/sc41e33712/listen",
+      "homepage": "https://www.itisnowradio.com/",
+      "country": "GB",
+      "favicon": "https://www.itisnowradio.com/uploads/1/4/5/0/145020825/logo-web.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-kic-radio",
+      "name": "KIC Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.aiir.com/nbgvn4hgyrxuv",
+      "homepage": "https://www.kicradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "dance",
+        "hits",
+        "pop",
+        "top 40"
+      ],
+      "favicon": "https://mmo.aiircdn.com/1333/692847fae5e8f.jpg",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-laser-gold",
+      "name": "Laser Gold",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream1.hippynet.co.uk:8067/stream",
+      "homepage": "https://www.laserinternational.co.uk/laser-gold",
+      "country": "GB",
+      "tags": [
+        "classic hits",
+        "oldies",
+        "pop",
+        "rock"
+      ],
+      "favicon": "https://primary.jwwb.nl/public/t/a/i/temp-dozjcpvcaeqpdalqxwlr/205-high.jpg?enable-io=true&crop=1%3A1&width=816",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-mix-fm-glasgow",
+      "name": "Mix FM - Glasgow",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.mixfmonline.com:8443/listen/mix_fm/radio.aac",
+      "homepage": "https://www.mixfmglasgow.com/",
+      "country": "GB",
+      "favicon": "https://www.mixfm.pro/wp-content/uploads/2024/06/NEW-LOGO-768x186.png",
+      "bitrate": 64,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-mondo-radio",
+      "name": "Mondo Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streamer.radio.co/s1afcca186/listen",
+      "homepage": "https://www.mondo.radio/",
+      "country": "GB",
+      "tags": [
+        "community radio",
+        "variety"
+      ],
+      "favicon": "https://images.squarespace-cdn.com/content/v1/648cf7010ac2fb3561bc2154/5b5a7df2-8c59-49fa-9b71-dca00edfe7ff/favicon.ico?format=100w",
+      "bitrate": 96,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-motorsport-radio",
+      "name": "Motorsport Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.radio.co/sd88832e85/listen",
+      "homepage": "https://motorsport.radio/nowplaying/",
+      "country": "GB",
+      "tags": [
+        "motorsport",
+        "pop",
+        "rock"
+      ],
+      "favicon": "https://motorsport.radio/wp-content/uploads/2020/05/iTunes-Cover-512px.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-nufc-talk-radio",
+      "name": "NUFC Talk Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s4.radio.co/s35505f6df/listen",
+      "homepage": "https://www.nufctalkradio.com/",
+      "country": "GB",
+      "tags": [
+        "football",
+        "soccer",
+        "sport",
+        "talk"
+      ],
+      "favicon": "https://static.wixstatic.com/media/a2c77b_e4f745f8472e4e36aed9b628816b6e6e~mv2.jpg/v1/fill/w_2500,h_2500,al_c/a2c77b_e4f745f8472e4e36aed9b628816b6e6e~mv2.jpg",
+      "bitrate": 96,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-orryy-live",
+      "name": "Orryy Live",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.orryy.com/live",
+      "homepage": "https://orryy.com/live",
+      "country": "GB",
+      "tags": [
+        "24/7",
+        "bouncy",
+        "dance",
+        "dj",
+        "electronic",
+        "house"
+      ],
+      "favicon": "https://orryy.com/assets/logo.png",
+      "codec": "MP3",
+      "geo": [
+        55.8642,
+        -4.2518
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-osn-radio-plus",
+      "name": "OSN Radio Plus",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.stuallan.com/stream3",
+      "homepage": "https://osn.fm/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-past-perfect-radio",
+      "name": "Past Perfect Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.xrad.io:9646/;stream/1",
+      "homepage": "https://www.pastperfect.com/",
+      "country": "GB",
+      "favicon": "https://www.pastperfect.com/wp-content/uploads/2023/07/Past-Perfect-Radio-e1688392518104-768x473.png",
+      "bitrate": 48,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-premier-gospel",
+      "name": "Premier Gospel",
+      "broadcaster": "independent",
+      "streamUrl": "https://pcr.streamguys1.com/pgospel-96k.aac",
+      "homepage": "https://www.premier.plus/stations/premier-gospel",
+      "country": "GB",
+      "tags": [
+        "christian",
+        "gospel"
+      ],
+      "bitrate": 56,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-premier-praise",
+      "name": "Premier Praise",
+      "broadcaster": "independent",
+      "streamUrl": "https://pcr.streamguys1.com/ppeace-96k.aac",
+      "homepage": "https://www.premier.plus/stations/premier-peace",
+      "country": "GB",
+      "tags": [
+        "chill",
+        "christian",
+        "peace"
+      ],
+      "bitrate": 56,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-quality-radio",
+      "name": "Quality Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://uksoutha.streaming.broadcast.radio/quality_FM",
+      "homepage": "https://qualityradio.uk/",
+      "country": "GB",
+      "favicon": "https://qualityradio.uk/wp-content/uploads/2022/08/qar-logo-e1661895864614.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-hillingdon",
+      "name": "Radio Hillingdon",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.broadcast.radio/hrhillingdonaac?1699805800701=",
+      "homepage": "https://www.radiohillingdon.com/",
+      "country": "GB",
+      "favicon": "https://www.radiohillingdon.com/images/Listen%20Live%20Button%202023.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-lear",
+      "name": "Radio LEAR",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.maxxwave.co.uk/lear",
+      "homepage": "https://radiolear.uk/",
+      "country": "GB",
+      "tags": [
+        "arts",
+        "culture"
+      ],
+      "favicon": "https://img-284.media.info/i/bg/7/7941-1759585321.webp",
+      "bitrate": 80,
+      "codec": "AAC",
+      "geo": [
+        52.6288,
+        -1.1562
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-wester-ross",
+      "name": "Radio Wester Ross",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rcs.revma.com/96z3d1qs5bcwv",
+      "homepage": "https://www.radiowesterross.scot/",
+      "country": "GB",
+      "tags": [
+        "folklore",
+        "pop"
+      ],
+      "favicon": "https://www.radiowesterross.scot/application/files/3917/0852/2702/favicon.ico",
+      "codec": "MP3",
+      "geo": [
+        57.7309,
+        -5.6994
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-xtra",
+      "name": "Radio Xtra",
+      "broadcaster": "independent",
+      "streamUrl": "https://n18a-eu.rcs.revma.com/nye22yatz42vv?rj-ttl=5&rj-tok=AAABm86No4cAj3cUwHekQ5GQLQ",
+      "homepage": "https://radioxtra.co.uk/",
+      "country": "GB",
+      "tags": [
+        "2000s",
+        "2010s",
+        "2020s",
+        "80s",
+        "90s",
+        "charts"
+      ],
+      "favicon": "https://radioxtra.co.uk/wp-content/uploads/2023/07/Radio-XTRA-2.svg",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radiowave",
+      "name": "RadioWave",
+      "broadcaster": "independent",
+      "streamUrl": "https://1.radiowave.eu/listen/test/aacHQ",
+      "homepage": "https://radiowave.eu/public/test",
+      "country": "GB",
+      "favicon": "https://radiowave.eu/static/uploads/browser_icon/192.1743030143.png",
+      "bitrate": 320,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-reiver-fm-scottish-borders-radio",
+      "name": "Reiver FM – Scottish Borders Radio ",
+      "broadcaster": "independent",
+      "streamUrl": "https://s10.myradiostream.com/35820/listen.mp3",
+      "homepage": "https://reiverfm.com/",
+      "country": "GB",
+      "tags": [
+        "oldies",
+        "pop music",
+        "rock",
+        "soul"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-rutland-and-stamford-sound",
+      "name": "Rutland and Stamford Sound",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.aiir.com/lqeblzjduoduv",
+      "homepage": "https://www.rutlandandstamfordsound.co.uk/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/500/6035405e0d05a.png",
+      "codec": "MP3",
+      "geo": [
+        52.6697,
+        -0.73
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-slim-radio",
+      "name": "Slim Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://a2.asurahosting.com:6260/radio.mp3",
+      "homepage": "http://www.slimradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "deep house",
+        "disco",
+        "funk",
+        "house",
+        "soul",
+        "soulful house"
+      ],
+      "favicon": "https://www.slimradio.co.uk",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        51.4919,
+        0.1208
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-spark-fm",
+      "name": "Spark FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream1.hippynet.co.uk:8117/live.mp3",
+      "homepage": "https://www.sparksunderland.com/",
+      "country": "GB",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        54.9119,
+        -1.3729
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-td1-radio",
+      "name": "TD1 Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.mbc.scot/listen/td1_radio/radio.mp3",
+      "homepage": "https://www.td1radio.scot/",
+      "country": "GB",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-the-cat-107-9",
+      "name": "The Cat 107.9",
+      "broadcaster": "independent",
+      "streamUrl": "https://uksoutha.streaming.broadcast.radio/thecatcloud?1769875744264=",
+      "homepage": "https://thecat.radio/",
+      "country": "GB",
+      "tags": [
+        "community radio",
+        "local radio",
+        "pop"
+      ],
+      "favicon": "https://thecat.radio/favicon.ico?i=5365",
+      "codec": "MP3",
+      "geo": [
+        53.087,
+        -2.4565
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-triphop-radio",
+      "name": "TripHop.Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.triphop.radio/",
+      "homepage": "https://www.triphop.radio/",
+      "country": "GB",
+      "tags": [
+        "chill",
+        "chillout",
+        "downtempo",
+        "electronic",
+        "lounge",
+        "lounge downtempo chillout ambient easy listening"
+      ],
+      "favicon": "https://pages.register.radio/uploads/triphop-radio-69d395851f50d.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-truck-beat-fm",
+      "name": "Truck Beat FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://streamer.radio.co/s895c9762a/listen",
+      "homepage": "https://truck-beat-fm.github.io/Truck-Beat-FM-radio/index.html",
+      "country": "GB",
+      "tags": [
+        "trucking"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-vdub-radio",
+      "name": "VDub Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.radio.co/s6fb3318ac/listen",
+      "homepage": "https://www.vdubradio.com/",
+      "country": "GB",
+      "tags": [
+        "alternative",
+        "funk",
+        "house",
+        "rnb"
+      ],
+      "favicon": "https://www.vdubradio.com/uploads/1/2/3/2/123248749/new-2024-aerial-line-x-1200_orig.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-vibe-1",
+      "name": "Vibe 1",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream3.themediasite.co.uk:8106/stream",
+      "homepage": "https://www.vibe1.uk/",
+      "country": "GB",
+      "favicon": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQX-73EE6UPXYWRfGsZ6WkesAy6ef2fwE3pSA&s",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-weald-radio",
+      "name": "Weald Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://uksoutha.streaming.broadcast.radio/oastradio",
+      "homepage": "https://www.wealdradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "pop"
+      ],
+      "favicon": "https://mmo.aiircdn.com/2225/687d0e4b722ce.jpg",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-word-central-radio",
+      "name": "Word Central Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://play.radioking.io/word-central-radio/707122",
+      "homepage": "https://wordcentralradio.com/",
+      "country": "GB",
+      "favicon": "https://image.radioking.io/radios/643897/logo/1cf1f955-b76c-4d78-a4ea-5af7c21909c5.jpeg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-2day-mix-radio",
+      "name": "2day mix radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://2day.2daymixradio.org:8000/radio.mp3",
+      "homepage": "https://2daymixradio.org/",
+      "country": "GB",
+      "tags": [
+        "00s",
+        "2010s",
+        "2020s",
+        "80s",
+        "90s",
+        "enjoy the moments of our vibes"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-arp-radio",
+      "name": "ARP Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://arpradio.com:8443/listen/arp_radio/arp.mp3",
+      "homepage": "https://arpradio.com/",
+      "country": "GB",
+      "tags": [
+        "dub",
+        "dub techno",
+        "electro",
+        "electronic music",
+        "house",
+        "techno"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        53.8236,
+        -1.4612
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-ashdown-radio",
+      "name": "Ashdown Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.broadcast.radio/uckfieldfmmp3?_=365639",
+      "homepage": "https://www.ashdownradio.com/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/592/61d2dbf595ad9.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bexhill-radio",
+      "name": "Bexhill Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://a13.asurahosting.com/listen/bexhill_radio/radio.mp3",
+      "homepage": "https://bexhillradio.com/",
+      "country": "GB",
+      "favicon": "https://bexhillradio.com/wp-content/uploads/2025/11/PHOTO-2025-08-04-19-38-26.jpg",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bounce-nation-radio",
+      "name": "Bounce Nation Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.stuallan.com/stream4",
+      "homepage": "https://www.stuallan.com/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bournemouth-one",
+      "name": "Bournemouth One",
+      "broadcaster": "independent",
+      "streamUrl": "https://n10a-eu.rcs.revma.com/bq0p6qbnpucwv?rj-ttl=5&rj-tok=AAABm8kwEu0ATCenU6Ba4CGEmg",
+      "homepage": "https://www.bournemouthone.com/",
+      "country": "GB",
+      "tags": [
+        "pop"
+      ],
+      "favicon": "https://mmo.aiircdn.com/743/6773b4fd7db3a.png",
+      "codec": "AAC",
+      "geo": [
+        50.7341,
+        -1.8173
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-branchfm",
+      "name": "BranchFM",
+      "broadcaster": "independent",
+      "streamUrl": "https://s11.ssl-stream.com/ssl/branchfm?mp=%2Fstream&rp_source=1&=&&___cb=797689455893916",
+      "homepage": "https://branchfm.com/",
+      "country": "GB",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-castle-radio",
+      "name": "Castle Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://c36.radioboss.fm:8114/stream",
+      "homepage": "https://www.castleradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://www.castleradio.co.uk/set1.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-central-radio",
+      "name": "Central Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://n33a-eu.rcs.revma.com/aehah7wnpp3vv",
+      "homepage": "http://www.central.radio/",
+      "country": "GB",
+      "tags": [
+        "classic hits",
+        "hot ac",
+        "pop"
+      ],
+      "favicon": "https://mmo.aiircdn.com/778/673b04861e76c.png",
+      "codec": "AAC",
+      "geo": [
+        53.7603,
+        -2.6931
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-crucial-sounds-radio",
+      "name": "crucial sounds radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://usa19.fastcast4u.com:9420/stream",
+      "homepage": "https://crucialsoundsradio.uk/",
+      "country": "GB",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-da-hub-radio",
+      "name": "Da Hub Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.dahubradio.co.uk:8848/stream",
+      "homepage": "https://dahubradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "dancehall",
+        "electronic",
+        "electronic dance music",
+        "house",
+        "r&b/urban"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-dork-radio",
+      "name": "Dork Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.radio.co/s3e57f0675/listen",
+      "homepage": "https://readdork.com/",
+      "country": "GB",
+      "favicon": "https://readdork.com/wp-content/uploads/2025/02/dork_logo_new_nearblack-768x185.webp",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-eava-fm",
+      "name": "EAVA FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.canstream.co.uk:8000/eavafm.mp3",
+      "homepage": "https://www.eavafm.com/",
+      "country": "GB",
+      "favicon": "https://www.eavafm.com/wp-content/uploads/2021/12/eava_logo_Clear_3400.png",
+      "bitrate": 96,
+      "codec": "MP3",
+      "geo": [
+        52.654,
+        -1.1254
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-electric-circus",
+      "name": "electric circus",
+      "broadcaster": "independent",
+      "streamUrl": "https://a5.asurahosting.com:7990/radio.mp3",
+      "homepage": "https://www.electriccircus.uk/radio/",
+      "country": "GB",
+      "favicon": "https://www.electriccircus.uk/wp-content/uploads/go-x/u/3c3ed3c4-f457-43f2-b909-fbee7590e08b/image-384x304.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hfm-102-3",
+      "name": "HFM 102.3",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-harboroughfm.sharp-stream.com/harboroughfm.mp3",
+      "homepage": "https://harboroughfm.co.uk/",
+      "country": "GB",
+      "tags": [
+        "adult contemporary",
+        "community radio",
+        "local radio",
+        "pop"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        52.4799,
+        -0.913
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hgv1-radio",
+      "name": "HGV1 Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream4.themediasite.co.uk/stream/hgv1-main",
+      "homepage": "https://hgvradio.com/",
+      "country": "GB",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.4595,
+        -0.0989
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-huntingdon-community-radio-hcr-fm",
+      "name": "Huntingdon Community Radio - HCR FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.streamaudio.co/proxy/hcr/stream",
+      "homepage": "https://www.hcrfm.co.uk/",
+      "country": "GB",
+      "favicon": "https://www.hcrfm.co.uk/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-indie-soul-radio",
+      "name": "Indie Soul Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.citrus3.com:8404/stream",
+      "homepage": "https://www.indiesoulradio.com/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-kick-radio",
+      "name": "KICK RADIO",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast4.my-control-panel.com/proxy/edp/stream",
+      "homepage": "https://www.kickradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://www.kickradio.co.uk/public/themes/default/assets/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-laser-dance",
+      "name": "Laser Dance",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.airwavebroadcast.com:8010/laserdancehq",
+      "homepage": "https://www.laserinternational.co.uk/laser-dance",
+      "country": "GB",
+      "tags": [
+        "garage",
+        "house",
+        "live shows",
+        "modern dance",
+        "old school"
+      ],
+      "favicon": "https://primary.jwwb.nl/public/t/a/i/temp-dozjcpvcaeqpdalqxwlr/315-high.jpg?enable-io=true&width=1252",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-laser-hot-hits",
+      "name": "Laser Hot Hits",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.airwavebroadcast.com:8040/laserhq",
+      "homepage": "https://www.laserinternational.co.uk/laser-hot-hits-international",
+      "country": "GB",
+      "tags": [
+        "oldies",
+        "pop",
+        "recent hits",
+        "rock"
+      ],
+      "favicon": "https://primary.jwwb.nl/public/t/a/i/temp-dozjcpvcaeqpdalqxwlr/225-high.png?enable-io=true&width=816",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-love-da-beat-radio",
+      "name": "Love Da Beat Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://love-da-beat-radio-cf8d1146.radiocult.fm/stream",
+      "homepage": "https://www.lovedabeatradio.co.uk/",
+      "country": "GB",
+      "bitrate": 160,
+      "codec": "MP3",
+      "geo": [
+        51.4141,
+        -0.052
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-lyme-out-live",
+      "name": "lyme out live",
+      "broadcaster": "independent",
+      "streamUrl": "https://centova87.shoutcastservices.com/proxy/lymeout/stream",
+      "homepage": "https://centova87.shoutcastservices.com/proxy/lymeout/stream",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-mearns-fm",
+      "name": "Mearns FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream2.hippynet.co.uk:8002/lowquality",
+      "homepage": "https://www.mearnsfm.org.uk/",
+      "country": "GB",
+      "favicon": "https://www.mearnsfm.org.uk/wp-content/uploads/2020/06/imageedit_5_7574751306.png",
+      "bitrate": 96,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-nitro-fm",
+      "name": "nitro-FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.nitro-server.uk/listen/nitrohost/radio.mp3",
+      "homepage": "https://radio.nitro-server.uk/listen/nitrohost/",
+      "country": "GB",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-outreach-radio",
+      "name": "Outreach Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.ukrp.tv/outreachradio.aac",
+      "homepage": "https://www.outreachradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://cdn.outreachradio.co.uk/wp-content/uploads/2020/11/cropped-logo_website.jpg",
+      "bitrate": 32,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-piestream",
+      "name": "Piestream",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.psymusic.co.uk/listen/piestream/hifi.mp3",
+      "homepage": "https://www.psymusic.co.uk/",
+      "country": "GB",
+      "favicon": "https://psymusic.co.uk/images/alien-head32.png",
+      "bitrate": 320,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-polish-radio-london",
+      "name": "Polish Radio London",
+      "broadcaster": "independent",
+      "streamUrl": "https://n19a-eu.rcs.revma.com/prfmwmwy768uv?rj-ttl=5&rj-tok=AAABnQg2ZmsA5RX2yPMR7AlE5w",
+      "homepage": "https://prl24.co.uk/",
+      "country": "GB",
+      "codec": "AAC",
+      "geo": [
+        51.5009,
+        -0.1159
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-camarthenshire",
+      "name": "Radio Camarthenshire",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-nation.sharp-stream.com/tccarmarthenshire.mp3",
+      "homepage": "https://www.nationplayer.com/radio-carmarthenshire/",
+      "country": "GB",
+      "tags": [
+        "local news",
+        "pop music",
+        "welsh language"
+      ],
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/thumb/a/ac/Radiocarmar.png/250px-Radiocarmar.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.69,
+        -4.1288
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-victory",
+      "name": "Radio Victory",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream3.themediasite.co.uk:8380/stream",
+      "homepage": "https://radiovictory.co.uk/",
+      "country": "GB",
+      "bitrate": 256,
+      "codec": "MP3",
+      "geo": [
+        50.8395,
+        -1.0703
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radiowave-eu",
+      "name": "Radiowave.eu",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiowave.eu/hls/test/live.m3u8",
+      "homepage": "https://radiowave.eu/",
+      "country": "GB",
+      "favicon": "https://radiowave.eu/static/uploads/browser_icon/192.1743030143.png",
+      "bitrate": 211,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-raiders-radio",
+      "name": "Raiders Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.citrus3.com:8464/stream",
+      "homepage": "https://raidersradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "dnb",
+        "drum and bass",
+        "funky house",
+        "hard house",
+        "hard techno",
+        "house"
+      ],
+      "favicon": "https://raidersradio.co.uk/favicon.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        51.8983,
+        -1.1577
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-retrobyte-radio",
+      "name": "RetroByte Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://retrobytesradio.radioca.st/stream",
+      "homepage": "https://www.retrobyteradio.com/",
+      "country": "GB",
+      "tags": [
+        "retro",
+        "retro games",
+        "soundtracks",
+        "video game music"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        52.8593,
+        -3.0551
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-rtm-fm",
+      "name": "RTM.FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://streams.radio.co/s3d2f05f8f/listen",
+      "homepage": "https://rtm.fm/",
+      "country": "GB",
+      "favicon": "https://rtm.fm/favicon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.4993,
+        0.1091
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-selecta-radio-uk",
+      "name": "Selecta Radio UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.live365.com/a40232",
+      "homepage": "https://www.selectaradiouk.co.uk/",
+      "country": "GB",
+      "tags": [
+        "2tone",
+        "punk",
+        "reggae",
+        "ska"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        52.8699,
+        -1.6344
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-sle-radio-one",
+      "name": "SLE RADIO ONE",
+      "broadcaster": "independent",
+      "streamUrl": "https://sleradiogroup.com/listen/sle_radio_1/sleone.mp3",
+      "homepage": "https://sleradio.com/",
+      "country": "GB",
+      "favicon": "https://sleradio.com/station1.png",
+      "bitrate": 256,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-sle-radio-rave",
+      "name": "SLE RADIO RAVE",
+      "broadcaster": "independent",
+      "streamUrl": "https://sleradiogroup.com/listen/sle_radio_rave/radio.mp3",
+      "homepage": "https://sleradio.com/",
+      "country": "GB",
+      "favicon": "https://sleradio.com/station-rave.png",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-smooth-tyne-wear",
+      "name": "Smooth Tyne & Wear",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ice.musicradio.com/SmoothNorthEastNMP3",
+      "homepage": "https://www.smoothradio.com/",
+      "country": "GB",
+      "tags": [
+        "easy listening",
+        "newcastle",
+        "smooth"
+      ],
+      "favicon": "http://www.smoothradio.com/assets_v4r/smooth/img/favicon-196x196.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        54.9741,
+        -1.6197
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-toby-s-tunes",
+      "name": "Toby's Tunes",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.aiir.com/he5hocuryqbvv",
+      "homepage": "https://classichits.co.uk/",
+      "country": "GB",
+      "tags": [
+        "classic h"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-toohotradio-net",
+      "name": "TooHotRadio.net",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.toohotradio.net/128",
+      "homepage": "https://toohotradio.net/#",
+      "country": "GB",
+      "favicon": "https://toohotradio.net/resize/toohot2.png?w=180",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-ttns",
+      "name": "TTNS",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.thethursdaynightshow.com/live",
+      "homepage": "https://www.thethursdaynightshow.com/",
+      "country": "GB",
+      "tags": [
+        "eclectic",
+        "f",
+        "jazz"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.8204,
+        -0.1368
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-tuneskool-radio",
+      "name": "Tuneskool Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://c18.radioboss.fm:8423/stream",
+      "homepage": "https://tuneskoolradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://tuneskoolradio.co.uk/wp-content/uploads/2024/01/Tune_school_radio-768x384.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-xpression-fm",
+      "name": "Xpression FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.broadcastradio.com:10855/xpression",
+      "homepage": "http://www.xpression.fm/",
+      "country": "GB",
+      "favicon": "http://www.xpression.fm/uploads/3/7/0/6/37062627/image-removebg-preview.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-zack-fm",
+      "name": "Zack FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.streamer1.com/listen/zackfm/zackTEST.mp3",
+      "homepage": "https://www.zackfm.com/",
+      "country": "GB",
+      "favicon": "https://www.zackfm.com/templates/joomla3_005/images/logo.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Full Radio Browser sweep of GB stations — imports **841 stream-only stubs** (no cap, per sponsor override).

### Scan stats
- Total RB stations in analysis file: 2060
- Playable (ok + ok-hls): 1082 (1060 ok + 22 ok-hls)
- Broken/mixed-content: 977 (894 broken-mixed + 73 broken-network + 10 redirect-downgrade + 1 needs-playlist)
- Already curated by uuid: 9

### What was imported: 841 stations
All sorted by votes descending.

**Top 3 by votes:**
| Name | Votes | Stream URL |
|---|---|---|
| TMM 1 | 20,324 | https://listen-msmn.sharp-stream.com/nme1.mp3 |
| Heart 70s | 17,896 | https://media-ssl.musicradio.com/Heart70sMP3 |
| Heart Dance | 11,581 | https://media-ssl.musicradio.com/HeartDanceMP3 |

### Skipped
- 9 skipped: uuid already in YAML (curated stations)
- 7 skipped: name conflict with existing YAML entry
- 4 skipped: stream URL conflict with existing YAML entry
- 27 skipped: intra-set name deduplication (lower-voted duplicate)

### Verification
- `npm run catalog` ✓ (3406 stations published)
- `npm run check-catalog` ✓ (0 errors)
- `npm run check-duplicates` ✓ (0 collisions)
- `npm test -- --run` ✓ (294 tests passed)

### Branch note
Stacked on `origin/main`. Next country: FR (`curate/fr-2026-05-04`).