### PR TITLE
curate: IT sweep (~426 stations)

### DIFF
--- a/data/stations.yaml
+++ b/data/stations.yaml
@@ -48449,3 +48449,11668 @@
   stationuuid: 7df157a2-7a65-4dea-9278-af66f9d8292c
   changeuuid: 41226e84-b7ac-44ba-b7b8-1a9e4e67cf44
   reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-eurodance-90-radio
+  broadcaster: independent
+  name: EuroDance 90 radio
+  streamUrl: https://stream-eurodance90.fr/radio/8000/128.mp3?1627933323
+  bitrate: 128
+  codec: MP3
+  favicon: https://eurodance90.fr/favicon.ico
+  homepage: https://eurodance90.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 60ceaabd-4efd-4f47-b961-0dab6f475731
+  changeuuid: 3f5f5c18-483d-42af-85a6-4e12838bc481
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-abc-lounge-radio
+  broadcaster: independent
+  name: ABC Lounge Radio
+  streamUrl: https://eu1.fastcast4u.com/proxy/kpmxz?mp=/1
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.abc-lounge.com/radio/lounge-jazz-folk/#home
+  country: FR
+  status: stream-only
+  stationuuid: 4a018de7-b452-4412-b86f-86254c5d53be
+  changeuuid: aeb4319d-6491-4274-9343-75c625cc4c71
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-
+  broadcaster: independent
+  name: 法国国际广播电台
+  streamUrl: https://rfienchinois64k.ice.infomaniak.ch/rfienchinois-64.mp3
+  bitrate: 64
+  codec: MP3
+  country: FR
+  status: stream-only
+  stationuuid: 21ef0997-adba-46c7-a2e1-03e3130bd5ad
+  changeuuid: 1e8a6aef-a157-452c-aea9-7efb94a249fb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-urban-hit-maroc
+  broadcaster: independent
+  name: Urban Hit Maroc
+  streamUrl: https://urbanhitrai.ice.infomaniak.ch/urbanhitrai.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://bocir-prod-bucket.s3.eu-west-1.amazonaws.com/radios/urbanhit/images/favicon.vnd.microsoft.icon
+  homepage: https://www.urbanhit.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 422c303d-2e17-11ea-aa0c-52543be04c81
+  changeuuid: 7b561eba-61cf-495a-b91a-cae6e681b985
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-jazzradio-fr-jazz-classique
+  broadcaster: independent
+  name: "Jazzradio.fr Jazz & Classique"
+  streamUrl: https://jazz-wr17.ice.infomaniak.ch/jazz-wr17-128.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.jazzradio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: c5bc6ba3-5adf-4bb6-8982-82d53a682799
+  changeuuid: 3d7ed7a2-c63f-4054-b496-2f6c3de8defc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-abc-lounge-jazz
+  broadcaster: independent
+  name: ABC Lounge Jazz
+  streamUrl: https://eu1.fastcast4u.com/proxy/kpmxz/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.abc-lounge.com/radio/wp-content/uploads/2019/11/logo-ABC-Lounge100.png
+  homepage: https://www.abc-lounge.com/
+  country: FR
+  status: stream-only
+  stationuuid: 9261257f-c8a0-4dba-8cb5-a0746f3323dc
+  changeuuid: 68835402-45c5-4f88-8b29-083f54473ed0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-algorythme-drum-bass
+  broadcaster: independent
+  name: "Algorythme Drum & Bass"
+  streamUrl: https://radio9.pro-fhi.net/flux-endvtlna/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.algorythmeradio.com/assets/images/icon-algo.ico
+  homepage: https://www.algorythmeradio.com/
+  country: FR
+  status: stream-only
+  stationuuid: b5be28a3-4fa3-42b9-a9dd-168cc25961a3
+  changeuuid: eb1beba0-9f25-4a67-a32b-99fb60fffc87
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-fm-80-funky-music
+  broadcaster: independent
+  name: FM 80 Funky Music
+  streamUrl: https://listen.radioking.com/radio/467555/stream/523739
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.fm80.fr/en/
+  country: FR
+  status: stream-only
+  stationuuid: f872bfc4-b09a-405f-9c7f-d535adba238e
+  changeuuid: 53814965-3502-408e-b2ba-3cda1007082e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-b4b-radio-disco-funk
+  broadcaster: independent
+  name: B4B Radio DISCO FUNK
+  streamUrl: https://eu10.fastcast4u.com:8120/
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.b4bradio.com/
+  country: FR
+  status: stream-only
+  stationuuid: ab91bc51-8ddd-4d13-a349-26955c326541
+  changeuuid: 1683ae57-2db8-484d-acf0-bcc46a4abd21
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-rfm-pop-rock
+  broadcaster: independent
+  name: RFM POP-ROCK
+  streamUrl: https://stream.rfm.fr/rfm-wr10.aac
+  bitrate: 128
+  codec: AAC+
+  favicon: http://cdn-rfm.lanmedia.fr/apple-touch-icon-120x120.png
+  homepage: http://www.rfm.fr/programmes/les-webradios
+  country: FR
+  status: stream-only
+  stationuuid: dbdae111-2ceb-48e8-aa6b-cc544c57d043
+  changeuuid: 76459cd1-eac6-438d-bc3e-090d16116334
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-rfi-kiswahili
+  broadcaster: independent
+  name: RFI Kiswahili
+  streamUrl: https://rfiswahili96k.ice.infomaniak.ch/rfiswahili-96k.mp3
+  bitrate: 96
+  codec: MP3
+  favicon: https://www.rfi.fr/favicon-194x194.png
+  homepage: http://www.kiswahili.rfi.fr/
+  country: FR
+  status: stream-only
+  stationuuid: b8d8be2b-f217-4499-b2f6-533dfb5d49e1
+  changeuuid: 4f3a3d75-351b-4568-b06b-8a20b985dcc9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-heavy-metal
+  broadcaster: independent
+  name: Radio Heavy Metal
+  streamUrl: https://manager7.streamradio.fr:1435/stream
+  bitrate: 320
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/bae3bf_0b6fc93bb1584f329723c0241a93c65c~mv2.png/v1/fill/w_111,h_111,al_c,usm_0.66_1.00_0.01,enc_auto/LOGO%20RHM%20SUR%20ROUGE.png
+  homepage: https://radioheavymetal76.wixsite.com/monsite
+  country: FR
+  status: stream-only
+  stationuuid: e1302232-248d-4433-88c6-c12b1bfafc81
+  changeuuid: cd6c8a1f-b186-4290-a560-21b6e286c63d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-latina-reggaeton
+  broadcaster: independent
+  name: Latina reggaeton
+  streamUrl: https://latinareggaeton.ice.infomaniak.ch/latinareggaeton.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://bocir-prod-bucket.s3.eu-west-1.amazonaws.com/radios/latina/images/favicon.ico
+  homepage: https://www.latina.fr/
+  country: FR
+  status: stream-only
+  stationuuid: ff25f556-1f64-4e7d-9c3f-68e51d3a43c3
+  changeuuid: 38f77cae-9835-42e6-891e-a2952e7690cc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-choco
+  broadcaster: independent
+  name: Radio Choco
+  streamUrl: https://listen.radioking.com/radio/669715/stream/733765
+  bitrate: 128
+  codec: MP3
+  favicon: https://image.radioking.io/radios/669715/logo/e0191854-a603-41f5-9729-121a1f215f57.jpeg
+  homepage: https://radiochoco.com/
+  country: FR
+  status: stream-only
+  stationuuid: 5c781485-ee91-47bc-aa2d-bbe66024ff52
+  changeuuid: 2866745a-d314-479c-a608-69c8132021bf
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-vibration
+  broadcaster: independent
+  name: Radio Vibration
+  streamUrl: https://vibration.ice.infomaniak.ch/vibration-high.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://bocir-prod-bucket.s3.amazonaws.com/radios/vibration/images/favicon.vnd.microsoft.icon
+  homepage: http://www.vibration.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 7b20f515-d6c3-11e8-a2a6-52543be04c81
+  changeuuid: 5943a60d-953c-42f8-88b8-872a3452b683
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-bfm-business
+  broadcaster: independent
+  name: BFM Business
+  streamUrl: https://audio.bfmtv.com/bfmbusiness_128.mp3
+  bitrate: 256
+  codec: MP3
+  homepage: https://bfmbusiness.bfmtv.com/mediaplayer/live-audio/
+  country: FR
+  status: stream-only
+  stationuuid: 3a83c34b-ca9d-48c8-916e-9563216ddcdf
+  changeuuid: a668cc47-4170-4ebd-bae7-c25e4bb93b2e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-reggae-fr
+  broadcaster: independent
+  name: Reggae.fr
+  streamUrl: https://listen.radioking.com/radio/50473/stream/87415
+  bitrate: 128
+  codec: MP3
+  homepage: http://www.reggae.fr/popup-radio.php
+  country: FR
+  status: stream-only
+  stationuuid: f48ce4f1-3f31-11e8-b74d-52543be04c81
+  changeuuid: c57d0976-6ae2-4b47-a59c-1d85f0743330
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-classique
+  broadcaster: independent
+  name: Radio Classique
+  streamUrl: https://str0.creacast.com/classique1
+  bitrate: 128
+  codec: MP3
+  favicon: http://favicons.teamtailor-cdn.com/icon?size=80..120..200&url=https%3a%2f%2fwww.radioclassique.fr%2f
+  homepage: https://www.radioclassique.fr/
+  country: FR
+  status: stream-only
+  stationuuid: d1aa02d7-e611-4208-b38b-da21bc236cd8
+  changeuuid: eeacabc3-3b79-45ff-87a1-266dfdbb8a48
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-rfi-monde
+  broadcaster: independent
+  name: 📺 RFI Monde
+  streamUrl: https://rfiafrique64k.ice.infomaniak.ch/rfimonde-64.mp3
+  bitrate: 64
+  codec: MP3
+  favicon: https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEi076SvIq9FK1ila6iO0HpdpC6f6eMrCLPrNli3Y6WYe_7cVIM8GTSIKi5L2v3bmwD298Xc2jjmRlPX9nzJseyatmlnRhmrgL7QBGiUKBWhNDpmpSigoBKW-DQg-ytDeOF-iUaikzXDJef87-Or9eBq7fXL13kARxykDqVbhhIuT_e9niBlF0ZMztzw/s1600/Capture%20d%E2%80%99%C3%A9cran_2024-11-19_14-44-01.png
+  homepage: https://www.karibshebdo.info/radios-web/rfi-radio
+  country: FR
+  status: stream-only
+  stationuuid: cbca0f46-ced9-4154-8157-c87039765207
+  changeuuid: 0cecbeb4-adfe-41ab-8900-d281e59aad72
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-franceinfo
+  broadcaster: independent
+  name: franceinfo
+  streamUrl: https://stream.radiofrance.fr/franceinfo/franceinfo_hifi.m3u8?id=radiofrance
+  codec: UNKNOWN
+  favicon: https://www.radiofrance.fr/s3/cruiser-production/2022/06/52e277e9-95f8-44c4-8fda-6dfabc337b12/1200x680_franceinfo-logo-rs.jpg
+  homepage: https://www.radiofrance.fr/franceinfo
+  country: FR
+  status: stream-only
+  stationuuid: 0e9765da-71c6-41b5-b358-dddab24e302b
+  changeuuid: e9384535-610d-441d-b528-db60185aad7b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-fip-pop
+  broadcaster: independent
+  name: FIP Pop
+  streamUrl: https://icecast.radiofrance.fr/fippop-hifi.aac
+  bitrate: 192
+  codec: AAC
+  favicon: https://www.fip.fr/dist/favicons/logo-120.png
+  homepage: https://www.fip.fr/pop/webradio
+  country: FR
+  status: stream-only
+  stationuuid: 76b129aa-45cc-46cf-b6b2-1fde08a2c8f9
+  changeuuid: 9d2ab926-ecc0-4b1f-a105-41dc80c6711a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-latina-bachata
+  broadcaster: independent
+  name: Latina bachata
+  streamUrl: https://latinabachata.ice.infomaniak.ch/latinabachata.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://bocir-prod-bucket.s3.eu-west-1.amazonaws.com/radios/latina/images/favicon.ico
+  homepage: https://www.latina.fr/
+  country: FR
+  status: stream-only
+  stationuuid: d1b4a4ee-e101-4191-aecb-05ec78bb92d3
+  changeuuid: 7b3c9e8c-3847-4233-b255-eb3b66a0e7aa
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-italopower
+  broadcaster: independent
+  name: "Radio ItaloPower!"
+  streamUrl: https://stream.deevaradio.net:10443/italopower
+  bitrate: 192
+  codec: MP3
+  favicon: http://www.radioitalopower.com/assets/img/apple-touch-icon.png
+  homepage: http://www.radioitalopower.com/
+  country: FR
+  status: stream-only
+  stationuuid: 962b49da-0601-11e8-ae97-52543be04c81
+  changeuuid: b11e43f5-ecb8-49fd-a2eb-6abc8d240aeb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-love-radio-only-love-songs-70s80s90s-www-love-ra
+  broadcaster: independent
+  name: LOVE RADIO Only Love Songs 70s80s90s - www.love.radio
+  streamUrl: https://loveradio.streamingmedia.it/france
+  bitrate: 192
+  codec: AAC+
+  homepage: https://love.radio/
+  country: FR
+  status: stream-only
+  stationuuid: 26d8d87a-1329-4cf3-b947-d587bbeccd1e
+  changeuuid: ed45917c-fd96-494b-84ac-fccfd99d796e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-europe-2-radio-officiel
+  broadcaster: independent
+  name: Europe 2 Radio Officiel
+  streamUrl: https://europe2.lmn.fm/europe2-57600/playlist.m3u8?aw_0_1st.playerid=lagardereappEurope2
+  bitrate: 128
+  codec: AAC
+  homepage: https://www.europe2.fr/webradios
+  country: FR
+  status: stream-only
+  stationuuid: 2f2875a6-bf0a-41bc-b31b-d181c323654d
+  changeuuid: d9797f6c-26e1-4a7f-ba27-d7e6f0f683bc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-courtoisie
+  broadcaster: independent
+  name: Radio Courtoisie
+  streamUrl: https://ice.creacast.com/radio-courtoisie
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radiocourtoisie.fr/
+  country: FR
+  status: stream-only
+  stationuuid: b84a0128-72de-455a-82ca-bbc8d13e4bac
+  changeuuid: 7f5888f1-ab95-4a75-8dd2-0ad675662e6c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-mc-doualiya
+  broadcaster: independent
+  name: MC doualiya
+  streamUrl: https://montecarlodoualiya128k.ice.infomaniak.ch/mc-doualiya.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.mc-doualiya.com/
+  country: FR
+  status: stream-only
+  stationuuid: 4e172524-8554-463a-bb5d-668720a7fec6
+  changeuuid: 8884585b-d491-4051-bbf1-cb08a8a19c0b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-cinemix
+  broadcaster: independent
+  name: Cinemix
+  streamUrl: https://kathy.torontocast.com:1825/stream
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.cinemix.us/
+  country: FR
+  status: stream-only
+  stationuuid: a5331ae6-1196-46c4-b8d6-6a013018bbfe
+  changeuuid: 17855cf9-f531-4740-9166-b83e65bcb2b2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-le-bon-mix-hifi-flac-1411-kbps
+  broadcaster: independent
+  name: Le Bon Mix HiFi Flac 1411 Kbps
+  streamUrl: https://stream10.xdevel.com/audio17s976748-2218/stream/icecast.audio
+  codec: OGG
+  favicon: https://static.wixstatic.com/media/8f2aad_93ae56d1764947358ca5524a248f789e~mv2.png
+  homepage: https://www.lebonmix.radio/hifi
+  country: FR
+  status: stream-only
+  stationuuid: ee24e264-06fd-46cb-8f92-798aadde0aef
+  changeuuid: de3e980d-7588-42e3-b78f-df8dd054b8bb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-galaxie-new-wave
+  broadcaster: independent
+  name: Galaxie New Wave
+  streamUrl: https://www.radioking.com/play/galaxienewwave
+  bitrate: 128
+  codec: MP3
+  favicon: http://galaxie-radio1.radio-website.com/upload/578f3bce151616.43092430.ico
+  homepage: http://galaxie-radio1.radio-website.com/
+  country: FR
+  status: stream-only
+  stationuuid: 9624d0bb-0601-11e8-ae97-52543be04c81
+  changeuuid: 8bb432ab-32d7-4e61-8629-ffd05c3c0643
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-fip-no-pub
+  broadcaster: independent
+  name: FIP (no pub)
+  streamUrl: https://stream.radiofrance.fr/fip/fip_hifi.m3u8
+  codec: UNKNOWN
+  favicon: https://www.radiofrance.fr/s3/cruiser-production/2023/03/3a1422a4-6f1f-4e17-874c-bad21e67f39b/300x300_sc_fip-avatar.jpg
+  homepage: https://www.radiofrance.fr/fip
+  country: FR
+  status: stream-only
+  stationuuid: 55bdaccc-a91e-4440-9587-4832a8451745
+  changeuuid: fd68652d-352e-435c-a4e8-40df09260824
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-rfm-la-radio-couleur
+  broadcaster: independent
+  name: RFM - La Radio Couleur
+  streamUrl: https://stream.rfm.fr/rfm-wr3.aac
+  bitrate: 128
+  codec: AAC+
+  favicon: http://cdn-rfm.lanmedia.fr/apple-touch-icon-120x120.png
+  homepage: http://www.rfm.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 78f153c2-13d0-4b5b-b51f-d22e5f63ff34
+  changeuuid: 21fe7f37-07f1-4af1-bd45-941f240ed622
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-esperance-parole-de-dieu
+  broadcaster: independent
+  name: Radio Espérance Parole de Dieu
+  streamUrl: https://esperance.streamakaci.com/parole-de-dieu.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: http://radio-esperance.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 960d53c0-0601-11e8-ae97-52543be04c81
+  changeuuid: 28783ad0-067a-429e-8acf-93a81f469dd3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-france-bleu-provence
+  broadcaster: independent
+  name: France Bleu Provence
+  streamUrl: https://icecast.radiofrance.fr/fbprovence-midfi.mp3?ID=radiofrance
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.francebleu.fr/img/logo-france-bleu-seo.jpg
+  homepage: https://www.francebleu.fr/provence
+  country: FR
+  status: stream-only
+  stationuuid: d94c5090-1b7d-11ea-a620-52543be04c81
+  changeuuid: fe562939-5cf3-4fe5-ae79-96c0ade32894
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-djam-radio-aac192lc
+  broadcaster: independent
+  name: Djam Radio - AAC192LC
+  streamUrl: https://stream9.xdevel.com/audio1s976748-1515/stream/icecast.audio
+  codec: AAC+
+  favicon: https://static.wixstatic.com/media/8f2aad_b81fa83db54340c3af97af5cf2cd0d0e~mv2.png
+  homepage: https://www.djam.radio/
+  country: FR
+  status: stream-only
+  stationuuid: f956de7a-cf01-49d3-8acf-45a25e5bdf5e
+  changeuuid: edd01c59-6951-4a14-82fc-aaf772ecade7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-rtl-france
+  broadcaster: independent
+  name: RTL France
+  streamUrl: https://live.m6radio.quortex.io/webpHJPXnXrN7B6J7Q8mcqmxP/grouprtl/national/long/audio-64000/index.m3u8
+  bitrate: 64
+  codec: AAC
+  favicon: https://www.radio.fr/images/broadcasts/da/51/10220/c300.png
+  homepage: https://www.rtl.fr/direct
+  country: FR
+  status: stream-only
+  stationuuid: fb398bd6-9873-4c06-b6d3-e2e3ca6d5c3c
+  changeuuid: 5ef9b21d-76bd-4f77-af40-81cf0fb9b790
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-latina-fiesta
+  broadcaster: independent
+  name: Latina fiesta
+  streamUrl: https://latinafiesta.ice.infomaniak.ch/latinafiesta.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://ecouter.lesindesradios.net/logos/orange329.png
+  homepage: https://www.latina.fr/
+  country: FR
+  status: stream-only
+  stationuuid: ca19e388-4c86-4765-aed9-0ecbd1abd6d6
+  changeuuid: 57724eb6-023f-4f23-ad93-04535c162798
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-oui-fm-les-slows-du-rock
+  broadcaster: independent
+  name: OUI FM LES SLOWS DU ROCK
+  streamUrl: https://ouifmlesslowsdurock.ice.infomaniak.ch/ouifmslowrock.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://bocir-prod-bucket.s3.eu-west-1.amazonaws.com/radios/oui-fm/images/favicon.ico
+  homepage: https://www.ouifm.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 0dcaca42-06fc-4433-8b17-bad6c5841dd5
+  changeuuid: 299e080a-5aa2-4063-b379-58b261da4ba0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-esperance-gregorien
+  broadcaster: independent
+  name: Radio Espérance Grégorien
+  streamUrl: https://esperance.streamakaci.com/gregorien.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: http://radio-esperance.fr/wp-content/themes/radio-esperance/fichiers/ico/apple-touch-icon-120x120.png
+  homepage: http://radio-esperance.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 960bf247-0601-11e8-ae97-52543be04c81
+  changeuuid: 77c88f7d-754f-4075-bdf4-82f0b7f990e6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-record-goa-psy
+  broadcaster: independent
+  name: Record Goa Psy
+  streamUrl: https://radiorecord.hostingradio.ru/goa96.aacp
+  codec: AAC
+  favicon: https://s1.wp.com/i/favicon.ico
+  homepage: https://caribshebdo.wordpress.com/category/radios-web/
+  country: FR
+  status: stream-only
+  stationuuid: ca151a81-ce20-4dd4-b6df-66f5c52a559c
+  changeuuid: 83a82ccc-b34d-4eb5-8f0e-85a806622b89
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-latcho-flamenco
+  broadcaster: independent
+  name: Latcho Flamenco
+  streamUrl: https://listen.radioking.com/radio/109486/stream/148513
+  bitrate: 128
+  codec: MP3
+  homepage: https://latchoflamenco.wifeosite.com/
+  country: FR
+  status: stream-only
+  stationuuid: 881a0f74-533c-415c-8184-f09fa63c8895
+  changeuuid: 85787967-f75f-4a57-8059-8ca2fa02de63
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-djam-radio-flac-1411-kbps
+  broadcaster: independent
+  name: Djam Radio - Flac 1411 Kbps
+  streamUrl: https://stream10.xdevel.com/audio15s976748-2280/stream/icecast.audio
+  codec: OGG
+  favicon: https://static.wixstatic.com/media/8f2aad_f0ad87746b3f4cebb1e67e1a25e89b6e~mv2.png
+  homepage: https://www.djam.radio/
+  country: FR
+  status: stream-only
+  stationuuid: cb510c9c-2445-4003-8467-0ea4fe9688e5
+  changeuuid: 4b99cd2f-98eb-45d0-ae26-45219661bb23
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-allzik-disney
+  broadcaster: independent
+  name: "Allzik Disney "
+  streamUrl: https://allzic52.ice.infomaniak.ch/allzic52.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.allzicradio.com/media/radios/allzic-disney_600px-carre.png
+  homepage: https://www.allzicradio.com/en/player/listen/3700/allzic-radio-disney
+  country: FR
+  status: stream-only
+  stationuuid: 482ada2f-4cef-46f0-9bee-5fec787e456b
+  changeuuid: 7468bf71-713b-4e1d-8f54-83c900826f7d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-metal-invasion-radio
+  broadcaster: independent
+  name: Metal Invasion Radio
+  streamUrl: https://radio.metal-invasion.fr/radio/8000/stream96
+  bitrate: 96
+  codec: AAC
+  homepage: https://metal-invasion.fr/
+  country: FR
+  status: stream-only
+  stationuuid: b8246f43-7136-4328-8027-e137515b68dd
+  changeuuid: 609ae48a-6e84-422c-aa4d-86c9d0899a76
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-france-musique-opera
+  broadcaster: independent
+  name: France Musique Opéra
+  streamUrl: https://icecast.radiofrance.fr/francemusiqueopera-hifi.aac
+  bitrate: 192
+  codec: AAC
+  homepage: https://www.francemusique.fr/opera
+  country: FR
+  status: stream-only
+  stationuuid: ddd75838-e97a-439e-a9c9-e6f697be95df
+  changeuuid: a5cac5ec-e827-4f2d-af86-9ed13f06070a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-allzic-radio-orientale
+  broadcaster: independent
+  name: Allzic Radio Orientale
+  streamUrl: https://allzic33.ice.infomaniak.ch/allzic33.aac
+  bitrate: 64
+  codec: AAC+
+  homepage: https://global.superradio.cc/
+  country: FR
+  status: stream-only
+  stationuuid: 75cb7408-5f1a-4b0a-bafe-7dd621372f39
+  changeuuid: da98e48f-32eb-4d44-96f6-790d656a4a07
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-skyrock-100-francais
+  broadcaster: independent
+  name: "Skyrock 100% FRANÇAIS "
+  streamUrl: https://icecast.skyrock.net/s/francais_aac_64k?tvr_name=radiofr&tvr_section1=64aac
+  bitrate: 128
+  codec: AAC
+  country: FR
+  status: stream-only
+  stationuuid: 6e7900f4-a927-4bf9-b0cb-5855493b0ce5
+  changeuuid: 5538977c-f4bb-44b2-8c54-32f12950b47c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-oui-fm-rock-80-s
+  broadcaster: independent
+  name: "OUI FM ROCK 80's"
+  streamUrl: https://ouifmrock80s.ice.infomaniak.ch/ouifmeighties.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://bocir-prod-bucket.s3.amazonaws.com/radios/oui-fm/radiostream/6fo6l1uD2X/vignette.png
+  homepage: https://www.ouifm.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 924985e9-ecb4-4126-b3f1-34ddeb93f4a4
+  changeuuid: 78b3463e-89ff-4f13-b33d-2cf839b60b37
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-la-grosse-radio-reggae
+  broadcaster: independent
+  name: La Grosse Radio Reggae
+  streamUrl: https://hd.lagrosseradio.info/lagrosseradio-reggae-192.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: https://caribshebdo.wordpress.com/2020/09/02/radio-web-la-grosse-reggae/
+  country: FR
+  status: stream-only
+  stationuuid: 9f30d02d-ad16-4b8a-8d10-745d147f83cc
+  changeuuid: dda7be53-a18b-416b-9110-2ce1345d708b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-oui-fm-blues-n-rock
+  broadcaster: independent
+  name: "OUI FM BLUES'N'ROCK"
+  streamUrl: https://ouifmbluesnrock.ice.infomaniak.ch/ouifmbluesnrock-128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://bocir-prod-bucket.s3.eu-west-1.amazonaws.com/radios/oui-fm/images/favicon.ico
+  homepage: https://www.ouifm.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 37b84f17-81b6-4f44-8562-fd62b53be6f4
+  changeuuid: 40bbaedd-ea9a-4db5-834d-809c11f0a16e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-francia-internacional
+  broadcaster: independent
+  name: RADIO FRANCIA INTERNACIONAL
+  streamUrl: https://rfienespagnol64k.ice.infomaniak.ch/rfienespagnol-64.mp3
+  bitrate: 64
+  codec: MP3
+  favicon: https://www.rfi.fr/apple-touch-icon.png
+  homepage: https://www.rfi.fr/es/
+  country: FR
+  status: stream-only
+  stationuuid: b0b9ed65-52e7-463c-8c0b-d16ffbbcf661
+  changeuuid: 40866223-b732-4d13-862e-71f98d568566
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-rfm-100-francais
+  broadcaster: independent
+  name: "RFM 100% Français"
+  streamUrl: https://wr.lmn.fm/rfm-wr11.aac
+  bitrate: 128
+  codec: AAC+
+  favicon: http://cdn-rfm.lanmedia.fr/favicon-32x32.png
+  homepage: http://www.rfm.fr/
+  country: FR
+  status: stream-only
+  stationuuid: a3036ea3-9457-4e13-bb45-8c96751f81ba
+  changeuuid: 46d7f157-ad41-4d95-91be-af1c9817ed78
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-littoral-fm-perpignan
+  broadcaster: independent
+  name: LITTORAL FM Perpignan
+  streamUrl: https://littoralfmperpignan.ice.infomaniak.ch/littoralfmperpignan.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://bocir-prod-bucket.s3.eu-west-1.amazonaws.com/radios/littoral/images/favicon.ico
+  homepage: https://littoral.fm/
+  country: FR
+  status: stream-only
+  stationuuid: ba9d204c-0c81-4450-86c3-cde631e492be
+  changeuuid: 1c31eefd-1955-491d-af4e-2e6cf5b95d02
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-oui-fm-alternatif
+  broadcaster: independent
+  name: OUI FM ALTERNATIF
+  streamUrl: https://ouifm2.ice.infomaniak.ch/ouifm2.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://bocir-prod-bucket.s3.amazonaws.com/radios/oui-fm/radiostream/S2UWS5S3lJ/vignette.png
+  homepage: https://www.ouifm.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 81bc1bcb-cab2-4011-b85c-5001ff8b708b
+  changeuuid: bcc7154a-119e-4246-ae5d-0d25b9131749
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-fip-metal
+  broadcaster: independent
+  name: FIP Metal
+  streamUrl: https://icecast.radiofrance.fr/fipmetal-hifi.aac?id=radiofrance
+  bitrate: 192
+  codec: AAC
+  favicon: https://www.radiofrance.fr/s3/cruiser-production/2022/07/160994f8-296b-4cd8-97a0-34c9111cdd9d/400x400_fip-metal-20222x_2.webp
+  homepage: https://www.radiofrance.fr/fip/radio-metal
+  country: FR
+  status: stream-only
+  stationuuid: 75b6b22f-f4b7-43ae-aa73-96a7b47eeb4f
+  changeuuid: 449f08ad-59a4-4a7f-bcdd-44ae280d6a46
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-badradio-24-7-og-phonk-memphis-houston-trap-tril
+  broadcaster: independent
+  name: "badradio 24/7 OG Phonk, Memphis, Houston, Trap & Trill"
+  streamUrl: https://s2.radio.co/s2b2b68744/listen
+  bitrate: 320
+  codec: MP3
+  favicon: https://yt3.ggpht.com/ytc/AMLnZu8eXtkd-wn5s-Ww_RXId5AsUc0kqfM-1hikJJtzjw=s88-c-k-c0x00ffffff-no-rj
+  homepage: https://badradio.nz/
+  country: FR
+  status: stream-only
+  stationuuid: da3ad9cf-b8f2-4327-8f64-edfbaeb4f111
+  changeuuid: 5651b8dd-f5bb-430d-8e37-98d1175c01de
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-blackbox-classic-us
+  broadcaster: independent
+  name: BlackBox classic US
+  streamUrl: https://blackbox-classic-us.ice.infomaniak.ch/blackbox-classic-us.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://bocir-prod-bucket.s3.eu-west-1.amazonaws.com/radios/blackbox/images/favicon.ico
+  homepage: https://www.blackboxfm.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 4bdea53b-2d67-11ea-aa0c-52543be04c81
+  changeuuid: f5825b64-574e-44e1-86b8-7a10951371ce
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-pulsradio-dance
+  broadcaster: independent
+  name: Pulsradio Dance
+  streamUrl: https://sc4.gergosnet.com/pulsHD.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.pulsradio.com/
+  country: FR
+  status: stream-only
+  stationuuid: 17d5a94b-db1b-49bf-82a3-bab108ec2acd
+  changeuuid: 8f7996d4-e9b0-41d5-b061-3f71ebee69b1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-rock-folk-rock-n-folk
+  broadcaster: independent
+  name: "Rock & Folk (rock n folk)"
+  streamUrl: https://rockfolk.ice.infomaniak.ch/rockfolk.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.rocknfolk.com/
+  country: FR
+  status: stream-only
+  stationuuid: 3a6c5ce7-0c5c-11ea-a87e-52543be04c81
+  changeuuid: 1ae07acb-75de-4cdc-9afa-c0b667e691aa
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-esperance-enseignement
+  broadcaster: independent
+  name: Radio Espérance Enseignement
+  streamUrl: https://esperance.streamakaci.com/enseignement.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: http://radio-esperance.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 960c22d1-0601-11e8-ae97-52543be04c81
+  changeuuid: f6089cd0-9c34-4f2a-947f-671a618ddf27
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-esperance-louange
+  broadcaster: independent
+  name: Radio Espérance Louange
+  streamUrl: https://esperance.streamakaci.com/louange.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: http://radio-esperance.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 960e2fdb-0601-11e8-ae97-52543be04c81
+  changeuuid: 178c4302-b016-4d34-b88d-db18eedfd41d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-oui-fm-rock-inde
+  broadcaster: independent
+  name: OUI FM ROCK INDÉ
+  streamUrl: https://ouifm5.ice.infomaniak.ch/ouifm5.mp3
+  bitrate: 64
+  codec: MP3
+  favicon: https://bocir-prod-bucket.s3.eu-west-1.amazonaws.com/radios/oui-fm/images/favicon.ico
+  homepage: https://www.ouifm.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 6e7e241a-6984-4797-ab2d-6f6e80f7a0e3
+  changeuuid: 6cb5149b-3b8d-45bd-9b3f-41d3942e10bc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-vaticana-francais
+  broadcaster: independent
+  name: Radio Vaticana Francais
+  streamUrl: https://radio.vaticannews.va/stream-fr
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.vaticannews.va/etc/designs/vatican-news/release/library/main/images/favicons/apple-icon-114x114.png
+  homepage: https://www.vaticannews.va/fr.html
+  country: FR
+  status: stream-only
+  stationuuid: 7d913888-3cfa-4254-aa88-8683f9002eb8
+  changeuuid: b0802911-0ba9-4826-ad47-09eba4b3f5f6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-rfi-russia
+  broadcaster: independent
+  name: RFI Russia
+  streamUrl: https://rfiukraine.ice.infomaniak.ch/rfiukraine-96.mp3
+  bitrate: 96
+  codec: MP3
+  favicon: https://www.rfi.fr/apple-touch-icon.png
+  homepage: https://www.rfi.fr/ru/
+  country: FR
+  status: stream-only
+  stationuuid: 4bfa3b18-478b-4057-9bff-90ee4943a0ee
+  changeuuid: ddbb77f3-68af-446d-9c0f-b6d57f8ef705
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-jazz-radio-electro-swing
+  broadcaster: independent
+  name: Jazz Radio Electro Swing
+  streamUrl: https://jazz-wr04.ice.infomaniak.ch/jazz-wr04-64.aac?i=67090
+  bitrate: 64
+  codec: AAC+
+  favicon: https://www.jazzradio.fr/media/radio/thumb/180x180_electro-swing.png
+  homepage: https://www.jazzradio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 0b3ff698-3282-483c-96bc-1ba9ff08ea25
+  changeuuid: 6691a650-ae35-4905-8107-63b54c640796
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-europe-1-musique-classique
+  broadcaster: independent
+  name: Europe 1 Musique Classique
+  streamUrl: https://wr.lmn.fm/e1-wr3.aac?aw_0_1st.playerid=lgrdnwsRadioplayer
+  bitrate: 128
+  codec: AAC+
+  favicon: https://resize-europe1.lanmedia.fr/f/webp/r/622,311,forcex,center-middle/img/var/europe1/storage/images/europe1/culture/nouveau-ecoutez-europe-musiqueclassique-4095055/58235479-1-fre-FR/NOUVEAU-Ecoutez-Europe-musique-classique.png
+  homepage: https://www.europe1.fr/culture/nouveau-ecoutez-europe-musiqueclassique-4095055
+  country: FR
+  status: stream-only
+  stationuuid: 91c85715-0065-4304-83b7-e5dfada6a5ec
+  changeuuid: ef429b82-3fe0-4ea7-a685-02843bceed35
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-urban-afro
+  broadcaster: independent
+  name: Urban afro
+  streamUrl: https://urbanhitblack.ice.infomaniak.ch/urbanhitblack128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://bocir-prod-bucket.s3.eu-west-1.amazonaws.com/radios/urbanhit/images/favicon.vnd.microsoft.icon
+  homepage: https://www.urbanhit.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 1a9c8c79-2e17-11ea-aa0c-52543be04c81
+  changeuuid: 8f4b2305-ce79-4259-9540-c9d306eeec8a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-rmc-gold
+  broadcaster: independent
+  name: RMC GOLD
+  streamUrl: https://hls-rmcgold.nextradiotv.com/ssai/192k/media.m3u8
+  codec: UNKNOWN
+  homepage: https://rmc.bfmtv.com/en-direct/rmc-gold/
+  country: FR
+  status: stream-only
+  stationuuid: f6184d82-b381-4d94-81d7-858189b423a3
+  changeuuid: 05c29a70-c32e-4da7-adc5-025b839bfae9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-notre-dame-lower-bitrate
+  broadcaster: independent
+  name: Radio Notre Dame (lower bitrate)
+  streamUrl: https://windu.radionotredame.net/RadioNotreDame-Fm.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://radionotredame.net/favicon.ico
+  homepage: https://radionotredame.net/
+  country: FR
+  status: stream-only
+  stationuuid: 5e7d27fd-478a-458e-9a3f-85e47332a011
+  changeuuid: a8a518f7-e072-48c2-b6ba-aadc31da139f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-oui-fm-rock-70-s
+  broadcaster: independent
+  name: "OUI FM ROCK 70's"
+  streamUrl: https://ouifmrock70s.ice.infomaniak.ch/ouifmseventies.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://bocir-prod-bucket.s3.eu-west-1.amazonaws.com/radios/oui-fm/images/favicon.ico
+  homepage: https://www.ouifm.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 5ab5b266-a643-4666-a69b-31a748c62b73
+  changeuuid: 2963735c-e24b-40a2-8528-2421895f861e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-africa-radio-rumba-webradio
+  broadcaster: independent
+  name: Africa Radio Rumba Webradio
+  streamUrl: https://webradio1.ice.infomaniak.ch/webradio4-128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://images.lesindesradios.fr/fit-in/300x2000/filters:format(webp)/radios/africaradio/radiostream/dnV47tflYH/vignette.png
+  homepage: https://www.africaradio.com/
+  country: FR
+  status: stream-only
+  stationuuid: 83b983ae-483b-4767-be4a-916f3a9d680b
+  changeuuid: 86efe33b-4358-4bd2-866f-8f322dda9b3a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-ici-nord
+  broadcaster: independent
+  name: ICI NORD
+  streamUrl: https://stream.radiofrance.fr/fbnord/fbnord_midfi.m3u8
+  codec: UNKNOWN
+  favicon: https://www.francebleu.fr/images/logo-ici.jpg
+  homepage: https://www.francebleu.fr/nord
+  country: FR
+  status: stream-only
+  stationuuid: c09dbfe5-71f6-45fb-819e-839a58cdef10
+  changeuuid: 501a4e18-50de-47fc-8d1d-6842aae272e4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-oui-fm-rock-90-s
+  broadcaster: independent
+  name: "OUI FM ROCK 90's"
+  streamUrl: https://ouifmrock90s.ice.infomaniak.ch/ouifmnineties.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://bocir-prod-bucket.s3.eu-west-1.amazonaws.com/radios/oui-fm/images/favicon.ico
+  homepage: https://www.ouifm.fr/
+  country: FR
+  status: stream-only
+  stationuuid: ac8b0eda-c69b-4f3e-acb7-71666085dc33
+  changeuuid: 3627f705-e854-4d83-9d7b-b482a9955377
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-pulsradio-2000-64k-aac
+  broadcaster: independent
+  name: PulsRadio 2000 (64k AAC)
+  streamUrl: https://sc6.gergosnet.com:80/puls00AAC64.mp3
+  bitrate: 64
+  codec: AAC+
+  favicon: https://www.pulsradio.com/apple-icon-120x120.png
+  homepage: https://www.pulsradio.com/2000/
+  country: FR
+  status: stream-only
+  stationuuid: e6f300d8-ed0d-4cf3-9dd2-9e117d74b244
+  changeuuid: aa8cfd1e-4d16-4234-9cee-218a348ff82b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-fip-jazz-hi-fi
+  broadcaster: independent
+  name: FIP Jazz (Hi-Fi)
+  streamUrl: https://stream.radiofrance.fr/fipjazz/fipjazz_hifi.m3u8?id=radiofrance
+  codec: UNKNOWN
+  favicon: https://www.radiofrance.fr/s3/cruiser-production/2019/06/840a4431-0db0-4a94-aa28-53f8de011ab6/300x300_fip-jazz-01.jpg
+  homepage: https://www.radiofrance.fr/fip/radio-jazz
+  country: FR
+  status: stream-only
+  stationuuid: f1aad29c-8013-45a8-8d94-9bb63eb90320
+  changeuuid: 55b5edf2-42d1-4c93-8037-06fd1d78f54d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-nostalgie-france
+  broadcaster: independent
+  name: Radio Nostalgie France
+  streamUrl: https://streaming.nrjaudio.fm/oug7girb92oc?origine=tingfm
+  bitrate: 128
+  codec: MP3
+  homepage: http://www.nostagie.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 88496158-90c1-411f-9a3b-719397a8dcca
+  changeuuid: a41a9b24-0679-4631-bae8-0159e60c8a07
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-urban-hit-rap-fr
+  broadcaster: independent
+  name: Urban Hit rap FR
+  streamUrl: https://urbanhitrapfr.ice.infomaniak.ch/urbanhitrapfr-128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://bocir-prod-bucket.s3.eu-west-1.amazonaws.com/radios/urbanhit/images/favicon.vnd.microsoft.icon
+  homepage: https://www.urbanhit.fr/
+  country: FR
+  status: stream-only
+  stationuuid: b1e155e8-2e16-11ea-aa0c-52543be04c81
+  changeuuid: 1dcf7edb-11a6-416b-ac97-d31e44580def
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-europe-2-classics
+  broadcaster: independent
+  name: Europe 2 Classics
+  streamUrl: https://europe2.lmn.fm/vr-wr2.mp3?aw_0_1st.playerid=lagardereappVirgin
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.europe2.fr/wp-content/themes/melty/europeradio/assets/images/radio/radio_2002.png
+  homepage: https://www.europe2.fr/webradios
+  country: FR
+  status: stream-only
+  stationuuid: 693fc913-647b-4ee1-b654-d71fb022ce05
+  changeuuid: 94c4e84f-b349-47d7-bd25-d8ebcc457e75
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-metal
+  broadcaster: independent
+  name: Radio Metal
+  streamUrl: https://radio3.pro-fhi.net/live/Radio%20Metal
+  bitrate: 320
+  codec: MP3
+  homepage: http://www.radiometal.com/
+  country: FR
+  status: stream-only
+  stationuuid: 9e219cbd-9bd0-4950-997d-f17bd8fbe793
+  changeuuid: 0adb1471-6286-459a-a4fb-401446f7d65c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-rire-et-chansons
+  broadcaster: independent
+  name: Rire et Chansons
+  streamUrl: https://streaming.nrjaudio.fm/ou8o8xgk7oiu?origine=fluxradios
+  bitrate: 128
+  codec: MP3
+  favicon: https://img.nrj.fr/OImjPWH1tkT1NaUMPlxsY49g9BI=/medias%2F2024%2F03%2Fvvscnx9i3yteabtkx8nlpdusmqj6uo8hshh9iphoit8_65fbfe026c3a5.png
+  homepage: https://www.rireetchansons.fr/
+  country: FR
+  status: stream-only
+  stationuuid: a70cdc64-9a33-4432-91a1-957beb5ac6e7
+  changeuuid: f4bc9f47-d48e-45ed-9de6-3774bd6f413a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-vintage-80-90
+  broadcaster: independent
+  name: Vintage 80 90
+  streamUrl: https://radio8.pro-fhi.net/live/VINTAGE80-90
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.facebook.com/favicon.ico
+  homepage: https://www.facebook.com/radiovintage8090
+  country: FR
+  status: stream-only
+  stationuuid: a25b97e7-9b23-413e-823e-baec874d0bf8
+  changeuuid: 145b1846-77b0-4576-839d-d8354aa79d8b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-buddha-beach
+  broadcaster: independent
+  name: Buddha Beach
+  streamUrl: https://radio4.vip-radios.fm:18054/stream-128kmp3-BuddhaBeach
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.vip-radios.fm/favicon.ico
+  homepage: https://www.vip-radios.fm/station/buddha-beach/
+  country: FR
+  status: stream-only
+  stationuuid: be2d4017-870b-4049-9b0c-418dbe28eb36
+  changeuuid: 59b76705-f87a-45c6-9539-6e7e5380b165
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-frequence-3-gold-flac
+  broadcaster: independent
+  name: Frequence 3 Gold FLAC
+  streamUrl: https://frequence3.net-radio.fr/frequence3gold.flac
+  bitrate: 128
+  codec: OGG
+  favicon: https://api2.frequence3.net/static/img/stations/horizontal/frequence3gold.png
+  homepage: https://www.frequence3.com/les-radios-frequence-3/gold/
+  country: FR
+  status: stream-only
+  stationuuid: 4ed72eba-d787-40bb-8528-9ade9fd0113a
+  changeuuid: 1ad68b02-bd3b-48b9-83ed-3a281320f4ce
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-galaxietek
+  broadcaster: independent
+  name: GalaxieTek
+  streamUrl: https://fr.radioking.com/play/galaxietek
+  bitrate: 128
+  codec: MP3
+  favicon: http://www.galaxieradio.fr/upload/578f3bce151616.43092430.ico
+  homepage: http://www.galaxieradio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: c33b8b99-4e62-11e9-a4d7-52543be04c81
+  changeuuid: 8d442ca8-4e27-49fb-a6b6-b8aef7a47203
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-oui-fm-rock-2000
+  broadcaster: independent
+  name: OUI FM ROCK 2000
+  streamUrl: https://ouifmrock2000s.ice.infomaniak.ch/ouifmrock2000.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.ouifm.fr/
+  country: FR
+  status: stream-only
+  stationuuid: c6009d9c-d19b-4d98-853f-1ae3789b17b2
+  changeuuid: cca908e4-73fc-4bab-98b6-ce4607d97d66
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-esperance
+  broadcaster: independent
+  name: Radio Espérance
+  streamUrl: https://esperance.streamakaci.com/esperance.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: http://radio-esperance.fr/wp-content/themes/radio-esperance/fichiers/ico/apple-touch-icon-120x120.png
+  homepage: http://radio-esperance.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 960df395-0601-11e8-ae97-52543be04c81
+  changeuuid: e6491e5d-03ba-408a-9acd-c7067c59b5c1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-oui-fm-reggae
+  broadcaster: independent
+  name: OUI FM REGGAE
+  streamUrl: https://ouifmganja.ice.infomaniak.ch/ouifmganja-128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://bocir-prod-bucket.s3.amazonaws.com/radios/oui-fm/radiostream/ufIfkfDXSl/vignette.png
+  homepage: https://www.ouifm.fr/
+  country: FR
+  status: stream-only
+  stationuuid: bf16cbc0-164f-4736-bc61-0ffa1c988f47
+  changeuuid: de8e9734-ec12-4e1b-89dd-afea418bf276
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-meme-dans-les-orties
+  broadcaster: independent
+  name: "* Meme dans les orties *"
+  streamUrl: https://radio.sk8ter.org:8443/stream
+  bitrate: 192
+  codec: MP3
+  favicon: https://memeradio.org/favicon_meme.png
+  homepage: http://memeradio.org/
+  country: FR
+  status: stream-only
+  stationuuid: cff87807-bbd6-44b2-9c17-f96fcfdd78d9
+  changeuuid: 3c4f275b-822f-4e36-bfa5-90b59432d30a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-oui-fm-classic-rock
+  broadcaster: independent
+  name: OUI FM CLASSIC ROCK
+  streamUrl: https://ouifm3.ice.infomaniak.ch/ouifm3.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://bocir-prod-bucket.s3.amazonaws.com/radios/oui-fm/radiostream/3qhtSltZ27/vignette.png
+  homepage: https://www.ouifm.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 689824b5-1dd7-464d-a913-8c363337a883
+  changeuuid: 0fb05787-ace6-406f-8f1c-42645d5530e6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-jazzradio-fr-funk
+  broadcaster: independent
+  name: JazzRadio.fr Funk
+  streamUrl: https://jazz-wr06.ice.infomaniak.ch/jazz-wr06-128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.jazzradio.fr/apple-touch-icon-120x120.png
+  homepage: https://www.jazzradio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 03539f87-897e-408a-9bff-31f1be7d0b2c
+  changeuuid: b76e8a10-5e53-403b-be0e-a0bc50bbf9cc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-couleurs-jazz
+  broadcaster: independent
+  name: Couleurs JAZZ
+  streamUrl: https://www.radioking.com/play/couleurs-jazz/216016
+  bitrate: 320
+  codec: MP3
+  homepage: https://couleursjazz.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 505f1686-0ddd-488b-8355-2f7d7a83ba65
+  changeuuid: 20713efc-5cfc-4c98-b649-92f4f57e81f9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-tsugi
+  broadcaster: independent
+  name: Tsugi
+  streamUrl: https://www.radioking.com/play/tsugi-radio
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.tsugi.fr/tsugi-radio/
+  country: FR
+  status: stream-only
+  stationuuid: 3c4caeb0-56ce-11e8-b0ce-52543be04c81
+  changeuuid: 01b77aef-611f-43c7-a375-6bde9cecf786
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-jazzradio-fr-blues
+  broadcaster: independent
+  name: JazzRadio.fr Blues
+  streamUrl: https://jazzblues.ice.infomaniak.ch/jazzblues-high.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.jazzradio.fr/media/radio/thumb/100x100_blues.png
+  homepage: https://www.jazzradio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 9872dc1a-363b-4675-817a-afc30ecc4183
+  changeuuid: eb50f1ec-fb5f-43c9-89a2-457a7e222f55
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-fip-metal-2
+  broadcaster: independent
+  name: "Fip : Metal"
+  streamUrl: https://stream.radiofrance.fr/fipmetal/fipmetal_hifi.m3u8
+  codec: UNKNOWN
+  favicon: https://www.radiofrance.fr/dist/favicons/logo-120.png
+  homepage: https://www.radiofrance.fr/fip/radio-metal
+  country: FR
+  status: stream-only
+  stationuuid: 05232733-7804-47c4-b9d8-b570739900c7
+  changeuuid: 40e83396-e42f-463d-9763-125e0e447b3c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-galaxie-radio
+  broadcaster: independent
+  name: Galaxie Radio
+  streamUrl: https://www.radioking.com/play/galaxieradio
+  bitrate: 128
+  codec: MP3
+  homepage: http://galaxie-radio1.radio-website.com/
+  country: FR
+  status: stream-only
+  stationuuid: 96148733-0601-11e8-ae97-52543be04c81
+  changeuuid: 2db93005-2418-4b10-bb92-bbfce6c07e06
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-bide-et-musique
+  broadcaster: independent
+  name: Bide et Musique
+  streamUrl: https://relay2.bide-et-musique.com:9143/
+  bitrate: 128
+  codec: MP3
+  homepage: http://www.bide-et-musique.com/
+  country: FR
+  status: stream-only
+  stationuuid: 9605a4dd-0601-11e8-ae97-52543be04c81
+  changeuuid: d45f0b92-2326-492c-9837-9933febf3413
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-mbs-gold
+  broadcaster: independent
+  name: MBS Gold
+  streamUrl: https://mbs.ice.infomaniak.ch/mbs-128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://bocir-prod-bucket.s3.amazonaws.com/radios/mbs/images/favicon.x-icon
+  homepage: https://radiombs.fr/
+  country: FR
+  status: stream-only
+  stationuuid: f4ac9c6d-7833-460a-9060-3f87112fdc6e
+  changeuuid: 98ab8a24-f19b-47c6-a70c-0a4d04590edb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-le-bon-mix-radio-97-9
+  broadcaster: independent
+  name: Le Bon Mix Radio 97.9
+  streamUrl: https://stream10.xdevel.com/audio13s976748-2017/stream/icecast.audio
+  bitrate: 320
+  codec: AAC+
+  favicon: https://admuzzum.xdevel.com/cloud/x/cid/35/im/png/XZXW/Q/XY/20dcef61bfe95be20b65258bba132163.png
+  homepage: https://www.lebonmix.radio/
+  country: FR
+  status: stream-only
+  stationuuid: 6affdd69-650a-46a9-94bf-cff80541e152
+  changeuuid: 51d30968-159f-48dc-9154-fff810f5e143
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-france-bleu-alsace
+  broadcaster: independent
+  name: France Bleu Alsace
+  streamUrl: https://icecast.radiofrance.fr/fbalsace-midfi.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.francebleu.fr/images/favicon-112.png
+  homepage: https://www.francebleu.fr/alsace
+  country: FR
+  status: stream-only
+  stationuuid: a7d3f6fb-9b43-44dd-96cd-f8035d647e50
+  changeuuid: 3fcd4be0-5a8f-4a1a-991c-25a9b3e0569e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-classic-fm-france
+  broadcaster: independent
+  name: Classic FM France
+  streamUrl: https://classicfm.ice.infomaniak.ch/classic-fm.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.classicfm.fr/
+  country: FR
+  status: stream-only
+  stationuuid: cadd6537-1841-4127-a98c-dba96a7c5417
+  changeuuid: 5edf50c2-23b9-4cd5-9409-bad424023e63
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-esperance-musique-sacree
+  broadcaster: independent
+  name: Radio Espérance Musique Sacrée
+  streamUrl: https://esperance.streamakaci.com/musique.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: http://radio-esperance.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 960e4f1a-0601-11e8-ae97-52543be04c81
+  changeuuid: 7839b697-ea4f-498d-ac14-efa77953118d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-rtl-2
+  broadcaster: independent
+  name: RTL 2
+  streamUrl: https://icecast.rtl.fr/rtl2-1-44-128?listen=webGJmqBU59boQ7rZDjrGO5e4
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.rtl2.fr/
+  country: FR
+  status: stream-only
+  stationuuid: cf927e12-2208-41ba-b66d-7a2fc05f8d9d
+  changeuuid: ed22d317-75f0-4558-9a51-85c2e259e39a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-star
+  broadcaster: independent
+  name: Radio STAR
+  streamUrl: https://listen.radioking.com/radio/9728/stream/20210
+  bitrate: 128
+  codec: MP3
+  homepage: http://radio-star.site-radio.com/
+  country: FR
+  status: stream-only
+  stationuuid: 960a00b0-0601-11e8-ae97-52543be04c81
+  changeuuid: 97777afb-b94b-411c-b4ca-510d5e031c1a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-africa-radio-paris
+  broadcaster: independent
+  name: Africa Radio Paris
+  streamUrl: https://african1paris.ice.infomaniak.ch/african1paris-128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://images.lesindesradios.fr/fit-in/300x2000/filters:format(webp)/filters:quality(100)/radios/africaradio/images/logo_RvDT2jBisJ.png
+  homepage: https://www.africaradio.com/
+  country: FR
+  status: stream-only
+  stationuuid: 07b28e11-a8da-47ee-a96a-8930192c8163
+  changeuuid: 9eb96d68-99f8-4dac-9c26-1294113ee584
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-frequence-3-dance-flac-powered-by-ikoula-m2-club
+  broadcaster: independent
+  name: "FREQUENCE 3 - DANCE FLAC [Powered by IKOULA] - M2 Club"
+  streamUrl: https://onair.net-radio.fr/frequence3dance.flac
+  bitrate: 128
+  codec: OGG
+  homepage: https://www.frequence3.com/
+  country: FR
+  status: stream-only
+  stationuuid: 764caa2f-ccf8-459f-99d7-1e15009b1474
+  changeuuid: d2fea12f-d119-4fbb-932c-ad8de7f09f18
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-fip-sacre-francais
+  broadcaster: independent
+  name: "FIP Sacré Français !"
+  streamUrl: https://stream.radiofrance.fr/fipsacrefrancais/fipsacrefrancais.m3u8?id=radiofrance
+  bitrate: 107
+  codec: AAC
+  favicon: https://upload.wikimedia.org/wikipedia/commons/thumb/1/16/FIP_logo_2021.svg/2048px-FIP_logo_2021.svg.png
+  homepage: https://www.radiofrance.fr/fip/radio-sacre-francais
+  country: FR
+  status: stream-only
+  stationuuid: 50420f6a-fe77-40c5-a065-b12c5c7d5299
+  changeuuid: 932baa18-a325-460f-b944-53060a6d0494
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-rfm-slow
+  broadcaster: independent
+  name: RFM Slow
+  streamUrl: https://stream.rfm.fr/rfm-wr13.aac
+  bitrate: 128
+  codec: AAC+
+  homepage: https://stream.rfm.fr/rfm-wr13.aac
+  country: FR
+  status: stream-only
+  stationuuid: 797a7993-543c-4004-8868-0818261d6373
+  changeuuid: 5a2ad7a5-63b8-43ba-9fc8-2cc9534b765a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-skyrock-plm
+  broadcaster: independent
+  name: Skyrock PLM
+  streamUrl: https://icecast.skyrock.net/s/plm_aac_128k?tvr_name=apistreamfm
+  bitrate: 128
+  codec: AAC+
+  homepage: https://skyrock.fm/plm/
+  country: FR
+  status: stream-only
+  stationuuid: 51cd3357-11e6-4746-96ea-b56b4e6e5b8e
+  changeuuid: dc283d83-1b03-472e-b676-19684b9645e7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-oui-fm-rock-60-s
+  broadcaster: independent
+  name: "OUI FM ROCK 60's"
+  streamUrl: https://ouifmrock60s.ice.infomaniak.ch/ouifmsixties.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://bocir-prod-bucket.s3.eu-west-1.amazonaws.com/radios/oui-fm/images/favicon.ico
+  homepage: https://www.ouifm.fr/
+  country: FR
+  status: stream-only
+  stationuuid: cc4e4416-c0ce-4360-8488-ed9925136344
+  changeuuid: e0907655-94dc-483f-8ae8-f34f09490f54
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-virage-radio-metal
+  broadcaster: independent
+  name: Virage Radio Metal
+  streamUrl: https://virage-radio-metal.ice.infomaniak.ch/virage-radio-metal.aac?i=65804
+  bitrate: 64
+  codec: AAC+
+  favicon: https://www.virageradio.com/apple-touch-icon-120x120.png
+  homepage: https://www.virageradio.com/
+  country: FR
+  status: stream-only
+  stationuuid: d220916c-2d5c-48de-a785-b4a466ec790b
+  changeuuid: 9089b755-b2a2-47bb-8a83-9a2cb234c543
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-jazz-radio-blues
+  broadcaster: independent
+  name: JAZZ RADIO Blues
+  streamUrl: https://jazzblues.ice.infomaniak.ch/jazzblues-high.aac?i=77905
+  bitrate: 64
+  codec: AAC+
+  homepage: https://www.jazzradio.fr/radio/webradio/3/blues
+  country: FR
+  status: stream-only
+  stationuuid: d84f33bc-61d5-4b9f-9f5e-3a2b0d13fcd2
+  changeuuid: 0ca204ee-14c2-4ec9-a870-40ddb9bfe916
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-jazz-radio-jazz-fusion
+  broadcaster: independent
+  name: Jazz Radio Jazz Fusion
+  streamUrl: https://jazz-radio-fusion.ice.infomaniak.ch/jazz-radio-fusion.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.allzicradio.com/media/radios/jazzradio-1400x1400_fusion.png
+  homepage: https://www.jazzradio.fr/radio/webradio/43/afro-jazz
+  country: FR
+  status: stream-only
+  stationuuid: 7e27dacb-0faf-4213-a633-71e39c3bf395
+  changeuuid: c4fe1ac7-61c0-4282-b037-f4131fbe1ff9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-50-50
+  broadcaster: independent
+  name: Radio 50/50
+  streamUrl: https://stream.radio5050.com/
+  bitrate: 128
+  codec: AAC
+  favicon: https://www.radio5050.com/assets/img/favicons/apple-touch-icon.png
+  homepage: https://www.radio5050.com/
+  country: FR
+  status: stream-only
+  stationuuid: 0efe7505-f1e6-11e9-a96c-52543be04c81
+  changeuuid: 8a615456-4a01-4461-9965-4fa794a8c73e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-rva-radio
+  broadcaster: independent
+  name: RVA radio
+  streamUrl: https://rva.ice.infomaniak.ch/rva-high.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.radiorva.com/apple-touch-icon-120x120.png
+  homepage: https://www.radiorva.com/
+  country: FR
+  status: stream-only
+  stationuuid: 5f424682-5bce-11ea-be63-52543be04c81
+  changeuuid: 72dee637-880d-4933-8ccf-6a60a4942207
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-kohina
+  broadcaster: independent
+  name: Kohina
+  streamUrl: https://kohina.duckdns.org/icecast/stream.ogg
+  codec: OGG
+  homepage: http://www.kohina.com/
+  country: FR
+  status: stream-only
+  stationuuid: d04248fb-040c-11e9-a1be-52543be04c81
+  changeuuid: 06531829-bb0c-4819-8b15-6fbfa361c9cd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-galaxie-vintage
+  broadcaster: independent
+  name: Galaxie Vintage
+  streamUrl: https://www.radioking.com/play/galaxievintage
+  bitrate: 128
+  codec: MP3
+  favicon: http://galaxie-radio1.radio-website.com/upload/578f3bce151616.43092430.ico
+  homepage: http://galaxie-radio1.radio-website.com/
+  country: FR
+  status: stream-only
+  stationuuid: 9624d00b-0601-11e8-ae97-52543be04c81
+  changeuuid: 03f965f6-415a-4e76-9d6c-c8c0584292f1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-grenouille
+  broadcaster: independent
+  name: Radio grenouille
+  streamUrl: https://live.radiogrenouille.com:8443/live
+  bitrate: 256
+  codec: MP3
+  homepage: http://www.radiogrenouille.com/
+  country: FR
+  status: stream-only
+  stationuuid: e6639188-dc36-4441-ba83-4b6832a58c83
+  changeuuid: ec310776-19db-4013-a733-11cc937481ff
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-nova-reggae
+  broadcaster: independent
+  name: Nova Reggae
+  streamUrl: https://nova-reggae.ice.infomaniak.ch/nova-reggae-256.aac
+  bitrate: 256
+  codec: AAC
+  homepage: https://www.nova.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 244c5472-4df7-47f8-be34-b8d175ec973a
+  changeuuid: 3952da06-1623-4112-a1ef-09c7cd65ba7d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-alouette
+  broadcaster: independent
+  name: Alouette
+  streamUrl: https://alouette.ice.infomaniak.ch/alouette-high.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://bocir-prod-bucket.s3.amazonaws.com/radios/alouette/images/favicon.x-icon
+  homepage: http://www.alouette.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 0af72e12-050b-477e-bec9-ed7b5bcb56c6
+  changeuuid: e3228d8a-a56a-433e-bbe5-490f9fe9ff5d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-87-5-nantes
+  broadcaster: independent
+  name: "..87,5!. Nantes"
+  streamUrl: https://listen.radioking.com/radio/15130/stream/28217
+  bitrate: 128
+  codec: MP3
+  homepage: https://875naoned.wixsite.com/radio
+  country: FR
+  status: stream-only
+  stationuuid: 038c8fb4-6939-11e9-af37-52543be04c81
+  changeuuid: 75ad03b3-50a4-42e1-b366-c38fff9e56bc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-lyl-radio
+  broadcaster: independent
+  name: LYL Radio
+  streamUrl: https://icecast.lyl.live/live
+  bitrate: 192
+  codec: MP3
+  favicon: https://lyl.live/favicon.ico
+  homepage: https://lyl.live/
+  country: FR
+  status: stream-only
+  stationuuid: e11c170a-474f-11e9-aa55-52543be04c81
+  changeuuid: 5b24e9ac-b4f7-48c7-a073-3181aff9d8cc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-cinemusic-radio
+  broadcaster: independent
+  name: CINEMUSIC Radio
+  streamUrl: https://listen.radioking.com/radio/422/stream/62785
+  bitrate: 192
+  codec: MP3
+  favicon: https://cinemusicradio.com/upload/design/63b2a6080fdb31.87854813.png
+  homepage: https://cinemusic.fr/
+  country: FR
+  status: stream-only
+  stationuuid: dac522ea-640f-4e23-a90c-770e8cf7140f
+  changeuuid: e10e79cc-f2a9-4c64-a051-60c923c6f5e3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-galaxie-lounge
+  broadcaster: independent
+  name: Galaxie Lounge
+  streamUrl: https://listen.radioking.com/radio/45838/stream/82624
+  bitrate: 128
+  codec: MP3
+  favicon: http://galaxie-radio1.radio-website.com/upload/578f3bce151616.43092430.ico
+  homepage: http://galaxie-radio1.radio-website.com/
+  country: FR
+  status: stream-only
+  stationuuid: 9624d2d8-0601-11e8-ae97-52543be04c81
+  changeuuid: 52a82f57-733a-4965-8777-b37d576335c0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-rjr-radio-jeunes-reims-mp3-128k
+  broadcaster: independent
+  name: RJR - Radio Jeunes Reims (MP3 128k)
+  streamUrl: https://stream.rjrradio.fr/rjr.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.rjrradio.fr/sites/default/files/logo2016.png
+  homepage: https://www.rjrradio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 93151cc8-6953-11ea-b1cf-52543be04c81
+  changeuuid: 90ef50e1-0507-4184-acf4-dc8d2d65abf7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-sun-classique
+  broadcaster: independent
+  name: SUN Classique
+  streamUrl: https://diffusion.lafrap.fr/sun-classique.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.lesonunique.com/datasun/images_flux/logos/SD/classique.png
+  homepage: https://www.lesonunique.com/
+  country: FR
+  status: stream-only
+  stationuuid: 859ec680-93f3-4b6a-a7f8-4524e6df36b2
+  changeuuid: 5e1c41ff-ecf1-480a-b6f9-efbf135b39ed
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-europe-1-musique
+  broadcaster: independent
+  name: Europe 1 Musique
+  streamUrl: https://wr.lmn.fm/e1-wr5.aac?aw_0_1st.playerid=lgrdnwsRadioplayer
+  bitrate: 128
+  codec: AAC+
+  homepage: https://www.europe1.fr/culture/nouveau-ecoutez-europe-musique-4095053
+  country: FR
+  status: stream-only
+  stationuuid: b7fe3684-01b8-4ba3-a854-c1d823615882
+  changeuuid: 9710a748-dcf2-44bc-b704-ab83a1928226
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-meuh
+  broadcaster: independent
+  name: Radio Meuh
+  streamUrl: https://radiomeuh2.ice.infomaniak.ch/radiomeuh2-128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.radiomeuh.com/android-icon-192x192.png
+  homepage: https://www.radiomeuh.com/
+  country: FR
+  status: stream-only
+  stationuuid: d19052d9-963d-4559-98d2-ebd8337023cb
+  changeuuid: 7d34f32e-2948-4e3a-a880-a8f179a30a21
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-swigg
+  broadcaster: independent
+  name: Swigg
+  streamUrl: https://start-adofm.ice.infomaniak.ch/start-adofm-high.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://ecouter.lesindesradios.net/logos/orange4.png
+  homepage: https://www.swigg.fr/
+  country: FR
+  status: stream-only
+  stationuuid: ab95a200-992b-48b9-94b0-99464f1d7c78
+  changeuuid: 82838675-166e-441c-8dad-1026c9475c66
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radiogospel
+  broadcaster: independent
+  name: RadioGospel
+  streamUrl: https://d3m456gauclwb5.cloudfront.net/radiogospel_high
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.radiogospel.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 4cc78f5b-c30e-4648-984d-50bc813b3ad9
+  changeuuid: 62c3f6b5-bb71-467e-9b45-eddb9fdefb68
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-frequence-3-world-flac
+  broadcaster: independent
+  name: Fréquence 3 - World FLAC
+  streamUrl: https://frequence3.net-radio.fr/frequence3world.flac
+  bitrate: 128
+  codec: OGG
+  homepage: https://www.frequence3.com/
+  country: FR
+  status: stream-only
+  stationuuid: 46eb7347-e63c-49a2-80af-e7df471c9703
+  changeuuid: a1139adf-5506-422e-ac8d-e04b73552d71
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-hotel-costes
+  broadcaster: independent
+  name: Hotel Costes
+  streamUrl: https://s3.radio.co/s39c195d74/listen
+  bitrate: 192
+  codec: AAC
+  homepage: https://www.hotelcostes.com/en
+  country: FR
+  status: stream-only
+  stationuuid: fb87433e-2095-4c03-b411-ca0a0603ebcd
+  changeuuid: e6a9a651-fa42-4278-aad1-7185e72eb5dd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-pomme-d-api
+  broadcaster: independent
+  name: "Radio Pomme D'api"
+  streamUrl: https://www.radiopommedapi.com/radio.aac
+  bitrate: 128
+  codec: MP3
+  country: FR
+  status: stream-only
+  stationuuid: 71525423-1e57-11e9-a80b-52543be04c81
+  changeuuid: 4205828c-b929-4501-b2cc-afc31725928f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-kizrock-metal
+  broadcaster: independent
+  name: Kizrock Métal
+  streamUrl: https://go.2stream.net/kizrock_metal
+  bitrate: 128
+  codec: MP3
+  homepage: https://kizrock.com/
+  country: FR
+  status: stream-only
+  stationuuid: 45a5ab73-ccd5-4e2e-9e9e-3c0895e2e95a
+  changeuuid: 720cd47e-42ad-4959-9739-e3c846ebeb3d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-nrj-hits
+  broadcaster: independent
+  name: Nrj Hits
+  streamUrl: https://streaming.nrjaudio.fm/ou7xugf3s5gi?origine=playernrj&aw_0_req.userConsentV2=&aw_0_1st.station=NRJ-Hits
+  bitrate: 128
+  codec: AAC+
+  favicon: https://img.nrj.fr/8loJFyDgG_Gm_fgnk1fhkYIewhI=/medias%2F2021%2F06%2Flogo-nrj_60db2627d4729.svg
+  homepage: https://www.nrj.fr/webradios/mur-des-radios/nrj-hits
+  country: FR
+  status: stream-only
+  stationuuid: 36eba167-5c51-4421-98f0-d2cda24be928
+  changeuuid: 30289b28-438e-485f-8f7b-55e43b37404d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-oui-fm-acoustic
+  broadcaster: independent
+  name: OUI FM ACOUSTIC
+  streamUrl: https://ouifmacoustic.ice.infomaniak.ch/ouifmacoustic.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://bocir-prod-bucket.s3.amazonaws.com/radios/oui-fm/radiostream/NSzUtv6XGF/vignette.png
+  homepage: https://www.ouifm.fr/
+  country: FR
+  status: stream-only
+  stationuuid: bdd8838b-c054-4399-9fc5-2105aac45f39
+  changeuuid: c8bb8d25-4925-44e9-a4d2-b73ca92dc7a8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-france-bleu-100-chanson-francaise
+  broadcaster: independent
+  name: "France Bleu 100% chanson française "
+  streamUrl: https://icecast.radiofrance.fr/fbchansonfrancaise-midfi.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.francebleu.fr/favicons/apple-touch-icon-180x180.png
+  homepage: https://www.francebleu.fr/radio-chanson-francaise
+  country: FR
+  status: stream-only
+  stationuuid: 3526f94b-d456-4370-96a1-8bdfc6f27090
+  changeuuid: 16cbf5f4-b8aa-45a1-8eae-c66fd7b5837e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-ici-maintenant
+  broadcaster: independent
+  name: "Radio Ici & Maintenant"
+  streamUrl: https://s64.radiolize.com/radio/8090/radio.mp3
+  bitrate: 64
+  codec: AAC
+  favicon: https://fr.wikipedia.org/wiki/Ici_et_Maintenant_!#/media/Fichier:RIM.jpg
+  homepage: https://didierdeplaige.com/
+  country: FR
+  status: stream-only
+  stationuuid: 81a41011-330f-46b3-be46-a10cf8cdc3b0
+  changeuuid: 1dca7777-7cae-4524-8d43-d7f1fa371ab1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-crooner-radio
+  broadcaster: independent
+  name: Crooner Radio
+  streamUrl: https://direct.croonerradio.fr/croonerradio-midfi.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.croonerradio.fr/favicon.ico
+  homepage: https://www.croonerradio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: efedae79-7cd7-43c0-ad23-a149466efec8
+  changeuuid: 8449555b-4070-486e-a13b-52555527a2f5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-opensky-flac-868kb
+  broadcaster: independent
+  name: Opensky (flac)868kb
+  streamUrl: https://audio.opensky.radio:8082/flac?_res_tag_=audio
+  codec: OGG
+  favicon: null
+  homepage: https://opensky.radio/
+  country: FR
+  status: stream-only
+  stationuuid: 697be853-6f4a-461b-ac11-5edc34cd08f4
+  changeuuid: 671cd2f9-0543-4742-976c-cea986044724
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-virage-radio-legendes-du-rock
+  broadcaster: independent
+  name: Virage Radio Légendes du Rock
+  streamUrl: https://virage-radio-legende-du-rock.ice.infomaniak.ch/virage-radio-legende-du-rock.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://www.virageradio.com/media/radio/thumb/150x150_61e543e1c1713-virage-legendes-plan-de-travail-1.webp
+  homepage: https://www.virageradio.com/radio/webradio/1/virage-radio
+  country: FR
+  status: stream-only
+  stationuuid: 9dcbee15-ce91-4656-9760-925e480e86d3
+  changeuuid: 2f99a69c-9f52-4a2a-bdcc-606660d2bd10
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-douce-france
+  broadcaster: independent
+  name: Douce France
+  streamUrl: https://stream.chantefrance.com/Chante_France.aac
+  bitrate: 96
+  codec: AAC+
+  favicon: https://doucefrance.radio/favicon.ico
+  homepage: https://doucefrance.radio/
+  country: FR
+  status: stream-only
+  stationuuid: bdeb9265-efe5-47c6-bded-33233e8fe044
+  changeuuid: 1a87a209-10f1-4404-ad5e-e45a8bf575f1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-superloustic
+  broadcaster: independent
+  name: Superloustic
+  streamUrl: https://www.superloustic.com/listen
+  bitrate: 320
+  codec: MP3
+  favicon: https://i0.wp.com/www.superloustic.com/wp-content/uploads/logo500-2-.png?fit=180%2c180&#038;ssl=1
+  homepage: https://www.superloustic.com/
+  country: FR
+  status: stream-only
+  stationuuid: 966fd838-473a-11e9-aa55-52543be04c81
+  changeuuid: 87a1f2c7-1220-4a08-91c8-49efd3b1bf8b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-europe-2-hits
+  broadcaster: independent
+  name: Europe 2 Hits
+  streamUrl: https://europe2.lmn.fm/vr-wr4.mp3?aw_0_1st.playerid=lagardereappVirgin
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.europe2.fr/webradios
+  country: FR
+  status: stream-only
+  stationuuid: b5cde5d0-5b6c-41aa-90de-ed54bd311c11
+  changeuuid: f26d0a63-40fa-4c13-988f-8006219dea00
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-italienne-de-grenoble
+  broadcaster: independent
+  name: Radio Italienne de Grenoble
+  streamUrl: https://listen.radioking.com/radio/204517/stream/247270
+  bitrate: 128
+  codec: MP3
+  homepage: https://radioitaliennegrenoble.fr/
+  country: FR
+  status: stream-only
+  stationuuid: bcb612df-ce26-11e9-8502-52543be04c81
+  changeuuid: cd786411-3702-4ab1-b493-89e58d9c046e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-wave-radio-89-8-hossegor
+  broadcaster: independent
+  name: WAVE RADIO 89.8 Hossegor
+  streamUrl: https://s34.myradiostream.com/12340/listen.mp3
+  bitrate: 160
+  codec: MP3
+  favicon: https://waveradio.fm/wp-content/themes/waveradio/img/favicons/apple-icon-120x120.png
+  homepage: https://waveradio.fm/
+  country: FR
+  status: stream-only
+  stationuuid: 45095bd5-633f-4673-8476-9d4ab889ad90
+  changeuuid: beec9b6b-4a53-4508-9e18-4ba9ef96e30e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-krimi
+  broadcaster: independent
+  name: Radio Krimi
+  streamUrl: https://radio13.pro-fhi.net/flux-nwsimjda2/stream
+  bitrate: 320
+  codec: MP3
+  homepage: http://www.radiokrimi.com/
+  country: FR
+  status: stream-only
+  stationuuid: 247a9f2b-6deb-40ae-b130-59dc12c82f59
+  changeuuid: 79b8ea53-2d18-4241-81b2-c87a5c0243a3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-frequence-3-urban-flac
+  broadcaster: independent
+  name: Fréquence 3 Urban FLAC
+  streamUrl: https://frequence3.net-radio.fr/frequence3urban.flac
+  bitrate: 128
+  codec: OGG
+  homepage: https://www.frequence3.com/les-radios-frequence-3/urban/
+  country: FR
+  status: stream-only
+  stationuuid: b5c3c88f-cef2-43cb-87f6-2c57d81c1827
+  changeuuid: 01ed5481-48db-44f4-8742-8777448558b2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-europe-2-happy-rock-hours
+  broadcaster: independent
+  name: Europe 2 Happy Rock Hours
+  streamUrl: https://europe2.lmn.fm/vr-wr5.mp3?aw_0_1st.playerid=lagardereappVirgin
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.europe2.fr/wp-content/themes/melty/europeradio/assets/images/radio/radio_2005.png
+  homepage: https://www.europe2.fr/webradios
+  country: FR
+  status: stream-only
+  stationuuid: 01899f00-cbe9-46bc-85ee-e7bfe6496f97
+  changeuuid: 7ef6c0fa-1b76-4cf6-8e5d-35d311d87c17
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-barbouillots
+  broadcaster: independent
+  name: Radio Barbouillots
+  streamUrl: https://stream.rcvfm.fr:8000/barbouillots-192k.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://radiobarbouillots.com/__ovh/common/img/favicon.ico
+  homepage: https://radiobarbouillots.com/
+  country: FR
+  status: stream-only
+  stationuuid: 7f4f0e83-b1c5-4009-b53b-cda0f9bb3d19
+  changeuuid: ab3a5dd5-09d1-49ff-b567-1ba80fe15bfd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-lyon-1ere
+  broadcaster: independent
+  name: Lyon 1ère
+  streamUrl: https://lyon1ere.ice.infomaniak.ch/lyon1ere-high.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: http://i2.cdn-image.com/__media__/pics/468/netsol-favicon-2020.jpg
+  homepage: http://www.lyonpremiere.com/
+  country: FR
+  status: stream-only
+  stationuuid: 960868b5-0601-11e8-ae97-52543be04c81
+  changeuuid: ea7587b8-256f-4e81-9192-675a6ebe16ff
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-m40-generation-do
+  broadcaster: independent
+  name: M40 Génération Do
+  streamUrl: https://live.m40radio.fr/listen/m40-generation-do/m40-generation-do-128.mp3
+  bitrate: 128
+  codec: AAC
+  favicon: https://cdn.m40radio.fr/wp-content/uploads/radio-m40-generation-do-370x370.webp
+  homepage: https://m40radio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 835f13e2-3a7e-4d2c-b5d1-367fab894688
+  changeuuid: b9905773-bebd-4a25-9c74-5c0e13ea9664
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-jazz-radio-lounge
+  broadcaster: independent
+  name: Jazz Radio Lounge
+  streamUrl: https://jazzlounge.ice.infomaniak.ch/jazzlounge-high.aac?i=57064
+  bitrate: 64
+  codec: AAC+
+  homepage: https://www.jazzradio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: f9ed3148-8c92-4d52-9faf-df953e2de074
+  changeuuid: f842c0d2-27df-484b-b596-9639adca297b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-africa-radio-naija-webradio
+  broadcaster: independent
+  name: Africa Radio Naija Webradio
+  streamUrl: https://webradio1.ice.infomaniak.ch/webradio3-128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://images.lesindesradios.fr/fit-in/300x2000/filters:format(webp)/radios/africaradio/radiostream/QP0HYlUIr3/vignette.png
+  homepage: https://www.africaradio.com/
+  country: FR
+  status: stream-only
+  stationuuid: c84fa9f3-7d48-4909-9de7-206c810577d4
+  changeuuid: 6fd12abc-f84c-42eb-ad35-87c890b71c19
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-girl-power
+  broadcaster: independent
+  name: Girl Power
+  streamUrl: https://scoopgirls.ice.infomaniak.ch/radioscoop-girls-64.aac
+  bitrate: 64
+  codec: AAC+
+  homepage: http://www.radioscoop.com/
+  country: FR
+  status: stream-only
+  stationuuid: 59b761cf-67cd-4e6d-a4a4-2e13cf42ff07
+  changeuuid: eb90a1ad-4841-438e-8900-fa2a831eebd0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-starsystem-fm-max
+  broadcaster: independent
+  name: Starsystem FM (MAX)
+  streamUrl: https://radiosurle.net:8765/starsystemfm
+  bitrate: 96
+  codec: MP3
+  homepage: https://radiosurle.net/
+  country: FR
+  status: stream-only
+  stationuuid: adda58fa-85c7-44f6-b146-61336dfc7dc4
+  changeuuid: 5c804b0b-9c81-4d94-a509-e9ce0301147e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-le-grigri
+  broadcaster: independent
+  name: Le Grigri
+  streamUrl: https://www.radioking.com/play/legrigri/273715
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.le-grigri.com/favicon.ico
+  homepage: https://www.le-grigri.com/
+  country: FR
+  status: stream-only
+  stationuuid: d8104a4f-865d-438a-92c1-2ac2442459cf
+  changeuuid: 62b3e752-a91b-4606-bea3-619d90853703
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-esperance-en-marie
+  broadcaster: independent
+  name: Radio Espérance En Marie
+  streamUrl: https://esperance.streamakaci.com/aufil.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: http://radio-esperance.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 960e74d4-0601-11e8-ae97-52543be04c81
+  changeuuid: d777130d-410c-4328-9228-9e7d6a0781fc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-1-splash-jazz
+  broadcaster: independent
+  name: "#1 Splash Jazz"
+  streamUrl: https://ais-sa2.cdnstream1.com/2346_128.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.splashradio.eu/
+  country: FR
+  status: stream-only
+  stationuuid: 378e44cb-c6be-445e-bcd9-dd6c4fdbd0eb
+  changeuuid: d05ce7a4-7ee2-4274-9c3f-395a90cebf5c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-africa-radio-abidjan-webradio
+  broadcaster: independent
+  name: Africa Radio Abidjan Webradio
+  streamUrl: https://africaradio.ice.infomaniak.ch/abidjan128.mp3
+  bitrate: 96
+  codec: MP3
+  favicon: https://images.lesindesradios.fr/fit-in/300x2000/filters:format(webp)/radios/africaradio/radiostream/4D9oGPMZbK/vignette_CL9ZJm8Vsg.png
+  homepage: https://www.africaradio.com/
+  country: FR
+  status: stream-only
+  stationuuid: c7d3432b-af45-4f58-b2c3-99dcf36dce45
+  changeuuid: 82ce9014-9797-4a4d-b0f7-7c55117fb2be
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-rinse-france
+  broadcaster: independent
+  name: Rinse France
+  streamUrl: https://radio10.pro-fhi.net/radio/9041/stream
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.rinse.fm/channels/france/
+  country: FR
+  status: stream-only
+  stationuuid: 6b5b7e02-c21a-4fdc-ab01-53d775502f6d
+  changeuuid: 4c0f8c50-021a-4012-bf05-08aa4269aabf
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-roots-legacy-radio
+  broadcaster: independent
+  name: Roots Legacy Radio
+  streamUrl: https://l.rootslegacy.fr/;
+  bitrate: 224
+  codec: MP3
+  favicon: https://www.rootslegacy.fr/images/logo.webp
+  homepage: https://www.rootslegacy.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 7cc4e7b5-8ba9-4da9-a406-43c1b2df2748
+  changeuuid: 0ad5cbff-eb86-43fa-8358-5a586cff62ad
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-yumi-co-radio
+  broadcaster: independent
+  name: Yumi Co. Radio
+  streamUrl: https://yumicoradio.net/stream
+  bitrate: 256
+  codec: MP3
+  favicon: https://i.imgur.com/cVC439t.png
+  homepage: https://yumicoradio.net/
+  country: FR
+  status: stream-only
+  stationuuid: 74884688-e3a7-41f8-8105-bc249a37963e
+  changeuuid: 84a625c0-be79-4f93-8299-d6329f91182d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-allzic-radio-rock-fm
+  broadcaster: independent
+  name: Allzic Radio Rock FM
+  streamUrl: https://allzic17.ice.infomaniak.ch/allzic17.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.allzicradio.com/favicon.ico
+  homepage: https://www.allzicradio.com/fr/player/listen/1087/allzic-radio-rock-fm
+  country: FR
+  status: stream-only
+  stationuuid: 691dc4a7-e42a-407c-a05f-cc23599e34bb
+  changeuuid: 8709d8be-6f2d-495b-bb80-494fb9c558a2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-oui-fm-girls-rock
+  broadcaster: independent
+  name: OUI FM GIRLS ROCK
+  streamUrl: https://ouifmgirlsrock.ice.infomaniak.ch/ouifmgirlsrock.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://bocir-prod-bucket.s3.eu-west-1.amazonaws.com/radios/oui-fm/images/favicon.ico
+  homepage: https://www.ouifm.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 5362a6d8-5ac5-4433-98e7-f3711809fb34
+  changeuuid: 561d6f4d-abbd-4299-8766-27becbd0e164
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-blues-cafe-radio
+  broadcaster: independent
+  name: Blues Café Radio
+  streamUrl: https://manager4.streamradio.fr/bluescaferadio?x=1693763714913
+  bitrate: 192
+  codec: MP3
+  favicon: https://cdn.onlineradiobox.com/img/l/8/73528.v11.png
+  homepage: https://bluesactu.wixsite.com/bluescaferadio
+  country: FR
+  status: stream-only
+  stationuuid: d7c359ff-97c7-480c-b1c2-70641ad3d2ea
+  changeuuid: c6f1bc49-9e80-4a2b-853e-fe2e1aea68fb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-oui-fm-rock-francais
+  broadcaster: independent
+  name: OUI FM ROCK FRANCAIS
+  streamUrl: https://ouifmrockfrancais.ice.infomaniak.ch/ouifmrockfrancais.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://bocir-prod-bucket.s3.amazonaws.com/radios/oui-fm/radiostream/3fkpVzB8Cc/vignette.png
+  homepage: https://www.ouifm.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 58dab9ac-8bd1-4059-96c3-d2d48f84ec49
+  changeuuid: ab49a99c-dda0-4837-8bcb-9b2d26d35e17
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-yiddish-pour-tous
+  broadcaster: independent
+  name: Yiddish pour tous
+  streamUrl: https://www.radioking.com/play/radio-yiddish-pour-tous
+  bitrate: 128
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/b8f8f5_53a68559e3164f088e45f9f66f18954d%7Emv2.png/v1/fill/w_32%2Ch_32%2Clg_1%2Cusm_0.66_1.00_0.01/b8f8f5_53a68559e3164f088e45f9f66f18954d%7Emv2.png
+  homepage: https://www.yiddishpourtous.com/
+  country: FR
+  status: stream-only
+  stationuuid: 67aac61f-1417-11e9-a80b-52543be04c81
+  changeuuid: 3879fe54-5d0a-43bc-b686-2b0adcabe43e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-algorythme-lounge-bossa
+  broadcaster: independent
+  name: "Algorythme Lounge & Bossa"
+  streamUrl: https://radio8.pro-fhi.net/flux-sinllzly/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.algorythmeradio.com/assets/images/icon-algo.ico
+  homepage: https://www.algorythmeradio.com/
+  country: FR
+  status: stream-only
+  stationuuid: 9c82f49e-0c88-4a36-a938-3c092f27531f
+  changeuuid: 8934b928-8be6-487f-a13d-40d7ec056804
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-guadeloupe-france-television
+  broadcaster: independent
+  name: Guadeloupe France Télévision
+  streamUrl: https://guadeloupe.ice.infomaniak.ch/guadeloupe-128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://s1.wp.com/i/favicon.ico
+  homepage: https://caribshebdo.wordpress.com/2020/03/30/guadeloupe-1ere-radio-live/
+  country: FR
+  status: stream-only
+  stationuuid: 3a140fb2-9e3e-4e21-9609-1170bb2e255b
+  changeuuid: 537600ee-4519-434b-8221-5430d9fe5995
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-soul-radio-classics
+  broadcaster: independent
+  name: SOUL RADIO Classics
+  streamUrl: https://listen.soulradio.eu/eu
+  bitrate: 192
+  codec: AAC+
+  homepage: https://soulradio.eu/
+  country: FR
+  status: stream-only
+  stationuuid: b83f7d3a-3ab2-47c2-9860-8941488cfced
+  changeuuid: d88f0ba9-e978-4f95-81f7-6c243cce7c02
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-made-in-80
+  broadcaster: independent
+  name: Made in 80
+  streamUrl: https://madein80.leswebradios.fr/
+  bitrate: 192
+  codec: MP3
+  favicon: https://madein80.fr/wp-content/uploads/2020/12/Logo-Made-in-80-V2-blanc-400-ssslog.png
+  homepage: https://madein80.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 766f2be3-676f-40af-80e7-eab16f0da225
+  changeuuid: 9570cf1d-a52f-41d8-bfb5-827aa8bb6021
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-modular-station
+  broadcaster: independent
+  name: Modular-Station
+  streamUrl: https://broadcast.modular-station.com/radio/8000/radio.aac
+  bitrate: 192
+  codec: AAC
+  favicon: https://modular-station.com/app/themes/modular-station/dist/images/modular-station-192_3bcbc4e6.png
+  homepage: https://modular-station.com/
+  country: FR
+  status: stream-only
+  stationuuid: 9a4fe10d-7a27-47ac-bedf-f3253fd3bf9d
+  changeuuid: 2322536d-d9ee-4f48-94ee-33319efa27fb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-heavy1
+  broadcaster: independent
+  name: Heavy1
+  streamUrl: https://listen.radioking.com/radio/119653/stream/159127
+  bitrate: 320
+  codec: MP3
+  favicon: https://static.mytuner.mobi/media/tvos_radios/sdapkvmjcrmh.jpg
+  homepage: https://www.heavy1.radio/
+  country: FR
+  status: stream-only
+  stationuuid: e389696c-5217-43d3-aa41-bc3c5b52f049
+  changeuuid: c6b8d2c3-4d3b-4602-b004-9bb1845349a1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-le-poste-parisien
+  broadcaster: independent
+  name: "Le poste parisien "
+  streamUrl: https://stream10.xdevel.com/audio12s976748-1798/stream/icecast.audio
+  codec: AAC+
+  favicon: https://static.wixstatic.com/media/8f2aad_f34c5a8400a54644a8d1c5845b03ce35~mv2.png/v1/fill/w_360,h_128,al_c,q_85,usm_0.66_1.00_0.01,enc_auto/8f2aad_f34c5a8400a54644a8d1c5845b03ce35~mv2.png
+  homepage: https://www.posteparisien.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 8dfec44a-f1f9-4e73-807e-2ab9e4bfb414
+  changeuuid: b089c1fd-3c8b-4c7b-bcfa-40c5859bc745
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-jazz-saxo
+  broadcaster: independent
+  name: Jazz Saxo
+  streamUrl: https://jzr-saxo.ice.infomaniak.ch/jzr-saxo.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.jazzradio.fr/media/radio/thumb/180x180_lounge.webp
+  homepage: https://www.jazzradio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: a04b0aa4-f68a-42f4-96d9-a4f51050ca8a
+  changeuuid: efae16c9-3056-4a46-9e8b-9c294396bd2b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-oui-fm-woodstock
+  broadcaster: independent
+  name: OUI FM WOODSTOCK
+  streamUrl: https://ouifmwoodstock.ice.infomaniak.ch/ouifmwoodstock.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://bocir-prod-bucket.s3.amazonaws.com/radios/oui-fm/radiostream/xD29y7pjPX/vignette.png
+  homepage: https://www.ouifm.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 361112dd-f9cf-4a08-86ad-c26ff48ba890
+  changeuuid: 9877bddf-09ea-4473-a108-05f24d0b5d0f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-tsfjazz
+  broadcaster: independent
+  name: TSFJazz
+  streamUrl: https://tsfjazz.ice.infomaniak.ch/tsfjazz-high.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.tsfjazz.com/
+  country: FR
+  status: stream-only
+  stationuuid: f7ec0780-18bf-4c57-a97d-651a9eed0cb0
+  changeuuid: da1529c0-2525-47bc-aeff-cd6c27426192
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-jazz-only-women
+  broadcaster: independent
+  name: Jazz Only Women
+  streamUrl: https://jazz-wr16.ice.infomaniak.ch/jazz-wr16-128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.jazzradio.fr/media/radio/thumb/180x180_only-women.webp
+  homepage: https://www.jazzradio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 1e78e9b8-f8d1-4364-9085-04ab15677607
+  changeuuid: 0f60fa8a-d843-4e0e-85bd-ea8e2065273f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-brony
+  broadcaster: independent
+  name: Radio Brony
+  streamUrl: https://radio.radiobrony.fr/mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://radiobrony.fr/img/icons/bwavatar-details.png
+  homepage: https://radiobrony.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 7afe45d4-0227-11ea-bbf2-52543be04c81
+  changeuuid: f43e88f7-c485-443e-a48f-8ac02bb793f6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-brony-ogg
+  broadcaster: independent
+  name: Radio Brony (OGG)
+  streamUrl: https://radio.radiobrony.fr/ogg
+  codec: OGG
+  favicon: https://radiobrony.fr/img/icons/bwavatar-details.png
+  homepage: https://radiobrony.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 35eab8a2-b5ad-449e-8e4d-98725ffd727d
+  changeuuid: b3266e17-c2fb-4a06-86e9-9e3519c99d40
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-jazz-classic
+  broadcaster: independent
+  name: Jazz Classic
+  streamUrl: https://jazz-wr01.ice.infomaniak.ch/jazz-wr01-128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.jazzradio.fr/media/radio/thumb/180x180_classic-jazz.webp
+  homepage: https://www.jazzradio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 7c3f0830-a2b8-4f8b-a24d-b0ea95f33122
+  changeuuid: 76499e60-9766-429a-8949-66f828f48fef
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-le-grigri-radio-porte-bonheur
+  broadcaster: independent
+  name: "Le Grigri, radio porte-bonheur"
+  streamUrl: https://listen.radioking.com/radio/139090/stream/179170
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.le-grigri.com/
+  country: FR
+  status: stream-only
+  stationuuid: 7eddd7dd-c32a-46f9-8a2f-5a430299c370
+  changeuuid: 4875f614-df54-43fd-89a1-43f7a8f505b1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-brume
+  broadcaster: independent
+  name: radio brume
+  streamUrl: https://www.radioking.com/play/brume-campus-lyon/546695
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.radiobrume.fr/
+  country: FR
+  status: stream-only
+  stationuuid: af43998d-ff18-4bd0-b075-8574545a9509
+  changeuuid: 5157c4f3-bb62-4959-aa25-ffc4550d1881
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-positively-meditation
+  broadcaster: independent
+  name: 📻 Positively Meditation
+  streamUrl: https://streaming.positivity.radio/pr/posimeditation/icecast.audio
+  codec: MP3
+  favicon: https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEgtmuQxXsk4FaNYHUD5IPcExKD0y4EU8OU1rSzpdaIrX-0CrYddUFVaGixVG6WJDz7A5EYjo_UbJ-DSt56f9J5Z0rK4O_JhDCrH2nkc6BViZLmpa9gwh3ZUzyHavUE2Buz_DVrLMbwBX_VKxqxrDLCgV11NeUZmxbI4MTZ0KSkjhoWAePu_j2xXVuhTRA/s1600/Capture%20d%E2%80%99%C3%A9cran_2024-12-19_16-17-59.png
+  homepage: https://multimedias.karibshebdo.info/radios-web/positively-meditation
+  country: FR
+  status: stream-only
+  stationuuid: 33e9106b-aef2-400e-9e50-2281aa341d67
+  changeuuid: 406a477f-aaba-4a7b-b5de-ec78be7d7528
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-africa-radio-coupe-decale-webradio
+  broadcaster: independent
+  name: Africa Radio Coupé Decalé Webradio
+  streamUrl: https://webradio1.ice.infomaniak.ch/webradio1-128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://images.lesindesradios.fr/fit-in/300x2000/filters:format(webp)/radios/africaradio/radiostream/CkIE3S769N/vignette.png
+  homepage: https://www.africaradio.com/
+  country: FR
+  status: stream-only
+  stationuuid: 3cda5ab9-521c-4609-aeda-cd6e80992d04
+  changeuuid: c331966c-627f-4daf-808d-504edafea9c5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-reggae-mix-station
+  broadcaster: independent
+  name: Reggae Mix Station
+  streamUrl: https://france1.coollabel-productions.com/proxy/reggaemix340/stream
+  bitrate: 192
+  codec: MP3
+  favicon: http://www.reggaemixstation.com/templates/rsjuno/favicon.ico
+  homepage: http://www.reggaemixstation.com/
+  country: FR
+  status: stream-only
+  stationuuid: 729b0821-5729-48a1-a469-80138fc0dda4
+  changeuuid: fe4ad2b7-96fc-41f7-a88b-3d3cc3b821fd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-jazzradio-fr-jazz-cinema
+  broadcaster: independent
+  name: "Jazzradio.fr Jazz & Cinema"
+  streamUrl: https://jzr-wr20.ice.infomaniak.ch/jzr-wr20.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.jazzradio.fr/apple-touch-icon-120x120.png
+  homepage: https://www.jazzradio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 23a0da86-22d9-4d53-a45e-710974c0c398
+  changeuuid: bcb5e419-39e1-42e0-af39-f35033ee5e00
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-hits-1
+  broadcaster: independent
+  name: Hits 1
+  streamUrl: https://radio12.pro-fhi.net/live/Hits%201%20radio
+  bitrate: 256
+  codec: MP3
+  favicon: https://www.hits1radio.com/wp-content/uploads/2019/03/cropped-1024-5-180x180.png
+  homepage: https://www.hits1radio.com/
+  country: FR
+  status: stream-only
+  stationuuid: 68c6f990-7d00-4c8f-b2a8-5d396884ad96
+  changeuuid: 4678f042-6bda-4896-8977-18d3b83272b5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-broussaille
+  broadcaster: independent
+  name: Radio Broussaille
+  streamUrl: https://stream.radiobroussaille.fr:8443/broussaille-hifi
+  bitrate: 320
+  codec: AAC
+  favicon: https://stream.radiobroussaille.fr:8443/favicon-32x32.png
+  homepage: https://radiobroussaille.fr/
+  country: FR
+  status: stream-only
+  stationuuid: e2463686-5185-44b5-bc98-1fb63a929600
+  changeuuid: 658d6ccc-4514-41ce-a9e0-8354e331d94e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-larzac
+  broadcaster: independent
+  name: Radio Larzac
+  streamUrl: https://stream.radiolarzac.org/hls/master.m3u8
+  bitrate: 320
+  codec: UNKNOWN
+  favicon: https://www.radiolarzac.org/wp-content/uploads/2019/01/Petit-logo-couleurs-sans-fond.png
+  homepage: https://radiolarzac.org/
+  country: FR
+  status: stream-only
+  stationuuid: 493ee67f-c366-46e0-b9c9-97fdbdfb5b07
+  changeuuid: 3fad48bb-f83b-4881-ac05-5b1ae73516c7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-rtl-100-france
+  broadcaster: independent
+  name: "RTL 100% FRANCE"
+  streamUrl: https://live.m6radio.quortex.io/webpHJPXnXrN7B6J7Q8mcqmxP/webradio/rtl100pc80/130/audio-64000/index.m3u8
+  bitrate: 64
+  codec: AAC
+  favicon: https://images.rtl.fr/~c/300v300/rtl/www/1374199-100-webradio-2800x2800.jpg
+  homepage: https://www.rtl.fr/radios
+  country: FR
+  status: stream-only
+  stationuuid: a69f62bf-2d0d-4d75-8d9a-a7d4e97c72e1
+  changeuuid: e1ed5141-d9f9-4894-a27b-1be531f609ca
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-frequence-3-dance
+  broadcaster: independent
+  name: Fréquence 3 Dance
+  streamUrl: https://frequence3.net-radio.fr/frequence3dance.mp3
+  bitrate: 160
+  codec: MP3
+  homepage: https://www.frequence3.com/
+  country: FR
+  status: stream-only
+  stationuuid: ebe1b024-1ed2-4dca-a22c-77eac95ef612
+  changeuuid: c48d6cff-b3f2-4e00-9a64-9559a1f0d07d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-jazz-manouche
+  broadcaster: independent
+  name: Jazz Manouche
+  streamUrl: https://jazz-wr02.ice.infomaniak.ch/jazz-wr02-128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.jazzradio.fr/media/radio/thumb/180x180_jazz-manouche.webp
+  homepage: https://www.jazzradio.fr/radio/webradio/10/jazz-manouche
+  country: FR
+  status: stream-only
+  stationuuid: f55f47d1-355b-4265-a92b-1f573c34fb17
+  changeuuid: 1046288e-a53f-4c48-aa9b-ab892079aa45
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-doudou
+  broadcaster: independent
+  name: Radio Doudou
+  streamUrl: https://listen.radioking.com/radio/11565/stream/22961
+  bitrate: 128
+  codec: MP3
+  favicon: http://radiodoudou.com/upload/52f8cc26745829.05897109.ico
+  homepage: http://radiodoudou.com/
+  country: FR
+  status: stream-only
+  stationuuid: c31f994e-6669-11e8-b15b-52543be04c81
+  changeuuid: fb25b6e2-f2e4-4241-bf2d-c2eceea2b2f1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-rbs
+  broadcaster: independent
+  name: Radio RBS
+  streamUrl: https://www.radioking.com/play/radio-rbs-1
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.radiorbs.com/app/themes/rbs/build/images/favicon/apple-touch-icon.png
+  homepage: https://www.radiorbs.com/
+  country: FR
+  status: stream-only
+  stationuuid: 16e673e4-ffa0-11e8-a1be-52543be04c81
+  changeuuid: e3136757-81e2-4173-b6eb-1e5bbc2c43ba
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-alternative-radio-hd
+  broadcaster: independent
+  name: Alternative Radio HD
+  streamUrl: https://www.radioking.com/play/alternative-radio-1/224215
+  bitrate: 320
+  codec: MP3
+  country: FR
+  status: stream-only
+  stationuuid: 9021457c-696d-43d1-8da0-915e50f48cbf
+  changeuuid: a1be1a7b-be06-40e5-8969-9573eaaa21cf
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-les-inrocks-radio
+  broadcaster: independent
+  name: Les Inrocks Radio
+  streamUrl: https://inrocksradio.ice.infomaniak.ch/inrocksradio-128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.lesinrocks.com/wp-content/thumbnails/uploads/2021/02/Inrockuptibles-10-t-400x496.gif
+  homepage: https://www.lesinrocks.com/radios/les-inrocks-radio/
+  country: FR
+  status: stream-only
+  stationuuid: efc58a9b-7d2c-4f07-a8a2-a3c3f3893d0b
+  changeuuid: 4e0f7381-c43a-4d61-9fc3-e419262c9823
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-phare-fm-france
+  broadcaster: independent
+  name: PHARE FM FRANCE
+  streamUrl: https://str0.creacast.com/pharefm
+  bitrate: 128
+  codec: MP3
+  favicon: https://static.mytuner.mobi/media/tvos_radios/FbDDtBn6v5.png
+  homepage: https://pharefm.com/
+  country: FR
+  status: stream-only
+  stationuuid: a5f8cc5b-f99c-4828-869b-bc3d84f1a80f
+  changeuuid: 39f98d48-6872-4bae-9d9b-36c70df5b6eb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-blagues-courtes
+  broadcaster: independent
+  name: bLaGuEs cOuRtEs
+  streamUrl: https://radio.blagues-courtes.fr/stream
+  codec: MP3
+  homepage: https://blagues-courtes.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 71d33fae-e022-4a2f-954b-8d556a08d4ae
+  changeuuid: 55ea3bc4-efe4-4068-9746-843dfe6f2e3a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-sun-soul-funk
+  broadcaster: independent
+  name: "SUN Soul & Funk"
+  streamUrl: https://diffusion.lafrap.fr/sun-soul.funk.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.lesonunique.com/datasun/images_flux/logos/HD/soulandfunk.png
+  homepage: https://www.lesonunique.com/
+  country: FR
+  status: stream-only
+  stationuuid: e5df2775-8ae3-4c76-a5e5-c7c3d5c50eda
+  changeuuid: 1cc0b3ab-d8f7-450a-a511-a008cbe49421
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-aioli-radio
+  broadcaster: independent
+  name: Aïoli Radio
+  streamUrl: https://stream.aioli-radio.org/main.ogg
+  codec: OGG
+  favicon: https://www.aioli-radio.org/icons/icon-144x144.png?v=1fcb4097b832c16b2996c0ec84a6fd0e
+  homepage: https://www.aioli-radio.org/
+  country: FR
+  status: stream-only
+  stationuuid: c9ec53fe-004b-48dd-8bec-27f339092a22
+  changeuuid: 4597a463-4950-44ce-9f33-56865b1a9bdf
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-ici-100-chanson-francaise
+  broadcaster: independent
+  name: "ICI 100% Chanson française"
+  streamUrl: https://icecast.radiofrance.fr/fbchansonfrancaise-hifi.aac
+  bitrate: 192
+  codec: AAC
+  favicon: https://www.francebleu.fr/favicons/apple-touch-icon-180x180.png
+  homepage: https://www.francebleu.fr/radio/radio-chanson-francaise
+  country: FR
+  status: stream-only
+  stationuuid: f7afd469-77b0-4950-b17e-ff82eaa291d8
+  changeuuid: 6b62869a-fc5a-418c-825f-951aad6feec4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-rjfm-club-80
+  broadcaster: independent
+  name: rjfm club 80
+  streamUrl: https://listen.radioking.com/radio/2725/stream/72647
+  bitrate: 192
+  codec: MP3
+  homepage: https://fr.radioking.com/radio/rjfm-club-80
+  country: FR
+  status: stream-only
+  stationuuid: 7e5c14a7-779c-4af1-800d-f745ca9953f7
+  changeuuid: 53cb608d-7cf0-4ce3-b0eb-29c0a3b43a6e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-francais-dans-le-monde
+  broadcaster: independent
+  name: Francais dans le monde
+  streamUrl: https://listen.radioking.com/radio/2079/stream/63043
+  bitrate: 192
+  codec: MP3
+  homepage: https://link.radioking.com/francaisdanslemonde
+  country: FR
+  status: stream-only
+  stationuuid: 816b8c76-1e0a-4375-ad0d-5d3466d09fff
+  changeuuid: 4de1498a-b535-489a-b251-05abf000b333
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-sun-hip-hop
+  broadcaster: independent
+  name: SUN Hip Hop
+  streamUrl: https://diffusion.lafrap.fr/sun-hip-hop.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.lesonunique.com/datasun/images_flux/logos/SD/hiphop.png
+  homepage: https://www.lesonunique.com/
+  country: FR
+  status: stream-only
+  stationuuid: 561c69c8-7b8c-46d1-be67-fcf32b0d6107
+  changeuuid: a20d0ec6-f389-45e9-964a-c5561017bf98
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-abc-dance
+  broadcaster: independent
+  name: ABC Dance
+  streamUrl: https://www.radioking.com/play/abc-dance/374263
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.abcdanceradio.com/
+  country: FR
+  status: stream-only
+  stationuuid: 252859a8-1ed5-41cf-aa7c-9a8ab6892e8a
+  changeuuid: 6f51cc63-2ab9-440e-a7d8-e01925e107e5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-fly-foot-selecta
+  broadcaster: independent
+  name: Fly Foot Selecta
+  streamUrl: https://manager5.streamradio.fr:1185/stream
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.radio-fly-foot-selecta.com/
+  country: FR
+  status: stream-only
+  stationuuid: 205c5091-6ea1-4368-8774-def7301f7251
+  changeuuid: 99276496-dd7f-421d-95de-2ace51b05d46
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-nova-hiphop
+  broadcaster: independent
+  name: Nova HipHop
+  streamUrl: https://nova-odn.ice.infomaniak.ch/nova-odn-256.aac
+  bitrate: 256
+  codec: AAC
+  favicon: https://www.nova.fr/wp-content/uploads/sites/2/2022/11/Nova-Hip-Hop.png?resize=503%2C503&quality=75
+  homepage: https://www.nova.fr/radios/nova-hip-hop/
+  country: FR
+  status: stream-only
+  stationuuid: 94d42cb6-14ea-48cd-9523-6c3ee2ded1a2
+  changeuuid: 33370817-5284-4bc5-8aeb-84ca73e1d4db
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-jazz
+  broadcaster: independent
+  name: Jazz
+  streamUrl: https://jazz-wr18.ice.infomaniak.ch/jazz-wr18-128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.jazzradio.fr/media/radio/thumb/180x180_nouveautes-soul.webp
+  homepage: https://www.jazzradio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: f71124a5-b24d-46a3-8296-024b794e9fc3
+  changeuuid: 8e654a94-5534-4826-9d76-d55d6369b3e4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-fpp-frequence-paris-plurielle-rfpp
+  broadcaster: independent
+  name: FPP Fréquence Paris Plurielle rfpp
+  streamUrl: https://direct.rfpp.net/fpp.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://rfpp.net/favicon.ico
+  homepage: https://rfpp.net/
+  country: FR
+  status: stream-only
+  stationuuid: 0842377e-9c21-4567-a326-6303a48b0ea1
+  changeuuid: 69d9345a-d9bc-4463-8a63-c553ed18464c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-clapas
+  broadcaster: independent
+  name: Radio Clapas
+  streamUrl: https://stations.radioclapas.fr/radio/8130/radio.mp3
+  bitrate: 320
+  codec: MP3
+  favicon: https://www.radioclapas.fr/wp-content/uploads/2015/10/favicon.png
+  homepage: https://www.radioclapas.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 96168502-0601-11e8-ae97-52543be04c81
+  changeuuid: f232d0aa-9ccb-41be-bdf4-e2c57cd6a16a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-jazz-piano
+  broadcaster: independent
+  name: Jazz Piano
+  streamUrl: https://jzr-piano.ice.infomaniak.ch/jzr-piano.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.jazzradio.fr/media/radio/thumb/180x180_piano-jazz2.webp
+  homepage: https://www.jazzradio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 323a5037-2173-438c-9e0b-221f1ad87356
+  changeuuid: f0a7d4d9-4ad2-43cb-ae75-a0d8717a1987
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-urban-hit-a-l-ancienne
+  broadcaster: independent
+  name: "Urban Hit à l'ancienne"
+  streamUrl: https://urbanhitalancienne.ice.infomaniak.ch/urbanhitalancienne.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.urbanhit.fr/favicon.ico
+  homepage: https://www.urbanhit.fr/
+  country: FR
+  status: stream-only
+  stationuuid: b072c493-2e17-11ea-aa0c-52543be04c81
+  changeuuid: 24fbfd79-aef6-42a7-967a-5d294d31b869
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-isekoi-radio-non-stop-ambient
+  broadcaster: independent
+  name: "ISEKOI Radio | Non-Stop Ambient"
+  streamUrl: https://public.isekoi-radio.com/listen/ambient/ambientradio.flac
+  codec: OGG
+  favicon: https://i.postimg.cc/3rFkNkY4/LOGO-3-2-bg3.png
+  homepage: https://isekoi-radio.com/
+  country: FR
+  status: stream-only
+  stationuuid: 737c84ae-4529-40cc-970c-bcd1ec561068
+  changeuuid: 99c806eb-e3ca-4e86-964c-98f12e4978cb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-allzic-radio-zouk
+  broadcaster: independent
+  name: Allzic Radio Zouk
+  streamUrl: https://allzic28.ice.infomaniak.ch/allzic28.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png
+  homepage: https://www.allzicradio.com/en/player/listen/1767/allzic-radio-zouk
+  country: FR
+  status: stream-only
+  stationuuid: 148cbb07-2856-44f9-9486-5b4f1ab41244
+  changeuuid: ed592c2d-b280-450d-a68a-30de75ac9608
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-generations-dancehall
+  broadcaster: independent
+  name: 🕺 Générations Dancehall
+  streamUrl: https://generations-dancehall.ice.infomaniak.ch/generations-dancehall.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEjnhJmvti_BH6oOOGOTfiuUc26pCXXZbu2kSzAztx5Djgb1TqKDf64tgGm2EGlhR08B10iUj4Aa0YcM1960rrGNkQd9R_-nj5hJ4mOhz119h-ipkZtnyblHix9CHBS_vnoSa2QXCGHtWPDWg0M2oANax1FdG8cAey3Sw10FuQMWx8z8Sh9RH6Jw48py/s1600/Capture%20d%E2%80%99%C3%A9cran_2024-11-18_11-39-43.png
+  homepage: https://www.karibshebdo.info/radios-web/g%C3%A9n%C3%A9rations-dancehall
+  country: FR
+  status: stream-only
+  stationuuid: cf918f1b-1aa8-49e7-a34c-a30c2dd8dc6d
+  changeuuid: 708cd57f-157f-4705-b5d8-86176419c8d7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-chante-france-70-s
+  broadcaster: independent
+  name: "Chante France 70's"
+  streamUrl: https://chantefrance70s.ice.infomaniak.ch/chantefrance70s-128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://m209.syncusercontent.com/mfs-60:c37f584aa5c7deb8c9c57eeb95104ba0=============================/p/Chante_France_70s.png?allowdd=0&datakey=nPZKWcukh3jvtGxH1MwrXHYJ3SBhifDYRyUBJ1fD+Yttofsl+mR7i+L1Cf9SNqIRQsa92m974+b6ltDsSj063imF9rT5QDVvXQuINdV63Npsr2X1Rn0r+wW4lTuZ/3CWmbCNOwyKcy3TcmPD+SbmnEzreg/C2ixTt4rACINutdGq4ke4n/Umd/z/oDgbI/mfDFqYCEpImYWXRUAAmXYiBPFQV1FQ8uzQTHmDUbnUAe28czGpswLbFGV6oqQ3vavsPvS6QZEPXrqgm6PgtxLuZG/BH31qST4ESPaXEETFE2p89kYS+V3fj7SQ7iYcY1s2XGwsKpDXSzaHkr/L1zzRNg&engine=ln-3.1.38&errurl=C1ZxI/xCDYvTxV4BPvWu7W0iiS/zZJpJoyjiNwOu3R4h/FFap7neKIORizWM82OsnayL9mmVtakaby4s30SPSpjLV5ceJmlX4CTUwjmyeMPXpJoZIDthJTEQKYSk+v7+6TYEznqOVi6xJFkGnc88JGWLi9DTf1D7A03U03IirrQXHPd9YJjiTeDewr+HoUpqAXMxoqqHgDmghJv3o9HTe6OYHqrwbUU3UXD8164mdSw/kdz189eAa6oie9kndmO65zz9+NTmXlY5r4ofnTGmQY/SF3L+rbIqGsPDnu7G1ZU4XojrH9j2QIoylqvHdF7C5wuckgedUMqcC5hETNGSMQ==&header1=Q29udGVudC1UeXBlOiBpbWFnZS9wbmc&header2=Q29udGVudC1EaXNwb3NpdGlvbjogaW5saW5lOyBmaWxlbmFtZT0iQ2hhbnRlX0ZyYW5jZV83MHMucG5nIjtmaWxlbmFtZSo9VVRGLTgnJ0NoYW50ZV9GcmFuY2VfNzBzLnBuZzs&ipaddress=1414030563&linkcachekey=72262aa90&linkoid=1991610004&mode=101&sharelink_id=17962746020004&timestamp=1708276526046&uagent=3b50c75381f12107280e9099b5b7674cf455a2e5&signature=12b2a47aa6dc67a944284a87b56a794977b5fb89&cachekey=60:c37f584aa5c7deb8c9c57eeb95104ba0=============================
+  homepage: http://www.chantefrance.com/
+  country: FR
+  status: stream-only
+  stationuuid: 4d717d77-35bf-4d25-8cd0-32e3288ee0d0
+  changeuuid: eae53a70-88b3-4d87-b4a1-e46373d1dbb7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-monte-carlo-french
+  broadcaster: independent
+  name: Radio Monte Carlo French
+  streamUrl: https://misato.ru-hoster.com:8079/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.montecarlo.uno/favicon.ico  
+  homepage: https://www.montecarlo.uno/
+  country: FR
+  status: stream-only
+  stationuuid: 8473ba43-94bd-4127-a13d-a5883e607f0a
+  changeuuid: c3bed07b-6a4d-49ba-b58a-23b6e7de609c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-france-inter-la-musique-d-inter-hifi
+  broadcaster: independent
+  name: "France Inter La musique d'Inter Hifi"
+  streamUrl: https://icecast.radiofrance.fr/franceinterlamusiqueinter-hifi.aac
+  bitrate: 192
+  codec: AAC
+  favicon: https://www.radiofrance.fr/s3/cruiser-production-eu3/2024/06/2eb99120-ff28-414d-a805-c354c3967edf/300x300_sc_fi-webradio-c3b2.jpg
+  homepage: https://www.radiofrance.fr/franceinter/la-musique-inter
+  country: FR
+  status: stream-only
+  stationuuid: e830db90-b6ac-4eef-82a3-2c14ad41b055
+  changeuuid: cd86bdaa-4b2b-4188-b321-5929e1990bac
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-jazzradio-fr-groove
+  broadcaster: independent
+  name: JazzRadio.fr Groove
+  streamUrl: https://jazz-wr08.ice.infomaniak.ch/jazz-wr08-128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.jazzradio.fr/media/radio/thumb/100x100_groove.png
+  homepage: https://www.jazzradio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 5a6b2917-906e-4c40-b043-a754c3a7d2fe
+  changeuuid: 9fab1d9d-2e84-4fcc-b22c-49f835192fad
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-liberte-fm
+  broadcaster: independent
+  name: Liberté FM
+  streamUrl: https://stream.libertefm.fr/libertefm.192.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://libertefm.fr/upload/logos/touch-icon.png
+  homepage: https://libertefm.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 9c258e1a-c4ea-4986-ae99-20dfda43dece
+  changeuuid: 5fe87d3b-fbc5-4342-b459-950b7e945738
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-chante-france-80-s
+  broadcaster: independent
+  name: "Chante France 80's"
+  streamUrl: https://chantefrance80s.ice.infomaniak.ch/chantefrance80s-128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://m209.syncusercontent.com/mfs-60:62a5d44bbf259b3cd1bfc46b554dc870=============================/p/Chante_France_80s.PNG?allowdd=0&datakey=IiyCboqbabGVcgKaDzHK02vXW3Wky759JGLowzH0RO5kZXgBRhFkorPIHuNpTR9+35SR35ZpNbQ+kwtHURxsIulDqyud/UkpFEYEPU2UGLy4FjPkgwUl2C1PIScCRX0ZnWXDKcH6sbuJiRtmdarH0A3qt31L+jTBhgOETWvJ8i7zNIOy7FUFOnyiKGULsFiYVZ5Ta4FsdARFqu+JXxkZ1fSE4/W/E4ePYH58jkI7KHopwc5VG2wlbGy2zRmW+xW99ck7BeLtgglYJ1IGwflB1yYRLr3ZhnxqGAgiBRnZVFO6SB/N1HF3DduX2eg8RKl1oBkSoCFgzf3YnS9Tp83S3Q&engine=ln-3.1.38&errurl=hClSQ4MkSQjg1qv64K1t4MZGzA8/95NcIiROqX2SC/ATAZg9EuQgUaHPydUV/+gizUbVpzxtzONz1ZmDAbcLjzb6JI+kLZRjdmKO+ZDa2/ZLq3DGtvsXxJihIBsyGdnVlLT0/Yzm3hfa1ftoaMNbjzV2Jud3IZw5CxZ69QsIutUsC0Gv93kawZLvsFQ2QJFDUjzYHYCZC3Pm0hcy1N6EWSDH2snTlxy8erDa13+FluIyc4h6GS9V3Di2XS28g2K8BVRaqHzzhtwNnc7H2Q6s7L5YkN8KgPyq/PWt74IrfkeUXBUd4IHpqOhoz2kKVbnynrMRu+T2mg02oep3HFcT1g==&header1=Q29udGVudC1UeXBlOiBpbWFnZS9wbmc&header2=Q29udGVudC1EaXNwb3NpdGlvbjogaW5saW5lOyBmaWxlbmFtZT0iQ2hhbnRlX0ZyYW5jZV84MHMuUE5HIjtmaWxlbmFtZSo9VVRGLTgnJ0NoYW50ZV9GcmFuY2VfODBzLlBORzs&ipaddress=1414030563&linkcachekey=d0286fb30&linkoid=1991610004&mode=101&sharelink_id=17962735040004&timestamp=1708276131659&uagent=3b50c75381f12107280e9099b5b7674cf455a2e5&signature=05c24b5e57cc52ad8f43654652244e0a257732ff&cachekey=60:62a5d44bbf259b3cd1bfc46b554dc870=============================
+  homepage: http://www.chantefrance.com/
+  country: FR
+  status: stream-only
+  stationuuid: e093a1fe-1466-4c11-8cba-12db6de65b74
+  changeuuid: 448e10da-2e34-4c08-b7af-d35420c662ce
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-oui-fm-bring-the-noise
+  broadcaster: independent
+  name: OUI FM BRING THE NOISE
+  streamUrl: https://ouifmbringthenoise.ice.infomaniak.ch/ouifmbringthenoise.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://bocir-prod-bucket.s3.amazonaws.com/radios/oui-fm/radiostream/tBdigJT2rb/vignette.png
+  homepage: https://www.ouifm.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 7f444ebc-8409-44f0-bd43-cdefd6091cf6
+  changeuuid: db90f86e-fafb-4080-a3fa-dd6df4f3e378
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-jazzradio-fr-gospel
+  broadcaster: independent
+  name: Jazzradio.fr Gospel
+  streamUrl: https://jazz-wr07.ice.infomaniak.ch/jazz-wr07-64.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://www.jazzradio.fr/apple-touch-icon-120x120.png
+  homepage: https://www.jazzradio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 48cd9436-c37d-4faf-a415-0a5524b1f8d6
+  changeuuid: e04e05b1-1499-46b3-a860-696eee38bca5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-la-grosse-radio-metal
+  broadcaster: independent
+  name: La Grosse Radio Métal
+  streamUrl: https://hd.lagrosseradio.info/lagrosseradio-metal-192.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://s1.wp.com/i/favicon.ico
+  homepage: https://caribshebdo.wordpress.com/2020/09/02/radio-web-la-grosse-reggae/
+  country: FR
+  status: stream-only
+  stationuuid: 3d24cc49-e97f-4a98-9431-25f794c8efe7
+  changeuuid: 1f7af213-a858-4bba-96d6-8f2012f96c42
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-sun-jazz
+  broadcaster: independent
+  name: SUN Jazz
+  streamUrl: https://diffusion.lafrap.fr/sun-jazz.mp3
+  bitrate: 320
+  codec: MP3
+  favicon: https://www.lesonunique.com/favicon.ico
+  homepage: https://www.lesonunique.com/
+  country: FR
+  status: stream-only
+  stationuuid: b4f0bb6e-8ecd-465f-b86f-5bb622de353f
+  changeuuid: 52b489b0-30a7-47bb-817f-013d6ac7cfae
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-allzic-radio-electro-chill
+  broadcaster: independent
+  name: Allzic Radio Electro Chill
+  streamUrl: https://allzic57.ice.infomaniak.ch/allzic57.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://super-radio-global.devhub.top/logo/default.png
+  homepage: https://global.superradio.cc/
+  country: FR
+  status: stream-only
+  stationuuid: 47b14a98-e785-4729-8a75-e6c7abeb098a
+  changeuuid: 7561b8bc-86fd-4fa8-b195-6aca1194e6cf
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-chante-france-60-s
+  broadcaster: independent
+  name: "Chante France 60's"
+  streamUrl: https://chantefrance60s.ice.infomaniak.ch/chantefrance60s-128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://m209.syncusercontent.com/mfs-60:55d74e4ae967d2ce5319d319cd6cb6b4=============================/p/Chante_France_60s.png?allowdd=0&datakey=p4icmWAsP/iW76rIaDQC9Ysg5dCQp9i4iJbCdJ2w5vKh0mRJVmfh+5kkDcpRlS0ndGWjloOl6YLsYvCVKJCxbujo+EwVrnJwPdcMvC7vzD98e4iXFvh88hYDxmH2wyKZV8VPzlZXTfs7ThGK/xsieaiXjCeYAS6lvlTTE8db9sG0pXfKT2xHPrw3dD9aoHwoNxmo981FsKTP7AvZYBod21SlnGPpPHwMhm/Nhk649CooxAAG/8+MiRjLXA/VfiDltNldjZnXQgkDlGMgmJGzH0UzipVQSvuxF1PvTPstBJijeW6ilix/UzLdBjo/AImXBejg3v2yWYmHa8zxuK8mWg&engine=ln-3.1.38&errurl=eQ0fhQZycZt8LWx0aGP5KQvGt9ubloQoWjo/7GljAfAkIy+vm/to/as6JUhgrWy66YRhOGRFivSnewW+cRaF+NzD9oBx7E0FBJB1eGXJPsPnG4qQb6N4lvmu9gXz/xrx5gWr2Cwmerj+3+3okPeAclq7iwxW5OQI5hSZ7AXlsTaShUJ0aDqSHK0kwUL7bqUqN/5hGsyGO/OZpWM+6DiF//f3qlEQacDDrRHyDB5Tro1eMrymmNtEiZ1qk9iVg3L9pWbLUpLzWNCGxCZa58GfhpE18kC3ugmpVOjvSWWi0Q/Qub0pUtTfGdvTg2ymdWVOSgj2QNBtd4X0aAboE0ihWA==&header1=Q29udGVudC1UeXBlOiBpbWFnZS9wbmc&header2=Q29udGVudC1EaXNwb3NpdGlvbjogaW5saW5lOyBmaWxlbmFtZT0iQ2hhbnRlX0ZyYW5jZV82MHMucG5nIjtmaWxlbmFtZSo9VVRGLTgnJ0NoYW50ZV9GcmFuY2VfNjBzLnBuZzs&ipaddress=1414030563&linkcachekey=5de014cb0&linkoid=1991610004&mode=101&sharelink_id=17962599040004&timestamp=1708274054580&uagent=3b50c75381f12107280e9099b5b7674cf455a2e5&signature=92710090a3c3d30b2d50444687a77b3287fc2049&cachekey=60:55d74e4ae967d2ce5319d319cd6cb6b4=============================
+  homepage: http://www.chantefrance.com/
+  country: FR
+  status: stream-only
+  stationuuid: ab6601ea-3d4d-4fc2-9b41-77f1953f0d88
+  changeuuid: 74d0fd55-f615-43c9-9426-96bb11526b5e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-generation-soul-disco-funk
+  broadcaster: independent
+  name: GENERATION SOUL DISCO FUNK
+  streamUrl: https://gestream.fr/g-radio-sd.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://www.generationdiscofunk.com/wp-content/uploads/2022/08/Logo_G_Radio_500px-370x370.png
+  homepage: https://www.generationdiscofunk.com/
+  country: FR
+  status: stream-only
+  stationuuid: 4d34923c-c97a-48fb-8b52-93710c163105
+  changeuuid: b7424e66-b425-43c2-a529-57401a8888fc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-vinyltimes
+  broadcaster: independent
+  name: VINYLTIMES
+  streamUrl: https://listen.radioking.com/radio/7551/stream/385141
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.vinylestimes.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 424e6a71-ba31-45d1-852c-edcd06378c1e
+  changeuuid: 6a156507-2cb5-4ec6-92ca-d8abd7e856fd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-chansons-oubliees-ou-presque
+  broadcaster: independent
+  name: Chansons oubliees ou presque
+  streamUrl: https://manager7.streamradio.fr:2580/stream?1701295921862
+  bitrate: 128
+  codec: MP3
+  homepage: https://lasourcedelian.wixsite.com/chansons-oubliees
+  country: FR
+  status: stream-only
+  stationuuid: 24e2291a-e782-4d49-a351-7135cc151a70
+  changeuuid: aa738906-f641-4164-91f2-456dfa630ddb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-666
+  broadcaster: independent
+  name: Radio 666
+  streamUrl: https://stream2.radio666.net/remote192.aac
+  bitrate: 192
+  codec: AAC
+  favicon: https://ferarock.org/sites/default/files/ferarock/styles/auto_1280/public/ged/666_haut_coul_jpg.jpg?itok=mSLbBGGd
+  homepage: https://radio666.com/
+  country: FR
+  status: stream-only
+  stationuuid: da50801d-6e02-413f-8011-5f8e609be44b
+  changeuuid: 69d988a6-25a0-4a11-8c0c-9614fc6b0df0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-sunset-jazz-radio
+  broadcaster: independent
+  name: SUNSET JAZZ RADIO
+  streamUrl: https://radio2.vip-radios.fm:18077/stream-mp3-SunsetJazz
+  bitrate: 128
+  codec: MP3
+  homepage: http://www.sunset-jazz-radio.com/
+  country: FR
+  status: stream-only
+  stationuuid: 9218cf37-a265-47d0-8afb-c6484d222b0f
+  changeuuid: 18388f7d-49b0-4d7c-857c-f2a4c8b57864
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-africa-radio-mandingue-webradio
+  broadcaster: independent
+  name: Africa Radio Mandingue Webradio
+  streamUrl: https://webradio1.ice.infomaniak.ch/webradio2-128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://images.lesindesradios.fr/fit-in/300x2000/filters:format(webp)/radios/africaradio/radiostream/pmoKDezn85/vignette.png
+  homepage: https://www.africaradio.com/
+  country: FR
+  status: stream-only
+  stationuuid: 2ea7f481-bd69-405e-b41e-a75a390bebb2
+  changeuuid: 7f92f7a8-37a5-4770-91fd-12766b752645
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-equinoxe
+  broadcaster: independent
+  name: Radio Equinoxe
+  streamUrl: https://www.radioking.com/play/radio-equinoxe
+  bitrate: 128
+  codec: MP3
+  homepage: http://radioequinoxe.com/
+  country: FR
+  status: stream-only
+  stationuuid: 722a62ef-1407-11e8-ae97-52543be04c81
+  changeuuid: 7d5dd3be-9d3b-4a77-99d3-61af12d5689d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-lovely
+  broadcaster: independent
+  name: LOVELY
+  streamUrl: https://lovely.ice.infomaniak.ch/lovely-128.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://radiolovely.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 9ca106e3-1491-43e9-99e2-0ab135bc535e
+  changeuuid: bde821c6-7244-4677-8225-f6d6ca92ea29
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-maxi-80
+  broadcaster: independent
+  name: Maxi 80
+  streamUrl: https://audio1.maxi80.com/;?1722579303309
+  bitrate: 128
+  codec: MP3
+  favicon: https://cdn-radiotime-logos.tunein.com/s108907d.png
+  homepage: https://www.maxi80.com/
+  country: FR
+  status: stream-only
+  stationuuid: 7d503e58-c210-4e7d-bd81-e9142bebcfd5
+  changeuuid: fb84e465-d340-4806-b45a-291d4a030e9f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-soft-radio
+  broadcaster: independent
+  name: Soft Radio
+  streamUrl: https://stream10.xdevel.com/audio14s976748-2279/stream/icecast.audio
+  bitrate: 192
+  codec: AAC+
+  favicon: https://static.wixstatic.com/media/8f2aad_aa6143964e8d4a1f80be28d048517260~mv2.png
+  homepage: https://www.softradio.net/
+  country: FR
+  status: stream-only
+  stationuuid: 50ab0fd5-bd39-4561-89c0-797de8001a16
+  changeuuid: d0896b52-8452-4a30-94a2-225b223a9409
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-frequence-plus
+  broadcaster: independent
+  name: Fréquence Plus
+  streamUrl: https://freqplus.ice.infomaniak.ch/freqplus-high.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://www.frequenceplus.fr/img/favicon-32x32.png
+  homepage: http://www.frequenceplusfm.com/
+  country: FR
+  status: stream-only
+  stationuuid: 96418b24-0601-11e8-ae97-52543be04c81
+  changeuuid: 68a6097b-d7d9-4393-85b6-3979425e08fc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-mona-fm-plus-de-fiesta
+  broadcaster: independent
+  name: Mona FM Plus De Fiesta
+  streamUrl: https://www.radioking.com/play/mona-fm-plus-de-fiesta
+  bitrate: 128
+  codec: MP3
+  favicon: http://www.monafm.fr/upload/56780b7eab7e73.51115541.ico
+  homepage: http://www.monafm.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 963f899d-0601-11e8-ae97-52543be04c81
+  changeuuid: 6325eb3d-484d-4aca-af0e-a951ad22e5fc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-france-inter-la-musique-d-inter
+  broadcaster: independent
+  name: "France Inter La musique d'Inter"
+  streamUrl: https://icecast.radiofrance.fr/franceinterlamusiqueinter-midfi.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.radiofrance.fr/s3/cruiser-production-eu3/2024/06/2eb99120-ff28-414d-a805-c354c3967edf/300x300_sc_fi-webradio-c3b2.jpg
+  homepage: https://www.radiofrance.fr/franceinter/la-musique-inter
+  country: FR
+  status: stream-only
+  stationuuid: a33727b7-812f-4461-84b4-3d76f5efbd3f
+  changeuuid: be16d3bf-26a9-4caa-b242-5e176065a950
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-jazz-latin
+  broadcaster: independent
+  name: Jazz Latin
+  streamUrl: https://jazz-wr09.ice.infomaniak.ch/jazz-wr09-128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.jazzradio.fr/media/radio/thumb/180x180_latin-jazz.webp
+  homepage: https://www.jazzradio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: c3c356ed-c3bd-42a0-a396-8abf8a51dc1e
+  changeuuid: 755140d0-8234-4641-80fd-62e9aa992204
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-blackbox-us
+  broadcaster: independent
+  name: BlackBox US
+  streamUrl: https://blackbox-us.ice.infomaniak.ch/blackbox-us.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.blackboxfm.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 75b985cc-2d66-11ea-aa0c-52543be04c81
+  changeuuid: 9a63ba29-fdcb-4932-af16-3fab80a41845
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-oui-fm-summertime
+  broadcaster: independent
+  name: OUI FM SUMMERTIME
+  streamUrl: https://ouifmsummertime.ice.infomaniak.ch/ouifmsummertime.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://bocir-prod-bucket.s3.eu-west-1.amazonaws.com/radios/oui-fm/images/favicon.ico
+  homepage: https://www.ouifm.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 4510debb-71f7-4477-b762-f03f3b84967b
+  changeuuid: 67196f03-b11a-4c19-97a3-3f2c015f50ef
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-oxygene-radio
+  broadcaster: independent
+  name: Oxygène Radio
+  streamUrl: https://ice.creacast.com/ofm_hq.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://bocir-prod-bucket.s3.amazonaws.com/radios/oxygeneradio/images/favicon.ico
+  homepage: https://www.oxygeneradio.com/
+  country: FR
+  status: stream-only
+  stationuuid: c33212bf-6321-4b89-8194-bb7f7c7460da
+  changeuuid: e00b6b76-14c6-4e47-874d-80b6e1f40ca9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-maxi-france-radio
+  broadcaster: independent
+  name: Maxi France radio
+  streamUrl: https://stream.maxifrance.radio/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.maxifrance.radio/wp-content/uploads/2023/03/cropped-logo-512.jpg
+  homepage: https://www.maxifrance.radio/
+  country: FR
+  status: stream-only
+  stationuuid: 7c2bdd5a-81e4-49ec-9128-dd7d3a6e2db2
+  changeuuid: ebf954bb-0d5b-47f4-b288-7d9175260e11
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-toutes-les-couleurs-du-trad
+  broadcaster: independent
+  name: Toutes les couleurs du trad
+  streamUrl: https://my2.radiolize.com/radio/8100/radio.mp3
+  bitrate: 96
+  codec: AAC
+  homepage: http://couleursdutrad.dx.am/
+  country: FR
+  status: stream-only
+  stationuuid: b1939f76-1417-4058-8657-403e6fcf45ea
+  changeuuid: 4abf5163-a4e5-4b27-b956-0c60f452433f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-fip-cultes
+  broadcaster: independent
+  name: FIP Cultes
+  streamUrl: https://stream.radiofrance.fr/fipcultes/fipcultes.m3u8?id=radiofranceBose
+  bitrate: 105
+  codec: AAC
+  homepage: https://www.radiofrance.fr/fip/radio-cultes
+  country: FR
+  status: stream-only
+  stationuuid: 1231ed9e-9697-4242-92b2-2d94a6ade243
+  changeuuid: f66e0fb2-65ad-4aaf-89ce-9df068d51f99
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-kiss-pop-rock
+  broadcaster: independent
+  name: KISS Pop Rock
+  streamUrl: https://radiola.me/listen/kiss_pop_rock/radio.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: http://kiss-pop-rock.net/
+  country: FR
+  status: stream-only
+  stationuuid: 53548d01-14fa-4c90-92c5-8a13ce0ae0fd
+  changeuuid: 1873139d-4d69-4e25-a48d-45060d94a70d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-rire-et-chansons-sketches
+  broadcaster: independent
+  name: Rire et Chansons Sketches
+  streamUrl: https://streaming.nrjaudio.fm/ou8oqegk7oiu?aw_0_1st.station=Rire-Chansons-SKETCHES&origine=mytuner
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.rireetchansons.fr/webradios/mur-des-radios/rire-et-chansons-sketches
+  country: FR
+  status: stream-only
+  stationuuid: 64179b77-7c6f-4e74-af5b-4bf3b5a1265a
+  changeuuid: 13e0ddb8-4a18-4c6b-ad7c-b82d6634864e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-1000-hits-90s
+  broadcaster: independent
+  name: "1000 Hits 90s"
+  streamUrl: https://c4.auracast.net:8050/;
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.splashradio.eu/
+  country: FR
+  status: stream-only
+  stationuuid: 66c137bc-1caa-4ef0-a2e0-1f8e6d7fe694
+  changeuuid: 867a7dfb-5ebd-4d10-9d78-545d3149d705
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-espace-latino
+  broadcaster: independent
+  name: Espace Latino
+  streamUrl: https://egwr-espace-latino.ice.infomaniak.ch/egwr-espace-latino.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.radioespace.com/media/radio/thumb/180x180_64ecb84d55b4a-latino-sans-fond.webp
+  homepage: https://www.radioespace.com/radio/webradio/14/radio-espace-latino
+  country: FR
+  status: stream-only
+  stationuuid: 1d1a2896-0cd1-4248-bc72-b64d84799ac0
+  changeuuid: 885e1db7-a035-4c1a-a508-2b81cd6838a6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-nova-soul
+  broadcaster: independent
+  name: Nova Soul
+  streamUrl: https://nova-soul.ice.infomaniak.ch/nova-soul-256.aac
+  bitrate: 256
+  codec: AAC
+  homepage: https://www.nova.fr/radios/nova-soul/
+  country: FR
+  status: stream-only
+  stationuuid: 08549db1-69bd-4194-a20b-37227e10c809
+  changeuuid: d1cfb780-0288-44a9-b285-91d83d1af3cd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-lamellotron
+  broadcaster: independent
+  name: LaMellotron
+  streamUrl: https://listen.radioking.com/radio/477719/stream/534044
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.lemellotron.com/
+  country: FR
+  status: stream-only
+  stationuuid: c88e1951-6073-4fd8-9f77-079618f0d659
+  changeuuid: 1e687fe4-685e-410a-b3d2-7d208f9ec537
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-b4b-disco-funk-hd
+  broadcaster: independent
+  name: "B4B DISCO FUNK [HD]"
+  streamUrl: https://eu10.fastcast4u.com:8120/stream?icy=http
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.b4bradio.com/radio-funk.html#radios
+  country: FR
+  status: stream-only
+  stationuuid: fbca0349-ceec-467b-857a-6ce3a8c7afe6
+  changeuuid: 41faa5a2-8c78-423b-94d8-aa76d6aa913e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-phare-fm-worship
+  broadcaster: independent
+  name: Phare FM Worship
+  streamUrl: https://str0.creacast.com/pharefm_worship
+  bitrate: 128
+  codec: MP3
+  homepage: http://www.pharefm.com/
+  country: FR
+  status: stream-only
+  stationuuid: 262d2c9e-c249-45e8-8cb8-2e1d9c960852
+  changeuuid: 4fccd0ab-b1e8-4b3b-90c2-e94981e1fb0f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-pais
+  broadcaster: independent
+  name: Ràdio País
+  streamUrl: https://stunnel2.cyber-streaming.com:9272/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.radiopais.fr/favicon.ico
+  homepage: https://www.radiopais.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 18b51dd3-3a14-4eef-83e6-b516ee20996a
+  changeuuid: 3c61476e-6f77-4d76-ac95-e3b85f5b6729
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-rfi-portugais
+  broadcaster: independent
+  name: RFI Portugais
+  streamUrl: https://rfienportugais64k.ice.infomaniak.ch/rfienportugais-64.mp3
+  bitrate: 64
+  codec: MP3
+  favicon: https://www.rfi.fr/apple-touch-icon.png
+  homepage: https://www.rfi.fr/pt/
+  country: FR
+  status: stream-only
+  stationuuid: 3aae0dfe-040c-48fc-81f4-1f1295dd0e91
+  changeuuid: e36e0099-f45a-4acc-ae53-682f5ae264cc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-crooner-radio-premium
+  broadcaster: independent
+  name: Crooner Radio Premium
+  streamUrl: https://direct.croonerradio.fr/croonerradio-inprivate-midfi.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.croonerradio.fr/favicon.ico
+  homepage: https://www.croonerradio.fr/stations-de-radio/crooner-radio-premium-webradio/
+  country: FR
+  status: stream-only
+  stationuuid: d8174254-b105-4e78-9e4b-3d5776327bab
+  changeuuid: 6887e9f2-ed54-4209-bae7-2638042aa8aa
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-isekoi-radio-chill-zone
+  broadcaster: independent
+  name: "ISEKOI Radio | Chill Zone"
+  streamUrl: https://public.isekoi-radio.com/listen/chill/radio.mp3
+  codec: MP3
+  favicon: https://i.postimg.cc/ncdMKNsn/LOGO-3-2-bg4.png
+  homepage: https://isekoi-radio.com/
+  country: FR
+  status: stream-only
+  stationuuid: 9467b580-dd8b-44d6-b99a-6ac688a50786
+  changeuuid: 6b822fd3-6e49-45ed-ada3-48284e9a5887
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-oui-fm-top-of-the-week
+  broadcaster: independent
+  name: OUI FM TOP OF THE WEEK
+  streamUrl: https://ouifmtopoftheweek.ice.infomaniak.ch/ouifmtopweek.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://bocir-prod-bucket.s3.eu-west-1.amazonaws.com/radios/oui-fm/images/favicon.ico
+  homepage: https://www.ouifm.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 4b27614b-ba49-4106-a760-8a4c41db9c9e
+  changeuuid: ea07f5a9-af5f-4da6-a2d1-59455eebd2dd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-blackbox-fr
+  broadcaster: independent
+  name: BlackBox FR
+  streamUrl: https://blackbox-fr.ice.infomaniak.ch/blackbox-fr.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://bocir-prod-bucket.s3.eu-west-1.amazonaws.com/radios/blackbox/images/favicon.ico
+  homepage: https://www.blackboxfm.fr/
+  country: FR
+  status: stream-only
+  stationuuid: def12704-2d66-11ea-aa0c-52543be04c81
+  changeuuid: 0b2b7712-850d-4286-8d28-6d7a65b49c38
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-brony-aac
+  broadcaster: independent
+  name: Radio Brony (AAC+)
+  streamUrl: https://radiobrony.live/aac
+  bitrate: 96
+  codec: AAC
+  favicon: https://radiobrony.fr/img/icons/bwavatar-details.png
+  homepage: https://radiobrony.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 91de6a20-9c7b-4718-b9a1-ebbd14bd9841
+  changeuuid: 9bff8813-1298-4f8e-a7e1-73c2f5473431
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-mylenefarmer
+  broadcaster: independent
+  name: MyleneFarmer
+  streamUrl: https://www.mylene.net/mp3/a_tout_jamais_npd_s_remix.mp3
+  codec: MP3
+  favicon: https://www.mylene.net/favicon.ico
+  homepage: https://www.mylene.net/mp3/a_tout_jamais_npd_s_remix.mp3
+  country: FR
+  status: stream-only
+  stationuuid: f35c1111-b2fa-4a3a-92a4-504e7246c190
+  changeuuid: bf3c61dd-1f98-4b32-8988-eaafac76771e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-oui-fm-garage
+  broadcaster: independent
+  name: OUI FM GARAGE
+  streamUrl: https://ouifmgaragerock.ice.infomaniak.ch/ouifmgaragerock-128.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.ouifm.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 0ac941a5-bc8f-4bd8-9f80-f94d7d997316
+  changeuuid: 523158ab-240d-4034-961f-4b8fb00c16df
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-le-bon-mix-dynamic-aac192lc
+  broadcaster: independent
+  name: Le Bon Mix Dynamic - AAC192LC
+  streamUrl: https://stream10.xdevel.com/audio15s976748-2112/stream/icecast.audio
+  bitrate: 192
+  codec: AAC+
+  favicon: https://static.wixstatic.com/media/8f2aad_dcbd6c98b6d541609e600ae3d73de849~mv2.png
+  homepage: https://www.lebonmix.radio/
+  country: FR
+  status: stream-only
+  stationuuid: 6eb547a4-1ef6-4a25-ae04-1074b38707fe
+  changeuuid: 5bff3571-3d28-438c-b952-5e46602861cb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-africa-radio-africa-club-webradio
+  broadcaster: independent
+  name: Africa Radio Africa Club Webradio
+  streamUrl: https://webradio1.ice.infomaniak.ch/webradio5-128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://bocir-prod-bucket.s3.eu-west-1.amazonaws.com/radios/africaradio/images/favicon.x-icon
+  homepage: https://www.africaradio.com/
+  country: FR
+  status: stream-only
+  stationuuid: 4dfde0a1-f20f-4775-a947-7e77bc8ad02a
+  changeuuid: 7931832e-27a6-4fc4-9f16-c09726fbad11
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-oui-fm-girls-rock-aac-64k
+  broadcaster: independent
+  name: "OUI FM GIRLS ROCK [AAC 64k]"
+  streamUrl: https://ouifmgirlsrock.ice.infomaniak.ch/ouifmgirlsrock.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://www.ouifm.fr/favicon.ico
+  homepage: https://www.ouifm.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 1cc8fcdd-a39e-4dc1-979d-563562f27168
+  changeuuid: 2c148c67-f142-4be3-af97-402f45eac0b6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-aviva
+  broadcaster: independent
+  name: Radio Aviva
+  streamUrl: https://radio13.pro-fhi.net/listen-tpgmxyoe-stream.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.radio-aviva.com/
+  country: FR
+  status: stream-only
+  stationuuid: 6efb6188-fcee-4a56-86ce-26e3e6fcd2fa
+  changeuuid: 846188a1-22b0-42c2-b976-91d7647cff46
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-europe-2-pays-de-la-loire
+  broadcaster: independent
+  name: Europe 2 Pays de la Loire
+  streamUrl: https://europe2.lmn.fm/europe2-44000/playlist.m3u8
+  bitrate: 127
+  codec: AAC
+  favicon: https://www.europe2.fr/wp-content/themes/melty/europeradio/assets/images/favicons/favicon128.png
+  homepage: https://www.europe2.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 24bbbd96-ff72-4c57-8b6a-d9de6ceb50ff
+  changeuuid: 4e584e7d-6699-4be2-a956-7508672ab05d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-micheline
+  broadcaster: independent
+  name: Radio Micheline
+  streamUrl: https://hosting.studioradiomedia.fr:2165/stream
+  bitrate: 256
+  codec: MP3
+  favicon: https://www.radiomicheline.com/style/favicon.gif
+  homepage: https://www.radiomicheline.com/
+  country: FR
+  status: stream-only
+  stationuuid: 20c9bb20-aeeb-4111-bcea-616c67682692
+  changeuuid: 55bc46e1-d06a-4df8-9033-e9e7560fa6fe
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-nolife-radio
+  broadcaster: independent
+  name: NoLife-Radio
+  streamUrl: https://listen.nolife-radio.com/
+  bitrate: 96
+  codec: MP3
+  homepage: https://nolife-radio.com/
+  country: FR
+  status: stream-only
+  stationuuid: 398f9d1d-1a4d-48ca-b956-63194b84b2f9
+  changeuuid: 544e6066-96d1-458b-a062-5124c67ac60e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-chante-france
+  broadcaster: independent
+  name: Chante France
+  streamUrl: https://chantefrance.ice.infomaniak.ch/chantefrance-128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://m209.syncusercontent.com/mfs-60:cb6f4bc6ae404acfd00aa8544532d2ee=============================/p/Chante_France.png?allowdd=0&datakey=R5YpRVrhYNeD+1hOJOFXmKaneQKyptagGRsnPqFrMgk09zt/aoimFAWj1E4bzIjOU0g1o5MxlP746mGz5VH3wucpR5G6vC+Me0h0ZeYV7EIbiWelnDRsKOCxz2SmUhhfBttEkOZKO5UkFp/tRjvFV/vr9BzlZwzWen8c4n7G0K1otVJmrwPADQlhBtYAytiT/Jl4ZxmCEtDVv0JTRPofYBE20DvltkTD6lbo4R6kJWG2GsPW0Wy528a/cu0Vbjfu4kw2ondZeMahCBtPufqoymgCOpBIbD4jmaYN2YJqVBzLLbNJFyjkuGHbszVKrIOf4GFEFtc/+5ZwfK9ph5HhGw&engine=ln-3.1.38&errurl=RSx/vozVCnVLZv1bk0MyaWdETxt++NDMXx9XYlrZeFiSATv5OY89vUAfztxyJMSadtZ+3VKLgARqcHmRX/vO1WsIByONH7dqCTePiCMNrEDofZw2E5fG9FLHL0O3MdUBqsE9PQPFyiyLgxh4jt3M8h2/CyQ5k/kAUiil4fRBsSeY0tUY/lr40FfGlLbDdFSo5G7EXEcpUcRSpRiUGOVAqpbWuOlNvypwAPo5Fg6jpoZwyB9o/Oquhovzrne5RL+gKBq3rIzDh8TK+cdBy2lWpH/8SgTv1YcB+qoyjtsQMl8S+PGdKrpU/uvcwFY7fO6exyMiUlhjK3Y6nd+MsyJJDQ==&header1=Q29udGVudC1UeXBlOiBpbWFnZS9wbmc&header2=Q29udGVudC1EaXNwb3NpdGlvbjogaW5saW5lOyBmaWxlbmFtZT0iQ2hhbnRlX0ZyYW5jZS5wbmciO2ZpbGVuYW1lKj1VVEYtOCcnQ2hhbnRlX0ZyYW5jZS5wbmc7&ipaddress=1414030563&linkcachekey=7e09c8630&linkoid=1991610004&mode=101&sharelink_id=17962716890004&timestamp=1708275384958&uagent=3b50c75381f12107280e9099b5b7674cf455a2e5&signature=12c67b7cb607d73d96ee853fdb7988614ac1afcb&cachekey=60:cb6f4bc6ae404acfd00aa8544532d2ee=============================
+  homepage: http://www.chantefrance.com/
+  country: FR
+  status: stream-only
+  stationuuid: 0b75d36d-decf-4fbb-8ee9-a7324de6b532
+  changeuuid: 271bcb9b-fae5-4703-9957-ddfb94404d53
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-chante-france-emotion
+  broadcaster: independent
+  name: Chante France Emotion
+  streamUrl: https://chantefranceemotion.ice.infomaniak.ch/chantefranceemotion-128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://m209.syncusercontent.com/mfs-60:43ecf5b292ac1b6f285193c7c725f5dd=============================/p/Chante_France_Emotion.png?allowdd=0&datakey=i/PT4c2NxHrPaDTi+Yeso3NvhzVjXGY8e854v2JgVqcZcRzCJNt03VboxcYBmUmkQ5VZqXzxuWfBHpvJAOBJPhTkpDOl2PdazHOSQ8LGw8KqNIW+ei8epzQOcBoj0d9esLBXCgRtyMIheoK/tJ6I1aHmX1qMkJ0rhyamKh7RdTrgT4LWCQHlcPiSYpRyjmoFwjolU5GdfshKXsSzarrfgVp0po08SEV5x3qbY8QcTEWSIbEuQdAz0TUEmZ8VzFJTIjYjLXgRMEIvwRfDlMA948hMiyDHShUa1lKUFxjEfjo53q8WwX0tccXAh39Liy51s3DLgwhpRNuc0DfzCc6/HQ&engine=ln-3.1.38&errurl=b8sHYYFv+3CSKKM8U+y2mAAUUUvBJ9F7ajDZzVNEa+J2tFuqLNNhMMuhPyAwv3N1N7Ij2L63a/GXER7pk8+kJqLD98Ai2occw4p2kDEpZ4IF3Sy4gtyzvoZv6jafPMrhYeNZcvDNdMu2XlnPa/ci7vav/JfIHi99UKKGyY+lNfAj8bQ4RyHyLZwznF8vgYJ0zFjXX97q/wAA3CW0cfPmLUVHzyVsPX7AZS2qR7CaEO6oQKRMuKZfYwYvTfCGIWunFafV9q2GcqBzZP3VvTM9qiVazDfDqLc6pnJKfBroAgvW6Sg1xbyEt+z17yec5mEjnb3UqdKcqne4nffJfM8sjg==&header1=Q29udGVudC1UeXBlOiBpbWFnZS9wbmc&header2=Q29udGVudC1EaXNwb3NpdGlvbjogaW5saW5lOyBmaWxlbmFtZT0iQ2hhbnRlX0ZyYW5jZV9FbW90aW9uLnBuZyI7ZmlsZW5hbWUqPVVURi04JydDaGFudGVfRnJhbmNlX0Vtb3Rpb24ucG5nOw&ipaddress=1414030563&linkcachekey=6d4567cd0&linkoid=1991610004&mode=101&sharelink_id=17962625190004&timestamp=1708274362118&uagent=3b50c75381f12107280e9099b5b7674cf455a2e5&signature=7d74438887f3bb4ff771a5a1858c57ffca49c156&cachekey=60:43ecf5b292ac1b6f285193c7c725f5dd=============================
+  homepage: http://www.chantefrance.com/
+  country: FR
+  status: stream-only
+  stationuuid: a61be78b-d52e-4dd4-befb-b77d4d2de2ca
+  changeuuid: fe9bcb6d-39e1-4490-afa0-f281e200e8a2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-dio
+  broadcaster: independent
+  name: Radio Dio
+  streamUrl: https://live.aurafm.org/RadioDio
+  bitrate: 160
+  codec: MP3
+  favicon: https://radiodio.org/wp-content/themes/point/apple-touch-icon.png
+  homepage: https://radiodio.org/
+  country: FR
+  status: stream-only
+  stationuuid: 2a5dc8a9-be0f-461a-a33f-bf0709de5418
+  changeuuid: e1959648-7955-49fc-8d1c-b866040d96a1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-orient
+  broadcaster: independent
+  name: Radio Orient
+  streamUrl: https://stream.rcs.revma.com/7hnrkawf4p8uv.mp3
+  codec: MP3
+  favicon: https://cdn.instant.audio/images/logos/ecouterradioenligne-com/orient.png
+  homepage: https://https//www.radioorient.com
+  country: FR
+  status: stream-only
+  stationuuid: e3ecb332-be77-4641-9b52-39cb4e79e042
+  changeuuid: 989117af-6f64-47bb-9f0a-64611aa4283c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-generations-r-b
+  broadcaster: independent
+  name: "🕺 Générations R&B"
+  streamUrl: https://generationfm-slowjam.ice.infomaniak.ch/generationfm-slowjam-high.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEg5HJuS6yWCZCykQR-TGHZWdD1_-17zir7HncDBK8NG2ZQI-fdZP8JiFabyZi8Qlw5qGkBK3rIQ0GX4D5bRVYLE1M2hgsgGwZGY-chOArST8GHIMaS-yj7f_-jOl9ytuB_WgH1v_bDZia8cmgF_1t6RBLbht4wZr_ZzixiYFhDAp71uB5kj_ggwDU56/s1600/Capture%20d%E2%80%99%C3%A9cran_2024-11-18_11-48-02.png
+  homepage: https://www.karibshebdo.info/radios-web/g%C3%A9n%C3%A9rations-rb
+  country: FR
+  status: stream-only
+  stationuuid: 9ed1d3b7-a394-4a28-a5da-617b59f04b54
+  changeuuid: b1453e98-90bf-45ce-aedb-b66bd4d25568
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-allzic-radio-jazz-lounge
+  broadcaster: independent
+  name: Allzic Radio Jazz Lounge
+  streamUrl: https://allzic03.ice.infomaniak.ch/allzic03.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png
+  homepage: https://www.allzicradio.com/en/player/listen/1/allzic-radio-jazz-lounge
+  country: FR
+  status: stream-only
+  stationuuid: ddccc4ff-93c7-4fed-bdf2-c170b2b48f47
+  changeuuid: a82a7211-7799-4236-bdf7-4e5261295f36
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-maxi-france
+  broadcaster: independent
+  name: Maxi France
+  streamUrl: https://sr3.publicssl.net/srv/8358/stream
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.maxifrance.radio/
+  country: FR
+  status: stream-only
+  stationuuid: bbee27e9-d2e6-4d57-8f9c-ed10ca80ea34
+  changeuuid: cb32a09f-bfbc-4523-bc42-1d5f5d23bf99
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-rfm-party-90
+  broadcaster: independent
+  name: RFM PARTY 90
+  streamUrl: https://rfm.lmn.fm/rfm-wr5.aac
+  bitrate: 128
+  codec: AAC+
+  homepage: http://www.rfm.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 2e1cc485-f61c-473d-a6f2-df30a0d1fd1e
+  changeuuid: 97ec43b6-c4d8-4ce6-98ab-971d6b757f17
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-rtl-100-hits
+  broadcaster: independent
+  name: "RTL 100% Hits"
+  streamUrl: https://live.m6radio.quortex.io/webpHJPXnXrN7B6J7Q8mcqmxP/webradio/rtl/201/audio-64000/index.m3u8
+  bitrate: 64
+  codec: AAC
+  favicon: https://images.rtl.fr/~c/300v300/rtl/www/1197826-webradio-1400x1400.jpg
+  homepage: https://www.rtl.fr/radios
+  country: FR
+  status: stream-only
+  stationuuid: 16d88efb-dc34-43c4-969d-ae36e8284d57
+  changeuuid: 73d6cd95-ec67-4f36-ac88-c4cb2d63102e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-maurice-radio-libre
+  broadcaster: independent
+  name: Maurice Radio Libre
+  streamUrl: https://radio13.pro-fhi.net/live/MauriceRadioLibre
+  bitrate: 192
+  codec: MP3
+  favicon: https://i0.wp.com/mauriceradiolibre.com/wp-content/uploads/2021/03/cropped-fav.jpg
+  homepage: https://mauriceradiolibre.com/
+  country: FR
+  status: stream-only
+  stationuuid: e404e5c9-8a16-4a15-b789-5d3fa6a980ec
+  changeuuid: e34f35ce-3f92-441b-b03a-790418ffd082
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-abc-relax
+  broadcaster: independent
+  name: ABC Relax
+  streamUrl: https://listen.abcrelax.com/
+  bitrate: 128
+  codec: MP3
+  favicon: https://abcrelax.com/img/abc.png
+  homepage: https://abcrelax.com/
+  country: FR
+  status: stream-only
+  stationuuid: 0d2b32b6-063b-40e0-9064-99c7f1fd2931
+  changeuuid: 381dc193-829a-4a9f-829b-c7e7ca807353
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-generations-rnb-gold
+  broadcaster: independent
+  name: 🕺 Générations RNB Gold
+  streamUrl: https://generations-rnb-gold.ice.infomaniak.ch/generations-rnb-gold.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEisO5t14VXrwoJGhJNwKv7yTJFODlagq6q5wcl_a49WiMtiYf1Wk2B648liuElB_H-G6MG1nvjCIeI7fuiC5Pa2_8Ps14AMHAOWAsi6Wine2B3PDGe7NWijzJanue0AboSEpe_SWmAjvIvLqokAyoa3LNwxIl2uPmkBqx2iJKP_jy0DEihoJ9rHBTQbBA/s1600/Capture%20d%E2%80%99%C3%A9cran_2024-11-14_19-24-08.png
+  homepage: https://www.karibshebdo.info/radios-web/g%C3%A9n%C3%A9rations-rnb-gold
+  country: FR
+  status: stream-only
+  stationuuid: c83f261c-1acf-41c9-ad65-cdf8a1821139
+  changeuuid: a7013e87-487c-434a-b0fb-07f97e05ca6f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-fip-hip-hop
+  broadcaster: independent
+  name: FIP Hip-Hop
+  streamUrl: https://stream.radiofrance.fr/fiphiphop/fiphiphop.m3u8
+  bitrate: 107
+  codec: AAC
+  favicon: https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png
+  country: FR
+  status: stream-only
+  stationuuid: 35eab5f7-4e43-4667-b6db-ef135bb9d33b
+  changeuuid: 7c6fe974-6ddf-48f7-9729-44527d4fb70b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-chante-france-nouveautes
+  broadcaster: independent
+  name: Chante France Nouveautés
+  streamUrl: https://chantefrancenouveautes.ice.infomaniak.ch/chantefrancenouveautes-128.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: http://www.chantefrance.com/
+  country: FR
+  status: stream-only
+  stationuuid: 6a45193e-4b2b-480a-b501-df694d439081
+  changeuuid: ae4a717d-ce66-4c9d-9887-25dc606ca2a9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-m40-eurodance
+  broadcaster: independent
+  name: M40 Eurodance
+  streamUrl: https://live.m40radio.fr/listen/m40-eurodance/m40-eurodance-128.mp3
+  bitrate: 128
+  codec: AAC
+  favicon: https://cdn.m40radio.fr/wp-content/uploads/radio-m40-eurodance-370x370.webp
+  homepage: https://m40radio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 48d735a2-586c-4857-8a26-3332aa475962
+  changeuuid: 21ee6241-e9fd-4458-aad4-ff2f3d0f21d5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-zai-zai
+  broadcaster: independent
+  name: Radio Zaï Zaï
+  streamUrl: https://listen.radioking.com/radio/204667/stream/247420
+  bitrate: 128
+  codec: MP3
+  favicon: https://zaizai-radio.org/favicon.ico
+  homepage: https://zaizai-radio.org/
+  country: FR
+  status: stream-only
+  stationuuid: a7760c28-7212-4155-9610-21fea3bcd5e0
+  changeuuid: ab932303-0e42-4fe2-883c-64bb68cfc6b4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-dubsideradio
+  broadcaster: independent
+  name: dubsideradio
+  streamUrl: https://puma.streemlion.com:5505/stream
+  bitrate: 320
+  codec: MP3
+  homepage: https://www.dubsideradio.com/
+  country: FR
+  status: stream-only
+  stationuuid: db695122-b64f-4be3-a2b6-633e8722d4ba
+  changeuuid: b5164b3f-77a5-4f90-8975-253cbefa438c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-presence-toulouse
+  broadcaster: independent
+  name: Radio Présence Toulouse
+  streamUrl: https://direct.radiopresence.com/presence
+  bitrate: 128
+  codec: MP3
+  favicon: http://www.radiopresence.com/plugins/theme_presence/img/favicon.ico
+  homepage: http://www.radiopresence.com/
+  country: FR
+  status: stream-only
+  stationuuid: 96151071-0601-11e8-ae97-52543be04c81
+  changeuuid: 21b007f4-73f6-4b7d-96f2-591a3b2b24e7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-allzic-radio-pop-queens
+  broadcaster: independent
+  name: Allzic Radio Pop Queens
+  streamUrl: https://allzic54.ice.infomaniak.ch/allzic54.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://super-radio-global.devhub.top/logo/default.png
+  homepage: https://global.superradio.cc/
+  country: FR
+  status: stream-only
+  stationuuid: 5fa8f3d6-9c2f-4a70-ab0d-89b9af03fe65
+  changeuuid: ad9ec23a-70cc-40a1-a523-65828a39cc53
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-europe-2-new
+  broadcaster: independent
+  name: Europe 2 New
+  streamUrl: https://europe2.lmn.fm/vr-wr1.mp3?aw_0_1st.playerid=lagardereappVirgin
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.europe2.fr/wp-content/themes/melty/europeradio/assets/images/radio/radio_2001.png
+  homepage: https://www.europe2.fr/webradios
+  country: FR
+  status: stream-only
+  stationuuid: 6ee163d6-be5c-411c-84b0-5a4f12a02365
+  changeuuid: 73b58e9a-c453-4f62-b1b3-09bd55d59c27
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-france-musique-la-b-o
+  broadcaster: independent
+  name: France Musique la B.O.
+  streamUrl: https://icecast.radiofrance.fr/francemusiquelabo-hifi.aac
+  bitrate: 192
+  codec: AAC
+  country: FR
+  status: stream-only
+  stationuuid: a3bd3630-5157-47a5-965d-d57374851482
+  changeuuid: 6e0da7d1-8ba9-4418-a28e-aee67cefc5aa
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-campus-paris
+  broadcaster: independent
+  name: Radio Campus Paris
+  streamUrl: https://www.radiocampusparis.org/stream/
+  bitrate: 128000
+  codec: MP3
+  homepage: https://www.radiocampusparis.org/
+  country: FR
+  status: stream-only
+  stationuuid: 3859f931-66c5-4264-afc1-682e186d7263
+  changeuuid: bbc6b5f3-b5ff-43e1-bcf3-e8ea893f5dd0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-reccord-trance-hits
+  broadcaster: independent
+  name: 📻 Reccord Trance Hits
+  streamUrl: https://radiorecord.hostingradio.ru/trancehits96.aacp
+  codec: AAC
+  favicon: https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEjjTv4bYwmRWORccw4X-4Uv7nRsWg9-dWxvvTceRT7MqMaK6c8KS_n_iqet7hMwg3V6uspvj3iUG_3Nl19_rC49PF3btRucbk2fXVHglfO1U09ddwuD8POvSShyVXSn86HAQLK0r6J4x37bE32LK19egO7R3VAOcYz0A5JSQE7f-4HO8dMwX5zSvH8b/s1600/Capture%20d%E2%80%99%C3%A9cran_2024-12-08_08-45-54.png
+  homepage: https://radiosweb.karibshebdo.info/radios-web/reccord-trance-hits
+  country: FR
+  status: stream-only
+  stationuuid: 808103dc-2c26-44be-9bd1-e340caf4c50d
+  changeuuid: 7870f867-1afe-4ce1-ac83-c386cf61565e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-europa-radio-jazz-hd
+  broadcaster: independent
+  name: Europa Radio Jazz HD
+  streamUrl: https://streams.radiomast.io/818607ce-8815-42fb-8dfc-344234a0ff83
+  bitrate: 320
+  codec: MP3
+  homepage: https://www.europaradiojazz.org/
+  country: FR
+  status: stream-only
+  stationuuid: d7af7983-d776-45ff-802b-44e84c1adf6a
+  changeuuid: eaa970a2-7109-482c-a979-c2c6ec5f2b0d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-europe-2-mix-rock-electro-pop
+  broadcaster: independent
+  name: "Europe 2 Mix / Rock, Electro, Pop"
+  streamUrl: https://europe2.lmn.fm/vr-wr6.mp3?aw_0_1st.playerid=lagardereappVirgin
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.europe2.fr/wp-content/themes/melty/europeradio/assets/images/radio/radio_wr6_v2.jpg
+  homepage: https://www.europe2.fr/webradios
+  country: FR
+  status: stream-only
+  stationuuid: ba6de61a-f8e7-4362-b2ec-a03d999ddba3
+  changeuuid: a3f74ed8-ad32-4154-8409-35b6b667be83
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-europe-2-nouvelle-scene
+  broadcaster: independent
+  name: Europe 2 Nouvelle Scène
+  streamUrl: https://europe2.lmn.fm/vr-wr8.mp3?aw_0_1st.playerid=lagardereappVirgin
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.europe2.fr/wp-content/themes/melty/europeradio/assets/images/radio/radio_2008.png
+  homepage: https://www.europe2.fr/webradios
+  country: FR
+  status: stream-only
+  stationuuid: 6c8a9169-612a-4a7f-a02a-da8794c1bbbe
+  changeuuid: 55f95b3b-773b-4502-831a-9643c7f55320
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-hotmix-lounge
+  broadcaster: independent
+  name: hotmix Lounge
+  streamUrl: https://streaming.hotmixradio.com/hotmix-lounge-en-mp3?
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.radio.fr/300/hotmixlounge.jpeg?version=cf0ac3e994b5c65899372a763b4b9cdf
+  homepage: https://www.radio.fr/s/hotmixlounge
+  country: FR
+  status: stream-only
+  stationuuid: e20e95c4-884f-447f-aac6-c4a685ae2eb9
+  changeuuid: 9aa486d7-c35f-4010-a132-d09fac731f70
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-flouka
+  broadcaster: independent
+  name: Radio Flouka
+  streamUrl: https://flouka.out.airtime.pro/flouka_a
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.radioflouka.com/favicon.ico
+  homepage: https://www.radioflouka.com/
+  country: FR
+  status: stream-only
+  stationuuid: 14582ba2-827c-4dba-b4db-19d0320741af
+  changeuuid: ced0bd9f-3dcd-433f-ba73-5cc849e67459
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-rstlss
+  broadcaster: independent
+  name: RSTLSS
+  streamUrl: https://stream.radiosolution.fr/rstlss.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://rstlss.com/favicon.ico
+  homepage: https://rstlss.com/
+  country: FR
+  status: stream-only
+  stationuuid: 5eba8312-e5c9-4dfc-8db2-2abde7044976
+  changeuuid: a06ef3f8-ce68-4706-b713-489ea440385c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-virgin-radio-metal
+  broadcaster: independent
+  name: Virgin Radio Metal
+  streamUrl: https://virginmetal.ice.infomaniak.ch/virgin-radio-metal.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.virginradio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: d820e06b-d0dc-4727-9aa8-f1e22cb27e72
+  changeuuid: 041b0b22-6700-429f-bf1c-c5fea8533254
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-africa-radio-selecta-webradio
+  broadcaster: independent
+  name: Africa Radio Selecta Webradio
+  streamUrl: https://webradio6.ice.infomaniak.ch/webradio6-128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.africaradio.com/favicon.ico
+  homepage: https://www.africaradio.com/
+  country: FR
+  status: stream-only
+  stationuuid: 13395e4c-b6a2-4521-9536-f7863cc4965f
+  changeuuid: fd3196d6-4706-43fa-98fd-282e36eea8e2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-gege
+  broadcaster: independent
+  name: Radio Gege
+  streamUrl: https://www.mistercouzin.net/listen
+  codec: OGG
+  homepage: https://www.mistercouzin.net/
+  country: FR
+  status: stream-only
+  stationuuid: b82a4cc4-ff89-4d24-952d-c5a07a6f424d
+  changeuuid: 77ee107f-ee1f-425f-80a9-9e4f68ab4186
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-rcv-99-fm
+  broadcaster: independent
+  name: RCV 99 fm
+  streamUrl: https://listen.radioking.com/radio/3086/stream/9476
+  bitrate: 128
+  codec: MP3
+  favicon: https://rcv-lille.radio-website.com/upload/5db063f7699121.01150875.ico
+  homepage: https://rcv-lille.radio-website.com/
+  country: FR
+  status: stream-only
+  stationuuid: 3ade0f6c-dc3b-40d2-9eef-0417ae127c2a
+  changeuuid: 60d4df17-c8bb-4d92-a8a4-9295f7f20711
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-rjr-radio-jeunes-reims-aac-128k
+  broadcaster: independent
+  name: RJR - Radio Jeunes Reims (AAC 128k)
+  streamUrl: https://stream.rjrradio.fr/rjr.aac
+  bitrate: 192
+  codec: AAC
+  favicon: https://www.rjrradio.fr/sites/default/files/logo2016.png
+  homepage: https://www.rjrradio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: d485cf84-a553-4b9b-b075-9951642cfffd
+  changeuuid: dca71c50-ea45-4e9f-85dc-01ba84b009de
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-sun-rock
+  broadcaster: independent
+  name: SUN Rock
+  streamUrl: https://diffusion.lafrap.fr/sun-rock.mp3
+  bitrate: 160
+  codec: MP3
+  favicon: https://www.lesonunique.com/datasun/images_flux/logos/SD/rock.png
+  homepage: https://www.lesonunique.com/
+  country: FR
+  status: stream-only
+  stationuuid: 286a3681-d1b4-4e49-abe8-68c540d70408
+  changeuuid: 4079174d-b388-43df-a97b-2e33bcce14b4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-playlist-music-radio
+  broadcaster: independent
+  name: Playlist Music Radio
+  streamUrl: https://radio13.pro-fhi.net/listen/pdpyrses/stream.mp3
+  bitrate: 320
+  codec: MP3
+  favicon: https://www.playlist-webradio.net/wp-content/uploads/logo-web-1.jpg
+  homepage: https://www.playlist-webradio.net/
+  country: FR
+  status: stream-only
+  stationuuid: f6f5525c-aadc-4d98-923d-ca2033c7171c
+  changeuuid: 4ff9c00c-354c-4d87-83f0-17ba09decbef
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-alouette-le-club
+  broadcaster: independent
+  name: Alouette Le Club
+  streamUrl: https://alouetteleclub.ice.infomaniak.ch/alouetteleclub-128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://bocir-prod-bucket.s3.eu-west-1.amazonaws.com/radios/alouette/radiostream/CACNRjDCGu/vignette_NM9owAwwwM.png
+  homepage: https://www.alouette.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 52a2f88c-0ffa-46ec-98ef-a067a668bf90
+  changeuuid: 688f7847-f6df-4701-9753-193d85e7ec7a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-frequence-3-gold
+  broadcaster: independent
+  name: Fréquence 3 Gold
+  streamUrl: https://frequence3.net-radio.fr/frequence3gold.mp3
+  bitrate: 160
+  codec: MP3
+  homepage: https://www.frequence3.com/
+  country: FR
+  status: stream-only
+  stationuuid: 35815119-ff80-4700-8d81-bd359fb7ce03
+  changeuuid: fddd901b-74a6-44d7-9d1a-abfb84c8a330
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-allzic-radio-annees-70
+  broadcaster: independent
+  name: Allzic Radio Années 70
+  streamUrl: https://allzic50.ice.infomaniak.ch/allzic50.aac
+  bitrate: 64
+  codec: AAC+
+  homepage: https://global.superradio.cc/
+  country: FR
+  status: stream-only
+  stationuuid: 9d4f64c4-184f-4b8b-aa5c-b59ca9c4e9e3
+  changeuuid: 1fdcd2a8-1068-4a4c-be33-4c3fa963bfba
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-irulegiko-irratia
+  broadcaster: independent
+  name: Irulegiko Irratia
+  streamUrl: https://hosting.studioradiomedia.fr:1365/stream
+  bitrate: 320
+  codec: MP3
+  homepage: https://www.irulegikoirratia.eus/
+  country: FR
+  status: stream-only
+  stationuuid: 2c8ee373-4f48-4319-b9a2-09208b5fc24c
+  changeuuid: 98554c61-4046-4c0f-8131-c2ad6eecd624
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-rci-guadeloupe
+  broadcaster: independent
+  name: RCI Guadeloupe
+  streamUrl: https://stream.rcs.revma.com/v4hf7bwspwzuv
+  codec: AAC
+  favicon: https://rci.fm/sites/default/files/webradio/radioguadeloupe.png
+  homepage: https://rci.fm/guadeloupe
+  country: FR
+  status: stream-only
+  stationuuid: fab55181-afe9-4322-8d21-5445bd86d133
+  changeuuid: 69d37ce7-a1fb-433f-bf4e-c6e5e05e6b84
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-slowly-radio
+  broadcaster: independent
+  name: Slowly Radio
+  streamUrl: https://stream.slowlyradio.com/
+  bitrate: 192
+  codec: MP3
+  favicon: https://slowlyradio.com/wp-content/uploads/2023/06/slowlyradio-iconlogo_v-2_4.png
+  homepage: https://slowlyradio.com/
+  country: FR
+  status: stream-only
+  stationuuid: e754703b-1356-4eac-a182-c105cd2009b9
+  changeuuid: 0c37ed26-ea65-4dff-88d9-9eb6a2ef664d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-africa-radio-manu-dibango-webradio
+  broadcaster: independent
+  name: Africa Radio Manu Dibango Webradio
+  streamUrl: https://webradio7.ice.infomaniak.ch/webradio7-128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://images.lesindesradios.fr/fit-in/300x2000/filters:format(webp)/radios/africaradio/radiostream/yXjSg233Sq/vignette_Tf3DO2vq08.png
+  homepage: https://www.africaradio.com/
+  country: FR
+  status: stream-only
+  stationuuid: 3862fa12-c44b-447e-b1e4-70244dfd2c49
+  changeuuid: bdc73c6b-cada-4c42-899f-e4ebbbb4dc55
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-allzic-radio-love
+  broadcaster: independent
+  name: Allzic Radio Love
+  streamUrl: https://allzic34.ice.infomaniak.ch/allzic34.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://super-radio-global.devhub.top/logo/default.png
+  homepage: https://global.superradio.cc/
+  country: FR
+  status: stream-only
+  stationuuid: 2abc9609-6fb7-4449-b8c1-63bf3f933f7d
+  changeuuid: dd690eeb-f208-4935-b00c-7d77bd03f1b1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-efr12-radio
+  broadcaster: independent
+  name: EFR12 Radio
+  streamUrl: https://listen.radioking.com/radio/151768/stream/192217
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.efr12.com/radio/
+  country: FR
+  status: stream-only
+  stationuuid: ba5d1af9-660b-11ea-be63-52543be04c81
+  changeuuid: 5847ef0f-d956-4ff4-8c6f-2cfd44027723
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-egregore-radio
+  broadcaster: independent
+  name: Egregore Radio
+  streamUrl: https://radio.egrego.re/radio/8000/radio.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.egrego.re/RESOURCES/IMAGES/EGREGORELOGO.png
+  homepage: https://www.egrego.re/
+  country: FR
+  status: stream-only
+  stationuuid: 176a6a11-7111-4d32-bd04-202dbb501f09
+  changeuuid: e4a0c66a-b033-416e-ba9e-3ae9f797a709
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-latina-work
+  broadcaster: independent
+  name: "Latina @work"
+  streamUrl: https://latinawork.ice.infomaniak.ch/latinawork.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://bocir-prod-bucket.s3.eu-west-1.amazonaws.com/radios/latina/images/favicon.ico
+  homepage: https://www.latina.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 40b678f9-078a-411b-bcd2-c916be12e06a
+  changeuuid: 46eee5a2-ded3-4fbd-81be-830b5d913486
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-neo
+  broadcaster: independent
+  name: Radio Néo
+  streamUrl: https://ice.creacast.com/radio-neo-paris
+  bitrate: 128
+  codec: MP3
+  homepage: http://www.radioneo.org/
+  country: FR
+  status: stream-only
+  stationuuid: 14dd545b-0444-4951-93a1-5bc773ed6273
+  changeuuid: 7e051393-5734-4fdf-88b0-5cc45f48aab1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-sanef-107-7-est
+  broadcaster: independent
+  name: "Sanef 107.7 - Est\r\n"
+  streamUrl: https://sanef.ice.infomaniak.ch/sanef1077-est.mp3
+  bitrate: 128
+  codec: MP3
+  country: FR
+  status: stream-only
+  stationuuid: 788da040-330e-4429-ac4a-79ce36e01b40
+  changeuuid: 218eb065-62c9-4abb-bc0f-24960c452eaf
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-crooner-radio-movies
+  broadcaster: independent
+  name: Crooner Radio - Movies
+  streamUrl: https://croonerradio_movies.ice.infomaniak.ch/croonerradio-movies-midfi.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://superradio.cc/
+  country: FR
+  status: stream-only
+  stationuuid: c4668753-11ed-463b-8b76-c4a8fca9cbd6
+  changeuuid: 1d0ae6fd-d740-41f5-af84-67149c0b2f8e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-france-culture-sans-pub
+  broadcaster: independent
+  name: France Culture (sans pub)
+  streamUrl: https://stream.radiofrance.fr/franceculture/franceculture.m3u8?id=radiofranceBose
+  bitrate: 107
+  codec: AAC
+  homepage: http://www.franceculture.fr/
+  country: FR
+  status: stream-only
+  stationuuid: a431bb8a-8440-4d9c-88a5-57b93c33e099
+  changeuuid: 9b437d11-4853-423a-a699-4028fc3332b6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-hotmix-dance
+  broadcaster: independent
+  name: Hotmix Dance
+  streamUrl: https://streaming.hotmixradio.com/hotmix-dance-en-mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://web.hotmixradio.com/favicon.ico
+  homepage: https://web.hotmixradio.com/
+  country: FR
+  status: stream-only
+  stationuuid: b49cf4c8-c37c-419a-a21f-70fe0b78beb1
+  changeuuid: 6f72aa06-6c42-4658-8e7b-dc41b2458d29
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-lyon-demain
+  broadcaster: independent
+  name: Lyon Demain
+  streamUrl: https://listen.radioking.com/radio/93388/stream/131857
+  bitrate: 128
+  codec: MP3
+  favicon: https://i1.wp.com/www.lyondemain.fr/wp-content/uploads/2018/09/cropped-logo-1-1.png?fit=300%2C100
+  homepage: https://www.lyondemain.fr/
+  country: FR
+  status: stream-only
+  stationuuid: e443776d-f369-41d1-ae3a-446342752a6a
+  changeuuid: 35569105-4738-4b49-b5b9-1594d6c70bc2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-campus-bordeaux
+  broadcaster: independent
+  name: Radio campus bordeaux
+  streamUrl: https://live.radio-campus.org:8002/campus-bordeaux
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radiocampusbordeaux.fr/
+  country: FR
+  status: stream-only
+  stationuuid: e2a62b4b-ff61-44f2-b550-a68be151ef08
+  changeuuid: 4ae94761-4a76-49ab-a8cb-c92a3ac1f54f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-uylenspiegel
+  broadcaster: independent
+  name: Radio Uylenspiegel
+  streamUrl: https://listen.radioking.com/radio/474857/stream/531260
+  bitrate: 192
+  codec: MP3
+  homepage: http://www.uylenspiegel.eu/
+  country: FR
+  status: stream-only
+  stationuuid: 0c889849-9a9d-4cfd-ac3d-3ce5cdb3f478
+  changeuuid: beca6169-e30b-4344-8541-c6a47f684dfc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radyoga
+  broadcaster: independent
+  name: Radyoga
+  streamUrl: https://play.radioking.io/radyoga/72311
+  bitrate: 320
+  codec: MP3
+  homepage: https://www.radyoga.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 8ecf2342-245a-44eb-842d-49df27fd5851
+  changeuuid: 5c498824-a8be-44b1-a0e4-d808592a6e0c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-rire-et-chansons-canulars
+  broadcaster: independent
+  name: Rire et Chansons Canulars
+  streamUrl: https://streaming.nrjaudio.fm/ouwgjmsk6j4d?aw_0_1st.station=Rire-Chansons-CANULARS&origine=mytuner
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.rireetchansons.fr/webradios/mur-des-radios/rire-et-chansons-canulars
+  country: FR
+  status: stream-only
+  stationuuid: 53adaf12-1dd1-4700-852b-f55da044ee7f
+  changeuuid: b6db0b70-02e2-4c93-91e2-63c5cbe38100
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-virage-radio-legende-du-rock
+  broadcaster: independent
+  name: Virage radio Légende du rock
+  streamUrl: https://virage-radio-legende-du-rock.ice.infomaniak.ch/virage-radio-legende-du-rock.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.virageradio.com/apple-touch-icon-120x120.png
+  homepage: https://www.virageradio.com/radio/webradio/12/virage-radio-legendes-du-rock
+  country: FR
+  status: stream-only
+  stationuuid: b16622c4-f314-467c-95ba-78150a4dd651
+  changeuuid: a39cad38-78cb-48e4-833d-ff234ab06a36
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-100-radio-80
+  broadcaster: independent
+  name: "100% Radio 80"
+  streamUrl: https://streaming.brol.tech/jamendolounge?https://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendolounge
+  bitrate: 128
+  codec: MP3
+  favicon: https://zws.im/󠁵󠁢󠁱󠁡󠁱󠁩󠁴
+  homepage: https://www.youtube.com/watch?v=Fkk9DI-8el4
+  country: FR
+  status: stream-only
+  stationuuid: d74136e8-23e4-4397-90a4-6355005b3d73
+  changeuuid: 47014fb2-6c2f-4710-8230-0599c5e7d54d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-music-radio
+  broadcaster: independent
+  name: Music Radio
+  streamUrl: https://radio.musicradio.ai/listen/musicradio.ai/radio.mp3
+  codec: MP3
+  favicon: https://musicradio.ai/wp-content/uploads/2025/03/logo_musicradio.jpg
+  homepage: https://musicradio.ai/
+  country: FR
+  status: stream-only
+  stationuuid: df2ef0fb-5019-4eb0-bfea-fa21e6a7e609
+  changeuuid: 63430ef1-4d41-42dc-bc5e-734b0e81d9ab
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-marseillette
+  broadcaster: independent
+  name: Radio Marseillette
+  streamUrl: https://rcast.pro-fhi.net:9006/stream
+  bitrate: 192
+  codec: MP3
+  favicon: http://www.marseillettefm.com/upload/design/5fb2b8c9ef7578.99339700.png
+  homepage: http://www.marseillettefm.com/
+  country: FR
+  status: stream-only
+  stationuuid: d8f56780-991c-4de0-ae89-f265ddc8ea97
+  changeuuid: 5001cb53-8338-495d-820a-806bd9702fa6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-reccord-techno
+  broadcaster: independent
+  name: 📻 Reccord Techno
+  streamUrl: https://radiorecord.hostingradio.ru/techno96.aacp
+  codec: AAC
+  favicon: https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEiI5_Myi5uOecneUImHJK8q-e0Io_-5O-gV_OnFXXNqLUgmNsSFvXsopp4uVR78Xiwo2vaQNk8EU8Z7LO-rKfES0PaKMs-JIxUTtGa2U1DzGnJHFYl_xE46dh5XEekozg0QLbzZHKRWbLMNqh7-gIBUSWsZE-GayFYEv5tIApyEkBPf4rAUntjFT2n9/s1600/Capture%20d%E2%80%99%C3%A9cran_2024-12-08_09-03-57.png
+  homepage: https://radiosweb.karibshebdo.info/radios-web/reccord-techno
+  country: FR
+  status: stream-only
+  stationuuid: 8eb6c4b5-07e7-4d2e-8254-88109790a598
+  changeuuid: 1b56b987-1ddc-411c-87c3-22d44cdd6e5f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-algorythme-radio
+  broadcaster: independent
+  name: Algorythme Radio
+  streamUrl: https://radio3.pro-fhi.net/flux-ejzloxke/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.algorythmeradio.com/assets/images/icon-algo.ico
+  homepage: https://www.algorythmeradio.com/
+  country: FR
+  status: stream-only
+  stationuuid: b49f54e5-9a3b-4696-9333-068991d3fb18
+  changeuuid: 133024f5-c263-4729-8d88-ad28ea13e95f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-isekoi-radio
+  broadcaster: independent
+  name: ISEKOI Radio
+  streamUrl: https://public.isekoi-radio.com/listen/isekoi/radio.flac
+  codec: OGG
+  favicon: https://i.postimg.cc/BQZXKJnh/LOGO-3-2-bg1.png
+  homepage: https://isekoi-radio.com/
+  country: FR
+  status: stream-only
+  stationuuid: c7a2d78d-357d-4d5e-8324-e0732c75d048
+  changeuuid: 73f3b956-0687-41b1-88c1-6435dbfe69d5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-campus-clermont-ferrand
+  broadcaster: independent
+  name: Radio Campus Clermont-Ferrand
+  streamUrl: https://live.radio-campus.org:8002/clermont-ferrand
+  bitrate: 256
+  codec: MP3
+  homepage: https://www.campus-clermont.net/
+  country: FR
+  status: stream-only
+  stationuuid: 6639d21a-7de0-4194-93b8-ba63982c7a92
+  changeuuid: 24c45d39-d873-4cd8-8b87-f4595b78cded
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-kreiz-breizh
+  broadcaster: independent
+  name: Radio Kreiz Breizh
+  streamUrl: https://stream.radios.bzh/listen/rkb/radio.mp3
+  bitrate: 256
+  codec: MP3
+  homepage: https://www.rkb.bzh/
+  country: FR
+  status: stream-only
+  stationuuid: eac52cfb-6410-4a41-b2ea-49ac5e76ed78
+  changeuuid: 54bec385-d072-427f-804d-cd5f68c7c781
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-slow-radio
+  broadcaster: independent
+  name: Slow Radio
+  streamUrl: https://play.radioking.io/slow-radio/601307
+  bitrate: 320
+  codec: MP3
+  homepage: https://www.slow-village.fr/en
+  country: FR
+  status: stream-only
+  stationuuid: e8d58e00-cd6c-4359-b084-3b8c471158aa
+  changeuuid: c3337f41-c925-4327-80b0-baec98d0a55a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-galaxie-fm-95-30
+  broadcaster: independent
+  name: " Galaxie FM 95.30 "
+  streamUrl: https://listen.radioking.com/radio/15684/stream/29075
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.galaxieradio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 16e02827-f653-4d44-8229-a9c003b304c5
+  changeuuid: fa611ce7-e657-44a6-9f47-f434a2232244
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr--2
+  broadcaster: independent
+  name: ".. مختصر التفسير "
+  streamUrl: https://qurango.net/radio/mukhtasartafsir
+  bitrate: 128
+  codec: MP3
+  country: FR
+  status: stream-only
+  stationuuid: 99dd5e60-67bd-4307-89a1-9614a42d572b
+  changeuuid: 6d532481-c263-4362-8213-84d73c01181a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-generation-jul
+  broadcaster: independent
+  name: Génération JUL
+  streamUrl: https://generations-jul.ice.infomaniak.ch/generations-jul.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://generations.fr/apple-touch-icon-120x120.png
+  homepage: https://generations.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 3a60ec86-9cfc-4d5b-b28b-e98f68c9dff8
+  changeuuid: 0fb85ddb-6bad-4eba-830f-378c892bd0ee
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-generation-mix
+  broadcaster: independent
+  name: Génération Mix
+  streamUrl: https://ecmanager2.pro-fhi.net/generationmix
+  bitrate: 64
+  codec: AAC
+  homepage: https://www.generation-mix.fr/
+  country: FR
+  status: stream-only
+  stationuuid: e2cb6f04-5ed9-4008-8563-9abfdb4bc068
+  changeuuid: 2e41493b-d079-4c91-abae-700acd1c3590
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-nrj-clermont
+  broadcaster: independent
+  name: NRJ Clermont
+  streamUrl: https://streaming.nrjaudio.fm/oumrck8fnozc
+  bitrate: 64
+  codec: AAC+
+  favicon: https://www.nrj.fr/uploads/assets/nrj/favicon.png
+  homepage: https://www.nrj.fr/
+  country: FR
+  status: stream-only
+  stationuuid: e777ff20-d45b-4ccd-81fa-ca0ab4ec229a
+  changeuuid: b79bd8ce-4cde-4256-b4b2-aeae735cc0c1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-collection
+  broadcaster: independent
+  name: Radio collection
+  streamUrl: https://listen.radioking.com/radio/251653/stream/296545
+  bitrate: 320
+  codec: MP3
+  favicon: https://www.radiocollection.fr/upload/favicon.ico
+  homepage: https://www.radiocollection.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 47357ec6-f935-44df-89c3-65fb44013733
+  changeuuid: 4a214f0d-d5b9-44df-9480-f103e545c032
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-lapurdi-irratia
+  broadcaster: independent
+  name: Radio Lapurdi Irratia
+  streamUrl: https://direct.lapurdi.net/radio-lapurdi
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.lapurdi.net/squelettes/img/logo_web_small.png
+  homepage: https://www.lapurdi.net/
+  country: FR
+  status: stream-only
+  stationuuid: 9a118736-445c-40cb-9bd4-3a73a4a34dfc
+  changeuuid: 0cab13e2-a9f5-4374-8bd7-5d9dd9c0478f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-wit-fm
+  broadcaster: independent
+  name: Wit FM
+  streamUrl: https://start-witfm.ice.infomaniak.ch/start-witfm-high.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://bocir-prod-bucket.s3.amazonaws.com/radios/witfm/images/favicon.vnd.microsoft.icon
+  homepage: http://www.witfm.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 1055c1a4-07be-4a65-9b14-cc3d9009bc92
+  changeuuid: f0750b93-b230-41cf-97c1-b62fc0a57e57
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-france-inter-la-musique-inter
+  broadcaster: independent
+  name: France inter - La musique Inter
+  streamUrl: https://stream.radiofrance.fr/franceinterlamusiqueinter/franceinterlamusiqueinter_hifi.m3u8?id=radiofrance
+  codec: UNKNOWN
+  favicon: https://www.radiofrance.fr/dist/favicons/logo-120.png
+  homepage: https://www.radiofrance.fr/franceinter/la-musique-inter
+  country: FR
+  status: stream-only
+  stationuuid: d267775c-c24e-4d63-a494-0dfd216e5f06
+  changeuuid: 863718d1-ce79-493d-84eb-53dd75c7ad8a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-la-grosse-radio-rock
+  broadcaster: independent
+  name: La Grosse Radio Rock
+  streamUrl: https://hd.lagrosseradio.info/lagrosseradio-rock-192.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://s1.wp.com/i/favicon.ico
+  homepage: https://caribshebdo.wordpress.com/2020/09/02/radio-web-la-grosse-reggae/
+  country: FR
+  status: stream-only
+  stationuuid: d31d09da-95fa-4790-bdda-512fb79689a8
+  changeuuid: 712b5b49-6e78-4a27-8891-2c0a45e1e8f1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-8-ardennes
+  broadcaster: independent
+  name: Radio 8 Ardennes
+  streamUrl: https://sc.creacast.com/radio8.mp3
+  codec: MP3
+  favicon: https://radio8fm.com/img/logo120.png
+  homepage: https://radio8fm.com/
+  country: FR
+  status: stream-only
+  stationuuid: b8dd4a48-bd1b-47cb-ab24-869b1ac98b3b
+  changeuuid: 31ee5781-8d1d-4c24-bedb-e66a76f0d8d0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-allzicradio-jazz-lounge
+  broadcaster: independent
+  name: AllzicRadio Jazz Lounge
+  streamUrl: https://allzic03.ice.infomaniak.ch/allzic03.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://www.allzicradio.com/media/radios/thumb/160x160_allzic-jazz_600px-carre.png
+  homepage: https://www.allzicradio.com/
+  country: FR
+  status: stream-only
+  stationuuid: 5ba9e717-eea0-47c6-bbd9-c0901c719e18
+  changeuuid: 517d5a3e-47f7-4871-b974-1bbdb6396dc0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-m-radio-sur-la-route
+  broadcaster: independent
+  name: M Radio - Sur la route
+  streamUrl: https://voix-du-sud.ice.infomaniak.ch/voix-du-sud.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://mradio.fr/media/radio/thumb/180x180_62569c3c02364-sur-la-route.png
+  homepage: https://mradio.fr/radio/webradio/18/m-radio-sur-la-route
+  country: FR
+  status: stream-only
+  stationuuid: bdfcd87e-3598-4ea6-93a8-667fe79d8e41
+  changeuuid: 974fcf07-d779-4ab5-a4ac-cddd899cd07d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-presence-lot
+  broadcaster: independent
+  name: Radio Presence Lot
+  streamUrl: https://direct.radiopresence.com/radio-presence-lot
+  bitrate: 128
+  codec: MP3
+  favicon: http://direct.radiopresence.com/presence.png
+  homepage: https://www.radiopresence.com/
+  country: FR
+  status: stream-only
+  stationuuid: 53c8c7df-7292-4ed7-8e3b-86f97d8ca87a
+  changeuuid: 778fb5b2-30db-40e6-a315-ab6b284c4336
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-rjr-radio-jeunes-reims-opus-128k
+  broadcaster: independent
+  name: RJR - Radio Jeunes Reims (Opus 128k)
+  streamUrl: https://stream.rjrradio.fr/rjr.ogg
+  codec: OGG
+  favicon: https://www.rjrradio.fr/sites/default/files/logo2016.png
+  homepage: https://www.rjrradio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 9f819a23-e660-4c37-a78c-7476b04caef3
+  changeuuid: df8585ca-30ee-4e2c-b157-362e8f12bbe2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-100-pop-new-wave
+  broadcaster: independent
+  name: "100% POP - NEW WAVE"
+  streamUrl: https://nationalanthems.info/fr-52.mp3?https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3
+  codec: MP3
+  favicon: https://www.youtube.com/s/desktop/dd166493/img/logos/favicon_144x144.png
+  homepage: https://rb.gy/jbj7y1
+  country: FR
+  status: stream-only
+  stationuuid: 3630ef0a-4cab-480d-8ee4-d09a85edad5b
+  changeuuid: 0586bf41-3549-4ef5-acbf-47dd11710538
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-jazz-lounge
+  broadcaster: independent
+  name: Jazz Lounge
+  streamUrl: https://jazzlounge.ice.infomaniak.ch/jazzlounge-high.mp3
+  bitrate: 128
+  codec: MP3
+  country: FR
+  status: stream-only
+  stationuuid: a3ae5ba2-da41-4443-8789-a99a3d003b6c
+  changeuuid: 7b16cc97-11c6-4294-a0aa-fef6fea519d5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-lfm-radio
+  broadcaster: independent
+  name: LFM Radio
+  streamUrl: https://www.radioking.com/play/passionauto974/63343
+  bitrate: 192
+  codec: MP3
+  homepage: http://lfm.re/
+  country: FR
+  status: stream-only
+  stationuuid: 964a2fdc-0601-11e8-ae97-52543be04c81
+  changeuuid: f0352c94-a879-4e8c-b694-06c8dcacafd5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-sun-nantes
+  broadcaster: independent
+  name: SUN Nantes
+  streamUrl: https://diffusion.lafrap.fr/sunhd.mp3
+  bitrate: 160
+  codec: MP3
+  favicon: https://lesonunique.com/images/pwa/icon-512x512.png
+  homepage: https://lesonunique.com/
+  country: FR
+  status: stream-only
+  stationuuid: 2d087131-2826-4aba-b79d-e9397c2e657c
+  changeuuid: 21c38edc-95c1-471b-a0f3-6044be3a1f00
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-allzic-radio-kitch
+  broadcaster: independent
+  name: Allzic Radio Kitch
+  streamUrl: https://allzic59.ice.infomaniak.ch/allzic59.aac
+  bitrate: 64
+  codec: AAC+
+  homepage: https://global.superradio.cc/
+  country: FR
+  status: stream-only
+  stationuuid: cdcea49e-4394-496a-8390-4198aaf4d5e2
+  changeuuid: 6f23f47c-3298-4523-b241-7fe5fb6a8530
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-couleursjazz
+  broadcaster: independent
+  name: CouleursJAZZ
+  streamUrl: https://listen.radioking.com/radio/127546/stream/167344
+  bitrate: 128
+  codec: MP3
+  favicon: https://couleursjazz.fr/wp-content/uploads/2020/04/favicon.ico
+  homepage: https://couleursjazz.fr/
+  country: FR
+  status: stream-only
+  stationuuid: acf95e81-6ef5-4e6b-a385-cc2888f9d592
+  changeuuid: 4b07109e-9f42-416c-9371-589d9f3ba011
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-generations-90
+  broadcaster: independent
+  name: Générations 90
+  streamUrl: https://generations-90.ice.infomaniak.ch/generations-90.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://generations.fr/media/radio/generations-90s-logo-smartphone.webp
+  homepage: https://generations.fr/radio/webradio/23/generations-90-s
+  country: FR
+  status: stream-only
+  stationuuid: d0c489b3-b696-40f5-8e2f-6cee95fa0c3a
+  changeuuid: 81c6723c-af07-4f5c-8163-8e7de2b883bc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-fuze
+  broadcaster: independent
+  name: Radio Fuze
+  streamUrl: https://stream-ssl.radios-arra.fr:8443/fuze
+  bitrate: 192
+  codec: MP3
+  favicon: https://radiofuze.fr/wp-content/uploads/2020/06/cropped-Frame-17-1-192x192.jpg
+  homepage: https://radiofuze.fr/
+  country: FR
+  status: stream-only
+  stationuuid: fbb7e55d-61d3-4009-856f-90a586ec5ae0
+  changeuuid: 520c3e55-a3bc-4ce7-b3f7-6ccdda47b140
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-allzic-radio-zouk-2
+  broadcaster: independent
+  name: 🕺 Allzic Radio Zouk
+  streamUrl: https://allzic28.ice.infomaniak.ch/allzic28.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEjAeMRiwfT_G0MkzgGmbeKtGXCiK19-Xybb5ra4fGd9a4bpI_kx_RhuoZ3j9Xuwg6MTSgfrlMF6BB6YQTgLKAoKkEnuMqmmnNbqbcM-ilOKnjNiOD3khYfzD6krS-AfKoC2mKjRym2xaFMzq_e_RbCXPPqu9phHygrLJhkAH4DLMOBTu5tPBbg99Tiw/s320/Capture%20d%E2%80%99%C3%A9cran_2024-11-21_19-52-06.png
+  homepage: https://www.karibshebdo.info/radios-web/allzic-radio-zouk
+  country: FR
+  status: stream-only
+  stationuuid: 7dbd477b-2f11-4e32-864c-a138aa383cf6
+  changeuuid: 04802210-8f2a-43a4-9617-61b3a58ebb8d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-la-belle-aventure
+  broadcaster: independent
+  name: Radio La Belle Aventure
+  streamUrl: https://flux.radiolabelleaventure.com/listen/radio_la_belle_aventure/radio.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.radiolabelleaventure.com/wp-content/uploads/2025/05/cropped-logo-transparent-192x192.png
+  homepage: https://www.radiolabelleaventure.com/
+  country: FR
+  status: stream-only
+  stationuuid: c2bad206-b3ca-49a8-bfd6-a3b1ea275b09
+  changeuuid: be49ab97-f9d6-47c1-a96b-feb4c7f068f9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-reccord-reggae
+  broadcaster: independent
+  name: 📻 Reccord Reggae
+  streamUrl: https://radiorecord.hostingradio.ru/reggae96.aacp
+  codec: AAC
+  favicon: https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEiwmIz_Xot-rVbingUduX4x6zZ7Fhni986FZenMwEP9bDu0RfUai1I9W85y2u3ki-SBF4XPMybR8QibwM2m1Y1fwn-CmvxDDpcRNe_bSeA865IVBbbeV02naE2voMhdKC8h6c-LsxI4_hyucURzfLhcQXO0RbbGADS7s7f8LVJkjdpTsPnslYA72S1S/s1600/Capture%20d%E2%80%99%C3%A9cran_2024-12-08_10-07-00.png
+  homepage: https://radiosweb.karibshebdo.info/radios-web/reccord-reggae
+  country: FR
+  status: stream-only
+  stationuuid: d0f0dd9e-b43d-407e-913d-3ef470591193
+  changeuuid: 3221c64d-b8e7-4e8d-abf9-8b784d336d3e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-alouette-indie
+  broadcaster: independent
+  name: ALOUETTE INDIE
+  streamUrl: https://alouetteindie.ice.infomaniak.ch/alouetteindie-128.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.alouette.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 71e33a1c-1eed-401e-a885-a8c080d58966
+  changeuuid: 6cb6bb65-c6ff-41b1-8e79-5b8aafd67d7d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-big-bang-radio
+  broadcaster: independent
+  name: BIG BANG RADIO
+  streamUrl: https://streams.radiomast.io/2b410ada-8653-40aa-a654-3e8954cf4a4d
+  bitrate: 1500
+  codec: OGG
+  favicon: https://bigbangradio.live/wp-content/uploads/2022/06/LOGO0080-big-bang.png
+  homepage: https://bigbangradio.live/
+  country: FR
+  status: stream-only
+  stationuuid: 2ad40e09-bf13-4cff-8fba-9d7164a38e7a
+  changeuuid: 052c76f6-d3e7-47ec-974b-7c9685ae470a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-hotmix-meal
+  broadcaster: independent
+  name: Hotmix meal
+  streamUrl: https://streaming.hotmixradio.com/hotmix-metal-en-mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://web.hotmixradio.com/favicon.ico
+  homepage: https://web.hotmixradio.com/
+  country: FR
+  status: stream-only
+  stationuuid: aca299dd-d28d-43e4-a731-beed1a532fec
+  changeuuid: 70f5a35c-9146-45dd-9284-83ee08b829ed
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-m-radio-2000
+  broadcaster: independent
+  name: "m radio 2000 "
+  streamUrl: https://mfmwr-020.ice.infomaniak.ch/mfmwr-020.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://mradio.fr/apple-touch-icon-120x120.png
+  homepage: https://mradio.fr/radio/webradio/13/annees-2000
+  country: FR
+  status: stream-only
+  stationuuid: 3a844c14-d13f-4223-84b7-cdadb9809841
+  changeuuid: d160555b-189f-4bac-9e89-21990fb66dab
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-allzic-radio-golds-francais
+  broadcaster: independent
+  name: Allzic Radio Golds Français
+  streamUrl: https://allzic30.ice.infomaniak.ch/allzic30.aac
+  bitrate: 64
+  codec: AAC+
+  homepage: https://global.superradio.cc/
+  country: FR
+  status: stream-only
+  stationuuid: b473fb3e-21d7-4b5d-8ddd-9c69b0d11a97
+  changeuuid: 8df0b204-c551-44c7-9afa-81097b524505
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-allzic-radio-hommage-johnny
+  broadcaster: independent
+  name: Allzic Radio Hommage Johnny
+  streamUrl: https://allzic56.ice.infomaniak.ch/allzic56.aac
+  bitrate: 64
+  codec: AAC+
+  homepage: https://global.superradio.cc/
+  country: FR
+  status: stream-only
+  stationuuid: 34992881-ee9a-4c55-abad-21ee8285fa14
+  changeuuid: 9e12b3e5-fd17-40b4-be80-645d1a37512b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-allzic-radio-noel
+  broadcaster: independent
+  name: Allzic Radio Noël
+  streamUrl: https://allzic42.ice.infomaniak.ch/allzic42.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://super-radio-global.devhub.top/logo/default.png
+  homepage: https://global.superradio.cc/
+  country: FR
+  status: stream-only
+  stationuuid: e0f81501-956d-44be-9aa6-6b4962359f65
+  changeuuid: 8aefb475-1a80-4736-8e35-e09c5a8135e8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-plein-air-jura-la-radio-hit-regionale
+  broadcaster: independent
+  name: Radio Plein Air Jura - La Radio Hit Régionale
+  streamUrl: https://stream-1.pleinair.net:8443/dr_jura.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: https://pleinair.net/
+  country: FR
+  status: stream-only
+  stationuuid: 4ee0e8ac-48ac-4720-8ad0-c296f040ab2f
+  changeuuid: 0b4fc295-d56c-4144-afc0-c7c556969c62
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-allzic-radio-lounge
+  broadcaster: independent
+  name: Allzic Radio Lounge
+  streamUrl: https://allzic21.ice.infomaniak.ch/allzic21.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png
+  homepage: https://www.allzicradio.com/en/player/listen/1655/allzic-radio-lounge
+  country: FR
+  status: stream-only
+  stationuuid: 8039b46b-b68c-409b-ac1c-e5322f75be15
+  changeuuid: 7f621502-944a-494a-abd8-b251cb0c9e0d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-alouette-nouveaux-talents
+  broadcaster: independent
+  name: Alouette nouveaux talents
+  streamUrl: https://alouettenouveauxtalents.ice.infomaniak.ch/alouettenouveauxtalents-128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://bocir-prod-bucket.s3.amazonaws.com/radios/alouette/images/favicon.x-icon
+  homepage: https://www.alouette.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 0c9c8e21-3859-4bb5-9620-9234e3a74bd4
+  changeuuid: a5e2ea22-15e3-4123-8da9-afdb99dd0f92
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-happyness-radio-amiens
+  broadcaster: independent
+  name: Happyness Radio Amiens
+  streamUrl: https://azuracast-broadcast.happynessamiens.fr/listen/happyness_dab/player
+  bitrate: 320
+  codec: MP3
+  favicon: https://happynessamiens.fr/wp-content/uploads/2024/04/favicon.jpg
+  homepage: https://happynessamiens.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 1cd97940-240e-4aed-840c-5bb4b82f5c94
+  changeuuid: f93cfe25-9df9-40f7-96da-5b7bbf6366cd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-open-sky
+  broadcaster: independent
+  name: Open Sky
+  streamUrl: https://audio.opensky.radio:8082/stream
+  bitrate: 192
+  codec: MP3
+  favicon: https://opensky.radio/images/small-logo.png
+  homepage: https://opensky.radio/
+  country: FR
+  status: stream-only
+  stationuuid: 67408ac5-49c4-4c2e-9110-a32e26fb1adf
+  changeuuid: 63f7960a-5f25-4c6c-908d-2ecd08f62c52
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-nissa-pantai
+  broadcaster: independent
+  name: Ràdio Nissa Pantai
+  streamUrl: https://listen.radioking.com/radio/79270/stream/117373
+  bitrate: 128
+  codec: MP3
+  homepage: http://www.nissapantai.com/
+  country: FR
+  status: stream-only
+  stationuuid: 9621ea45-0601-11e8-ae97-52543be04c81
+  changeuuid: dfe78dff-5971-4291-99c5-a8a0ac680fe1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-wave-radio
+  broadcaster: independent
+  name: Wave Radio
+  streamUrl: https://s34.myradiostream.com/:12340/listen.mp3
+  bitrate: 160
+  codec: MP3
+  favicon: https://waveradio.fm/wp-content/themes/waveradio/img/favicons/apple-icon-120x120.png
+  homepage: https://waveradio.fm/
+  country: FR
+  status: stream-only
+  stationuuid: 64e55abd-5992-4b2a-98cc-354754b5063f
+  changeuuid: 312e4f21-6994-4ca6-b8e0-a3b0cc561f72
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-canal-b-94mhz
+  broadcaster: independent
+  name: Canal B - 94Mhz
+  streamUrl: https://stream.levillage.org/canalb
+  codec: MP3
+  homepage: http://www.canalb.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 9c17272f-8cad-4bf8-80a9-bcb35d73c8bf
+  changeuuid: c9efd31c-f26e-49af-bcf3-ee28c3407a77
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-frequence-tropicale
+  broadcaster: independent
+  name: Frequence tropicale
+  streamUrl: https://ecmanager2.pro-fhi.net:1640/stream
+  bitrate: 320
+  codec: MP3
+  homepage: https://frequence-tropicale.fr/
+  country: FR
+  status: stream-only
+  stationuuid: f7da4ec3-b8df-42fa-a153-b0e0219f8c90
+  changeuuid: 9c21acc5-4b8a-47f4-b642-c9e9f5ebe5d0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-jazz-radio-afro
+  broadcaster: independent
+  name: Jazz Radio Afro
+  streamUrl: https://jazz-radio-afro.ice.infomaniak.ch/jazz-radio-afro.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.jazzradio.fr/apple-touch-icon-120x120.png
+  homepage: https://www.jazzradio.fr/radio/webradio/43/afro-jazz
+  country: FR
+  status: stream-only
+  stationuuid: 5417b987-40c0-427b-b461-ff9a00c9ba94
+  changeuuid: a6c7c90e-22b7-491d-9d8c-2250efe3ea27
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-nostalgie
+  broadcaster: independent
+  name: Nostalgie
+  streamUrl: https://streaming.nrjaudio.fm/ouwgwqsk6j4d
+  bitrate: 128
+  codec: AAC+
+  favicon: https://img.nrj.fr/L3zosrZkW7lmgFtxF9yG8USZq6c=/medias%2F2022%2F02%2F62150f1f4ce26_62150f240ef6d.svg
+  homepage: https://www.nostalgie.fr/
+  country: FR
+  status: stream-only
+  stationuuid: c785b4aa-d774-4a2f-9d66-c168ee45ed08
+  changeuuid: 34d75a8a-4a12-4f8c-a715-ae5eb5b68a1c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-saint-ferreol
+  broadcaster: independent
+  name: Radio Saint Ferréol
+  streamUrl: https://live.aurafm.org/RadioSaintFerreol
+  codec: MP3
+  homepage: https://www.radiosaintfe.com/
+  country: FR
+  status: stream-only
+  stationuuid: ae363684-a13c-4f70-9dcb-497193b0cd61
+  changeuuid: 4905d7a1-d9e8-4acf-9e1b-232dae9c142c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-scoop-lyon
+  broadcaster: independent
+  name: Radio SCOOP - Lyon
+  streamUrl: https://radioscooplyon.ice.infomaniak.ch/radioscoop-lyon-64.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://www.radioscoop.com/favicon.ico
+  homepage: https://www.radioscoop.com/
+  country: FR
+  status: stream-only
+  stationuuid: 1aa0c8f2-4cc8-4497-aa9d-4dad4b357280
+  changeuuid: 4a9aae84-c09f-489f-8dfa-baf825e0ea41
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-sofa
+  broadcaster: independent
+  name: Radio Sofa
+  streamUrl: https://listen.radioking.com/radio/292531/stream/338878
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radio-sofa.com/
+  country: FR
+  status: stream-only
+  stationuuid: 4a72fae3-8384-473c-8d1b-f17cdc60f387
+  changeuuid: c6018405-fe75-4175-814b-21729e3e37da
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-rmf-radio
+  broadcaster: independent
+  name: RMF Radio
+  streamUrl: https://www.radioking.com/play/rmf-radio/376729
+  bitrate: 64
+  codec: AAC+
+  favicon: https://static.wixstatic.com/media/773fc3_1242bcad92c741eeb1aca7bfd293f577~mv2.jpg/v1/fill/w_180%2Ch_180%2Clg_1%2Cusm_0.66_1.00_0.01/773fc3_1242bcad92c741eeb1aca7bfd293f577~mv2.jpg
+  homepage: https://www.rmf-radio.com/
+  country: FR
+  status: stream-only
+  stationuuid: 1e9819b2-e5c9-443a-9483-3db71100c44f
+  changeuuid: d3294834-7166-4a0e-a164-23b3090e2a9d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-ultra-max
+  broadcaster: independent
+  name: Ultra Max
+  streamUrl: https://ssl-1.radiohost.pl:9111/stream
+  bitrate: 256
+  codec: MP3
+  homepage: https://ultra-max.fun/
+  country: FR
+  status: stream-only
+  stationuuid: f74cc72f-a168-49e0-bbfe-627bae61b22a
+  changeuuid: 9029b053-4ae0-4eb6-a8e3-ccd0b9823efb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-urban-hit-rai
+  broadcaster: independent
+  name: Urban hit raï
+  streamUrl: https://urbanhitus.ice.infomaniak.ch/urbanhitus-128.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://urbanhitus.ice.infomaniak.ch/urbanhitus-128.mp3
+  country: FR
+  status: stream-only
+  stationuuid: b1985c38-5468-11e8-b0ce-52543be04c81
+  changeuuid: 686ad8d2-829d-4e6c-b033-0a43c0bd8545
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-8beats
+  broadcaster: independent
+  name: "8Beats"
+  streamUrl: https://n10.radiojar.com/2fa4wbch308uv
+  codec: MP3
+  favicon: https://8beats.co/favicon.png
+  homepage: https://8beats.co/
+  country: FR
+  status: stream-only
+  stationuuid: dbc3fc04-a00d-45f8-aea9-d9ee1c376743
+  changeuuid: ab55f5f7-4584-4e66-81e0-86ba2c5260c4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-allzic-radio-jazz
+  broadcaster: independent
+  name: Allzic Radio Jazz
+  streamUrl: https://allzic40.ice.infomaniak.ch/allzic40.aac
+  bitrate: 64
+  codec: AAC+
+  homepage: https://global.superradio.cc/
+  country: FR
+  status: stream-only
+  stationuuid: 6752d8f8-2864-48f5-a314-3629113e7966
+  changeuuid: bc4d66e7-3c3b-44e0-9028-6ab94e695a69
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-pistache-la-radio
+  broadcaster: independent
+  name: Pistache La Radio
+  streamUrl: https://rpstrm.pistache.org:9443/pistache.mp3
+  bitrate: 320
+  codec: MP3
+  favicon: https://www.pistache.org/favicon.ico
+  homepage: https://www.pistache.org/
+  country: FR
+  status: stream-only
+  stationuuid: 2b33b33e-cc07-4f22-ae3e-a88ad8aff53a
+  changeuuid: 3361b1d7-56f1-45c8-ac62-9782ee097e73
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-boa
+  broadcaster: independent
+  name: Radio BOA
+  streamUrl: https://stream.radios.bzh/hls/boa/aac_hifi.m3u8
+  codec: UNKNOWN
+  favicon: https://radio-boa.bzh/_ipx/f_webp&s_250x329/logo_white_vertical.svg
+  homepage: https://radio-boa.bzh/
+  country: FR
+  status: stream-only
+  stationuuid: c1323b51-ba5a-414c-aa6b-403250163523
+  changeuuid: 5c71ac08-222c-4d8f-b381-f77e180a471f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-mdm
+  broadcaster: independent
+  name: Radio MDM
+  streamUrl: https://stream.radio-mdm.fr:8443/stream.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.radio-mdm.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 24ad556e-94c9-4dde-af5d-c10f89e8fb9b
+  changeuuid: 4d805350-6661-4e04-8964-0aecda28eb8d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-scoop-pop-rock
+  broadcaster: independent
+  name: "Radio SCOOP - Pop & Rock"
+  streamUrl: https://scooprock.ice.infomaniak.ch/radioscoop-rock-64.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://static.mytuner.mobi/media/tvos_radios/qCy5jNEamp.png
+  homepage: https://www.radio-en-ligne.fr/radio-scoop-pop
+  country: FR
+  status: stream-only
+  stationuuid: 64ada574-64f8-4741-9467-1d0a85ab28bf
+  changeuuid: c5735d17-5ae5-4348-9079-5a1207bcfca6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-alouette-maine-et-loire
+  broadcaster: independent
+  name: ALOUETTE MAINE ET LOIRE
+  streamUrl: https://alouette-angers.ice.infomaniak.ch/alouette-angers-128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: http://www.alouette.fr/favicon.ico
+  homepage: http://www.alouette.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 4ce3facf-f2e6-455b-832b-77155ab8ee23
+  changeuuid: 4707edf5-9f94-435b-9ea2-08839812c763
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-crooner-radio-frenchy
+  broadcaster: independent
+  name: Crooner Radio Frenchy
+  streamUrl: https://direct.croonerradio.fr/croonerradio-frenchy-midfi.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.croonerradio.fr/favicon.ico
+  homepage: https://www.croonerradio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 9277eb7a-28c5-4a07-9080-60c2e05d3676
+  changeuuid: 32d61da5-3e21-4695-a1c2-fa87d38370ca
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-europe-2-centre
+  broadcaster: independent
+  name: Europe 2 Centre
+  streamUrl: https://europe2.lmn.fm/europe2-37000/playlist.m3u8
+  bitrate: 127
+  codec: AAC
+  favicon: https://www.facebook.com/favicon.ico
+  homepage: https://www.facebook.com/Europe2Centre/
+  country: FR
+  status: stream-only
+  stationuuid: db435270-3fcb-47e6-b6b8-659e58ffbc46
+  changeuuid: 9bf4050b-0619-4469-9beb-c01d7367feae
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-nouvo-nova
+  broadcaster: independent
+  name: Nouvo Nova
+  streamUrl: https://nova-nouvo.ice.infomaniak.ch/nova-nouvo-256.aac
+  bitrate: 255
+  codec: AAC
+  favicon: https://www.nova.fr/favicon.ico
+  homepage: https://www.nova.fr/
+  country: FR
+  status: stream-only
+  stationuuid: b79f244b-5f1b-42fe-a2f7-d87758eb89f7
+  changeuuid: 997fbb5d-0d6e-439d-b100-ec810f3831e7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-grand-brive
+  broadcaster: independent
+  name: Radio Grand Brive
+  streamUrl: https://hosting.studioradiomedia.fr:1420/stream.mp3
+  bitrate: 320
+  codec: MP3
+  homepage: https://www.radiograndbrive.fr/
+  country: FR
+  status: stream-only
+  stationuuid: c774a25c-179f-4c94-b459-976fdf57f364
+  changeuuid: 0d428285-568e-4f4d-87d1-dde9dfc3b2c2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-mega
+  broadcaster: independent
+  name: Radio Méga
+  streamUrl: https://stream.ferarock.org:8020/radio-mega
+  bitrate: 320
+  codec: MP3
+  favicon: null
+  homepage: https://www.radio-mega.com/
+  country: FR
+  status: stream-only
+  stationuuid: 06216e8a-e964-4098-9ec9-393331b86d74
+  changeuuid: 00b676f9-04d8-418c-aebd-ae03a08b6850
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-rencontre-dunkerque
+  broadcaster: independent
+  name: Radio Rencontre Dunkerque
+  streamUrl: https://listen.radioking.com/radio/153745/stream/194338
+  bitrate: 128
+  codec: MP3
+  homepage: http://radio-rencontre.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 1d765207-b908-473e-a8fe-6b7e3cee48e6
+  changeuuid: 44c428e4-ddec-43e1-9d27-53b12f5e1cad
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-reccord-chill-house
+  broadcaster: independent
+  name: 📻 Radio Reccord Chill House
+  streamUrl: https://radiorecord.hostingradio.ru/organic96.aacp
+  codec: AAC
+  favicon: https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEiaywxXeHlWtxJ-YR4cdblac_NbEi3yK_drJqEg109pJe2Halhyphenhyphenp7sm_Uoa19TkNkkWh3vUOpKBR8hxUp0c8LSAM2GJNetn1eMWRaQ3ZeGG-PIRmTNPbT9y-_jY_Nd138VO6Jc5TU7BlFlAkvBl3B6ypWP9jXyJg5Z4xIEbgQGzivsuLizFAQDSOzMx/s1600/Capture%20d%E2%80%99%C3%A9cran_2024-11-20_10-10-10.png
+  homepage: https://multimedias.karibshebdo.info/radios-web/record-chill-house
+  country: FR
+  status: stream-only
+  stationuuid: 845cc973-26c2-4485-b767-22079cff36b0
+  changeuuid: de9e0a7e-1fb3-4419-b0f1-4f376c1e0ade
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-reccord-garage-uk
+  broadcaster: independent
+  name: 📻 Reccord Garage UK
+  streamUrl: https://radiorecord.hostingradio.ru/ukgarage96.aacp
+  codec: AAC
+  favicon: https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEj_3RdF5cVH6q2LM_ODf6MgxlD4oSISDe8zLTTyN7wQ65ftFxfjOC4FvoW3wEHDeoZPI46pnJcUp0jESGo-NPwN8hwwipe5XXXsvNUsv5qonbUtcnAubEmtqkfNtHohWY6VdQPJUUBDp4XYUCwvlIaxu5ASAFKM49y3XSwlCRUjvYXboeK587WhM6hL/s1600/Capture%20d%E2%80%99%C3%A9cran_2024-12-08_09-36-30.png
+  homepage: https://radiosweb.karibshebdo.info/radios-web/reccord-garage-uk
+  country: FR
+  status: stream-only
+  stationuuid: a25de834-5805-4c53-be9f-8b2184e2bc72
+  changeuuid: 5cb380c4-e304-4164-b682-1427191e5cfb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-frequence-3-world
+  broadcaster: independent
+  name: Fréquence 3 World
+  streamUrl: https://frequence3.net-radio.fr/frequence3world.mp3
+  bitrate: 160
+  codec: MP3
+  homepage: https://www.frequence3.com/
+  country: FR
+  status: stream-only
+  stationuuid: f063bdeb-9ea8-4dea-a645-fd4909a8a820
+  changeuuid: e3cd14bd-6c0f-4a18-9824-9cc2522e07f2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-le-grand-studio-rtl
+  broadcaster: independent
+  name: Le Grand Studio RTL
+  streamUrl: https://live.m6radio.quortex.io/webpHJPXnXrN7B6J7Q8mcqmxP/webradio/legrandstudiortl/130/audio-64000/index.m3u8
+  bitrate: 64
+  codec: AAC
+  homepage: https://www.rtl.fr/radios
+  country: FR
+  status: stream-only
+  stationuuid: 24d0357e-bb74-476c-82b3-3c26a5f6865b
+  changeuuid: bd1f4de5-10b2-4cb3-9571-5aeb4d6be7a9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-playloud
+  broadcaster: independent
+  name: Playloud
+  streamUrl: https://stream2.playloud.fr/stream
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.playloud.fr/wp-content/uploads/2019/09/cropped-logopld-1-192x192.png
+  homepage: https://www.playloud.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 4fd337cb-4166-4f84-8b98-382cef87d404
+  changeuuid: f387a5ad-4bfb-4206-8fc8-cbcf6b5f4f3f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-allzic-radio-road-66
+  broadcaster: independent
+  name: Allzic Radio Road 66
+  streamUrl: https://allzic37.ice.infomaniak.ch/allzic37.aac
+  bitrate: 64
+  codec: AAC+
+  homepage: https://global.superradio.cc/
+  country: FR
+  status: stream-only
+  stationuuid: d1de8d3c-dc89-4425-b0d7-676ac0b3f69c
+  changeuuid: 53db52c3-a789-4703-a651-e400ce87f50e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-c-lab
+  broadcaster: independent
+  name: C-Lab
+  streamUrl: https://www.c-lab.fr/stream/
+  bitrate: 320
+  codec: MP3
+  favicon: https://www.c-lab.fr/apple-icon-57x57.png
+  homepage: https://www.c-lab.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 2708758d-a5ef-41e2-b100-126b63313967
+  changeuuid: ad2b5ca1-13c1-40b3-bd7c-07ccf3499552
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-hotmix
+  broadcaster: independent
+  name: hotmix
+  streamUrl: https://streaming.hotmixradio.fr/hotmix-blues-en-mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://web.hotmixradio.com/en
+  country: FR
+  status: stream-only
+  stationuuid: 7353f1f9-6ec5-4d38-8fe9-134e5a9bf3ab
+  changeuuid: 3f8ba265-c6d8-4612-9d58-4c60d45aee7f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-infraordinary-five-radio-stations
+  broadcaster: independent
+  name: Infraordinary Five Radio Stations
+  streamUrl: https://infraordinary.fiveradiostations.com:8443/stream
+  codec: MP3
+  homepage: https://www.fiveradiostations.com/infraordinaryfm
+  country: FR
+  status: stream-only
+  stationuuid: 53e9e3fa-2406-4ad1-b382-80c4a0cdf190
+  changeuuid: 340dd490-11ce-4a66-b09e-63c7562c7708
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-les-enfants-du-rhone
+  broadcaster: independent
+  name: Les enfants du Rhône
+  streamUrl: https://listen.radioking.com/radio/300/stream/1430
+  bitrate: 128
+  codec: MP3
+  homepage: https://ledr.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 0397e0d7-aeac-4985-a169-bf582dda00c3
+  changeuuid: 32836944-7a91-4d16-a773-5999ffc04f25
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-bro-gwened
+  broadcaster: independent
+  name: Radio Bro Gwened
+  streamUrl: https://stream.radios.bzh/listen/rbg/radio.mp3
+  bitrate: 256
+  codec: MP3
+  favicon: https://rbg.bzh//app/themes/rbg-radio/assets/images/logo_RBG.png
+  homepage: https://rbg.bzh/
+  country: FR
+  status: stream-only
+  stationuuid: 5715a750-bb5e-4204-9621-a8fe05ebe3ff
+  changeuuid: a5c4b192-59e3-4e65-acb2-20af92456334
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-de-noel
+  broadcaster: independent
+  name: "Radio de Noël "
+  streamUrl: https://live1.jupinfo.fr:8443/radiodenoel
+  bitrate: 140
+  codec: MP3
+  country: FR
+  status: stream-only
+  stationuuid: 26638d27-486d-4621-a6a9-a9554647f237
+  changeuuid: 923ea2bd-f7ff-48bb-b94b-5c4c67548b06
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radios-libres-en-perigord-rlp102-3-mp3-192
+  broadcaster: independent
+  name: Radios Libres en Perigord - RLP102.3 - MP3 192
+  streamUrl: https://direct.radioslibresenperigord.com/rlp.192.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.radioslibresenperigord.com/wp-content/uploads/2023/09/LOGO-Transparent-RLP-2021.png
+  homepage: http://www.radioslibresenperigord.com/
+  country: FR
+  status: stream-only
+  stationuuid: b8a41025-4a40-4cc6-9313-68a1bbc7a403
+  changeuuid: c879b633-c107-4886-9713-e09a717dd345
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-generations-g-funk
+  broadcaster: independent
+  name: 🕺Générations G-Funk
+  streamUrl: https://generationsgfunk.ice.infomaniak.ch/generations-g-funk.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEjwPKCWHMqaCU1Ec6MPYdlqPT71jCL6sTfO8gf_3ZTYr3HYFrfZcZtO_gq6UdWfAu5QHY3X5Q2gUvrtPOLbHWmf2HlsB9oC6jCxIH3FtCL9iS0-kz_iZE-FgMWmZ8JYYrPOzYOxEb0VsDz16Im3SCKtrCIrlDBlzT5H3FLfInkzkyI2d4_1HARLbURg/s239/Capture%20d%E2%80%99%C3%A9cran_2024-11-18_11-54-00.png
+  homepage: https://www.karibshebdo.info/radios-web/g%C3%A9n%C3%A9rations-g-funk
+  country: FR
+  status: stream-only
+  stationuuid: 1769df12-0f89-4ffd-9167-6e39b86c852d
+  changeuuid: 79a4a61d-f500-4933-8bea-564ca510a14d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-frequence-3-urban
+  broadcaster: independent
+  name: Fréquence 3 Urban
+  streamUrl: https://frequence3.net-radio.fr/frequence3urban-128.mp3
+  bitrate: 160
+  codec: MP3
+  homepage: https://www.frequence3.com/
+  country: FR
+  status: stream-only
+  stationuuid: 08ddda12-2b00-49db-b044-cb23ca4d4a54
+  changeuuid: af481116-3975-431b-8d87-eb4c51626457
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-kto-radio
+  broadcaster: independent
+  name: KTO Radio
+  streamUrl: https://liveradiokto.akamaized.net/hls/live/20000054/ktoradio/master.m3u8
+  bitrate: 466
+  codec: UNKNOWN
+  favicon: https://www.ktoradio.com/_next/image?url=https%3A%2F%2Fns3200830.ip-141-94-133.eu%2Fradioscreen%2Fdata%2Fprod%2Fe7696813-ef6f-4d8a-b522-ddf327bdd87a%2Fdab-gen%2Fimage.jpg%3Fts%3D1768733601157&w=256&q=75
+  homepage: https://www.ktoradio.com/
+  country: FR
+  status: stream-only
+  stationuuid: 1365b58b-5486-440f-b2b2-044093540e56
+  changeuuid: 8fddcd21-4e7d-4913-b322-aaf9e998860f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-presence-figeac
+  broadcaster: independent
+  name: Radio Presence Figeac
+  streamUrl: https://direct.radiopresence.com/radio-presence-figeac
+  bitrate: 128
+  codec: MP3
+  favicon: http://direct.radiopresence.com/presence.png
+  homepage: https://www.radiopresence.com/
+  country: FR
+  status: stream-only
+  stationuuid: bc3c5254-d607-45dc-91e9-dd38de1c8f7f
+  changeuuid: 1c5892e1-2d22-4eec-b3ab-7a52412b13cb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-rca-nantes
+  broadcaster: independent
+  name: RCA Nantes
+  streamUrl: https://rcanantes.ice.infomaniak.ch/rcanantes-192.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://bocir-prod-bucket.s3.eu-west-1.amazonaws.com/radios/rca/images/favicon.ico
+  homepage: https://www.rcalaradio.com/
+  country: FR
+  status: stream-only
+  stationuuid: 380f95bf-1b26-45e4-9287-177fe50e2d25
+  changeuuid: 48b3c187-938a-4aea-9d63-dfc5e640447b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-generations-afrobeat
+  broadcaster: independent
+  name: 🕺 Générations Afrobeat
+  streamUrl: https://generations-wr001.ice.infomaniak.ch/generations-wr001.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEiZy0wOk5FYtm_-xPGU6ybRw0xs5yDONOacu2katB3tZiXrYQdy37NQdoRza9lxQzl-dJ6rBvETfPgDK5ubuw_Wcp4pmIzWsX8YJ0FrU4CQPhgWPibEb7-vXVhrylaH-QPO7qN16aOe5k49nIR98GobZRyZBHk4aRZdXX8mqJ4j5ULmK1uME5eX3TYd/s1600/Capture%20d%E2%80%99%C3%A9cran_2024-11-18_11-28-48.png
+  homepage: https://www.karibshebdo.info/radios-web/g%C3%A9n%C3%A9rations-afrobeat
+  country: FR
+  status: stream-only
+  stationuuid: e4de79f6-735e-44b4-b29d-27605b75f599
+  changeuuid: ba0fb115-3426-48ad-aa57-d011328c5cf7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-campus-grenoble
+  broadcaster: independent
+  name: Radio Campus Grenoble
+  streamUrl: https://live.campusgrenoble.org/rcg112
+  codec: MP3
+  homepage: https://campusgrenoble.org/
+  country: FR
+  status: stream-only
+  stationuuid: b4d13f88-bd21-433e-9dd2-abe75fcee334
+  changeuuid: 6d005e9d-7fc0-4bf6-8967-017d4bb3ae25
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-mbs
+  broadcaster: independent
+  name: Radio MBS
+  streamUrl: https://mbs.ice.infomaniak.ch/mbs-64.aac
+  bitrate: 64
+  codec: AAC+
+  homepage: https://www.radiombs.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 1b425b95-ace3-4c48-b9e6-df9a4d6c0735
+  changeuuid: 9958271b-8866-4ef1-81ee-ecf1efbe331f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-titine
+  broadcaster: independent
+  name: Radio Titine
+  streamUrl: https://listen.radioking.com/radio/435545/stream/489533
+  bitrate: 128
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/578136_24e4883683c748a2a776595e66118a35%7emv2.png/v1/fit/w_2500,h_1330,al_c/578136_24e4883683c748a2a776595e66118a35%7emv2.png
+  homepage: http://radiotitine.com/
+  country: FR
+  status: stream-only
+  stationuuid: 0f25690e-5556-4ecc-aef9-e1dd85266647
+  changeuuid: 8677e866-abba-4609-89e5-bd094293e7aa
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-millenium-fm-electro-dj-webradio
+  broadcaster: independent
+  name: Millenium FM Electro DJ Webradio
+  streamUrl: https://radio7.pro-fhi.net:19141/milleniumfm.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://milleniumfm.fr/wp-content/uploads/2022/01/Logo-Millenium-FM_2021_grand.png
+  homepage: https://milleniumfm.fr/
+  country: FR
+  status: stream-only
+  stationuuid: cdc22c75-9ac3-4969-80a7-c7bf01f80d80
+  changeuuid: 6c42f200-5336-4d92-82e7-70df997377b3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-phare-fm-louange
+  broadcaster: independent
+  name: "Phare FM Louange "
+  streamUrl: https://str0.creacast.com/pharefm_louange
+  bitrate: 128
+  codec: MP3
+  homepage: http://www.pharefm.com/
+  country: FR
+  status: stream-only
+  stationuuid: aa10e246-ad83-4ec6-8c05-d40ee7cd381e
+  changeuuid: 91056997-f773-43db-b4ad-62d9cb592da5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-gatine
+  broadcaster: independent
+  name: Radio Gâtine
+  streamUrl: https://hosting.radiomedia.fr:1615/stream
+  bitrate: 170
+  codec: MP3
+  favicon: https://radiogatine.fr/upload/design/5d0a55c722f2a8.17678226.png
+  homepage: https://radiogatine.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 92b6401b-9085-4eee-b22d-a252583b1cc4
+  changeuuid: 320bfa7b-df1b-4a09-891d-7d2acdf04d67
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-univers
+  broadcaster: independent
+  name: Radio Univers
+  streamUrl: https://stream4.vestaradio.com/RadioUnivers
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.radio-univers.com/wp-includes/images/w-logo-blue-white-bg.png
+  homepage: https://www.radio-univers.com/
+  country: FR
+  status: stream-only
+  stationuuid: ae3dcdb6-0770-447d-bbb1-2e2c224aa1ff
+  changeuuid: a6457e02-9e07-4822-ab22-24d072993f88
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-eklectywaves-the-sharing-radio
+  broadcaster: independent
+  name: EklectyWaves - The Sharing Radio
+  streamUrl: https://play.radioking.io/eklectywaves-the-sharing-radio
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.radioplug.co.uk/img/channel/19-03-2025-22-43-21-c.png
+  homepage: https://www.eklectywaves.com/
+  country: FR
+  status: stream-only
+  stationuuid: 058fd4fb-d101-41f2-a4f5-78299e3705a0
+  changeuuid: 6e20d071-03a2-4991-8bab-d8f7f7ec1d86
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-frequence-7
+  broadcaster: independent
+  name: Fréquence 7
+  streamUrl: https://live.aurafm.org/Frequence7
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.frequence7.net/images/logo.jpg
+  homepage: https://www.frequence7.net/
+  country: FR
+  status: stream-only
+  stationuuid: d1298c14-014d-40d7-8864-715c79d45b95
+  changeuuid: 60186d3c-5656-4efc-8425-7f53b6b433f7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-groove-cabane
+  broadcaster: independent
+  name: Groove Cabane
+  streamUrl: https://listen.radioking.com/radio/314264/stream/361499
+  bitrate: 320
+  codec: MP3
+  favicon: https://www.groovecabane.com/upload/5fc908afba9a83.98129202.ico
+  homepage: https://www.groovecabane.com/
+  country: FR
+  status: stream-only
+  stationuuid: d39a9f9f-e9b3-454a-994a-d474f8c4e82e
+  changeuuid: 50a3daf2-8d24-4888-ba49-c96f241b0d60
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-m-radio-au-travail
+  broadcaster: independent
+  name: M Radio - Au travail
+  streamUrl: https://mradio-au-travail.ice.infomaniak.ch/mradio-au-travail.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://mradio.fr/media/option/logo.webp
+  homepage: https://mradio.fr/radio/webradio
+  country: FR
+  status: stream-only
+  stationuuid: 36618520-603c-48ba-b0f8-662814cbe657
+  changeuuid: 8156d513-024b-4daf-8965-206242f0bd4a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-m-radio-nouveautes
+  broadcaster: independent
+  name: M Radio - Nouveautés
+  streamUrl: https://mfmwr-005.ice.infomaniak.ch/mfmwr-005.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://mradio.fr/media/radio/thumb/160x160_61f1616475e1c-nouveautes.webp
+  homepage: https://mradio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 2e107903-859d-4041-873f-f400493262ce
+  changeuuid: cf3dd10c-7b49-49d9-a5d4-127063cf718d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-m40-deep-dance
+  broadcaster: independent
+  name: M40 Deep dance
+  streamUrl: https://live.m40radio.fr/listen/m40-deep-dance/m40-deep-dance-128.mp3
+  bitrate: 128
+  codec: AAC
+  favicon: https://cdn.m40radio.fr/wp-content/uploads/radio-m40-deep-dance-370x370.webp
+  homepage: https://m40radio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 2faac538-3fc5-42d5-9f39-ef26fb978c81
+  changeuuid: 0f566938-fb6c-4187-bc29-56dd282eeda9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-mydoom-666
+  broadcaster: independent
+  name: Mydoom-666
+  streamUrl: https://mydoom666.radio.fm/md666-128k
+  bitrate: 128
+  codec: MP3
+  favicon: https://cdn.instant.audio/images/logos/ecouterradioenligne-com/mydoom-666.png
+  homepage: https://mydoom666.radio.fm/
+  country: FR
+  status: stream-only
+  stationuuid: 5f6081fb-5f52-4a30-ad36-b8f82e45a5b3
+  changeuuid: 64bdcbcd-d815-4542-bb06-35e456cb47bf
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-rockenfolie
+  broadcaster: independent
+  name: Rockenfolie
+  streamUrl: https://player.rockenfolie.com/
+  bitrate: 256
+  codec: MP3
+  favicon: https://rockenfolie.fr/wp-content/uploads/2021/01/LOGO_ROCKENFOLIE_65.png
+  homepage: https://rockenfolie.com/
+  country: FR
+  status: stream-only
+  stationuuid: 68b98f96-d026-4b6a-a0df-e6e93180f637
+  changeuuid: f4dacb6b-28a7-473c-b02a-99f1de5a1bf6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-generations-reggae
+  broadcaster: independent
+  name: 🕺Générations Reggae
+  streamUrl: https://generations-caraibes.ice.infomaniak.ch/generations-caraibes-high.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEiTBk8X74XIwW8i4X_NDA9IBt-HBCTczbmzpMQdTdCKxOSNo8rw0dD4gTvvkbRQpBsCGHrS7QWvwWMvwLMN18__X8QLaLGl093m1lJ81DsW_KHtiIF1CnZp8bmf8qb5Q48YwB_2JGAf1WlicRQmY3Y2uuLBRlL4FwowcOTrh6s5avSQ93yN1S7ZeBeU/s1600/Capture%20d%E2%80%99%C3%A9cran_2024-11-18_12-42-25.png
+  homepage: https://www.karibshebdo.info/radios-web/g%C3%A9n%C3%A9rations-reggae
+  country: FR
+  status: stream-only
+  stationuuid: 4fcc46a6-51a7-4e4d-aa3c-e695c5a956b2
+  changeuuid: e603e684-0795-49c5-b092-14ff839d2561
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-air-connect
+  broadcaster: independent
+  name: Air Connect
+  streamUrl: https://stream.airconnectradio.com/ac192.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: https://airconnectradio.com/
+  country: FR
+  status: stream-only
+  stationuuid: 910703ee-6c0e-4801-9ad4-cd073ca27409
+  changeuuid: 838ed6ee-ace0-4b49-a183-fdfa8ec64cfd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-beemboomradio
+  broadcaster: independent
+  name: beemboomradio
+  streamUrl: https://listen.radioking.com/radio/299368/stream/356549
+  bitrate: 192
+  codec: MP3
+  favicon: https://d1taocs3kfk7z6.cloudfront.net/track/cover/35e0182a-2536-4cb0-9f3a-2be4f244da02
+  homepage: https://beemboomradio.com/
+  country: FR
+  status: stream-only
+  stationuuid: 311a43d9-29c5-4896-8af2-04a655467d2f
+  changeuuid: 0e3bf70e-499b-48a1-81c1-c85843bccd30
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-rbr-103-4-106-8fm
+  broadcaster: independent
+  name: RBR 103.4/106.8FM
+  streamUrl: https://stream.vestaradio.com/RBR?nocache=72616#
+  bitrate: 192
+  codec: MP3
+  favicon: https://rbrfm.com/sites/default/files/logo_site_1.png
+  homepage: https://rbrfm.com/
+  country: FR
+  status: stream-only
+  stationuuid: 256ed4d1-8e7b-4d6c-8381-ca82dd725182
+  changeuuid: 419d96cc-ab27-4aa8-8d4f-57f699c14d52
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-zone-mix
+  broadcaster: independent
+  name: Zone Mix
+  streamUrl: https://zone-mix.stream.laut.fm/zone-mix?t302=2018-02-12_08-42-17&uuid=960992d8-7019-468f-8628-5cec46e9fa42
+  bitrate: 128
+  codec: MP3
+  country: FR
+  status: stream-only
+  stationuuid: 28891f72-7035-4dc7-a869-de89f81ee807
+  changeuuid: ea517602-93db-4727-a9f5-b741d76a3cda
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-nova-danse
+  broadcaster: independent
+  name: Nova Danse
+  streamUrl: https://nova-dance.ice.infomaniak.ch/nova-dance-128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.nova.fr/wp-content/thumbnails/uploads/sites/2/2020/09/Cards-Nova-Danse-t-400x496.png
+  homepage: https://www.nova.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 3b5b5b7d-7cb1-424b-a7d6-84c21ec26abd
+  changeuuid: adac4182-ba1f-4f0c-87c2-c563aa3b02da
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-black-corvette
+  broadcaster: independent
+  name: Black Corvette
+  streamUrl: https://radio2.vip-radios.fm:18084/stream-mp3-BlackCorvette
+  bitrate: 128
+  codec: MP3
+  homepage: http://www.black-corvette.com/
+  country: FR
+  status: stream-only
+  stationuuid: 74483def-4d3a-41d0-bd04-fb63be328cb7
+  changeuuid: 132dfc37-1168-475d-adc8-cac50f6b613a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-cool-radio
+  broadcaster: independent
+  name: Cool Radio
+  streamUrl: https://listen.radioking.com/radio/530131/stream/588580
+  bitrate: 128
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/a276e6_268d8bb5969c4360808f3688aa0f7ce4~mv2.png/v1/fill/w_454,h_454,al_c,q_85,usm_0.66_1.00_0.01,enc_auto/LOGO%20COOL%20RADIO%20MAI%202023.png
+  homepage: https://www.lamusiquequifaitdubien.com/cool-radio
+  country: FR
+  status: stream-only
+  stationuuid: b4e36350-d6ca-41eb-a8e5-e25a3c1fea5a
+  changeuuid: 16d9c203-55a2-4ff3-88ee-a8dd01c23089
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-d4b
+  broadcaster: independent
+  name: D4B
+  streamUrl: https://d4b.ice.infomaniak.ch/d4b-96.mp3
+  bitrate: 96
+  codec: MP3
+  favicon: https://www.radiod4b.asso.fr/wp-content/uploads/2023/06/logo.png
+  homepage: https://www.radiod4b.asso.fr/
+  country: FR
+  status: stream-only
+  stationuuid: b61de71c-ae9c-4518-8036-bc0049a364d7
+  changeuuid: 1563bb96-5471-48c0-8207-b70f91223975
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-generation-soul
+  broadcaster: independent
+  name: génération Soul
+  streamUrl: https://gene-wr07.ice.infomaniak.ch/gene-wr07.mp3
+  bitrate: 128
+  codec: MP3
+  country: FR
+  status: stream-only
+  stationuuid: 1061f84d-bc8b-47e3-ba33-eb476a3c7a41
+  changeuuid: b3c402c8-03e1-4e93-ae77-bedbbe505b26
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-generations-france
+  broadcaster: independent
+  name: GENERATIONS France
+  streamUrl: https://generationfm.ice.infomaniak.ch/generationfm-high.aac?i=70138
+  bitrate: 64
+  codec: AAC+
+  favicon: https://generations.fr/media/option/logo.webp
+  homepage: https://generations.fr/
+  country: FR
+  status: stream-only
+  stationuuid: e38d98a6-9172-4b4e-805c-56444cb92ca1
+  changeuuid: 84c0c563-7822-42e7-93de-6b3865a7c40b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-hello-provence
+  broadcaster: independent
+  name: Hello Provence
+  streamUrl: https://ice.creacast.com/hello-provence-mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.helloprovence.fr/img/news/61561d9050c77.png
+  homepage: https://www.helloprovence.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 06e3e520-1bfe-4ade-98cc-c07197047679
+  changeuuid: a1a81cf0-3a5e-4e44-b67e-afa56d66f706
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-info-rc
+  broadcaster: independent
+  name: Info RC
+  streamUrl: https://live.aurafm.org/InfoRC
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.inforc.fr/
+  country: FR
+  status: stream-only
+  stationuuid: a441c835-d244-4d74-9a6c-b0d4a171641d
+  changeuuid: 813994ab-f713-42cd-b788-54c50de9f7b4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-m40-electro-swing
+  broadcaster: independent
+  name: M40 Electro Swing
+  streamUrl: https://live.m40radio.fr/listen/m40-electro-swing/m40-electro-swing-128.mp3
+  bitrate: 128
+  codec: AAC
+  favicon: https://cdn.m40radio.fr/wp-content/uploads/radio-m40-electro-swing-370x370.webp
+  homepage: https://m40radio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: b44b324a-b6f0-4a81-b93a-4fcaec48372c
+  changeuuid: 66a341ad-674a-4e3a-afc6-664f2ab50e32
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-arpitania
+  broadcaster: independent
+  name: Radio Arpitania
+  streamUrl: https://listen.radioking.com/radio/28783/stream/64720
+  bitrate: 128
+  codec: MP3
+  homepage: http://www.oarp.eu/
+  country: FR
+  status: stream-only
+  stationuuid: 4fc7fe67-2b6f-4554-a98c-48ab5d701e37
+  changeuuid: de9cc3e3-87b3-43e9-9d54-0c012b862b56
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-fil-de-l-eau
+  broadcaster: independent
+  name: "Radio Fil de l'eau"
+  streamUrl: https://hosting.studioradiomedia.fr:2495/stream
+  bitrate: 128
+  codec: MP3
+  favicon: http://radiofildeleau.fr/wp-content/uploads/logo-rfe-2016.png
+  homepage: https://radiofildeleau.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 9a66d2ad-531f-49f5-bf4f-cfd4d37ec867
+  changeuuid: c0c85680-3058-4b6f-9c84-1dade5160039
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-vinci-autoroutes-ouest-centre
+  broadcaster: independent
+  name: Radio VINCI Autoroutes Ouest Centre
+  streamUrl: https://sc.creacast.com/rva-cofiroute-1
+  bitrate: 128
+  codec: MP3
+  favicon: https://radio.vinci-autoroutes.com/images/flux/ouest-centre-1400.jpg
+  homepage: https://radio.vinci-autoroutes.com/
+  country: FR
+  status: stream-only
+  stationuuid: 36d7f8a0-d03f-4d9d-a87b-54d406e889d2
+  changeuuid: c821c610-4b3c-49fc-ae8c-992f52c4734a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-rts-programme-frequence-plus
+  broadcaster: independent
+  name: RTS programme Fréquence Plus
+  streamUrl: https://frequenceplus71.ice.infomaniak.ch/frequenceplus71-128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.frequenceplus.fr/img/favicon-32x32.png
+  homepage: http://www.frequenceplusfm.com/
+  country: FR
+  status: stream-only
+  stationuuid: 9606dfa3-0601-11e8-ae97-52543be04c81
+  changeuuid: ab3b5410-bf1a-48b6-ba8d-fbb940b8d15b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-virgin-radio-rock-party
+  broadcaster: independent
+  name: "Virgin Radio Rock Party "
+  streamUrl: https://virginradio.ice.infomaniak.ch/virgin-radio.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://virginradio.fr/radio/webradio
+  country: FR
+  status: stream-only
+  stationuuid: 528fe45d-401d-430a-9ade-09fa08a22350
+  changeuuid: b33a48a8-9248-4f87-a39e-833aa966e749
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-allzic-french-mix
+  broadcaster: independent
+  name: Allzic French Mix
+  streamUrl: https://allzic65frenchmix.ice.infomaniak.ch/allzic65.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://www.allzicradio.com/media/radios/thumb/195x195_65d4a0817a09d-french-mix.jpg
+  homepage: https://www.allzicradio.com/player/listen/4307/allzic-french-mix
+  country: FR
+  status: stream-only
+  stationuuid: fb39f9cc-5795-4108-99cb-fece93ce6f02
+  changeuuid: 30a2ae5a-7991-43e7-9051-f26a7446a518
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-christmas-hits-1
+  broadcaster: independent
+  name: Christmas hits 1
+  streamUrl: https://hits1christmas-audiomediaradio.radioca.st/christmas
+  bitrate: 320
+  codec: MP3
+  favicon: https://www.hits1radio.com/wp-content/uploads/2019/03/dummy-e1554135926529.jpg
+  homepage: https://www.hits1radio.com/
+  country: FR
+  status: stream-only
+  stationuuid: 7da7c343-fdfa-4177-86fb-6278d1f6cccc
+  changeuuid: f5121861-a548-4be4-b276-2d86b5d2f30a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-cuberadio-fr
+  broadcaster: independent
+  name: Cuberadio.fr
+  streamUrl: https://api.cuberadio.fr/play
+  bitrate: 128
+  codec: MP3
+  homepage: https://cuberadio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: c3a64b55-c685-494a-8431-8d585ccf9141
+  changeuuid: 23246b5f-c918-4ec7-b927-b61fde80692d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-le-bouquet-granvillais
+  broadcaster: independent
+  name: Le bouquet Granvillais
+  streamUrl: https://www.radioking.com/play/lebouquetgranvillais
+  bitrate: 128
+  codec: MP3
+  favicon: https://radio.lebouquetgranvillais.fr/upload/51bf0534b8eaa1.96289316.ico
+  homepage: https://radio.lebouquetgranvillais.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 47257cb1-a7f6-4f70-ac36-543e027838ca
+  changeuuid: a12fcea0-67c7-4546-8156-02de59144859
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-nrj-new-hits-friday
+  broadcaster: independent
+  name: Nrj New Hits Friday
+  streamUrl: https://streaming.nrjaudio.fm/ou8vstgk7oiu?origine=playernrj&aw_0_req.userConsentV2=&aw_0_1st.station=NRJ-New-Hits-Friday
+  bitrate: 128
+  codec: AAC+
+  favicon: https://www.nrj.fr/uploads/assets/nrj/favicon.ico
+  homepage: https://www.nrj.fr/webradios/mur-des-radios/nrj
+  country: FR
+  status: stream-only
+  stationuuid: 8b49e963-09e2-4295-b4f7-d8c2489f4e86
+  changeuuid: c3a1e779-1b82-468c-ae17-6f041d14a957
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-plum-fm
+  broadcaster: independent
+  name: Plum fm
+  streamUrl: https://stream.radios.bzh/listen/plumfm/radio.mp3
+  bitrate: 256
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/695ef4_9d20d326e8d243788c285f11121c9994~mv2.png/v1/crop/x_0,y_2,w_2101,h_737/fill/w_326,h_114,al_c,q_85,usm_0.66_1.00_0.01,enc_auto/LOGO%20ok%20PLUMFM.png
+  homepage: https://www.plumfm.net/
+  country: FR
+  status: stream-only
+  stationuuid: 00541be2-ceb8-48a7-892f-812761c46360
+  changeuuid: 2e9bb993-20ca-42b8-b01b-2cf635107803
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-occitania
+  broadcaster: independent
+  name: Radio Occitania
+  streamUrl: https://sd-151888.dedibox.fr/proxy/occitania/occitania
+  bitrate: 128
+  codec: MP3
+  favicon: https://i0.wp.com/radio-occitania.com/wp-content/uploads/2020/10/logo-ROC-2lignes.jpg?w=373&ssl=1
+  homepage: https://radio-occitania.com/
+  country: FR
+  status: stream-only
+  stationuuid: a51f4499-5c75-4317-9273-a462c54541cf
+  changeuuid: eb9f0427-46dd-4c1e-ad07-31579cd75c56
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-pitchoun
+  broadcaster: independent
+  name: Radio Pitchoun
+  streamUrl: https://webradio.tvradio-pitchoun.fr:8443/radiopitchoun.aac
+  codec: AAC
+  homepage: http://tvradio-pitchoun.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 2534c8ea-1005-47a4-b199-cb0c2c1a18c9
+  changeuuid: b0af2dec-caf8-4264-8929-86468a770355
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-scoop-powerdance
+  broadcaster: independent
+  name: Radio Scoop Powerdance
+  streamUrl: https://scooppowerdance.ice.infomaniak.ch/radioscoop-powerdance-64.aac
+  bitrate: 64
+  codec: AAC+
+  homepage: https://www.radioscoop.com/
+  country: FR
+  status: stream-only
+  stationuuid: 7029052e-cc81-442a-a26e-dff6e41a1b42
+  changeuuid: 3adf843b-6f2f-4ecd-8254-0ee386ab6d7f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-allzic-radio-top-10
+  broadcaster: independent
+  name: Allzic Radio TOP 10
+  streamUrl: https://allzic22.ice.infomaniak.ch/allzic22.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://super-radio-global.devhub.top/logo/default.png
+  homepage: https://global.superradio.cc/
+  country: FR
+  status: stream-only
+  stationuuid: aba7eef8-7b8a-4185-88f7-3637e8d9f126
+  changeuuid: 554f68ce-87b5-49ae-9110-2d7763d11bbd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-eipm
+  broadcaster: independent
+  name: EIPM
+  streamUrl: https://stunnel1.cyber-streaming.com:9046/stream?type=http&nocache=30
+  bitrate: 192
+  codec: MP3
+  favicon: https://radio-eipm.fr/favicon.ico
+  homepage: https://radio-eipm.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 3b33bd4e-bee6-407d-9d67-15e2fd48c110
+  changeuuid: 7dd394d6-810e-4890-af0d-7807bbb661d8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-france-bleu-armorique
+  broadcaster: independent
+  name: France Bleu Armorique
+  streamUrl: https://direct.francebleu.fr/live/fbarmorique-midfi.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://upload.wikimedia.org/wikipedia/commons/thumb/e/e1/France_Bleu_2021.svg/800px-France_Bleu_2021.svg.png
+  homepage: https://www.francebleu.fr/armorique
+  country: FR
+  status: stream-only
+  stationuuid: c99547fd-9f05-4025-86eb-5274898e23c1
+  changeuuid: e36a14b3-4300-40c2-83bc-e9f4d6fbe880
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-graffiti-urban-radio
+  broadcaster: independent
+  name: Graffiti Urban Radio
+  streamUrl: https://diffusion.lafrap.fr/graffiti
+  bitrate: 56
+  codec: AAC+
+  homepage: https://www.graffitiradio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: ac9c27f8-ed13-40be-81cb-8e90abb1d2a8
+  changeuuid: 05cfb4b6-72ce-44a5-a6f3-d6a20cfe9a64
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-kolectiv
+  broadcaster: independent
+  name: "Kolectiv'"
+  streamUrl: https://listen.radioking.com/radio/480/stream/1844
+  bitrate: 128
+  codec: MP3
+  homepage: http://www.kolectiv.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 6d5f7e1e-a35c-4db0-9211-282ef9f4643f
+  changeuuid: 430d83e9-bbb8-475d-a9fe-4f9fa98a34c2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-le-bon-mix
+  broadcaster: independent
+  name: LE BON MIX
+  streamUrl: https://stream10.xdevel.com/audio11s976748-2015/stream/icecast.audio
+  bitrate: 192
+  codec: AAC+
+  favicon: https://admuzzum.xdevel.com/cloud/x/cid/35/im/png/XZXW/Q/XY/20dcef61bfe95be20b65258bba132163.png
+  homepage: https://www.lebonmix.radio/
+  country: FR
+  status: stream-only
+  stationuuid: f4a1ce19-b1b4-4233-98e9-637ab3becec0
+  changeuuid: ac631e13-9058-4b2d-a4ef-aa296c7d3dbd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-pulsradio-trance
+  broadcaster: independent
+  name: PulsRadio Trance
+  streamUrl: https://sc4.gergosnet.com/pulstranceHD.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://static2.mytuner.mobi/media/tvos_radios/269/pulsradio-trance.f0336c60.png
+  homepage: https://www.pulsradio.com/trance
+  country: FR
+  status: stream-only
+  stationuuid: d425c9ba-f40a-4669-8867-60b3b1ab61d3
+  changeuuid: 753487b2-7619-4f27-bfa8-29a2ae881c49
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-karata
+  broadcaster: independent
+  name: Radio Karata
+  streamUrl: https://dynstreamgradioflux.fr:8060/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.radiokarata.com/favicon.png
+  homepage: https://www.radiokarata.com/
+  country: FR
+  status: stream-only
+  stationuuid: 4ec93d0c-9d5f-4960-849c-b7958e33ef6c
+  changeuuid: 43f35193-c99a-47c9-9902-15f712f21378
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-pfm
+  broadcaster: independent
+  name: Radio PFM
+  streamUrl: https://diff.radiopfm.com/flux.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.radiopfm.com/static/img/favicon.d95773dc7037.ico
+  homepage: https://www.radiopfm.com/article/pfm-en-ligne
+  country: FR
+  status: stream-only
+  stationuuid: 71557429-6c6f-4fd4-b0f3-15773a1dcd87
+  changeuuid: d016be03-d578-4afe-a4ae-f0c3b9f4086d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radios-libres-en-perigord-rlp102-3-aac-64
+  broadcaster: independent
+  name: Radios Libres en Perigord - RLP102.3 - AAC+ 64
+  streamUrl: https://direct.radioslibresenperigord.com/rlp.64.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://www.radioslibresenperigord.com/wp-content/uploads/2023/09/LOGO-Transparent-RLP-2021.png
+  homepage: http://www.radioslibresenperigord.com/
+  country: FR
+  status: stream-only
+  stationuuid: 8311c31b-4e30-4647-910a-385039b98868
+  changeuuid: f84d03ba-b94b-4057-80a5-0c3f06b52aaf
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-retro-souvenirs-radio
+  broadcaster: independent
+  name: Retro Souvenirs Radio
+  streamUrl: https://listen.radioking.com/radio/108/stream/890
+  bitrate: 128
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/82b05f_8193c647efa94b70a93346c2a9e39f19%7emv2.jpg/v1/fill/w_32%2ch_32%2clg_1%2cusm_0.66_1.00_0.01/82b05f_8193c647efa94b70a93346c2a9e39f19%7emv2.jpg
+  homepage: https://www.retrosouvenirs.com/
+  country: FR
+  status: stream-only
+  stationuuid: 639f5f1a-9502-47e6-8aee-7e5f4393f6fa
+  changeuuid: cfcf5ea7-a430-4c6a-8a35-778a1f0d9457
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-generations-rap-u-s
+  broadcaster: independent
+  name: 🕺Générations Rap U.S
+  streamUrl: https://generationfm-underground.ice.infomaniak.ch/generationfm-underground-high.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEhDDint7_sPO4IWJn2Hunk69PuUwNl8hG_loo5oRMDVrePNuuzqneX2yRe1iE2KHLJUx3nkrLkco7sTbbjwP_m0GCmYisEB7jsI0trOiGlBJUFS_kE9U52Gipjhm4r70XmHnBzf8i13FH5MhW3DxykjyyGBhu5yj7T3RN_puqjtWp0hIn5Uq1sUKpXi/s1600/Capture%20d%E2%80%99%C3%A9cran_2024-11-18_12-32-28.png
+  homepage: https://www.karibshebdo.info/radios-web/g%C3%A9n%C3%A9rations-rap-u-s
+  country: FR
+  status: stream-only
+  stationuuid: cb484fe2-de97-4718-8c4e-171abc92b8a0
+  changeuuid: 95386067-3551-4d66-a41d-586c08394b8e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-allzic-radio-live-gold
+  broadcaster: independent
+  name: Allzic Radio Live GOLD
+  streamUrl: https://allzic45.ice.infomaniak.ch/allzic45.aac
+  bitrate: 64
+  codec: AAC+
+  homepage: https://global.superradio.cc/
+  country: FR
+  status: stream-only
+  stationuuid: 94141365-02d9-47dc-97bd-0b7bb6789383
+  changeuuid: a70e25d1-36b0-4d08-8b25-e151ee7933b8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-antxeta-irratia
+  broadcaster: independent
+  name: Antxeta irratia
+  streamUrl: https://streaming.antxetamedia.eus:8443/antxeta1
+  bitrate: 192
+  codec: MP3
+  homepage: https://antxetamedia.eus/
+  country: FR
+  status: stream-only
+  stationuuid: fe29fd5a-8f7e-4c26-87c5-5a04729b3415
+  changeuuid: fe43481e-4e1a-4aa5-be2e-5cb438bb2716
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-collector-radio
+  broadcaster: independent
+  name: Collector Radio
+  streamUrl: https://ouifm6.ice.infomaniak.ch/collector-rnt.mp3?ua=InfomaniakPlayer
+  bitrate: 128
+  codec: MP3
+  favicon: https://images.lesindesradios.fr/filters:quality(100)/radios/collector-radio/images/logo.png
+  homepage: https://www.collectorradio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: f69d8609-4e24-4db2-9114-f9fb126df890
+  changeuuid: 1bda4e70-5a6c-42df-a345-f1a45aecc395
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-euradio
+  broadcaster: independent
+  name: EURadio
+  streamUrl: https://euradio.fr/stream/
+  bitrate: 256
+  codec: MP3
+  favicon: https://euradio.fr/apple-touch-icon.png
+  homepage: https://euradio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: d690383f-6012-4a12-a2b3-5676a50e6059
+  changeuuid: 64e7f3bb-dd24-43ed-99f5-162dc5a6084d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-fm43
+  broadcaster: independent
+  name: FM43
+  streamUrl: https://fm43.ice.infomaniak.ch/fm43-64.aac
+  bitrate: 128
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/a5ad8a_939ac18665c14249bff6512b85ba3fb2%7emv2.png/v1/fill/w_180%2ch_180%2clg_1%2cusm_0.66_1.00_0.01/a5ad8a_939ac18665c14249bff6512b85ba3fb2%7emv2.png
+  homepage: https://www.radiofm43.org/
+  country: FR
+  status: stream-only
+  stationuuid: c8e4822b-e078-44dd-be95-4671285ca90c
+  changeuuid: e7f7febd-19d8-49d5-8a35-403c71862c6b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-frequence-luz
+  broadcaster: independent
+  name: Frequence Luz
+  streamUrl: https://stream-ssl.radios-arra.fr:8443/frequenceluz
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.frequenceluz.com/
+  country: FR
+  status: stream-only
+  stationuuid: dfd4d310-2e15-4fe7-9604-45b2fff2bef5
+  changeuuid: fe6521db-d2fa-44c3-8b05-121714fd542b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-pinata
+  broadcaster: independent
+  name: Pinata
+  streamUrl: https://listen.radioking.com/radio/96031/stream/134656
+  bitrate: 128
+  codec: MP3
+  favicon: https://i1.sndcdn.com/avatars-WNhpWtZWyficOMFg-CT1Hyw-t200x200.jpg
+  homepage: https://www.pinataradio.com/
+  country: FR
+  status: stream-only
+  stationuuid: 0deb7fbb-71e4-422c-8124-884e2ba74aa2
+  changeuuid: 58a1883c-7a80-4979-8e63-b03b27c8a803
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-pulsradio-90
+  broadcaster: independent
+  name: PulsRadio - 90
+  streamUrl: https://sc4.gergosnet.com/puls90HD.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://cdn.onlineradiobox.com/img/l/1/8671.v9.png
+  homepage: https://www.pulsradio.com/90/
+  country: FR
+  status: stream-only
+  stationuuid: 41451362-28e4-4dcb-a40d-57fed44698a4
+  changeuuid: fd78bb9b-747a-4e50-8326-79a2344cae0a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-broussaille-lo-fi-aac-128
+  broadcaster: independent
+  name: Radio Broussaille (Lo-Fi AAC 128)
+  streamUrl: https://stream.radiobroussaille.fr:8443/broussaille-lofi
+  bitrate: 128
+  codec: AAC
+  favicon: https://stream.radiobroussaille.fr:8443/favicon-32x32.png
+  homepage: https://radiobroussaille.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 209ab9fe-7493-4af3-9391-e996a026c7e5
+  changeuuid: 25dbf4b5-657e-463c-adda-ba8c9781c31b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-deja-vu
+  broadcaster: independent
+  name: Radio Déjà Vu
+  streamUrl: https://listen.radioking.com/radio/22274/stream/63592
+  bitrate: 192
+  codec: MP3
+  homepage: https://radio-dejavu.com/
+  country: FR
+  status: stream-only
+  stationuuid: b8d55af4-dd99-4995-b1e5-04288ea14129
+  changeuuid: 2b6b75f1-7f4f-416c-918f-6a7e45d685f9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-tempete
+  broadcaster: independent
+  name: Radio Tempête
+  streamUrl: https://listen.radioking.com/radio/372772/stream/422929
+  bitrate: 128
+  codec: MP3
+  homepage: https://radiotempete.com/
+  country: FR
+  status: stream-only
+  stationuuid: 6dfa3796-9a8d-4dce-85df-d16271ecb650
+  changeuuid: 97844eaa-f961-4ff5-98bf-ed810e0b5303
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-virage-radio-chambery
+  broadcaster: independent
+  name: VIRAGE RADIO CHAMBERY
+  streamUrl: https://virageradio.ice.infomaniak.ch/virageradio-chambery.aac?i=47784
+  bitrate: 64
+  codec: AAC+
+  favicon: https://www.virageradio.com/media/option/logo-virage.webp
+  homepage: https://www.virageradio.com/
+  country: FR
+  status: stream-only
+  stationuuid: 35d24975-8580-4aea-8433-c897164433d9
+  changeuuid: 2173a7c4-fd42-4792-8adb-9dd6e992c062
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-ecoutez-mon-petit-france-inter
+  broadcaster: independent
+  name: Écoutez Mon petit France Inter
+  streamUrl: https://stream.radiofrance.fr/monpetitfranceinter/monpetitfranceinter_hifi.m3u8
+  codec: UNKNOWN
+  favicon: https://www.radiofrance.fr/pikapi/images/cbfde3c3-8213-45a6-ac89-b6a3b521025c/200x200
+  homepage: https://www.radiofrance.fr/podcasts/enfants
+  country: FR
+  status: stream-only
+  stationuuid: 71103f1e-b4df-4c10-ad42-f6ff3e5dae10
+  changeuuid: 7bea1d21-f111-4e52-b829-80e914bfd57c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-forum-maine-et-loire
+  broadcaster: independent
+  name: Forum Maine et Loire
+  streamUrl: https://start-forum.ice.infomaniak.ch/start-forum-high.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://bocir-prod-bucket.s3.eu-west-1.amazonaws.com/radios/forum/images/favicon.ico
+  homepage: https://www.forum.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 3b0ccffd-6c3f-489d-accd-9b0fde403335
+  changeuuid: acb4751a-6758-46cb-9339-2d8c58c291bb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-max-radio-grenoble
+  broadcaster: independent
+  name: Max Radio Grenoble
+  streamUrl: https://maxfm.ice.infomaniak.ch/maxfm-945.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://max.radio/player/img/logo.png
+  homepage: https://max.radio/
+  country: FR
+  status: stream-only
+  stationuuid: b1aba9d9-ae9b-48c3-84a5-79403f677e96
+  changeuuid: 487b7d6a-d3a7-4324-ac6d-6f14c826d9f0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-nrj-pop
+  broadcaster: independent
+  name: NRJ POP
+  streamUrl: https://streaming.nrjaudio.fm/oumrai8fnozc?origine=fluxurlradio&aw_0_1st.station=NRJ-Best-Hits-Ever
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.nrj.com/
+  country: FR
+  status: stream-only
+  stationuuid: 191345ea-44ea-44f9-8fc8-00429a539c7d
+  changeuuid: 34381bdb-29f5-4a6e-a01c-a4f972c47a7b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-bartas
+  broadcaster: independent
+  name: Radio Bartas
+  streamUrl: https://stream-ssl.radios-arra.fr:8443/radiobartas
+  bitrate: 224
+  codec: MP3
+  favicon: https://www.radiobartas.net/wp-content/uploads/2019/08/logo-RADIO-BARTAS-final.jpg
+  homepage: https://www.radiobartas.net/
+  country: FR
+  status: stream-only
+  stationuuid: f2925b6e-5522-45be-9672-a1e1baa090b9
+  changeuuid: c1c12213-61f1-46fd-9db9-c414d5ab0488
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-kerne
+  broadcaster: independent
+  name: Radio Kerne
+  streamUrl: https://stream.radios.bzh/listen/kerne/radio.mp3
+  bitrate: 256
+  codec: MP3
+  homepage: https://www.radiokerne.bzh/fr/
+  country: FR
+  status: stream-only
+  stationuuid: 449d37bc-bf28-4fe4-8d83-c3b20eac6571
+  changeuuid: efdff5c4-387c-40d3-89f0-60766bd82ef7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-rvr
+  broadcaster: independent
+  name: RVR
+  streamUrl: https://live.aurafm.org:7443/rvr-tarareplata
+  bitrate: 160
+  codec: AAC
+  homepage: http://www.rvrradio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 222cf226-6ddc-4af8-bc27-3c4ff3a1be78
+  changeuuid: c5100d63-dcce-4051-913f-537331a9c225
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-reccord-groove-tribal
+  broadcaster: independent
+  name: 📻 Reccord Groove/Tribal
+  streamUrl: https://radiorecord.hostingradio.ru/groovetribal96.aacp
+  codec: AAC
+  favicon: https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEicK_fRt2NiH5qCq-6CRWb4vZ2x3fDQOZgW49y2X6pr62c04UDZstgaBYWrhOljUQHGJOrofLCvUw3YZ913xV7yB0F3CijWFQj-vHDwiKO5tWO-q3vPBxEM9iJVe9uTAAmAOFkiai2ihdIfhry7SpjavxU1N9YguCr2SyghRFoLQp-HU1-TCxuJdIZg/s1600/Capture%20d%E2%80%99%C3%A9cran_2024-12-08_09-45-42.png
+  homepage: https://radiosweb.karibshebdo.info/radios-web/reccord-groovetribal
+  country: FR
+  status: stream-only
+  stationuuid: 651e2573-1426-426f-9ab8-0e149fb3b181
+  changeuuid: de638470-7831-4cb2-9630-2ca446fd0e01
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-marsanaryas
+  broadcaster: independent
+  name: " MARSANARYAS"
+  streamUrl: https://www.marsanaryas.com/radio/live/
+  codec: MP3
+  homepage: https://www.marsanaryas.com/
+  country: FR
+  status: stream-only
+  stationuuid: 6acbfc41-778d-4c9d-b8df-5701a51e433b
+  changeuuid: a2e679a3-46e1-4441-8502-fe00fbd5266b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-4u-70s-flower
+  broadcaster: independent
+  name: "4U 70s Flower"
+  streamUrl: https://str4uice.streamakaci.com/4u70s.mp3
+  codec: MP3
+  homepage: https://www.4urock.com/
+  country: FR
+  status: stream-only
+  stationuuid: 4ab7335b-9e79-41b3-b558-e0fcff5b7d63
+  changeuuid: b95eae3a-5e9d-4669-bf6c-f79b2c7c83d9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-gu-radio
+  broadcaster: independent
+  name: Gu Radio
+  streamUrl: https://listen.radioking.com/radio/371/stream/1583
+  bitrate: 128
+  codec: MP3
+  homepage: http://g-u.tv/
+  country: FR
+  status: stream-only
+  stationuuid: de4ae1f8-65c3-4777-8c96-959ab86ff4b2
+  changeuuid: a8852269-d643-4e0b-b1d9-d4050aa659f1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-jade-fm
+  broadcaster: independent
+  name: Jade FM
+  streamUrl: https://diffusion.lafrap.fr/radiochrono.mp3
+  bitrate: 80
+  codec: MP3
+  favicon: https://jadefm.fr/upload/6034f72fbd05f4.03480480.ico
+  homepage: https://jadefm.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 3fddebf5-d49f-48b5-afd0-d0d71b852f2c
+  changeuuid: 6e8115d6-498b-43b2-a549-f72b9e2a1d23
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-m40-latino
+  broadcaster: independent
+  name: M40 Latino
+  streamUrl: https://live.m40radio.fr/listen/m40-latino/m40-latino-128.mp3
+  bitrate: 128
+  codec: AAC
+  favicon: https://cdn.m40radio.fr/wp-content/uploads/radio-m40-latino-370x370.webp
+  homepage: https://m40radio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 7884f8d8-fb06-4ca6-9d0c-112de041411d
+  changeuuid: a7dbc585-76bb-4770-9096-0886ba236466
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-m40-rnb
+  broadcaster: independent
+  name: M40 Rnb
+  streamUrl: https://live.m40radio.fr/listen/m40-rnb/m40-rnb-128.mp3
+  bitrate: 128
+  codec: AAC
+  favicon: https://cdn.m40radio.fr/wp-content/uploads/radio-m40-rnb-370x370.webp
+  homepage: https://m40radio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 8de91b56-079b-443b-94e5-d1a363b67299
+  changeuuid: 1a986a99-1ad7-4e89-9e0a-08d5d616a358
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-playlist-radio
+  broadcaster: independent
+  name: Playlist Radio
+  streamUrl: https://playlist.ice.infomaniak.ch/playlist-192.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://playlistradio.fr/images/logo.png
+  homepage: https://playlistradio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 7a695b8a-437d-4db5-8389-3347eff277c2
+  changeuuid: dfb197ef-8a94-4302-bdce-a87f51c495bc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-delta
+  broadcaster: independent
+  name: Radio Delta
+  streamUrl: https://s4.radio.co/s2fcf9497b/listen
+  bitrate: 128
+  codec: MP3
+  favicon: https://deltaradio.fr/favicon.ico
+  homepage: https://deltaradio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 22bac2ff-f5cc-4169-ab50-cea177e1c8c8
+  changeuuid: 4191e7d5-430c-4de5-9048-682ac799ce28
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-primitive
+  broadcaster: independent
+  name: RADIO PRIMITIVE
+  streamUrl: https://streaming.radioprimitive.fr:8443/live.mp3
+  bitrate: 160
+  codec: MP3
+  favicon: https://www.radioprimitive.fr/images/permanent/logo-square
+  homepage: http://radioprimitive.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 33f9f2d0-206f-4f89-b78e-1c2863f40895
+  changeuuid: 99a69ef5-31a3-415f-a450-fb4f8ae50377
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-rtl-la-collection-georges-lang
+  broadcaster: independent
+  name: RTL La Collection Georges Lang
+  streamUrl: https://live.m6radio.quortex.io/webpHJPXnXrN7B6J7Q8mcqmxP/webradio/rtl-georges-lang/130/audio-64000/index.m3u8
+  bitrate: 64
+  codec: AAC
+  homepage: https://www.rtl.fr/radios
+  country: FR
+  status: stream-only
+  stationuuid: d6840161-12bd-42ba-97f0-059ee1894c3c
+  changeuuid: 08e62836-5800-4478-b36d-619dfb6554f2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-4u-classic-rock
+  broadcaster: independent
+  name: "4U Classic Rock"
+  streamUrl: https://str4uice.streamakaci.com/4uclassicrock.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.4urock.com/favicon.ico
+  homepage: https://www.4urock.com/
+  country: FR
+  status: stream-only
+  stationuuid: 176833ee-0888-4f8a-bc51-51fc800e34d6
+  changeuuid: cfe290a6-42b4-46f8-bff1-31f42fecd962
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-cpc-scene-radio
+  broadcaster: independent
+  name: CPC Scene Radio
+  streamUrl: https://a1.asurahosting.com/listen/cpc_scene_radio/radio.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://radio.cpcscene.net/
+  country: FR
+  status: stream-only
+  stationuuid: bd900c1f-e557-4fbb-a70a-cbaea0e1e632
+  changeuuid: 6d22ad9e-4ac3-428b-af79-a0c1f2a39715
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-france-bleu-haute-normandie
+  broadcaster: independent
+  name: France Bleu Haute Normandie
+  streamUrl: https://direct.francebleu.fr/live/fbhautenormandie-midfi.mp3
+  bitrate: 128
+  codec: MP3
+  country: FR
+  status: stream-only
+  stationuuid: d536624c-c484-426e-884b-b981f648964e
+  changeuuid: cdafdad4-56a8-448e-81e0-6c4bce64f91c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-frequence-hit
+  broadcaster: independent
+  name: Fréquence Hit
+  streamUrl: https://stream.frequencehit.com/frequencehit.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.frequencehit.com/favicon.ico
+  homepage: https://www.frequencehit.com/
+  country: FR
+  status: stream-only
+  stationuuid: f2a24005-a68f-43dc-96a8-4c6e03e4ad88
+  changeuuid: 60d83818-2411-4e27-8052-209f204c3088
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-kizrock-rock
+  broadcaster: independent
+  name: Kizrock Rock
+  streamUrl: https://go.2stream.net/kizrock
+  bitrate: 128
+  codec: MP3
+  homepage: https://kizrock.com/
+  country: FR
+  status: stream-only
+  stationuuid: 88c42d8f-b008-41fc-b5ad-548f3aea95a2
+  changeuuid: e1f3614d-368b-4ce4-a290-dea40bee61fe
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-la-grosse-tambouille
+  broadcaster: independent
+  name: La Grosse Tambouille
+  streamUrl: https://flux.lagrossetambouille.fr/main
+  bitrate: 192
+  codec: MP3
+  favicon: https://lagrossetambouille.fr/logo.png
+  homepage: https://lagrossetambouille.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 2c151880-db7e-4568-a9f1-267609deb45a
+  changeuuid: 3fd2041f-940b-424b-a9ca-b71567448e6c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-m-radio-live
+  broadcaster: independent
+  name: M Radio Live
+  streamUrl: https://mfmwr-008.ice.infomaniak.ch/mfmwr-008.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://mradio.fr/radio/webradio/21/m-radio-live
+  country: FR
+  status: stream-only
+  stationuuid: e94742c2-037c-4e82-87b8-0e1bb066719e
+  changeuuid: e258e1d6-f6aa-4cbd-89c1-2d9bafdd08ea
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-m40-makina
+  broadcaster: independent
+  name: M40 Makina
+  streamUrl: https://live.m40radio.fr/listen/m40-makina/m40-makina-128.mp3
+  bitrate: 128
+  codec: AAC
+  favicon: https://cdn.m40radio.fr/wp-content/uploads/radio-m40-makina-370x370.webp
+  homepage: https://m40radio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 5ce993c4-55d1-433c-9487-c3e8a6840dc1
+  changeuuid: 13664d42-d172-4cfb-86a3-b9eec0cac865
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-neptune-fm
+  broadcaster: independent
+  name: Neptune FM
+  streamUrl: https://diffusion.lafrap.fr/neptune.mp3
+  bitrate: 256
+  codec: MP3
+  favicon: https://neptunefm.com/upload/538ef0b6cab2e5.71343553.ico
+  homepage: https://neptunefm.com/
+  country: FR
+  status: stream-only
+  stationuuid: f194f488-d946-4be7-8fe2-76dc90d13b8f
+  changeuuid: 515c45d7-ca7c-4f6a-aad8-ea1464ee7037
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-party-dance-francehttps-www-vip-radios-fm-statio
+  broadcaster: independent
+  name: "Party Dance Francehttps://www.vip-radios.fm/station/party-dance-radio/"
+  streamUrl: https://radio4.vip-radios.fm:18042/stream-128kmp3-PartyDance
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.vip-radios.fm/station/party-dance-radio/
+  country: FR
+  status: stream-only
+  stationuuid: 4bfc1043-fc16-4cbd-a3c5-5d5783d9a5fb
+  changeuuid: cb177103-fc87-4e76-90f6-3d56efc351e6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-pulsradio-2000
+  broadcaster: independent
+  name: PulsRadio 2000
+  streamUrl: https://sc6.gergosnet.com/puls00HD.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://cdn.onlineradiobox.com/img/l/4/8674.v8.png
+  homepage: https://www.pulsradio.com/2000/
+  country: FR
+  status: stream-only
+  stationuuid: 74779a1e-9ebc-448a-9d9d-adc26ab7077d
+  changeuuid: 7cfe916b-38df-42a7-afb5-835ad3fa754e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-ac-s
+  broadcaster: independent
+  name: "Radio AC'S"
+  streamUrl: https://listen.radioking.com/radio/33824/stream/199675
+  bitrate: 320
+  codec: MP3
+  favicon: https://radioacs.radio-website.com/upload/design/63ca6b9be24252.73424119.png
+  homepage: https://radioacs.radio-website.com/
+  country: FR
+  status: stream-only
+  stationuuid: 7f103ff9-6562-46f0-bbb7-9dbb68734944
+  changeuuid: 0504304f-b11c-41f7-b80f-67b37d348f97
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-rennes
+  broadcaster: independent
+  name: Radio Rennes
+  streamUrl: https://stream4.vestaradio.com/RADIORENNES
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radiorennes.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 8692f42d-b3cf-4a43-889d-e9f52706193e
+  changeuuid: 8f3a088c-083f-497c-86dc-f079329f1189
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-allzic-radio-live-fr
+  broadcaster: independent
+  name: Allzic Radio Live FR
+  streamUrl: https://allzic44.ice.infomaniak.ch/allzic44.aac
+  bitrate: 64
+  codec: AAC+
+  homepage: https://global.superradio.cc/
+  country: FR
+  status: stream-only
+  stationuuid: 6084a8d9-ef4c-4d12-a21a-088586450f77
+  changeuuid: 6e198599-1c58-46ec-bc44-bad3f99ab188
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-hag-fm
+  broadcaster: independent
+  name: "Hag' FM"
+  streamUrl: https://hagfm.streamakaci.com/hagfm.mp3
+  bitrate: 256
+  codec: MP3
+  favicon: https://www.hagfm.com/wp-content/uploads/2023/06/Logo-sans-fond-110x69.png
+  homepage: https://www.hagfm.com/
+  country: FR
+  status: stream-only
+  stationuuid: 094a534b-ef38-4cbf-a9ef-86b8e9d9c85b
+  changeuuid: 0d96fa39-b889-4a3c-92d8-973dad7dd9f6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-ici-armorique
+  broadcaster: independent
+  name: ici Armorique
+  streamUrl: https://icecast.radiofrance.fr/fbarmorique-midfi.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.francebleu.fr/favicon56.ico
+  homepage: https://www.francebleu.fr/radio/armorique
+  country: FR
+  status: stream-only
+  stationuuid: 36cd3aa5-11c0-432b-b10a-d5c2939039d4
+  changeuuid: df5fa75f-da19-4509-bbdb-35c8f0e86e9e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-m40-le-klub
+  broadcaster: independent
+  name: "M40 le klub'"
+  streamUrl: https://live.m40radio.fr/listen/le-klub-by-m40/le-klub-by-m40-128.mp3
+  bitrate: 128
+  codec: AAC
+  favicon: https://cdn.m40radio.fr/wp-content/uploads/favicon-100x100.webp
+  homepage: https://m40radio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: d62a209f-1bbe-49a6-9ff3-e46f8d96ada7
+  changeuuid: cc225e6f-1fae-431f-9148-1de86052c9fe
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-m40-maxi-dance
+  broadcaster: independent
+  name: M40 Maxi Dance
+  streamUrl: https://live.m40radio.fr/listen/m40-maxi-dance/m40-maxi-dance-128.mp3
+  bitrate: 128
+  codec: AAC
+  favicon: https://cdn.m40radio.fr/wp-content/uploads/radio-m40-maxi-dance-370x370.webp
+  homepage: https://m40radio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 37a53031-a692-440f-9d38-d7524d0a0408
+  changeuuid: 12e6bfca-4955-4fa0-8508-60f956efc52e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-dynamo
+  broadcaster: independent
+  name: Radio Dynamo
+  streamUrl: https://dynamo.ice.infomaniak.ch/dynamo.aac
+  bitrate: 96
+  codec: AAC
+  favicon: https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Flookaside.fbsbx.com%2Flookaside%2Fcrawler%2Fmedia%2F%3Fmedia_id%3D239189915631042&f=1&nofb=1&ipt=4eb369aa11463f4c4d2b6adfdad6d8b2f9a7dc22b4d5b714a31f44e1e787a9b9&ipo=images
+  homepage: https://radiodynamo.org/
+  country: FR
+  status: stream-only
+  stationuuid: 5db77a8c-c04b-4dcc-b39e-21414acd7495
+  changeuuid: 2fcc1dec-393a-4bd5-914a-3199dd539b42
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-troutrou
+  broadcaster: independent
+  name: Radio Troutrou
+  streamUrl: https://listen.radioking.com/radio/353374/stream/413698
+  bitrate: 192
+  codec: MP3
+  favicon: https://radiotroutrou.com/apple-touch-icon.png?
+  homepage: https://radiotroutrou.com/
+  country: FR
+  status: stream-only
+  stationuuid: dfe8f10c-4223-477c-92af-0da5ec1cf059
+  changeuuid: 3bdf63de-3758-4fe4-a45d-5def1c624471
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-rig-90-7-fm
+  broadcaster: independent
+  name: Rig 90.7 fm
+  streamUrl: https://stream.aquifm.fr/listenrig.mp3
+  codec: MP3
+  homepage: https://www.rigfm.fr/
+  country: FR
+  status: stream-only
+  stationuuid: bd904b64-e14e-45f2-b31f-148e7905867a
+  changeuuid: 32a50dd6-56fc-4d21-aece-2cb9eeaec991
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-zeno-fm-hypnotissimo
+  broadcaster: independent
+  name: ZENO FM - HYPNOtissimo
+  streamUrl: https://stream.zeno.fm/m7rg3ynt9k0uv
+  codec: MP3
+  favicon: https://zeno.fm/_ipx/f_webp&q_85&fit_cover&s_288x288/https://images.zeno.fm/YYNPJHO5wNHx7Hm8tQ6bIj3vkg4FQW64oMBvitFZ_As/rs:fill:288:288/g:ce:0:0/aHR0cHM6Ly9wcm94eS56ZW5vLmZtL2NvbnRlbnQvc3RhdGlvbnMvYWd4emZucGxibTh0YzNSaGRITnlNZ3NTQ2tGMWRHaERiR2xsYm5RWWdJQ1F3ZjNkdmdrTUN4SU9VM1JoZEdsdmJsQnliMlpwYkdVWWdJRFFxYm5WNXdvTW9nRUVlbVZ1YncvaW1hZ2UvP3U9MTY2MTU3MjE2MDAwMA.webp
+  homepage: https://www.youtube.com/playlist?list=PL46FdNad6dC2qDK3S7kAf-abxQcRsFcqO
+  country: FR
+  status: stream-only
+  stationuuid: 92e9088e-892e-4c1f-9353-d52efa1090bf
+  changeuuid: 4f1ae109-a464-43dc-b5e8-d21bb83584e1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-generations-funk
+  broadcaster: independent
+  name: 🕺 Générations Funk
+  streamUrl: https://gene-wr05.ice.infomaniak.ch/gene-wr05.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEg5HJuS6yWCZCykQR-TGHZWdD1_-17zir7HncDBK8NG2ZQI-fdZP8JiFabyZi8Qlw5qGkBK3rIQ0GX4D5bRVYLE1M2hgsgGwZGY-chOArST8GHIMaS-yj7f_-jOl9ytuB_WgH1v_bDZia8cmgF_1t6RBLbht4wZr_ZzixiYFhDAp71uB5kj_ggwDU56/s1600/Capture%20d%E2%80%99%C3%A9cran_2024-11-18_11-48-02.png
+  homepage: https://www.karibshebdo.info/radios-web/g%C3%A9n%C3%A9rations-funk
+  country: FR
+  status: stream-only
+  stationuuid: d20048b4-7058-452a-be7b-39f5e688acf8
+  changeuuid: b5ef7a7e-6663-41a7-a6ed-9599bebf86ee
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-europe-2-maine-et-loire
+  broadcaster: independent
+  name: Europe 2 Maine et loire
+  streamUrl: https://europe2.lmn.fm/europe2-49000/playlist.m3u8
+  bitrate: 127
+  codec: AAC
+  homepage: https://www.facebook.com/Europe2PaysdelaLoire/
+  country: FR
+  status: stream-only
+  stationuuid: 2a0bf2fb-c1a4-425f-a689-14093680723e
+  changeuuid: 8201b624-8eec-4b80-a5d4-a18909a69b60
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-melody-vintage-radio
+  broadcaster: independent
+  name: Melody Vintage Radio
+  streamUrl: https://stream.rcs.revma.com/5a05fstup42vv
+  codec: MP3
+  favicon: https://cdn.onlineradiobox.com/img/l/9/67559.v9.png
+  homepage: https://www.melody.tv/radio/melody/
+  country: FR
+  status: stream-only
+  stationuuid: 3e9281cc-aa27-4ddb-8a74-e48c5f7ea854
+  changeuuid: d61e0a52-8d5e-4afa-a0dc-10dc2f05da3d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-prune
+  broadcaster: independent
+  name: Prune
+  streamUrl: https://www.prun.net/stream/
+  bitrate: 320
+  codec: MP3
+  favicon: https://www.prun.net/favicon.ico
+  homepage: https://www.prun.net/
+  country: FR
+  status: stream-only
+  stationuuid: a71764a8-4e2c-472c-9f5f-18e93079a4e5
+  changeuuid: 8ce2b444-3d8f-43fc-888e-5ed0df9b3ce7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-campus-orleans
+  broadcaster: independent
+  name: Radio Campus Orléans
+  streamUrl: https://streams.labomedia.org:8443/stream_rco
+  bitrate: 320
+  codec: MP3
+  favicon: https://www.magcentre.fr/wp-content/uploads/2015/03/radio-campus-orleans.jpg
+  homepage: https://orleans.radiocampus.org/
+  country: FR
+  status: stream-only
+  stationuuid: a440c86f-c114-4c06-a1d5-de3e53ab95b2
+  changeuuid: f0db7552-9773-44d7-b36b-c631a63ee986
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-fg-98-2
+  broadcaster: independent
+  name: Radio FG 98.2
+  streamUrl: https://stream.rcs.revma.com/wknqhm4yuchvv
+  codec: MP3
+  favicon: https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse1.mm.bing.net%2Fth%2Fid%2FOIP.xYs-7QDFZLe3JLyEmOuMHAHaGb%3Fpid%3DApi&f=1&ipt=a4b9fe03598a6c8d9f40fc0dcc26deccfa541340435253746eb3def913cf03d0&ipo=images
+  homepage: https://www.radiofg.com/
+  country: FR
+  status: stream-only
+  stationuuid: 4a1bbe28-0675-43bb-98dc-fae037b0b026
+  changeuuid: 24be27f0-77b2-4c8d-b31a-facdcc52bd71
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-pulsar
+  broadcaster: independent
+  name: Radio Pulsar
+  streamUrl: https://radiopulsar.ice.infomaniak.ch/radiopulsar-192.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.radio-pulsar.org/wp-content/uploads/2018/10/cropped-PULSAR_Logo-officiel-192x192.png
+  homepage: https://www.radio-pulsar.org/
+  country: FR
+  status: stream-only
+  stationuuid: 22c6a81b-4ff7-4f90-86b0-e44c573ac4bd
+  changeuuid: 5d0e65aa-b1a7-4d13-afee-efdc954df9c9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-saint-louis
+  broadcaster: independent
+  name: Radio Saint Louis
+  streamUrl: https://stunnel2.cyber-streaming.com:9142/;stream.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://webradio.radiosaintlouis.com/assets/images/logo_rsl_globe_slogan.png
+  homepage: https://webradio.radiosaintlouis.com/
+  country: FR
+  status: stream-only
+  stationuuid: fc28bffb-d8ca-4211-9be9-c93659c352c9
+  changeuuid: 627cefce-12b0-4c30-8580-84d041869d39
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radiocanut
+  broadcaster: independent
+  name: RadioCanut
+  streamUrl: https://live.aurafm.org/radiocanut
+  bitrate: 128
+  codec: MP3
+  homepage: https://radiocanut.org/
+  country: FR
+  status: stream-only
+  stationuuid: 1242554d-1b52-427d-8427-da2fe09fe044
+  changeuuid: 2ec59bd7-5d5c-4436-9583-212c64f1a794
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-tst-radio
+  broadcaster: independent
+  name: TST Radio
+  streamUrl: https://listen.radioking.com/radio/113992/stream/153202
+  bitrate: 128
+  codec: MP3
+  favicon: https://cdn.onlineradiobox.com/img/l/8/74428.v2.png
+  homepage: https://www.tst-radio.com/
+  country: FR
+  status: stream-only
+  stationuuid: 4ae3c661-9917-436d-90c3-34af1fdb5c03
+  changeuuid: 9ed7c20b-349a-4417-bbf9-5cc1150944ba
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-generations-soul
+  broadcaster: independent
+  name: 🕺Générations Soul
+  streamUrl: https://gene-wr07.ice.infomaniak.ch/gene-wr07.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEjKuoeFfqhbcNxeo-YM3ea420CIU4V9z16HIoDo25FqM0Cc6u8eF7Yrm1Aa4FEs0Kex8-1-YggLWwCyuLxPGk28-9dSEpVCDCR_FkGxO8S4-qd9sF9SHuVYjhInufPYGHc5Xi19v39GOZHmrYBQ-e0z8KWVOYDbLfPKHn5_v80g1f3Wmm6NNqPteKcX/s1600/Capture%20d%E2%80%99%C3%A9cran_2024-11-18_12-47-27.png
+  homepage: https://www.karibshebdo.info/radios-web/g%C3%A9n%C3%A9rations-soul
+  country: FR
+  status: stream-only
+  stationuuid: 728068be-7af4-4fd4-89f0-08584ff1cc17
+  changeuuid: 76aea20f-409c-4309-b4f4-435117151509
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-cob-fm-saint-brieuc
+  broadcaster: independent
+  name: "COB' FM Saint-Brieuc"
+  streamUrl: https://myradiostream.com/embed/assets/mp3/test.mp3
+  codec: MP3
+  homepage: https://www.cobfm.com/
+  country: FR
+  status: stream-only
+  stationuuid: 1d3f3033-fbc0-441a-87b7-675b0752de92
+  changeuuid: 8b519c78-6cd9-4586-a0e0-c77fd7c60fc6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-gure-irratia
+  broadcaster: independent
+  name: Gure irratia
+  streamUrl: https://hosting.studioradiomedia.fr:1345/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.inakinoblia.com/wp-content/uploads/2019/11/gure-irratia.jpg
+  homepage: https://www.gureirratia.eus/
+  country: FR
+  status: stream-only
+  stationuuid: 7d77ba3f-b961-4bc6-a9c2-6f9b53a339b2
+  changeuuid: 788904f8-ddab-41d1-b46c-f3ad6061f477
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-le-village-pop
+  broadcaster: independent
+  name: Le village pop
+  streamUrl: https://listen.radioking.com/radio/200437/stream/243028
+  bitrate: 128
+  codec: MP3
+  homepage: http://levillagepop.com/
+  country: FR
+  status: stream-only
+  stationuuid: 4d90c38f-b1c2-442c-91ff-ed4068b36454
+  changeuuid: 7392e0da-dc2f-43e8-bb5f-361a65570a16
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-m40-poprock
+  broadcaster: independent
+  name: M40 PopRock
+  streamUrl: https://live.m40radio.fr/listen/m40-pop-rock/m40-pop-rock-128.mp3
+  bitrate: 128
+  codec: AAC
+  favicon: https://cdn.m40radio.fr/wp-content/uploads/radio-m40-pop-rock-370x370.webp
+  homepage: https://m40radio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 2c17fecb-a5a2-4af5-9e7e-eaab5841fcca
+  changeuuid: c032e777-b93e-4407-a730-b7f0d2fc96db
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-mon-tout-petit-france-inter
+  broadcaster: independent
+  name: "Mon tout petit France Inter "
+  streamUrl: https://stream.radiofrance.fr/montoutpetitfranceinter/montoutpetitfranceinter_hifi.m3u8?id=radiofrance
+  codec: UNKNOWN
+  favicon: https://www.radiofrance.fr/pikapi/images/cbfde3c3-8213-45a6-ac89-b6a3b521025c/200x200
+  homepage: https://www.radiofrance.fr/podcasts/enfants
+  country: FR
+  status: stream-only
+  stationuuid: 0c1614d3-db11-447c-9da8-42107929fae6
+  changeuuid: d513d16b-ce15-419f-8e15-519bc32e504c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-nrj-tiktok
+  broadcaster: independent
+  name: NRJ TIKTOK
+  streamUrl: https://streaming.nrjaudio.fm/ougfbmrb92oc?origine=playernrj&aw_0_req.userConsentV2=&aw_0_1st.station=NRJ-TIKTOK
+  bitrate: 128
+  codec: AAC+
+  favicon: https://img.nrj.fr/iGYpE-czKe0IPznKQ-vMWxbwXxQ=/80x80/https%3A%2F%2Fplayers.nrjaudio.fm%2Flive-metadata%2Fplayer%2Fimg%2Fplayer-files%2Fnrj%2Flogos%2F640x640%2FNRJ-WR--TIKTOK.jpg
+  homepage: https://www.nrj.fr/webradios/mur-des-radios/nrj-tiktok
+  country: FR
+  status: stream-only
+  stationuuid: 5c1e0bdf-1f98-4d4f-b6ca-8c81aca76b1b
+  changeuuid: f5cb6253-c6cc-4537-af6c-a24c450a01dd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-public-health-radio-arabic
+  broadcaster: independent
+  name: Public Health Radio Arabic
+  streamUrl: https://publichealthradioar.ice.infomaniak.ch/publichealthradioar-128.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.publichealthradio.net/
+  country: FR
+  status: stream-only
+  stationuuid: 823f0807-fc2f-4062-a8f5-a033c6203a8a
+  changeuuid: fa6ccd68-2654-448b-bd3f-4ec3d3f50fdc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-replay-news-story-francais
+  broadcaster: independent
+  name: REPLAY NEWS - Story (Français)
+  streamUrl: https://replaynewsstory.ice.infomaniak.ch/replaynewsstory-128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.publicsante.com/BIENVENU/LOGO%20REPLAY%20NEWS%20STORY.png
+  homepage: https://www.replaynews.net/
+  country: FR
+  status: stream-only
+  stationuuid: 3d6cf296-6c24-4a01-97dc-58f872bf922e
+  changeuuid: 0a610352-06ad-45f6-9c60-6ea6b73f048c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-alencon-fm
+  broadcaster: independent
+  name: Alençon FM
+  streamUrl: https://listen.radioking.com/radio/290959/stream/337222
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.alenconfm.fr/favicon.ico
+  homepage: https://www.alenconfm.fr/index.php
+  country: FR
+  status: stream-only
+  stationuuid: 6e92ed1b-6a6a-47aa-b481-e4651e363b81
+  changeuuid: 1981b674-b123-4411-8917-4b974765f032
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-allzic-radio
+  broadcaster: independent
+  name: Allzic radio
+  streamUrl: https://allzic53.ice.infomaniak.ch/allzic53.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.allzicradio.com/fr/player/listen/3693/allzic-radio-chill-out
+  country: FR
+  status: stream-only
+  stationuuid: d683d131-01e1-4f00-b45b-c63435abde77
+  changeuuid: 7e15e381-9af4-49ce-8493-5bbee48266d9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-dhectar
+  broadcaster: independent
+  name: DHECTAR
+  streamUrl: https://manager.dhectar.fr:1065/stream
+  bitrate: 320
+  codec: MP3
+  homepage: https://www.dhectar.fr/index.php
+  country: FR
+  status: stream-only
+  stationuuid: 6d553735-f582-40bb-99f2-483afae74d2b
+  changeuuid: e5512b04-f817-4732-8407-dafe8d963321
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-e-kwality-radio
+  broadcaster: independent
+  name: E-KWALITY RADIO
+  streamUrl: https://www.radioking.com/play/e-kwality-radio/478513
+  bitrate: 64
+  codec: AAC+
+  favicon: https://e-kwalityradio.com/wp-content/uploads/2023/11/LogoTransp_FondFonce_650x200.png
+  homepage: https://e-kwalityradio.com/
+  country: FR
+  status: stream-only
+  stationuuid: e1c8b753-03c2-4049-ad69-fedbde260321
+  changeuuid: 81fef750-1fef-4edd-9dee-4905a7180daf
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-europa-radio-jazz-sd
+  broadcaster: independent
+  name: Europa Radio Jazz SD
+  streamUrl: https://streams.radiomast.io/e947f0b4-cf71-4ed7-934d-2f4661acb0a3
+  bitrate: 192
+  codec: MP3
+  homepage: https://europaradiojazz.org/
+  country: FR
+  status: stream-only
+  stationuuid: 6abfbee0-bef2-401d-8eb6-4a33ebd40986
+  changeuuid: 1180088f-d707-499b-93e0-9a041de65b8c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-f-hits
+  broadcaster: independent
+  name: F. HITS
+  streamUrl: https://listen.fhits.fr:8000/fhits_96.aac
+  bitrate: 96
+  codec: AAC
+  favicon: https://www.fhits.fr/inc/img/FHITS_LOGO.png
+  homepage: https://www.fhits.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 5717291d-0909-4fb3-8ab3-0403fec9d89f
+  changeuuid: 5bd537c5-8fbf-4b97-9666-c2838df2e379
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-iaradio-new-wave
+  broadcaster: independent
+  name: IAradio New Wave
+  streamUrl: https://iaradionewwave.ice.infomaniak.ch/iaradionewwave-128.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://iaradio.eu/
+  country: FR
+  status: stream-only
+  stationuuid: 2c5e5b6b-193a-4cc4-ab6f-1a84044fd48a
+  changeuuid: f1a4a548-0606-4737-bcd5-5d930e6c9008
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-le-son-parisien
+  broadcaster: independent
+  name: Le Son Parisien
+  streamUrl: https://stream.lesonparisien.com/hi.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.lesonparisien.com/images/lsp/logos/le_son_parisien_logo_120x120.png
+  homepage: https://www.lesonparisien.com/en/
+  country: FR
+  status: stream-only
+  stationuuid: 1e072fe4-0e2f-400f-a6c6-c8d3c11aecb1
+  changeuuid: bdbd192c-df52-422e-9d6d-8282e0459ad8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-m40-80s
+  broadcaster: independent
+  name: M40 80s
+  streamUrl: https://live.m40radio.fr/listen/m40-80s/m40-80s-128.mp3
+  bitrate: 128
+  codec: AAC
+  favicon: https://cdn.m40radio.fr/wp-content/uploads/radio-m40-80s-370x370.webp
+  homepage: https://m40radio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 0b751ded-4f4a-485e-bd0d-c4b91298a1bf
+  changeuuid: b66c4b19-3c62-428c-95b4-d0db3431ea6f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-nova-vintage
+  broadcaster: independent
+  name: Nova Vintage
+  streamUrl: https://nova-vnt.ice.infomaniak.ch/nova-vnt-128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.nova.fr/wp-content/thumbnails/uploads/sites/2/2021/02/cropped-favicon-t-180x180.png
+  homepage: https://www.nova.fr/radios/nova-classics/
+  country: FR
+  status: stream-only
+  stationuuid: 5d56dafd-abe4-4092-a7e4-e458f5c1f7f5
+  changeuuid: 5b352c80-72fa-454f-91b4-e2c64342fd5c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-open-sky-192kbps-mp3-oise
+  broadcaster: independent
+  name: "Open Sky (192kbps mp3, \"OISE\")"
+  streamUrl: https://audio.opensky.radio:8082/oise
+  bitrate: 192
+  codec: MP3
+  homepage: https://opensky.radio/
+  country: FR
+  status: stream-only
+  stationuuid: 5d1ab3d9-9f30-4538-bb26-abdf10e0413a
+  changeuuid: d51f84cf-009c-4644-ac28-de02f927ae7c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-beton-tours-93-6
+  broadcaster: independent
+  name: Radio Béton - Tours 93.6
+  streamUrl: https://stream.radiobeton.com:8001/stream.mp3
+  bitrate: 320
+  codec: MP3
+  homepage: https://www.radiobeton.com/
+  country: FR
+  status: stream-only
+  stationuuid: 0eeb750f-40b2-44e8-ab43-4d881454bcd0
+  changeuuid: 202e9e67-6ce0-4541-a4d7-9b11109ccca4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-lengadoc
+  broadcaster: independent
+  name: Ràdio Lengadòc
+  streamUrl: https://stream-ssl.radios-arra.fr:8443/lengadocnarbonne
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.lengadoc.eu/favicon.ico
+  homepage: https://www.lengadoc.eu/
+  country: FR
+  status: stream-only
+  stationuuid: 760ec261-8e5f-4333-8f7f-1db5717a9540
+  changeuuid: 3d158a0f-bc29-433d-bbe4-915f84c94218
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-rdwa
+  broadcaster: independent
+  name: RDWA
+  streamUrl: https://live.aurafm.org/R-Dwa
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.aurafm.org/wp-content/uploads/rdwa.png
+  homepage: https://www.rdwa.fr/
+  country: FR
+  status: stream-only
+  stationuuid: ab30ca84-c228-4f57-8cac-816c69ef651d
+  changeuuid: 69a4691b-6e47-4ebc-99dd-a967fd12a514
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-skylegend
+  broadcaster: independent
+  name: SKYLEGEND
+  streamUrl: https://webradiostream.eu:8200/stream
+  bitrate: 320
+  codec: MP3
+  homepage: https://www.skylegend2024.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 9a6cd7f3-fd11-47d0-8755-9bbf228d4ef3
+  changeuuid: 1f88e30c-d1c5-4649-84d4-b8b7548923c4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-timbre-fm
+  broadcaster: independent
+  name: Timbre FM
+  streamUrl: https://stream.radios.bzh/listen/timbrefm/radio.mp3
+  bitrate: 256
+  codec: MP3
+  favicon: https://api.radios.bzh/assets/ff89d84e-f51e-4427-aa00-a5f58a195ee8
+  homepage: https://timbrefm.fr/fr
+  country: FR
+  status: stream-only
+  stationuuid: 53cd0efb-b6ab-44c6-b042-681843bb82d3
+  changeuuid: 50ce9650-82f2-49f9-94db-83e058881bbb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-generations-rap-u-s-gold
+  broadcaster: independent
+  name: 🕺Générations RAP U.S Gold
+  streamUrl: https://gene-wr08.ice.infomaniak.ch/gene-wr08.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEjIigPaU9oa23mO6Wm0WejrEozwAahxyAgLd2rm2mVCHHYmSUarkXJuygYvhLxjINVfp9ixKvpjAr9RYnnK7KOBaWX9Jbcq6KEo54VbXJ7LekPZyURmnnUg8UlbC17V9OMgDZzNdxSTT7hx1oDDC8BzZwbNxuHJ_cBJ6K9HLd-DrHN2hb8CH9DXgZnt/s1600/Capture%20d%E2%80%99%C3%A9cran_2024-11-18_12-26-34.png
+  homepage: https://www.karibshebdo.info/radios-web/g%C3%A9n%C3%A9rations-rap-u-s-gold
+  country: FR
+  status: stream-only
+  stationuuid: 27d9ffb6-a887-4340-b9b5-af8907d27fa1
+  changeuuid: 3347bc77-8b04-46f9-a3ef-aaa619ad6782
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-mohammed-ayyub
+  broadcaster: independent
+  name: .mohammed ayyub
+  streamUrl: https://qurango.net/radio/mohammed_ayyub
+  bitrate: 128
+  codec: MP3
+  country: FR
+  status: stream-only
+  stationuuid: 88b450d6-3e61-4008-a69b-d82a52323e3a
+  changeuuid: 8386601d-2e14-4992-b070-644a5c3c3bde
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-c9-radio
+  broadcaster: independent
+  name: C9 Radio
+  streamUrl: https://stream.c9.fr/c9radio-192.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.c9.fr/favicon.ico
+  homepage: https://www.c9.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 603111e6-0b5e-49ed-8bab-93f7dab8d83f
+  changeuuid: 72f3710c-31a7-4988-841f-b301a6c539a6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-elise-radio
+  broadcaster: independent
+  name: "Elise radio "
+  streamUrl: https://elise.wanastream.com:25000/;stream.nsv
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.eliseradio.com/
+  country: FR
+  status: stream-only
+  stationuuid: 5558dc4e-c104-49fe-828d-eadae5631f16
+  changeuuid: 9e8ec48e-fa28-4476-9779-a737f0efe129
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-france-musique-ocora
+  broadcaster: independent
+  name: France Musique Ocora
+  streamUrl: https://icecast.radiofrance.fr/francemusiqueocoramonde-midfi.mp3
+  bitrate: 128
+  codec: MP3
+  country: FR
+  status: stream-only
+  stationuuid: 18c9ab24-a043-4a9a-9db6-7bb8dcb4e55a
+  changeuuid: 6449de24-8485-4ed9-ac2d-ab48108163df
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-la-grande-evasion
+  broadcaster: independent
+  name: La grande évasion
+  streamUrl: https://radio.lagrandeevasion.fr/evasion
+  bitrate: 128
+  codec: AAC
+  favicon: https://www.lagrandeevasion.fr/wp-content/themes/gnu/library/fav/favicon-32x32.png
+  homepage: https://lagrandeevasion.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 5289087e-23c9-4fab-bd42-7942a35258b7
+  changeuuid: 6f55ec97-ccb0-430a-af49-c0a16743d38b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-m40
+  broadcaster: independent
+  name: M40
+  streamUrl: https://live.m40radio.fr/listen/m40/m40-128.mp3
+  bitrate: 128
+  codec: AAC
+  favicon: https://cdn.m40radio.fr/wp-content/uploads/radio-m40-370x370.webp
+  homepage: https://m40radio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: b09cd187-2575-4c56-8988-e56be1638652
+  changeuuid: 3a7fbc55-87e1-481d-8da2-0c8c998175a0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-platine-45-radio
+  broadcaster: independent
+  name: Platine 45 Radio
+  streamUrl: https://ecmanager.pro-fhi.net:1710/;
+  bitrate: 320
+  codec: MP3
+  homepage: https://www.platine45radio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 3604e9ba-45c0-4963-85d4-22dfc4f62e44
+  changeuuid: 0a75b06e-8b3a-40ef-9ca7-61c3349265c1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-public-sante-generation-seniors
+  broadcaster: independent
+  name: Public Santé Génération Seniors
+  streamUrl: https://publicsantegenerationsenior.ice.infomaniak.ch/publicsantegenerationsenior-192.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.publicsante.com/LOGO_SENIORS.png
+  homepage: https://www.publicsante.com/PLAYER/PLAYERFOFF.php?r=1
+  country: FR
+  status: stream-only
+  stationuuid: d70550b3-4647-49a4-8a1a-a82b017eb4b2
+  changeuuid: a4a8873e-d7d5-4ccd-9e60-bf6f7bb1302c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-boom-boom
+  broadcaster: independent
+  name: Radio Boom Boom
+  streamUrl: https://listen.radioboomboom.com/listen/rbb/radio.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://i.ibb.co/9sVFjX6/boomboom400.png
+  homepage: https://www.radioboomboom.com/
+  country: FR
+  status: stream-only
+  stationuuid: 0c914bf0-2cfb-46a3-92b6-519e8b78b61e
+  changeuuid: 2e2682bd-8dc7-423e-a246-c38f88cc87d5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-couleur-chartreuse
+  broadcaster: independent
+  name: Radio Couleur Chartreuse
+  streamUrl: https://vps.cbad.fr:8443/rcc
+  codec: MP3
+  favicon: https://i0.wp.com/www.radiocc.fr/wp-content/uploads/2024/05/cropped-Logo_RCC_Vert_3_Frequences.png?resize=270%2C270&ssl=1
+  homepage: https://www.radiocc.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 36e632ae-a132-4620-a1ac-9fee4858b9f0
+  changeuuid: 95b2d038-d21c-489a-823b-23a9d3165cff
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-grand-lieu
+  broadcaster: independent
+  name: Radio Grand Lieu
+  streamUrl: https://listen.radioking.com/radio/377152/stream/427591
+  bitrate: 320
+  codec: MP3
+  favicon: https://radiograndlieu.fr/wp-content/uploads/2021/05/cropped-cropped-radio-grand-lieu_logo_t1-81.png
+  homepage: https://radiograndlieu.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 0e66891d-0941-40c9-ac9c-e4c052c369f6
+  changeuuid: afea175a-caf7-4129-af56-c301e447097b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-vallee-bergerac
+  broadcaster: independent
+  name: Radio Vallée Bergerac
+  streamUrl: https://hosting.studioradiomedia.fr:1755/stream
+  codec: MP3
+  favicon: https://rvb-radio.fr/images/br.png
+  homepage: https://rvb-radio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 6a2dafc6-0705-4671-b98d-564af56d97e1
+  changeuuid: 457a84c2-b3cd-4b0e-99b9-6f8b9ddbd839
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-valois-multien
+  broadcaster: independent
+  name: Radio Valois Multien
+  streamUrl: https://streaming.radio-valois-multien.fr/live.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.radio-valois-multien.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 96149652-0601-11e8-ae97-52543be04c81
+  changeuuid: b39bb1a8-a4f9-4d06-9662-e34ff15e2281
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-roots-legacy
+  broadcaster: independent
+  name: Roots Legacy
+  streamUrl: https://l.rootslegacy.fr/mp3test
+  bitrate: 224
+  codec: MP3
+  favicon: https://rootslegacy.fr/favicon.ico
+  homepage: https://rootslegacy.fr/index.html
+  country: FR
+  status: stream-only
+  stationuuid: 65475b5b-30b0-41f4-98e1-8b3eb883f54f
+  changeuuid: 054c8f5b-32b3-49ba-9a8e-c5497e1e0ab5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-saravadio
+  broadcaster: independent
+  name: Saravadio
+  streamUrl: https://manager8.streamradio.fr:3355/stream
+  bitrate: 320
+  codec: MP3
+  homepage: https://saravadio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: a39e28d2-2f0e-4731-a49a-96becad754f7
+  changeuuid: 9f7caa92-090b-4237-a5e1-1bf97d30a67d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-veronica-60-s-70-s
+  broadcaster: independent
+  name: "Veronica 60's & 70's"
+  streamUrl: https://eu1.fastcast4u.com/proxy/veronica?mp=/1
+  bitrate: 96
+  codec: MP3
+  favicon: http://veronica.atspace.eu/images/Slide%20Show/veronica_slide.jpg
+  homepage: http://veronica.atspace.eu/
+  country: FR
+  status: stream-only
+  stationuuid: 49f0b2d7-deb7-40bb-a3c5-8140d7e4ce53
+  changeuuid: cf392a27-74e1-4c55-b214-82d6cd14c3b5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-xiberoko-botza
+  broadcaster: independent
+  name: Xiberoko Botza
+  streamUrl: https://hosting.studioradiomedia.fr:2975/stream
+  bitrate: 320
+  codec: MP3
+  favicon: https://xiberokobotza.org/images/korporatiboa/xiberobotza_logoa_web-txiki.png
+  homepage: https://xiberokobotza.org/
+  country: FR
+  status: stream-only
+  stationuuid: 7d01f470-d94d-42a3-af10-dd8ea9d06bac
+  changeuuid: c2a18ae7-f014-4e85-b837-82f2b13d5b2b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-reccord-latina
+  broadcaster: independent
+  name: 📻 Reccord Latina
+  streamUrl: https://radiorecord.hostingradio.ru/latina96.aacp
+  codec: AAC
+  favicon: https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEjdJb2y7bqVOTkYUc29lfrzoMrCtu1_-74ZYJlTfpBl648rSQKwsvQz8oK4d1p3UvF334b7ATeVmsnHJpbfPjkVEGveU9SlfPCpROnF8Xk8sn5RH_mxoE5W0DoJnF3QueF7GO_cBzaRHmV3Ffo0_-cYISj7WM_J1_Eu9o5T2H8WlbyjupVtRUq8HiTH/s1600/Capture%20d%E2%80%99%C3%A9cran_2024-12-08_09-23-05.png
+  homepage: https://radiosweb.karibshebdo.info/radios-web/reccord-latina
+  country: FR
+  status: stream-only
+  stationuuid: 8d27d64c-b391-4f12-a085-a0f4d5a965df
+  changeuuid: b65edffe-1316-45f8-831e-35198567632a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-alouette-indre-et-loire
+  broadcaster: independent
+  name: ALOUETTE INDRE ET LOIRE
+  streamUrl: https://alouette-tours.ice.infomaniak.ch/alouette-tours-128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.alouette.fr/favicon.ico
+  homepage: https://www.alouette.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 2403c6bb-0043-4ad1-b3c6-b30b63de4e3d
+  changeuuid: c4c49d53-64b3-4ab4-9642-01812c1b8480
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-l-eko
+  broadcaster: independent
+  name: "L'Eko"
+  streamUrl: https://radio.ekodesgarrigues.com/eko-des-garrigues-256k.ogg
+  bitrate: 320
+  codec: OGG
+  favicon: https://www.ekodesgarrigues.com/images/logoeko.jpg
+  homepage: http://ekodesgarrigues.com/
+  country: FR
+  status: stream-only
+  stationuuid: f1389d78-77a2-4963-a73c-f444496215b6
+  changeuuid: 9196e409-78a1-483c-a18b-439af4c8e425
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-la-radio-de-jet
+  broadcaster: independent
+  name: la radio de Jet
+  streamUrl: https://diffusion.lafrap.fr/jetfm.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.jetfm.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 0727b188-4447-45e0-91e1-83fe9091b967
+  changeuuid: 960657a5-65fc-46b9-b63b-22b092666be1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-lars-n
+  broadcaster: independent
+  name: "LARS'N"
+  streamUrl: https://radio.larsn.fr:8443/main
+  codec: OGG
+  homepage: https://radio.larsn.fr/
+  country: FR
+  status: stream-only
+  stationuuid: c0af99dc-3a8d-4ea5-b57f-71d636129cdb
+  changeuuid: fa307582-f201-4752-9ddf-7d33e6fc827d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-open-sky-128kbps-mp3-hd
+  broadcaster: independent
+  name: "Open Sky (128kbps mp3, \"HD\")"
+  streamUrl: https://audio.opensky.radio:8082/stream128
+  bitrate: 128
+  codec: MP3
+  homepage: https://opensky.radio/
+  country: FR
+  status: stream-only
+  stationuuid: ee2661c3-1cfb-4aa2-829d-1a2e93290595
+  changeuuid: 248752d4-17e6-4dc3-aa0e-9318986118ce
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-puls-radio-trance
+  broadcaster: independent
+  name: Puls Radio - Trance
+  streamUrl: https://icecastlb.pulsradio.com/pulstranceHD.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.radio.pl/300/pulsradiotrance.png?version=5f8e49ae10ab7623baa67f8f41b5507c535057d6
+  homepage: https://www.pulsradio.com/trance
+  country: FR
+  status: stream-only
+  stationuuid: bf10cd09-d594-413e-85e0-b27e3cdb01d0
+  changeuuid: 4dd75b84-f5de-4411-bd4e-0df770032460
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-activ
+  broadcaster: independent
+  name: "radio Activ'"
+  streamUrl: https://stream.radios.bzh/hls/radioactiv/live.m3u8
+  bitrate: 52
+  codec: AAC
+  favicon: https://www.radio-activ.com/wp-content/uploads/2025/03/cropped-LOGO-RADIO-ACTIV.png
+  homepage: https://www.radio-activ.com/
+  country: FR
+  status: stream-only
+  stationuuid: b8ba1fc2-e855-44c3-a712-74b113ebf425
+  changeuuid: c1fa8a54-3b36-42fb-a966-ed86b66523fd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-dance-annees-90
+  broadcaster: independent
+  name: RADIO DANCE années 90
+  streamUrl: https://radiodance.streamingmedia.it/fr.aac
+  bitrate: 320
+  codec: AAC+
+  favicon: https://www.radio.dance/logo_radiodance90s_512.png
+  homepage: https://www.radio.dance/fr
+  country: FR
+  status: stream-only
+  stationuuid: 4ac0f894-d201-4759-a345-bebcedd2ff68
+  changeuuid: 878025be-080d-4dad-8d60-87dc4a7017a3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-fusion
+  broadcaster: independent
+  name: RADIO FUSION
+  streamUrl: https://stunnel2.cyber-streaming.com:9276/stream?type=http&nocache=27045
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radiofusion.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 6e372e6c-3b2e-4fa2-aa49-d87b96cbc91f
+  changeuuid: fed3686c-5149-4508-9206-1176e311cbb1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-rwl
+  broadcaster: independent
+  name: Radio RWL
+  streamUrl: https://ecmanager3.pro-fhi.net:1835/stream
+  bitrate: 320
+  codec: MP3
+  homepage: https://radiorwl.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 817145de-2fd8-4df8-82e3-7e916ca15350
+  changeuuid: 8e366ebe-1133-4bde-98b7-d0dce4b2ae07
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-show
+  broadcaster: independent
+  name: Radio Show
+  streamUrl: https://listen.radioking.com/radio/22937/stream/63601
+  codec: MP3
+  homepage: http://www.radioshow.fr/
+  country: FR
+  status: stream-only
+  stationuuid: d5938e4f-79d1-41c5-a893-ded8f807bf71
+  changeuuid: 429a4649-0d22-49af-82ff-34172b881dfc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-ringard-willycat
+  broadcaster: independent
+  name: Ringard Willycat
+  streamUrl: https://listen.radioking.com/radio/441272/stream/495536
+  bitrate: 128
+  codec: MP3
+  homepage: https://fr.play.radioking.com/radio/ringard-willycat
+  country: FR
+  status: stream-only
+  stationuuid: 723a4a89-15c7-42d6-8796-5360e4305c97
+  changeuuid: f214cf44-dd7b-4a68-a44b-3f8e9aa38530
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-shadowfr69-radio
+  broadcaster: independent
+  name: shadowfr69 Radio
+  streamUrl: https://radio.shadowfr69.eu/mp3
+  bitrate: 256
+  codec: MP3
+  homepage: https://shadowfr69.eu/
+  country: FR
+  status: stream-only
+  stationuuid: 488f07f0-14e7-492e-a7ae-25003b72426a
+  changeuuid: 9692d0c5-57f6-4c8c-ad2e-e0e752d5bba0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-vip-radios-hit-club-dance
+  broadcaster: independent
+  name: Vip Radios - Hit Club Dance
+  streamUrl: https://radio4.vip-radios.fm:18051/stream-128kmp3-HitClubDance
+  bitrate: 128
+  codec: MP3
+  favicon: null
+  homepage: https://radio.vip-radios.fm/
+  country: FR
+  status: stream-only
+  stationuuid: 971eac59-42e4-4f81-ae4b-f2d4454bfe3d
+  changeuuid: f1d3cc0a-2956-4d96-b9e3-33be87face17
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-yellow-radio
+  broadcaster: independent
+  name: Yellow Radio
+  streamUrl: https://yellowradio.ice.infomaniak.ch/yellowradio.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://yellow.radio/Logo_Yellow_Radio_180x180.png
+  homepage: https://yellow.radio/
+  country: FR
+  status: stream-only
+  stationuuid: 40ffc43d-4b03-48f5-bf3f-482185d0b52a
+  changeuuid: 16c4529d-e797-4c1e-ae27-c40751c35562
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-adhan-92100
+  broadcaster: independent
+  name: Adhan-92100
+  streamUrl: https://azuracast-canada.myautodj.com/listen/adhane_92100/radio.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://cdn-profiles.tunein.com/s350855/images/logod.png?t=639027000500000000
+  homepage: https://tunein.com/radio/Adhan-999-s350855/?lang=fr
+  country: FR
+  status: stream-only
+  stationuuid: 73e650e1-310c-4eac-b671-7e0b776d44f3
+  changeuuid: 95b12e78-3592-46e7-86e5-94553f538308
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-bls-guyane
+  broadcaster: independent
+  name: BLS GUYANE
+  streamUrl: https://servidor15.brlogic.com:7292/live
+  bitrate: 128
+  codec: MP3
+  favicon: https://blsguyane.webradiosite.com/
+  homepage: https://blsguyane.webradiosite.com/
+  country: FR
+  status: stream-only
+  stationuuid: 80ad071f-af2e-42f3-8c7e-0b546a125696
+  changeuuid: 327b7be4-d6c4-459f-ad06-dfea9b1a3e86
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-distorsion
+  broadcaster: independent
+  name: Distorsion
+  streamUrl: https://hosting.studioradiomedia.fr:2955/stream
+  bitrate: 140
+  codec: MP3
+  favicon: https://www.assodistorsion.fr/wp-content/uploads/2022/10/cropped-Banniere-1024x267.png
+  homepage: https://www.assodistorsion.fr/la-radio-en-streaming-en-direct/
+  country: FR
+  status: stream-only
+  stationuuid: ec6d643e-e025-4d3e-892e-e67863f1a054
+  changeuuid: 2d79aa88-db48-4611-b23c-a97610ac83d1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-iaradio-metal
+  broadcaster: independent
+  name: IAradio Metal
+  streamUrl: https://iaradiometal.ice.infomaniak.ch/iaradiometal-128.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://iaradio.eu/
+  country: FR
+  status: stream-only
+  stationuuid: 84429c3e-65ad-4a27-b160-ce2d8d4cd204
+  changeuuid: e4c5c82a-2703-4b2d-8532-1d98998e7f9b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-iaradio-world-music
+  broadcaster: independent
+  name: IAradio World music
+  streamUrl: https://iaradioworldmusic.ice.infomaniak.ch/iaradioworldmusic-128.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://iaradio.eu/
+  country: FR
+  status: stream-only
+  stationuuid: 8030539f-d895-4627-87b2-1ae86853486c
+  changeuuid: e7232b82-2356-4490-8cce-fc3d573cf536
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-m40-by-oskana
+  broadcaster: independent
+  name: M40 by Oskana
+  streamUrl: https://live.m40radio.fr/listen/m40-by-oskana/m40-by-oskana-128.mp3
+  bitrate: 128
+  codec: AAC
+  favicon: https://cdn.m40radio.fr/wp-content/uploads/favicon-100x100.webp
+  homepage: https://m40radio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: fbb68d66-9c3f-4ad1-b8af-0555b5d4917d
+  changeuuid: 2638ffe2-d37a-42fd-abda-0b4c757f436a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-m40-fiesta
+  broadcaster: independent
+  name: M40 Fiesta
+  streamUrl: https://live.m40radio.fr/listen/m40-fiesta/m40-fiesta-128.mp3
+  bitrate: 128
+  codec: AAC
+  favicon: https://cdn.m40radio.fr/wp-content/uploads/radio-m40-fiesta-370x370.webp
+  homepage: https://m40radio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 8022a27d-e69f-4dc2-9caf-34bbd4dc56a6
+  changeuuid: 0d6ed526-1d2e-47b9-b6a8-42cbbdb89028
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-maritima-radio
+  broadcaster: independent
+  name: Maritima Radio
+  streamUrl: https://maritima936.ice.infomaniak.ch/maritima936-128.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://maritima.fr/radio
+  country: FR
+  status: stream-only
+  stationuuid: 556bb7f3-ee0c-4bd0-b6a3-ca732951bdcd
+  changeuuid: 9c9c03b8-6336-4392-bba0-736eda1c9bf1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-mixfeever
+  broadcaster: independent
+  name: MixFeever
+  streamUrl: https://listen.mixfeever.com/feevermix
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.mixfeever.com/
+  country: FR
+  status: stream-only
+  stationuuid: 4be9d556-91de-4ad4-a767-8c8aa5d09e40
+  changeuuid: 536fed2f-e9f1-4a09-9579-79f854265cbe
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-nrj-beauvais
+  broadcaster: independent
+  name: NRJ Beauvais
+  streamUrl: https://streaming.nrjaudio.fm/ouamuxw2dqao
+  bitrate: 128
+  codec: AAC+
+  favicon: https://www.nrj.fr/uploads/assets/nrj/favicon.png
+  homepage: https://www.nrj.fr/
+  country: FR
+  status: stream-only
+  stationuuid: c398dc6a-7e6e-4d6f-b520-b21e49ccc7d2
+  changeuuid: 024e720b-cf8e-41fb-b6ce-924ac6935e05
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-ods-radio-rock
+  broadcaster: independent
+  name: ODS Radio Rock
+  streamUrl: https://ods-rock.ice.infomaniak.ch/ods-rock.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.odsradio.com/media/radio/thumb/360x360_691f2bc5851bf-plan-de-travail-1.webp
+  homepage: https://www.odsradio.com/radio/webradio/23/ods-radio-rock
+  country: FR
+  status: stream-only
+  stationuuid: 0df2b943-49bb-4843-9f07-c73f0fa30e50
+  changeuuid: 713e6774-5d19-4ba0-bd13-d0ed783cff54
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-public-health-radio-italiano
+  broadcaster: independent
+  name: Public Health Radio Italiano
+  streamUrl: https://publichealthradioit.ice.infomaniak.ch/publichealthradioit-128.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.publicsante.com/
+  country: FR
+  status: stream-only
+  stationuuid: 335b15dc-ea3a-4edb-8b64-e9f1083b3bb6
+  changeuuid: 0cdf9460-4e56-4c2d-9dce-43cbe71b3add
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-scoop-clermont
+  broadcaster: independent
+  name: Radio SCOOP - Clermont
+  streamUrl: https://radioscoopclermont-ferrand.ice.infomaniak.ch/radioscoop-clermont-64.aac
+  bitrate: 64
+  codec: AAC+
+  homepage: https://www.radioscoop.com/
+  country: FR
+  status: stream-only
+  stationuuid: 931d2d34-c32a-437c-8b34-aee3926e2bf3
+  changeuuid: eba73e30-2504-4d0b-a18c-14585443abac
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-val-d-or-rvo
+  broadcaster: independent
+  name: "Radio Val d'Or - RVO"
+  streamUrl: https://stream3.vestaradio.com/RADIOVALDOR?nocache=34033
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.radiovaldor.com/favicon.ico
+  homepage: https://www.radiovaldor.com/
+  country: FR
+  status: stream-only
+  stationuuid: cb9efaf4-042f-4ce5-8851-bdfa875dda3a
+  changeuuid: 260d6d0b-8050-4dce-9896-a027f42e784d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-rcb
+  broadcaster: independent
+  name: RCB
+  streamUrl: https://radio12.pro-fhi.net/radio/9013/stream.mp3
+  bitrate: 320
+  codec: MP3
+  favicon: https://assets.zyrosite.com/cdn-cgi/image/format=auto,w=450,fit=crop,q=95/AwvLXg02pQhzqaMQ/cropped-logo-rcb-transparent-web-redimensionna-c-e-A3QEZ6BJlKFnx09B.png
+  homepage: https://www.radiorcb.net/
+  country: FR
+  status: stream-only
+  stationuuid: b8c22c94-6a2e-47df-9541-c9707b362c0d
+  changeuuid: 16c16d2f-8227-4d74-99d2-9241bab2d9f6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-rdwa-luc
+  broadcaster: independent
+  name: RDWA Luc
+  streamUrl: https://live.aurafm.org/R-Dwa-LUC
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.aurafm.org/wp-content/uploads/rdwa.png
+  homepage: https://www.rdwa.fr/
+  country: FR
+  status: stream-only
+  stationuuid: fba3d98e-87bd-4ad5-98d0-2fdb6970a1c0
+  changeuuid: 5fb6f616-7479-4c63-9f19-87105a716d5e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-supernana
+  broadcaster: independent
+  name: Supernana
+  streamUrl: https://radiosurle.net:8765/showsupernana
+  bitrate: 96
+  codec: MP3
+  homepage: https://www.show-supernana.com/
+  country: FR
+  status: stream-only
+  stationuuid: 5b2809b5-3615-4fbd-9551-7d2abd5c6cf6
+  changeuuid: b1ae8e2d-f0ba-4d8a-b90c-f441c3e2c593
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-terre-marine-fm
+  broadcaster: independent
+  name: Terre Marine FM
+  streamUrl: https://radio3.pro-fhi.net:19045/stream
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.terremarinefm.com/
+  country: FR
+  status: stream-only
+  stationuuid: 9a8e0a21-bb31-488c-b39b-b634347f92d9
+  changeuuid: 403c6464-f721-4c16-b572-9ce935daf853
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-toulouse-fm
+  broadcaster: independent
+  name: Toulouse FM
+  streamUrl: https://n32a-eu.rcs.revma.com/1x41712gy7uvv
+  codec: MP3
+  favicon: https://medias.preprod.bocir.fr/t:app(web)/t:r(unknown)/fit-in/300x2000/filters:format(webp)/filters:quality(100)/radios/toulousefm/images/logo_kQmQJ1D8OB.png
+  homepage: https://toulousefm.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 2a5fdf2a-63fe-4542-8f9b-2ad4ee1f1eff
+  changeuuid: 159d61e7-f9d4-47a5-ab74-35a20ab861b9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-100-radio-carcassonne
+  broadcaster: independent
+  name: "100% Radio Carcassonne"
+  streamUrl: https://100radio-carcassonne.ice.infomaniak.ch/100radio-carcassonne-128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://images.lesindesradios.fr/fit-in/300x2000/filters:format(webp)/filters:quality(100)/radios/centpourcent/images/logo_HuGMY5WoOm.png
+  homepage: https://www.centpourcent.com/
+  country: FR
+  status: stream-only
+  stationuuid: 943d83df-76d5-4782-b1ba-0c24ba96ebf9
+  changeuuid: 25d42a20-2075-4290-8602-b8ab4626b3bc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-agora-cote-d-azur
+  broadcaster: independent
+  name: AGORA CÔTE D’AZUR
+  streamUrl: https://agoracotedazur.ice.infomaniak.ch/agoracotedazur.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.agoracotedazur.fr/
+  country: FR
+  status: stream-only
+  stationuuid: dba1c613-ea0d-4507-b0c8-0f0a78153027
+  changeuuid: ae1fd416-3535-403c-a202-7ce3cbd71abf
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-h2o-lac-d-annecy
+  broadcaster: independent
+  name: "H2O Lac d'Annecy"
+  streamUrl: https://h2oradio.net-radio.fr/h2oradio-256.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: http://www.h2oradio.fr/assets/img/basic/b2_lac.png
+  homepage: http://www.h2oradio.fr/index.php
+  country: FR
+  status: stream-only
+  stationuuid: 40a475d5-994f-4577-bbe2-7bb75e0ccb21
+  changeuuid: b13fa839-5e1b-4345-b4cc-cf4977d8b374
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-helia
+  broadcaster: independent
+  name: Helia
+  streamUrl: https://stream.heliaradios.fr/listen/helia/radio.mp3
+  codec: AAC
+  favicon: https://heliaradios.fr/wp-content/uploads/2022/10/helia-radios-2024-clr.png
+  homepage: https://heliaradios.fr/players/helia
+  country: FR
+  status: stream-only
+  stationuuid: 4bfcf7db-89c2-4195-aaad-482e3ac89a77
+  changeuuid: 873a3e90-6242-4718-afb5-0e4303bca55a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-hit53
+  broadcaster: independent
+  name: Hit53
+  streamUrl: https://azura.hit53.fr/hit128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://hit53.fr/favicon.png
+  homepage: https://hit53.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 79ec7eae-9623-4397-bd62-2926d31d3148
+  changeuuid: ac9f4dd5-01d4-4853-a0b8-d7a2a1fd0eb1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-hits-1-cognac
+  broadcaster: independent
+  name: Hits 1 Cognac
+  streamUrl: https://hits1cognac-audiomediaradio.radioca.st/hits1cognac
+  bitrate: 256
+  codec: MP3
+  favicon: https://www.hits1radio.com/wp-content/uploads/2019/03/dummy-e1554135926529.jpg
+  homepage: https://www.hits1radio.com/
+  country: FR
+  status: stream-only
+  stationuuid: fda4d9df-c48a-41e9-ade4-aba7f04c0e75
+  changeuuid: b44d3fe2-d70d-4083-a91d-3f95f8416b36
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-horizon-la-radio-libre-100-9fm
+  broadcaster: independent
+  name: Horizon la radio libre 100.9fm
+  streamUrl: https://horizonlaradiolibre.ice.infomaniak.ch/horizonlaradiolibre-128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://horizon-fm.fr/wp-content/uploads/2015/03/logoanimeRouge.gif
+  homepage: https://www.horizon-fm.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 195337d1-7990-4d58-b08d-056c3d52ccfc
+  changeuuid: 3a1f2ae3-6741-401f-af6f-2c3c2f7edbba
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-ma
+  broadcaster: independent
+  name: ma
+  streamUrl: https://rfimandingue64k.ice.infomaniak.ch/rfimandingue-64k.mp3
+  bitrate: 64
+  codec: MP3
+  homepage: https://rfimandingue64k.ice.infomaniak.ch/rfimandingue-64k.mp3
+  country: FR
+  status: stream-only
+  stationuuid: bf3f013a-11c7-4beb-b9ba-b9ce00a2428d
+  changeuuid: be419197-e93a-4c17-b4bb-12a66cb897c7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-odc-live
+  broadcaster: independent
+  name: ODC Live
+  streamUrl: https://radio.zest.radio/radio/8000/radio.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://zest.radio/
+  country: FR
+  status: stream-only
+  stationuuid: eb2d37d8-36cd-4965-be98-0dbc928474bd
+  changeuuid: 33d9bfa7-3136-448f-be92-e88ab3889ac8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-fuori-campo
+  broadcaster: independent
+  name: Radio Fuori Campo
+  streamUrl: https://listen.radioking.com/radio/397948/stream/449947
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.radiofuoricampo.com/upload/60a6b1ff356589.85028903.ico
+  homepage: https://www.radiofuoricampo.com/
+  country: FR
+  status: stream-only
+  stationuuid: df966d38-7642-4bbf-a68d-f91588ca224b
+  changeuuid: 6febdec5-2a3f-4a63-bec5-cb27567de4dd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-lenga-d-oc
+  broadcaster: independent
+  name: "Radio lenga d'Oc"
+  streamUrl: https://stream-ssl.radios-arra.fr:8443/rlo
+  bitrate: 128
+  codec: MP3
+  favicon: https://radiolengadoc.com/wp-content/themes/radiolengadoc/template-parts/header/logo-rlo/LOGO-RLO_CARNAVAL.png
+  homepage: http://radiolengadoc.com/
+  country: FR
+  status: stream-only
+  stationuuid: 1ce655f7-7896-42ec-bb91-6b20875aa9d7
+  changeuuid: 725895a3-9a38-4e69-a4b8-5a1d7bec2d5c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-scoop-bourg
+  broadcaster: independent
+  name: Radio SCOOP - Bourg
+  streamUrl: https://radioscoopbourg-en-bresse.ice.infomaniak.ch/radioscoop-bourg-64.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://www.radioscoop.com/favicon.ico
+  homepage: https://www.radioscoop.com/
+  country: FR
+  status: stream-only
+  stationuuid: fb8fb8c0-81b6-4015-ada8-32c50b7ab7a6
+  changeuuid: 7ea1f998-f22a-4774-9bbf-4f6a612e6210
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-scoop-stetienne
+  broadcaster: independent
+  name: Radio SCOOP - StEtienne
+  streamUrl: https://radioscoopsaintetienne.ice.infomaniak.ch/radioscoop-stetienne-64.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://www.radioscoop.com/favicon.ico
+  homepage: https://www.radioscoop.com/
+  country: FR
+  status: stream-only
+  stationuuid: 3c63203c-e53f-4bd7-a985-44e0e6248519
+  changeuuid: fb83950d-d7d7-4a3e-9185-c23b133aac84
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-top-side
+  broadcaster: independent
+  name: Radio Top Side
+  streamUrl: https://listen.radioking.com/radio/33560/stream/275656
+  bitrate: 320
+  codec: MP3
+  favicon: https://www.radiotopside.com/upload/design/6446351012a075.09916797.jpeg
+  homepage: https://www.radiotopside.com/
+  country: FR
+  status: stream-only
+  stationuuid: a2785419-14fb-4a85-ab1d-74f3a683fe4a
+  changeuuid: 2ccd6839-1c91-44af-8c91-adbef28fb260
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-rlocale-radio
+  broadcaster: independent
+  name: Rlocale Radio
+  streamUrl: https://rlocale.org/listen/rlocale//rlocale-128k.aac
+  bitrate: 128
+  codec: AAC
+  favicon: https://rlocale.fr/wp-content/uploads/2023/11/cropped-logo-rlocale-245x245-1-180x180.png
+  homepage: https://rlocale.fr/
+  country: FR
+  status: stream-only
+  stationuuid: dcb87b4b-d82a-4024-9b0d-06020880762c
+  changeuuid: 3fd397bd-5462-4932-8c2f-71e8ff2f595b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-soulbox
+  broadcaster: independent
+  name: Soulbox
+  streamUrl: https://eu1.fastcast4u.com/proxy/soulbox?mp=/1
+  bitrate: 96
+  codec: MP3
+  homepage: http://soulbox.legtux.org/
+  country: FR
+  status: stream-only
+  stationuuid: 0cb0dd8e-9f46-472f-8b0d-6af15c945833
+  changeuuid: ee4e1358-3932-4527-b071-f2cd07f20a4e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-clapas-jazz
+  broadcaster: independent
+  name: Clapas Jazz
+  streamUrl: https://stream.radioclapas.fr/listen/clapas_jazz/radio.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.radioclapas.fr/player/jazz.jpg
+  homepage: https://www.radioclapas.fr/#
+  country: FR
+  status: stream-only
+  stationuuid: 2e504efc-4ece-4956-84d9-c72e3e640599
+  changeuuid: 86875196-455f-43d3-b4a4-14b4c67c3f10
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-cote-sud-fm
+  broadcaster: independent
+  name: COTE SUD FM
+  streamUrl: https://sd-151888.dedibox.fr/proxy/cotesud/csfm
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.cotesudfm.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 4cded4cf-15d1-479f-8819-668d56b4b025
+  changeuuid: c3d1a3fb-5146-4567-b6c7-a13853ab068f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-divergence-fm
+  broadcaster: independent
+  name: Divergence FM
+  streamUrl: https://stream.divergence-fm.org:8001/divergence.mp3
+  bitrate: 256
+  codec: MP3
+  favicon: https://upload.wikimedia.org/wikipedia/fr/6/6d/Logo_Divergence-FM.jpg
+  homepage: https://divergence-fm.org/
+  country: FR
+  status: stream-only
+  stationuuid: 226fb33e-40c1-487f-906e-adca526081ce
+  changeuuid: f59e86c9-38b8-4564-a44d-060e4fc03337
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-frequence-sille
+  broadcaster: independent
+  name: Fréquence Sillé
+  streamUrl: https://stric6.streamakaci.com/frequencesille.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: https://frequence-sille.org/
+  country: FR
+  status: stream-only
+  stationuuid: bf672dc7-9596-4ed2-96c8-ca0b23d9467b
+  changeuuid: 1efe16f6-175e-421b-8445-089d1319bb69
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-globule-radio
+  broadcaster: independent
+  name: Globule Radio
+  streamUrl: https://905.ice.infomaniak.ch/905-128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://globule.chamonix.radio/favicon.ico
+  homepage: https://globule.chamonix.radio/
+  country: FR
+  status: stream-only
+  stationuuid: 325b587b-7e9a-4378-89c0-e82c53327457
+  changeuuid: c12b4bd8-24a8-4e75-8dba-21704ed1e714
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-hotmixradio-frenchy
+  broadcaster: independent
+  name: "Hotmixradio frenchy "
+  streamUrl: https://streaming.hotmixradio.com/hotmix-frenchy-fr-mp3?
+  bitrate: 128
+  codec: MP3
+  homepage: https://hotmixradio.com/en
+  country: FR
+  status: stream-only
+  stationuuid: 5f2af2f0-156e-48dd-94e4-9b7b25ecb037
+  changeuuid: d13b5262-1a7a-4ce4-9bb4-726048023b03
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-iaradio-classique
+  broadcaster: independent
+  name: IAradio Classique
+  streamUrl: https://iaradioclassique.ice.infomaniak.ch/iaradioclassique-128.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://iaradio.eu/
+  country: FR
+  status: stream-only
+  stationuuid: dd500737-cdf1-4411-8a48-c925130893d1
+  changeuuid: 72c83d3b-8ce9-423b-94f7-e3482617de77
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-iaradio-dance-house
+  broadcaster: independent
+  name: IAradio Dance House
+  streamUrl: https://iaradiodance.ice.infomaniak.ch/iaradiodance-128.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://iaradio.eu/
+  country: FR
+  status: stream-only
+  stationuuid: b6aa464b-fb8b-4e6b-9650-67c77ff7edb8
+  changeuuid: d5e2e268-9f2a-45e6-95ad-32c04b341765
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-iaradio-disco-funk
+  broadcaster: independent
+  name: IAradio Disco Funk
+  streamUrl: https://iaradiodisco.ice.infomaniak.ch/iaradiodisco-128.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://iaradio.eu/
+  country: FR
+  status: stream-only
+  stationuuid: ea8b9e7e-e088-496a-9cdd-f4025ad09610
+  changeuuid: f0ec6e20-6b43-4aca-a3f2-af31006fed84
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-ici-picardie
+  broadcaster: independent
+  name: ICI Picardie
+  streamUrl: https://stream.radiofrance.fr/fbpicardie/fbpicardie_lofi.m3u8
+  codec: UNKNOWN
+  favicon: https://france3-regions.francetvinfo.fr/image/thQ-APUfopLbhRQ-a29GfT_Hmb8/1398x819/regions/2024/11/04/capture-6728a8716f4ef458287475.jpg
+  homepage: https://www.francebleu.fr/radio/picardie
+  country: FR
+  status: stream-only
+  stationuuid: e2c84fce-bf78-4db2-8d74-c9222c5faf97
+  changeuuid: 37ef1cf0-6b9a-4734-8a3b-b479339618aa
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-mix-machine-radio
+  broadcaster: independent
+  name: Mix Machine Radio
+  streamUrl: https://a6.asurahosting.com:7520/radio.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.mixmachine.fr/
+  country: FR
+  status: stream-only
+  stationuuid: c3ad0d65-0f5e-4049-87fc-fa60530f83f0
+  changeuuid: 903a4fe3-073b-4ef3-9e12-c0cab5db731c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-ola-radio
+  broadcaster: independent
+  name: Ola Radio
+  streamUrl: https://ola-radio.radiocult.fm/stream
+  bitrate: 320
+  codec: MP3
+  favicon: https://www.olaradio.fr/favicon.ico
+  homepage: https://www.olaradio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: ecb854f2-4a6c-43ec-8805-e9e475b190ca
+  changeuuid: 4bec8b63-d00c-4917-85d7-0e5f80b44376
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-oz-fm
+  broadcaster: independent
+  name: OZ FM
+  streamUrl: https://ozfm.streamb.live/SB00174?ver=460097
+  bitrate: 96
+  codec: MP3
+  favicon: https://ozfm.com/wp-content/uploads/2023/07/OZFM.retro_.png
+  homepage: https://ozfm.com/
+  country: FR
+  status: stream-only
+  stationuuid: a2bdcebe-f678-4658-971d-03812d1d5dfd
+  changeuuid: b53ccb50-f70c-4aa9-8843-d2a727a3ee30
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-public-sante-sexo
+  broadcaster: independent
+  name: Public Santé Sexo
+  streamUrl: https://publicsantesexo.ice.infomaniak.ch/publicsantesexo-192.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.publicsante.com/
+  country: FR
+  status: stream-only
+  stationuuid: 1b9306c9-69ca-427a-b0d9-f12d1a190afe
+  changeuuid: 4b0f25fa-8e27-4b9b-beb7-b94d171808c2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-contact
+  broadcaster: independent
+  name: Radio Contact
+  streamUrl: https://n22a-eu.rcs.revma.com/6gygqc1gy7uvv
+  codec: MP3
+  favicon: https://medias.lesindesradios.fr/t:app(web)/t:r(unknown)/fit-in/300x2000/filters:format(webp)/filters:quality(100)/radios/contactfm/images/logo_dBRvfZGGAL.png
+  homepage: https://radiocontact.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 684561b0-6b99-4491-a425-34362325ce44
+  changeuuid: c3dded75-8d3d-4933-bd7a-061a625dab9e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-fatx
+  broadcaster: independent
+  name: Radio FATX
+  streamUrl: https://radio.fatx.fr/radio_fatx
+  bitrate: 320
+  codec: MP3
+  homepage: https://www.fatx.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 31f1da66-9648-4b5f-b27e-8ce8b5ae5849
+  changeuuid: 4601300e-6816-4343-8adb-463d10dd806d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-fg-underground
+  broadcaster: independent
+  name: Radio FG Underground
+  streamUrl: https://radiofg.impek.com/ufg.mp3
+  codec: MP3
+  favicon: https://www.lawebradio.com/news/wp-content/uploads/2017/10/ima2-fgradio-undrgrnd-102017.jpg
+  homepage: https://www.radiofg.com/
+  country: FR
+  status: stream-only
+  stationuuid: 4bf2c65a-4daf-43b8-b401-7fc1b56173fb
+  changeuuid: cdfee10b-b4e0-460d-a4dd-f8d044a42ffe
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-gandharva-gana
+  broadcaster: independent
+  name: Radio Gandharva Gana
+  streamUrl: https://listen.radioking.com/radio/45994/stream/82780
+  bitrate: 128
+  codec: MP3
+  favicon: https://image.jimcdn.com/app/cms/image/transf/dimension=785x10000:format=jpg/path/s9008a6e38990bd8e/image/id0a55168bf28da62/version/1681464442/image.jpg
+  homepage: https://www.rggweb.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 1131babb-f76a-4531-be8c-17c6d1f99064
+  changeuuid: 064e2a9b-b49e-4ee5-ba29-56e8073f12f3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-gresivaudan
+  broadcaster: independent
+  name: Radio Grésivaudan
+  streamUrl: https://live.aurafm.org/Radio-Gresivaudan
+  bitrate: 320
+  codec: MP3
+  homepage: https://www.radio-gresivaudan.org/
+  country: FR
+  status: stream-only
+  stationuuid: fb71aa45-cf9f-4744-a4bc-e0b751e649c8
+  changeuuid: 47b9b956-02ba-40a1-8beb-52cb158fe539
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-media-antilles-le-son-des-iles
+  broadcaster: independent
+  name: Radio Media Antilles - Le Son Des Iles
+  streamUrl: https://radio3.pro-fhi.net/listen/pzjdzjjq/stream.mp3
+  bitrate: 320
+  codec: MP3
+  homepage: https://www.radiomediaantilles.com/
+  country: FR
+  status: stream-only
+  stationuuid: 92e6efc3-e398-4641-a672-f845102521a4
+  changeuuid: 258587dc-bf55-42ab-b72f-edfdb122d289
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-new-s-fm
+  broadcaster: independent
+  name: "Radio New's FM"
+  streamUrl: https://live.aurafm.org/RadioNewsFM
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.radio-newsfm.com/wp-content/uploads/2020/09/Logo-Newsfm-1.png
+  homepage: https://www.radio-newsfm.com/
+  country: FR
+  status: stream-only
+  stationuuid: b8772af6-92db-40e8-87b9-66ed4d1b9d80
+  changeuuid: ac8892da-b7a2-4b7c-bedf-4706c141df65
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-nunc
+  broadcaster: independent
+  name: Radio Nunc
+  streamUrl: https://diffusion.radionunc.org:8443/stream
+  bitrate: 96
+  codec: MP3
+  homepage: https://radionunc.org/
+  country: FR
+  status: stream-only
+  stationuuid: bb8cbfda-1f7b-4a6e-875a-a26e53dfbe5c
+  changeuuid: dfd3cd3d-c5ef-4456-9f3d-195dc5fbd070
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-zig-zag-pays-de-romans
+  broadcaster: independent
+  name: Radio Zig Zag - Pays de Romans
+  streamUrl: https://zig.syndicastream.fr:8443/stream
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.radiozigzag.com/upload/players/5e8c9be47883d0.52483364.jpg
+  homepage: https://www.radiozigzag.com/
+  country: FR
+  status: stream-only
+  stationuuid: dfdadf43-07e3-4209-a4c5-d77d0d0a31c9
+  changeuuid: b8746331-35c5-4336-b849-22c9629e58f5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radiovino
+  broadcaster: independent
+  name: RadioVino
+  streamUrl: https://listen.radioking.com/radio/40700/stream/77213
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radiovino.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 8e8d0a4f-6a01-4c93-8156-bf22552d715e
+  changeuuid: a6c9e334-963f-4be9-8665-2d9170e0d629
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-rci-martinique
+  broadcaster: independent
+  name: RCI Martinique
+  streamUrl: https://stream.rcs.revma.com/t0abpqyspwzuv
+  codec: MP3
+  favicon: https://rci.fm/sites/default/files/webradio/radiomartinique.png
+  homepage: https://rci.fm/martinique
+  country: FR
+  status: stream-only
+  stationuuid: dc84a42e-729e-4fa5-940b-f47862bc0122
+  changeuuid: d7a8140a-640c-46d1-b93f-e410d622e78a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-replay-news-eco-francais
+  broadcaster: independent
+  name: REPLAY NEWS - Eco (Français)
+  streamUrl: https://replaynewseco.ice.infomaniak.ch/replaynewseco-128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.publicsante.com/BIENVENU/LOGO%20REPLAY%20NEWS%20ECO.png
+  homepage: https://www.replaynews.net/
+  country: FR
+  status: stream-only
+  stationuuid: 382d2cb6-e6a0-488e-9a61-8195d59ba481
+  changeuuid: 34f55fff-f9cb-4b96-a54d-c5b229ba7a74
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-rtvfm
+  broadcaster: independent
+  name: RTVFM
+  streamUrl: https://stream.vestaradio.com/RTVFM
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.rtvfm.net/
+  country: FR
+  status: stream-only
+  stationuuid: 4c9788f1-2c92-4cb7-9093-2c2b749faa0e
+  changeuuid: cf172bec-305b-4c25-9d68-19f8c89f7667
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-sun-radio-bar
+  broadcaster: independent
+  name: Sun Radio Bar
+  streamUrl: https://radio2.vip-radios.fm:18065/stream-128kmp3-BarSoulside
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.vip-radios.fm/favicon.ico
+  homepage: https://www.vip-radios.fm/
+  country: FR
+  status: stream-only
+  stationuuid: e8ac37fb-343c-47f1-9c84-5c4200361ee6
+  changeuuid: 105e2be5-40aa-4d1a-8445-302992e9961c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-the-lounge-hour
+  broadcaster: independent
+  name: The Lounge Hour
+  streamUrl: https://listen2.streamaudio.co/stream/8056
+  bitrate: 128
+  codec: AAC
+  homepage: https://theloungehour.netlify.app/
+  country: FR
+  status: stream-only
+  stationuuid: 88d007e1-dcf8-4f7e-a8c0-a0b2c2ad41fb
+  changeuuid: 2e960981-5aad-464a-a438-c53e3aec509a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-villages-fm
+  broadcaster: independent
+  name: Villages FM
+  streamUrl: https://stream3.vestaradio.com/VILLAGESFM
+  codec: MP3
+  favicon: https://www.villagesfm.com/wp-content/uploads/2023/12/logo-villagesFM-980x576.png
+  homepage: https://www.villagesfm.com/
+  country: FR
+  status: stream-only
+  stationuuid: ec2a9fc9-a887-46f0-b2f7-3d276ab79352
+  changeuuid: 11f0cace-f545-4a5d-b7f7-fed3c8aa3982
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-klm-fm
+  broadcaster: independent
+  name: 📻 KLM FM
+  streamUrl: https://us3new.listen2myradio.com:2199/listen.php?port=8117
+  codec: MP3
+  favicon: https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEjTw3lsCbI8ZcwYsEss5GhURlItGfxXLAeI0kDc5D_dOyc_yS8XrLoPJaUy8wlvdJem90NpWW65skgJCwlSCtBWaGH3Mw7CIm3F1PlaKvimGM2skZIUutxYWplI8wG-emyVONIMby2rc8IfAc017YEs3RWwwFdXpUFqONUABApu3JL36HW3lgJ5ubhL/s1600/Capture%20d%E2%80%99%C3%A9cran_2024-12-12_11-09-39.png
+  homepage: https://radiosweb.karibshebdo.info/radios-web/klm-fm
+  country: FR
+  status: stream-only
+  stationuuid: a8e146d3-0c2e-4519-9018-86e0862d7bca
+  changeuuid: 1949fa46-ad22-432f-8565-1bd0819b7cf7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-generations-west-indies
+  broadcaster: independent
+  name: 🕺Générations West Indies
+  streamUrl: https://generationswestindies.ice.infomaniak.ch/generations-westindies.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEhiFozjJWY-tZRSm8l1R7JyIRiXTBa1ErIgz5b9B8xti42-yyi_jh9f23snj8vitHJ2pjz0ELbL54TGzgWvXMHpy6ILH1mri0yUZUWtsul-QIlPyocgNWFy7y10qRxg3BSwLO8uQNXBr150GiSDyYPyGoLdiZFP4WZ8tdr5IzgEOxxjGtFM_yvzT633/s1600/Capture%20d%E2%80%99%C3%A9cran_2024-11-18_12-56-44.png
+  homepage: https://www.karibshebdo.info/radios-web/g%C3%A9n%C3%A9rations-west-indies
+  country: FR
+  status: stream-only
+  stationuuid: 7dacd722-e2a7-48e3-b6b6-1d6995df9010
+  changeuuid: e3001ae0-08cb-4af8-a312-e95c9b09a141
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-4u-hard-fm
+  broadcaster: independent
+  name: "4U Hard FM"
+  streamUrl: https://live.4uradios.com/4uhardfm.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.4uradios.com/images/4uhardfm.jpg
+  homepage: https://www.4uradios.com/hard-fm/
+  country: FR
+  status: stream-only
+  stationuuid: a60a0243-00bd-492d-8802-7cf4b97e9e24
+  changeuuid: 8f7bda7f-2a24-4d59-8d19-a8aa805729ee
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-crazy-radio
+  broadcaster: independent
+  name: Crazy Radio
+  streamUrl: https://radio10.pro-fhi.net/flux-bphdrtog/stream?1722411025208
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.crazyradio.fr/wp-content/uploads/2020/10/Suivez-Sportissimeaux-01-300x122.png
+  homepage: https://www.crazyradio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 34f2e221-f956-43cd-945a-9d89a0598ae0
+  changeuuid: d689f5c5-bbb9-4f57-94d0-6e1090abd40d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-f-hits-classics
+  broadcaster: independent
+  name: F. HITS Classics
+  streamUrl: https://listen.fhits.fr:8014/fhits_classics_96.aac
+  bitrate: 96
+  codec: AAC
+  homepage: https://www.fhits.fr/
+  country: FR
+  status: stream-only
+  stationuuid: daa23b6d-fdc4-4547-8276-ec81f0cd09a4
+  changeuuid: 81020c72-ff07-4196-b9eb-2bb00bec9449
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-franceinfo-aac-lofi
+  broadcaster: independent
+  name: franceinfo aac lofi
+  streamUrl: https://icecast.radiofrance.fr/franceinfo-lofi.aac
+  bitrate: 32
+  codec: AAC
+  homepage: https://icecast.radiofrance.fr/franceinfo-lofi.aac
+  country: FR
+  status: stream-only
+  stationuuid: 58eb6299-de74-4eb3-a292-c09e6d81a5e7
+  changeuuid: 39e4b5cd-79ea-40a2-809c-c13056c7f943
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-iaradio-jazz
+  broadcaster: independent
+  name: IAradio Jazz
+  streamUrl: https://iaradiojazz.ice.infomaniak.ch/iaradiojazz-128.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://iaradio.eu/
+  country: FR
+  status: stream-only
+  stationuuid: a73a2e00-2ad4-4304-af41-a2e27bce1556
+  changeuuid: d6d3f587-345a-485b-99cb-8c364aa01e4c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-iaradio-slow-crooner
+  broadcaster: independent
+  name: "IAradio Slow & Crooner"
+  streamUrl: https://iaradioslowcrooner.ice.infomaniak.ch/iaradioslowcrooner-128.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://iaradio.eu/
+  country: FR
+  status: stream-only
+  stationuuid: 8301395c-5a39-4867-9516-f81303bb12ee
+  changeuuid: 709af4a3-fb08-4518-ac7f-3a84ecd27419
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-identite-radio
+  broadcaster: independent
+  name: Identité radio
+  streamUrl: https://listen.radioking.com/radio/26860/stream/59584
+  bitrate: 128
+  codec: MP3
+  homepage: https://identiteradio.com/
+  country: FR
+  status: stream-only
+  stationuuid: 78d95e17-4c97-4ed7-8783-69eaf44064d6
+  changeuuid: a74bd9b6-bbe2-464f-ba46-7fe1f7cacd85
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-in2-mix-fr
+  broadcaster: independent
+  name: In2 Mix FR
+  streamUrl: https://listen.radioking.com/radio/384/stream/1613
+  bitrate: 128
+  codec: MP3
+  homepage: https://in2mixxradio.com/
+  country: FR
+  status: stream-only
+  stationuuid: b82db9ef-0b63-41ff-8a97-1361c02261b6
+  changeuuid: 76070763-5aa3-4f95-b148-ab0e9d413292
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-la-radio-des-artistes-oublies
+  broadcaster: independent
+  name: La Radio Des Artistes Oubliés
+  streamUrl: https://stream-179.zeno.fm/hg9eg9q5quzuv?zt=eyJhbGciOiJIUzI1NiJ9.eyJzdHJlYW0iOiJoZzllZzlxNXF1enV2IiwiaG9zdCI6InN0cmVhbS0xNzkuemVuby5mbSIsInRtIjpmYWxzZSwicnR0bCI6NSwianRpIjoiNk1IbmR3V29Td0dRVzhGUUkwME1iQSIsImlhdCI6MTc2ODQ1ODU0MywiZXhwIjoxNzY4NDU4NjAzfQ.SZ9a15333MeMXeGDqwTCEKtPvQpV57TgK4Wl3j6PyH4
+  codec: MP3
+  homepage: https://onlineradiobox.com/fr/desartistesoublies
+  country: FR
+  status: stream-only
+  stationuuid: 5903243b-6291-4891-9c4d-c2cd7b4ec4bc
+  changeuuid: 42239580-66d7-486f-86d4-c0735bb20466
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-latitude
+  broadcaster: independent
+  name: Latitude
+  streamUrl: https://latitude.ice.infomaniak.ch/troyes.aac
+  codec: AAC+
+  favicon: https://www.latitude.fm/wp-content/uploads/2020/09/favicon.jpg
+  homepage: https://latitude.fm/
+  country: FR
+  status: stream-only
+  stationuuid: 24f4ec95-2d66-4429-9788-2b87b2ee7e40
+  changeuuid: cbdf1c9f-4db9-4674-89f3-791f82dd39c9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-live-nation-radio
+  broadcaster: independent
+  name: Live Nation Radio
+  streamUrl: https://livenationradio.ice.infomaniak.ch/livenationradio-midfi.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://networksites.livenationinternational.com/networksites/qlnlvvtn/ln-radio-stacked-4.jpg
+  homepage: https://www.livenation.fr/radio
+  country: FR
+  status: stream-only
+  stationuuid: 6d6099c6-7c44-423b-9ed1-93f4b126985c
+  changeuuid: e160a840-0a30-4d05-9e4d-1e77b0090db3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-m40-rai
+  broadcaster: independent
+  name: M40 Raî
+  streamUrl: https://live.m40radio.fr/listen/m40-rai/m40-rai-128.mp3
+  bitrate: 128
+  codec: AAC
+  favicon: https://cdn.m40radio.fr/wp-content/uploads/radio-m40-rai-370x370.webp
+  homepage: https://m40radio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: a4728c46-8ef0-4d3a-ad50-640c72acbb02
+  changeuuid: ab269f2e-d441-43a5-8b3d-e391693d4206
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-nrj-bruno-mars
+  broadcaster: independent
+  name: NRJ BRUNO MARS
+  streamUrl: https://streaming.nrjaudio.fm/ouycwb36zcw2?origine=playernrj&aw_0_req.userConsentV2=&aw_0_1st.station=
+  bitrate: 128
+  codec: AAC
+  favicon: https://static.mytuner.mobi/media/tvos_radios/399/nrj-bruno-mars.eb7a1976.jpg
+  homepage: https://www.nrj.fr/webradios/mur-des-radios
+  country: FR
+  status: stream-only
+  stationuuid: 72d46167-8403-4481-8785-16a7964cd185
+  changeuuid: ecfcb60b-9869-4d32-b7a3-44dabe556985
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-power-maxx
+  broadcaster: independent
+  name: POWER MAXX
+  streamUrl: https://sr3.publicssl.net/srv/7016/stream
+  bitrate: 192
+  codec: MP3
+  favicon: https://cdn.onlineradiobox.com/img/l/4/76854.v16.png
+  homepage: https://onlineradiobox.com/fr/powermaxx/?lang=en&p=5
+  country: FR
+  status: stream-only
+  stationuuid: 7d97725c-0537-4903-a398-d779714594e3
+  changeuuid: 4704a31f-89d1-4830-9c1a-3607eb7074fd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-proxi-radio
+  broadcaster: independent
+  name: Proxi Radio
+  streamUrl: https://hosting.studioradiomedia.fr:2390/stream
+  codec: MP3
+  favicon: https://www.proxiradio.eu/favicon.png
+  homepage: https://www.proxiradio.eu/
+  country: FR
+  status: stream-only
+  stationuuid: a041d5c1-2d62-4bd2-86f8-5f36fef506f1
+  changeuuid: 281c6c54-94a5-439a-992c-28f298df9597
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-public-health-radio-espanol
+  broadcaster: independent
+  name: Public Health Radio Espanol
+  streamUrl: https://publichealthradioes.ice.infomaniak.ch/publichealthradioes-128.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.publicsante.com/
+  country: FR
+  status: stream-only
+  stationuuid: 5c20b577-1524-4085-873e-2d94737f90b3
+  changeuuid: ff81c3a7-7231-4147-b401-3edf1c17efd0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-public-sante-detente
+  broadcaster: independent
+  name: Public Sante Detente
+  streamUrl: https://publicsantedetente.ice.infomaniak.ch/publicsantedetente-192.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.publicsante.com/
+  country: FR
+  status: stream-only
+  stationuuid: 9b1bdb05-395d-4daf-b8dd-71c6b6c608cb
+  changeuuid: bd79a3b9-f5c2-4828-9983-ebf2975e82e2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-public-sante-loisirs-sports
+  broadcaster: independent
+  name: "Public Santé Loisirs & Sports"
+  streamUrl: https://publicsanteloisirssports.ice.infomaniak.ch/publicsanteloisirssports-192.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.publicsante.com/
+  country: FR
+  status: stream-only
+  stationuuid: f05b2a57-d248-4a65-aa01-925317be2a39
+  changeuuid: cee9d956-25b5-433d-b404-a70e14ba9278
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-public-sante-nutri-conso
+  broadcaster: independent
+  name: Public Santé Nutri Conso
+  streamUrl: https://publicsantenutri-conso.ice.infomaniak.ch/publicsantenutri-conso-192.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.publicsante.com/
+  country: FR
+  status: stream-only
+  stationuuid: cdc7a08c-7bc9-4864-b420-7f7766ad9df9
+  changeuuid: cabcd110-52a5-4086-b52b-e7c978794bb6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-capsule
+  broadcaster: independent
+  name: Radio Capsule
+  streamUrl: https://radiocapsule.com/radio/radio320.mp3
+  bitrate: 320
+  codec: MP3
+  favicon: https://radiocapsule.com/images/logo_capsule_transparent_320.png
+  homepage: https://radiocapsule.com/
+  country: FR
+  status: stream-only
+  stationuuid: 3eacf7e4-c7b7-494d-9bfd-a92cbefc3aa8
+  changeuuid: 7d1bd302-f389-417c-8543-9b3921bca0b1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-club-105-7fm
+  broadcaster: independent
+  name: RADIO CLUB 105.7FM
+  streamUrl: https://stunnel1.cyber-streaming.com:9128/listen.mp3
+  bitrate: 320
+  codec: MP3
+  favicon: https://radioclub.fr/wp-content/uploads/2024/08/cropped-269965503_533759981882903_4768925474557172552_n-270x270.jpg
+  homepage: https://radioclub.fr/wp-admin/
+  country: FR
+  status: stream-only
+  stationuuid: c6f50828-73ca-417e-a7e9-acfeafabcf32
+  changeuuid: f0c7a268-335d-49a9-84b7-ef6d10f3901d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-disney-paris
+  broadcaster: independent
+  name: Radio Disney Paris
+  streamUrl: https://stream-176.zeno.fm/ks5wfxkubv8uv?zt=eyJhbGciOiJIUzI1NiJ9.eyJzdHJlYW0iOiJrczV3ZnhrdWJ2OHV2IiwiaG9zdCI6InN0cmVhbS0xNzYuemVuby5mbSIsInJ0dGwiOjUsImp0aSI6IkVJTkxJclhkVEMtSEZHSzZFWS1iQVEiLCJpYXQiOjE3NzI3MDE4NDQsImV4cCI6MTc3MjcwMTkwNH0.QREohi8XJgDrhW8gOyF6uCpTTT6L-MOCMR6KO44intw
+  codec: MP3
+  favicon: https://res.cloudinary.com/dfuxhgkej/image/upload/v1772702338/aHR0cHM6Ly9wcm94eS56ZW5vLmZtL2NvbnRlbnQvc3RhdGlvbnMvYWd4emZucGxibTh0YzNSaGRITnlNZ3NTQ2tGMWRHaERiR2xsYm5RWWdJQ3drb1BwekFvTUN4SU9VM1JoZEdsdmJsQnliMlpwYkdVWWdJQ3dzdmpVdEFnTW9nRUVlbVZ1YncvaW1hZ2UvP3U9MTY2MTM1MDE3NjAwM_xzvuqi.png
+  homepage: https://zeno.fm/radio/radio-disney-paris
+  country: FR
+  status: stream-only
+  stationuuid: 753384b5-2762-42bf-8fd1-75441e6846aa
+  changeuuid: 0fa1d5e1-5e41-4d9d-a1d4-fcf3dd240005
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-dunes
+  broadcaster: independent
+  name: Radio Dunes
+  streamUrl: https://stream.rcast.net/62863
+  bitrate: 320
+  codec: MP3
+  favicon: https://radiodunes.com/wp-content/uploads/2021/05/cropped-logo-dunes.jpg
+  homepage: https://radiodunes.com/
+  country: FR
+  status: stream-only
+  stationuuid: 6112bd78-7af3-4372-924a-9a1aceee4ff1
+  changeuuid: b4986108-9c02-4938-b298-e87a94a2e6b7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-echo-des-choucas-rec
+  broadcaster: independent
+  name: Radio Echo des Choucas (REC)
+  streamUrl: https://hosting.radiomedia.fr:2005/stream
+  bitrate: 192
+  codec: MP3
+  favicon: https://radiorec.fr/wp-content/uploads/2025/03/cropped-logo-REC-2024-1-32x32.png
+  homepage: https://radiorec.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 5243b6c0-9e59-40fd-91b9-c62ff88d8206
+  changeuuid: fb6893be-75ba-47ab-aed4-c9dcbed998cd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-galaxie-31
+  broadcaster: independent
+  name: Radio Galaxie 31
+  streamUrl: https://stream-ssl.radios-arra.fr:8443/radiogalaxie
+  bitrate: 128
+  codec: MP3
+  favicon: https://radiogalaxie31.com/wp-content/uploads/Site/Commun/RGalaxie.ico
+  homepage: https://radiogalaxie31.com/
+  country: FR
+  status: stream-only
+  stationuuid: ffa6834d-6c2c-42fe-acb2-2e1d663efb19
+  changeuuid: 93b0637f-2dae-4509-aa68-6163f1697760
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-gresivaudan-chambery
+  broadcaster: independent
+  name: Radio Gresivaudan Chambery
+  streamUrl: https://live.aurafm.org/Radio-Gresivaudan-Chambery
+  bitrate: 320
+  codec: MP3
+  favicon: https://www.radio-gresivaudan.org/wp-content/uploads/2024/02/cropped-New_Logo-Photoroom.png-Photoroom-768x284.png
+  homepage: https://www.radio-gresivaudan.org/
+  country: FR
+  status: stream-only
+  stationuuid: 830d8816-d0c5-46b4-bf2d-e443c4b8011a
+  changeuuid: d61d8cc9-a53b-490a-b8dd-dde76265c4f7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-scarpe-sensee
+  broadcaster: independent
+  name: Radio Scarpe Sensée
+  streamUrl: https://radioscarpe.ice.infomaniak.ch/radioscarpe-128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://radioscarpesensee.com/index/wp-content/uploads/cropped-logo-scarpe-200x200.jpg
+  homepage: https://radioscarpesensee.com/
+  country: FR
+  status: stream-only
+  stationuuid: aadc87db-6131-4a83-b894-973ebc9de551
+  changeuuid: a2cd96e1-df97-4680-8c29-7f443eade924
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-scoop-roanne
+  broadcaster: independent
+  name: Radio SCOOP - Roanne
+  streamUrl: https://radioscooproanne.ice.infomaniak.ch/radioscoop-roanne-64.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://www.radioscoop.com/dyn/img.php?id=506831.jpg&w=512&h=512
+  homepage: https://www.radioscoop.com/
+  country: FR
+  status: stream-only
+  stationuuid: 5dd7ee79-2a35-4b5a-8f8f-2097e6a83d29
+  changeuuid: db058752-e3ed-40ee-bc3c-f55d6212d257
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-tou-caen
+  broadcaster: independent
+  name: "RADIO TOU'CAEN"
+  streamUrl: https://str0.creacast.com/direct-toucaen
+  bitrate: 192
+  codec: MP3
+  favicon: https://radio-toucaen.fr/wp-content/themes/radiotoucaen/img/logo-player-toucaen.png
+  homepage: https://radio-toucaen.fr/
+  country: FR
+  status: stream-only
+  stationuuid: e498daad-0139-46a4-8e44-56851c030997
+  changeuuid: 28a1f0e2-d387-4d39-83a3-4c004cf9c419
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-sing-sing
+  broadcaster: independent
+  name: Sing Sing
+  streamUrl: https://stream.sing-sing-bis.org:8443/singsingaac128
+  bitrate: 128
+  codec: AAC
+  favicon: https://www.sing-sing-bis.org/navi/images/haut.gif
+  homepage: https://www.sing-sing-bis.org/index.php
+  country: FR
+  status: stream-only
+  stationuuid: d5bad3fa-127d-4169-bd54-f997f2d5c70f
+  changeuuid: 45addf68-db23-4ef5-a91a-a777df1e932d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-tikka-radio
+  broadcaster: independent
+  name: TIKKA Radio
+  streamUrl: https://libretimetikka-8b513026764d.herokuapp.com/stream
+  codec: OGG
+  favicon: https://www.tikka.live/tikkalogowhite.ico
+  homepage: https://www.tikka.live/
+  country: FR
+  status: stream-only
+  stationuuid: 5d1c313d-1810-4b6c-befc-839b61b77608
+  changeuuid: d006555b-0b08-4dc9-9f8a-9a6a310fab4c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-tsumugi
+  broadcaster: independent
+  name: Tsumugi
+  streamUrl: https://azuracast.mahoro-net.org/listen/tsumugi/radio.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: https://azuracast.mahoro-net.org/public/tsumugi
+  country: FR
+  status: stream-only
+  stationuuid: fb95e603-0ccf-452e-8ac3-4d95116e0cae
+  changeuuid: cd225afe-a2ca-4151-a060-728ac9e4175d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-vertige-radio
+  broadcaster: independent
+  name: Vertige Radio
+  streamUrl: https://stream.vestaradio.com/VertigeRadio
+  bitrate: 320
+  codec: MP3
+  favicon: https://uploads.monsiteradio.com/logo/23-23-logovertigeradioone.png
+  homepage: https://vertigeradio.com/
+  country: FR
+  status: stream-only
+  stationuuid: 67208700-9c71-44a6-9d7e-1043b67cc188
+  changeuuid: 6a21b729-67aa-4557-8abc-9f68df006938
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-agnes-b-radio-europe
+  broadcaster: independent
+  name: Agnes B Radio Europe
+  streamUrl: https://listen.radioking.com/radio/131488/stream/171370
+  bitrate: 320
+  codec: MP3
+  homepage: https://www.agnesb.com/en-eu/radio.html
+  country: FR
+  status: stream-only
+  stationuuid: eda837bc-afdd-45df-9a5d-5f4e542643f5
+  changeuuid: 72951a16-2db8-43b0-a263-1a1518ef7146
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-bien-etre-animal
+  broadcaster: independent
+  name: Bien Etre Animal
+  streamUrl: https://bienetreanimal.ice.infomaniak.ch/bienetreanimal-128.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: http://www.radiobienetreanimal.com/
+  country: FR
+  status: stream-only
+  stationuuid: 691b8760-01d6-47fa-b59e-67a7206e0ec2
+  changeuuid: e71cc208-c646-4653-9e1d-d49649b2d07c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-blt-radio
+  broadcaster: independent
+  name: BLT Radio
+  streamUrl: https://play.radioking.io/blt-radio
+  bitrate: 128
+  codec: MP3
+  homepage: https://blt-radio.com/
+  country: FR
+  status: stream-only
+  stationuuid: 92d7dc6e-4a12-4556-93a7-8ace0f2280e5
+  changeuuid: 7003e7d8-5bfe-4d8b-a257-4ebb90b30c73
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-clapas-chanson
+  broadcaster: independent
+  name: Clapas Chanson
+  streamUrl: https://stream.radioclapas.fr/listen/clapas_chanson/radio.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.radioclapas.fr/player/chanson.jpg
+  homepage: https://www.radioclapas.fr/#
+  country: FR
+  status: stream-only
+  stationuuid: 12dde7af-bf57-4d89-854a-f77f57df5a0e
+  changeuuid: c5c1b188-3d42-4571-bd3a-503c40be51ac
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-dy10
+  broadcaster: independent
+  name: DY10
+  streamUrl: https://flux.radiody10.com/airtime_128
+  bitrate: 256
+  codec: MP3
+  favicon: https://res.cloudinary.com/bshano/image/upload/f_auto/v1623968490/webradio/stations/radio-dy10.jpg
+  homepage: https://radiody10.com/
+  country: FR
+  status: stream-only
+  stationuuid: f4b7898d-1ee5-4b5b-8e83-e26350364e13
+  changeuuid: 6cdb65f4-29af-4aa1-a993-3c3e2ce9aee5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-ed92
+  broadcaster: independent
+  name: ED92
+  streamUrl: https://listen.radioking.com/radio/497074/stream/554176
+  bitrate: 128
+  codec: MP3
+  favicon: https://image.radioking.io/radios/497074/logo/8a111dde-c44f-4c3b-a142-517a57f6fbf8.png
+  homepage: https://www.ed92.org/
+  country: FR
+  status: stream-only
+  stationuuid: 4645352c-a33b-4cd4-926b-69c0364d024d
+  changeuuid: 20d9bea3-f2aa-4ce9-aaf2-416c7724eee7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-happyness-amiens
+  broadcaster: independent
+  name: Happyness Amiens
+  streamUrl: https://azuracast-scrs-2.foxoud.synology.me/listen/happyness_amiens/player
+  codec: MP3
+  favicon: https://happynessamiens.fr/wp-content/uploads/2025/01/Happyness-Amiens@3x-50.jpg
+  homepage: https://happynessradio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: ffa8dead-f759-4f99-b76b-cfb89a575da3
+  changeuuid: 089d1431-d7e1-442a-9f69-4cd7204d92dc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-iaradio-guinguette
+  broadcaster: independent
+  name: IAradio Guinguette
+  streamUrl: https://iaradioguinguette.ice.infomaniak.ch/iaradioguinguette-128.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://iaradio.eu/
+  country: FR
+  status: stream-only
+  stationuuid: 29f8cc36-24f1-4a83-a6e4-b778bae61b48
+  changeuuid: 96d5f200-7f09-4a32-8376-d4696695c51f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-iaradio-opera
+  broadcaster: independent
+  name: IAradio Opéra
+  streamUrl: https://iaradioopera.ice.infomaniak.ch/iaradioopera-128.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://iaradio.eu/
+  country: FR
+  status: stream-only
+  stationuuid: 215a1ab7-13c2-400f-92e7-4306cb298b36
+  changeuuid: 86591e61-37a5-4640-b7a1-fb4c88b2a6d7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-la-grande-ourse
+  broadcaster: independent
+  name: La Grande Ourse ✨
+  streamUrl: https://cast.lagrandeourse.radio.fm/listen/radio/live.mp3
+  codec: MP3
+  homepage: https://lagrandeourse.radio.fm/
+  country: FR
+  status: stream-only
+  stationuuid: 42061a86-54e3-4462-a0a7-20653b65c7e5
+  changeuuid: 0beff6eb-5cf7-4258-b744-56289b0fb432
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-la-radio-sous-la-cerise
+  broadcaster: independent
+  name: "La radio sous la cerise "
+  streamUrl: https://laradio.souslacerise.fr/radio.m3u8
+  bitrate: 46
+  codec: AAC
+  homepage: https://laradio.souslacerise.fr/radio/
+  country: FR
+  status: stream-only
+  stationuuid: 7e378609-8644-46e1-859a-e66cf32b5fe2
+  changeuuid: e4ce9a42-1700-4583-8436-89d119239dc9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-mathis-fm
+  broadcaster: independent
+  name: MATHIS FM
+  streamUrl: https://mathisfm57.stream.laut.fm/mathisfm57?t302=2026-03-08_16-21-19&uuid=52d1fa64-f5a7-4c02-a729-8c44d7098970
+  bitrate: 128
+  codec: MP3
+  favicon: https://assets.laut.fm/98c165c3cf1ebe429ada106a3ba14932?t=_640x640
+  homepage: https://laut.fm/mathisfm57
+  country: FR
+  status: stream-only
+  stationuuid: 13ff2bf0-91d9-4d09-b567-aa15ed26f364
+  changeuuid: 59ab0a9d-13a4-4782-9ae3-f34f2622c038
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-open-sky-96kbps-mp3-low
+  broadcaster: independent
+  name: "Open Sky (96kbps mp3, \"low\")"
+  streamUrl: https://audio.opensky.radio:8082/stream96
+  bitrate: 96
+  codec: MP3
+  homepage: https://opensky.radio/
+  country: FR
+  status: stream-only
+  stationuuid: 1be5b02c-e9d8-4e2e-a9c4-4bc7932acd2b
+  changeuuid: 0f084b6b-ce15-4c1d-b67e-a37a71e5c40c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-public-health-radio-deutch
+  broadcaster: independent
+  name: Public Health Radio Deutch
+  streamUrl: https://publichealthradiode.ice.infomaniak.ch/publichealthradiode-128.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.publichealth.net/
+  country: FR
+  status: stream-only
+  stationuuid: 28adef2d-9ad3-465b-a15f-e08a01b089b7
+  changeuuid: 95f83f82-1a50-491b-9598-b26bd45b0dc0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-public-health-radio-russian
+  broadcaster: independent
+  name: Public Health Radio Russian
+  streamUrl: https://publichealthradioru.ice.infomaniak.ch/publichealthradioru-128.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.publichealthradio.net/
+  country: FR
+  status: stream-only
+  stationuuid: 968914a3-a016-49bf-8f1a-9718dceeff01
+  changeuuid: 6a5e6eb7-5a0b-47e7-b6f9-97ab280139f5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-agape
+  broadcaster: independent
+  name: Radio Agape
+  streamUrl: https://agape.jireh.ovh/;?type=http&nocache=68
+  bitrate: 64
+  codec: MP3
+  favicon: https://agape1.fr/wp-content/uploads/2019/11/cropped-Sanstitre-34.png
+  homepage: https://agape1.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 5300cf7b-26ce-479f-91b7-a80447eaa81f
+  changeuuid: f37d2ee9-6260-4b39-a381-0b921192528c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-jeans
+  broadcaster: independent
+  name: Radio Jeans
+  streamUrl: https://stream.mandragola.com/radiojeans
+  codec: MP3
+  favicon: https://www.radiojeans.net/images/logo_radiojeans.gif
+  homepage: https://www.radiojeans.net/
+  country: FR
+  status: stream-only
+  stationuuid: 6b6e0025-1885-4966-9c2e-abb48dd0b060
+  changeuuid: 2680d34f-cf8d-4840-a217-7e3c6672adc5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-rempart
+  broadcaster: independent
+  name: Radio Rempart
+  streamUrl: https://radio.pro-fhi.net:19112/;stream1
+  bitrate: 128
+  codec: MP3
+  homepage: https://radiorempart.fr/
+  country: FR
+  status: stream-only
+  stationuuid: cbc85b5b-7753-4368-bc9f-b6745066f1b5
+  changeuuid: 538f906f-d301-4405-b7e1-01dfd0f6692c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-sud-besancon
+  broadcaster: independent
+  name: Radio Sud Besançon
+  streamUrl: https://radiosudbesancon.ice.infomaniak.ch/radiosudbesancon-128.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://radiosud.net/
+  country: FR
+  status: stream-only
+  stationuuid: 58de269b-d3cc-46fc-987e-328711d1a0cc
+  changeuuid: d42c9891-acef-4fb1-86be-694f2fa9110e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-redzing-radio
+  broadcaster: independent
+  name: Redzing Radio
+  streamUrl: https://onair.redzingradio.com/redzing-256
+  bitrate: 256
+  codec: MP3
+  favicon: https://redzingradio.com/wp-content/uploads/2020/06/cropped-logo_cerclebleu_RedzingRadio_2022.png
+  homepage: https://redzingradio.com/
+  country: FR
+  status: stream-only
+  stationuuid: 5143c13f-62c3-4785-9b71-52d9b251a0d5
+  changeuuid: baf0dacf-efc6-436e-8223-57d7d090055e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-sensuelle-radio
+  broadcaster: independent
+  name: sensuelle radio
+  streamUrl: https://radio10.pro-fhi.net/live/SENSUELLERADIO
+  bitrate: 320
+  codec: MP3
+  homepage: https://www.sensuelleradio.com/
+  country: FR
+  status: stream-only
+  stationuuid: 5f8c23d9-ec55-4f69-b4eb-7c9c5a86cd83
+  changeuuid: fd800f60-55dd-495c-814c-f2993b153773
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-soov-radio
+  broadcaster: independent
+  name: Soov Radio
+  streamUrl: https://play.radioking.io/soovradio
+  bitrate: 128
+  codec: MP3
+  favicon: https://ibb.co/Txw6DG8n
+  homepage: https://soovradio.page.radio/
+  country: FR
+  status: stream-only
+  stationuuid: c04bc62d-4485-4bad-81d5-8b78d3a945d0
+  changeuuid: ac7c90ac-51fd-4789-918b-3f05f722a650
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-stellarfm
+  broadcaster: independent
+  name: StellarFM
+  streamUrl: https://radio.stellarfm.fr/listen/stellarfm/radio.mp3
+  bitrate: 256
+  codec: MP3
+  homepage: https://stellarfm.fr/
+  country: FR
+  status: stream-only
+  stationuuid: bff8776e-28ec-4839-842b-ed589b2285ec
+  changeuuid: ad0507c3-b954-4688-b9b7-ddff20c87e84
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-x-move
+  broadcaster: independent
+  name: X-Move
+  streamUrl: https://s26.myradiostream.com:11428/stream.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.xmove.fr/wp-content/uploads/2023/09/LOGO-770x513.png
+  homepage: https://www.xmove.fr/
+  country: FR
+  status: stream-only
+  stationuuid: e03eb9a1-91eb-4e98-9008-11bf1d0abac3
+  changeuuid: 0d335eed-1cde-46f2-95f3-6b1f471f971e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-gwoka-radio
+  broadcaster: independent
+  name: 🕺 Gwoka Radio
+  streamUrl: https://ecmanager2.pro-fhi.net:1650/;
+  bitrate: 320
+  codec: MP3
+  favicon: https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEgc3tUvjP7AVS0LRQbqIVESMlT3_nHdOWLRN1KjF78k4FOHy6OavrGUAzPgqU3VjCsscsejqNIbCeZfUW9FIPrwqGMMUJS2ttBm8zcr0tSpzvFZHT7xXSvybD6gA58ed8ejsDBWkKJkfFbu_bBAN76qukujOFI3TcUPmcCZpFAN1SSdnNbskIVfkS3i/s320/Capture%20d%E2%80%99%C3%A9cran_2024-11-21_10-59-47.png
+  homepage: https://www.karibshebdo.info/radios-web/gwoka-radio
+  country: FR
+  status: stream-only
+  stationuuid: 0f8c10fa-40c8-4297-9f73-13718ad19a78
+  changeuuid: ed78a1ca-4cd3-4362-b3aa-f612359fd0f2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-duuu
+  broadcaster: independent
+  name: "*Duuu"
+  streamUrl: https://duuu.out.airtime.pro/duuu_a
+  bitrate: 192
+  codec: MP3
+  homepage: https://duuuradio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: ac970dda-2513-4b7a-b6d4-990f09e78eb5
+  changeuuid: 0e6324b4-2b65-493e-8905-cda3bfa960c0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-bcc-blues-rock-radio
+  broadcaster: independent
+  name: BCC Blues Rock Radio
+  streamUrl: https://radio12.pro-fhi.net/radio/9132/stream.mp3
+  bitrate: 256
+  codec: MP3
+  favicon: https://www.bccrock.fr/media/yootheme/cache/ba/Logo_BCC_blues_ROCK-baa97e44.webp?src=images/logo/Logo_BCC_blues_ROCK.png&thumbnail=400,400,&type=webp,100&hash=69c0ddd3
+  homepage: https://www.bigcactuscountry.fr/player/#BCC-Blues-Rock-Radio
+  country: FR
+  status: stream-only
+  stationuuid: 81df1f6e-7860-4500-a757-320f2d46ee9c
+  changeuuid: 950e0a12-ad67-4057-99fd-6680bd63c64d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-camp-radio
+  broadcaster: independent
+  name: CAMP Radio
+  streamUrl: https://listen.camp/campradio.ogg
+  codec: OGG
+  favicon: https://favicon.im/listen.camp
+  homepage: https://listen.camp/
+  country: FR
+  status: stream-only
+  stationuuid: c81a32bf-7916-4c1f-9436-a1f70d87cc56
+  changeuuid: 9aab0cc4-90ac-4911-9d4f-948d630b57c5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-clapas-rock
+  broadcaster: independent
+  name: Clapas Rock
+  streamUrl: https://stream.radioclapas.fr/listen/clapas_rock/radio.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.radioclapas.fr/player/rock.jpg
+  homepage: https://www.radioclapas.fr/
+  country: FR
+  status: stream-only
+  stationuuid: ccb5c755-9d3f-46a5-9f9e-a7e104254d79
+  changeuuid: e4d4fc7a-e11d-434b-9b31-ca92183f1cee
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-dunkerque-street-radio
+  broadcaster: independent
+  name: Dunkerque Street Radio
+  streamUrl: https://azuracast.conceptradio.fr/hls/dunkerque_street_radio/live.m3u8
+  bitrate: 211
+  codec: AAC
+  favicon: https://image.noelshack.com/fichiers/2026/16/6/1776466582-3f50cb77-2c14-4e71-8c62-fbe061fba9dc.jpg
+  homepage: https://dunkerquestreetradio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: a7ce8699-81ba-476a-b9a1-bbd2e25cd415
+  changeuuid: cb99bf39-fc9e-425b-ace2-47248907f246
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-france-bleu-azur
+  broadcaster: independent
+  name: France Bleu Azur
+  streamUrl: https://stream.radiofrance.fr/fbazur/fbazur.m3u8?id=radiofrance
+  bitrate: 107
+  codec: AAC
+  favicon: https://www.francebleu.fr/client/immutable/assets/logo-ici-small.DwiLDMIK.svg
+  homepage: https://www.francebleu.fr/radio/azur
+  country: FR
+  status: stream-only
+  stationuuid: fdda8d22-9789-40da-a94a-d3edd47621ad
+  changeuuid: bba08345-29b5-438b-b5f2-cb80c9ec9e63
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-friendly-radio
+  broadcaster: independent
+  name: Friendly Radio
+  streamUrl: https://listen.radioking.com/radio/6014/stream/14771
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.friendlyradio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: d342f654-f0d1-4c7d-8413-c51956fe094a
+  changeuuid: 050b04d4-8be7-4cb1-826a-f439c6db4041
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-g-one-radio
+  broadcaster: independent
+  name: G One Radio
+  streamUrl: https://radio.garden/api/ara/content/listen/pahlMAe0/channel.mp3?1726401108732
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.goneradio.com/
+  country: FR
+  status: stream-only
+  stationuuid: 8acd85d4-0232-44be-9bc1-7708f95c66c1
+  changeuuid: 9565173c-94fe-4651-8f2d-31916e7a2051
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-groove-nation
+  broadcaster: independent
+  name: Groove Nation
+  streamUrl: https://listen.radioking.com/radio/70135/stream/107968
+  bitrate: 128
+  codec: MP3
+  favicon: https://uk.radio.net/300/groovenationradio.png?version=272d1ee194194d1596a58f38cbb9ccad
+  homepage: https://groovenation.radio/
+  country: FR
+  status: stream-only
+  stationuuid: e67d8329-b546-4537-b44f-8a7e976f430f
+  changeuuid: 22cc5e37-a7dd-46f1-9ca0-16e5c0bca7eb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-happyness-oise
+  broadcaster: independent
+  name: Happyness Oise
+  streamUrl: https://azuracast-scrs-2.foxoud.synology.me/listen/happyness_oise/player
+  codec: MP3
+  favicon: https://happynessoise.fr/wp-content/uploads/2025/01/Happyness-Oise@3x-50.jpg
+  homepage: https://happynessradio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 7716ccd0-bfd7-475b-b25a-41abb8da2e21
+  changeuuid: ce673188-d124-4680-ba43-4b55732203c7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-hotmix-80
+  broadcaster: independent
+  name: Hotmix 80
+  streamUrl: https://streaming.hotmixradio.com/hotmix-80-en-mp3?provider=radiobrowser
+  bitrate: 128
+  codec: MP3
+  homepage: https://web.hotmixradio.com/fr
+  country: FR
+  status: stream-only
+  stationuuid: a885c5ea-632e-4c09-b069-7a3ca49399e3
+  changeuuid: adebc1aa-7456-4907-ab3c-996e1c86ab56
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-hotmix-lofi
+  broadcaster: independent
+  name: hotmix LoFi
+  streamUrl: https://streaming.hotmixradio.com/hotmix-lofi-en-mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://hotmixradio.com/
+  country: FR
+  status: stream-only
+  stationuuid: 26c2fd92-1412-4e55-8334-96b5a4005b46
+  changeuuid: de0f492a-373f-4839-a774-bc041de5a59f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-hotmix-rnb
+  broadcaster: independent
+  name: Hotmix RnB
+  streamUrl: https://streaming.hotmixradio.fr/hotmix-rnb-en-pre
+  bitrate: 320
+  codec: MP3
+  homepage: http://https//streaming.hotmixradio.fr
+  country: FR
+  status: stream-only
+  stationuuid: b3fb8244-cfe6-437f-99df-dbcce3c520ca
+  changeuuid: 59761b48-e820-4931-84a4-9bfdf0e7ca23
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-i2-radio
+  broadcaster: independent
+  name: i2 Radio
+  streamUrl: https://listen.radioking.com/radio/635275/stream/698023
+  bitrate: 128
+  codec: MP3
+  favicon: https://drive.google.com/file/d/1EMB3qjCKgDO2dd26B58GKmzIsF6EfByM/view?usp=sharing
+  homepage: https://www.radioking.com/
+  country: FR
+  status: stream-only
+  stationuuid: eef605ce-210a-4cd9-9cb5-8c89610942de
+  changeuuid: 04ad7c72-3fd3-4715-9ad5-fab33741c416
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-iaradio-lounge
+  broadcaster: independent
+  name: IAradio Lounge
+  streamUrl: https://iaradiolounge.ice.infomaniak.ch/iaradiolounge-128.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://iaradio.eu/
+  country: FR
+  status: stream-only
+  stationuuid: 3e29e08f-bd9c-4cf0-b723-e0318312a347
+  changeuuid: a251caad-be5c-4965-a6ee-e85bbb67d90a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-iaradio-pop-rock
+  broadcaster: independent
+  name: IAradio Pop Rock
+  streamUrl: https://iaradiopoprock.ice.infomaniak.ch/iaradiopoprock-128.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://iaradio.eu/
+  country: FR
+  status: stream-only
+  stationuuid: 04d1fc76-54b3-45d1-a636-95c0602ec020
+  changeuuid: e28dbfec-4dfc-47ed-bd65-d8e3f112b7b4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-iaradio-reggae
+  broadcaster: independent
+  name: IAradio Reggae
+  streamUrl: https://iaradioreggae.ice.infomaniak.ch/iaradioreggae-128.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://iaradio.eu/
+  country: FR
+  status: stream-only
+  stationuuid: ab48412b-69d1-437b-9cb6-0c634ce24f4a
+  changeuuid: bb196d9e-da01-4e14-a425-07ec8f1ef1a7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-lradio
+  broadcaster: independent
+  name: Lradio
+  streamUrl: https://listen.radioking.com/radio/267025/stream/312298
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.lradio.fr/img/upload/65993118959aa.png
+  homepage: https://www.lradio.fr/index
+  country: FR
+  status: stream-only
+  stationuuid: 3b41868a-decf-4221-b110-5e53b5ee71b4
+  changeuuid: 8d9ea1b4-fc16-4fba-af02-ddaa9a0fb9da
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-m2s-radio
+  broadcaster: independent
+  name: M2S Radio
+  streamUrl: https://icecast.m2sradio.fr/radio.aac
+  bitrate: 128
+  codec: AAC
+  favicon: https://listen.m2sradio.fr/assets/logo-01.png
+  homepage: https://mordus2savoie.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 474834a2-8ad0-4a90-b14d-b3544db2c79c
+  changeuuid: edba3b1b-7e07-4a83-8ae8-af3f8ff36082
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-meteo-terrasse-fab
+  broadcaster: independent
+  name: Météo Terrasse Fab
+  streamUrl: https://fqboy.com/labo/weather/rss/audio/meteo.mp3
+  codec: MP3
+  homepage: https://fqboy.com/
+  country: FR
+  status: stream-only
+  stationuuid: 51b628f9-7b2a-4ab7-86e3-98f897ec8920
+  changeuuid: 90ffdcde-0a83-4bcb-8d6c-2bf96a8b4ad1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-milo-radio
+  broadcaster: independent
+  name: Milo Radio
+  streamUrl: https://listen.radioking.com/radio/779491/stream/847056
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.miloradio.com/img/milo.png
+  homepage: https://www.miloradio.com/
+  country: FR
+  status: stream-only
+  stationuuid: 82756524-03fb-4015-806b-ddf9f3e58803
+  changeuuid: a42ac349-fd65-488d-a856-c5d6d50e116c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-mix-maxi-radio
+  broadcaster: independent
+  name: Mix Maxi Radio
+  streamUrl: https://ecmanager.pro-fhi.net:1455/stream
+  bitrate: 320
+  codec: MP3
+  favicon: https://www.mixmaxiradio.fr/favicon.ico
+  homepage: https://www.mixmaxiradio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 5a9c267c-1054-454d-817b-ca42224b6152
+  changeuuid: 2ba3e259-c6dc-4641-b1d1-80d4bf89f795
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-musique-d-inter
+  broadcaster: independent
+  name: "Musique d'Inter"
+  streamUrl: https://stream.radiofrance.fr/franceinterlamusiqueinter/franceinterlamusiqueinter.m3u8?id=radiofranceBose
+  bitrate: 107
+  codec: AAC
+  favicon: https://cmsphoto.ww-cdn.com/superstatic/36765/art/grande/81114591-58479823.jpg?v=1718955523
+  homepage: https://www.radiofrance.fr/franceinter/la-musique-inter
+  country: FR
+  status: stream-only
+  stationuuid: f247398d-189f-4a89-a4b1-274f2ad47d19
+  changeuuid: fb0e2c3c-d9ff-47a8-95aa-5c7a6cac06da
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-nova-nouva
+  broadcaster: independent
+  name: Nova Nouva
+  streamUrl: https://nova-nouvo.ice.infomaniak.ch/nova-nouvo-128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.nova.fr/wp-content/thumbnails/uploads/sites/2/2024/04/NOVA-NOUVO-400x496-1-t-1006x1006.png
+  homepage: https://www.nova.fr/radios/nouvo-nova/
+  country: FR
+  status: stream-only
+  stationuuid: db898a6b-87d0-4374-8f59-0a826c52e159
+  changeuuid: 2b0da34c-91f6-4d69-b6c8-60a694661e4c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-nrj-disney-hits-live
+  broadcaster: independent
+  name: NRJ DISNEY HITS live
+  streamUrl: https://streaming.nrjaudio.fm/oudbxj2h9r57
+  bitrate: 128
+  codec: MP3
+  favicon: https://res.cloudinary.com/dfuxhgkej/image/upload/v1773587606/nrj-la-playlist-disney-du-genie.e889f0e6_okvkyw.jpg
+  homepage: https://www.nrj.fr/webradios/mur-des-radios/nrj-disney-hits
+  country: FR
+  status: stream-only
+  stationuuid: 8e19b386-db97-4700-8a94-54a2048d1bd3
+  changeuuid: 12e60932-e01e-4dd6-8055-bdb3008aa590
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-nrj-linkin-park
+  broadcaster: independent
+  name: NRJ LINKIN PARK
+  streamUrl: https://streaming.nrjaudio.fm/ouvfbfoarp52
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.radio.net/300/nrjlinkinpark.jpeg?version=9ec7666b0204107fd6befaf6e99299f6a38aaff9
+  homepage: https://www.nrj.fr/webradios/mur-des-radios/nrj-linkin-park
+  country: FR
+  status: stream-only
+  stationuuid: d27842b3-97d8-4be7-9152-503167301955
+  changeuuid: 364afc64-79a3-48a9-8b09-2cbb2aa62803
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-abf
+  broadcaster: independent
+  name: Radio ABF
+  streamUrl: https://stream.radioabf.com/abf-low.aac
+  bitrate: 32
+  codec: AAC
+  favicon: https://radioabf.com/logo-abf.png
+  homepage: https://radioabf.com/
+  country: FR
+  status: stream-only
+  stationuuid: 7a7e2de0-199e-4f28-8e39-d27bfd46cfb0
+  changeuuid: 3558dd9e-b8af-4a77-897e-4e1955ed51f5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-atlantis-107fm
+  broadcaster: independent
+  name: Radio Atlantis 107FM
+  streamUrl: https://radio8.pro-fhi.net/radio/9005/atlantis320
+  bitrate: 320
+  codec: MP3
+  favicon: https://i0.wp.com/radioatlantis.fr/wp-content/uploads/elementor/thumbs/LogoAtlantisBlack-pfblhncaz7c4p0k8iv0x6p2lgpz65o1tplvp2kpgnu.png?w=1170&ssl=1
+  homepage: https://radioatlantis.fr/
+  country: FR
+  status: stream-only
+  stationuuid: f718597c-6115-483d-8ab2-371f59a71eb1
+  changeuuid: 209c5b6e-4fb8-42f2-9fa0-c04c2ca58560
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-brassens
+  broadcaster: independent
+  name: Radio Brassens
+  streamUrl: https://www.zestream.eu/listen/radiobrassens/radio.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.radiobrassens.com/wp-content/uploads/2024/02/cropped-logo-radio-brassens-1-1.png
+  homepage: https://www.radiobrassens.com/
+  country: FR
+  status: stream-only
+  stationuuid: c2cf59db-ff09-4d5f-a3b4-ec36ab559bb8
+  changeuuid: d0bbdeae-f740-4947-9ab6-153942b44ac5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-cagnac
+  broadcaster: independent
+  name: Radio Cagnac
+  streamUrl: https://go.2stream.net/cagnac_sd.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.radiocagnac.fr/img/slidertop.jpg
+  homepage: https://www.radiocagnac.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 0dedeb6a-05c0-4a05-9cca-ff8d5046c07f
+  changeuuid: b190fa26-2b4c-493f-ba23-01078a1a9c36
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-contact-vosges
+  broadcaster: independent
+  name: Radio Contact Vosges
+  streamUrl: https://s2.ssl-stream.com/listen/radio_contact/radio.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.facebook.com/profile.php?id=61584378462518
+  homepage: https://rcvradio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 5c7701e8-ba7c-4e0d-9a92-26397aaaa368
+  changeuuid: 34fd690d-1722-44fc-9393-e2a7bd8f4970
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-de-la-save
+  broadcaster: independent
+  name: Radio de la Save
+  streamUrl: https://sd-151888.dedibox.fr/proxy/radiodelasave/rdls
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radiodelasave.com/
+  country: FR
+  status: stream-only
+  stationuuid: 8426697b-dd09-40ec-bae7-3bee41892934
+  changeuuid: f09e9fbc-4d76-4d7d-b656-47f0cf6227ed
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-of-magic
+  broadcaster: independent
+  name: Radio of Magic
+  streamUrl: https://listen.radioking.com/radio/418372/stream/471466
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.radio-of-magic.com/wp-content/uploads/2021/05/favicon-512x512-1.png
+  homepage: https://www.radio-of-magic.com/fr/
+  country: FR
+  status: stream-only
+  stationuuid: b58113e5-4f1a-4250-9302-20c097c3fbf2
+  changeuuid: c7c39d9b-df13-4c9b-8f5c-439df5002d1f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-presence-pyrenees
+  broadcaster: independent
+  name: Radio Presence Pyrenees
+  streamUrl: https://live.radiopresence.com/radio-presence-pyrenees
+  bitrate: 128
+  codec: MP3
+  favicon: http://direct.radiopresence.com/presence.png
+  homepage: https://www.radiopresence.com/
+  country: FR
+  status: stream-only
+  stationuuid: c837dd9a-2e80-4ab5-866e-4353b2c924ce
+  changeuuid: acea87cd-76a2-4c7e-a664-c8ee3d814f11
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-sisko-fm
+  broadcaster: independent
+  name: Radio sisko fm
+  streamUrl: https://stream.zeno.fm/nesckintyb8uv
+  codec: MP3
+  favicon: https://primary.jwwb.nl/public/o/l/o/temp-ibtrsekethdwduzkuoxo/reel-video-instagram-voyage-moderne-minimaliste-blanc-et-jaune-publication_20240929_182455_0000-high-high-t1jvz2.png?enable-io=true&enable=upscale&height=140&quality=70
+  homepage: https://www.radiosiskofm.fr/
+  country: FR
+  status: stream-only
+  stationuuid: bd31d66b-a45d-4620-81af-c72b478ba65a
+  changeuuid: 591260fa-27c5-41a8-88df-e4e09bc25346
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio230
+  broadcaster: independent
+  name: Radio230
+  streamUrl: https://listen.radio230.com/
+  bitrate: 256
+  codec: MP3
+  favicon: https://radio230.com/favicon.ico
+  homepage: https://radio230.com/
+  country: FR
+  status: stream-only
+  stationuuid: f812f2b6-d7be-4895-b02a-7e38f2cb6944
+  changeuuid: e0769fde-a609-4471-9508-9d8449a90655
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radionysos
+  broadcaster: independent
+  name: Radionysos
+  streamUrl: https://listen.radioking.com/radio/254980/stream/299539
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radionysos.com/
+  country: FR
+  status: stream-only
+  stationuuid: 4740cdb0-8435-468c-9872-b50ace5eca20
+  changeuuid: 48a56c5b-29d4-499d-a240-01e3888d8336
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-replay-news-sport-francais
+  broadcaster: independent
+  name: REPLAY NEWS - Sport (Français)
+  streamUrl: https://replaynewssport.ice.infomaniak.ch/replaynewssport-128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.publicsante.com/BIENVENU/LOGO%20REPLAY%20NEWS%20SPORT.png
+  homepage: https://www.replaynews.net/
+  country: FR
+  status: stream-only
+  stationuuid: c0f4983e-988c-449f-9a2e-1b21c5090de3
+  changeuuid: fc4bab16-f530-4905-b7ab-92ab11387fee
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-rvb-radio-vallee-bergerac
+  broadcaster: independent
+  name: RVB - Radio Vallée Bergerac
+  streamUrl: https://hosting.studioradiomedia.fr:1750/stream
+  codec: MP3
+  favicon: https://rvb-radio.fr/upload/design/68b6fce80cf423.82381308.jpeg
+  homepage: https://rvb-radio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: e8a63d49-ecbd-4152-b1fa-9ebf2cbf118a
+  changeuuid: 94ad51ef-8aa9-414a-9391-41f7fa19cfef
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-station-b
+  broadcaster: independent
+  name: Station B
+  streamUrl: https://stream.lastationb.fr/stationb
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.lastationb.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 067809db-8d50-43ba-bc9e-f6b0f863880a
+  changeuuid: 2b5a0eb5-e04d-488a-966d-e8f7c9b7a816
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-sunshine-radio
+  broadcaster: independent
+  name: Sunshine Radio
+  streamUrl: https://sunshine.ice.infomaniak.ch/sunshine-mp3.mp3
+  codec: MP3
+  favicon: https://sunshineradio.fr/wp-content/uploads/2024/08/favicon.png
+  homepage: https://sunshineradio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 2846503c-9aab-42ab-9426-07cf58de2f48
+  changeuuid: defbf1cc-3904-4ba6-b7bb-e502568dd426
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-tempo-62
+  broadcaster: independent
+  name: TEMPO 62
+  streamUrl: https://www.radioking.com/play/tempo-62
+  bitrate: 128
+  codec: MP3
+  favicon: https://tempo62.com/upload/photos/6571e750aad770.98045674_carre.png
+  homepage: https://tempo62.com/
+  country: FR
+  status: stream-only
+  stationuuid: de1c1d52-147c-4bbd-8a76-a916772c487b
+  changeuuid: 8785cca0-ad15-4861-80fe-79740ffad7cf
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-vertige-radio-gold
+  broadcaster: independent
+  name: Vertige Radio Gold
+  streamUrl: https://stream.vestaradio.com/VertigeRadioGold
+  bitrate: 128
+  codec: MP3
+  favicon: https://vertigeradio.fr/uploads/streams/stream_1_1769945055_7d9e28fd.jpg
+  homepage: https://vertigeradio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: c747f09b-4eb3-40c5-9649-3adab5eef049
+  changeuuid: 33484759-c72b-4329-a855-bf6ee2cca8d2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-mlpfm
+  broadcaster: independent
+  name: /mlpfm/
+  streamUrl: https://dash.mlp.radio:8020/radio.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://mlp.radio/static/uploads/browser_icon/180.1732808201.png
+  homepage: https://mlp.radio/
+  country: FR
+  status: stream-only
+  stationuuid: 85cdf2d1-5d3b-4f74-b0ba-71119cf1c5cf
+  changeuuid: 1c0bbfea-49c8-422f-b880-9664f31b0add
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-5sens-radio
+  broadcaster: independent
+  name: "5Sens Radio"
+  streamUrl: https://radio.5sens.fr/radio/stream.php
+  bitrate: 128
+  codec: MP3
+  favicon: https://radio.5sens.fr/photos/podcasts/favicon.png
+  homepage: https://radio.5sens.fr/
+  country: FR
+  status: stream-only
+  stationuuid: cf336227-ab60-4f80-b4c5-5262d721fd85
+  changeuuid: 5e6102e5-6faa-470f-8f44-88e01ca5744c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-air-connect-radio
+  broadcaster: independent
+  name: Air Connect Radio
+  streamUrl: https://stream.airconnectradio.com/ac64.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://airconnectradio.com/wp-content/uploads/2025/01/ac-grand.png
+  homepage: https://airconnectradio.com/
+  country: FR
+  status: stream-only
+  stationuuid: bf266770-77f3-49fc-acbc-da577f578e9d
+  changeuuid: f82acce9-3b09-45cb-855b-9cc408c13a74
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-akro-radio
+  broadcaster: independent
+  name: Akro Radio
+  streamUrl: https://stream.akroradio.com:10012/AkroRadio
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.akroradio.com/
+  country: FR
+  status: stream-only
+  stationuuid: c15fa404-a8d3-4f6a-8b17-c70ba6953a7a
+  changeuuid: e33ba77e-2ccd-4a1b-afa5-f83ae9f0b9c9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-akroradio-www-akroradio-com
+  broadcaster: independent
+  name: AkroRadio - www.akroradio.com
+  streamUrl: https://stream.akroradio.com/listen/akroradio/AkroRadio
+  codec: MP3
+  favicon: https://akroradio.com/wp-content/uploads/2023/09/cropped-icone.png
+  homepage: https://www.akroradio.com/
+  country: FR
+  status: stream-only
+  stationuuid: 0988d5b9-1469-4be6-a6c7-b8cf890a0136
+  changeuuid: e810266f-fb61-4f68-8da0-e52e44bfe62a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-aubymix
+  broadcaster: independent
+  name: AubyMix
+  streamUrl: https://stream.aubymix.fr:8443/mp3?1771423833872
+  bitrate: 192
+  codec: MP3
+  favicon: https://aubymix.fr/wp-content/uploads/2025/03/logo_aubymix_avec_texte_transparent.png
+  homepage: https://aubymix.fr/
+  country: FR
+  status: stream-only
+  stationuuid: d028d6e4-5821-46c7-9529-f56bcea02252
+  changeuuid: 6fb0ea1d-77a5-4de8-8850-c400f8b0111f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-bcc-classic-rock-radio
+  broadcaster: independent
+  name: BCC Classic Rock Radio
+  streamUrl: https://radio12.pro-fhi.net/radio/9134/stream.mp3
+  bitrate: 256
+  codec: MP3
+  favicon: https://www.bccrock.fr/media/yootheme/cache/e0/Logo_BCC_ROCK_-e037e6ac.webp?src=images/logo/Logo_BCC_ROCK_.png&thumbnail=400,400,&type=webp,100&hash=c6ecc033
+  homepage: https://www.bigcactuscountry.fr/player/#BCC-Classic-Rock-Radio
+  country: FR
+  status: stream-only
+  stationuuid: 39c76506-78a6-45c8-a98e-9b9314c1741d
+  changeuuid: cc192f81-138b-4a35-9eb0-da224e89a1bf
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-breniges-fm
+  broadcaster: independent
+  name: Bréniges FM
+  streamUrl: https://stream.rcs.revma.com/uzz0fgg64zcwv
+  codec: MP3
+  homepage: https://www.breniges-fm.com/
+  country: FR
+  status: stream-only
+  stationuuid: 30d68a1a-35ae-423a-a73a-1f7c5de79e49
+  changeuuid: f6971965-d6c8-43e2-8e89-511c42ab93a6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-comtoise-radio
+  broadcaster: independent
+  name: Comtoise Radio
+  streamUrl: https://stream.tiennot.net/comtoise.aac
+  bitrate: 192
+  codec: AAC
+  favicon: https://www.comtoiseradio.fr/images/logo.png
+  homepage: https://www.comtoiseradio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 2e475a7d-5bc0-4288-aad0-13deb1c008dc
+  changeuuid: def5368d-03a9-4bb0-b002-92423560b9f3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-crooner-radio-192-48
+  broadcaster: independent
+  name: Crooner Radio 192/48
+  streamUrl: https://croonerradio.ice.infomaniak.ch/croonerradio-hifi.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.croonerradio.fr
+  homepage: https://www.croonerradio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: d8ccb9fa-bac4-4da0-8110-f952d1ab8ce9
+  changeuuid: d45821d0-f952-45ee-b036-2deb1bf62926
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-crooner-radio-julio-iglesias
+  broadcaster: independent
+  name: Crooner Radio Julio Iglesias
+  streamUrl: https://croonerradio_julioiglesias.ice.infomaniak.ch/croonerradio-julioiglesias-midfi.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.croonerradio.fr/wp-content/uploads/2019/04/crooner-julio-iglesias-bio-190424.png
+  homepage: https://www.croonerradio.fr/player/#crooner_j_iglesias
+  country: FR
+  status: stream-only
+  stationuuid: a2031cf4-dfd2-4c19-aad2-ac402f440f3a
+  changeuuid: a679dfea-880d-4e9a-8be7-7111f8db92d2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-dlrp
+  broadcaster: independent
+  name: DLRP
+  streamUrl: https://stream4.vestaradio.com/DLRP
+  bitrate: 192
+  codec: MP3
+  favicon: https://dlrp.fr/wp-content/uploads/2023/08/dlrp-jaune.png
+  homepage: https://dlrp.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 324aabba-8887-4d10-b9ad-bcad9b99b0c3
+  changeuuid: 90f80db2-a1f7-4143-a5bb-8687eb967c3f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-dzfishradio
+  broadcaster: independent
+  name: DZFISHRADIO
+  streamUrl: https://radio.dzfishradio.com/listen/dzfishradio/radio.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.dzfishradio.com/IMG/logo/dzfishradio_sticker.png?1693428086
+  homepage: https://www.dzfishradio.com/
+  country: FR
+  status: stream-only
+  stationuuid: caf476fb-2cc4-4e1f-83fa-06e844762411
+  changeuuid: b428cf56-bcc4-44ba-82e7-b2a3c296c687
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-f-hits-aquitaine
+  broadcaster: independent
+  name: F. HITS AQUITAINE
+  streamUrl: https://listen.f-group.fr/listen/fhitsaquitaine/fhits_aquitaine_96.aac
+  bitrate: 96
+  codec: AAC
+  favicon: https://i.postimg.cc/QCrDdq8S/PP-FB-INSTA-FHITS-AQUITAINE.png
+  homepage: https://fhits-aquitaine.fr/
+  country: FR
+  status: stream-only
+  stationuuid: c6af3fe3-21ab-4add-8961-ea0ac4854a85
+  changeuuid: a7646c1b-1099-4f7d-b143-83966bc944b8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-france-antilles-radio
+  broadcaster: independent
+  name: France Antilles Radio
+  streamUrl: https://2stream.net/fa_radio.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://assets.franceantilles.fr/common/images/logo_FAR-Color.png
+  homepage: https://www.martinique.franceantilles.fr/
+  country: FR
+  status: stream-only
+  stationuuid: bb7c45ed-b207-4413-998f-d337f2a2cae3
+  changeuuid: 53490502-bbd3-45ac-82fd-3cb0c0dffdd7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-g-tracks-radio
+  broadcaster: independent
+  name: G-tracks Radio
+  streamUrl: https://s2.citrus3.com:8010/stream
+  bitrate: 128
+  codec: AAC
+  favicon: https://gtracksradio.com/wp-content/uploads/2023/04/cropped-GTRLogo.png
+  homepage: https://gtracksradio.com/#
+  country: FR
+  status: stream-only
+  stationuuid: a85dd830-127f-4a33-b478-5000e3a85cdc
+  changeuuid: 8ca74c42-96e4-499a-9f30-f92dcd45e536
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-generation-soul-disco-funk-radio
+  broadcaster: independent
+  name: GENERATION SOUL DISCO FUNK RADIO
+  streamUrl: https://gestream.fr/g-radio-hd.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://generationdiscofunk.com/favicon.ico
+  homepage: https://www.generationdiscofunk.com/
+  country: FR
+  status: stream-only
+  stationuuid: 6512fd8f-a693-4b42-9c69-a3300d4db38f
+  changeuuid: d472ee46-7e61-41c2-bdd6-e15392f67c9c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-good-morning-poker
+  broadcaster: independent
+  name: Good Morning Poker
+  streamUrl: https://streamer.radio.co/s43556a89a/listen
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.goodmorningpoker.com/
+  country: FR
+  status: stream-only
+  stationuuid: 17caf307-de76-4bed-a0bf-2389c7f13b55
+  changeuuid: 4cbc12ef-5bb0-44f5-8bb0-a2b3a2983505
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-iaradio
+  broadcaster: independent
+  name: IAradio
+  streamUrl: https://iaradio.ice.infomaniak.ch/iaradio-128.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://iaradio.eu/
+  country: FR
+  status: stream-only
+  stationuuid: b6d5c725-fc13-4d35-8eb6-9e02bd0eb504
+  changeuuid: fb542042-6ed5-4ec5-926c-c756d58d5b7b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-iaradio-rap
+  broadcaster: independent
+  name: IAradio Rap
+  streamUrl: https://iaradiorap.ice.infomaniak.ch/iaradiorap-128.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://iaradio.eu/
+  country: FR
+  status: stream-only
+  stationuuid: c86513df-a640-47b2-b2f3-15a70e61fbc6
+  changeuuid: 7ebaed2d-2b72-4654-b8b0-f17e17a90932
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-jack-rocks-live
+  broadcaster: independent
+  name: Jack Rocks LIVE
+  streamUrl: https://radio12.pro-fhi.net/radio/9174/stream?fbclid=IwAR3SdOLxThn4vewpYN2LWNu1a_R8iZAmAU4hT7_VTD5wRNTiuKzQ3h5liE8
+  bitrate: 128
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/f8b2f4_df1d1ffd77474f71ab448ac5c9c5f866~mv2.jpg/v1/fill/w_260,h_260,al_c,q_80,usm_0.66_1.00_0.01,enc_avif,quality_auto/Logo_derni%C3%A8re_version_rec_c.jpg
+  homepage: https://www.jackrockslive.net/
+  country: FR
+  status: stream-only
+  stationuuid: d40b8264-6298-42a6-bbe4-1094e52961d9
+  changeuuid: 58d38e18-f68b-44cc-b521-456a1f328b95
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-knaradio
+  broadcaster: independent
+  name: KNAradio
+  streamUrl: https://webradiostream.eu/radio/8070/stream
+  codec: MP3
+  homepage: https://knaradio.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 5ce26a0e-cb03-48e0-b1f7-ab306b7543f6
+  changeuuid: 9b2a5ec6-2b25-4e72-95dc-4b415dc316e7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-line-out-radio
+  broadcaster: independent
+  name: Line Out Radio ����
+  streamUrl: https://listen.radioking.com/radio/416299/stream/469240
+  bitrate: 64
+  codec: AAC+
+  country: FR
+  status: stream-only
+  stationuuid: 819108bd-0256-477c-b5e6-de1e97adc3c3
+  changeuuid: 1d7ab8e2-1fae-4865-b346-688177a16333
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-magic-radio-proxima
+  broadcaster: independent
+  name: Magic Radio - Proxima
+  streamUrl: https://mp3.magic-radio.net/prox192
+  bitrate: 192
+  codec: MP3
+  favicon: https://magic-radio.net/fichier_000_1.png
+  homepage: https://magic-radio.net/
+  country: FR
+  status: stream-only
+  stationuuid: ad9f878f-c7e3-4865-8292-7f778cafe0ee
+  changeuuid: bb1f08d3-141e-45ff-b932-a4a5d8f6d06a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-nia-pacifique
+  broadcaster: independent
+  name: NIA Pacifique
+  streamUrl: https://radio.nia.nc/radio/8000/pacific-hq-stream.aac?1772351904
+  bitrate: 128
+  codec: AAC
+  favicon: https://nia.nc/static/icons/favicon.ico
+  homepage: https://nia.nc/
+  country: FR
+  status: stream-only
+  stationuuid: e9d17507-298f-496d-81f4-7b8190006905
+  changeuuid: a4e763f0-f135-49b5-908d-35813da77911
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-projet-xy
+  broadcaster: independent
+  name: PROJET XY
+  streamUrl: https://flux.saaslys.com:8000/radio.mp3
+  codec: MP3
+  favicon: https://cdn-images.dzcdn.net/images/artist/bec649ded67ae4a1741650e148d9af6b/500x500-000000-80-0-0.jpg
+  homepage: https://flux.saaslys.com/public/projectxy
+  country: FR
+  status: stream-only
+  stationuuid: ababbced-5e73-41d5-b6d5-33e0fa2fa611
+  changeuuid: 883f0661-af5e-4e0c-b110-344c724e3080
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-public-health-radio-polish
+  broadcaster: independent
+  name: Public Health Radio Polish
+  streamUrl: https://publichealthradiopl.ice.infomaniak.ch/publichealthradiopl-128.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www/
+  country: FR
+  status: stream-only
+  stationuuid: 244e694d-32a8-4db3-9168-0bc323735bcb
+  changeuuid: d96d41be-fc4f-4c72-8617-52c86da07320
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-public-health-radio-portugues
+  broadcaster: independent
+  name: Public Health Radio Portugues
+  streamUrl: https://publichealthradiopt.ice.infomaniak.ch/publichealthradiopt-128.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.publicsante.com/
+  country: FR
+  status: stream-only
+  stationuuid: 55999430-151f-4dca-9d2c-9d43de1aad16
+  changeuuid: 470078e9-e1df-458a-9158-67ce56a8ab95
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-cap-a-cap
+  broadcaster: independent
+  name: Ràdio Cap a cap
+  streamUrl: https://listen.radioking.com/radio/361189/stream/410758
+  codec: MP3
+  homepage: https://www.radiocapacap.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 4b9498b8-2a75-4923-8780-5faeddc65499
+  changeuuid: cc7d007a-25fa-4977-adca-3d67abc9506d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-stonewall
+  broadcaster: independent
+  name: radio Stonewall
+  streamUrl: https://www.radioking.com/play/radio-stonewall
+  bitrate: 128
+  codec: MP3
+  favicon: https://radiostonewall.com/wp-content/uploads/2024/11/cropped-462553932_532380849605032_4391091688937223115_n.jpg
+  homepage: https://radiostonewall.com/
+  country: FR
+  status: stream-only
+  stationuuid: 89707a77-092b-4e82-af71-4101f61599c1
+  changeuuid: e2e5555d-62da-49ae-baaa-158e5aeb86eb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-temps-rodez
+  broadcaster: independent
+  name: Radio Temps Rodez
+  streamUrl: https://sd-151888.dedibox.fr/proxy/radiotemps/rtr
+  bitrate: 128
+  codec: MP3
+  favicon: https://radiotemps.com/wp-content/uploads/2020/12/LOGO.png
+  homepage: https://radiotemps.com/
+  country: FR
+  status: stream-only
+  stationuuid: 3a373e8f-4eed-4e09-bcd9-a78e436e5ecb
+  changeuuid: 68f8708d-db4e-43e7-854e-8b1f4de4275a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radio-shoppe-com
+  broadcaster: independent
+  name: radio-shoppe.com
+  streamUrl: https://stream.radio-shoppe.ydns.eu/
+  bitrate: 128
+  codec: MP3
+  favicon: http://radio-shoppe.ydns.eu/radio-shoppe/img/base_logo_cet.png
+  homepage: http://radio-shoppe.ydns.eu/#page-top
+  country: FR
+  status: stream-only
+  stationuuid: 776134b3-f0de-458b-b798-f59ed0ed7261
+  changeuuid: f42076be-d1ac-4ab6-a601-fcfa880b8eb4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-radiosmp
+  broadcaster: independent
+  name: RadioSMP
+  streamUrl: https://icecast.lf-corp.fr/smpnational
+  bitrate: 128
+  codec: AAC+
+  homepage: https://radiosmp.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 7fd2d591-42db-4a97-ba8a-c317c9d6b0ab
+  changeuuid: 51332e51-6767-4e28-a7d0-49da44f48771
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-rayvox
+  broadcaster: independent
+  name: Rayvox
+  streamUrl: https://www.rayvox.org:8443/flux
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.rayvox.org/
+  country: FR
+  status: stream-only
+  stationuuid: eba2b6d3-e973-4857-b5b9-61c73bc64ec4
+  changeuuid: aa384aac-0fee-47d2-8208-f43e6f732862
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-reggae-arte-radio
+  broadcaster: independent
+  name: Reggae Arte radio
+  streamUrl: https://listen.radioking.com/radio/269104/stream/314461
+  bitrate: 128
+  codec: MP3
+  homepage: https://reggaearte.wixsite.com/accueil/en
+  country: FR
+  status: stream-only
+  stationuuid: 086b5f7d-9c71-4135-8c45-ba7b3a1744c4
+  changeuuid: 8acf7e73-a2f5-49af-816d-95021d7e52ad
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-satellite-fm-paris
+  broadcaster: independent
+  name: Satellite FM Paris
+  streamUrl: https://manager11.streamradio.fr:2935/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://assets.zyrosite.com/AR0lXpjaNMcx2PBw/satellite-fm-paris-logo-2026_800-i6cWKluIZLl2TQtC.jpg
+  homepage: https://www.satellitefmparis.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 67557692-7259-480f-a3f3-44e5ec7dbf7c
+  changeuuid: bec41fd5-2b04-4790-93eb-7b09b162dbc1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-sun-junior
+  broadcaster: independent
+  name: SUN Junior
+  streamUrl: https://diffusion.lafrap.fr/sun-junior.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://lesonunique.com/images/pwa/icon-512x512.png
+  homepage: https://lesonunique.com/
+  country: FR
+  status: stream-only
+  stationuuid: 020226b5-f52c-4fd3-bc5d-78930692718c
+  changeuuid: 81031ac6-97ef-4aa4-a632-e651f63b2181
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: fr-unfazed-onair
+  broadcaster: independent
+  name: Unfazed OnAir
+  streamUrl: https://srv.webradiomanager.fr:1045/stream
+  bitrate: 192
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/cc8d99_6770b0d30090457aa528788c142a1c36~mv2.png/v1/fill/w_1200,h_900,fp_0.50_0.50,q_95,enc_avif,quality_auto/cc8d99_6770b0d30090457aa528788c142a1c36~mv2.png
+  homepage: https://www.unfazedonair.fr/
+  country: FR
+  status: stream-only
+  stationuuid: 7c4ef4d1-0595-43e1-9f26-0b815f1c5b96
+  changeuuid: 1d358ce2-e722-4899-82d4-826d8d8fe608
+  reviewedAt: "2026-05-04"

--- a/data/stations.yaml
+++ b/data/stations.yaml
@@ -36241,3 +36241,12211 @@
   stationuuid: 1659d626-b7db-48e0-82d7-d0d645bf43ae
   changeuuid: ee6f62b6-cc71-4f97-86ec-6e62e23cdb96
   reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-tmm-1
+  broadcaster: independent
+  name: TMM 1
+  streamUrl: https://listen-msmn.sharp-stream.com/nme1.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://cdn-profiles.tunein.com/s159857/images/logod.png
+  homepage: https://www.themusicmachine.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 9619e7d7-0601-11e8-ae97-52543be04c81
+  changeuuid: 584f10b8-4ea5-4692-9728-abdf0a0c279a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-heart-70s
+  broadcaster: independent
+  name: Heart 70s
+  streamUrl: https://media-ssl.musicradio.com/Heart70sMP3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.heart.co.uk/70s
+  country: GB
+  status: stream-only
+  stationuuid: e7205cd4-dc30-11e9-a8ba-52543be04c81
+  changeuuid: 0786366e-80e1-444f-a397-791746479373
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-heart-dance
+  broadcaster: independent
+  name: Heart Dance
+  streamUrl: https://media-ssl.musicradio.com/HeartDanceMP3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.heart.co.uk/assets_v4r/heart/img/favicon-196x196.png
+  homepage: https://www.heart.co.uk/dance
+  country: GB
+  status: stream-only
+  stationuuid: fa76f16f-dc31-11e9-a8ba-52543be04c81
+  changeuuid: 300a20c6-6807-4ebd-86af-53f9de78c60b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-tmm-2
+  broadcaster: independent
+  name: TMM 2
+  streamUrl: https://listen-msmn.sharp-stream.com/nme2.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://cdn-profiles.tunein.com/s155539/images/logod.png
+  homepage: https://www.themusicmachine.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 9619e894-0601-11e8-ae97-52543be04c81
+  changeuuid: 59e59348-0901-47d1-8438-4966a449e562
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-love-radio-only-love-songs-70s80s90s
+  broadcaster: independent
+  name: LOVE.radio Only Love Songs 70s80s90s
+  streamUrl: https://loveradio.streamingmedia.it/england
+  bitrate: 192
+  codec: AAC+
+  homepage: https://love.radio/
+  country: GB
+  status: stream-only
+  stationuuid: 6dea6c7d-9b22-4698-889f-e7c34203ee6a
+  changeuuid: 858b5e59-54fa-4b3e-8500-5895bc17caa0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bbc-news-hd-720p
+  broadcaster: independent
+  name: BBC News HD (720P)
+  streamUrl: https://vs-hls-push-ww-live.akamaized.net/x=4/i=urn:bbc:pips:service:bbc_news_channel_hd/t=3840/v=pv14/b=5070016/main.m3u8
+  codec: UNKNOWN
+  favicon: https://upload.wikimedia.org/wikipedia/en/thumb/2/24/BBC_News_HD_Logo.svg/2560px-BBC_News_HD_Logo.svg.png
+  homepage: https://bbc.co.uk/news
+  country: GB
+  status: stream-only
+  stationuuid: ea391ded-00f0-47e0-841c-d92663e11854
+  changeuuid: c93de57c-a2b4-4446-8582-93f1af247c0f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-exclusively-dire-straits
+  broadcaster: independent
+  name: Exclusively Dire Straits
+  streamUrl: https://streaming.exclusive.radio/er/direstraits/icecast.audio
+  codec: MP3
+  homepage: https://exclusive.radio/
+  country: GB
+  status: stream-only
+  stationuuid: 70ce5567-4d1e-4a07-baa5-f5f08ca4b2f6
+  changeuuid: 459b4533-b81f-43f6-88a6-c1c8ea832d18
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-virgin-radio-chilled
+  broadcaster: independent
+  name: Virgin Radio Chilled
+  streamUrl: https://radio.virginradio.co.uk/stream-chilled?aw_0_1st.platform=vr-web
+  bitrate: 128
+  codec: AAC
+  homepage: https://virginradio.co.uk/radioplayer/live/virginradio-player-chilled.html
+  country: GB
+  status: stream-only
+  stationuuid: 8e630042-ef66-4063-a403-7632117ef5c8
+  changeuuid: 7c69ba50-9bb0-4c81-82cb-37b079c0753d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-seva-novgorodsev
+  broadcaster: independent
+  name: Радио Сева (Radio Seva Novgorodsev)
+  streamUrl: https://seva.ru/radio/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://seva.ru/radio/radio.png
+  homepage: https://seva.ru/
+  country: GB
+  status: stream-only
+  stationuuid: 30820d12-0409-44b7-b5e8-edc594910d92
+  changeuuid: bd18d070-0a99-4eb7-99fd-00307e00acd1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-tmm-2-hq
+  broadcaster: independent
+  name: TMM 2 (HQ)
+  streamUrl: https://listen-msmn.sharp-stream.com/nme2high.mp3
+  bitrate: 256
+  codec: MP3
+  favicon: https://cdn-profiles.tunein.com/s155539/images/logod.png
+  homepage: https://www.themusicmachine.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 2c788192-ca75-42c9-ace6-866087380796
+  changeuuid: 04552a42-88c4-40a5-b960-caedcdde4c4d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-exclusively-supertramp
+  broadcaster: independent
+  name: Exclusively Supertramp
+  streamUrl: https://streaming.exclusive.radio/er/supertramp/icecast.audio
+  codec: MP3
+  homepage: https://exclusive.radio/
+  country: GB
+  status: stream-only
+  stationuuid: dfa6d153-83de-4112-bd36-2156720bdfc5
+  changeuuid: 98abcb49-eb6e-4274-b26a-1cde5a4270c9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-britcom-2-pumpkin-fm
+  broadcaster: independent
+  name: BritCom 2 - Pumpkin FM
+  streamUrl: https://cast2.asurahosting.com/proxy/britcom2/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://pumpkinfm.com/wp-content/uploads/2019/02/BritComTwo300x300.jpg
+  homepage: https://pumpkinfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: 47416a39-4289-47a9-8747-056843a60c0b
+  changeuuid: 1706648d-4568-4dc8-80ea-d8e319fe4d1e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-exclusively-ac-dc
+  broadcaster: independent
+  name: Exclusively AC/DC
+  streamUrl: https://nl4.mystreaming.net/er/acdc/icecast.audio
+  codec: MP3
+  homepage: https://play.exclusive.radio/
+  country: GB
+  status: stream-only
+  stationuuid: ba93ec29-66c9-4bee-8f71-b71481001c8e
+  changeuuid: f2442dde-8410-46ae-aaf4-1848309384b9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-sky-news-uk
+  broadcaster: independent
+  name: sky news UK
+  streamUrl: https://tunein.cdnstream1.com/3688_96.mp3?aw_0_1st.skey=1718490659&aw_0_1st.abtest=&aw_0_1st.stationId=s2583&aw_0_1st.premium=false&source=TuneIn&aw_0_1st.platform=tunein&aw_0_1st.genre_id=g255&aw_0_1st.class=talk&aw_0_1st.ads_partner_alias=ce.Other&aw_0_azn.planguage=en
+  bitrate: 96
+  codec: MP3
+  favicon: https://news.sky.com/resources/apple-touch-icon.png?v=2
+  homepage: https://news.sky.com/
+  country: GB
+  status: stream-only
+  stationuuid: 512e876e-806b-4a61-8a57-f15e39b64907
+  changeuuid: 12422947-d548-411a-948a-d6e03a7c5465
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-soul-radio-only-classic-soul
+  broadcaster: independent
+  name: SOUL RADIO Only Classic Soul
+  streamUrl: https://listen.soulradio.uk/uk
+  bitrate: 192
+  codec: AAC+
+  homepage: https://soulradio.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 9f61ef81-bf7d-4bc4-8135-3fc8be52dafb
+  changeuuid: 0f25cbfb-ab07-4ce5-9116-d677f8458500
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-teenage-kicks-radio
+  broadcaster: independent
+  name: Teenage Kicks Radio
+  streamUrl: https://onlineradiobox.com/json/fr/teenagekicks/play
+  bitrate: 128
+  codec: MP3
+  homepage: https://teenagekicksradio.blogspot.com/
+  country: GB
+  status: stream-only
+  stationuuid: c9aabff3-95d1-4f9e-8b29-6682f7e031e2
+  changeuuid: ecdb95ea-eb38-499d-a731-38a6a5a91eed
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-house-nation-uk
+  broadcaster: independent
+  name: House Nation UK
+  streamUrl: https://streaming.radio.co/s06bd9d805/listen
+  bitrate: 192
+  codec: MP3
+  favicon: https://static.mytuner.mobi/media/tvos_radios/aWa7xGKfBh.jpg
+  homepage: https://housenationuk.com/
+  country: GB
+  status: stream-only
+  stationuuid: 8c78482a-17db-4057-a7c7-8fa14b3c3ce9
+  changeuuid: 20bd64f0-e93c-49f6-85ac-89bfbfe55cf0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-strange-radio-pumpkin-fm
+  broadcaster: independent
+  name: Strange Radio - Pumpkin FM
+  streamUrl: https://cast2.asurahosting.com/proxy/strangeradio/stream
+  bitrate: 64
+  codec: MP3
+  homepage: https://pumpkinfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: dce75ec5-a0f8-4bba-bf4c-2827c871490c
+  changeuuid: d2f9e431-182b-40a0-ac61-4d468ff7b4a5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-x-classic-rock
+  broadcaster: independent
+  name: Radio X Classic Rock
+  streamUrl: https://media-ice.musicradio.com/RadioXClassicRockMP3
+  bitrate: 128
+  codec: MP3
+  favicon: https://i.imgur.com/eBIsjQw.jpg
+  homepage: https://www.radiox.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 83bb028f-9cd6-489d-a9e0-6dc0821a071b
+  changeuuid: b824bda2-26fd-4513-8afa-61d568a18977
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-britcom-1-british-comedy-radio-pumpkin-fm-otrn
+  broadcaster: independent
+  name: BritCom 1 - British Comedy Radio  (Pumpkin FM OTRN)
+  streamUrl: https://cast2.asurahosting.com/proxy/britcom1/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://pumpkinfm.com/wp-content/uploads/2019/02/BritComOne300x300.jpg
+  homepage: https://britishcomedyradio.org/
+  country: GB
+  status: stream-only
+  stationuuid: 8cf13f16-df99-4fd8-b152-ab8218563a36
+  changeuuid: bac9b434-9908-4bed-a06f-18914dc96d38
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-happy-hardcore
+  broadcaster: independent
+  name: Happy Hardcore
+  streamUrl: https://audio-edge-3mayu.fra.h.radiomast.io/73055724-1141-41e2-a69b-24a6ca96c8e7
+  bitrate: 256
+  codec: MP3
+  homepage: https://www.happyhardcore.com/
+  country: GB
+  status: stream-only
+  stationuuid: 21dbb37d-60a6-4ec2-b5c8-28b46fc2bfea
+  changeuuid: 12240e5b-cfe4-40ea-aebe-9f4259bf6fc5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-kniteforce-radio
+  broadcaster: independent
+  name: Kniteforce Radio
+  streamUrl: https://kniteforce.out.airtime.pro/kniteforce_a
+  bitrate: 192
+  codec: MP3
+  homepage: https://kniteforce-radio.com/
+  country: GB
+  status: stream-only
+  stationuuid: fba2054a-0812-4a8f-b9bf-ab0546c5cccd
+  changeuuid: 79687ae0-00e4-438d-9fe9-354ef2703db8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-slow-focus-nts
+  broadcaster: independent
+  name: "Slow Focus | NTS"
+  streamUrl: https://stream-mixtape-geo.ntslive.net/mixtape
+  codec: MP3
+  favicon: https://www.nts.live/apple-touch-icon.png?v=47re43rrzb
+  homepage: https://www.nts.live/infinite-mixtapes/slow-focus
+  country: GB
+  status: stream-only
+  stationuuid: d5468df4-e6d0-11e9-a96c-52543be04c81
+  changeuuid: b53980ab-1494-46a5-8558-f34a7d196d55
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-rokit-radio-science-fiction
+  broadcaster: independent
+  name: ROKit Radio Science Fiction
+  streamUrl: https://streaming05.liveboxstream.uk/proxy/roksta12/stream
+  bitrate: 48
+  codec: MP3
+  favicon: https://rokitradio.com/images/channels/scifi.jpg
+  homepage: https://rokitradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 68f52212-e3b0-479b-9da6-962a6c5e713d
+  changeuuid: cac3c984-961b-427f-a0bb-c39714bfc4a1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-britcom-3-british-comedy-radio-pumpkin-fm-otrn
+  broadcaster: independent
+  name: BritCom 3 - British Comedy Radio (Pumpkin FM OTRN)
+  streamUrl: https://cast2.asurahosting.com/proxy/britcom3/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://pumpkinfm.com/wp-content/uploads/2023/02/BritComThreeNew300x300-3.jpg
+  homepage: https://britishcomedyradio.org/
+  country: GB
+  status: stream-only
+  stationuuid: 37bf8039-77ed-4805-9030-c40d5cb2820a
+  changeuuid: 3333dc19-6fe0-4a5c-81b9-bff4fcd4c22c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-fun-kids
+  broadcaster: independent
+  name: Fun Kids
+  streamUrl: https://listen-funkids.sharp-stream.com/funkids.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.funkidslive.com/
+  country: GB
+  status: stream-only
+  stationuuid: ff871225-7731-45a1-aee0-9e8fa463dfc3
+  changeuuid: b1ccb0e1-ee4e-4627-82c0-7e14b7052ee2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hearme-classic-hard-rock
+  broadcaster: independent
+  name: HearMe - Classic Hard Rock
+  streamUrl: https://radio.hearme.fm:8250/stream
+  codec: MP3
+  homepage: https://hearme.fm/
+  country: GB
+  status: stream-only
+  stationuuid: 1f951feb-544e-447b-8143-8b9656a46cf2
+  changeuuid: 545c907c-b6ae-433a-9957-1041c6028540
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-uk-bass-radio
+  broadcaster: independent
+  name: UK Bass Radio
+  streamUrl: https://www.ukbassradio.com/stream
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.ukbassradio.com/wp-content/uploads/2021/03/cropped-thumbnail_ukbass-radio5.png
+  homepage: https://www.ukbassradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 29dc48c6-adf5-49bf-a9d7-dfde3e9cfc6d
+  changeuuid: 502878b0-3ced-4c86-aacb-5b3f2a14ec25
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-box-uk
+  broadcaster: independent
+  name: box uk
+  streamUrl: https://boxstream.danceradiouk.com/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://boxuk.danceradiouk.com/favicon.ico
+  homepage: https://boxuk.danceradiouk.com/
+  country: GB
+  status: stream-only
+  stationuuid: 7ae5f001-8112-4e6c-abf4-d069dc37e3a9
+  changeuuid: 6ac2900e-90c9-4ca3-9583-2bc1bbb91d3b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-now-70s
+  broadcaster: independent
+  name: Now 70s
+  streamUrl: https://lightning-now70s-samsungnz.amagi.tv/playlist.m3u8
+  bitrate: 1020
+  codec: AAC,H.264
+  favicon: https://upload.wikimedia.org/wikipedia/commons/c/cd/NOW_70s.png
+  homepage: https://nowmusic.com/
+  country: GB
+  status: stream-only
+  stationuuid: 6925c7e9-116b-42ab-9126-4c13c1b65baf
+  changeuuid: a300ab3c-ff31-4500-b2d6-fe90106d97f5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-capital-chill
+  broadcaster: independent
+  name: Capital Chill
+  streamUrl: https://media-ssl.musicradio.com/CapitalChill
+  bitrate: 48
+  codec: AAC
+  homepage: https://capitalchill.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: dfaf9dd9-6705-494d-bf96-ce7fbdbba021
+  changeuuid: 6997ef3c-7ab0-4465-b5aa-0af7b61db6d7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-rokit-radio-british-comedy-1
+  broadcaster: independent
+  name: "ROKit Radio : British Comedy 1"
+  streamUrl: https://streaming04.liveboxstream.uk/proxy/roksta14/stream
+  bitrate: 48
+  codec: MP3
+  favicon: https://rokitradio.com/images/channels/british_comedy_1.jpg
+  homepage: https://rokitradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: da52663e-bf3e-40aa-b863-28c1d12d6464
+  changeuuid: bca1e0d6-a8e2-4700-98a0-8592921ecd97
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-eric-clapton
+  broadcaster: independent
+  name: "Eric Clapton "
+  streamUrl: https://streaming.exclusive.radio/er/ericclapton/icecast.audio
+  codec: MP3
+  favicon: https://upload.wikimedia.org/wikipedia/commons/thumb/0/0a/Eric_Clapton_-_Royal_Albert_Hall_-_Wednesday_24th_May_2017_EricClaptonRAH240517-30_%2834987232355%29_%28cropped%29.jpg/1200px-Eric_Clapton_-_Royal_Albert_Hall_-_Wednesday_24th_May_2017_EricClaptonRAH240517-30_%2834987232355%29_%28cropped%29.jpg
+  homepage: https://tunein.com/artist/Eric-Clapton-m473626/
+  country: GB
+  status: stream-only
+  stationuuid: e70ca27e-0c1a-4045-8996-d754914b999d
+  changeuuid: 6e37cd7d-3101-431c-adff-85c13671f163
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-classic-fm-calm
+  broadcaster: independent
+  name: Classic FM Calm
+  streamUrl: https://media-ice.musicradio.com/ClassicFMCalmMP3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.classicfm.com/calm/
+  country: GB
+  status: stream-only
+  stationuuid: 2babf29a-811c-4a51-93c3-9f3531ef2e97
+  changeuuid: a4913661-8293-4b42-a897-22784d6f5a14
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-house-music-radio
+  broadcaster: independent
+  name: House Music Radio
+  streamUrl: https://uk4-vn.mixstream.net/8128/listen.mp3
+  bitrate: 320
+  codec: MP3
+  homepage: https://www.housemusicradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: c58c0009-ad0d-4ed5-a208-a8e797885a75
+  changeuuid: 481387cc-709a-4414-bbab-80403b863194
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-smooth-relax
+  broadcaster: independent
+  name: Smooth Relax
+  streamUrl: https://icecast.thisisdax.com/SmoothRelaxMP3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.smoothradio.com/relax/
+  country: GB
+  status: stream-only
+  stationuuid: 15a7162c-45a3-4bde-b864-aa7731c6dd87
+  changeuuid: 70049744-0c76-42c7-80b6-bff1e686433a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-diva-radio-funk-disco-music-paradise
+  broadcaster: independent
+  name: "Diva Radio - Funk & Disco Music Paradise"
+  streamUrl: https://stream.deevaradio.net:10443/divaradiofunk
+  bitrate: 192
+  codec: MP3
+  homepage: https://deevaradio.net/
+  country: GB
+  status: stream-only
+  stationuuid: 5c850da2-076b-43b5-aa38-91e72fac39f6
+  changeuuid: f86a5be5-5da3-4441-a8a8-9ccab61ce225
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-nation-60s
+  broadcaster: independent
+  name: Nation 60s
+  streamUrl: https://listen-nation.sharp-stream.com/nation60s.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: http://www.nationradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: dd4e349c-77df-43da-a97d-34234ab08a2f
+  changeuuid: bedd057f-81b0-4b18-a042-3c6f573ff623
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-100-hip-hop-nts
+  broadcaster: independent
+  name: "100% Hip Hop | NTS"
+  streamUrl: https://stream-mixtape-geo.ntslive.net/mixtape2
+  codec: MP3
+  homepage: https://www.nts.live/infinite-mixtapes/100-percent-hip-hop
+  country: GB
+  status: stream-only
+  stationuuid: afd853b3-e6d1-11e9-a96c-52543be04c81
+  changeuuid: f0f8f136-ab5a-4701-a6f9-f5ae309ae659
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-danceradiouk-dance-uk
+  broadcaster: independent
+  name: DanceRadioUK - Dance UK
+  streamUrl: https://dancestream.danceradiouk.com/stream/1/
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.danceradiouk.com/wp-content/uploads/2021/02/druk300-150x150.png
+  homepage: https://danceradiouk.com/
+  country: GB
+  status: stream-only
+  stationuuid: 30369d73-370f-4403-b5d5-39843a00fcec
+  changeuuid: 1aec7145-f48a-42ec-9566-17294261e95d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-naim-jazz-flac
+  broadcaster: independent
+  name: "Naim Jazz [flac]"
+  streamUrl: https://mscp3.live-streams.nl:8342/jazz-flac.flac
+  bitrate: 128
+  codec: OGG
+  favicon: https://www.naimaudio.com/build/assets/apple-touch-icon-2a4e35a0.png
+  homepage: https://www.naimaudio.com/new-naim-radio
+  country: GB
+  status: stream-only
+  stationuuid: fe6cd053-2fef-43e3-88af-8fac82591868
+  changeuuid: 7ca38ffe-624f-4e33-be66-c53dabf38259
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-kool-fm
+  broadcaster: independent
+  name: Kool FM
+  streamUrl: https://admin.stream.rinse.fm/proxy/kool/stream
+  bitrate: 128
+  codec: AAC+
+  favicon: https://pbs.twimg.com/profile_images/1638236080674578434/Hbww_nFm_400x400.jpg
+  homepage: https://rinse.fm/channels/kool/
+  country: GB
+  status: stream-only
+  stationuuid: 973c30a5-a178-4daf-89c7-272ec6c47456
+  changeuuid: 3e70a3df-7ab8-41dc-9ccd-68766ed8a1dc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-virgin-radio-anthems
+  broadcaster: independent
+  name: Virgin Radio Anthems
+  streamUrl: https://radio.virginradio.co.uk/stream-anthems
+  bitrate: 128
+  codec: AAC
+  homepage: https://virginradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 1a1ef3a9-0f99-11ea-a87e-52543be04c81
+  changeuuid: baf3bf4b-fb13-46f0-a703-f36d8f1410cd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-rokit-radio-british-comedy-2
+  broadcaster: independent
+  name: "ROKit Radio : British Comedy 2"
+  streamUrl: https://streaming05.liveboxstream.uk/proxy/jondreas/stream
+  bitrate: 48
+  codec: MP3
+  favicon: https://rokitradio.com/favicon.ico
+  homepage: https://rokitradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 99f4e5bf-e2a0-4386-b116-3ecd4e4de6b5
+  changeuuid: 78a1f015-f105-4b96-ae74-8a62e9d56abc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-classic-fm-hd
+  broadcaster: independent
+  name: Classic FM HD
+  streamUrl: https://ice-sov.musicradio.com/ClassicFMHD?hdauth=:2000000000:a290d4b39a16153061d4c743008b9fe8d424a7e5ec6469d40acf51fdcd336e80
+  bitrate: 192
+  codec: AAC
+  favicon: https://is1-ssl.mzstatic.com/image/thumb/Purple116/v4/bd/a7/bf/bda7bf4f-16e9-6b60-0d87-a39d432b505e/AppIcon-1x_U007emarketing-0-7-0-85-220.png/492x0w.webp
+  homepage: https://www.classicfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: bd1c441c-132a-4d48-a3f3-bdb386f4b09a
+  changeuuid: 91f37a09-67d6-4471-9251-6a9ff8f4a45b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-boom-radio-uk
+  broadcaster: independent
+  name: Boom Radio UK
+  streamUrl: https://listen-boomradio.sharp-stream.com/65_boom_radio_live_192
+  bitrate: 256
+  codec: AAC
+  favicon: https://mmo.aiircdn.com/460/5fb3bb6151ee4.png
+  homepage: https://www.boomradiouk.com/
+  country: GB
+  status: stream-only
+  stationuuid: 5ed77642-9f68-484a-8bbc-af00a4acc629
+  changeuuid: e22af6c9-b26c-459f-be06-d11177a00687
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-street-sounds-radio
+  broadcaster: independent
+  name: Street Sounds Radio
+  streamUrl: https://streaming.broadcastradio.com:10525/streetsd
+  codec: MP3
+  homepage: https://www.streetsoundsradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 5ed6b080-b967-4202-8bb5-96b4557aee5d
+  changeuuid: acbe3229-b63c-48d3-a247-a7c1ca42be48
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-45-radio
+  broadcaster: independent
+  name: "45 Radio"
+  streamUrl: https://stream1.themediasite.co.uk:7009/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.my45radio.co.uk/apple-touch-icon.png
+  homepage: https://www.my45radio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 1408a44f-4c34-49ac-a746-80715c2fea54
+  changeuuid: 71364805-0163-42d0-8b4a-dabb02a8da9a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bbc-for-australasia
+  broadcaster: independent
+  name: BBC for Australasia
+  streamUrl: https://stream.live.vc.bbcmedia.co.uk/bbc_world_service_australasia
+  bitrate: 56
+  codec: MP3
+  favicon: https://bbc.co.uk/favicon.ico
+  homepage: https://bbc.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: c0ba5cba-d388-4ecc-824e-734e767174e2
+  changeuuid: 16742ff4-bc46-4f22-bc2b-2810ec8ac969
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-smooth-country
+  broadcaster: independent
+  name: Smooth Country
+  streamUrl: https://media-ssl.musicradio.com/SmoothCountry
+  bitrate: 48
+  codec: AAC
+  favicon: https://www.smoothradio.com/assets_v4r/smooth/img/favicon-196x196.png
+  homepage: https://www.smoothradio.com/country/
+  country: GB
+  status: stream-only
+  stationuuid: 46f13c3e-823f-4f1e-ab82-5a7b145c337f
+  changeuuid: f5022d84-23e8-423a-8ef0-2c4ef7397c47
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hypedem-reggae-radio
+  broadcaster: independent
+  name: HypeDem Reggae Radio
+  streamUrl: https://mrwolfman2.radioca.st/;
+  bitrate: 128
+  codec: MP3
+  homepage: https://hypedem-radio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 353cb65a-3706-4e7c-8f91-d13eb2829557
+  changeuuid: f1f96f00-f12e-4365-a686-969ad1401525
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-london-music-radio
+  broadcaster: independent
+  name: London Music Radio
+  streamUrl: https://radiobossrelay.radioca.st/stream
+  bitrate: 320
+  codec: MP3
+  favicon: https://londonmusicradio.com/wp-content/uploads/2017/04/thumbnail_Logo2-2-copyY-copy-black-e1519168864488.jpg
+  homepage: https://londonmusicradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 61bdc00f-5a55-4e0b-a841-7747d66fa7dd
+  changeuuid: f8563276-db7b-4d39-a1e2-9b3dbe2e8298
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-kiss-uk
+  broadcaster: independent
+  name: KISS UK
+  streamUrl: https://live-kiss.sharp-stream.com/kiss100.mp3
+  bitrate: 112
+  codec: MP3
+  favicon: https://media.bauerradio.com/image/upload/c_crop,g_custom/v1678797505/brand_manager/stations/mahvph4fqjmnp4y8d6wt.png
+  homepage: https://kissfmuk.com/
+  country: GB
+  status: stream-only
+  stationuuid: 5984167a-b25e-4eec-a878-ff9253ee0c4a
+  changeuuid: 09b39b4f-05ce-4dea-a203-19c02a62d860
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-essex
+  broadcaster: independent
+  name: Radio Essex
+  streamUrl: https://stream.aiir.com/ujzy590c3stvv
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/339/67698698b4c61.png
+  homepage: https://www.radioessex.com/
+  country: GB
+  status: stream-only
+  stationuuid: b7925a87-ce5d-48f1-b0df-fb30d75aa2c4
+  changeuuid: 29e794e7-5131-41ca-b6d7-4fbe05293b84
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-rinse-uk
+  broadcaster: independent
+  name: Rinse UK
+  streamUrl: https://admin.stream.rinse.fm/proxy/rinse_uk/stream
+  bitrate: 128
+  codec: AAC+
+  favicon: https://i1.sndcdn.com/avatars-HFUM5iVBOYInWEED-oro7Vg-t200x200.jpg
+  homepage: https://www.rinse.fm/channels/uk/
+  country: GB
+  status: stream-only
+  stationuuid: 9c100db7-ba97-4e6f-821f-dba1ed08ad52
+  changeuuid: 661f694b-d0fb-4900-8201-b8acb8e9d8ec
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-classic-fm-movies
+  broadcaster: independent
+  name: Classic FM Movies
+  streamUrl: https://media-ice.musicradio.com/ClassicFMMoviesMP3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.classicfm.com/movies/
+  country: GB
+  status: stream-only
+  stationuuid: 7cc0c486-92cb-4509-9b93-775e41950ed3
+  changeuuid: 8b39f00a-eb56-4ddd-a76c-7dd1e09d150d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-intamixx-80s-90s-radio-uk
+  broadcaster: independent
+  name: Intamixx 80s 90s Radio UK
+  streamUrl: https://radio.intamixx.uk:8443/radio2
+  bitrate: 128
+  codec: MP3
+  favicon: https://80s.intamixx.uk/images/imc8090.jpg
+  homepage: https://80s.intamixx.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 8c45fcc8-a9fe-4e07-9a53-67b6a2a1fc76
+  changeuuid: b282f593-a91e-4b23-8b17-8d303fd40dd6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-cruiseone-radio
+  broadcaster: independent
+  name: CruiseOne Radio
+  streamUrl: https://solid24.streamupsolutions.com/proxy/cmxicxxx?mp=/256kbps
+  bitrate: 256
+  codec: MP3
+  favicon: https://i1.sndcdn.com/avatars-000037533466-mgfbsp-t500x500.jpg
+  homepage: https://cruiseoneradio.net/
+  country: GB
+  status: stream-only
+  stationuuid: 10edd1ec-192b-40ff-aaf2-645471d04dfb
+  changeuuid: f15ef263-3066-4b15-87d8-5f84f8ebba77
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-kicks-fm
+  broadcaster: independent
+  name: KICKS fm
+  streamUrl: https://s6.citrus3.com:8452/stream
+  bitrate: 160
+  codec: MP3
+  homepage: https://www.kicks.fm/
+  country: GB
+  status: stream-only
+  stationuuid: 58341289-63e4-4ef6-b760-09bbfd420659
+  changeuuid: 49595981-68b9-4f85-8742-7ecee9cdfffd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-expansions-nts
+  broadcaster: independent
+  name: "Expansions | NTS"
+  streamUrl: https://stream-mixtape-geo.ntslive.net/mixtape3
+  codec: MP3
+  favicon: https://www.nts.live/apple-touch-icon.png?v=47re43rrzb
+  homepage: https://www.nts.live/infinite-mixtapes/expansions
+  country: GB
+  status: stream-only
+  stationuuid: 7a6953ac-e6d1-11e9-a96c-52543be04c81
+  changeuuid: a8a443fb-2978-4060-ad74-2584ca66c3a4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-energy-fm-dance-music-radio
+  broadcaster: independent
+  name: Energy FM - Dance Music Radio
+  streamUrl: https://radio.streemlion.com:1875/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://cdn.onlineradiobox.com/img/logo/9/35209.v3.png
+  homepage: https://www.energyfm.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 14ed260e-abd1-401c-8cf0-7e4625f58dae
+  changeuuid: 195ce884-1a23-41b1-98c8-3528717fc8ec
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-1940s-radio-hs-pumpkin-fm
+  broadcaster: independent
+  name: "1940s Radio HS - Pumpkin FM"
+  streamUrl: https://cast2.asurahosting.com/proxy/1940sradio/stream
+  bitrate: 128
+  codec: MP3
+  homepage: https://pumpkinfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: dbb7ac2b-cda4-42ef-9e7a-18c62dade3f6
+  changeuuid: 01256fd7-c42c-46d4-9e06-db10a01b6274
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-davide-of-mimic
+  broadcaster: independent
+  name: Davide of MIMIC
+  streamUrl: https://streaming04.liveboxstream.uk/proxy/davideof?mp=/stream
+  bitrate: 320
+  codec: MP3
+  homepage: https://www.davideofmimic.com/
+  country: GB
+  status: stream-only
+  stationuuid: 86cbd3d9-dfce-4c62-830a-c92fe552d476
+  changeuuid: fba19669-2d7d-4c0e-8ba3-52d0667bc6a7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-classic-fm-essential-classical
+  broadcaster: independent
+  name: Classic FM Essential Classical
+  streamUrl: https://icecast.thisisdax.com/ClassicFM-M-Essential
+  bitrate: 48
+  codec: AAC
+  favicon: https://www.radio.de/images/broadcasts/a1/f8/126083/1/c300.png
+  homepage: https://www.classicfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: e847f0b7-4694-4d96-a56a-3bc9543c5705
+  changeuuid: 4c12011d-7c39-4dee-b6b9-f8edbc95b021
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-psychedelicized-radio
+  broadcaster: independent
+  name: Psychedelicized Radio
+  streamUrl: https://cast1.asurahosting.com/proxy/psychedelicized/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://cdn-radiotime-logos.tunein.com/s155704q.png
+  homepage: https://psychedelicized.com/
+  country: GB
+  status: stream-only
+  stationuuid: ded0682b-5b6b-4be7-a351-a03b765e91de
+  changeuuid: 1b1ec539-857e-4e85-b280-21f9f4a719d7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-dire-straits
+  broadcaster: independent
+  name: Dire Straits
+  streamUrl: https://stream.pcradio.ru/dire_straits-hi
+  codec: AAC
+  favicon: null
+  homepage: https://pcradio.ru/
+  country: GB
+  status: stream-only
+  stationuuid: e5d11c60-4d05-41cd-84dc-60ccf9445caf
+  changeuuid: 17d6c6ab-ed11-4d0c-aa41-232e08751141
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-gold-london
+  broadcaster: independent
+  name: Gold London
+  streamUrl: https://media-ssl.musicradio.com/Gold?isLoggedIn=false&dax_version=release_2019&dax_player=GlobalPlayer&dax_platform=Web&aisDelivery=streaming&listenerid=1612127423858_0.6253666805372976&aw_0_1st.playerid=GlobalPlayer&aw_0_1st.skey=1612127423&aw_0_req.userConsentV2=CPA5x3uPA5x3uAGABCENBLCgAAAAAAAAAATIAAAAAAAA.YAAAAAAAAAAA
+  bitrate: 48
+  codec: AAC
+  favicon: https://media-ssl.musicradio.com/favicon.ico
+  homepage: https://media-ssl.musicradio.com/Gold?isLoggedIn=false&dax_version=release_2019&dax_player=GlobalPlayer&dax_platform=Web&aisDelivery=streaming&listenerid=1612127423858_0.6253666805372976&aw_0_1st.playerid=GlobalPlayer&aw_0_1st.skey=1612127423&aw_0_req.userConsentV2=CPA5x3uPA5x3uAGABCENBLCgAAAAAAAAAATIAAAAAAAA.YAAAAAAAAAAA
+  country: GB
+  status: stream-only
+  stationuuid: 996a22a8-9bc1-48dc-8f08-e46b71dafc66
+  changeuuid: 803e5d19-f8a8-4e01-b2c1-dade9b23f57c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-greatest-hits-non-stop
+  broadcaster: independent
+  name: Greatest Hits Non-Stop
+  streamUrl: https://s8.myradiostream.com/58238//listen.mp3
+  bitrate: 160
+  codec: MP3
+  favicon: https://greatesthitsnonstop.com/wp-content/uploads/2020/02/GHNS_512-1.png
+  homepage: https://greatesthitsnonstop.com/
+  country: GB
+  status: stream-only
+  stationuuid: 291e80cf-fe08-42f6-ae95-7a1dfac2d5de
+  changeuuid: db70013c-bf1b-4455-80f2-95cbdf9d7be1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-reprezent-radio
+  broadcaster: independent
+  name: Reprezent Radio
+  streamUrl: https://radio.canstream.co.uk:8022/live.mp3
+  bitrate: 256
+  codec: MP3
+  favicon: https://cdn.prod.website-files.com/62bc4b9b51f455e9a386fdd1/62be3ea967ffbeb32ccfe453_android-chrome-256x256.png
+  homepage: https://www.reprezentradio.org.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 962d6d54-0601-11e8-ae97-52543be04c81
+  changeuuid: 44fd999c-f777-48d8-8bb7-d6b92f53055e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-naim-radio-320k-aac
+  broadcaster: independent
+  name: "Naim Radio [320k aac]"
+  streamUrl: https://mscp3.live-streams.nl:8362/high.aac
+  bitrate: 320
+  codec: AAC
+  favicon: https://www.naimaudio.com/build/assets/apple-touch-icon-2a4e35a0.png
+  homepage: https://www.naimaudio.com/radio/player
+  country: GB
+  status: stream-only
+  stationuuid: bc67e55c-26b9-4426-8412-8c16032694be
+  changeuuid: a0c1d1f9-bc16-438e-b486-c14b1fd72e0b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-box-uk-radio
+  broadcaster: independent
+  name: Box UK Radio
+  streamUrl: https://boxstream.danceradiouk.com/stream/1/stream.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.danceradiouk.com/players/files/images/albumart/13040-BoxUK-300.jpg
+  homepage: https://www.danceradiouk.com/
+  country: GB
+  status: stream-only
+  stationuuid: ce62430f-e971-48c3-b31c-ee55a2a81974
+  changeuuid: af817c5c-aa4f-435c-837a-516d109f68ee
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-classic-fm-video-game-music
+  broadcaster: independent
+  name: Classic FM Video Game Music
+  streamUrl: https://icecast.thisisdax.com/ClassicFM-M-Gaming
+  bitrate: 48
+  codec: AAC
+  favicon: https://www.classicfm.com/assets_v4r/classic/img/favicon-196x196.png
+  homepage: https://www.classicfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: 1cedf594-9460-47c9-ad66-1c3bda41901b
+  changeuuid: e59fdce7-0cdb-4724-b26c-618d6a8822a0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bbc-arabic
+  broadcaster: independent
+  name: "BBC Arabic "
+  streamUrl: https://stream.live.vc.bbcmedia.co.uk/bbc_arabic_radio
+  bitrate: 56
+  codec: MP3
+  favicon: null
+  homepage: https://stream.live.vc.bbcmedia.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: fd7898b9-e442-4824-a313-77f25cb59de1
+  changeuuid: 07972fb4-5076-444e-8956-afc2ca71a3d6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-birdsong-radio
+  broadcaster: independent
+  name: Birdsong Radio
+  streamUrl: https://a1.radio.co/s5c5da6a36/listen
+  codec: MP3
+  favicon: https://images.radio.co/station_logos/s5c5da6a36.20240717025356.png
+  homepage: https://www.birdsong.fm/
+  country: GB
+  status: stream-only
+  stationuuid: ceab5124-608a-4eb1-8149-d65829f9a9d7
+  changeuuid: 766f4f0a-a7fa-4196-aa6d-07a2212daf13
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-4-to-the-floor-nts
+  broadcaster: independent
+  name: "4 To The Floor | NTS"
+  streamUrl: https://stream-mixtape-geo.ntslive.net/mixtape5
+  codec: MP3
+  favicon: https://www.nts.live/apple-touch-icon.png?v=47re43rrzb
+  homepage: https://www.nts.live/infinite-mixtapes/4-to-the-floor
+  country: GB
+  status: stream-only
+  stationuuid: e231378a-e6d1-11e9-a96c-52543be04c81
+  changeuuid: 4b3645e0-91c2-4d01-a8a2-1b358a7f8be0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-truckstopradio
+  broadcaster: independent
+  name: TruckStopRadio
+  streamUrl: https://oreo.truckstopradio.co.uk/radio/8000/radio.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://truckstopradio.co.uk/favicon.ico
+  homepage: https://truckstopradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: bf9bf08f-836d-481f-8837-19e419363fd3
+  changeuuid: d11d4d3c-88d8-435c-bd19-b0769dafc2a5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-x
+  broadcaster: independent
+  name: Radio X
+  streamUrl: https://media-ssl.musicradio.com/RadioXLondonMP3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radiox.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: fc057e27-07f1-4556-bd31-bceb31d5eabd
+  changeuuid: 1324879f-f17e-4305-96a4-e0429e3c6190
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-the-english-909-radio
+  broadcaster: independent
+  name: The English 909 Radio
+  streamUrl: https://www.radioking.com/play/the-english-909
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.google.co.uk/search?q=the+english+909+radio+favicon&tbm=isch&ved=2ahUKEwjy5ois1dX6AhVYgc4BHX2PCx8Q2-cCegQIABAA&oq=the+english+909+radio+favicon&gs_lcp=CgNpbWcQAzoECCMQJ1CSB1jdRWC8SGgAcAB4AIABR4gBmASSAQE5mAEAoAEBqgELZ3dzLXdpei1pbWfAAQE&sclient=img&ei=jBBEY_LwF9iCur4P_Z6u-AE&authuser=0&bih=711&biw=1431&hl=en-GB#imgrc=BAdZB6F91SYoWM
+  homepage: https://english909.com/
+  country: GB
+  status: stream-only
+  stationuuid: b996ea20-7d49-4409-baa6-4d44989dc3d4
+  changeuuid: 69af3e1a-aba2-4640-b586-0bd06ff7ea88
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-rokit-radio-comedy-gold
+  broadcaster: independent
+  name: "ROKit Radio : Comedy Gold"
+  streamUrl: https://streaming06.liveboxstream.uk/proxy/rokstar8/stream
+  bitrate: 48
+  codec: MP3
+  favicon: https://rokitradio.com/images/channels/comedy_gold.jpg
+  homepage: https://rokitradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 4b6aebf2-0ced-4058-8e71-52c701359b93
+  changeuuid: 67a4c443-f8c2-4200-9df1-51a37a3d07bb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-just-house-music
+  broadcaster: independent
+  name: Just House Music
+  streamUrl: https://justhousemusic.radioca.st/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://cdn-profiles.tunein.com/s293430/images/logod.png?t=638095610890000000
+  homepage: https://justhousemusic.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: f9a4e918-7df8-42ba-862f-21828d7c9b09
+  changeuuid: e139fdad-ff60-4b11-95e2-e2df99aae93b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-england-pumpkin-fm
+  broadcaster: independent
+  name: Radio England - Pumpkin FM
+  streamUrl: https://cast2.asurahosting.com/proxy/radioengland/stream
+  bitrate: 64
+  codec: MP3
+  homepage: https://pumpkinfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: 0816371a-d5a5-439e-beb2-717d9cf7e689
+  changeuuid: 1c1f9041-daee-4d39-8756-b76fe431d5ac
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-dandelion-radio
+  broadcaster: independent
+  name: Dandelion Radio
+  streamUrl: https://solid41.streamupsolutions.com/proxy/bqbyzdhi?mp=/stream
+  bitrate: 128
+  codec: MP3
+  favicon: http://www.dandelionradio.com/favicon.ico
+  homepage: http://www.dandelionradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 961fe58c-0601-11e8-ae97-52543be04c81
+  changeuuid: ede017bd-104b-4f0b-a97a-28440178166b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-jfsr-jazz-funk-soul-radio
+  broadcaster: independent
+  name: JFSR - Jazz Funk Soul Radio
+  streamUrl: https://s2.radio.co/s22ae5a8a6/listen
+  bitrate: 320
+  codec: AAC
+  favicon: https://jfsr.co.uk/wp-content/uploads/2020/08/cropped-JFSR-Favicon-300x300.png
+  homepage: https://jfsr.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: e392aeac-2fb8-4f34-9543-6f4c8209d3a7
+  changeuuid: 616f5197-18a1-4c05-909b-554ceead7fd5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-totally-80s-radio
+  broadcaster: independent
+  name: Totally 80s Radio
+  streamUrl: https://ukstream.radiohost.co.uk/listen/totally_80s_radio/radio.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://lh3.googleusercontent.com/YJxyM8-pCOf0oai9UTisHiudRJ1ni2Xt3s7DdPYQKp_oMCuHBn75zpZMSpFd_CBt6PdCKjlOWk9ToqItZPzcrlcgtMXK_h0k=s500
+  homepage: https://www.totally80sradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 74b45490-b3ff-45a9-9087-d021f3fd7282
+  changeuuid: 2800b94a-da7e-42d5-a480-a4aa4111aaf0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-now-80s
+  broadcaster: independent
+  name: Now 80s
+  streamUrl: https://lightning-now80s-samsunguk.amagi.tv/playlist.m3u8
+  bitrate: 1020
+  codec: AAC,H.264
+  homepage: https://nowmusic.com/
+  country: GB
+  status: stream-only
+  stationuuid: fa6de722-63b8-443d-a39f-50e3b96e5009
+  changeuuid: 2fb704bf-6845-484c-8654-e073c9afcad5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-poolside-nts
+  broadcaster: independent
+  name: "Poolside | NTS"
+  streamUrl: https://stream-mixtape-geo.ntslive.net/mixtape4
+  codec: MP3
+  favicon: https://www.nts.live/favicon.ico
+  homepage: https://www.nts.live/infinite-mixtapes/poolside
+  country: GB
+  status: stream-only
+  stationuuid: 4f9dd235-e6d1-11e9-a96c-52543be04c81
+  changeuuid: 0109a5d6-13fa-4c96-8694-5d051f0b8a8f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-rokit-radio-classic-old-time-radio-shows
+  broadcaster: independent
+  name: "ROKit Radio : Classic Old Time Radio Shows"
+  streamUrl: https://streaming04.liveboxstream.uk/proxy/roksta18/stream
+  bitrate: 48
+  codec: MP3
+  favicon: https://rokitradio.com/images/channels/old_time_gold.jpg
+  homepage: https://rokitradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 68e826da-67e5-4df8-a179-9f105aa46f87
+  changeuuid: e188dbec-e8de-438e-8d91-e28cad114049
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-fsn-world-news
+  broadcaster: independent
+  name: FSN World News
+  streamUrl: https://www.fsnradionews.com/FSNNews/FSNWorldNews.mp3
+  codec: MP3
+  homepage: https://www.featurestorynews.com/
+  country: GB
+  status: stream-only
+  stationuuid: f0f9c15e-7b8a-49b5-8d3d-96563d8972e3
+  changeuuid: 16df0773-71df-4302-9f34-60cecc6e174c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-24-7-disco
+  broadcaster: independent
+  name: "24-7 Disco"
+  streamUrl: https://antares.dribbcast.com/proxy/s8190/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://24-7nicheradio.com/wp-content/uploads/2017/04/xDisco.jpg.pagespeed.ic.Z0Vjw3zxU-.webp
+  homepage: https://24-7nicheradio.com/audiogallery/24-7-disco/
+  country: GB
+  status: stream-only
+  stationuuid: 2816ef39-ba7d-42fc-9f81-443c386ac3dc
+  changeuuid: ce8a2465-59c6-452a-9d76-a02e36713682
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-tonic-ska-radio
+  broadcaster: independent
+  name: Tonic Ska Radio
+  streamUrl: https://eu10.fastcast4u.com/tonicska
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.tonicskaradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: cfe03119-0437-4b8d-b9fd-2bace1551bd1
+  changeuuid: f59a7395-d7ad-4560-8af2-49fe4bd8613c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-crime-incorporated-pumpkin-fm
+  broadcaster: independent
+  name: Crime Incorporated - Pumpkin FM
+  streamUrl: https://cast2.asurahosting.com/proxy/crimeinc/stream
+  bitrate: 64
+  codec: MP3
+  favicon: https://pumpkinfm.com/wp-content/uploads/2019/02/CrimeInc300x300.jpg
+  homepage: https://pumpkinfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: 07afab0b-d31a-4a1a-9e32-cc7f5bfbd53f
+  changeuuid: 052ead58-649e-4ce9-8cdf-c061a7ff113e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-aah-classical-radio-bach
+  broadcaster: independent
+  name: Aah Classical Radio - Bach
+  streamUrl: https://radio.hearme.fm:9040/stream
+  codec: MP3
+  favicon: http://img.sedoparking.com/templates/logos/sedo_logo.png
+  homepage: http://classical.aahradio.com/channel/bach/
+  country: GB
+  status: stream-only
+  stationuuid: 15dfa7b3-70f5-4dda-9eb3-daf62daae922
+  changeuuid: 86550aae-8f3a-47f9-a712-4d6e4f6774de
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-rokit-radio-adventure-stories
+  broadcaster: independent
+  name: "ROKit Radio : Adventure Stories"
+  streamUrl: https://streaming06.liveboxstream.uk/proxy/rokstar7/stream
+  bitrate: 48
+  codec: MP3
+  favicon: https://rokitradio.com/images/channels/adventure_stories.jpg
+  homepage: https://rokitradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 6d73fb63-8785-4e74-be33-8f55da6ae89f
+  changeuuid: 4c1a8af0-b4db-4c0b-90d8-9190ad098235
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-the-tube-nts
+  broadcaster: independent
+  name: "The Tube | NTS"
+  streamUrl: https://stream-mixtape-geo.ntslive.net/mixtape26
+  codec: MP3
+  favicon: https://www.nts.live/apple-touch-icon.png?v=47re43rrzb
+  homepage: https://www.nts.live/infinite-mixtapes/the-tube
+  country: GB
+  status: stream-only
+  stationuuid: cda70b2c-e8f0-4d05-9b74-dc26b0a187b1
+  changeuuid: 61fc089e-2a61-4d9a-b0d1-8a49d4743292
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-flashback-radio
+  broadcaster: independent
+  name: Flashback Radio
+  streamUrl: https://live.flashbackcentral.co.uk/radio/8000/apple
+  bitrate: 128
+  codec: AAC
+  favicon: https://irp.cdn-website.com/d8990fde/site_favicon_16_1654769166393.ico
+  homepage: https://www.flashbackradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: dca27db4-05db-4fc6-91fe-5d55992c2339
+  changeuuid: 38b72e67-219a-4ebc-a1d3-55b0183fb701
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-memory-lane-nts
+  broadcaster: independent
+  name: "Memory Lane | NTS"
+  streamUrl: https://stream-mixtape-geo.ntslive.net/mixtape6
+  codec: MP3
+  favicon: https://www.nts.live/favicon.ico
+  homepage: https://www.nts.live/infinite-mixtapes/memory-lane
+  country: GB
+  status: stream-only
+  stationuuid: 3c66c82a-e6d0-11e9-a96c-52543be04c81
+  changeuuid: 89d13ecf-55ae-44eb-8337-75295bf4d479
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-pink-floyd
+  broadcaster: independent
+  name: Pink Floyd
+  streamUrl: https://stream.pcradio.ru/Pink_Floyd-hi
+  codec: AAC
+  favicon: null
+  homepage: https://pcradio.ru/
+  country: GB
+  status: stream-only
+  stationuuid: 39c07f86-2d14-469a-994b-968de965e75a
+  changeuuid: b1dbddd6-7a52-4482-8d2e-5fff384acc2c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-tmm-1-hq
+  broadcaster: independent
+  name: TMM 1 (HQ)
+  streamUrl: https://listen-msmn.sharp-stream.com/nme1high.mp3
+  bitrate: 256
+  codec: MP3
+  favicon: https://cdn-profiles.tunein.com/s159857/images/logod.png
+  homepage: https://www.themusicmachine.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 6d55f9ad-5a50-4ac3-be1c-4abcbb68fd09
+  changeuuid: e41cca24-06ae-4311-8185-ae84d1d338f7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-actual-radio
+  broadcaster: independent
+  name: Actual Radio
+  streamUrl: https://securestreams.autopo.st:1174/;
+  bitrate: 128
+  codec: MP3
+  homepage: https://actualradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: d8d21c43-efbb-4d27-9abc-c0671e769d71
+  changeuuid: 49849f09-0835-4b01-95fa-9517e09f6347
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-subtle-radio
+  broadcaster: independent
+  name: Subtle Radio
+  streamUrl: https://subtle.out.airtime.pro/subtle_a
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.subtleradio.com/wp-content/uploads/2022/11/favicon.png
+  homepage: https://www.subtleradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 1dbdc89f-f0d1-4bf7-8922-266edeb912dd
+  changeuuid: d333ec2c-b64a-4277-a2e0-81d25bc26489
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-field-recordings-nts
+  broadcaster: independent
+  name: "Field Recordings | NTS"
+  streamUrl: https://stream-mixtape-geo.ntslive.net/mixtape23
+  codec: MP3
+  favicon: https://www.nts.live/apple-touch-icon.png?v=47re43rrzb
+  homepage: https://www.nts.live/infinite-mixtapes/field-recordings
+  country: GB
+  status: stream-only
+  stationuuid: 3fb45633-813e-4c6b-b262-e90c3846d10d
+  changeuuid: 6bf42c01-9b52-41b0-ad60-915c90a128cb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-soho-radio-london
+  broadcaster: independent
+  name: Soho Radio London
+  streamUrl: https://sohoradiomusic.doughunt.co.uk:8010/128mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://sohoradiolondon.com/wp-content/themes/sohoradio-jan-2023/build/images/favicons/sohoradio-192x192.jpg
+  homepage: https://sohoradiolondon.com/
+  country: GB
+  status: stream-only
+  stationuuid: 20bcbbc0-75b1-43ab-9919-6230ce0d8bba
+  changeuuid: 5c982868-d3cc-41db-be8e-ac8998ba8655
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-labyrinth-nts
+  broadcaster: independent
+  name: "Labyrinth | NTS"
+  streamUrl: https://stream-mixtape-geo.ntslive.net/mixtape31
+  codec: MP3
+  favicon: https://www.nts.live/apple-touch-icon.png?v=47re43rrzb
+  homepage: https://www.nts.live/infinite-mixtapes/labyrinth
+  country: GB
+  status: stream-only
+  stationuuid: 9391f9be-cbc1-4c84-8da5-cf7eebefaab2
+  changeuuid: 3f636f54-d44f-42ae-82be-96ea75a6ecf4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-the-voice-of-doom
+  broadcaster: independent
+  name: The Voice Of Doom
+  streamUrl: https://streaming.galaxywebsolutions.com:9046/stream
+  bitrate: 320
+  codec: AAC
+  homepage: https://www.thevoiceofdoom.com/
+  country: GB
+  status: stream-only
+  stationuuid: 94e61c2c-a6fb-4ff0-8b3d-1041a3e8e42e
+  changeuuid: 69a17e90-9f14-4cae-abec-82b4d53ed63b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-dnbradio-com
+  broadcaster: independent
+  name: DnBRadio.com
+  streamUrl: https://fw.dnbradio.com/dnbradio_main.mp3
+  bitrate: 320
+  codec: MP3
+  favicon: https://dnbradio.com/img/logotags.png
+  homepage: https://dnbradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 705c6f01-92b5-4766-9c6f-53540414b6c3
+  changeuuid: 4fe59181-2c9e-4d2a-9c55-eb3fa9ef3783
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-gen-x-radio
+  broadcaster: independent
+  name: Gen X Radio
+  streamUrl: https://s2.radio.co/sf25229e16/listen
+  bitrate: 320
+  codec: AAC
+  favicon: https://genxradio.co.uk/wp-content/uploads/2021/11/cropped-GenXAsset-9-192x192.png
+  homepage: https://genxradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 5df5fc8a-3259-4d29-988d-814ab6332ece
+  changeuuid: 2fdd1015-e56c-470d-bfc7-a3d714fccdd5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-house-fusion-radio-uk
+  broadcaster: independent
+  name: House Fusion Radio (UK)
+  streamUrl: https://housefusionradiouk.out.airtime.pro/housefusionradiouk_a
+  bitrate: 192
+  codec: MP3
+  favicon: https://d1di2lzuh97fh2.cloudfront.net/files/1j/1j3/1j3767.ico?ph=a9529f376f
+  homepage: https://house-fusion-radio5.webnode.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: b6d47672-aa01-4363-bd26-32f0e8d9570e
+  changeuuid: 529189a2-528e-4165-aea8-65f88f554d0f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-the-british-home-front-radio-service
+  broadcaster: independent
+  name: The British Home Front Radio Service
+  streamUrl: https://solid24.streamupsolutions.com/proxy/mmpplqiv?mp=/;type=mp3
+  bitrate: 128
+  codec: MP3
+  homepage: http://www.1940sukradio.co.uk/BHFR/
+  country: GB
+  status: stream-only
+  stationuuid: d53f641f-8321-4d46-b062-506ee653760b
+  changeuuid: f1cce0a8-d8bc-4cee-91c0-3ca60631ce71
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-heart-musicals
+  broadcaster: independent
+  name: Heart Musicals
+  streamUrl: https://media-ice.musicradio.com/HeartMusicalsMP3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.heart.co.uk/musicals/
+  country: GB
+  status: stream-only
+  stationuuid: 0ea2b325-307b-45d4-80ce-f948302b1366
+  changeuuid: 3ed8e67d-152d-4299-9cd0-c22448efa3ef
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-boogaloo-radio
+  broadcaster: independent
+  name: Boogaloo Radio
+  streamUrl: https://streams.radio.co/sb88c742f0/listen
+  bitrate: 192
+  codec: MP3
+  homepage: https://boogalooradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: df185514-161b-476d-a913-d2c2927033a8
+  changeuuid: e1673b42-93aa-4d6c-b3ae-131f21ea10e8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-easy-50s
+  broadcaster: independent
+  name: Easy 50s
+  streamUrl: https://streaming.exclusive.radio/uber/easy50/icecast.audio
+  codec: MP3
+  favicon: https://manager.uber.radio/static/uploads/station/45f6ba11-a495-4500-abae-41c0b999df6c.png
+  homepage: https://easy.radio/station/47/658
+  country: GB
+  status: stream-only
+  stationuuid: 634d8abf-8a2f-4e4e-ac85-58a4c4b831ca
+  changeuuid: 3d8962df-f918-4e19-b596-b77dac162f33
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-mi-soul
+  broadcaster: independent
+  name: "Mi-Soul "
+  streamUrl: https://listen-misoul.sharp-stream.com/462_mi_soul_128_mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://upload.wikimedia.org/wikipedia/en/thumb/c/cc/Mi-Soul_logo.png/220px-Mi-Soul_logo.png
+  homepage: https://mi-soul.com/
+  country: GB
+  status: stream-only
+  stationuuid: 67b7f9d7-2ead-4525-95de-b105b63d2451
+  changeuuid: e2e8d42d-4d88-4161-929e-5861a79185fc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-liquid-dnb
+  broadcaster: independent
+  name: Liquid DnB
+  streamUrl: https://antares.dribbcast.com/proxy/dave1/stream/
+  bitrate: 128
+  codec: MP3
+  homepage: https://liquid-dnb.com/
+  country: GB
+  status: stream-only
+  stationuuid: b8148b29-09d0-4aa1-8bfe-43d236260170
+  changeuuid: 3b56d0d8-29aa-477f-9647-345b1399697d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bbc-radio-one
+  broadcaster: independent
+  name: BBC Radio One
+  streamUrl: https://a.files.bbci.co.uk/ms6/live/3441A116-B12E-4D2F-ACA8-C1984642FA4B/audio/simulcast/hls/nonuk/audio_syndication_low_sbr_v1/aks/bbc_radio_one.m3u8
+  bitrate: 101
+  codec: AAC+
+  favicon: https://cdn-radiotime-logos.tunein.com/s24939q.png
+  homepage: http://www.bbc.co.uk/radio1
+  country: GB
+  status: stream-only
+  stationuuid: a1b40e7a-94fe-4199-bd8f-31a7ed074a53
+  changeuuid: 430146e7-5eff-4b5a-9638-efdaa06108c8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-funkuradio
+  broadcaster: independent
+  name: FunkURadio
+  streamUrl: https://furfmcou.radioca.st/stream
+  bitrate: 128
+  codec: MP3
+  homepage: http://www.funkuradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 3e841d56-72bc-4728-a8df-fa8389f0f974
+  changeuuid: d3d1542e-45b7-414b-95f8-1ccd58c0f738
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-american-gold-pumpkin-fm
+  broadcaster: independent
+  name: American Gold - Pumpkin FM
+  streamUrl: https://cast2.asurahosting.com/proxy/americangold/stream
+  bitrate: 64
+  codec: MP3
+  favicon: https://pumpkinfm.com/wp-content/uploads/2021/01/AmericanGold300x300.jpg
+  homepage: https://pumpkinfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: f422b275-d5e2-4702-8f75-43deed1c267b
+  changeuuid: fd8f191f-c14b-40f9-9266-c394f1988a2b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-diva-radio-disco
+  broadcaster: independent
+  name: Diva Radio Disco
+  streamUrl: https://stream.deevaradio.net:10443/divaradiodisco
+  bitrate: 192
+  codec: MP3
+  homepage: https://deevaradio.net/
+  country: GB
+  status: stream-only
+  stationuuid: ef93618c-686d-45fb-908e-8da696365f8b
+  changeuuid: 7eed6e42-4052-44dd-9bb6-f2f9691ab6f2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-dubplate-fm-dub-bass
+  broadcaster: independent
+  name: "Dubplate.fm Dub &Bass"
+  streamUrl: https://sc2.dubplate.fm/radio/8000/dubandbass/uhifi
+  bitrate: 256
+  codec: MP3
+  homepage: https://dubplate.fm/dub-and-bass-radio
+  country: GB
+  status: stream-only
+  stationuuid: 5a71d128-cb37-4d62-8b8b-a705e95ad2d8
+  changeuuid: aad8b21b-db62-4563-9567-21e28a3d0faa
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-neon-radio-80s-90s-pop-dance
+  broadcaster: independent
+  name: "Neon Radio - 80s & 90s Pop & Dance"
+  streamUrl: https://live.flashbackcentral.co.uk/radio/8050/tunein.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.neonradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 04bd267f-046a-4275-b7c5-c29f9e25efc9
+  changeuuid: e44dfd69-740f-4739-8481-cb7ade3f8ed6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-ozzy-osbourne
+  broadcaster: independent
+  name: Ozzy Osbourne
+  streamUrl: https://stream.pcradio.ru/ozzy_osbourne-hi
+  codec: AAC
+  favicon: null
+  homepage: https://pcradio.ru/
+  country: GB
+  status: stream-only
+  stationuuid: 2e79d453-28ec-45d2-b511-e9d5f8055f28
+  changeuuid: ef4d5e17-08a4-492a-9c11-0159a1b677a1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-heart-south-wales
+  broadcaster: independent
+  name: Heart South Wales
+  streamUrl: https://media-ssl.musicradio.com/HeartSouthWalesMP3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.heart.co.uk/assets_v4r/heart/img/favicon-196x196.png
+  homepage: https://www.heart.co.uk/southwales
+  country: GB
+  status: stream-only
+  stationuuid: 8b5d407b-dc32-11e9-a8ba-52543be04c81
+  changeuuid: 32b66766-5fe6-4e45-8f28-ad35b0016042
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-central-24
+  broadcaster: independent
+  name: Radio Central 24
+  streamUrl: https://casper.radioca.st/;
+  bitrate: 128
+  codec: MP3
+  favicon: http://radiocentral24.com/assets/images/transparent-121x64.png
+  homepage: http://radiocentral24.com/
+  country: GB
+  status: stream-only
+  stationuuid: bd24e3d2-3e2e-47c4-b0a2-73e551728f4c
+  changeuuid: ab1db302-82f7-47d3-8b84-61f36038c649
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-one-world-radio-tomorrowland-anthems
+  broadcaster: independent
+  name: One World Radio - Tomorrowland Anthems
+  streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/OWR_DAB.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.tomorrowland.com/home/apple-touch-icon.png
+  homepage: https://www.tomorrowland.com/home/radio
+  country: GB
+  status: stream-only
+  stationuuid: 5f3fa761-76be-4672-98fd-c5e71771834d
+  changeuuid: 8205726c-8269-4d3b-b83c-ec0a4f77cbda
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-total-soul-uk-192kb-mp3
+  broadcaster: independent
+  name: Total Soul (UK) 192kb mp3
+  streamUrl: https://onair7.xdevel.com/proxy/xautocloud_atvn_1069?mp=/;1/
+  bitrate: 192
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/440/66d2d8d6d54ea.png
+  homepage: https://www.totalsoul.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: afb31087-30b4-44c7-8469-b3526d8f3bb5
+  changeuuid: 5281feab-c507-4336-b4fc-fff1eabf7612
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-i-like-it-oldskool
+  broadcaster: independent
+  name: I Like It Oldskool
+  streamUrl: https://ilikeitoldskool.radioca.st/stream
+  bitrate: 320
+  codec: MP3
+  favicon: https://ilikeitoldskool.co.uk/favicon.ico
+  homepage: https://ilikeitoldskool.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: cc4928e9-f513-4c59-b42c-56097b881431
+  changeuuid: c4944f12-af26-4298-bc71-c3bdbcd63330
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-select-radio
+  broadcaster: independent
+  name: Select Radio
+  streamUrl: https://streaming05.liveboxstream.uk/proxy/selectr1/stream
+  bitrate: 128
+  codec: AAC+
+  favicon: https://selectradioapp.com/wp-content/uploads/2023/11/cropped-selecticon-180x180.png
+  homepage: https://selectradioapp.com/
+  country: GB
+  status: stream-only
+  stationuuid: ce9dced9-1160-450d-a81e-d2df3981e14e
+  changeuuid: 0307d013-6f90-4af8-a4d0-063af6ca5dc9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hot-radio
+  broadcaster: independent
+  name: Hot Radio
+  streamUrl: https://stream1.hippynet.co.uk/stream/hotradio/dorset
+  bitrate: 160
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/406/601068617960a.png
+  homepage: https://www.hot.radio/
+  country: GB
+  status: stream-only
+  stationuuid: 597d9f11-b953-4cae-8f8f-88ff846fe2e9
+  changeuuid: fd4490fe-6090-4762-b36b-01d0b4fb281f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-heart-xmas
+  broadcaster: independent
+  name: Heart Xmas
+  streamUrl: https://media-ssl.musicradio.com/HeartXmas
+  bitrate: 48
+  codec: AAC
+  country: GB
+  status: stream-only
+  stationuuid: 38c61264-4246-4ea1-a280-42a85d59ad25
+  changeuuid: d33cb22c-cd9f-40a0-a0c5-836c1c86cab3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-lite-radio
+  broadcaster: independent
+  name: Lite Radio
+  streamUrl: https://ais-sa2.cdnstream1.com/2382_128.mp3?rp_source=1&=&&___cb=212916936695709
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.literadio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: dcad0c3e-347d-41fb-b10a-3a37eae6dfed
+  changeuuid: c1bfeec3-0233-4d30-8844-4db1730553f3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-trancetechnic-radio
+  broadcaster: independent
+  name: "Trancetechnic Radio "
+  streamUrl: https://s11.ssl-stream.com/ssl/trancete?mp=/stream
+  bitrate: 128
+  codec: MP3
+  favicon: http://img.sedoparking.com/templates/logos/sedo_logo.png
+  homepage: http://www.trancetechnic.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 99d8fad1-51f0-44f3-943c-ee6b4a2864f4
+  changeuuid: b4c1bfb3-910f-4a7d-a965-528c7a6f034b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-easy-radio
+  broadcaster: independent
+  name: Easy Radio
+  streamUrl: https://listen-nation.sharp-stream.com/breezyradiouk.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.nationplayer.com/easy-radio-south/
+  country: GB
+  status: stream-only
+  stationuuid: 43e0dd7d-4d78-4355-9261-6b1f8042796a
+  changeuuid: 48be9943-7fe4-493f-bf24-7346ba56a3ea
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-kaos-sound-pink-floyd-radio
+  broadcaster: independent
+  name: KAOS Sound  - Pink Floyd Radio
+  streamUrl: https://s3.myradiostream.com/:59506/stream/1/
+  bitrate: 128
+  codec: MP3
+  favicon: https://cdn-profiles.tunein.com/s140303/images/logog.png?t=160685
+  homepage: https://kaos-sound.co.uk/mrsdocs/home.html
+  country: GB
+  status: stream-only
+  stationuuid: 0b7938b0-230f-4e3b-aea7-d5c3439969b9
+  changeuuid: 48b6d05a-82cb-4cb3-8f92-b30b0bcede12
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-netil-radio
+  broadcaster: independent
+  name: Netil Radio
+  streamUrl: https://netilradio.out.airtime.pro/netilradio_a
+  bitrate: 128
+  codec: MP3
+  homepage: http://netilradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 2a85a1c6-0cec-428a-a7df-126e4d8a90d9
+  changeuuid: ca341b21-16a2-4516-b1cb-120bdac5b3a4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-rokit-radio-classic-crime-and-suspense
+  broadcaster: independent
+  name: "ROKit Radio : Classic Crime and Suspense"
+  streamUrl: https://streaming04.liveboxstream.uk/proxy/roksta17/stream
+  bitrate: 48
+  codec: MP3
+  favicon: https://rokitradio.com/favicon.ico
+  homepage: https://rokitradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 02a7479c-dbbd-43f6-bbcf-70a3e0fcc481
+  changeuuid: 3336175a-d13e-413f-bdd7-2105cf65ed40
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-psychedelic-secret-radio
+  broadcaster: independent
+  name: Psychedelic Secret radio
+  streamUrl: https://solid48.streamupsolutions.com/proxy/bglsokon?mp=/=stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.psychedelicsecretsradio.com/favicon.ico
+  homepage: https://www.psychedelicsecretsradio.com/?m=1
+  country: GB
+  status: stream-only
+  stationuuid: d288325b-a5ed-42c4-820b-f7b99ab39bd1
+  changeuuid: ccc62068-6cdc-4494-bf58-a85af2334d55
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-x-90s
+  broadcaster: independent
+  name: Radio X 90s
+  streamUrl: https://media-ice.musicradio.com/RadioX90sMP3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radiox.co.uk/90s/
+  country: GB
+  status: stream-only
+  stationuuid: bf8c3fd8-80bb-46f3-929b-effac0a1c31f
+  changeuuid: 9b8dd89d-0147-4f57-b177-f5e2a91e5a04
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bfbs-beats
+  broadcaster: independent
+  name: BFBS Beats
+  streamUrl: https://edge-audio-01-cr.sharp-stream.com/ssvcbfbs20.aac?device=bfbs_beats
+  bitrate: 64
+  codec: AAC+
+  favicon: https://www.forces.net/themes/custom/forcesnet_2020/favicon.ico
+  homepage: https://www.forces.net/
+  country: GB
+  status: stream-only
+  stationuuid: eaddb63a-251a-11e8-91bf-52543be04c81
+  changeuuid: ba01fb10-7fba-4a41-945d-5d0e075352bc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-feelings-nts
+  broadcaster: independent
+  name: "Feelings | NTS"
+  streamUrl: https://stream-mixtape-geo.ntslive.net/mixtape27
+  codec: MP3
+  favicon: https://www.nts.live/apple-touch-icon.png?v=47re43rrzb
+  homepage: https://www.nts.live/infinite-mixtapes/feelings
+  country: GB
+  status: stream-only
+  stationuuid: 636a1133-b9d5-4412-9e8f-36c37f190176
+  changeuuid: d4d02648-11c2-44d8-bd9f-3784586c3ab3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-classic-fm-hall-of-fame
+  broadcaster: independent
+  name: Classic FM Hall of Fame
+  streamUrl: https://icecast.thisisdax.com/ClassicFM-M-HOF
+  bitrate: 48
+  codec: AAC
+  favicon: https://www.radio.de/images/broadcasts/a1/f8/126083/1/c300.png
+  homepage: https://www.classicfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: 2862466b-e997-4bc1-95d2-2ba51972a8ae
+  changeuuid: 50378baa-ae7c-4057-b116-47dd020cf92c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-nu-disco-funk-radio
+  broadcaster: independent
+  name: Nu Disco Funk Radio
+  streamUrl: https://my.radiolize.com/radio/8090/radio.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://uk.radio.net/300/nudiscofunkradio.jpeg?version=b5b29e74fa5bb43b3b8a3e9d27349a94
+  homepage: https://nu-disco-funk-radio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 05324cb6-8a7c-47a2-accb-5423f3d1e686
+  changeuuid: 125e47d2-46f0-4925-a6a1-5e4bad071c42
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-britasia-radio
+  broadcaster: independent
+  name: BritAsia Radio
+  streamUrl: https://s4.radio.co/sfefce156f/listen
+  bitrate: 320
+  codec: MP3
+  favicon: https://britasia.tv/wp-content/uploads/2021/01/britasia-radio-logo.jpg
+  homepage: https://britasia.tv/radio/
+  country: GB
+  status: stream-only
+  stationuuid: f2e9cd87-8f8c-4ebf-8479-eae9b2998168
+  changeuuid: 75bae926-a65c-4356-9caf-ea9d143e45ba
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-mystery-train-radio
+  broadcaster: independent
+  name: "Mystery Train Radio "
+  streamUrl: https://streamer.radio.co/sf662f27c0/listen
+  bitrate: 192
+  codec: AAC
+  homepage: https://www.mysterytrainradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 02da1082-5c2b-4db7-9465-a6f7ba25813b
+  changeuuid: a40dcc53-3079-4fcb-a2e4-593c03825b50
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-judas-priest
+  broadcaster: independent
+  name: Judas Priest
+  streamUrl: https://stream.pcradio.ru/judas_priest-hi
+  codec: AAC
+  favicon: null
+  homepage: https://pcradio.ru/
+  country: GB
+  status: stream-only
+  stationuuid: a1e4582c-af68-41f8-9785-77bd09f0a6b9
+  changeuuid: 1f7ed9ab-13b0-4c52-be51-d1636afd0f5f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-smooth-radio-suffolk
+  broadcaster: independent
+  name: Smooth Radio (Suffolk)
+  streamUrl: https://media-ssl.musicradio.com/SmoothSuffolk
+  bitrate: 48
+  codec: AAC
+  favicon: https://www.smoothradio.com/assets_v4r/smooth/img/favicon-196x196.png
+  homepage: https://www.smoothradio.com/suffolk/
+  country: GB
+  status: stream-only
+  stationuuid: f4928612-ed25-4c21-a852-0600deb0ff1e
+  changeuuid: 5eee99b2-73a4-4da3-8ebc-9a87989a3f18
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-led-zeppelin
+  broadcaster: independent
+  name: Led Zeppelin
+  streamUrl: https://stream.pcradio.ru/Led_Zeppelin-hi
+  codec: AAC
+  favicon: null
+  homepage: https://pcradio.ru/
+  country: GB
+  status: stream-only
+  stationuuid: 1d62a120-704a-4285-a574-c17f48b155f8
+  changeuuid: 76973c23-8790-4dd5-8dc6-0d9b415cccfe
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-smooth-christmas
+  broadcaster: independent
+  name: Smooth Christmas
+  streamUrl: https://media-ice.musicradio.com/SmoothXmasMP3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.smoothradio.com/news/christmas/
+  country: GB
+  status: stream-only
+  stationuuid: 052ee406-0369-44be-939d-a35d24f376c4
+  changeuuid: 1425474e-de06-475b-a1d3-820883a41581
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-boot-boy-radio
+  broadcaster: independent
+  name: Boot Boy Radio
+  streamUrl: https://streaming04.liveboxstream.uk/proxy/dwain?mp=/stream
+  bitrate: 192
+  codec: AAC+
+  favicon: https://bootboyradio.net/wp-content/uploads/2021/02/cropped-900logosquare-192x192.jpg
+  homepage: https://bootboyradio.net/
+  country: GB
+  status: stream-only
+  stationuuid: 9bc64606-6eb1-40bd-901e-aed7c510baa0
+  changeuuid: ec28cf6d-87e5-418f-9098-2fda2b3edd26
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-boom-light
+  broadcaster: independent
+  name: Boom Light
+  streamUrl: https://listen-boomradio.sharp-stream.com/65_boom_light_128_mp3
+  bitrate: 128
+  codec: MP3
+  country: GB
+  status: stream-only
+  stationuuid: 97826f0f-c91b-4e58-8c77-dc1a9ca1f519
+  changeuuid: 37d25fba-3a21-4583-9d12-8f631fa337ca
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-solar-radio
+  broadcaster: independent
+  name: Solar Radio
+  streamUrl: https://listen-msmn.sharp-stream.com/solarlow.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://solarradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 05a082a6-6b31-4515-939d-8896f69160ad
+  changeuuid: 4c0fb40e-b180-40f8-b9ab-8249de2b7301
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-twr-uk
+  broadcaster: independent
+  name: TWR UK
+  streamUrl: https://direct.sharp-stream.com/twruk.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.twr.org.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 7d2b22a8-a65b-11e9-a787-52543be04c81
+  changeuuid: f8ebb839-6a89-46dd-90ff-699e545d803c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-malvern-radio-international-pumpkin-fm
+  broadcaster: independent
+  name: Malvern Radio International - Pumpkin FM
+  streamUrl: https://cast2.asurahosting.com/proxy/radiomalvernint/stream
+  bitrate: 128
+  codec: MP3
+  homepage: https://pumpkinfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: a23a00e2-ca9b-4869-82ec-063d7303d98b
+  changeuuid: 4f7107e7-20a9-4182-9a1e-8c378c1ac372
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-gold-radio-uk
+  broadcaster: independent
+  name: Gold Radio UK
+  streamUrl: https://media-ice.musicradio.com/GoldMP3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.goldradio.com/?page=2
+  country: GB
+  status: stream-only
+  stationuuid: 9b3a5084-91ba-4d90-ac06-3e0ba8c50d67
+  changeuuid: 683b9b37-8408-4caa-a2ba-17c336d4a728
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-heart-fm-birmingham
+  broadcaster: independent
+  name: Heart FM (Birmingham)
+  streamUrl: https://media-ssl.musicradio.com/HeartWestMids?isLoggedIn=true&dax_version=release_4140&dax_player=GlobalPlayer&dax_platform=Web&delivery_type=streaming&aw_0_req.userConsentV2=CPytTYAPytTYAAGABCENATEoAP_AAAGAAAwIGMpF7D5VZWFC-OZ5YKsAMYhXQMCAIuQQCASAA-ABCAKQIIQGgmAQFASgBAAKAQAAIAJBAAIECAAQCQAAAAAAAACAAAAABAAIAAAAgAAAAAAIAAAGAAAAAAAIgAAAEAAAmAwAAIIAAADgkBkABAACwAKgAcAA8ACAAGQANAAeQBDAEQAJgATwAqgB-AEIAKUAW4AwwB7AD9AIGAVcAxQCkQF5hAAoADwASAA_AHOApsMABAU2IAAgAkFQAQAhjIAIAQx0BwABYAFQAOAAgABkADQAHkAQwBEACYAE8AKoAXQAxAB-AFGAKUAW4AwwBogD2AH6AQMAjoBVwCxAGKAReAvMcAOAAQAA8AC4AJAAcgA_AHOAQgAiIBFgCMgKQAU2AvohAIAAWAEMAJgAVQAxAClAKuAYogADAAQAOcAsRKAcAAgABYAHAAeABEACYAFUAMQAowBbgFXAMUAi8BeZIAIABcAHIA1ADMlIC4ACwAKgAcABAADIAGgAPIAhgCIAEwAJ4AUgAqgBiAD8AKMAUoAtwBogD9AI6AVcBF4C8ygA8AC4AJAAcgA_ADaANQAc4BFgCxAF1AMUAa8BSACmwF9A.YAAAAAAAAAAA&dax_listenerid=824C2FA8EC1A06EF990BEDF6BE300A70&gigya_id=aca49a64b4254a8ab5a088cd031e7efe&nlsid=1c499bb707f2fc48cfd210acda4433d0
+  bitrate: 48
+  codec: AAC
+  homepage: https://www.heart.co.uk/westmids/
+  country: GB
+  status: stream-only
+  stationuuid: ae60f33c-cdbe-4ff8-a416-01916d60bc98
+  changeuuid: f4806073-1a14-4c3e-92c6-8777a810d355
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-bloodstream
+  broadcaster: independent
+  name: Radio Bloodstream
+  streamUrl: https://uk1.internet-radio.com/proxy/bloodstream?mp=/stream
+  codec: MP3
+  favicon: https://www.radiobloodstream.com/favicon.ico
+  homepage: https://www.radiobloodstream.com/en/
+  country: GB
+  status: stream-only
+  stationuuid: 5f6f5a1e-4d61-4b5f-ab5c-74bcfd893ac4
+  changeuuid: fbbfbec1-4209-44ca-8e18-1fbfcffea489
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-monocle-radio
+  broadcaster: independent
+  name: Monocle Radio
+  streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/MONOCLE_24.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://pbs.twimg.com/profile_images/1641728752236281856/zeIa6wPU_400x400.jpg
+  homepage: https://monocle.com/radio/
+  country: GB
+  status: stream-only
+  stationuuid: c73b9eff-0ac5-4a43-b05a-346591c66675
+  changeuuid: 92dc58d7-e990-47aa-96e4-654da44a095b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-atlantic-252
+  broadcaster: independent
+  name: Atlantic 252
+  streamUrl: https://stream4.themediasite.co.uk:8042/
+  bitrate: 192
+  codec: MP3
+  favicon: https://play-lh.googleusercontent.com/kIp3BTHaetEyZcMXvOzQ41i15fTZkShTAhpmjS-643non9AxqB45R1--DyU1PbFV=w240-h480-rw
+  homepage: https://www.atlantic252radio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 4655694e-a599-4105-9298-55d590b30ac7
+  changeuuid: 887fdc65-1422-4034-a43e-8cec87bce5cf
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-24-7-blues-radio
+  broadcaster: independent
+  name: "24/7 Blues Radio"
+  streamUrl: https://ec3.yesstreaming.net:3685/stream
+  bitrate: 64
+  codec: MP3
+  favicon: https://www.247onlineradio.com/wp-content/uploads/2023/04/247-Blues-Radio.jpg
+  homepage: https://www.247onlineradio.com/24-7-online-radio-group-stations/24-7-blues-radio/
+  country: GB
+  status: stream-only
+  stationuuid: a648882e-b8d3-422a-9a79-307ccab8c406
+  changeuuid: 0b43b8b4-c3c4-4685-a498-976f001e1fbf
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-forest-gold
+  broadcaster: independent
+  name: Forest Gold
+  streamUrl: https://c2.prostream365.com:8000/live
+  bitrate: 128
+  codec: AAC
+  favicon: https://www.forestgoldradio.com/favicon.ico
+  homepage: https://www.forestgoldradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 1b599e3f-a35e-409a-82b2-dcaaf38d598e
+  changeuuid: 17a24972-9a53-4b89-b711-481ad0ad8190
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-news-radio-uk
+  broadcaster: independent
+  name: News Radio UK
+  streamUrl: https://stream.aiir.com/clcb6m0k9shvv
+  codec: AAC
+  favicon: https://newsradiouk.co.uk/wp-content/uploads/2022/06/Facebook-profile.png
+  homepage: https://newsradiouk.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: a0d298f1-ecfb-4faf-9fe0-5c59d9824131
+  changeuuid: ca9a9b21-23e4-4820-b87a-27d10ee747c2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-sheet-music-nts
+  broadcaster: independent
+  name: "Sheet Music | NTS"
+  streamUrl: https://stream-mixtape-geo.ntslive.net/mixtape35
+  codec: MP3
+  favicon: https://www.nts.live/apple-touch-icon.png?v=47re43rrzb
+  homepage: https://www.nts.live/infinite-mixtapes/sheet-music
+  country: GB
+  status: stream-only
+  stationuuid: 1e0ad463-0dbc-4913-b12d-7d0b7300882b
+  changeuuid: 06b3a8f2-1f22-47b1-b3c0-3c2ee539667f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-chocolate-radio
+  broadcaster: independent
+  name: Chocolate Radio
+  streamUrl: https://stream.radio.co/sa7336b687/listen?ver=712690
+  bitrate: 192
+  codec: AAC
+  homepage: https://chocolate-radio.com/
+  country: GB
+  status: stream-only
+  stationuuid: c2383b38-0b46-450e-8b9c-981e4b34c3aa
+  changeuuid: 5fed0fb0-718f-4dfc-9acb-042bbbaa1bd3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-nation-radio-wales
+  broadcaster: independent
+  name: Nation Radio Wales
+  streamUrl: https://edge-ads-05-gos2.sharp-stream.com/tcnationi.aac
+  bitrate: 48
+  codec: AAC+
+  homepage: https://nationradio.wales/
+  country: GB
+  status: stream-only
+  stationuuid: 9826efd7-b7bc-4469-926f-3dde50bb0bb5
+  changeuuid: b97d56a4-052a-4e4a-9c3e-1332aaa3f317
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-rockin50s-radio
+  broadcaster: independent
+  name: Rockin50s Radio
+  streamUrl: https://eu10.fastcast4u.com/rockin50s
+  bitrate: 128
+  codec: MP3
+  favicon: https://rockin50s.uk/images/site/site_logo2small.png
+  homepage: https://rockin50s.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 29e6919f-076d-4643-82df-a8bbaa6263a6
+  changeuuid: 5e765e97-2507-4d6a-ab34-5ae264984f78
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-uk-bass
+  broadcaster: independent
+  name: UK Bass
+  streamUrl: https://ukbassradio.com/stream
+  bitrate: 192
+  codec: MP3
+  homepage: https://ukbassradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 6e59a7ea-be41-4539-af11-ce78936d42d0
+  changeuuid: df50cbae-428b-4f3a-8997-b600e192c9f6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-dancefmlive-trance
+  broadcaster: independent
+  name: DanceFMLive Trance
+  streamUrl: https://broadcast.dancefmlive.com/radio/8010/radio.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.dancefmlive.com/wp-content/uploads/2021/02/trance.jpg
+  homepage: https://www.dancefmlive.com/
+  country: GB
+  status: stream-only
+  stationuuid: dcd3b0e9-a7bf-402e-8d0a-14f25af2d68c
+  changeuuid: d0e1b9f0-341c-4895-810d-63c2995c5d89
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-divine-radio-london
+  broadcaster: independent
+  name: Divine Radio London
+  streamUrl: https://uk2.internet-radio.com/proxy/divinestream?mp=/stream
+  bitrate: 64
+  codec: AAC+
+  homepage: https://www.divineradiolondon.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: b4491892-12f3-41b7-8252-5cd5e4cf61fb
+  changeuuid: 1eb2e997-e4b1-42e0-b9e9-a7e63886c9da
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-smooth-soul
+  broadcaster: independent
+  name: Smooth Soul
+  streamUrl: https://media-ice.musicradio.com/SmoothSoulMP3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.smoothradio.com/soul/
+  country: GB
+  status: stream-only
+  stationuuid: 866980e7-2ffb-4c3c-9bef-1195fb6f29d8
+  changeuuid: 8fc0b0ff-ddfc-4483-8285-ecf417c1853a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bolton-fm
+  broadcaster: independent
+  name: Bolton FM
+  streamUrl: https://radio.canstream.co.uk:8083/live.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.boltonfm.com/bfm_website_logos/BFM_Logos/BoltonFM-Logo-square.png
+  homepage: https://www.boltonfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: afe3f5a1-88b3-4a2d-b317-710c13d35689
+  changeuuid: d1b5376f-f4f9-4a7c-937a-06be3b644f3c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-sweat-nts
+  broadcaster: independent
+  name: "Sweat | NTS"
+  streamUrl: https://stream-mixtape-geo.ntslive.net/mixtape24
+  codec: MP3
+  favicon: https://www.nts.live/apple-touch-icon.png?v=47re43rrzb
+  homepage: https://www.nts.live/infinite-mixtapes/sweat
+  country: GB
+  status: stream-only
+  stationuuid: 7afce64a-1626-4391-9cad-cb6e664489a8
+  changeuuid: e097de17-5220-4b64-846c-171e7c8947dd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-dclm-radio
+  broadcaster: independent
+  name: DCLM Radio
+  streamUrl: https://airtime.dclm.org/radio/8000/live
+  bitrate: 64
+  codec: MP3
+  favicon: https://radio.dclm.org/assets/img/favicon.png
+  homepage: https://radio.dclm.org/
+  country: GB
+  status: stream-only
+  stationuuid: 78c2d08d-591c-482d-ad50-6939432fedc6
+  changeuuid: c8eae56e-afea-48f6-b49b-c13d54287346
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-5-rivers-radio
+  broadcaster: independent
+  name: "5 Rivers radio"
+  streamUrl: https://onlineradiobox.com/json/uk/5rivers/play?platform=web
+  bitrate: 320
+  codec: MP3
+  favicon: null
+  homepage: https://onlineradiobox.com/json/uk/5rivers/play?platform=web
+  country: GB
+  status: stream-only
+  stationuuid: 4ff45fd0-1ecb-4611-8d2d-38ff54dfcd54
+  changeuuid: a96d9c77-fb32-44b1-9cc5-87dc5217862b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bradford-asian-radio
+  broadcaster: independent
+  name: Bradford Asian Radio
+  streamUrl: https://cast1.asurahosting.com/proxy/bradford/stream
+  bitrate: 128
+  codec: MP3
+  favicon: null
+  homepage: https://cast1.asurahosting.com/proxy/bradford/stream
+  country: GB
+  status: stream-only
+  stationuuid: 77461b3b-d41e-4794-9884-6b9a2361ba70
+  changeuuid: ce12ebab-5cb9-4ddb-8f6c-70273fa9539f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-swu-fm
+  broadcaster: independent
+  name: SWU FM
+  streamUrl: https://admin.stream.rinse.fm/proxy/swu/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://rinse.fm/favicon.ico
+  homepage: https://rinse.fm/channels/swu/
+  country: GB
+  status: stream-only
+  stationuuid: fb156190-ade3-4f47-873a-2136cdc793d6
+  changeuuid: 1557094c-15ff-4475-99f1-d89bac25b481
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-brmb-radio
+  broadcaster: independent
+  name: BRMB Radio
+  streamUrl: https://radio.canstream.co.uk:8147/live.mp3
+  bitrate: 160
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/1111/64a34bf89acd7.png
+  homepage: https://www.brmbradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 44bf63a3-ff14-4248-923d-77291127475e
+  changeuuid: d9300be5-b33e-4f5d-932c-da591e38a073
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-resonance-104-4fm
+  broadcaster: independent
+  name: Resonance 104.4FM
+  streamUrl: https://stream.resonance.fm/resonance?rp_source=1&=&&___cb=309691324386261
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.resonancefm.com/assets/logo-a79206a34394173ba3e41d66a3388f4c.png
+  homepage: https://www.resonancefm.com/
+  country: GB
+  status: stream-only
+  stationuuid: fcb3ce76-8f7b-4949-897e-4158b67ed952
+  changeuuid: e4f5405f-2a08-4146-9e03-72d7cdcfbba4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-foundation-fm
+  broadcaster: independent
+  name: Foundation FM
+  streamUrl: https://streamer.radio.co/s0628bdd53/listen
+  bitrate: 192
+  codec: MP3
+  favicon: https://foundation.fm/images/favicon/favicon.ico
+  homepage: https://foundation.fm/
+  country: GB
+  status: stream-only
+  stationuuid: e8c409e9-ee6f-4670-84bf-02485247def0
+  changeuuid: 1054eb54-15df-47f7-8f5f-9c8f80d1141a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-maria-england
+  broadcaster: independent
+  name: Radio Maria England
+  streamUrl: https://dreamsiteradiocp5.com/proxy/rmengland?mp=/stream
+  bitrate: 48
+  codec: AAC+
+  homepage: https://radiomariaengland.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 095033f1-e833-4b6d-99c6-42efd5db789c
+  changeuuid: 8c79edf4-b96e-4051-82a0-45fbea7023de
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bloop-london-radio-channel-4-music-only-themed-s
+  broadcaster: independent
+  name: "Bloop London Radio (channel 4) - MUSIC ONLY THEMED STREAM.  NATURAL HIGH. DRENCHED IN GROOVES, AN ORGANIC JOURNEY OF BEATS DEDICATED TO MOVING YOUR ASS."
+  streamUrl: https://radio.canstream.co.uk:8058/live.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://blooplondon.com/favicon.ico
+  homepage: https://blooplondon.com/
+  country: GB
+  status: stream-only
+  stationuuid: dc67e4a5-1f90-456a-a8d5-f4a4a8dd5a4a
+  changeuuid: 638008eb-86a0-4a83-8c18-1df79952cb67
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-heart-00s
+  broadcaster: independent
+  name: Heart 00s
+  streamUrl: https://media-ssl.musicradio.com/Heart00sMP3
+  bitrate: 128
+  codec: MP3
+  homepage: https://media-ssl.musicradio.com/Heart00sMP3
+  country: GB
+  status: stream-only
+  stationuuid: ea5d9964-6b60-4f75-a95d-2bc5217d245b
+  changeuuid: 70447189-2bab-4073-94f3-7a7b829b7d9e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hearme-beethoven
+  broadcaster: independent
+  name: HearMe-Beethoven
+  streamUrl: https://radio.hearme.fm:9050/stream
+  codec: MP3
+  homepage: http://www.hearme.fm/
+  country: GB
+  status: stream-only
+  stationuuid: a2b45e00-4c11-4968-9fa8-180491247bf7
+  changeuuid: aedd9ec3-3c12-4770-a5a1-015f05cfb709
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hot-gold
+  broadcaster: independent
+  name: Hot Gold
+  streamUrl: https://stream1.hippynet.co.uk/stream/hotgold/dorset
+  bitrate: 160
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/406/61940c9fa5f84.png
+  homepage: https://www.hotgold.radio/
+  country: GB
+  status: stream-only
+  stationuuid: ea615435-d7b8-4957-903b-992acf3d58ca
+  changeuuid: fa2f320f-1877-42eb-8acf-506eab624dd1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-the-prodigy
+  broadcaster: independent
+  name: The Prodigy
+  streamUrl: https://stream.pcradio.ru/The_Prodigy-hi
+  codec: AAC
+  favicon: null
+  homepage: https://pcradio.ru/
+  country: GB
+  status: stream-only
+  stationuuid: 16584bf8-e3e5-447e-8fe1-dee16cc17268
+  changeuuid: e8facd55-922b-4124-9af1-94e22565256e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-ram-fm-80s-hit-radio
+  broadcaster: independent
+  name: Ram FM 80s Hit Radio
+  streamUrl: https://usa1-vn.mixstream.net/8084/listen.mp3
+  bitrate: 64
+  codec: AAC+
+  favicon: https://ramfm.org/favicon.ico
+  homepage: https://ramfm.org/
+  country: GB
+  status: stream-only
+  stationuuid: 36a14570-8c0d-4011-8d79-215dcf5abf8b
+  changeuuid: 1435e75e-73ad-4109-b2b3-171801692529
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-capital-fm-london
+  broadcaster: independent
+  name: Capital FM London
+  streamUrl: https://media-ssl.musicradio.com/CapitalMP3
+  bitrate: 128
+  codec: MP3
+  homepage: https://capitalfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: 038bfc04-cebb-4fc7-ac13-823b83c8a9d9
+  changeuuid: 1115c8cc-6cc1-43c5-a473-c43e30580451
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-rokit-radio-saturn-x-radio-shows
+  broadcaster: independent
+  name: "ROKit Radio : Saturn-X Radio Shows"
+  streamUrl: https://streaming05.liveboxstream.uk/proxy/jondre03/stream
+  bitrate: 48
+  codec: MP3
+  favicon: https://rokitradio.com/favicon.ico
+  homepage: https://rokitradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 12d06507-314e-49cd-85ee-2c454ea33421
+  changeuuid: a297a391-d073-4080-82da-32047e943560
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-totalrock-radio
+  broadcaster: independent
+  name: TotalRock Radio
+  streamUrl: https://s3.citrus3.com:8056/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://scontent.fcgk8-1.fna.fbcdn.net/v/t1.18169-9/11400985_1602513246663466_6035298720034077887_n.jpg?stp=cp0_dst-jpg_e15_fr_q65&_nc_cat=108&ccb=1-7&_nc_sid=7aed08&efg=eyJpIjoiYiJ9&_nc_eui2=AeEETQvQCq6lHutRRfK171iMKMnkfCxBQUgoyeR8LEFBSC8L74DpSPHz7DvwVuHvpZkIi6qJ0_1acvrVbfekHQL9&_nc_ohc=Oo7DzNH7oTMAX_ZluE8&tn=I4UqcoMHerbAkKms&_nc_ht=scontent.fcgk8-1.fna&oh=00_AfBCXINd2TGpeja3jEiHkpvCmVAH0sxg6_Q39XWj5iRvUA&oe=6407F56B
+  homepage: https://totalrock.com/
+  country: GB
+  status: stream-only
+  stationuuid: ee843b89-e69d-4a64-bb8f-0ed8da7a558a
+  changeuuid: b3331de2-4b47-4ef5-9ba2-c5290ec6807b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-asian-star-radio
+  broadcaster: independent
+  name: Asian Star Radio
+  streamUrl: https://radio.canstream.co.uk:9067/live.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: null
+  homepage: https://radio.canstream.co.uk:9067/live.mp3
+  country: GB
+  status: stream-only
+  stationuuid: 995c536d-b45f-4681-920b-3d4bd9661a1b
+  changeuuid: 0badf63e-7faf-4b41-9320-ff3b838563cd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-4tunesfm
+  broadcaster: independent
+  name: "4TunesFM"
+  streamUrl: https://c30.radioboss.fm:18274/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://assets.production.linktr.ee/profiles/_next/static/logo-assets/apple-icon-120x120.png
+  homepage: https://links.4tunefm.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 1be154bf-1aa6-4637-89d8-f394780479fc
+  changeuuid: f432b59f-1f77-4742-a67a-1adacf7293d2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-gb-news
+  broadcaster: independent
+  name: GB News
+  streamUrl: https://amg01076-lightningintern-gbnews-samsunguk-0lu52.amagi.tv/playlist/amg01076-lightningintern-gbnews-samsunguk/playlist.m3u8
+  bitrate: 1020
+  codec: AAC
+  homepage: https://superradio.cc/
+  country: GB
+  status: stream-only
+  stationuuid: 22eb42bb-ced7-4556-b902-e789d4411ff3
+  changeuuid: 0ac00d0a-3280-4d87-b34b-70c0a30766bb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-heart-fm
+  broadcaster: independent
+  name: Heart FM
+  streamUrl: https://media-ssl.musicradio.com/HeartUK
+  bitrate: 48
+  codec: AAC
+  favicon: https://cdn-profiles.tunein.com/s320841/images/logod.jpg?t=638651487420000000
+  homepage: https://www.heart.co.uk/london/radio/
+  country: GB
+  status: stream-only
+  stationuuid: 42679ed6-49cb-428e-9b74-94af62ad8a0a
+  changeuuid: 9aa60fed-b878-40bb-9965-8554962ff06b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hot-hits-uk-com
+  broadcaster: independent
+  name: Hot Hits UK.com
+  streamUrl: https://443-1.autopo.st/54/stream.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://hothitsuk.com/wp-content/uploads/2020/09/HHUK-3D-transparent-300-x-200.png
+  homepage: https://www.hothitsuk.com/
+  country: GB
+  status: stream-only
+  stationuuid: 5a7ddeac-be16-4090-a77b-b9ead4ed74db
+  changeuuid: 0f6c930a-7767-4e01-8a1c-ae297fe4b0ba
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-rokit-radio-american-classic-radio-shows
+  broadcaster: independent
+  name: "ROKit Radio : American Classic Radio Shows"
+  streamUrl: https://streaming05.liveboxstream.uk/proxy/jondre01/stream
+  bitrate: 48
+  codec: MP3
+  favicon: https://rokitradio.com/images/channels/american_classics.jpg
+  homepage: https://rokitradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 366dde91-14e4-4634-8d5b-ff70ccd97f3c
+  changeuuid: 767c296a-4bf6-4db8-93d4-05135193ea5a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-heart-80s
+  broadcaster: independent
+  name: Radio Heart 80s
+  streamUrl: https://ice-sov.musicradio.com/Heart80sMP3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.heart.co.uk/80s
+  country: GB
+  status: stream-only
+  stationuuid: 4054f742-9af5-4ef0-bca7-70366ad2dbaf
+  changeuuid: 35cc4022-1468-4075-9a9c-d7ba10383895
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-rafa-bible-radio-english
+  broadcaster: independent
+  name: Rafa Bible Radio English
+  streamUrl: https://gains.reviveradio.net/proxy/rafabibleradioeng?mp=/stream
+  bitrate: 128
+  codec: MP3
+  homepage: http://www.rafaradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 086b2f96-7453-45d8-b672-467cb54d8edf
+  changeuuid: 66cd91d0-cb91-4c6e-89fc-e412922284fc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-faza
+  broadcaster: independent
+  name: Radio Faza
+  streamUrl: https://radiocast.cr8tive-digital.com/radiofaza
+  bitrate: 128
+  codec: MP3
+  favicon: https://radiofaza.co.uk/favicon.ico
+  homepage: https://radiofaza.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 3101bfd5-5279-4fbb-864f-e742ac85cc55
+  changeuuid: 422bf2ae-c53b-4a32-abfd-2edf99c3d7c7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-smooth-80s
+  broadcaster: independent
+  name: Smooth 80s
+  streamUrl: https://media-ice.musicradio.com/Smooth80sMP3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.smoothradio.com/80s/
+  country: GB
+  status: stream-only
+  stationuuid: 96568036-4928-44ba-a54e-c4db0b5463f2
+  changeuuid: 28db5651-2cb2-430a-b7dd-d9cda0fc00d1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-sunrise-radio
+  broadcaster: independent
+  name: Sunrise Radio
+  streamUrl: https://direct.sharp-stream.com/sunriseradio.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.sunriseradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: d835e8dc-a3cd-490b-9881-fa5c7b1c2280
+  changeuuid: 096f5ebe-dda9-4921-9f46-6573c608572c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-calm-n-chill-radio
+  broadcaster: independent
+  name: Calm N Chill Radio
+  streamUrl: https://stream.zeno.fm/yvcddifycietv
+  codec: MP3
+  favicon: https://cloud-4shg5daq1-hack-club-bot.vercel.app/0calm_n_chill_radio_logo.png
+  homepage: https://theresmarty.pages.dev/
+  country: GB
+  status: stream-only
+  stationuuid: 108a36e8-75b9-4b4d-8893-1ea2bda3d0fa
+  changeuuid: 0ed66fc8-fb09-4fc8-8bbd-be92713e0a5f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-nazareth
+  broadcaster: independent
+  name: Nazareth
+  streamUrl: https://stream.pcradio.ru/Nazareth-hi
+  codec: AAC
+  favicon: null
+  homepage: https://pcradio.ru/
+  country: GB
+  status: stream-only
+  stationuuid: bab974f5-7ba2-4f4d-8dfb-9b462c5079fa
+  changeuuid: 83c5f6b5-b371-4a24-94cc-beede79d0cb2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-lyca-dil-se-radio
+  broadcaster: independent
+  name: Lyca Dil se radio
+  streamUrl: https://edge-ads-03-gos2.sharp-stream.com/1035.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: null
+  homepage: https://edge-ads-03-gos2.sharp-stream.com/1035.mp3
+  country: GB
+  status: stream-only
+  stationuuid: 1ddeb917-4826-4418-93f2-78aa8e4a5328
+  changeuuid: abca1fcc-c284-4bcd-8163-83a7cc5b4e1f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-old-skool-rave-tapes
+  broadcaster: independent
+  name: Old Skool Rave Tapes
+  streamUrl: https://azuracast.oldskoolravetapes.co.uk/listen/old_skool_rave_tapes/backup?refresh=1744812055358
+  bitrate: 96
+  codec: AAC
+  favicon: https://oldskoolravetapes.co.uk/wp-content/uploads/2023/02/Old-Skool-Rave-Tapes-New-512.jpg
+  homepage: https://oldskoolravetapes.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: e1a177e9-5947-46a4-8757-0415c9b106bc
+  changeuuid: 35ecd5bf-2cdc-4072-9f90-bd143aea8e96
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-24-7-edm-radio
+  broadcaster: independent
+  name: "24/7 EDM Radio"
+  streamUrl: https://ec6.yesstreaming.net:1455/stream
+  bitrate: 64
+  codec: MP3
+  favicon: https://www.247onlineradio.com/wp-content/uploads/2023/04/247-EDM-Radio.jpg
+  homepage: https://www.247onlineradio.com/24-7-edm-radio/
+  country: GB
+  status: stream-only
+  stationuuid: 917a434d-c9a0-4a68-9cc5-7def1ab1b957
+  changeuuid: 93027261-1dc5-48d4-8db7-8fdc61b8049f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-24-7-jazz-radio
+  broadcaster: independent
+  name: "24/7 Jazz Radio"
+  streamUrl: https://ec3.yesstreaming.net:3455/stream
+  bitrate: 64
+  codec: MP3
+  favicon: https://www.247onlineradio.com/wp-content/uploads/2020/02/247-Jazz-Radio.jpg
+  homepage: https://www.247onlineradio.com/24-7-jazz-radio/
+  country: GB
+  status: stream-only
+  stationuuid: 11c067d9-0f68-4773-9bc2-335072309c71
+  changeuuid: 47a1852a-b15e-4f33-9c18-02fda2b0e900
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-oldskool-uk
+  broadcaster: independent
+  name: Oldskool UK
+  streamUrl: https://usa10.fastcast4u.com:8880/
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.oldskool.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 6f8f7281-c0c9-48bd-955c-83f4729ec67c
+  changeuuid: 6eb4c526-676e-4975-bed3-9a4a6f350b26
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-now-rock
+  broadcaster: independent
+  name: Now Rock
+  streamUrl: https://lightning-now90s-samsungnz.amagi.tv/playlist.m3u8
+  bitrate: 1020
+  codec: AAC,H.264
+  homepage: https://nowmusic.com/
+  country: GB
+  status: stream-only
+  stationuuid: 524038f7-543b-4fed-91f9-8222adea4305
+  changeuuid: 1247ec9b-bbaa-41d1-a0e2-56713cfda065
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-the-beatles
+  broadcaster: independent
+  name: The Beatles
+  streamUrl: https://stream.pcradio.ru/The_Beatles-hi
+  codec: AAC
+  favicon: null
+  homepage: https://pcradio.ru/radio
+  country: GB
+  status: stream-only
+  stationuuid: 620bfdce-d62b-4b51-8125-3b6fde79a2b0
+  changeuuid: 891de09a-f637-4062-8eaa-0aa17e33f4b6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-80s-rhythm
+  broadcaster: independent
+  name: "80s Rhythm"
+  streamUrl: https://stream.mybroadbandradio.com/80srhythmhq/
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.80srhythm.com/
+  country: GB
+  status: stream-only
+  stationuuid: cab769d2-af4b-457c-b7e0-8d097ce872f1
+  changeuuid: 6f59e0d8-4042-427c-a66e-0df650210379
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-globl-funk-radio
+  broadcaster: independent
+  name: Globl Funk Radio
+  streamUrl: https://securestreams2.autopo.st:1148/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.globalfunkradio.com/favicon/128x128.png
+  homepage: https://www.globalfunkradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 88360635-3913-43c8-a72f-71a477fe3584
+  changeuuid: f5adab7d-a47d-4dad-9524-07f7a1428707
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-the-sounds-of-gta-nts
+  broadcaster: independent
+  name: "The Sounds of GTA | NTS"
+  streamUrl: https://stream-mixtape-geo.ntslive.net/mixtape33
+  codec: MP3
+  favicon: https://www.nts.live/favicon.ico
+  homepage: https://www.nts.live/infinite-mixtapes/the-sound-of-gta
+  country: GB
+  status: stream-only
+  stationuuid: ad8eab8a-6b18-4833-a13d-dad173aacc08
+  changeuuid: 6b43104a-b159-4406-a2f2-b65c979acfa1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bbc-radio-leeds
+  broadcaster: independent
+  name: BBC Radio Leeds
+  streamUrl: https://as-hls-ww-live.akamaized.net/pool_50115440/live/ww/bbc_radio_leeds/bbc_radio_leeds.isml/bbc_radio_leeds-audio%3d96000.norewind.m3u8
+  codec: UNKNOWN
+  favicon: https://sounds.files.bbci.co.uk/3.5.0/services/bbc_radio_leeds/blocks-colour_600x600.png
+  homepage: https://www.bbc.co.uk/schedules/p00fzl7w
+  country: GB
+  status: stream-only
+  stationuuid: 3c811494-8c26-4f97-b3da-5c0b7d49b6a0
+  changeuuid: d2d04146-0a70-4d5e-8a90-a481ba5c0d4a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bristol-sound-webradio
+  broadcaster: independent
+  name: Bristol Sound Webradio
+  streamUrl: https://thebristolsoundwebradio.stream.laut.fm/thebristolsoundwebradio
+  bitrate: 128
+  codec: MP3
+  favicon: https://64.media.tumblr.com/8d23b78c8346101f620e06d5ce5e7165/tumblr_pmqf9sPig21uq8z6lo1_r2_400.jpg
+  homepage: https://bristol-sound-webradio.tumblr.com/LISTEN
+  country: GB
+  status: stream-only
+  stationuuid: cdc4a71a-cb5f-4f05-8073-4ef3d72bfdf2
+  changeuuid: 1e47deef-d7e9-444c-9592-b346f9abbb02
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-venture-radio-pumpkin-fm
+  broadcaster: independent
+  name: Venture Radio - Pumpkin FM
+  streamUrl: https://cast2.asurahosting.com/proxy/ventureradio/stream
+  bitrate: 64
+  codec: MP3
+  favicon: https://pumpkinfm.com/wp-content/uploads/2019/02/VentureRadio300x300.jpg
+  homepage: https://pumpkinfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: 9d337e34-ff59-4933-be3e-16e21bea4318
+  changeuuid: 32308122-18a7-4a1b-9c53-6cf43a4a127a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-infrared-fm
+  broadcaster: independent
+  name: Infrared.fm
+  streamUrl: https://carol.epichosts.co.uk:8232/live.mp3
+  bitrate: 256
+  codec: MP3
+  favicon: http://infrared.fm/favicon.ico
+  homepage: http://infrared.fm/
+  country: GB
+  status: stream-only
+  stationuuid: 6a79ad48-3c95-472d-bdf0-850c1172cf69
+  changeuuid: d10573b5-82d1-4698-8720-7032ee88f235
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-revolution-radio-one
+  broadcaster: independent
+  name: Revolution Radio One
+  streamUrl: https://visual.shoutca.st/stream/revolutionone/stream
+  bitrate: 320
+  codec: AAC
+  favicon: https://static.wixstatic.com/media/a4f5c5_466d1b7b03424018be005a100fda1990%7emv2_d_1726_1562_s_2.png/v1/fill/w_180%2ch_180%2clg_1%2cusm_0.66_1.00_0.01/a4f5c5_466d1b7b03424018be005a100fda1990%7emv2_d_1726_1562_s_2.png
+  homepage: https://revolutionradio.online/revolutionone
+  country: GB
+  status: stream-only
+  stationuuid: 78290cd1-3301-4dd9-bc6a-999fcf70654b
+  changeuuid: e18bc30d-d4e8-4144-be9e-4672c03a8a3f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-deep-purple
+  broadcaster: independent
+  name: Deep Purple
+  streamUrl: https://stream.pcradio.ru/Deep_purple-hi
+  codec: AAC
+  favicon: null
+  homepage: https://pcradio.ru/
+  country: GB
+  status: stream-only
+  stationuuid: 53d055fb-9364-4d12-be68-f61d4c14c0b3
+  changeuuid: da1349e8-0fa2-44f2-96a3-e12c4871180a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hearme-60s-rock
+  broadcaster: independent
+  name: HearMe - 60s Rock
+  streamUrl: https://radio.hearme.fm:8230/stream
+  codec: MP3
+  homepage: https://hearme.fm/
+  country: GB
+  status: stream-only
+  stationuuid: dd24eb09-84cb-4d9e-aca4-4c2ed71e624d
+  changeuuid: 8678e808-b3b5-452b-a975-f0fdf1eee1fd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-xl-uk-radio
+  broadcaster: independent
+  name: "XL:UK Radio"
+  streamUrl: https://s3.radio.co/s113a5dc46/listen
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.xlukradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 124c45d7-57a9-46ed-8b93-83b306992126
+  changeuuid: 00cb2969-bf6f-47a5-811f-8a089bd9d265
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bbc-radio-nottingham
+  broadcaster: independent
+  name: BBC Radio Nottingham
+  streamUrl: https://a.files.bbci.co.uk/ms6/live/3441A116-B12E-4D2F-ACA8-C1984642FA4B/audio/simulcast/hls/nonuk/audio_syndication_low_sbr_v1/aks/bbc_radio_nottingham.m3u8
+  bitrate: 101
+  codec: AAC+
+  favicon: https://static.mytuner.mobi/media/tvos_radios/U3M5n4tQDu.png
+  homepage: https://www.radio-uk.co.uk/bbc-radio-nottingham
+  country: GB
+  status: stream-only
+  stationuuid: 3e0d94fa-114f-4135-88ac-28b084996929
+  changeuuid: 75c54d90-5930-4f13-ae67-9822a48b0ae3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-https-www-differentdrumz-co-uk
+  broadcaster: independent
+  name: "https://www.differentdrumz.co.uk/"
+  streamUrl: https://differentdrumz.radioca.st/stream%20;
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.differentdrumz.co.uk/wp-content/uploads/2016/02/Tune-In-Pic.png
+  homepage: https://www.differentdrumz.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: c0616d81-b9c1-4dfe-bfa2-8f6b486c6339
+  changeuuid: c8f852ae-c2ae-4d57-b759-35c07bf47617
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-the-pit-nts
+  broadcaster: independent
+  name: "The Pit | NTS"
+  streamUrl: https://stream-mixtape-geo.ntslive.net/mixtape34
+  codec: MP3
+  favicon: https://www.nts.live/favicon.ico
+  homepage: https://www.nts.live/infinite-mixtapes/the-pit
+  country: GB
+  status: stream-only
+  stationuuid: 2eb49b46-e056-4628-80c3-f63f685d22a4
+  changeuuid: 6d293761-83ad-4dda-93c1-cfe60e22d6c1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-classic-fm-music-for-pets
+  broadcaster: independent
+  name: Classic FM Music For Pets
+  streamUrl: https://media-ssl.musicradio.com/ClassicFM-M-Pets
+  bitrate: 48
+  codec: AAC
+  homepage: https://www.classicfm.com/lifestyle/pets/
+  country: GB
+  status: stream-only
+  stationuuid: 3485c69f-fc47-4081-aafd-ab77a24fdd7d
+  changeuuid: 45661f56-7807-4544-8efb-e1e6d7445d15
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-smooth-chill-focus
+  broadcaster: independent
+  name: Smooth Chill Focus
+  streamUrl: https://media-ssl.musicradio.com/SmoothChill-M-Concentration?
+  bitrate: 48
+  codec: AAC
+  homepage: https://www.radio-uk.co.uk/chill
+  country: GB
+  status: stream-only
+  stationuuid: a6491d20-4dff-491f-827e-af15b35df655
+  changeuuid: b30338b4-debe-4539-976b-012b386a913e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-dance-anthems-radio
+  broadcaster: independent
+  name: Dance Anthems Radio
+  streamUrl: https://stream3.themediasite.co.uk/stream/danceanthems
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.danceanthemsradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 9c099bc8-3bfa-46fc-90a8-6c7da95e6f3c
+  changeuuid: f641b074-30cf-4460-8b42-f3540c8e99e1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-love-soul-radio-london
+  broadcaster: independent
+  name: Love Soul Radio London
+  streamUrl: https://s1.citrus3.com:8018/stream
+  bitrate: 128
+  codec: AAC
+  favicon: https://static.thenounproject.com/png/128478-200.png
+  homepage: https://lovesoulradiolondon.org/
+  country: GB
+  status: stream-only
+  stationuuid: 7a2244bc-06e1-4307-99b1-4cdeaad2e8b3
+  changeuuid: ee9b2249-4639-40d5-abe9-26a8a2387fd3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-24-7-scifi-radio
+  broadcaster: independent
+  name: "24/7 SciFi Radio"
+  streamUrl: https://ec6.yesstreaming.net:1465/stream
+  bitrate: 64
+  codec: MP3
+  favicon: https://www.247onlineradio.com/wp-content/uploads/2023/04/2019-08-24-16.30.25-scaled.jpg
+  homepage: https://www.247onlineradio.com/24-7-online-radio-group-stations/24-7-scifi-radio/
+  country: GB
+  status: stream-only
+  stationuuid: 70bb22f0-8cd6-416f-ad17-54783844c7a4
+  changeuuid: 611be021-11f7-4401-ba88-7292e084d24f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-rainbow
+  broadcaster: independent
+  name: Rainbow
+  streamUrl: https://stream.pcradio.ru/Rainbow-hi
+  codec: AAC
+  favicon: null
+  homepage: https://pcradio.ru/
+  country: GB
+  status: stream-only
+  stationuuid: 2f15bbc2-be6f-459b-887b-01553272be62
+  changeuuid: 1f067083-90bb-4160-8a48-4a18efe64eae
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-itch-fm
+  broadcaster: independent
+  name: Itch.FM
+  streamUrl: https://streaming.radio.co/s264858a04/listen
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.itch.fm/
+  country: GB
+  status: stream-only
+  stationuuid: 6b957e67-a5ed-438a-b919-3d536d3d9019
+  changeuuid: 159933d0-1dd1-41c9-9311-2473e6f53ec6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-otaku-nts
+  broadcaster: independent
+  name: "Otaku | NTS"
+  streamUrl: https://stream-mixtape-geo.ntslive.net/mixtape36
+  codec: MP3
+  favicon: https://www.nts.live/favicon.ico
+  homepage: https://www.nts.live/infinite-mixtapes/otaku
+  country: GB
+  status: stream-only
+  stationuuid: 1047345d-6bf5-4d89-98d7-137eb552ddc6
+  changeuuid: 44797ab4-30a2-4f91-be39-0252155b626c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-dance-classics-uk
+  broadcaster: independent
+  name: Dance Classics UK
+  streamUrl: https://stream4.themediasite.co.uk/stream/danceclassics
+  bitrate: 192
+  codec: AAC
+  favicon: https://static2.mytuner.mobi/media/tvos_radios/ku8qxjlffvfr.png
+  homepage: http://www.danceclassics.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: b57cef96-d760-4d33-b743-46f0f1a4591b
+  changeuuid: 7e3009ce-6f5e-431c-9ea5-d62cc93e85e7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-dragon-radio
+  broadcaster: independent
+  name: Dragon Radio
+  streamUrl: https://listen-nation.sharp-stream.com/tcnationdigital.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.nationplayer.com/dragon-radio/
+  country: GB
+  status: stream-only
+  stationuuid: 339553b3-3e86-466e-b340-d0bd84353122
+  changeuuid: 29db4da4-54b6-44f7-b39a-69f7da314f0c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-malvern-radio-jrs-pumpkin-fm
+  broadcaster: independent
+  name: Malvern Radio JRS - Pumpkin FM
+  streamUrl: https://cast2.asurahosting.com/proxy/malvernradiojrs/stream
+  bitrate: 128
+  codec: MP3
+  homepage: https://pumpkinfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: 53c0f24f-7021-4349-a2e0-b63a40f2aed6
+  changeuuid: d128417e-37c5-4ff7-8560-1ffb0d611a8d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-playback-uk
+  broadcaster: independent
+  name: Playback UK
+  streamUrl: https://chilledstreaming.com:8650/mobile.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.playbackuk.com/wp-content/uploads/2021/01/cropped-pbuk-123-192x192.jpg
+  homepage: https://www.playbackuk.com/
+  country: GB
+  status: stream-only
+  stationuuid: 138e0496-c5f1-48a0-8cad-764fb23dfec9
+  changeuuid: 101b78ef-436b-4b10-b67b-febffd9e9d75
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-dance-90s
+  broadcaster: independent
+  name: RADIO DANCE 90s
+  streamUrl: https://radiodance.streamingmedia.it/uk.aac
+  bitrate: 320
+  codec: AAC+
+  favicon: https://www.radio.dance/logo_radiodance90s_512.png
+  homepage: https://www.radio.dance/
+  country: GB
+  status: stream-only
+  stationuuid: b712c71b-8dfd-4670-ba9e-33a1decea395
+  changeuuid: d274a88d-7bc1-46c3-8c56-a9037f46732a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-simulator-radio
+  broadcaster: independent
+  name: Simulator Radio
+  streamUrl: https://simulatorradio.stream/stream.mp3
+  bitrate: 320
+  codec: MP3
+  homepage: https://simulatorradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: f2a3a51f-e0cb-4b3a-b7dd-b7bc91f8ee3a
+  changeuuid: ed7ba5c2-06d8-4283-92f4-1780174773df
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-powerhouse-radio
+  broadcaster: independent
+  name: Powerhouse Radio
+  streamUrl: https://streaming.broadcastradio.com:11065/powerhouse
+  codec: MP3
+  homepage: https://powerhouseradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 4c67bfd4-c12e-4020-b294-cc41568f001e
+  changeuuid: d66cbdb1-8a22-4858-9a5c-76962fa68325
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-salaam-radio
+  broadcaster: independent
+  name: Salaam Radio
+  streamUrl: https://radio.canstream.co.uk:8005/live.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://storage.googleapis.com/salaamradio-live/landing-page/_ui/media/logo.png
+  homepage: https://www.salaamradio.co.uk/#
+  country: GB
+  status: stream-only
+  stationuuid: 7cae1159-a663-488a-952f-b98449b8ca51
+  changeuuid: cb11a469-bd25-43e6-80a0-f7fa9e486df2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-go-radio-glasgow
+  broadcaster: independent
+  name: Go Radio Glasgow
+  streamUrl: https://streaming.broadcastradio.com:8252/goradio
+  bitrate: 128
+  codec: MP3
+  favicon: https://thisisgo.co.uk/wp-content/uploads/2023/04/go-logo.png
+  homepage: https://thisisgo.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: f3d2adf5-822b-4e7d-928a-fe914ce4b8b1
+  changeuuid: 0ee58555-a766-4b43-bb0d-0c0f557e3e61
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-jazz-fm91
+  broadcaster: independent
+  name: JAZZ.FM91
+  streamUrl: https://jazzfm91.streamb.live/SB00009
+  bitrate: 131
+  codec: AAC
+  homepage: https://jazz.fm/
+  country: GB
+  status: stream-only
+  stationuuid: 64990fa2-2e54-4a32-a300-32b0232e11fc
+  changeuuid: c2be3ae0-4cb4-4db8-b288-d6c5df8775b6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-premier-christian-radio
+  broadcaster: independent
+  name: Premier Christian Radio
+  streamUrl: https://pcr.streamguys1.com/pcrnational-96k.aac
+  bitrate: 56
+  codec: AAC
+  favicon: https://www.premier.plus/images/common/logo-animated-50ms.gif
+  homepage: https://www.premier.plus/stations/premier-christian-radio
+  country: GB
+  status: stream-only
+  stationuuid: 87cbedde-e9ea-465b-87d8-3a72fcc4e3b5
+  changeuuid: 532b4ba5-cb7b-4212-91db-78ada02e443f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-xpression-fm-bollywood
+  broadcaster: independent
+  name: Xpression FM Bollywood
+  streamUrl: https://casper.radioca.st/
+  bitrate: 128
+  codec: MP3
+  favicon: null
+  homepage: https://casper.radioca.st/
+  country: GB
+  status: stream-only
+  stationuuid: b6622298-f0fd-4fbc-bdcf-f929da731642
+  changeuuid: f30c75fa-ede3-4f2f-a77f-ce3fc380d375
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-rustradio
+  broadcaster: independent
+  name: RustRadio
+  streamUrl: https://listen.rustradio.co.uk:8443/stream
+  bitrate: 320
+  codec: MP3
+  favicon: https://rustradio.co.uk/images/RRDefault.png
+  country: GB
+  status: stream-only
+  stationuuid: fe7013ef-1d5c-4966-9ad2-a68f36562325
+  changeuuid: ff70bdec-406e-4c40-bde2-5a8041142331
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-the-mix-radio-80s
+  broadcaster: independent
+  name: The Mix Radio 80s
+  streamUrl: https://tmr80s.radioca.st/stream
+  bitrate: 256
+  codec: MP3
+  favicon: https://static.mytuner.mobi/media/tvos_radios/390/the-mix-radio-80s.dd4413ea.png
+  homepage: https://www.themixradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 72fe5798-bf1e-4df9-b4d9-aa4712a189f4
+  changeuuid: e1cb12f8-4a91-4a44-b22b-354482ceb94f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-fred-film-radio-28-education
+  broadcaster: independent
+  name: Fred Film Radio-28 Education
+  streamUrl: https://s10.webradio-hosting.com/proxy/fredradioedu/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.fred.fm/wp-content/uploads/2014/12/Fred-Logo_trasp_-copia.png
+  homepage: https://www.fred.fm/
+  country: GB
+  status: stream-only
+  stationuuid: a9872d56-95ab-49d0-87a6-b740c0589c31
+  changeuuid: fb5acb6c-3206-48d4-91bb-46854000cdb2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-like-anthems
+  broadcaster: independent
+  name: Like Anthems
+  streamUrl: https://likeradiostream.com/likeanthemsaac
+  bitrate: 48
+  codec: AAC+
+  homepage: https://like.radio/
+  country: GB
+  status: stream-only
+  stationuuid: a9aa4326-cbf3-4dc7-9f97-c955d3c2c04d
+  changeuuid: b9d1ee1b-bdb3-49e2-9159-ed6d02573aab
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-smokie
+  broadcaster: independent
+  name: Smokie
+  streamUrl: https://stream.pcradio.ru/smokie-hi
+  codec: AAC
+  favicon: null
+  homepage: https://pcradio.ru/
+  country: GB
+  status: stream-only
+  stationuuid: dd100cfe-ec81-4aa5-929b-79f4bf47841c
+  changeuuid: 5b2a0ad0-1243-4961-ad4f-7095b7388e76
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-24-7-bossa-nova-radio
+  broadcaster: independent
+  name: "24/7 Bossa Nova Radio"
+  streamUrl: https://ec6.yesstreaming.net:1605/stream
+  bitrate: 64
+  codec: MP3
+  favicon: https://www.247onlineradio.com/wp-content/uploads/2023/04/247-Bossa-Nova-Radio.jpg
+  homepage: https://www.247onlineradio.com/24-7-online-radio-group-stations/24-7-bossa-nova-radio/
+  country: GB
+  status: stream-only
+  stationuuid: eda8b900-0ac5-4248-8499-fe23c729ad9c
+  changeuuid: 4e1e8e5a-70a2-4dca-9c79-102a92f72f8b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-fred-film-radio-english
+  broadcaster: independent
+  name: FRED FILM RADIO English
+  streamUrl: https://s10.webradio-hosting.com/proxy/fredradioen/stream
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.fred.fm/
+  country: GB
+  status: stream-only
+  stationuuid: 8a751974-b40c-4677-881d-8f0215a03c48
+  changeuuid: e1b7e04a-14ed-4a15-9ddd-064ea49b7425
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-progzilla-radio
+  broadcaster: independent
+  name: Progzilla_Radio
+  streamUrl: https://radio.progzilla.com/main
+  bitrate: 52
+  codec: AAC
+  favicon: http://www.progzilla.com/favicon.ico
+  homepage: http://www.progzilla.com/
+  country: GB
+  status: stream-only
+  stationuuid: 0c853606-cf48-43db-8e5e-3b6db2e7e678
+  changeuuid: a23e68ac-8344-47c3-88d2-a91c0de99f94
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-24-7-nature-radio
+  broadcaster: independent
+  name: "24/7 Nature Radio"
+  streamUrl: https://ec3.yesstreaming.net:3545/stream
+  bitrate: 64
+  codec: MP3
+  favicon: https://www.getmeradio.com/stations/247natureradio-4493/logos/512x512.png
+  homepage: https://www.247natureradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 8a4f4537-5231-4d3e-864e-e834ca2c4732
+  changeuuid: fddfa440-3215-4316-b778-b3e24f5e2cc3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-dance-uk
+  broadcaster: independent
+  name: Dance UK
+  streamUrl: https://dancestream.danceradiouk.com/stream/1/stream.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://danceradiouk.com/players/files/images/albumart/13040-DanceUK-300.jpg
+  homepage: https://www.danceradiouk.com/
+  country: GB
+  status: stream-only
+  stationuuid: 4f423b65-faae-4d46-992b-e865af169e9a
+  changeuuid: 8c2af463-20ce-481d-bf1c-1c0cf27c8ef5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-heart-wiltshire
+  broadcaster: independent
+  name: Heart Wiltshire
+  streamUrl: https://media-ssl.musicradio.com/HeartWiltshireMP3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.heart.co.uk/wiltshire/
+  country: GB
+  status: stream-only
+  stationuuid: 2b4cf5e1-0f29-4e0e-b04b-e743a79f729a
+  changeuuid: b0e5b8bd-9a88-4d2a-bdc8-acc94e24c8cb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-house-fm
+  broadcaster: independent
+  name: House FM
+  streamUrl: https://uksoutha.streaming.broadcast.radio:19920/housefm
+  bitrate: 128
+  codec: MP3
+  favicon: https://hse.fm/cdn/shop/files/logo_on_content_c7615023-6bff-4bf9-8841-9a9916b5a3b0_2500x.png?v=1615321261
+  homepage: https://hse.fm/
+  country: GB
+  status: stream-only
+  stationuuid: 1a421361-eb9f-40e9-9ab1-1a4ca39b90dd
+  changeuuid: d5c412c0-162e-432c-a732-8e9ffa97ee76
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-uk-health-radio
+  broadcaster: independent
+  name: UK Health Radio
+  streamUrl: https://streaming.radio.co/s8e535ff20/listen
+  bitrate: 128
+  codec: MP3
+  favicon: https://ukhealthradio.com/wp-content/themes/ukhealthradio_new/assets/img/ukhealthdario_logo.png
+  homepage: https://ukhealthradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: d019ccf6-722b-4828-817a-a56964ff2aab
+  changeuuid: ad816ef6-c6a6-4374-81cd-0fa72826904a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-capital-anthems
+  broadcaster: independent
+  name: Capital Anthems
+  streamUrl: https://media-ice.musicradio.com/CapitalAnthemsMP3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.capitalfm.com/anthems/
+  country: GB
+  status: stream-only
+  stationuuid: f0e3ae87-cdcd-4abe-bb25-7f1bc14e1ec2
+  changeuuid: 64564555-2e70-4aca-ad8c-e32e7aa58b20
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-easylistening-com
+  broadcaster: independent
+  name: EasyListening.com
+  streamUrl: https://easylistening.out.airtime.pro/easylistening_a
+  bitrate: 64
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/7c2261_da98addc261649d699647544ae301897~mv2.jpg/v1/fill/w_488,h_88,al_c,lg_1,q_80,enc_auto/7c2261_da98addc261649d699647544ae301897~mv2.jpg
+  homepage: https://www.easylistening.com/
+  country: GB
+  status: stream-only
+  stationuuid: 3b43bbfa-1562-41f8-9faf-7645e0215deb
+  changeuuid: 0c97c178-2174-470b-972f-fc6f2d7a8883
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-fred-film-radio-extra
+  broadcaster: independent
+  name: Fred Film Radio Extra
+  streamUrl: https://s10.webradio-hosting.com/proxy/fredradioec/stream
+  bitrate: 128
+  codec: MP3
+  homepage: http://www.fred.fm/
+  country: GB
+  status: stream-only
+  stationuuid: 71e40131-5d2f-44d0-ae14-40e22582c777
+  changeuuid: d78fc640-677b-4a88-92a9-7bfaf21a77e4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-intamixx-desi-radio-uk
+  broadcaster: independent
+  name: Intamixx Desi Radio UK
+  streamUrl: https://radio.intamixx.uk:8443/radio1
+  bitrate: 128
+  codec: MP3
+  favicon: https://radio.intamixx.uk/images/intamixx.jpg
+  homepage: https://radio.intamixx.uk/#hero
+  country: GB
+  status: stream-only
+  stationuuid: 9b59f5a2-6676-4276-a822-8461c7ba5d1b
+  changeuuid: 736dd99f-2615-45a5-8838-4848fa4dc40b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-totally-wired-radio
+  broadcaster: independent
+  name: Totally Wired Radio
+  streamUrl: https://totallywired.out.airtime.pro/totallywired_a
+  bitrate: 192
+  codec: MP3
+  favicon: https://totallywiredradio.com/radio/wp-content/uploads/2019/04/TWR-fb.png
+  homepage: https://totallywiredradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: a6f07bae-327a-4a76-bd1d-f305c1af35a1
+  changeuuid: 7e62c222-4021-44be-bd3e-f348e17dea7a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-great-yorkshire-radio
+  broadcaster: independent
+  name: Great Yorkshire Radio
+  streamUrl: https://stream1.superstreaming.co.uk/proxy/greatyorkshire/stream
+  bitrate: 192
+  codec: MP3
+  favicon: https://greatyorkshireradio.co.uk/images/GYRWEBLOGO.jpg
+  homepage: https://greatyorkshireradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 84a83085-ddf6-4113-8f7d-f7e87fd5011a
+  changeuuid: cc24490d-c11f-4678-b4cb-bb2b520e73f9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-ram-fm-80s-hit-radio-2
+  broadcaster: independent
+  name: RAM FM - 80s Hit Radio
+  streamUrl: https://cc6.beheerstream.com/proxy/ramfm?mp=/stream
+  bitrate: 320
+  codec: MP3
+  homepage: https://ramfm.org/
+  country: GB
+  status: stream-only
+  stationuuid: f36d78ce-98a7-43f1-8537-a36539ff7c04
+  changeuuid: 1e5e39ae-bcb7-45b8-989e-7a83b5888957
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-rap-house-infinite-mixtapes-nts
+  broadcaster: independent
+  name: "Rap House - Infinite Mixtapes | NTS"
+  streamUrl: https://stream-mixtape-geo.ntslive.net/mixtape22
+  codec: MP3
+  homepage: https://www.nts.live/infinite-mixtapes/rap-house
+  country: GB
+  status: stream-only
+  stationuuid: 4e5fc635-8d2a-4e80-b44f-d07315892705
+  changeuuid: 18b3097e-13fc-44ef-be4a-64b72fdafb4b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-planet-rock-where-rock-lives
+  broadcaster: independent
+  name: " PLANET ROCK: Where Rock Lives"
+  streamUrl: https://stream-mz.hellorayo.co.uk/planetrock.aac?direct=true&aw_0_1st.playerid=BMUK_Airable&aw_0_1st.skey=6778249992
+  bitrate: 47
+  codec: AAC+
+  favicon: https://cdn-profiles.tunein.com/s2377/images/logod.png
+  homepage: https://www.hellorayo.co.uk/planet-rock
+  country: GB
+  status: stream-only
+  stationuuid: dec031e0-4419-45d2-9f3e-76e91d876c40
+  changeuuid: f8191e12-58f1-4315-9208-90311bdb9ec0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-107-8-black-diamond-fm
+  broadcaster: independent
+  name: "107.8 Black Diamond FM"
+  streamUrl: https://icecast-s.bdfm.radio/blackdiamondfm?icecast
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.blackdiamondfm.com/favicon.ico
+  homepage: https://www.blackdiamondfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: ae9befe3-a2db-46be-9906-3383e3454d39
+  changeuuid: efe59af9-b0ec-47d4-875b-8e5a1b72e895
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-lcrfm-103-6-lincoln
+  broadcaster: independent
+  name: LCRFM 103.6 Lincoln
+  streamUrl: https://streaming.broadcast.radio/lincoln
+  codec: MP3
+  homepage: https://lcrlincoln.com/
+  country: GB
+  status: stream-only
+  stationuuid: 13b5607d-f44d-43db-b08d-b0bf7ebe3ca3
+  changeuuid: 53e9781f-e877-4698-a8ec-72b44a85acb1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-noods-radio
+  broadcaster: independent
+  name: "Noods Radio "
+  streamUrl: https://noods-radio.radiocult.fm/stream
+  bitrate: 192
+  codec: MP3
+  homepage: http://www.noodsradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 3f938990-dcbc-4931-be49-0ca558a0976e
+  changeuuid: 34674b78-999c-416b-8f1f-4ea3ae5b4fcd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-power-of-worship-radio
+  broadcaster: independent
+  name: Power of Worship Radio
+  streamUrl: https://fwd.autopo.st/powerofworshipradio?_=484910
+  codec: AAC
+  favicon: https://mmo.aiircdn.com/177/664992e2268f6.png
+  homepage: https://www.powerofworship.net/
+  country: GB
+  status: stream-only
+  stationuuid: 0566f8a8-8da3-422a-b623-b63bcc506acc
+  changeuuid: b6e85277-4043-4ece-912a-b03847edd5cb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-r5k-radio
+  broadcaster: independent
+  name: R5K Radio
+  streamUrl: https://stream.r5k.net/
+  bitrate: 320
+  codec: MP3
+  favicon: http://radio.r5k.uk/wp-content/uploads/2024/09/R-Black-Glow.png
+  homepage: https://r5k.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 0b5f4fba-344e-49c9-b23a-37e57a9aa242
+  changeuuid: 6a665e86-cf5a-4d01-8352-accd3768cacb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-riverside-radio
+  broadcaster: independent
+  name: Riverside Radio
+  streamUrl: https://streaming04.liveboxstream.uk/proxy/mtunstil?mp=/stream
+  bitrate: 64
+  codec: AAC+
+  homepage: https://riversideradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: ce89820e-1c1c-435b-a83e-0e1c3d7556a7
+  changeuuid: 87fe1edf-3632-4a20-9fc8-33bfb9e7ff3b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-capital-fm-birmingham
+  broadcaster: independent
+  name: Capital FM (Birmingham)
+  streamUrl: https://media-ice.musicradio.com/CapitalBirminghamMP3
+  bitrate: 128
+  codec: MP3
+  homepage: https://tunein.com/radio/Capital-Birmingham-1022-s25008/
+  country: GB
+  status: stream-only
+  stationuuid: 5514fe6a-b5da-4264-bc42-416cbd2bf42a
+  changeuuid: fbeca935-ad75-4af9-b027-c8e27743622f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hereme-2000s-pop
+  broadcaster: independent
+  name: Hereme 2000s pop
+  streamUrl: https://radio.hearme.fm:8040/stream
+  codec: MP3
+  homepage: https://hearme.fm/
+  country: GB
+  status: stream-only
+  stationuuid: bc1080a9-b10c-44f3-bf88-e879d146eff6
+  changeuuid: 6a32db9f-2203-4d10-85b4-800063649c04
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-one-world-radio
+  broadcaster: independent
+  name: One World Radio
+  streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/OWR_INTERNATIONAL.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: https://global.tomorrowland.com/
+  country: GB
+  status: stream-only
+  stationuuid: 35192ec4-e851-4ce3-a828-89992e99ba49
+  changeuuid: c0e37036-ec4b-4fe4-98a0-774c1f5c38ec
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-northsea-uk
+  broadcaster: independent
+  name: Radio Northsea UK
+  streamUrl: https://listentomystream.com:8008/;
+  bitrate: 320
+  codec: MP3
+  favicon: https://i1.sndcdn.com/artworks-000172944490-2m076q-t500x500.jpg
+  homepage: https://www.rniradio.net/
+  country: GB
+  status: stream-only
+  stationuuid: 1844f409-fab3-4f5e-b917-6e27d99d266b
+  changeuuid: 8c81d70b-f9a7-44e0-94f2-589d5c72889d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-24-7-lounge-radio
+  broadcaster: independent
+  name: "24/7 Lounge Radio"
+  streamUrl: https://ec3.yesstreaming.net:3665/stream
+  bitrate: 64
+  codec: MP3
+  favicon: https://www.247onlineradio.com/wp-content/uploads/2023/04/247-Lounge-Radio.jpg
+  homepage: https://www.247onlineradio.com/24-7-online-radio-group-stations/24-7-lounge-radio/
+  country: GB
+  status: stream-only
+  stationuuid: 4c9accd8-74c0-48b7-b42d-86ba204c0e24
+  changeuuid: 56acc964-3830-458e-beee-07cff2f5655b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-quantum-radio
+  broadcaster: independent
+  name: qUAntUm RaDio
+  streamUrl: https://radio.erb.pw/listen/subspace/radio.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://radio.erb.pw/public/subspace
+  country: GB
+  status: stream-only
+  stationuuid: e9465363-e12d-41fd-a68b-b50cbc19ee03
+  changeuuid: 1d7cba86-4560-4174-a03c-b9a4d83d1ad7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-taiyabah-masjid
+  broadcaster: independent
+  name: Taiyabah Masjid
+  streamUrl: https://taiyabahmbolton.radioca.st/stream
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.taiyabahmasjid.com/
+  country: GB
+  status: stream-only
+  stationuuid: f6bd573d-3fc2-490b-8cd5-7c5f8c840e78
+  changeuuid: 9e6f9d9b-d4fc-4fb2-8e25-c7deec612546
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-awaz-fm
+  broadcaster: independent
+  name: Awaz FM
+  streamUrl: https://uksoutha.streaming.broadcast.radio/awazfm?1709527674574=
+  codec: MP3
+  favicon: https://api.broadcast.radio/api/image/feb85d15-2e18-45a7-b50a-e35b957f7d5a.png?g=center&w=600&h=600&c=true
+  homepage: https://www.awazfm.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 8647c273-2831-4397-bef9-43111f85d7d7
+  changeuuid: 691d33ae-93e4-4d6e-b487-f86ff7491b5d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-crackers-radio
+  broadcaster: independent
+  name: Crackers Radio
+  streamUrl: https://crackersfresh.radioca.st/;
+  bitrate: 320
+  codec: MP3
+  homepage: https://www.crackersradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 76fca412-d9a9-43b2-bf32-a077e2082d90
+  changeuuid: 5394c398-6672-4a18-acec-e8ae9418a1a1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-xl-1296
+  broadcaster: independent
+  name: Radio XL 1296
+  streamUrl: https://xlradio.co.uk:8000/
+  bitrate: 128
+  codec: MP3
+  favicon: null
+  homepage: https://xlradio.co.uk:8000/
+  country: GB
+  status: stream-only
+  stationuuid: 0cb269e7-39ef-4904-b479-684791e744f1
+  changeuuid: 39bb7859-f1da-46d8-88e8-e2302abf7eb3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-97-country-fm
+  broadcaster: independent
+  name: "97 Country FM"
+  streamUrl: https://vistaradio.streamb.live/SB00040?=&&___cb=491767877535127
+  bitrate: 57
+  codec: AAC+
+  favicon: https://www.myprincegeorgenow.com/wp-content/uploads/2021/05/mynow-icon.png
+  homepage: https://www.myprincegeorgenow.com/on-air/countryfm/
+  country: GB
+  status: stream-only
+  stationuuid: 1ed64e91-ce3c-4f11-9090-d16b2d3fc32e
+  changeuuid: b06557b4-981f-48eb-b383-9f795fc1ead7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hearme-70s-rock
+  broadcaster: independent
+  name: HearMe - 70s Rock
+  streamUrl: https://radio.hearme.fm:8240/stream
+  codec: MP3
+  homepage: https://hearme.fm/
+  country: GB
+  status: stream-only
+  stationuuid: aecb407b-b446-4b3c-94f7-54a3ccbe4a91
+  changeuuid: 76551ff0-0cad-4f25-b21e-575944975208
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-regal-radio
+  broadcaster: independent
+  name: Regal Radio
+  streamUrl: https://stream.regalradio.net/stream.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.regalradio.net/apple-touch-icon.png
+  homepage: https://www.regalradio.net/
+  country: GB
+  status: stream-only
+  stationuuid: d9376b3c-0ada-4642-b042-504249f44d4a
+  changeuuid: 4fd2ca75-9903-497f-a8cf-363f73083c7c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-soulpower-radio-com
+  broadcaster: independent
+  name: SOULPOWER-RADIO.COM
+  streamUrl: https://s2.radio.co/sb0964023c/listen
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.enomcentral.com/favicon.ico?v=1731000855
+  homepage: https://soulpower-radio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 02b67015-c882-42f6-a986-63105ed6baab
+  changeuuid: a77c822e-c714-48be-84ee-21b9106ab542
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-masjid-e-salaam-bolton
+  broadcaster: independent
+  name: Masjid E Salaam Bolton
+  streamUrl: https://msalaambolton.radioca.st/Stream
+  bitrate: 56
+  codec: MP3
+  homepage: https://www.masjidesalaam.com/
+  country: GB
+  status: stream-only
+  stationuuid: eb20e6c3-e632-47c4-b405-3f549bbee456
+  changeuuid: abdbbbe0-008a-4963-95d7-4edaba6a593d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-sanskar-radio
+  broadcaster: independent
+  name: Sanskar Radio
+  streamUrl: https://radio.canstream.co.uk:8024/live.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: http://sanskarradio.com/wp-content/uploads/2018/10/logo-01.jpg
+  homepage: http://sanskarradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 28bd8ede-2eee-4b59-bdbd-1ed1e173f78b
+  changeuuid: 841ff3f0-1cbc-46d1-b8de-db0a236a43b1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-the-ambientscape-project
+  broadcaster: independent
+  name: The Ambientscape Project
+  streamUrl: https://listen.radioking.com/radio/504205/stream/561655
+  bitrate: 128
+  codec: MP3
+  favicon: https://lh3.googleusercontent.com/nl0-E_ry5_Nrnfl2EH1BfXZPxrajs0E4g1d6d2ApEAvm_6WUhnfGxWVPRV940ey0KuTLes7AddVA88dk1PlvRQw7gJPcuQ=s120
+  homepage: https://www.ambientscape.com/radio
+  country: GB
+  status: stream-only
+  stationuuid: c8107f2f-3b30-4631-ad1b-0b6c41f0f8a6
+  changeuuid: f41f51cd-0f13-40a2-8ece-4409311088d4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-big-l
+  broadcaster: independent
+  name: Big L
+  streamUrl: https://s2.streamer1.com/listen/bigl/biglTEST.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.bigl.co.uk/images/icon-2.png
+  homepage: https://www.bigl.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 30d35f4a-8df7-49d5-a4ae-ec9882358f06
+  changeuuid: 7f047548-2017-4857-b38a-2b3d598c7bae
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-do-you-radio
+  broadcaster: independent
+  name: Do You Radio
+  streamUrl: https://doyouworld.out.airtime.pro/doyouworld_a
+  bitrate: 128
+  codec: MP3
+  homepage: https://doyou.world/
+  country: GB
+  status: stream-only
+  stationuuid: 128d5561-8439-4e2a-9e6c-4e48ad4f0cc0
+  changeuuid: 3665592c-3239-40a3-bfbe-a382ad7b4471
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-fred-film-radio-entertainment
+  broadcaster: independent
+  name: Fred Film Radio Entertainment
+  streamUrl: https://s10.webradio-hosting.com/proxy/fredenter/stream
+  bitrate: 128
+  codec: MP3
+  favicon: http://www.fred.fm/favicon.ico
+  homepage: http://www.fred.fm/
+  country: GB
+  status: stream-only
+  stationuuid: 7c87afe9-384b-44ee-9b9e-af972fc507ab
+  changeuuid: 412c9c59-bdd4-47b0-aa00-4afe2f80e2b4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-shine-879
+  broadcaster: independent
+  name: Shine 879
+  streamUrl: https://s3.radio.co/sd4abfe69e/listen
+  bitrate: 128
+  codec: MP3
+  favicon: https://shinedab.com/favicon.ico
+  homepage: https://shinedab.com/
+  country: GB
+  status: stream-only
+  stationuuid: 877da38b-5657-47d6-81c1-e805e7400718
+  changeuuid: 9a37d0b6-b584-4311-80c2-db828c5134bc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-worldwide-fm
+  broadcaster: independent
+  name: Worldwide FM
+  streamUrl: https://worldwide-fm.radiocult.fm/stream
+  bitrate: 320
+  codec: MP3
+  favicon: https://scontent-fra5-2.xx.fbcdn.net/v/t39.30808-1/450237294_942043604601681_3306132891557988504_n.jpg?stp=dst-jpg_s200x200_tt6&_nc_cat=109&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=Ur-AWGYdJIEQ7kNvwHfsWWi&_nc_oc=Adn31I1juFGVfOprAsE1UsSz-7_H0ISFLok1gNrhmWqzfmlI6AbPJgNZB15dkduTEq4&_nc_zt=24&_nc_ht=scontent-fra5-2.xx&_nc_gid=60spXN55S49um4k8ceAfcA&oh=00_AfrO3IOBFCxwn4Bqxc2mOFTcigubLSqRjTY1N2cfbWsvxg&oe=696ED4DC
+  homepage: https://www.worldwidefm.net/
+  country: GB
+  status: stream-only
+  stationuuid: 1651c32f-55d8-4429-995d-872ea0dcf520
+  changeuuid: 782d83dd-17ad-4190-bd52-7499433de707
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-100-8-home-radio
+  broadcaster: independent
+  name: "100.8 Home Radio"
+  streamUrl: https://uksoutha.streaming.broadcast.radio/home?1721747577077=
+  codec: MP3
+  favicon: https://api.broadcast.radio/api/image/7ed6bffb-6808-4c08-8576-6132efe7bd78.png?g=center
+  homepage: https://www.homeradio.org/
+  country: GB
+  status: stream-only
+  stationuuid: 433bf375-2cd4-4018-99a0-ffc285ffb154
+  changeuuid: 5b78c351-d9f3-401f-9c41-6c97fb37a7e0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-jazz-london-radio
+  broadcaster: independent
+  name: Jazz London radio
+  streamUrl: https://radio.canstream.co.uk:8075/live.aac
+  bitrate: 64
+  codec: AAC
+  favicon: https://www.jazzlondonradio.com/images/favicon.ico
+  homepage: https://www.jazzlondonradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: a7d816c2-722f-4060-907d-b4c796482d87
+  changeuuid: 30220c72-08aa-4d96-8d3a-96cf3d4ae2aa
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-naim-classical
+  broadcaster: independent
+  name: Naim classical
+  streamUrl: https://mscp3.live-streams.nl:8252/class-flac.flac
+  bitrate: 128
+  codec: OGG
+  favicon: https://www.naimaudio.com/build/assets/apple-touch-icon-2a4e35a0.png
+  homepage: https://www.naimaudio.com/
+  country: GB
+  status: stream-only
+  stationuuid: b8cbbb93-dea3-47b9-be48-114b2f030667
+  changeuuid: ff359987-ab41-4397-96a8-b855f74a1701
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-isle-of-wight-radio
+  broadcaster: independent
+  name: Isle of Wight Radio
+  streamUrl: https://s2.xrad.io:9598/listen.mp3?=&&___cb=275280937051671
+  bitrate: 128
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/386/5ec2a4d8bc430.png
+  homepage: https://www.iwradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 74ab194b-5124-4bdc-8855-81e6bb6eb4d1
+  changeuuid: 369e37cf-3360-423c-8a45-b45c5329f475
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-rokit-radio-1940s-radio
+  broadcaster: independent
+  name: Rokit Radio 1940s Radio
+  streamUrl: https://streaming06.liveboxstream.uk/proxy/roksta13/stream
+  bitrate: 48
+  codec: MP3
+  favicon: https://www2.rokitradio.com/_next/image?url=%2Fimages%2Fchannels%2F1940s.jpg&w=128&q=75
+  homepage: https://www2.rokitradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: f40ed777-ea5c-45b0-a248-32393c656890
+  changeuuid: b0cdc82b-24fc-4df3-9e6f-67184c6d6e96
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-university-radio-york
+  broadcaster: independent
+  name: University Radio York
+  streamUrl: https://audio.ury.org.uk/live-high
+  bitrate: 192
+  codec: MP3
+  homepage: https://ury.org.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 22a01c34-8654-46fc-9c93-9d068e2e8730
+  changeuuid: 37ab231e-7e58-4b8c-b93a-95ca9d2854f1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-90s-2000s-more
+  broadcaster: independent
+  name: "90s 2000s & More"
+  streamUrl: https://lunar.citrus3.com:8162/stream
+  bitrate: 128
+  codec: AAC
+  favicon: https://lunar.citrus3.com:2020/pub/90s2000sandmore/background.jpg
+  homepage: https://lunar.citrus3.com:2020/public/90s2000sandmore
+  country: GB
+  status: stream-only
+  stationuuid: fb8ecb5b-51f9-410b-813f-6c125e020437
+  changeuuid: 6bd00f3c-493f-4210-84fa-05d6e91a6ebc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-golden-decades-radio
+  broadcaster: independent
+  name: Golden Decades Radio
+  streamUrl: https://streaming.live365.com/a99471
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.goldendecadesradio.net/favicin.ico
+  homepage: https://www.goldendecadesradio.net/
+  country: GB
+  status: stream-only
+  stationuuid: 329fecec-770f-4ec4-afdf-dfd25dcba6db
+  changeuuid: cab0035c-b6b9-40b2-bc3c-f72669124456
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hospital-radio-norwich
+  broadcaster: independent
+  name: Hospital Radio Norwich
+  streamUrl: https://hospita1.radioca.st/;
+  bitrate: 96
+  codec: MP3
+  homepage: https://hospitalradionorwich.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: ef43e14b-b8b6-41ac-8c64-a1fd08409783
+  changeuuid: 47b191e6-2fd8-4e06-ae63-6014d480f6a6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-real-roots-radio
+  broadcaster: independent
+  name: Real roots radio
+  streamUrl: https://streams.radio.co/s1df61e0af/listen
+  bitrate: 192
+  codec: MP3
+  homepage: https://realrootsradio.net/
+  country: GB
+  status: stream-only
+  stationuuid: 93b6eecb-d160-4fc6-8edc-e1c3d1f0613a
+  changeuuid: 0fae458d-6935-4504-b8f8-a51c66d0b124
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-sunshine-radio-online-uk
+  broadcaster: independent
+  name: Sunshine Radio Online UK
+  streamUrl: https://stream1.themediasite.co.uk/8036/stream
+  bitrate: 192
+  codec: MP3
+  homepage: https://sunshineradioonline.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: d4256d94-2dc8-4a3b-98a0-a4f6d580219f
+  changeuuid: d9b24401-5452-4135-bb40-8eee92e158f8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-this-is-the-coast
+  broadcaster: independent
+  name: This is the Coast
+  streamUrl: https://streaming.broadcastradio.com:10765/thisisthecoast
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/428/6192188de6d51.png
+  homepage: https://www.thisisthecoast.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: f198327c-97c7-4f13-8092-52fd115069d6
+  changeuuid: edc62a3e-d1a7-432b-a1e6-33145c16c9f6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-24-7-classical-radio
+  broadcaster: independent
+  name: "24/7 Classical Radio"
+  streamUrl: https://ec3.yesstreaming.net:3615/stream
+  bitrate: 64
+  codec: MP3
+  favicon: https://usercontent.one/wp/www.247onlineradio.com/wp-content/uploads/2019/10/Classical-Radio-logo.jpg
+  homepage: https://www.247onlineradio.com/classical-radio/
+  country: GB
+  status: stream-only
+  stationuuid: 651effd2-e319-46fe-9ff4-4acf17fb3165
+  changeuuid: d4171347-dc22-4d01-beda-996d9e099cde
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-belters-radio
+  broadcaster: independent
+  name: Belters Radio
+  streamUrl: https://uk2.internet-radio.com/proxy/belters?mp=/live
+  bitrate: 64
+  codec: MP3
+  favicon: https://seeded-session-images.scdn.co/v2/img/122/secondary/artist/6Q7SW1I96IGwqBDhIm55oj/en
+  homepage: https://www.belter-radio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 0d3c8b15-096e-4c87-ae3a-a429d2263c88
+  changeuuid: 6fc8ba97-82c2-4db5-988e-e721fc6aab2e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-original-106
+  broadcaster: independent
+  name: Original 106
+  streamUrl: https://listen-original.sharp-stream.com/original106.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/11/62090e452aff2.png
+  homepage: https://www.originalfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: 2b9745a6-9155-44f6-adfe-e62ff9361d7e
+  changeuuid: b88dcf3c-bf94-4b4b-b5b3-99a602477eba
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-the-buzz
+  broadcaster: independent
+  name: The Buzz
+  streamUrl: https://streaming05.liveboxstream.uk/proxy/kookyinc/stream
+  bitrate: 320
+  codec: MP3
+  favicon: https://media.licdn.com/dms/image/D5622AQGpwL9LyKlbdg/feedshare-shrink_800/0/1697466642566?e=2147483647&v=beta&t=aYyFGOmG4uUzv7nHS5wNnENGiObuOXs9dZ6gzAG6zrM
+  homepage: https://www.thisisthebuzz.com/
+  country: GB
+  status: stream-only
+  stationuuid: fb42e84d-7f35-41e8-b579-a3bbfbe94d75
+  changeuuid: d4c3a56b-7e22-4280-bd19-443eeffa830b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-aaja-radio-channel-2
+  broadcaster: independent
+  name: "Aaja Radio | Channel 2"
+  streamUrl: https://aaja-2.radiocult.fm/stream
+  bitrate: 192
+  codec: MP3
+  favicon: https://aajamusic.com/_nuxt/icons/icon_64x64.fafdcd.png
+  homepage: https://aajamusic.com/radio
+  country: GB
+  status: stream-only
+  stationuuid: ea6e4da5-087d-421c-95b6-5ccbedc58468
+  changeuuid: 85cdc845-c6eb-4d53-927c-fde1f7c262e2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-classical-radio-international
+  broadcaster: independent
+  name: CLASSICAL RADIO INTERNATIONAL
+  streamUrl: https://ec3.yesstreaming.net:3625/stream
+  bitrate: 64
+  codec: MP3
+  favicon: https://www.247onlineradio.com/wp-content/uploads/2019/01/Classical-Radio-logo.png
+  homepage: https://www.247onlineradio.com/classical-radio-international/
+  country: GB
+  status: stream-only
+  stationuuid: 0f3efc0c-1362-4ef5-a417-09699655dd6e
+  changeuuid: d0a937d3-460f-495e-ac3d-8ebfcd3efff4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-clyde-built-radio
+  broadcaster: independent
+  name: Clyde Built Radio
+  streamUrl: https://clydebuiltradio.out.airtime.pro/clydebuiltradio_a
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.clydebuiltradio.com/apple-touch-icon.png
+  homepage: https://www.clydebuiltradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: de8d7315-0779-4d4f-ba10-57260f51e194
+  changeuuid: 1e5da417-23c3-43e5-bc28-bd670ff000f8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-crucial-hip-hop-and-electro
+  broadcaster: independent
+  name: Crucial Hip Hop and Electro
+  streamUrl: https://uksoutha.streaming.broadcast.radio/crucial
+  codec: MP3
+  homepage: https://www.streetsoundsradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 30192e4e-48c4-4816-99e3-4112491a1d30
+  changeuuid: 37e313a4-ecff-49b4-8d50-438cf5850ba3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-dirty-radio-for-underworld-fans
+  broadcaster: independent
+  name: Dirty Radio for Underworld Fans
+  streamUrl: https://live.dirty.radio/stream
+  bitrate: 64
+  codec: AAC
+  homepage: https://dirty.radio/
+  country: GB
+  status: stream-only
+  stationuuid: 1a267e2e-69db-4fd8-ab27-cca867bbe59f
+  changeuuid: 2db61dce-61b2-4b00-bcc4-fbc6256e987a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-maritime-radio
+  broadcaster: independent
+  name: maritime radio
+  streamUrl: https://mediacp.nkpa.co.uk/stream/maritime%E2%80%8B/MRMP3
+  bitrate: 128
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/1353/65d08095711fe.png
+  homepage: https://www.maritimeradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 568f42b6-37d6-43f3-a0e2-e38f4d882c06
+  changeuuid: 2af43db5-1b30-477a-9524-6f1ad0599402
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-cdnx-radio
+  broadcaster: independent
+  name: CDNX Radio
+  streamUrl: https://streaming.cdnx.co.uk/proxy/cx128mp3?mp=/stream&=&&___cb=870564735813642
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.camdenmarket.com/journal/cdnx-radio
+  country: GB
+  status: stream-only
+  stationuuid: c67e3836-a66f-4786-a98e-b6dd91edfde2
+  changeuuid: af6b6499-147d-4d4f-b9b6-3c6123db2b5d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hearme-love-songs
+  broadcaster: independent
+  name: HearMe - Love songs
+  streamUrl: https://radio.hearme.fm:8140/stream
+  codec: MP3
+  homepage: https://hearme.fm/
+  country: GB
+  status: stream-only
+  stationuuid: f14fbd38-e6c0-4d9a-8d4d-b8f8f0c9fce6
+  changeuuid: ddb14a7e-2259-4ae6-8fa6-9a33953c9da7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-christmas
+  broadcaster: independent
+  name: Radio Christmas
+  streamUrl: https://streaming.radiochristmas.co.uk/RadioChristmas
+  bitrate: 256
+  codec: MP3
+  favicon: https://radiochristmas.co.uk/favicon.ico
+  homepage: https://radiochristmas.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 8555a8e5-6bc2-49bc-b08a-0cd7bcbb3beb
+  changeuuid: 6ace3acf-6244-4a85-8f0a-c44ffe419a72
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-resonance-extra
+  broadcaster: independent
+  name: Resonance Extra
+  streamUrl: https://stream.resonance.fm/resonance-extra
+  bitrate: 192
+  codec: MP3
+  favicon: https://extra.resonance.fm/favicon.ico
+  homepage: https://extra.resonance.fm/
+  country: GB
+  status: stream-only
+  stationuuid: d9e327ff-2c59-4145-83a9-67f7b33a1ab2
+  changeuuid: ca058a47-9f63-46f6-93ee-2353b44bc767
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-xtra-hot
+  broadcaster: independent
+  name: Xtra Hot
+  streamUrl: https://stream1.hippynet.co.uk/stream/xtrahot/live
+  bitrate: 160
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/406/63e29f650517e.png
+  homepage: https://www.xtrahot.radio/
+  country: GB
+  status: stream-only
+  stationuuid: ba26c3b2-80a4-42a4-8569-c5cf37d249e4
+  changeuuid: a1e36955-3975-4584-98c2-827090ca280e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-centreforce-883
+  broadcaster: independent
+  name: Centreforce 883
+  streamUrl: https://listen.centreforceradio.com/96
+  bitrate: 96
+  codec: MP3
+  homepage: https://www.centreforceradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 55495003-c899-48fe-a51a-12c4a381f0db
+  changeuuid: 1b5d46a9-e1b0-4da6-9d1c-8b8e98a1aa04
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-coffee-morning
+  broadcaster: independent
+  name: Coffee Morning
+  streamUrl: https://media-the.musicradio.com/Global-M-CoffeeMorning
+  bitrate: 48
+  codec: AAC
+  favicon: https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse4.mm.bing.net%2Fth%3Fid%3DOIP.urcOy5KLidgx_JRwHUewewAAAA%26pid%3DApi&f=1&ipt=52c4c14b37a85c76dcb3d11f83b678bf7eddd5574cb09cd4839d7e64110eb25d&ipo=images
+  homepage: https://global.com/global-player
+  country: GB
+  status: stream-only
+  stationuuid: ba60b138-3d74-4579-9f3f-e2c4eda58a80
+  changeuuid: c18df94b-f7fc-4e29-9660-2e3915f682b5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hardrock-hell
+  broadcaster: independent
+  name: Hardrock Hell
+  streamUrl: https://s3.radio.co/s1f74e2763/listen
+  bitrate: 192
+  codec: MP3
+  homepage: https://hardrockhellradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 2f281ed9-c336-4049-ab17-524f4bc81c0a
+  changeuuid: c9b832b9-aecb-4a30-8a3a-09e9c77d3444
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hearme-classic-rock
+  broadcaster: independent
+  name: HearMe - Classic Rock
+  streamUrl: https://radio.hearme.fm:8270/stream
+  codec: MP3
+  homepage: https://hearme.fm/
+  country: GB
+  status: stream-only
+  stationuuid: ca47a1f5-329a-45de-a0db-97eb6bce75ce
+  changeuuid: 018f363a-c795-4c27-80b2-b6e52b2591f7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-louder-than-war
+  broadcaster: independent
+  name: Louder Than War
+  streamUrl: https://s2.radio.co/sab795a38d/listen
+  bitrate: 128
+  codec: MP3
+  homepage: https://louderthanwar.com/
+  country: GB
+  status: stream-only
+  stationuuid: 43410501-8008-46a9-aaa2-f0372c023e64
+  changeuuid: 78252fe3-69c1-4561-8d2b-c93112d3f25f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-movedahouse
+  broadcaster: independent
+  name: MoveDaHouse
+  streamUrl: https://uk7.internet-radio.com/proxy/movedahouse?mp=//stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.movedahouse.com/wp-content/uploads/2018/01/mdh-172x172.jpg
+  homepage: https://www.movedahouse.com/
+  country: GB
+  status: stream-only
+  stationuuid: 568c844b-5a9c-4a37-a6bc-1a86f6093572
+  changeuuid: 35821de3-b250-43df-a01b-cc320c82927d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-smooth-bristol-and-bath
+  broadcaster: independent
+  name: Smooth Bristol and Bath
+  streamUrl: https://media-the.musicradio.com/SmoothBristolMP3
+  bitrate: 128
+  codec: MP3
+  favicon: http://www.smoothradio.com/assets_v4r/smooth/img/favicon-196x196.png
+  homepage: https://www.smoothradio.com/bristol/
+  country: GB
+  status: stream-only
+  stationuuid: 7942a5dc-9b99-40df-9e2b-c0940ee262cc
+  changeuuid: a2f34b0c-660f-4971-84f4-e4b7cef8754b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-jambo-radio
+  broadcaster: independent
+  name: "Jambo! Radio"
+  streamUrl: https://stream3.themediasite.co.uk:8130/stream
+  bitrate: 192
+  codec: MP3
+  favicon: https://jamboradio.co.uk/wp-content/uploads/2019/10/cropped-Jambo-Logo-1-192x192.png
+  homepage: https://jamboradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 54a67c4e-6e90-4741-aad2-958f7e1a1f73
+  changeuuid: 5c5cb846-07db-4f01-a55a-a166a2c03f9a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-power-ace-radio
+  broadcaster: independent
+  name: Power Ace Radio
+  streamUrl: https://music-station.live/radio/8030/radio.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.poweraceradio.com/favicon.ico
+  homepage: https://www.poweraceradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 68ec09af-5b30-46b4-acf1-71400cf95892
+  changeuuid: 55f9699e-5f3f-4d1e-be0b-203d34e4a9ef
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-rstv-dance
+  broadcaster: independent
+  name: RSTV Dance
+  streamUrl: https://radiozender.mpbnetwerken.nl/rstvdance.mp3
+  bitrate: 384
+  codec: AAC+
+  favicon: https://radiodns.mpbnl.nl/logos/rstv/dance.png
+  homepage: https://dance.rstvnetworks.com/
+  country: GB
+  status: stream-only
+  stationuuid: 863baf3f-c9c6-4f00-810b-acf4e9d8031a
+  changeuuid: b71176fc-4ca9-4c36-8fa6-674bf28f933f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-aaja-radio-channel-1
+  broadcaster: independent
+  name: "Aaja Radio | Channel 1"
+  streamUrl: https://aaja.radiocult.fm/stream
+  bitrate: 192
+  codec: MP3
+  favicon: https://aajamusic.com/_nuxt/icons/icon_64x64.fafdcd.png
+  homepage: https://aajamusic.com/radio
+  country: GB
+  status: stream-only
+  stationuuid: 7811e960-53ef-4e2c-a739-e2dff567ae86
+  changeuuid: 9a91c57e-9a2a-4ce7-a0fd-dcec4c6ab8b7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bikers-hangout-radio
+  broadcaster: independent
+  name: Bikers Hangout Radio
+  streamUrl: https://stream.radio.co/s803057ca0/listen
+  bitrate: 192
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/21bad3_49d2ec0019f24f83bffacbce6787fd0a%7emv2.png/v1/fill/w_180%2ch_180%2clg_1%2cusm_0.66_1.00_0.01/21bad3_49d2ec0019f24f83bffacbce6787fd0a%7emv2.png
+  homepage: https://www.bikershangout.co.uk/bikers-hangout-radio
+  country: GB
+  status: stream-only
+  stationuuid: fd819a4b-e016-444c-86bd-c6db40ce6eba
+  changeuuid: a3966273-8248-410e-921b-27abcd1a7425
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bluesradio-uk
+  broadcaster: independent
+  name: BluesRadio UK
+  streamUrl: https://streaming06.liveboxstream.uk/proxy/david125/stream
+  bitrate: 128
+  codec: MP3
+  homepage: http://www.bluesradio.co.uk/index.php
+  country: GB
+  status: stream-only
+  stationuuid: ecf8275b-bbe8-4035-a8b0-aa04d90a51dc
+  changeuuid: 48f256b1-72a5-4d70-91aa-0975d1549b1f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bar-latina-radio
+  broadcaster: independent
+  name: Bar Latina Radio
+  streamUrl: https://s2.citrus3.com:2000/stream/barlatinaradio
+  bitrate: 320
+  codec: MP3
+  homepage: https://www.barlatina.com/
+  country: GB
+  status: stream-only
+  stationuuid: adfd10cf-ec13-482e-98c7-ba32a8b33879
+  changeuuid: b07fd123-a402-4710-8bb3-3030883e1886
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-black-metal-radio
+  broadcaster: independent
+  name: Black Metal Radio
+  streamUrl: https://das-edge16-live365-dal02.cdnstream.com/a05584
+  bitrate: 192
+  codec: MP3
+  homepage: https://live365.com/station/BLACK-METAL-RADIO-a05584
+  country: GB
+  status: stream-only
+  stationuuid: 117587c0-b66a-437f-b76a-85adcfd146e9
+  changeuuid: e907afc2-e5cb-4e9d-ae9b-fc1d0b41347a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-naim-radio
+  broadcaster: independent
+  name: Naim Radio
+  streamUrl: https://mscp3.live-streams.nl:8362/flac.flac
+  bitrate: 160
+  codec: OGG
+  favicon: https://www.naimaudio.com/build/assets/apple-touch-icon-2a4e35a0.png
+  homepage: https://www.naimaudio.com/
+  country: GB
+  status: stream-only
+  stationuuid: d233c573-3902-444d-8cb0-70eef9142481
+  changeuuid: 83fd5198-c9f1-4a3e-b863-be13f832a89d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-big-beat-brighton
+  broadcaster: independent
+  name: Big Beat Brighton
+  streamUrl: https://s4.citrus3.com:8366/stream
+  bitrate: 256
+  codec: AAC
+  homepage: https://big-beat-brighton.ueniweb.com/
+  country: GB
+  status: stream-only
+  stationuuid: 0e9bf834-78ab-4202-9c32-6fbe35a9b996
+  changeuuid: 29114937-3b6d-4380-ad96-6d64db288402
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-brown-noise-radio
+  broadcaster: independent
+  name: Brown Noise Radio
+  streamUrl: https://uk1.internet-radio.com/proxy/brownnoise?mp=/stream;
+  bitrate: 64
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/996eee_494ede18f9684a0898e0fc38dc06869b%7Emv2.jpg/v1/fill/w_180%2Ch_180%2Clg_1%2Cusm_0.66_1.00_0.01/996eee_494ede18f9684a0898e0fc38dc06869b%7Emv2.jpg
+  homepage: https://www.brownnoiseradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: bb074b4a-c9cc-4811-8282-171ac9bc114f
+  changeuuid: 1fde3e76-4478-4475-a18d-0941f248bac2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-heart-10s
+  broadcaster: independent
+  name: Heart 10s
+  streamUrl: https://media-ice.musicradio.com/Heart10sMP3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.heart.co.uk/10s/
+  country: GB
+  status: stream-only
+  stationuuid: f45705b5-0410-46a7-bf0e-cbb83d4315d2
+  changeuuid: 9599401d-97d7-4a5b-a575-c365ccb70f6a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-majestic-jukebox-radio
+  broadcaster: independent
+  name: Majestic Jukebox Radio
+  streamUrl: https://uk3.internet-radio.com/proxy/majesticjukebox/live
+  bitrate: 16
+  codec: AAC+
+  favicon: https://static.wixstatic.com/media/83e446_a77f5ab906b7455689b82789c523e616~mv2.jpg/v1/fit/w_2500,h_1330,al_c/83e446_a77f5ab906b7455689b82789c523e616~mv2.jpg
+  homepage: https://www.majesticjukeboxradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 01cf48e3-25aa-4bf7-b6d7-563da99b95ac
+  changeuuid: 2fec48e2-4a0d-49c0-9a23-f2138d099fd4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-x-chilled
+  broadcaster: independent
+  name: Radio X Chilled
+  streamUrl: https://media-ice.musicradio.com/RadioXChilledMP3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radiox.co.uk/chilled/
+  country: GB
+  status: stream-only
+  stationuuid: c58bbc71-ad5d-4b92-bb4b-dd85e9d3c411
+  changeuuid: a94a1451-d438-49f0-ab37-24c0769b5556
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-sabotage
+  broadcaster: independent
+  name: Sabotage
+  streamUrl: https://listen.radioking.com/radio/634/stream/2282
+  bitrate: 128
+  codec: MP3
+  favicon: https://t4.ftcdn.net/jpg/04/69/34/51/360_F_469345184_YlmdPahjiPXs133mjIZf98YgZ5g8ZFSN.jpg
+  homepage: https://welove.radio/radio/sabotage/
+  country: GB
+  status: stream-only
+  stationuuid: fa951073-c9af-4216-b41e-899cb34feeb2
+  changeuuid: bc9ae266-2b5d-43c1-8612-936c4a0c4d35
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-60-north-radio
+  broadcaster: independent
+  name: "60 North Radio"
+  streamUrl: https://cdn1.zetcast.net/stream
+  bitrate: 320
+  codec: MP3
+  favicon: https://60north.radio/wp-content/uploads/2020/06/60n-radio-app-icon-108x108-1.jpeg
+  homepage: https://60north.radio/
+  country: GB
+  status: stream-only
+  stationuuid: fe4c2870-703c-4802-b2f6-a95664be32ff
+  changeuuid: f4fa1fa7-f946-412d-8f36-4bb5b1975435
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-dance-revolution
+  broadcaster: independent
+  name: Dance Revolution
+  streamUrl: https://s5.radio.co/s89dcf578d/listen
+  bitrate: 192
+  codec: MP3
+  favicon: http://dancerevradio.com/wp-content/uploads/2024/01/asset-10360-1.jpg
+  homepage: https://dancerevradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: b1d72676-8870-47da-91db-a88357b64c51
+  changeuuid: ffd09def-c3cd-425e-8085-b8463faec51f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-ekr-retro-rock
+  broadcaster: independent
+  name: EKR Retro Rock
+  streamUrl: https://streaming06.liveboxstream.uk/proxy/eastken4?mp=/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://ekrdigital.com/wp-content/themes/ekr-digital-radio/img/icons/retro-rock_180.png
+  homepage: https://ekrdigital.com/retro-rock/
+  country: GB
+  status: stream-only
+  stationuuid: fbc76c8d-fb4b-4e0d-9bac-f70a5bdbb909
+  changeuuid: 074aebd7-c574-4d9e-8b5c-1470f0bf6b46
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-electric-lion-radio-london
+  broadcaster: independent
+  name: Electric Lion Radio London
+  streamUrl: https://streaming04.liveboxstream.uk/proxy/electric?mp=/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://electriclionradio.com/resources/Electric%20Lion.jpg
+  homepage: https://electriclionradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 5de724c6-2781-446f-9d33-3b3d6e5c4130
+  changeuuid: 1656c235-1142-445c-aa8d-481f6b736468
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hearme-trance
+  broadcaster: independent
+  name: HearMe - trance
+  streamUrl: https://radio.hearme.fm:8100/stream
+  codec: MP3
+  homepage: https://hearme.fm/
+  country: GB
+  status: stream-only
+  stationuuid: 457a05d0-bad4-4fb3-80e2-481eb359113c
+  changeuuid: 63195550-37bc-4587-8ac5-ab82b5363145
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-intamixx
+  broadcaster: independent
+  name: Intamixx
+  streamUrl: https://intamixx.no-ip.com:8002/;
+  bitrate: 128
+  codec: MP3
+  favicon: https://radio.intamixx.uk/favicon.ico
+  homepage: https://radio.intamixx.uk/
+  country: GB
+  status: stream-only
+  stationuuid: b95e64c8-724a-4d3f-9df3-3df697b6700f
+  changeuuid: 6447e7e9-e30e-4c8b-a228-e41a08a170b6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-nostalgia-central
+  broadcaster: independent
+  name: Nostalgia Central
+  streamUrl: https://s5.radio.co/s6211fbeed/listen
+  bitrate: 192
+  codec: MP3
+  favicon: http://ncradio.com/wp-content/uploads/2024/08/nclogo.png
+  homepage: https://ncradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 490068a8-e5f9-40eb-8374-53bce3fecd4d
+  changeuuid: ba7fbe51-69fb-482a-8a57-0c24e6521d98
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-xtra-dance
+  broadcaster: independent
+  name: Radio Xtra Dance
+  streamUrl: https://c30.radioboss.fm:8613/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://radioxtra.co.uk/wp-content/uploads/2023/07/xTRA-DANCE-B-150x150-1.jpg
+  homepage: https://radioxtra.co.uk/xtra-dance/
+  country: GB
+  status: stream-only
+  stationuuid: fad87733-40e7-4e8e-9e10-93e9b250e8cb
+  changeuuid: 62b3c937-185d-4256-b17c-a4652b2e51eb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-soul-roots-radio
+  broadcaster: independent
+  name: Soul Roots Radio
+  streamUrl: https://streams.radio.co/sbdfc075c0/listen
+  bitrate: 192
+  codec: MP3
+  favicon: https://soulrootsradio.com/wp-content/uploads/2022/08/Soul-Roots-Header-Logo.png
+  homepage: https://soulrootsradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 2e4a7e87-2d9d-4e64-9e74-6a46bc4a627c
+  changeuuid: 13e64713-cf25-477b-9ca6-04cbfa15d938
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-ace-cafe-radio
+  broadcaster: independent
+  name: Ace Cafe Radio
+  streamUrl: https://listen.radioking.com/radio/69079/stream/106852
+  bitrate: 128
+  codec: MP3
+  homepage: https://acecafe.com/ace-cafe-radio/
+  country: GB
+  status: stream-only
+  stationuuid: 866e0a53-836e-4e07-8c10-aa044e8b61e5
+  changeuuid: 86aa73fa-eb74-4f0d-8a2d-de1f8f182bfd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-get-ready-to-rock
+  broadcaster: independent
+  name: Get Ready to Rock
+  streamUrl: https://streamer.radio.co/s24ae1285c/listen
+  bitrate: 128
+  codec: MP3
+  homepage: http://getreadytorockradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 687da7eb-816b-4865-ba51-240ba2573f55
+  changeuuid: dccd51b1-f552-4e6c-9441-3110da1c85d6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-healthcare-now-radio
+  broadcaster: independent
+  name: Healthcare Now Radio
+  streamUrl: https://healthcarenowradio.out.airtime.pro/healthcarenowradio_a
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.healthcarenowradio.com/wp-content/uploads/2017/12/HCNR-websiteheader-636.png
+  homepage: https://www.healthcarenowradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 78b769e1-2e66-476a-b564-f78921bf3fb3
+  changeuuid: 20fd37ae-f525-4f57-819b-1032f22bad6f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-sd-radio
+  broadcaster: independent
+  name: SD Radio
+  streamUrl: https://mystation.micast.media/radio/8020/radio.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://sdradiouk.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 4d8c78c0-a08d-481b-979a-ec1295af876e
+  changeuuid: 57292a6a-c06f-43f8-b4bf-3764d452ce04
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-ambur-radio
+  broadcaster: independent
+  name: Ambur Radio
+  streamUrl: https://radio.garden/api/ara/content/listen/FEBrvDEk/channel.mp3?1743950367875
+  bitrate: 128
+  codec: MP3
+  favicon: https://amburfm.co.uk/wp-content/uploads/2020/04/logo-ambur-original-composite-cropped.jpg.pagespeed.ce.wm1b2kWhy7.jpg
+  homepage: https://amburfm.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 8a0234a7-8e04-44f2-9dea-9026f8bdfb11
+  changeuuid: 019797a8-a7b5-4787-b522-bbdc495c79a8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-box-radio-dreamscapes
+  broadcaster: independent
+  name: Box radio dreamscapes
+  streamUrl: https://boxradio-edge-00.streamafrica.net/dreamscapes
+  codec: MP3
+  homepage: https://boxradio.net/opendata
+  country: GB
+  status: stream-only
+  stationuuid: 4d84f432-e22d-42c3-b23c-2c93f242146b
+  changeuuid: 88d8cfdc-e2ae-4fee-a462-d8f90339029f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-ehfm
+  broadcaster: independent
+  name: EHFM
+  streamUrl: https://ehfm.out.airtime.pro/ehfm_a
+  bitrate: 192
+  codec: MP3
+  favicon: https://static.mytuner.mobi/media/tvos_radios/lbvlm87gg7bp.png
+  homepage: https://www.ehfm.live/
+  country: GB
+  status: stream-only
+  stationuuid: 57c21dab-3c40-4ca6-b49b-8755bd7a3dcd
+  changeuuid: acd84655-502f-43ae-a219-9945955e73c9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-fresh-fm-radio-london
+  broadcaster: independent
+  name: Fresh Fm Radio London
+  streamUrl: https://eu4.fastcast4u.com/proxy/blacka?mp=/1
+  bitrate: 128
+  codec: MP3
+  homepage: https://freshfmradiolondon.com/
+  country: GB
+  status: stream-only
+  stationuuid: b5699b26-274e-4451-9c1f-cc307b642793
+  changeuuid: ddac1c5d-6d6c-4c9f-ad39-aa886cf07384
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-gaydio-london
+  broadcaster: independent
+  name: Gaydio London
+  streamUrl: https://listen-gaydio.sharp-stream.com/472_gaydio_london_128_mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/20/664f572bc2e7c.png
+  homepage: https://www.gaydio.co.uk/london/
+  country: GB
+  status: stream-only
+  stationuuid: 50f21d6e-02a0-476c-8361-cfa6e8509add
+  changeuuid: d0fd32be-dcb3-4ca6-ac89-37cb2107126e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-heart-love
+  broadcaster: independent
+  name: Heart Love
+  streamUrl: https://media-ice.musicradio.com/HeartLoveMP3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.heart.co.uk/love/
+  country: GB
+  status: stream-only
+  stationuuid: 0e7652b3-70d7-41d9-92a1-fc9badb346a6
+  changeuuid: 1ebe8a69-891c-4a8a-bd38-8681b4e306f1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-pure-beat-radio
+  broadcaster: independent
+  name: Pure Beat Radio
+  streamUrl: https://cast6.asurahosting.com/proxy/purebeat/stream
+  bitrate: 320
+  codec: MP3
+  favicon: http://purebeatradio.co.uk/gallery/favicons/favicon-120x120.png
+  homepage: http://purebeatradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: aeb74f1d-3bc7-470a-b141-fe5781dab116
+  changeuuid: d030d6d4-d408-4d30-a4d1-3e2ef3d86bbb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-24-7-cafe-radio
+  broadcaster: independent
+  name: "24/7 Cafe Radio"
+  streamUrl: https://ec6.yesstreaming.net:1555/stream
+  bitrate: 64
+  codec: MP3
+  favicon: https://www.247caferadio.com/wp-content/uploads/2020/11/cropped-247-Cafe-Radio.jpg
+  homepage: https://www.247caferadio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 265f18a1-be20-487e-8d6f-9a8146f6c63b
+  changeuuid: 8e9eab8d-77db-4974-b7ee-cedce02a162f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-dejavufm
+  broadcaster: independent
+  name: dejavufm
+  streamUrl: https://dejavufm.radioca.st/;
+  bitrate: 320
+  codec: MP3
+  favicon: https://i2.wp.com/dejavufm.com/wp-content/uploads/deja-pic-logo-.jpg?fit=600%2C600&ssl=1
+  homepage: https://dejavufm.com/
+  country: GB
+  status: stream-only
+  stationuuid: 706f58ed-0a92-48dc-a45e-4cb811d68e5d
+  changeuuid: ec524c43-539e-41c5-8228-d86ee9b7a6a9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-energy-fm-classic-dance-and-the-best-new-music
+  broadcaster: independent
+  name: ENERGY FM - classic dance and the best new music
+  streamUrl: https://s1.myradiostream.com/8838/listen.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.energyfm.co.uk/favicon.ico
+  homepage: https://www.energyfm.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: a6c51c25-270f-4796-9189-01d94149287b
+  changeuuid: debbeae3-6b4c-4e6a-92ca-fb66d7687c84
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-funky-corner-radio-uk
+  broadcaster: independent
+  name: Funky Corner Radio UK
+  streamUrl: https://ais-sa2.cdnstream1.com/2447_192.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: https://funkycorner.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 2c4ee091-6461-4e95-a982-06ad8995f1f7
+  changeuuid: c4a058ca-c1da-4175-b685-8521e16270c5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-soul-rhythms-radio-uk
+  broadcaster: independent
+  name: Soul Rhythms Radio UK
+  streamUrl: https://a7.asurahosting.com:8230/radio.mp3
+  bitrate: 320
+  codec: MP3
+  favicon: https://soulrhythmsradio.com/wp-content/uploads/2023/12/SRR-LOGOTHIS_ONE.jpg
+  homepage: https://soulrhythmsradio.com/home/
+  country: GB
+  status: stream-only
+  stationuuid: a933e805-8c3b-4842-b41f-05617340f68e
+  changeuuid: fd8f429b-7ebd-4417-8fcd-46af96fe4204
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-switch-fm-london
+  broadcaster: independent
+  name: Switch FM London
+  streamUrl: https://stream.switchfm.co.uk/listen/switchfm/switchfm.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://switchfm.co.uk/assets/img/favicon.ico
+  homepage: https://switchfm.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 6cb3c224-1fea-4b83-831c-34b691059dc1
+  changeuuid: 5de1ff37-452d-452e-8e37-17706452f8d7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-teamsport-radio
+  broadcaster: independent
+  name: Teamsport Radio
+  streamUrl: https://uksouth1.juiceboxradio.com/tsradionational
+  bitrate: 96
+  codec: AAC+
+  homepage: http://teamsportradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 98ef30cd-0bef-49aa-8a54-af4ffc4780f1
+  changeuuid: 6c3dde39-1f98-4e34-9f3b-89b7d35d25f1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-80s-zoom
+  broadcaster: independent
+  name: "80s Zoom"
+  streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/SAM03AAC226_SC.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTzUFC8MX_VPOLHcB32vggZZhwC928NeErEyQ&s.jpg
+  homepage: http://www.80szoom.com/
+  country: GB
+  status: stream-only
+  stationuuid: 5ba5ce07-cb82-46ef-874a-7c9613bf2abf
+  changeuuid: 0570107d-65e2-4aec-b9b9-86e17c53e98e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bloop-london-radio-live4
+  broadcaster: independent
+  name: Bloop London Radio - live4
+  streamUrl: https://radio.canstream.co.uk:8058/live4.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://blooplondon.com/favicon.ico
+  homepage: https://blooplondon.com/
+  country: GB
+  status: stream-only
+  stationuuid: d38c7d24-a8b5-4148-a3ef-0a64b2988ca8
+  changeuuid: 69fbcacb-16f0-4e8e-8e07-7607ab4fff32
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-d3ep-radio
+  broadcaster: independent
+  name: D3EP Radio
+  streamUrl: https://cast.d3ep.com:8008/192?v=1726246823
+  bitrate: 192
+  codec: MP3
+  favicon: https://d3ep.com/assets/images/topbar-logo.png
+  homepage: https://d3ep.com/
+  country: GB
+  status: stream-only
+  stationuuid: d210ac34-0fee-4586-b9d6-24b84e2c0c4e
+  changeuuid: efef6687-fbd1-4bda-9a9f-de53178d4cca
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-heart-bristol
+  broadcaster: independent
+  name: Heart Bristol
+  streamUrl: https://media-ssl.musicradio.com/HeartBristol?
+  bitrate: 48
+  codec: AAC
+  favicon: https://www.heart.co.uk/assets_v4r/dist/combined/img/logos/bristol.png
+  homepage: https://www.heart.co.uk/bristol/
+  country: GB
+  status: stream-only
+  stationuuid: 599d579a-5554-45ff-8787-e811f88a6d8b
+  changeuuid: 09165c2e-539f-4d8f-8e3f-c4ed72cb6d54
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-point-blank-fm
+  broadcaster: independent
+  name: Point Blank FM
+  streamUrl: https://pointblankradio.co.uk/stream.mp3?latency=high
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.pointblankradio.com/wp-content/uploads/2022/11/Primary-logo.png
+  homepage: https://www.pointblankradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 9957dc39-7c25-499c-8a9c-5ce871924316
+  changeuuid: 4673049e-3e83-4538-85e6-2a5cf8e83736
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-scifi-radio
+  broadcaster: independent
+  name: SCIFI.radio
+  streamUrl: https://station.kryptonradio.com:8080/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://i0.wp.com/scifi.radio/wp-content/uploads/2021/02/cropped-scifiradio-b-512x512-1.png?fit=180%2C180&ssl=1
+  homepage: http://scifi.radio/
+  country: GB
+  status: stream-only
+  stationuuid: 092bb25d-5416-49f4-a994-e49271fcff0e
+  changeuuid: 0f1718c2-2e35-4b9c-bc12-e48b9fb76bf5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-cbn-television
+  broadcaster: independent
+  name: CBN-Television
+  streamUrl: https://5790d294af2dc.streamlock.net/CBNVI/CBNVI/playlist.m3u8
+  bitrate: 2032
+  codec: AAC,H.264
+  favicon: https://static.wixstatic.com/media/a79bb4_69234cd7684d43fa85e3b8d0c18fe9ee~mv2.png/v1/fill/w_167,h_57,al_c,lg_1,q_85,enc_auto/a79bb4_69234cd7684d43fa85e3b8d0c18fe9ee~mv2.png
+  homepage: https://www.cbnvirginislands.com/cbn-tv
+  country: GB
+  status: stream-only
+  stationuuid: 7c335c13-2325-4659-9b1a-4a0d31e3c61f
+  changeuuid: 5eb02c22-a501-44fa-9752-0ce3441c93a6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-london-soul-radio
+  broadcaster: independent
+  name: London Soul Radio
+  streamUrl: https://londonsoulradio.out.airtime.pro/londonsoulradio_a
+  bitrate: 128
+  codec: MP3
+  favicon: https://cdn-profiles.tunein.com/s137728/images/logod.jpg?t=637190405260000000
+  homepage: https://www.thesouloflondonradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 4b137d96-506f-4b0e-ad9f-744fd29a865d
+  changeuuid: 7cd44fd5-2c7f-4ec1-b0b3-a246275655ca
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-moon-phase-radio
+  broadcaster: independent
+  name: Moon Phase Radio
+  streamUrl: https://dc1.serverse.com/proxy/dnutqhxl/stream
+  bitrate: 192
+  codec: MP3
+  homepage: http://moonphaseradio.uk/
+  country: GB
+  status: stream-only
+  stationuuid: fb75959e-29e7-4d50-9cb2-b8b10891d5ab
+  changeuuid: f893c575-ddf2-464e-9165-71bd76de9f3e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-queen
+  broadcaster: independent
+  name: Queen
+  streamUrl: https://stream.pcradio.ru/Queen-hi
+  codec: AAC
+  favicon: null
+  homepage: https://pcradio.ru/
+  country: GB
+  status: stream-only
+  stationuuid: f97e38e9-b0e8-459e-ac37-1983f83a75da
+  changeuuid: 541c73e0-84ee-4234-a99e-47f7cd860a39
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-fred-film-radio-27-industry
+  broadcaster: independent
+  name: Fred Film Radio-27 INDUSTRY
+  streamUrl: https://s10.webradio-hosting.com/proxy/fredradioind/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.fred.fm/wp-content/uploads/2014/12/Fred-Logo_trasp_-copia.png
+  homepage: https://www.fred.fm/
+  country: GB
+  status: stream-only
+  stationuuid: addba89c-d7f5-4467-889e-97e5675cce8c
+  changeuuid: 3dd5bfd2-d9a8-4ae1-9b0f-86f439ce6794
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-greatest-hits-radio
+  broadcaster: independent
+  name: Greatest Hits Radio
+  streamUrl: https://stream-mz.hellorayo.co.uk/net2westmidlands.aac?aw_0_1st.skey=1602676850&direct=true&rp_source=1
+  bitrate: 48
+  codec: AAC+
+  favicon: https://assets.planetradio.co.uk/img/ConfigWebHeaderLogoSVGImageUrl/381.svg?ver=1545132394
+  homepage: https://www.hellorayo.co.uk/greatest-hits/west-midlands
+  country: GB
+  status: stream-only
+  stationuuid: 1bfae443-4fa5-45ed-92a5-8aecd6a70756
+  changeuuid: 9947a32e-28d6-4479-be0b-56f1927e2917
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hearme-2020s-pop-music
+  broadcaster: independent
+  name: HearMe - 2020s Pop Music
+  streamUrl: https://radio.hearme.fm:8000/stream
+  codec: MP3
+  homepage: https://hearme.fm/
+  country: GB
+  status: stream-only
+  stationuuid: ba9841e1-4178-49df-9333-db5d443c7046
+  changeuuid: b669a06f-17c6-4698-af77-dc3ef7bf4e5d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-x-00s
+  broadcaster: independent
+  name: Radio X 00s
+  streamUrl: https://media-ice.musicradio.com/RadioX00sMP3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radiox.co.uk/00s/
+  country: GB
+  status: stream-only
+  stationuuid: 1406b2e7-76db-4b1e-890a-af7a76f839e5
+  changeuuid: e423b33d-a99a-4e78-9c21-f2a16f4916bb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radiohead
+  broadcaster: independent
+  name: Radiohead
+  streamUrl: https://stream.pcradio.ru/radiohead-hi
+  codec: AAC
+  favicon: null
+  homepage: https://pcradio.ru/
+  country: GB
+  status: stream-only
+  stationuuid: 3c7f3361-f72f-4ff5-ad1d-9af563f95584
+  changeuuid: b1633f71-25c1-4942-96e1-fb3b75f3a2c9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-replay-news-english-news-radio-every-5-minutes
+  broadcaster: independent
+  name: REPLAY NEWS - English           News radio every 5 minutes
+  streamUrl: https://replaynewsen.ice.infomaniak.ch/replaynewsen-128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.publicsante.com/BIENVENU/LOGO%20REPLAY%20NEWS-EN.png
+  homepage: https://www.replaynews.net/
+  country: GB
+  status: stream-only
+  stationuuid: 6802b74c-71ba-453b-935f-beb2c03a952c
+  changeuuid: a74c7dba-8e2f-4a23-ae91-e145db40c47a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-sab-radio-folkestone-uk
+  broadcaster: independent
+  name: SAB RADIO FOLKESTONE UK
+  streamUrl: https://spectrum.radioca.st/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://shepwayspectrumarts.co.uk/favicon.ico
+  homepage: https://shepwayspectrumarts.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 5796e0f8-6fef-4efe-b0bb-9fe421401135
+  changeuuid: 06f7880e-e145-45d0-ab07-6c9263ca8cd5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-sam-fm-hampshire
+  broadcaster: independent
+  name: SAM FM Hampshire
+  streamUrl: https://listen-nation.sharp-stream.com/samfmhampshire.aac
+  bitrate: 48
+  codec: AAC+
+  favicon: https://hellorayo.co.uk/tesla/static/favicons/rayo/favicon.svg
+  homepage: https://hellorayo.co.uk/greatest-hits/
+  country: GB
+  status: stream-only
+  stationuuid: 93f0757d-7dcb-440c-ab30-274f0c6e5425
+  changeuuid: 001c46d0-6373-43fd-bd0d-2e4420481cb9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-ujima-radio
+  broadcaster: independent
+  name: Ujima Radio
+  streamUrl: https://radio.canstream.co.uk:8037/live.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.ujimaradio.com/favicon.ico
+  homepage: https://radio.canstream.co.uk:8037/live.mp3
+  country: GB
+  status: stream-only
+  stationuuid: 23687a64-3d15-44ab-a45c-e0114719b277
+  changeuuid: 7dfbe053-688d-4806-8df7-f21cb88c7848
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-beyond-radio
+  broadcaster: independent
+  name: Beyond Radio
+  streamUrl: https://stream.beyondradio.co.uk/radio/8000/high
+  bitrate: 192
+  codec: AAC
+  favicon: https://mmo.aiircdn.com/458/61aa613685fdd.png
+  homepage: https://www.beyondradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 3ce2d8da-aa4f-458c-8316-601ad5375981
+  changeuuid: 0d2492c4-d41d-4389-8e50-43ac58c73b15
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-box-office-radio
+  broadcaster: independent
+  name: Box Office Radio
+  streamUrl: https://s2.citrus3.com:8400/stream
+  bitrate: 256
+  codec: MP3
+  favicon: https://raw.githubusercontent.com/AusIPTV/IPTVLogos/master/Box_Office_Radio.png
+  homepage: https://boxofficeradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 0bf68865-449b-4190-a11c-597a4a47c0e9
+  changeuuid: 19ed9884-ab93-448d-b3ed-912973bad3df
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-british-tamil-radio
+  broadcaster: independent
+  name: British Tamil Radio
+  streamUrl: https://hello.citrus3.com:8188/stream
+  bitrate: 128
+  codec: AAC
+  favicon: https://www.bitronline.com/wp-content/uploads/2023/12/cropped-logo_radio_main-1-300x300.png
+  homepage: https://www.bitronline.com/
+  country: GB
+  status: stream-only
+  stationuuid: 1e64ded1-bc95-479c-8f67-e98ad15010ad
+  changeuuid: c3a64798-f884-41d8-b6b9-77e04ab75cdf
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-chunt-fm
+  broadcaster: independent
+  name: Chunt FM
+  streamUrl: https://fm.chunt.org/stream
+  bitrate: 320
+  codec: MP3
+  favicon: https://chunt.org/images/logo_fishe_calm_256.png
+  homepage: https://chunt.org/
+  country: GB
+  status: stream-only
+  stationuuid: 02ec5302-9dc4-42f7-9801-2278c06c1073
+  changeuuid: 231f4145-cdb7-4d3c-8ccb-62efb45d302a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hearme-1990s-pop-music
+  broadcaster: independent
+  name: HearMe - 1990s pop music
+  streamUrl: https://radio.hearme.fm:8050/stream
+  codec: MP3
+  homepage: https://hearme.fm/
+  country: GB
+  status: stream-only
+  stationuuid: 72acc195-c972-464b-96ae-d90f4d117e4b
+  changeuuid: 2bef1584-aa85-4734-8db3-535b1ce4fa9a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-heckington-living-community-radio
+  broadcaster: independent
+  name: Heckington Living Community Radio
+  streamUrl: https://streaming.live365.com/a52107
+  bitrate: 128
+  codec: MP3
+  homepage: http://www.heckingtonliving.co.uk/heckington-living-community-radio/
+  country: GB
+  status: stream-only
+  stationuuid: b459a3de-39f9-4179-9ce2-19e9e74c8d94
+  changeuuid: 7f3744e0-eebc-4cb1-9c13-f1966df5daed
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-jazz-radio-international
+  broadcaster: independent
+  name: JAZZ RADIO INTERNATIONAL
+  streamUrl: https://ec3.yesstreaming.net:1815/stream
+  bitrate: 64
+  codec: MP3
+  favicon: https://www.247onlineradio.com/wp-content/uploads/2015/07/JIR-logo.jpg
+  homepage: https://www.247onlineradio.com/jazz-radio-international/
+  country: GB
+  status: stream-only
+  stationuuid: 5d2e1109-82a9-40dd-8f90-25dfb0cbf01c
+  changeuuid: 1bcab309-8162-4d8a-b614-de227950c189
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-laser-558
+  broadcaster: independent
+  name: Laser 558
+  streamUrl: https://s6.autopo.st/proxy/stfkrnfr?mp=/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://i0.wp.com/laser558.live/wp-content/uploads/2023/06/cropped-820eb3aa2e08a58fcf16db6aebbbdcb4_2000x.png?fit=180%2c180&#038;ssl=1
+  homepage: https://laser558.live/
+  country: GB
+  status: stream-only
+  stationuuid: 09b323c7-3130-490b-b3cc-0521a24634ff
+  changeuuid: 4b64dd14-9dba-4fde-b953-0b01086c8c80
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-nation-classic-hits
+  broadcaster: independent
+  name: Nation Classic Hits
+  streamUrl: https://listen-nation.sharp-stream.com/nationparty.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.nationplayer.com/nation-classic-hits/
+  country: GB
+  status: stream-only
+  stationuuid: 9d082320-7f24-4189-9d1e-19eb89a32018
+  changeuuid: a2fdd064-9488-4392-a631-5ba5b50a4598
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-angel-radio
+  broadcaster: independent
+  name: Angel Radio
+  streamUrl: https://edge.clrmedia.co.uk/angel_hb
+  bitrate: 96
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/d58553_797ec55eb22b47f38dd7203577e49e5e%7emv2.png/v1/fill/w_180%2ch_180%2clg_1%2cusm_0.66_1.00_0.01/d58553_797ec55eb22b47f38dd7203577e49e5e%7emv2.png
+  homepage: https://www.angelradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: fb441035-d115-444b-b57c-2a97adb6e681
+  changeuuid: 5b0d5118-5b6d-459a-9e32-e2e5fb3fcb9c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hearme-classic-eurodisco
+  broadcaster: independent
+  name: HearMe - Classic EuroDisco
+  streamUrl: https://radio.hearme.fm:9810/stream
+  codec: MP3
+  favicon: https://hearme.fm/wp-content/uploads/2024/06/2024-Redrafted-Transparent-Box-No-Text-1-1024x1024.png
+  homepage: https://hearme.fm/radio/classic-eurodisco/
+  country: GB
+  status: stream-only
+  stationuuid: f6fd2828-5e3a-4ae4-85d1-86e34a85a3c2
+  changeuuid: 3e33a31d-45e0-4b92-9ee9-d159de3158fa
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hot-fm-uk
+  broadcaster: independent
+  name: Hot FM UK
+  streamUrl: https://hotfmuk.radioca.st/;
+  bitrate: 128
+  codec: MP3
+  favicon: https://static.mytuner.mobi/media/tvos_radios/3tbgbthvw26v.webp
+  homepage: https://www.hotfm.org.uk/
+  country: GB
+  status: stream-only
+  stationuuid: da5e3f19-fced-4436-b276-0e6a0db39b59
+  changeuuid: 8f48dc01-e7d5-49e4-84e3-fd416b8cbccf
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-mellow-mountain-radio
+  broadcaster: independent
+  name: Mellow Mountain Radio
+  streamUrl: https://owncast.mellowmountainradio.com/hls/stream.m3u8
+  bitrate: 1108
+  codec: AAC,H.264
+  favicon: https://irp.cdn-website.com/5e4cb10b/site_favicon_16_1715929040005.ico
+  homepage: https://www.mellowmountainradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 58834354-1bc1-426d-9b93-a5eecff8a80b
+  changeuuid: 5095cfb0-691b-4017-ab95-dcb6fcd05d1e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-north-manchester-fm
+  broadcaster: independent
+  name: North Manchester FM
+  streamUrl: https://radio.canstream.co.uk:8061/live.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://northmanchester.fm/wp-content/uploads/2011/08/nmfm10661.jpg
+  homepage: https://northmanchester.fm/
+  country: GB
+  status: stream-only
+  stationuuid: a553dcde-0b66-4c2d-a860-1b1e1e0aa887
+  changeuuid: cc11ab95-dea5-49db-8edb-2d2187f4e4ac
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-poprockradiouk
+  broadcaster: independent
+  name: PopRockRadioUK
+  streamUrl: https://popradiouk.out.airtime.pro/popradiouk_a
+  bitrate: 64
+  codec: MP3
+  country: GB
+  status: stream-only
+  stationuuid: dc27386e-ca42-4caa-b014-f7a4318f8b6f
+  changeuuid: f47df7d7-6cce-4248-abf8-dbd9e032fdb4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-stones-live-the-24-7-maidstone-united-radio-stat
+  broadcaster: independent
+  name: "Stones Live! - The 24/7 Maidstone United Radio Station"
+  streamUrl: https://uk5.internet-radio.com/proxy/stoneslive?mp=/stream;
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.stoneslive.com/wp-content/uploads/2015/07/julystoneslive.png
+  homepage: https://www.stoneslive.com/
+  country: GB
+  status: stream-only
+  stationuuid: 49c326d1-0058-40e7-b627-208b7800ff3c
+  changeuuid: 900f746e-a399-43cd-ab4e-77ddfd96868b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-the-christmas-station
+  broadcaster: independent
+  name: The Christmas Station
+  streamUrl: https://stream.radio.co/s63541ce9b/listen
+  bitrate: 64
+  codec: AAC
+  favicon: https://thechristmasstation.org/images/stationlogo.webp
+  homepage: https://thechristmasstation.org/
+  country: GB
+  status: stream-only
+  stationuuid: ca900cf9-e425-469b-b8cc-06a179f1f240
+  changeuuid: 49bdcc68-3289-4c91-94b6-07f158f83cde
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-wey-valley
+  broadcaster: independent
+  name: Wey Valley
+  streamUrl: https://stream.readyformed.com:8443/wey1
+  bitrate: 64
+  codec: AAC+
+  favicon: https://www.weyvalleyradio.uk/favicon.ico
+  homepage: https://www.weyvalleyradio.uk/l
+  country: GB
+  status: stream-only
+  stationuuid: e5daba4f-428e-11e9-aa55-52543be04c81
+  changeuuid: 2a9c14c8-b852-4d5d-900b-c5d96337080c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-kisstory-non-stop-old-skool-anthems
+  broadcaster: independent
+  name: " KISSTORY: Non-Stop Old Skool & Anthems"
+  streamUrl: https://live-bauerkiss.sharp-stream.com/kisstory.aac?direct=true&aw_0_1st.playerid=BMUK_Airable&aw_0_1st.skey=6778249992
+  bitrate: 48
+  codec: AAC+
+  favicon: https://cdn-profiles.tunein.com/s77960/images/logod.png
+  homepage: https://www.hellorayo.co.uk/kisstory
+  country: GB
+  status: stream-only
+  stationuuid: 53733e08-7728-40ee-b968-59e71f0281b6
+  changeuuid: 9f1a18d0-fda1-498a-8b86-c3c2cdd9d54a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-24-7-london-radio-royalty-free-music
+  broadcaster: independent
+  name: "24/7 London Radio - Royalty Free Music"
+  streamUrl: https://ec3.yesstreaming.net:3645/stream
+  bitrate: 64
+  codec: MP3
+  favicon: https://usercontent.one/wp/www.247londonradio.com/wp-content/uploads/2020/02/cropped-247-london-Radio-Logo.jpg
+  homepage: https://www.247londonradio.com/royalty-free-music/
+  country: GB
+  status: stream-only
+  stationuuid: df0fb96e-4a82-44c7-af2b-d4a08cf55145
+  changeuuid: f6b56f78-04b2-4f23-b2a0-dff1505cf638
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-cj-carlos
+  broadcaster: independent
+  name: CJ Carlos
+  streamUrl: https://s3.radio.co/sf2bda8390/listen
+  bitrate: 192
+  codec: AAC
+  homepage: https://cjcarlosevents.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 88a2e73d-2dcd-4f66-85b1-d3ca91916218
+  changeuuid: 9c9902cd-f144-41f5-ba00-4fbaf7162506
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-gamingnow-radio
+  broadcaster: independent
+  name: GamingNow Radio
+  streamUrl: https://media01.gamingnow.net:8010/
+  bitrate: 256
+  codec: MP3
+  homepage: https://gamingnow.net/radio/
+  country: GB
+  status: stream-only
+  stationuuid: d19b61de-a1d8-4ade-8111-96f054897a14
+  changeuuid: c02e6236-38c8-4e06-9aa7-65e77ee9d9c2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-in2beats
+  broadcaster: independent
+  name: in2Beats
+  streamUrl: https://in2radio.co.uk/IN2MP3
+  bitrate: 192
+  codec: MP3
+  homepage: https://in2beats.com/
+  country: GB
+  status: stream-only
+  stationuuid: 64d7e167-a7e7-4a8f-b2b0-4fc19efa6099
+  changeuuid: f5255018-64f4-4c9b-af59-899977228255
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-laser-558-classic
+  broadcaster: independent
+  name: Laser 558 Classic
+  streamUrl: https://s6.autopo.st/proxy/neffjohd?mp=/stream
+  bitrate: 128
+  codec: MP3
+  homepage: https://laser558.live/
+  country: GB
+  status: stream-only
+  stationuuid: 25171269-205c-4872-8a1a-ccaa705fe8f8
+  changeuuid: 7f5ce6a3-f548-4742-ae54-1d56f0a0e357
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-ribblefm
+  broadcaster: independent
+  name: RibbleFM
+  streamUrl: https://uksouth.streaming.broadcast.radio/ribblefm
+  codec: MP3
+  favicon: https://ribblefm.com/wp-content/uploads/2023/02/ribblefm-logo.webp
+  homepage: https://ribblefm.com/
+  country: GB
+  status: stream-only
+  stationuuid: a17fbf18-ea95-4baf-aebd-4aba1ef1dd34
+  changeuuid: 917f0067-2472-48a6-ac8d-26c365ddb6a6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-starpoint-radio
+  broadcaster: independent
+  name: Starpoint Radio
+  streamUrl: https://stream2.hippynet.co.uk/stream/starpointradiohigh
+  bitrate: 192
+  codec: MP3
+  homepage: http://www.starpointradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: f226bc65-686a-49f1-b82c-6743612197ba
+  changeuuid: b4dfad64-4e41-4265-bcd4-b8ec7bffa68e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-uk-national-radio
+  broadcaster: independent
+  name: UK National Radio
+  streamUrl: https://das-edge14-live365-dal02.cdnstream.com/a80402
+  bitrate: 192
+  codec: MP3
+  favicon: https://media.live365.com/download/119460ab-eb43-4fca-a482-eadc9c4d9ef0.png
+  homepage: https://www.uknationalradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 38441808-02e0-4d04-88ae-4e67bee3fdf4
+  changeuuid: f7740d80-0d4d-4e59-b5de-bc11c55bf103
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-1btn
+  broadcaster: independent
+  name: "1BTN"
+  streamUrl: https://edge.clrmedia.co.uk/obfm_mp3
+  codec: MP3
+  homepage: https://1btn.fm/
+  country: GB
+  status: stream-only
+  stationuuid: 5c353e67-3f33-45b7-8a7f-eb4571907c4e
+  changeuuid: 90b896e6-0c5a-4ba5-b396-247cd29256e0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-24-7-restaurant-radio
+  broadcaster: independent
+  name: "24/7 Restaurant Radio"
+  streamUrl: https://ec6.yesstreaming.net:1655/stream
+  bitrate: 64
+  codec: MP3
+  favicon: https://usercontent.one/wp/www.247restaurantradio.com/wp-content/uploads/2021/04/cropped-247-Restaurant-Radio.jpg
+  homepage: https://www.247restaurantradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 2412aaa9-4a0e-48a5-b22f-245801bf064d
+  changeuuid: 46d341c0-11a2-4686-a9a8-ae83810cc1c7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-alpha-wave-radio
+  broadcaster: independent
+  name: Alpha Wave Radio
+  streamUrl: https://listentomystream.com:8068/stream
+  bitrate: 320
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/a8d0cc_272a834a431540a6a4bc2c9a7f652ec0~mv2.png/v1/fill/w_123,h_123,al_c,q_85,usm_0.66_1.00_0.01,enc_auto/Bright%20Blue.png
+  homepage: https://www.alphawaveradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: d275f459-7fb1-49a5-952c-1637718f0878
+  changeuuid: 1f2467fb-0392-4c7f-8cd9-1fddbe505006
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bbc-radio-tees
+  broadcaster: independent
+  name: BBC Radio Tees
+  streamUrl: https://a.files.bbci.co.uk/ms6/live/3441A116-B12E-4D2F-ACA8-C1984642FA4B/audio/simulcast/hls/nonuk/pc_hd_abr_v2/aks/bbc_tees.m3u8
+  bitrate: 101
+  codec: AAC+
+  favicon: https://static.files.bbci.co.uk/sounds/web/sounds-web/img/sounds-apple-touch-icon.ead169771d.png
+  homepage: https://www.bbc.co.uk/radiotees/
+  country: GB
+  status: stream-only
+  stationuuid: 47ee32eb-3d2b-4dc8-bb60-825ee57db0ed
+  changeuuid: 166c2b1f-f8d0-4480-9fff-5c07add88308
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-beware-the-radio
+  broadcaster: independent
+  name: "Beware! The Radio"
+  streamUrl: https://bewaretheradio.out.airtime.pro/bewaretheradio_a
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.bewaretheradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 7271f78c-519b-4fbc-b034-1a3213e0dbb3
+  changeuuid: fcc5c593-6b8a-4c23-a7eb-f83b4975f1dc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-fred-film-radio-mandarin
+  broadcaster: independent
+  name: FRED FILM RADIO Mandarin
+  streamUrl: https://s10.webradio-hosting.com/proxy/fredradiocn/stream/1/
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.fred.fm/wp-content/uploads/2014/12/Fred-Logo_trasp_-copia.png
+  homepage: https://www.fred.fm/
+  country: GB
+  status: stream-only
+  stationuuid: ac0d34c3-748d-4d2f-aa42-7cfb07145ef8
+  changeuuid: 58ac4297-cc98-4794-a00b-6d82775953f6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hearme-2010s-pop-music
+  broadcaster: independent
+  name: HearMe 2010s pop music
+  streamUrl: https://radio.hearme.fm:8030/stream
+  codec: MP3
+  homepage: https://hearme.fm/
+  country: GB
+  status: stream-only
+  stationuuid: af98071e-f1c2-4ca3-8120-1d68cf53661e
+  changeuuid: 27dea5af-bd91-4f86-a766-6e3b75918585
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-ostm-radio
+  broadcaster: independent
+  name: OSTM Radio
+  streamUrl: https://stream.zeno.fm/1vx25xbdmzzuv
+  codec: MP3
+  favicon: https://www.ostm.co.uk/img/favicon.ico
+  homepage: https://www.ostm.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: a6d8473d-e8fe-47e5-b05a-edcdf4c18934
+  changeuuid: 1d5d27e1-c82e-4f69-b9ac-550335ebcf86
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-capital-nottinghamshire
+  broadcaster: independent
+  name: Capital (Nottinghamshire)
+  streamUrl: https://media-ice.musicradio.com/CapitalNottinghamshireMP3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.capitalfm.com/assets_v4r/capital/img/favicon-196x196.png
+  homepage: https://www.capitalfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: 49d8ced8-12e6-40b3-a099-327bb146b946
+  changeuuid: af884f5b-8181-4f4e-88cd-d0259f3b0987
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-caravan-radio
+  broadcaster: independent
+  name: Caravan Radio
+  streamUrl: https://stream4.themediasite.co.uk:8044/stream?_=456752
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.caravanradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 064d9bd9-7246-462c-a544-bb91ce1e14e9
+  changeuuid: 77b4d4de-2d73-418c-8ba2-26903544d7ca
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-cosmic-fuzz-fm
+  broadcaster: independent
+  name: COSMIC FUZZ FM
+  streamUrl: https://26343.live.streamtheworld.com/SAM04AAC335_SC
+  bitrate: 320
+  codec: MP3
+  favicon: https://img1.wsimg.com/isteam/ip/a07df4e6-3874-46a7-b088-6a4e68a6123b/blob-6f3a7d7.png/:/cr=t:0%25,l:0%25,w:100%25,h:100%25/rs=w:806,h:403
+  homepage: https://cosmicfuzzfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: 274319b9-6662-465b-8016-c6fae9b14adb
+  changeuuid: 62f84619-7075-4edb-84e2-822a2b8394f2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-galaxy-of-stars
+  broadcaster: independent
+  name: "Galaxy of Stars "
+  streamUrl: https://media-ssl.musicradio.com/Global-M-GalaxyStars
+  bitrate: 48
+  codec: AAC
+  favicon: https://images.globalplayer.com/images/595200?width=450&signature=8QhLiiKoeaxJMt_Zc6w4S9Wekz0=
+  homepage: https://www.globalplayer.com/playlists/2SWmn/
+  country: GB
+  status: stream-only
+  stationuuid: 8005a59e-7245-4872-8e84-aced12f6f7c2
+  changeuuid: 1cffa0ce-aa90-41a1-9b31-8d2075107866
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-magic-classical
+  broadcaster: independent
+  name: Magic Classical
+  streamUrl: https://stream-mz.hellorayo.co.uk/scala.aac
+  bitrate: 48
+  codec: AAC+
+  homepage: https://www.hellorayo.co.uk/magic-classical
+  country: GB
+  status: stream-only
+  stationuuid: d18943f2-7c18-4e1d-8cf2-9ce1c5616f86
+  changeuuid: acc833af-5bcb-411f-aef5-edf645ef7573
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-ssradio
+  broadcaster: independent
+  name: SSRadio
+  streamUrl: https://ssradiol.radioca.st/listen.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://ssradio.com/wp-content/themes/ssradio/images/ssrDeepLogo.gif
+  homepage: https://ssradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 0753f1cf-8812-4133-a586-cec763884ba7
+  changeuuid: c64beda1-9d76-4fab-8e65-5741c30c3eeb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-the-people-s-radio-a-star-citizen-community-radi
+  broadcaster: independent
+  name: "The People's Radio - A Star Citizen Community Radio Station"
+  streamUrl: https://us1.streamingpulse.com/ssl/7058
+  bitrate: 320
+  codec: MP3
+  favicon: https://us7.streamingpulse.com/4232/tmp/images/logo.1632318369.png
+  homepage: https://thepeoplesradio.space/
+  country: GB
+  status: stream-only
+  stationuuid: 4ea91a6e-3b76-437e-8e5f-8e2d73d5ab39
+  changeuuid: 7edf0edf-3d3f-4d3e-ab1d-cad4abfebe6f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-winchester-radio
+  broadcaster: independent
+  name: Winchester Radio
+  streamUrl: https://winchest.radioca.st/stream?rp_source=1&=&&___cb=427101946874329
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.hampshirehospitals.nhs.uk/application/files/5715/9741/0233/WinchRadio-portrait250x109.png
+  homepage: http://winchester.radio/
+  country: GB
+  status: stream-only
+  stationuuid: 3361523d-d9c9-4908-ae39-84997ee09ea2
+  changeuuid: c9047f75-b7b6-4235-ad8e-547ee3cd86c6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-virgin-radio-uk-rock-n-roll-radio-from-the-top-o
+  broadcaster: independent
+  name: " VIRGIN RADIO UK: Rock‘n’Roll Radio From The Top Of The Tower"
+  streamUrl: https://virgin.live.stream.broadcasting.news/stream
+  bitrate: 128
+  codec: AAC
+  favicon: https://cdn-profiles.tunein.com/s266113/images/logod.png
+  homepage: https://virginradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 723e042f-3c2f-4562-b8fa-3f9a8d31cf3e
+  changeuuid: 52ad9798-438b-4fd3-bdfc-3fa3b0a06dc1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-24-7-seawaves-radio
+  broadcaster: independent
+  name: "24/7 Seawaves Radio"
+  streamUrl: https://ec6.yesstreaming.net:1505/stream
+  bitrate: 64
+  codec: MP3
+  favicon: https://www.247natureradio.com/wp-content/uploads/2021/09/247-Seawaves-Radio.jpg
+  homepage: https://www.247natureradio.com/24-7-seawaves-radio/
+  country: GB
+  status: stream-only
+  stationuuid: 04c6c260-eafc-419c-b374-f061080bfd81
+  changeuuid: 2c82e42e-a971-4499-9da5-9e27d3bb8029
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-big-barn-radio
+  broadcaster: independent
+  name: BIG BARN RADIO
+  streamUrl: https://s2.radio.co/s04214ea9a/listen
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.wix.com/favicon.ico
+  homepage: https://bigbarnradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 1ec70ece-e320-40f3-bc96-95f57f0ebf5a
+  changeuuid: eedad89a-2660-4c1b-b226-28d7a671b26d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-broradio
+  broadcaster: independent
+  name: broradio
+  streamUrl: https://streaming.broadcastradio.com:8422/brorad?=&&___cb=380218828489260
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.broradio.fm/
+  country: GB
+  status: stream-only
+  stationuuid: 8787051e-b4f7-4748-b70d-300532da5164
+  changeuuid: ce17dccb-c045-4e10-802c-8b08aadca165
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-burgess-hill-radio
+  broadcaster: independent
+  name: Burgess Hill Radio
+  streamUrl: https://streaming.broadcastradio.com:9312/burgesshillradio
+  codec: MP3
+  homepage: https://www.burgesshillradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 5b33e248-4dff-44c4-b3ce-e4eabf3d8d09
+  changeuuid: 8a382297-e6c8-449b-b8f0-ac09761e32c6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-heritage-chart-radio
+  broadcaster: independent
+  name: Heritage Chart Radio
+  streamUrl: https://s4.radio.co/sd5b175766/listen
+  bitrate: 320
+  codec: MP3
+  homepage: https://www.heritagechart.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 405ac58a-0ea5-4c5e-b158-0d750e871ea0
+  changeuuid: 1769cc17-0d05-48ca-8ae5-9c6614d34147
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-jingle-ark-jingle-jukebox
+  broadcaster: independent
+  name: Jingle Ark Jingle Jukebox
+  streamUrl: https://stream.zeno.fm/6q0ftbdzk2zuv
+  codec: MP3
+  favicon: https://zeno.fm/static/icons/apple-icon-120x120.png
+  homepage: https://zeno.fm/radio/jingle-ark-classics/
+  country: GB
+  status: stream-only
+  stationuuid: b55b73c6-20b6-4fd4-a86f-1f653d81dcf7
+  changeuuid: 948cf13a-d8cc-4702-8adc-99643a75eab3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-music-galaxy-radio
+  broadcaster: independent
+  name: Music Galaxy Radio
+  streamUrl: https://eu10.fastcast4u.com/themusi2
+  bitrate: 128
+  codec: MP3
+  favicon: https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRl5H_571Uc9TPjudUTSRXY6Kme_1deY38X0r8gWVmn1YclbOUPbBC3exlC4gEOZEs05r0&usqp=CAU
+  homepage: https://www.themusicgalaxyradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: a0beeffe-2cb5-43f0-bec0-cee8ea861dfe
+  changeuuid: 26d3333f-54fe-439d-a180-eae7f129ab83
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-retro-mix-radio
+  broadcaster: independent
+  name: Retro Mix Radio
+  streamUrl: https://stream.retromixradio.co.uk/radio48
+  bitrate: 48
+  codec: AAC+
+  homepage: https://www.retromixradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: fe3689b2-bf07-4e8c-92a8-8f491164e2b2
+  changeuuid: 7720f398-fe7e-49be-8949-baa368ae85f4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-sheppey-fm-92-2
+  broadcaster: independent
+  name: Sheppey FM 92.2
+  streamUrl: https://streaming05.liveboxstream.uk/proxy/sheppeyf?mp=/stream
+  bitrate: 256
+  codec: MP3
+  homepage: https://sheppeyfm.org.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 76e001af-8740-4da8-93cc-5eb83016050e
+  changeuuid: 83f8dcc5-ce7d-41f0-9a8f-84cb47fd0125
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-your-hits-digital
+  broadcaster: independent
+  name: Your Hits Digital
+  streamUrl: https://stream-yourhitsdigital.creativedork.com/
+  bitrate: 64
+  codec: AAC+
+  homepage: https://www.yourhitsdigital.com/
+  country: GB
+  status: stream-only
+  stationuuid: cce4d842-89f1-404d-b32b-8ba4f63bba40
+  changeuuid: 2edda94c-7295-47d5-a86d-5890bf81d62d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-242-radio
+  broadcaster: independent
+  name: "242 Radio"
+  streamUrl: https://uk7.internet-radio.com/proxy/242radio?mp=/stream&1705137844878
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.242radio.com/index_htm_files/17903@2x.jpg
+  homepage: https://www.242radio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 7790d186-8111-4c34-9d8f-ffdafa68732b
+  changeuuid: 778a3892-d07d-42c9-9682-f264916fa32d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-apocalypse-radio
+  broadcaster: independent
+  name: Apocalypse Radio
+  streamUrl: https://radiopanel.scoobynetworks.uk:10990/stream?type=http&nocache=28
+  bitrate: 320
+  codec: AAC+
+  homepage: https://apocalypse-radio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: df11295d-b998-4af0-b9b2-6f67b7615bbe
+  changeuuid: bbf5e69d-9500-4108-a223-02741d9a579c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bfbs-uk
+  broadcaster: independent
+  name: BFBS UK
+  streamUrl: https://listen-ssvcbfbs.sharp-stream.com/ssvcbfbs1.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://radio.bfbs.com/icons/icon-512x512.png?v=0afec91a27aaa6d57f2b000c6fbe8cac
+  homepage: https://radio.bfbs.com/stations/bfbs-uk
+  country: GB
+  status: stream-only
+  stationuuid: 5fb0e4b7-d7dd-4177-8521-3186746fd06e
+  changeuuid: a8fe9921-d08c-4883-a6e6-4ebdc3254976
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bloomberg-uk
+  broadcaster: independent
+  name: Bloomberg UK
+  streamUrl: https://bloomberg-live-prod-us-east-1.s3.amazonaws.com/rad/Channel-RAD-AWS-virginia-1/Source-RadUK-96-1_live.m3u8
+  codec: UNKNOWN
+  favicon: https://www.bloomberg.com/favicon.ico
+  homepage: https://www.bloomberg.com/audio
+  country: GB
+  status: stream-only
+  stationuuid: 24f61d87-4a36-4db7-b80a-df96755e9b7f
+  changeuuid: b9c3c34b-c19f-4bdc-b885-1428b22ea6be
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-frisk-guilty-pleasures
+  broadcaster: independent
+  name: Frisk Guilty Pleasures
+  streamUrl: https://www.friskradio.com:8443/stream31
+  codec: AAC
+  favicon: https://management.friskradio.com:7000/stations/logo?id=6
+  homepage: https://www.friskradio.com/?station=6#station-select-panel
+  country: GB
+  status: stream-only
+  stationuuid: 40adec4e-ed1e-4a28-b7ea-417d5bf6d7eb
+  changeuuid: f685ab39-76a7-496e-ab3a-863ed86f7d75
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-inverness-hospital-radio
+  broadcaster: independent
+  name: Inverness Hospital Radio
+  streamUrl: https://uksoutha.streaming.broadcast.radio/invernesshr?1699799769753=
+  codec: MP3
+  homepage: https://www.invernesshospitalradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 8af6269e-5a11-4ca3-bb57-9306fa0a7a34
+  changeuuid: b17aaf20-3c58-4859-abbe-79265bf4d3f2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-nation-xmas
+  broadcaster: independent
+  name: Nation Xmas
+  streamUrl: https://listen-nation.sharp-stream.com/nationxmas.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.nationplayer.com/nation-xmas/
+  country: GB
+  status: stream-only
+  stationuuid: 36733cfe-2acf-46ee-bd04-d243bc76cb80
+  changeuuid: fbebf74f-31f5-484f-b75c-1398301a80f6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-ocean-youth-radio
+  broadcaster: independent
+  name: Ocean Youth Radio
+  streamUrl: https://stream.radio.co/s7bb9c4fc8/low
+  bitrate: 64
+  codec: MP3
+  favicon: https://images.squarespace-cdn.com/content/v1/63b306b5c427c63f7ac443bb/a113998f-ade6-40ba-9e52-0ee49b945a1d/02_OYLogoWhite.png?format=1500w
+  homepage: https://www.oceanyouth.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 407a84ec-091c-4741-ad11-36698c83698b
+  changeuuid: 6e4db4af-8d11-45bb-a62b-081018ecadb2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-groovy
+  broadcaster: independent
+  name: Radio Groovy
+  streamUrl: https://stream.radio.co/s560edbdb7/listen
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radiogroovy.com/
+  country: GB
+  status: stream-only
+  stationuuid: d2243a22-f0a8-4f65-852f-ffbf58df7ee8
+  changeuuid: f19c9d01-0609-4fb2-988f-437204f56cc0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-101-8-wcr-fm
+  broadcaster: independent
+  name: "101.8 WCR FM"
+  streamUrl: https://stream3.themediasite.co.uk:8312/stream?_=580911
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.wcrfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: 7acde6d6-84b1-46dd-81bc-4fc8f1e4b6b0
+  changeuuid: fad87b4e-d319-4ee8-b724-a04f8616dbb6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-24-7-country-walks-radio
+  broadcaster: independent
+  name: "24/7 Country Walks Radio"
+  streamUrl: https://ec6.yesstreaming.net:1585/stream
+  bitrate: 64
+  codec: MP3
+  favicon: https://www.247onlineradio.com/wp-content/uploads/2023/04/247-Country-Walks.jpg
+  homepage: https://www.247onlineradio.com/24-7-online-radio-group-stations/24-7-country-walks-radio/
+  country: GB
+  status: stream-only
+  stationuuid: 9db7f22c-3997-40e6-a039-c045069ec42f
+  changeuuid: c77b3f5c-c5d8-48f2-932d-227a46e4196f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-crystal-107-4-fm
+  broadcaster: independent
+  name: Crystal 107.4 FM
+  streamUrl: https://crystalfm-radiohosting2.radioca.st/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.crystalfm.co.uk/index_htm_files/favicon.ico
+  homepage: https://www.crystalfm.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 70b27d48-d503-422a-b023-69b45b7759c7
+  changeuuid: 5c4be0ca-7784-420b-87fc-554d3d26fee4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-liverpool-live-radio
+  broadcaster: independent
+  name: Liverpool Live Radio
+  streamUrl: https://stream.aiir.com/xbmvsamvpnluv
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/417/5f8022222baf6.png
+  homepage: https://www.liverpoolliveradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 0c669041-51b8-4110-8c3f-8eee1ca15e68
+  changeuuid: 9fa6af1b-7423-4d4d-8f01-e22c9b1e86be
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-mechanical-music-radio
+  broadcaster: independent
+  name: Mechanical Music Radio
+  streamUrl: https://global.citrus3.com:2020/stream/mechanicalmusicradio
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.mechanicalmusicradio.co.uk/uploads/1/1/3/3/1133045/google-play-store-featured-section.png
+  homepage: https://www.mechanicalmusicradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: d9c58c54-f96a-4881-aa56-6150094252c0
+  changeuuid: 6fb811d3-6a94-4905-b2ea-360df252e64e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-buena-vida
+  broadcaster: independent
+  name: Radio Buena Vida
+  streamUrl: https://s4.radio.co/s69b281ac0/listen
+  bitrate: 192
+  codec: MP3
+  favicon: https://buenavida.co.uk/wp-content/uploads/2022/08/Small-logo-for-Soundcloud.jpg
+  homepage: https://buenavida.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 3bee72bd-0de4-448e-ae23-2e962923643f
+  changeuuid: 8952b4f6-48dc-4009-9481-4aad5129575f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-newark
+  broadcaster: independent
+  name: Radio Newark
+  streamUrl: https://streamer.radionewark.com/
+  bitrate: 64
+  codec: MP3
+  favicon: https://radionewark.org/images/favicon/apple-touch-icon.png
+  homepage: https://radionewark.org/
+  country: GB
+  status: stream-only
+  stationuuid: a07d5f19-88c6-4054-b3cd-60d31b93d569
+  changeuuid: 9e03f4f6-f08c-4678-89b0-46fc378e61f2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-sabras-radio
+  broadcaster: independent
+  name: Sabras Radio
+  streamUrl: https://radio.canstream.co.uk:8025/live.mp3?_=596083
+  bitrate: 128
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/232/6460ea059133d.png
+  homepage: https://www.sabrasradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 3c4f2b35-946b-4ce7-adda-13256d058512
+  changeuuid: ce12e9a9-ba64-494d-9aed-d6223509e08f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-24-7-spa-radio
+  broadcaster: independent
+  name: "24/7 Spa Radio"
+  streamUrl: https://ec6.yesstreaming.net:2915/stream
+  bitrate: 64
+  codec: MP3
+  favicon: https://usercontent.one/wp/www.247sparadio.com/wp-content/uploads/2021/04/cropped-247-Spa-Radio.jpg
+  homepage: https://www.247sparadio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 5b691932-daa8-44f0-a9d8-2533c2a28585
+  changeuuid: 344a7632-c237-4fea-935c-dee621f04cf9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-95-6-brfm
+  broadcaster: independent
+  name: "95.6 BRFM"
+  streamUrl: https://mediacp.nkpa.co.uk/stream/Brfm/BrfmMP3
+  bitrate: 128
+  codec: AAC
+  homepage: https://brfm.net/
+  country: GB
+  status: stream-only
+  stationuuid: 0a26cd0b-c61c-41ee-a4ad-9b4bde46da71
+  changeuuid: a1917b87-c01c-4ebd-8804-400425cb3abe
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-banita-maxx-radio
+  broadcaster: independent
+  name: Banita Maxx Radio
+  streamUrl: https://stream.zeno.fm/z5artz4g2wzuv
+  codec: MP3
+  homepage: https://banitamaxx.pl/
+  country: GB
+  status: stream-only
+  stationuuid: 22bc86f2-6572-4a85-ab55-74e92c3ad50f
+  changeuuid: 78c95a7e-f742-46c6-8888-9153cfc3f047
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-dance-radio-uk
+  broadcaster: independent
+  name: Dance Radio UK
+  streamUrl: https://dancestream.danceradiouk.com/
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.danceradiouk.com/
+  country: GB
+  status: stream-only
+  stationuuid: 0a525f49-59dc-463a-ad3a-904d707da6e0
+  changeuuid: 06b06b63-3312-472d-a25c-0e0b94426f2b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-fenland-youth-radio
+  broadcaster: independent
+  name: Fenland Youth Radio
+  streamUrl: https://streaming.broadcastradio.com:10445/youngtech
+  codec: UNKNOWN
+  favicon: https://irp.cdn-website.com/546fca48/site_favicon_16_1630357525872.ico
+  homepage: https://www.fenlandyouthradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: f9de3e59-bc15-4ec5-82af-788374a4f90a
+  changeuuid: e9a74638-a62f-4ec0-a34d-46915b89e6b1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-forest-fm
+  broadcaster: independent
+  name: Forest FM
+  streamUrl: https://radio.canstream.co.uk:8146/live.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://forestfm.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 7aa9c305-b5c2-4410-9605-ff8b1fe2fbed
+  changeuuid: 49d31121-a75b-4777-b285-436fde065fb7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-iconicextra
+  broadcaster: independent
+  name: IconicExtra
+  streamUrl: https://ukbeatz.radioca.st/stream
+  bitrate: 320
+  codec: MP3
+  favicon: https://www.iconicextra.com/wp-content/uploads/2020/06/cropped-logo_redo1cl-180x180.png
+  homepage: https://www.iconicextra.com/
+  country: GB
+  status: stream-only
+  stationuuid: 428d41dc-2879-47b2-91fc-eee02b5dfa84
+  changeuuid: 76ce20a5-96bf-4532-b239-9dd461e121ce
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-insanity-radio
+  broadcaster: independent
+  name: Insanity Radio
+  streamUrl: https://stream.cor.insanityradio.com/insanity.flac
+  codec: OGG
+  homepage: https://insanityradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 03c2017f-2ba2-4338-af52-5a1f5e67aa46
+  changeuuid: 7daa047e-d68b-424b-855b-daf72f24483b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-mix-92-6
+  broadcaster: independent
+  name: Mix 92.6
+  streamUrl: https://stream4.hippynet.co.uk/stream/8012/stream
+  codec: MP3
+  favicon: https://mix926.com/favicon.ico
+  homepage: https://mix926.com/
+  country: GB
+  status: stream-only
+  stationuuid: a82450a3-11b1-4054-812e-8e27e78e96e0
+  changeuuid: 66fb162a-6939-4f4d-8b9d-11ee05bfadcd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-music-box-radio
+  broadcaster: independent
+  name: Music Box Radio
+  streamUrl: https://uk5.internet-radio.com/proxy/musicboxradio?mp=/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.musicboxradio.co.uk/apple-touch-icon.png
+  homepage: https://www.musicboxradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: cd6a9b24-b02b-4d6a-82cf-74479f003fd6
+  changeuuid: 5ca21691-3dc0-4296-858e-cddf9188bff6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-nr1-drum-and-bass-radio
+  broadcaster: independent
+  name: NR1 Drum and Bass Radio
+  streamUrl: https://radio.listen-nr1dnb.com/listen/nr1_dnb_radio/radio.mp3
+  bitrate: 320
+  codec: MP3
+  favicon: https://listen.nr1dnb.com/icons/icon-512.png
+  homepage: https://listen.nr1dnb.com/
+  country: GB
+  status: stream-only
+  stationuuid: 52243a80-7713-4392-89c0-f3bde610993b
+  changeuuid: fb8de010-1592-470a-a17a-17eb2e643d9f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-powerstream
+  broadcaster: independent
+  name: PowerStream
+  streamUrl: https://my.powerstream.live/1985/stream
+  bitrate: 320
+  codec: MP3
+  favicon: https://dj-stream.com/favicon.ico
+  homepage: https://dj-stream.com/
+  country: GB
+  status: stream-only
+  stationuuid: d78d0c42-03c7-42a3-a5ac-f13aede07fcf
+  changeuuid: 8860d1fc-44da-4487-b56b-2ab38014ece4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-west-middlesex
+  broadcaster: independent
+  name: Radio West Middlesex
+  streamUrl: https://uk6.internet-radio.com/proxy/radiowestmiddlesex?mp=/stream;
+  bitrate: 128
+  codec: MP3
+  favicon: http://radiowestmiddlesex.org.uk/wordpress/wp-content/themes/RWMTheme4/images/page.jpg
+  homepage: http://radiowestmiddlesex.org.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 09709427-073f-48f0-96a0-be2e49851dba
+  changeuuid: 02d00d0b-887a-4dd0-b6bf-bcd1d0bdf88e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-thornbury-radio
+  broadcaster: independent
+  name: Thornbury Radio
+  streamUrl: https://s42.myradiostream.com/29400/listen.mp3?_=135900
+  bitrate: 192
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/222/5f4659d5167b4.png
+  homepage: https://www.thornbury.radio/
+  country: GB
+  status: stream-only
+  stationuuid: f08c35c9-489d-4934-81b8-50b707b16d83
+  changeuuid: 31f67cab-1b5e-40ab-aee5-f031263e74be
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-vintage-radio-birkenhead
+  broadcaster: independent
+  name: Vintage Radio birkenhead
+  streamUrl: https://streaming04.liveboxstream.uk/proxy/vintager/stream
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.vintageradio.org.uk/#
+  country: GB
+  status: stream-only
+  stationuuid: 4289ab0a-083c-45be-a044-d0e5e612cae2
+  changeuuid: 44a7ebbe-b2bf-428e-a3b6-1d6362776561
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-voices
+  broadcaster: independent
+  name: Voices
+  streamUrl: https://voicesradio.out.airtime.pro/voicesradio_a
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.voicesradio.co.uk/favicon.ico
+  homepage: https://www.voicesradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 66bf1eb0-9125-4e6c-a83a-4cb928493c0d
+  changeuuid: e1560e08-eb41-4bfa-a9cf-e7b47a688775
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-we-get-lifted-radio-wglr-192k-mp3
+  broadcaster: independent
+  name: We Get Lifted Radio (WGLR) 192k mp3
+  streamUrl: https://s3.radio.co/sa80d22794/listen
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.wegetliftedradio.com/wp-content/uploads/2020/03/cropped-WGLR-HEADER-1-1-1-600x343.png
+  homepage: https://wegetliftedradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 36c5b127-92df-447f-add6-02e91acbc238
+  changeuuid: ecc885b1-76c5-4ecd-af41-5f5b44e6266e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-britcom-4
+  broadcaster: independent
+  name: Britcom 4
+  streamUrl: https://cast2.asurahosting.com/proxy/britcom4/stream.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://pumpkinfm.com/wp-content/uploads/2022/03/pfmnewlogoSmall.jpg
+  homepage: https://pumpkinfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: 45daead0-5c3f-44f4-8bb3-177596bcf8ab
+  changeuuid: 25d9b55a-0ef2-467b-bf93-3e8b01bc3a12
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-cam-fm-97-2
+  broadcaster: independent
+  name: Cam FM 97.2
+  streamUrl: https://stream.camfm.co.uk/camfm
+  codec: MP3
+  favicon: https://www.camfm.co.uk/media/images/default_thumb.png
+  homepage: https://www.camfm.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: bdbb1fe5-0542-4a68-8b39-2556703d35f7
+  changeuuid: a1a7addb-2f14-4b22-907b-5b4d949d0405
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-fantasy-radio-devizes
+  broadcaster: independent
+  name: Fantasy Radio (Devizes)
+  streamUrl: https://server.fantasyradio.co.uk/fantasyradio
+  bitrate: 256
+  codec: MP3
+  favicon: https://www.fantasyradio.co.uk/files/9414/1236/5176/fbthumb.png
+  homepage: https://www.fantasyradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: c41b8b47-87e9-4c33-a4c0-f890c488a81a
+  changeuuid: f0839370-4ee1-44eb-bd51-241caf4d6b49
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-island-time-infinite-mixtapes-nts
+  broadcaster: independent
+  name: "Island Time - Infinite Mixtapes | NTS"
+  streamUrl: https://stream-mixtape-geo.ntslive.net/mixtape21
+  codec: MP3
+  homepage: https://www.nts.live/infinite-mixtapes/island-time
+  country: GB
+  status: stream-only
+  stationuuid: 94b2330d-3c81-4a2c-ad0f-a6c36f506edb
+  changeuuid: da5cf0f6-a686-4569-afe2-4b16bb983520
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-kennet-radio
+  broadcaster: independent
+  name: Kennet Radio
+  streamUrl: https://stream.kennetradio.com/64.aac
+  bitrate: 48
+  codec: AAC
+  favicon: https://kennetradio.com/wp-content/uploads/2021/05/kr_square_150.png
+  homepage: https://kennetradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 9029e03c-1645-49eb-bb36-de7a8161e6ad
+  changeuuid: 47ddbff3-42fa-415c-9d6c-3890c329af43
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-mkfm
+  broadcaster: independent
+  name: MKFM
+  streamUrl: https://mkfmradioplayer2.radioca.st/;stream.nsv?=&&___cb=838498533391580
+  bitrate: 128
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/171/6367c3f242240.png
+  homepage: https://www.mkfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: c39a0882-25ec-44c0-aede-80eef1dd2c32
+  changeuuid: d691e08a-ad21-49cf-8868-434711dc3ab7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-northwich
+  broadcaster: independent
+  name: Radio Northwich
+  streamUrl: https://stream.radio.co/s98163f694/listen
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radionorthwich.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 230d7f4c-1369-44f7-9d92-cee399912a1a
+  changeuuid: 4b1aa653-f4cf-473a-aae9-988dfa9ac4e6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-reform-radio
+  broadcaster: independent
+  name: Reform Radio
+  streamUrl: https://testform.out.airtime.pro/testform_a
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.reformradio.co.uk/favicon.ico
+  homepage: https://www.reformradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: cac4c694-99b2-40eb-8957-6361e7d3768e
+  changeuuid: 4b50f920-5ded-4645-8bf2-e55328a97786
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-smash-hits-radio-retro
+  broadcaster: independent
+  name: Smash hits radio retro
+  streamUrl: https://s3.radio.co/s802363087/listen
+  bitrate: 192
+  codec: MP3
+  homepage: https://s3.radio.co/s802363087/listen
+  country: GB
+  status: stream-only
+  stationuuid: c5553730-ed5c-4844-b62b-de559dbf08b7
+  changeuuid: bcd1c1b0-22fc-44c0-a390-a2e9fec11d47
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-sunny-g-community-radio
+  broadcaster: independent
+  name: Sunny G Community Radio
+  streamUrl: https://streaming06.liveboxstream.uk/proxy/gary1?mp=/stream
+  bitrate: 320
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/3455a1_7e4ecdcdcf7344fe88ca9633cc48aae4~mv2.png/v1/fill/w_315,h_315,al_c,lg_1,q_85,enc_auto/Sunny_G_logo%20(no%20background).png
+  homepage: https://www.sunnyg.org/
+  country: GB
+  status: stream-only
+  stationuuid: 7c320ee5-99f4-405b-8f68-30f64d38b28c
+  changeuuid: 6b60c390-a397-4e2e-8710-b3c82fb2dbd6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-york-hospital-radio
+  broadcaster: independent
+  name: York Hospital Radio
+  streamUrl: https://stream1.superstreaming.co.uk/proxy/yorkhospradio/stream
+  bitrate: 192
+  codec: MP3
+  favicon: https://yorkhospitalradio.com/wp-content/uploads/2024/01/cropped-yhr-site-logo-180x180.png
+  homepage: http://www.yorkhospitalradio.com/#
+  country: GB
+  status: stream-only
+  stationuuid: 4ac56f28-e3c9-4c7d-87b2-408458047cfc
+  changeuuid: 1c3ba7e4-08f3-4d0b-a119-5a5fc2f12377
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-kiss-the-best-vibes-energy
+  broadcaster: independent
+  name: " KISS - The Best Vibes & Energy"
+  streamUrl: https://live-bauerkiss.sharp-stream.com/kissnational.aac?direct=true&aw_0_1st.skey=1602676850&rp_source=1&=&&___cb=60456375243858
+  bitrate: 47
+  codec: AAC+
+  favicon: https://cdn-profiles.tunein.com/s6004/images/logod.png
+  homepage: https://www.hellorayo.co.uk/kiss
+  country: GB
+  status: stream-only
+  stationuuid: 0f1a8621-d35a-4073-83d3-7ee14207a9a9
+  changeuuid: 284c3e77-5b9b-49ed-a990-d2cd84fe7560
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-kiss-dance-the-biggest-dance-anthems-24-7
+  broadcaster: independent
+  name: " KISS DANCE: The Biggest Dance Anthems 24/7"
+  streamUrl: https://stream-kiss.hellorayo.co.uk/kissdance.aac?direct=true&aw_0_1st.skey=1602676850&rp_source=1&=&&___cb=60456375243858
+  bitrate: 127
+  codec: AAC
+  favicon: https://cdn-profiles.tunein.com/s321341/images/logod.png
+  homepage: https://www.hellorayo.co.uk/kiss-dance
+  country: GB
+  status: stream-only
+  stationuuid: 9c8f6141-f8e8-4779-bfed-5a79e14ed4dd
+  changeuuid: 3ec5d910-d1d0-417d-9c38-3cdaab3b6b22
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-100-whatever-westcountry
+  broadcaster: independent
+  name: "100% Whatever Westcountry"
+  streamUrl: https://dh1-sanityradio.radioca.st/stream
+  codec: MP3
+  favicon: https://whateverwestcountry.com/wp-content/uploads/2020/06/WHATEVER-WEST-GRN.png
+  homepage: https://whateverwestcountry.com/
+  country: GB
+  status: stream-only
+  stationuuid: 46ec3fff-4ebd-4c37-bbec-183771cd15e2
+  changeuuid: 92a55edc-6082-4cfc-8617-a067b940a38a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-academy-fm-folkestone
+  broadcaster: independent
+  name: Academy FM Folkestone
+  streamUrl: https://s2.xrad.io:9480/;stream/1
+  bitrate: 48
+  codec: AAC+
+  favicon: https://static.wixstatic.com/media/2a383b_fd22a81897514de18547bdf81eb202de~mv2.png/v1/fill/w_84,h_75,al_c,q_85,usm_0.66_1.00_0.01,enc_auto/Wordpress%20Transparent.png
+  homepage: https://www.radiofolkestone.com/
+  country: GB
+  status: stream-only
+  stationuuid: f9358d0f-770f-49e7-b8bd-06437ef808fb
+  changeuuid: 966d17df-db97-472f-8e70-98d137ef5856
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bhbn-radio
+  broadcaster: independent
+  name: BHBN Radio
+  streamUrl: https://uksoutha.streaming.broadcast.radio/stream/9400/BHBN?1699801420380=
+  bitrate: 64
+  codec: MP3
+  homepage: https://www.bhbn.net/
+  country: GB
+  status: stream-only
+  stationuuid: 9c97de3d-f160-48a9-83e0-0b71f5f3a90d
+  changeuuid: 4f87233c-789c-48ea-ac83-562aa91dd90b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-brooklands-radio
+  broadcaster: independent
+  name: Brooklands Radio
+  streamUrl: https://stream4.hippynet.co.uk/stream/brooklandsradio
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.brooklandsradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 44bbf65f-e461-4cf7-af03-dc835ddb1710
+  changeuuid: b75be62e-f7ff-4b78-8458-3743ecd67189
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-caresound-radio
+  broadcaster: independent
+  name: CareSound Radio
+  streamUrl: https://streaming.broadcast.radio/perth?1699803359553=
+  bitrate: 128
+  codec: MP3
+  favicon: https://caresound.radio/wp-content/uploads/CSR-Full-Colour-Round-Gradient-150px.png
+  homepage: https://caresound.radio/
+  country: GB
+  status: stream-only
+  stationuuid: 9d492832-5ea5-439e-b882-8eea969dbdad
+  changeuuid: d1c5889e-b76c-400b-b77e-955f1155f715
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-clubland-radio-uk
+  broadcaster: independent
+  name: Clubland Radio UK
+  streamUrl: https://s2.radio.co/sf1cecf191/listen
+  bitrate: 192
+  codec: MP3
+  favicon: https://cdn.onlineradiobox.com/img/l/3/33563.v13.png
+  homepage: https://clublandradiouk.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 2fb1e538-17d9-4fa4-8b3d-7b42dd80be41
+  changeuuid: 82b55ad7-d313-4a3b-ab9b-e4e9013a07ea
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-def-leppard
+  broadcaster: independent
+  name: Def Leppard
+  streamUrl: https://stream.pcradio.ru/def_leppard-hi
+  codec: AAC
+  favicon: null
+  homepage: https://pcradio.ru/
+  country: GB
+  status: stream-only
+  stationuuid: a7dd8e74-c836-4844-bd59-d44cac395952
+  changeuuid: 087fa495-1166-4339-b746-fa5387c3d4c9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-dnbradio-atmospheric
+  broadcaster: independent
+  name: DnBRadio Atmospheric
+  streamUrl: https://azura.drmnbss.org/listen/plushrecs/radio.mp3
+  bitrate: 320
+  codec: MP3
+  favicon: https://www.google.com/s2/favicons?sz=256&domain_url=https%3A%2F%2Fdnbradio.com%2F%3Fchannel%3Dplushrecs%26autoplay%3D0
+  homepage: https://dnbradio.com/?channel=plushrecs&autoplay=0
+  country: GB
+  status: stream-only
+  stationuuid: 0415274f-7dae-4410-8b2a-ed5913ba23fa
+  changeuuid: 9910a265-78fe-4cef-8c1b-be2ecc0acf63
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-frisk-radio-uk
+  broadcaster: independent
+  name: Frisk Radio UK
+  streamUrl: https://www.friskradio.com:8443/stream11
+  codec: AAC
+  favicon: https://management.friskradio.com:7000/stations/logo?id=1
+  homepage: https://www.friskradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 0c956e74-2e2a-49c6-b760-50a1c9a89f60
+  changeuuid: b90d5cde-d06c-4237-9bde-f77d901c676c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-grampian-hospital-radio
+  broadcaster: independent
+  name: Grampian Hospital Radio
+  streamUrl: https://uksoutha.streaming.broadcast.radio/ghr?1699804401378=
+  codec: MP3
+  homepage: https://www.grampianhospitalradio.org/
+  country: GB
+  status: stream-only
+  stationuuid: 5ec5b4d7-218c-4e83-8f50-14e72dbacd51
+  changeuuid: c618edb9-26f7-4d63-8401-3c0cb34e298d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-greatest-hits-radio-60s
+  broadcaster: independent
+  name: Greatest Hits Radio 60s
+  streamUrl: https://stream-al.hellorayo.co.uk/ghr60s.aac?aw_0_1st.skey=1602676850&direct=true&rp_source=1
+  bitrate: 48
+  codec: AAC+
+  favicon: https://media.bauerradio.com/image/upload/c_crop,g_custom/v1725015216/brand_manager/stations/pqnbvpmvgj7jnsopgpix.svg
+  homepage: https://www.hellorayo.co.uk/greatest-hits-60s
+  country: GB
+  status: stream-only
+  stationuuid: b2ad284d-bef1-4f68-8bbd-14195092ea5f
+  changeuuid: a5832174-e265-47de-a820-8248357f2048
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hwd-hospital-radio
+  broadcaster: independent
+  name: HWD Hospital Radio
+  streamUrl: https://streaming04.liveboxstream.uk/proxy/hwdhospi?mp=/stream
+  bitrate: 112
+  codec: AAC+
+  favicon: https://www.hwdhospitalradio.com/images/logo.png
+  homepage: https://www.hwdhospitalradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 98c34a8e-7971-45ed-b109-293e671d837d
+  changeuuid: d431c6b8-7dc4-4e7f-8a39-f9115a1d0915
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-one-world-radio-daybreak-session
+  broadcaster: independent
+  name: One World Radio - Daybreak Session
+  streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/OWR_DAYBREAK_ADP.aac
+  bitrate: 256
+  codec: AAC+
+  favicon: https://www.tomorrowland.com/home/apple-touch-icon.png
+  homepage: https://www.tomorrowland.com/home/radio
+  country: GB
+  status: stream-only
+  stationuuid: b29999a4-e837-4c61-b35d-2e20ad4f18ca
+  changeuuid: fc6f7aae-8e6e-4bf2-a1a2-2bf886ed6725
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-pure-radio
+  broadcaster: independent
+  name: Pure Radio
+  streamUrl: https://kathy.torontocast.com:4825/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://listentopure.uk/wp-content/uploads/2023/02/cropped-cropped-pure-logo-23-150.png
+  homepage: https://listentopure.uk/
+  country: GB
+  status: stream-only
+  stationuuid: d8f7834a-c176-402a-863e-5e6fbc918cee
+  changeuuid: 2e4d9c23-d19d-47fd-8220-c05f5bf20280
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-rominimal-radio
+  broadcaster: independent
+  name: ROminimal Radio
+  streamUrl: https://r4.rominimal.club/listen/rominimal.club/radio2.m4a
+  bitrate: 320
+  codec: AAC
+  favicon: https://rominimal.club/images/logo.png
+  homepage: https://rominimal.club/
+  country: GB
+  status: stream-only
+  stationuuid: 277d2d2f-92c7-4d64-837d-d7ac364cc027
+  changeuuid: 1bb01ccd-a945-4929-9500-7534c1ddb764
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-soar-sound
+  broadcaster: independent
+  name: Soar Sound
+  streamUrl: https://icecast.maxxwave.co.uk/soarsound
+  bitrate: 128
+  codec: AAC
+  favicon: https://i0.wp.com/www.soarsound.uk/wp-content/uploads/2024/03/cropped-SoarLogoFinal-Favicon-e1710351771330.png?fit=150%2C146&ssl=1
+  homepage: https://www.soarsound.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 3a54dd03-fe07-4907-9990-86fdc1184c0d
+  changeuuid: 2d1e8c18-f8de-492e-8a08-84f56ccd610b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-white-cliffs-radio
+  broadcaster: independent
+  name: White Cliffs Radio
+  streamUrl: https://listen.whitecliffsradio.co.uk/
+  codec: MP3
+  favicon: https://images.whitecliffsradio.co.uk/wcr_logo_new_r.webp
+  homepage: https://www.whitecliffsradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 5560f0c8-e50b-4cba-8cdb-07b964724adc
+  changeuuid: 548f0903-6169-4451-a1c2-77a3970c98b4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-wrexham-premier-radio
+  broadcaster: independent
+  name: Wrexham Premier Radio
+  streamUrl: https://uksoutha.streaming.broadcast.radio/premier?1709519917408=
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.premier-radio.co.uk/favicon.ico
+  homepage: https://www.premier-radio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 06bfd450-ddd1-4564-b104-0075489e6495
+  changeuuid: f89003a8-ebcf-4072-a55b-978a01079d60
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bcfm-93-2
+  broadcaster: independent
+  name: BCfm 93.2
+  streamUrl: https://bcfmradiomain.radioca.st/live.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.bcfmradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 31db87e1-58da-4141-bd92-cf0da3257c25
+  changeuuid: e36e956f-b06f-4724-8cd9-9a14cad1214a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-belfast-89
+  broadcaster: independent
+  name: Belfast 89
+  streamUrl: https://streaming.broadcast.radio/belfastfm
+  codec: MP3
+  homepage: https://www.belfast89.com/
+  country: GB
+  status: stream-only
+  stationuuid: adac65c9-8672-46f3-9784-506d43c045eb
+  changeuuid: 912f1276-194e-497e-a9b4-c4bdf4a3f982
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bouncy-vibes-radio
+  broadcaster: independent
+  name: Bouncy Vibes Radio
+  streamUrl: https://bouncy-host.co.uk/radio/8000/radio.mp3
+  bitrate: 320
+  codec: MP3
+  favicon: https://bouncy-vibes.co.uk/images/favicon.ico
+  homepage: https://bouncy-vibes.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 14ce05ef-34d7-49e0-8c78-e38935d81345
+  changeuuid: bd1def97-0536-46ed-8b23-f71e9b4fb9f8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-drama-radio
+  broadcaster: independent
+  name: Drama Radio
+  streamUrl: https://streaming06.liveboxstream.uk/proxy/roksta10/stream
+  bitrate: 48
+  codec: MP3
+  favicon: https://www2.rokitradio.com/_next/image?url=%2Fimages%2Fchannels%2Fdrama.jpg&w=128&q=75
+  homepage: https://www2.rokitradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 0f32ba45-efc8-4672-8add-1defc72bfd87
+  changeuuid: c17300af-9bf1-4035-8eec-c6477b2d259b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-heart-west-midlands
+  broadcaster: independent
+  name: Heart West Midlands
+  streamUrl: https://media-ice.musicradio.com/HeartWestMidsMP3
+  bitrate: 128
+  codec: MP3
+  favicon: http://www.heart.co.uk/assets_v4r/heart/img/favicon-196x196.png
+  homepage: https://www.heart.co.uk/westmids/
+  country: GB
+  status: stream-only
+  stationuuid: cd272f35-7183-48b8-92c7-366d5734bcbd
+  changeuuid: ffb15524-d18a-42f1-bb5d-944d1d303394
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-lazy-gold
+  broadcaster: independent
+  name: Lazy Gold
+  streamUrl: https://stream-lazyradio.creativedork.com/
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.lazygold.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 4ed32c27-aa84-4ff2-9a6e-0481878f0894
+  changeuuid: 08f8674a-76cd-499d-bbd7-a52eee254bf7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-memory-lane-radio
+  broadcaster: independent
+  name: Memory Lane Radio
+  streamUrl: https://memorylaneradio.radioca.st/;
+  bitrate: 192
+  codec: MP3
+  homepage: https://memorylaneradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 255ad4f9-990e-4090-85ed-203702b6dc51
+  changeuuid: 6254a4a1-024b-4140-90b1-e350d6480184
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-pure-west-radio
+  broadcaster: independent
+  name: Pure West Radio
+  streamUrl: https://uksoutha.streaming.broadcast.radio/stream/8580/purewest
+  bitrate: 256
+  codec: MP3
+  favicon: https://www.purewestradio.com/media/jjvja3hb/pure-west-radio-450x450.png
+  homepage: https://www.purewestradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 4dfee959-414e-4790-9c69-8f07937aaab6
+  changeuuid: 2a008376-5191-4438-aaa1-feb411694875
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-red-rose-radio
+  broadcaster: independent
+  name: Red Rose Radio
+  streamUrl: https://listen.red-roseradio.co.uk:8008/stream?_=520468
+  bitrate: 192
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/1552/6680100859da1.png
+  homepage: https://www.redroseradio.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 39065863-b3e0-4eb3-ae28-0cc4f6e26622
+  changeuuid: 278ac239-758e-4f6c-bcfd-32ca9b224738
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-sister-midnight-fm
+  broadcaster: independent
+  name: Sister Midnight FM
+  streamUrl: https://stream.radio.co/s35e4926a1/listen
+  bitrate: 128
+  codec: MP3
+  favicon: https://radio.sistermidnight.org/favicons/apple-touch-icon.png
+  homepage: https://radio.sistermidnight.org/
+  country: GB
+  status: stream-only
+  stationuuid: 75a1072f-3e3a-4c8f-b3e3-dc23386da6ba
+  changeuuid: 4dc51578-ce0b-452d-872f-119a21f37a74
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-soul-connexion-radio
+  broadcaster: independent
+  name: Soul Connexion Radio
+  streamUrl: https://stream.soulconnexionradio.com/1045
+  bitrate: 320
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/1cdeb2_d480bb8158f4469284f543e790063616%7Emv2.jpg/v1/fill/w_192%2Ch_192%2Clg_1%2Cusm_0.66_1.00_0.01/1cdeb2_d480bb8158f4469284f543e790063616%7Emv2.jpg
+  homepage: https://www.soulconnexionradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 7de072cb-08fe-471f-bb59-672d7a76079e
+  changeuuid: 4f0cf509-3bda-4fba-ad47-151ec983211e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-24-7-online-radio
+  broadcaster: independent
+  name: "24/7 Online Radio"
+  streamUrl: https://ec3.yesstreaming.net:3585/stream
+  bitrate: 64
+  codec: MP3
+  favicon: https://usercontent.one/wp/www.247onlineradio.com/wp-content/uploads/2020/02/247-Online-Radio-Station-Logo.jpg
+  homepage: https://www.247onlineradio.com/24-7-online-radio/
+  country: GB
+  status: stream-only
+  stationuuid: 4a1111a1-1f2a-4ede-8ef1-0c78caa0d142
+  changeuuid: ca47255a-13e0-4c39-b792-52905917b787
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-deal-radio
+  broadcaster: independent
+  name: Deal Radio
+  streamUrl: https://s2.radio.co/sa44aa697f/listen
+  bitrate: 128
+  codec: MP3
+  favicon: https://dev.dealradio.co.uk/wp-content/uploads/2020/06/Small-redblue.png
+  homepage: https://www.dealradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 17c8f661-9cbd-459e-97f5-aa24331747ae
+  changeuuid: 790a9f47-3679-43f8-86b6-0cc3b5fb6277
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-greatest-hits-radio-80s
+  broadcaster: independent
+  name: Greatest Hits Radio 80s
+  streamUrl: https://stream-al.hellorayo.co.uk/ghr80s.aac?aw_0_1st.skey=1602676850&direct=true&rp_source=1
+  bitrate: 47
+  codec: AAC+
+  favicon: https://media.bauerradio.com/image/upload/c_crop,g_custom/v1741162714/brand_manager/stations/tmeuw7bt9gwnbkuxpjab.png
+  homepage: https://www.hellorayo.co.uk/greatest-hits-radio-80s
+  country: GB
+  status: stream-only
+  stationuuid: 4cb7a690-b0cc-4259-8aac-4674c69da10e
+  changeuuid: 75d7a5fe-7057-414a-b7b0-c5959abbd72e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-margate-radio
+  broadcaster: independent
+  name: Margate Radio
+  streamUrl: https://margate-radio.radiocult.fm/stream
+  bitrate: 192
+  codec: MP3
+  favicon: https://images.squarespace-cdn.com/content/v1/55dccc18e4b080417ce5fafa/1585823097541-KVKK0PO2RTI5SZC6YLWF/MargateRadio_White_72dpi.png?format=1500w
+  homepage: https://margateradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: c23448e9-2bb5-48e1-9436-61fc13d79558
+  changeuuid: 4e5dd5cd-b278-4ee2-a742-b51b425afe05
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-midlands-radio
+  broadcaster: independent
+  name: Midlands Radio
+  streamUrl: https://stream-153.zeno.fm/2mn7tdzkug0uv
+  codec: AAC
+  favicon: https://static.mytuner.mobi/media/tvos_radios/CXYgFMyE7u.jpg
+  homepage: https://www.radio-uk.co.uk/midlands-radio-80s
+  country: GB
+  status: stream-only
+  stationuuid: f6622cbc-f029-4249-be56-dc839759a8ed
+  changeuuid: 5a5b5a4d-6f83-4039-9415-8bedca65f777
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-now-radio-80s
+  broadcaster: independent
+  name: NOW Radio 80s
+  streamUrl: https://stream.zeno.fm/ihij6rdighvtv
+  codec: MP3
+  favicon: https://www.mynowradio.co.uk/wp-content/uploads/2023/12/NOW-Radio-90s-1-scaled.jpg
+  homepage: https://www.mynowradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 810e8186-243d-4c9b-9487-c187ce32a7db
+  changeuuid: 445a66fe-0e28-4dad-8883-afabb9aec138
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-jupiter
+  broadcaster: independent
+  name: Radio Jupiter
+  streamUrl: https://s10.myradiostream.com/:7946/listen.mp3?nocache=1686498616
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.radiojupiter.studio/
+  country: GB
+  status: stream-only
+  stationuuid: 0615faee-8fb9-4681-96bf-df7928b3ab34
+  changeuuid: d91b0049-08b2-45dc-bf75-e31d2adeecb9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio2funky
+  broadcaster: independent
+  name: Radio2Funky
+  streamUrl: https://s6.citrus3.com:8006/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://radio2funky.co.uk/wp-content/uploads/2023/04/DAB-logo-new.png
+  homepage: https://radio2funky.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: c99ce535-30a0-4cf5-8399-68d550c5b50f
+  changeuuid: 20aa0cb5-7c65-4bba-b6bf-e4fa3f761cc1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-rainbow-radio-wales
+  broadcaster: independent
+  name: Rainbow Radio Wales
+  streamUrl: https://stream.zeno.fm/dtbgwan9sd0uv
+  codec: MP3
+  favicon: http://rainbowradio.uk/wp-content/uploads/2024/07/7h5TKbvAqe__1_-removebg-preview.png
+  homepage: https://rainbowradio.uk/
+  country: GB
+  status: stream-only
+  stationuuid: a6851e7a-d14a-42f9-88ec-549560426b23
+  changeuuid: d59cc166-2089-4624-8cf3-a08b7063e0df
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-southampton-hospital-radio
+  broadcaster: independent
+  name: Southampton Hospital Radio
+  streamUrl: https://s6.autopo.st/proxy/shrinternet?mp=/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.sohba.org/static/35df7ec86d.android-icon-192x192.png
+  homepage: https://www.sohba.org/
+  country: GB
+  status: stream-only
+  stationuuid: 91446e27-de4f-4641-844b-ad1f79249ff9
+  changeuuid: 47b29c63-bc83-4f35-9270-6e595d7a8e39
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-yo1-radio
+  broadcaster: independent
+  name: Yo1 Radio
+  streamUrl: https://stream1.themediasite.co.uk:8026/;?_=215164
+  bitrate: 192
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/706/6311ef9a56ac6.png
+  homepage: https://www.yo1radio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 68872342-3b4f-4cff-8bef-82e17ccacb2b
+  changeuuid: f1d8c882-b5bf-4d01-9a5b-098c86481409
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-kisstory-r-b-the-hottest-r-b-tracks-from-kisstor
+  broadcaster: independent
+  name: " KISSTORY R&B: The Hottest R&B tracks from KISSTORY"
+  streamUrl: https://live-bauerkiss.sharp-stream.com/kisstoryrb.aac?direct=true&aw_0_1st.playerid=BMUK_Airable&aw_0_1st.skey=6778249992
+  bitrate: 127
+  codec: AAC
+  favicon: https://cdn-profiles.tunein.com/s333201/images/logod.png
+  homepage: https://www.hellorayo.co.uk/kisstory-rnb
+  country: GB
+  status: stream-only
+  stationuuid: 19b250fe-9027-4caf-b6ea-33022f0b6392
+  changeuuid: d1915f1a-6fba-4f78-b79c-1195ecbfc72c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-air-gay-radio
+  broadcaster: independent
+  name: Air Gay Radio
+  streamUrl: https://ecmanager.pro-fhi.net:2655/stream
+  bitrate: 64
+  codec: AAC
+  favicon: https://www.airgayradio.net/wp-content/uploads/2020/06/qr-code.png
+  homepage: https://www.airgayradio.net/
+  country: GB
+  status: stream-only
+  stationuuid: 30590797-ad95-4c3e-98d6-93f76419032b
+  changeuuid: 9068aad1-e0d1-4c68-865c-bed19d9bacf6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-amber-radio
+  broadcaster: independent
+  name: Amber Radio
+  streamUrl: https://stream3.themediasite.co.uk:8240/listen.mp3?sid=3
+  bitrate: 128
+  codec: MP3
+  favicon: https://amber.radio/wp-content/uploads/2022/12/Amber-Radio-Logo-Assets_Original-Clear-Background.png
+  homepage: https://amber.radio/
+  country: GB
+  status: stream-only
+  stationuuid: 7b50bebb-b3a8-486c-a614-09c00429e2a1
+  changeuuid: a292e04f-83ee-461a-be7e-249a39fb958b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-armagh-city-radio
+  broadcaster: independent
+  name: Armagh City Radio
+  streamUrl: https://acrlive.radioca.st/stream?type=http&nocache=1702573713796
+  bitrate: 192
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/3bc95e_9e8eb3dcdc8c4162b6516cc4f1a781c6~mv2.png/v1/fill/w_522,h_530,al_c,q_85,usm_0.66_1.00_0.01,enc_auto/A-only-PNG.png
+  homepage: https://www.armaghcityradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: fd7c34c2-ff27-41c7-bf42-fd9c79aeeb80
+  changeuuid: 2bbe16c5-074f-45a7-9f1d-eb736c0fb99a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-aycliffe-radio
+  broadcaster: independent
+  name: Aycliffe Radio
+  streamUrl: https://solid41.streamupsolutions.com/proxy/catidbxp?mp=/;type=mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.ayclifferadio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 40da6b0f-d5a1-43f1-a57b-a66061b74292
+  changeuuid: 45c7f467-03ea-431c-a177-ff46d5231830
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-countryline-radio
+  broadcaster: independent
+  name: CountryLine Radio
+  streamUrl: https://listen-chriscountry.sharp-stream.com/chriscountry.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.countryline.radio/
+  country: GB
+  status: stream-only
+  stationuuid: 4e7766f3-dcd1-48a1-b721-e38f10f8d7ac
+  changeuuid: 07a6241c-bf82-4fdc-9eeb-2e183ed8e233
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-edge-1
+  broadcaster: independent
+  name: Edge 1
+  streamUrl: https://stream.aiir.com/8dhvgxm1kbvuv
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/703/666adc84d05bb.png
+  homepage: https://edgeradio.co.uk/edge1
+  country: GB
+  status: stream-only
+  stationuuid: de34afcd-c217-4114-a264-cd67a7176561
+  changeuuid: 2d42b6b5-9ad7-4488-b2cf-c81d14458888
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hifi-prime
+  broadcaster: independent
+  name: HiFi Prime
+  streamUrl: https://stream.cloudrad.io/5913/8160
+  bitrate: 128
+  codec: MP3
+  favicon: http://hifiradio.net/wp-content/uploads/2023/09/prime-crop.png
+  homepage: https://hifiradio.net/
+  country: GB
+  status: stream-only
+  stationuuid: bf22dc25-7408-47dd-bd9d-9eca530accf7
+  changeuuid: 75506a43-cf86-41d6-bc48-eed20de780ab
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hospital-radio-chelmsford
+  broadcaster: independent
+  name: Hospital Radio Chelmsford
+  streamUrl: https://solid55.streamupsolutions.com/proxy/mmbdfslu?mp=//stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://lirp.cdn-website.com/b164d775/dms3rep/multi/opt/IMG_0007-432w.jpg
+  homepage: https://www.hrc.org.uk/
+  country: GB
+  status: stream-only
+  stationuuid: f5f0f217-b134-498c-a583-f116dc241b79
+  changeuuid: fbfe7477-6f77-475e-93cd-cbe43854cd44
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hospital-radio-plymouth
+  broadcaster: independent
+  name: Hospital Radio Plymouth
+  streamUrl: https://hospitalradioplymouth.radioca.st/stream
+  bitrate: 128
+  codec: AAC
+  favicon: https://www.hospitalradioplymouth.org.uk/wp-content/uploads/2020/06/HRP-LogoNEWTRANS-100px-e1630450570740.png
+  homepage: https://www.hospitalradioplymouth.org.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 602b0dd5-37e8-4071-b27d-f36bce8ae3cb
+  changeuuid: 677e0672-9c65-4f52-ba50-b7ba019abb73
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-juice-liverpool
+  broadcaster: independent
+  name: Juice Liverpool
+  streamUrl: https://uksouth1.juiceboxradio.com/JuiceLiverpool
+  bitrate: 96
+  codec: AAC+
+  favicon: https://juiceliverpool.co.uk/assets/img/favicons/favicon-196x196.png
+  homepage: https://juiceliverpool.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: be847566-03e9-4d48-89b2-4c479e418464
+  changeuuid: aa0163c0-e7db-43b5-b97d-f2849874faef
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-kaos-sound
+  broadcaster: independent
+  name: Kaos Sound
+  streamUrl: https://s3.myradiostream.com:59506/stream
+  bitrate: 128
+  codec: MP3
+  homepage: https://kaos-sound.co.uk/mrsdocs/home.html
+  country: GB
+  status: stream-only
+  stationuuid: abded711-acf7-412a-bac3-b0436723bee0
+  changeuuid: 29ce77a3-1496-41f0-8c95-e684e82cdf94
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-lyca-gold-2
+  broadcaster: independent
+  name: Lyca Gold 2
+  streamUrl: https://listen-lycaradio.sharp-stream.com/lyca_gold_2.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://lycaradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: c4bb8fe8-0d8a-436b-9a79-24ac3e453177
+  changeuuid: e915c688-abd1-43ca-8a45-7903ad386111
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-mdog-radio
+  broadcaster: independent
+  name: Mdog Radio
+  streamUrl: https://stream2.hippynet.co.uk/stream/8212
+  bitrate: 320
+  codec: MP3
+  homepage: https://www.facebook.com/people/Mdog-Radio/100083286139973/
+  country: GB
+  status: stream-only
+  stationuuid: 2c849e24-23db-458a-addb-5df866c55fdb
+  changeuuid: 0fae8ce5-8bf8-4bf6-a1c1-9d6ee8f6c9d8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-neon-radio
+  broadcaster: independent
+  name: Neon Radio
+  streamUrl: https://live.flashbackcentral.co.uk/radio/8050/radio.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://images.leadconnectorhq.com/image/f_webp/q_80/r_480/u_https://assets.cdn.filesafe.space/dCZ3DwdyoW0OEpmHJlYP/media/66bb37b0e49a8129bd748aa2.png
+  homepage: https://www.neonradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 89c8bcec-e11f-4afb-aa98-e7ebeb5ebe68
+  changeuuid: fafe853a-0f34-4030-a7db-36b8726ef9c6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-northants-1
+  broadcaster: independent
+  name: Northants 1
+  streamUrl: https://solid41.streamupsolutions.com/proxy/svdkgaiq/stream?icecast
+  bitrate: 128
+  codec: MP3
+  favicon: https://northants1.co.uk/wp-content/uploads/2022/12/Northants-_1_-Symbol-Red.png
+  homepage: https://northants1.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 5f477a20-3eda-441d-881f-20f2e96c263a
+  changeuuid: 8cbcd418-ccee-409d-be01-3f6d1cc48277
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-park-radio
+  broadcaster: independent
+  name: Park Radio
+  streamUrl: https://s32.myradiostream.com/18756/listen.mp3
+  bitrate: 96
+  codec: MP3
+  favicon: null
+  homepage: https://parkradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 9a5fe43a-3a44-48a6-8b3f-be24071d4671
+  changeuuid: 5cff8b38-e4fa-450e-af00-d2a7baba78eb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-waters
+  broadcaster: independent
+  name: Radio Waters
+  streamUrl: https://uk5.internet-radio.com/proxy/radiowaters/stream
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.radiowaters.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: a12ac2ec-0539-4baa-b313-a119ef7a64b1
+  changeuuid: b9f96d45-0cf2-4417-8288-61f9bc1e059f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-rhubarb-radio
+  broadcaster: independent
+  name: Rhubarb Radio
+  streamUrl: https://securestreams2.autopo.st:1234/stream#.mp3?1702339792481
+  bitrate: 160
+  codec: MP3
+  homepage: https://www.rhubarbradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 48683066-a5a0-48be-805e-76ab6ffc15c6
+  changeuuid: c9875a99-a6c5-4f2f-8acc-ba24b3c1e5a8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-university-radio-falmer
+  broadcaster: independent
+  name: University Radio Falmer
+  streamUrl: https://listen-urfonline.sharp-stream.com/urfonline.mp3?nocache=0.1868666957825399
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.urfonline.com/favicon-256x256.png
+  homepage: https://www.urfonline.com/
+  country: GB
+  status: stream-only
+  stationuuid: f1be343e-84cb-48a5-b959-b7a851780586
+  changeuuid: a0d9e51e-5672-468e-8ec2-eef63014e071
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-zero-radio
+  broadcaster: independent
+  name: Zero Radio
+  streamUrl: https://uk7.internet-radio.com/proxy/0radio?mp=%2Flive&1731415265701
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.zeroradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 163517fc-1e28-4b02-a2d1-b3569b52dc3f
+  changeuuid: 153760d0-1c30-4657-aad0-5a697d04ab19
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bailrigg-fm
+  broadcaster: independent
+  name: Bailrigg FM
+  streamUrl: https://stream.bailriggfm.co.uk/listen/bfm/128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://bailriggfm.co.uk/wp-content/uploads/2020/06/cropped-Bailrigg-Mini-Logo-red-background-192x192.png
+  homepage: https://bailriggfm.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 96cbf714-1017-4ccf-9489-420a3ac6ca66
+  changeuuid: 356ea828-b5b2-4af8-9635-cc223a16503b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-derby-sound
+  broadcaster: independent
+  name: Derby Sound
+  streamUrl: https://uk7.internet-radio.com/proxy/in2derbyradio?mp=%2Fstream%3B
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.derbysound.org.uk/favicon.ico
+  homepage: https://www.derbysound.org.uk/
+  country: GB
+  status: stream-only
+  stationuuid: f854fb44-bf01-4049-ab58-6d5c9a1560a3
+  changeuuid: 7f3986f5-1f37-4516-81e4-c87db6fc86cc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-frisk-radio
+  broadcaster: independent
+  name: FRISK Radio
+  streamUrl: https://www.friskradio.com:8443/stream1
+  codec: AAC
+  favicon: https://www.friskradio.com/application/assets/images/favicon/64.png
+  homepage: https://www.friskradio.com/#station-select-panel
+  country: GB
+  status: stream-only
+  stationuuid: 2a038c93-626c-406a-9a85-d6c202f99a95
+  changeuuid: 8f13ae27-afcd-47b9-a15f-00fd13486954
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hearme-00s-rock
+  broadcaster: independent
+  name: HearMe - 00s rock
+  streamUrl: https://radio.hearme.fm:8130/stream
+  codec: MP3
+  favicon: https://hearme.fm/favicon.ico
+  homepage: https://hearme.fm/
+  country: GB
+  status: stream-only
+  stationuuid: 4c460069-0c47-4836-88a0-b08a3dfb9cf1
+  changeuuid: 8be81af1-d19c-4833-bae0-a143422f3705
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hearme-80s-rock
+  broadcaster: independent
+  name: Hearme - 80s rock
+  streamUrl: https://radio.hearme.fm:8310/stream
+  codec: MP3
+  homepage: https://hearme.fm/
+  country: GB
+  status: stream-only
+  stationuuid: b85932a8-c036-40c1-a3ae-fb5728f6fe91
+  changeuuid: 046a72df-9d12-4a67-8d66-911e381bf67f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hospital-radio-glamorgan
+  broadcaster: independent
+  name: Hospital Radio Glamorgan
+  streamUrl: https://streaming.broadcastradio.com:8002/glamorg?1725024804656=
+  bitrate: 128
+  codec: MP3
+  favicon: https://api.broadcast.radio/api/image/d57d29e6-9c41-4875-8cc9-952e32e08310.png?g=center
+  homepage: https://www.radioglamorgan.com/
+  country: GB
+  status: stream-only
+  stationuuid: 5e297a51-9d6f-4b8a-9903-90e2c770936a
+  changeuuid: c5723301-c22a-4eed-bf2d-65584ab629a2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-leeds-student-radio
+  broadcaster: independent
+  name: Leeds Student Radio
+  streamUrl: https://s2.radio.co/seb5cdba5b/listen
+  bitrate: 128
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/316c00_def14e5b8c604227b2fa666a3a15fa2d~mv2.png/v1/fill/w_105,h_107,al_c,q_85,usm_0.66_1.00_0.01,enc_auto/LSR%20Logo.png
+  homepage: https://www.thisislsr.com/
+  country: GB
+  status: stream-only
+  stationuuid: 42341185-03db-43cb-b64f-e70ae941d854
+  changeuuid: 04148efd-cd4e-4335-a7a9-797763244371
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-alty
+  broadcaster: independent
+  name: Radio Alty
+  streamUrl: https://streams.radio.co/s4d51ef3bf/listen
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.radioalty.co.uk/uploads/1/3/1/5/131514373/published/radio-alty-rgb-master-logo-transparent-bkground.png?1702248957
+  homepage: https://www.radioalty.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 505164d1-e17c-4e85-baff-38056f92fe62
+  changeuuid: aaf73de9-7331-4581-a49c-63adcd736a46
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-cherwell
+  broadcaster: independent
+  name: Radio Cherwell
+  streamUrl: https://uk6.internet-radio.com/proxy/cherwell?mp=/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://radiocherwell.com/wp-content/uploads/2019/05/RC_LOGO_RGB-150x115.png
+  homepage: https://radiocherwell.com/
+  country: GB
+  status: stream-only
+  stationuuid: 79ffdb88-78df-4493-afec-3735a5de1bd8
+  changeuuid: fc5feda5-7e3c-4da3-a12a-442fa59fa50b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-redhill-mp3
+  broadcaster: independent
+  name: Radio Redhill mp3
+  streamUrl: https://radioredhill.uk/stream/live.mp3
+  bitrate: 160
+  codec: MP3
+  favicon: https://radioredhill.uk/favicon.png
+  homepage: https://radioredhill.uk/
+  country: GB
+  status: stream-only
+  stationuuid: b1e98910-091c-4f6a-9462-9bfc7b072c9e
+  changeuuid: c9ae600c-b42e-4716-ad70-986b069aaf9f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-rare-groove-radio
+  broadcaster: independent
+  name: Rare Groove Radio
+  streamUrl: https://a9.asurahosting.com:7950/radio.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://assets.zyrosite.com/cdn-cgi/image/format=auto,w=268,fit=crop,q=95/Yyv7QeD1ZgiXyg7m/rgr-logo-YNqrVzg7QMF85M1n.png
+  homepage: https://raregrooveradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 867acea5-228c-459e-a431-9a3e95e3fda0
+  changeuuid: 66e7a98f-111c-4a00-bfa4-69d987d2106c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-satsang-radio
+  broadcaster: independent
+  name: Satsang Radio
+  streamUrl: https://icecast.maxxwave.co.uk/satsang
+  bitrate: 80
+  codec: AAC
+  favicon: https://images.squarespace-cdn.com/content/v1/6801621b014aea65690810ca/e422d15b-d3ab-43d3-97d7-8695fe43a7df/Screenshot+2025-07-30+at+22.34.52.png?format=1500w
+  homepage: https://satsangradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 41a5ddc2-d737-41d0-a4f6-8652d701329d
+  changeuuid: af24bb6e-e2c0-485b-bca1-cf1f13ee4d22
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-stirling-community-radio
+  broadcaster: independent
+  name: Stirling Community Radio
+  streamUrl: https://streaming.broadcastradio.com:11855/castlesound?8852
+  bitrate: 128
+  codec: MP3
+  favicon: https://stirlingcommunity.radio/images/radio/player/logo-1715587272.webp
+  homepage: https://stirlingcommunity.radio/
+  country: GB
+  status: stream-only
+  stationuuid: e499f1e5-5502-4f53-8a0c-7737e591a6be
+  changeuuid: b5020028-82d8-4980-995b-fa3799bf5b54
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-the-big-top-40-show-sundays-4-7pm
+  broadcaster: independent
+  name: The Big Top 40 Show (SUNDAYS 4 - 7PM)
+  streamUrl: https://icecast.thisisdax.com/BigTop40
+  bitrate: 48
+  codec: AAC
+  favicon: https://www.bigtop40.com/assets_v4r/bigtop40/img/logos/large.png
+  homepage: https://www.bigtop40.com/
+  country: GB
+  status: stream-only
+  stationuuid: 74e8b53d-10ac-4879-b27b-c93c4955ed1d
+  changeuuid: bbd083e6-1a5d-47af-9308-e440afb0b67a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-time-2-chill-radio
+  broadcaster: independent
+  name: Time 2 Chill Radio
+  streamUrl: https://ec6.yesstreaming.net:3615/stream
+  bitrate: 320
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/55ed4f_f43016b1c5784b71b344cd4504914340~mv2.png/v1/crop/x_0,y_342,w_1920,h_1376/fill/w_548,h_396,al_c,q_85,usm_0.66_1.00_0.01,enc_avif,quality_auto/hammock-icon_edited.png
+  homepage: https://www.time2chill.co.uk/radio
+  country: GB
+  status: stream-only
+  stationuuid: b7126702-9470-4eb5-99a5-11b8d00abf15
+  changeuuid: bbab21ee-60ab-451d-a4f7-2b77875020cf
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-trust-am-hospital-radio
+  broadcaster: independent
+  name: Trust AM Hospital Radio
+  streamUrl: https://streaming.galaxywebsolutions.com:9034/stream
+  bitrate: 128
+  codec: MP3
+  homepage: https://trustam.com/
+  country: GB
+  status: stream-only
+  stationuuid: d7b4b5e4-c330-4979-aec3-310393e220c1
+  changeuuid: 51785026-9600-4a10-9ff6-79e7721f038a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-wave-community-radio
+  broadcaster: independent
+  name: Wave Community Radio
+  streamUrl: https://streaming06.liveboxstream.uk/proxy/piraten1?mp=/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://wavewsm.co.uk/wp-content/uploads/2023/06/cropped-wavelogo-1.png
+  homepage: https://wavewsm.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 49049538-3414-4266-a694-dff2a49ec494
+  changeuuid: a2e005ce-93b1-4694-83c2-98bf229d836c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-95-6-b-radio
+  broadcaster: independent
+  name: "95.6 B Radio"
+  streamUrl: https://stream.aiir.com/t4k624qg11kuv?_=802765
+  codec: AAC
+  favicon: https://mmo.aiircdn.com/347/62b4dc758ba9d.jpg
+  homepage: https://www.bradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 28c077ac-49c6-48db-9f42-7cd2ff90570c
+  changeuuid: 29483ab9-4313-456b-a2ea-ba45499d9002
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bedrock-radio
+  broadcaster: independent
+  name: Bedrock Radio
+  streamUrl: https://s40.myradiostream.com:16652/bedrockradio
+  bitrate: 128
+  codec: MP3
+  favicon: https://i0.wp.com/www.bedrockradio.org.uk/wp-content/uploads/2019/06/alternate-logo-white.png?resize=300%2C135&ssl=1
+  homepage: https://www.bedrockradio.org.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 08e5af4b-0473-4c11-942d-f447490a9ce5
+  changeuuid: 76a2db8a-23b3-491b-b101-0d97fdcca9fe
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-blastfm-indie-radio-station
+  broadcaster: independent
+  name: BlastFM Indie Radio Station
+  streamUrl: https://blast-indie-radio.com:8000/live
+  bitrate: 256
+  codec: MP3
+  favicon: https://blastfmsocial.media/upload/photos/2019/08/e1Yzi7QNBg2Lw32vvghN_30_e2c846377ca16726ad65724674b98d3e_avatar.jpg?cache=0
+  homepage: https://blastfmsocial.media/BlastIndie
+  country: GB
+  status: stream-only
+  stationuuid: 82896fe3-f810-4e21-9209-90b120fc1ff1
+  changeuuid: 83a7029a-c74e-4227-9b42-9e06f030fa19
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-care-radio
+  broadcaster: independent
+  name: Care Radio
+  streamUrl: https://listen-careradio.sharp-stream.com/120_care_radio_128_mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/590/620694edbfb9e.jpg
+  homepage: https://www.careradio.org/
+  country: GB
+  status: stream-only
+  stationuuid: d3624951-3f7d-4959-b273-1392cf7fac8e
+  changeuuid: 7ae5994f-9713-422b-b036-700d03cfddfe
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-central-radio-north-west
+  broadcaster: independent
+  name: Central Radio North West
+  streamUrl: https://stream.central.radio/listen/web/high
+  bitrate: 128
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/778/673b04861e76c.png
+  homepage: https://www.central.radio/
+  country: GB
+  status: stream-only
+  stationuuid: 1e1fd495-149a-4f03-b43d-a830d92d1ed5
+  changeuuid: 1904a93f-2106-4df1-bb00-2eac17125cf7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-delite-radio
+  broadcaster: independent
+  name: Delite Radio
+  streamUrl: https://stream.deliteonline.com/live320
+  bitrate: 512
+  codec: AAC
+  favicon: http://www.deliteradio.com/upload/players/62fb755a427c40.95586069.jpg
+  homepage: http://www.deliteradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: ed9d6856-e938-4a7d-ba6f-aa5f5b53baa0
+  changeuuid: 42bfbdbb-09e0-4adc-a09f-9f348a371256
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-gems-top-40
+  broadcaster: independent
+  name: GEMS  TOP 40
+  streamUrl: https://stream.gemsradio.net:8000/;
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.gemsradio.net/wp-content/uploads/2021/10/cropped-Gems-Radio-icon-180x180.jpg
+  homepage: https://www.gemsradio.net/
+  country: GB
+  status: stream-only
+  stationuuid: eacbe68c-6c72-4882-910d-789616f21733
+  changeuuid: 4ecab968-5a6a-4aa1-b78f-d338ff959f4e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-glitterbeam-italia
+  broadcaster: independent
+  name: GlitterBeam Italia
+  streamUrl: https://quincy.torontocast.com:1740/stream
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.glitterbeam.net/
+  country: GB
+  status: stream-only
+  stationuuid: 34791e71-bdcd-4a11-9c7d-e486a90ea049
+  changeuuid: 86e5a336-54dd-437b-8b1c-78d36f0b0bc4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-glitterbeam-radio
+  broadcaster: independent
+  name: GlitterBeam Radio
+  streamUrl: https://ukwesta.streaming.broadcast.radio:17810/glitterbeam
+  bitrate: 128
+  codec: MP3
+  favicon: https://usercontent.one/wp/www.glitterbeam.co.uk/wp-content/uploads/2023/09/GBRECSMALL4.png
+  homepage: https://www.glitterbeam.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 1343d0f5-15fc-491b-8351-7bd8c7919300
+  changeuuid: 17b657af-9d5d-49e9-a8da-f85ad9eba933
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-global-pride
+  broadcaster: independent
+  name: Global Pride
+  streamUrl: https://media-sov.musicradio.com/Global-M-Pride
+  bitrate: 48
+  codec: AAC
+  favicon: https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse2.mm.bing.net%2Fth%3Fid%3DOIP.cmoF-nf5byb4GKWOVoVefAAAAA%26pid%3DApi&f=1&ipt=fb8665bb588c291de9ed9bd2765e62613792e1203899f9a45f639d973e894cf7&ipo=images
+  homepage: https://global.com/global-player
+  country: GB
+  status: stream-only
+  stationuuid: 410493e6-e279-4347-8884-702aabc0defb
+  changeuuid: 68126196-9bac-4452-80fe-c0137f3a4035
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-great-driffield-radio
+  broadcaster: independent
+  name: Great Driffield Radio
+  streamUrl: https://stream1.superstreaming.co.uk/proxy/greatdriffield/stream?rp_source=1&=&&___cb=720015281299521
+  bitrate: 192
+  codec: MP3
+  favicon: https://greatdriffieldradio.co.uk/wp-content/uploads/2023/12/gdr-150x150.jpg
+  homepage: https://greatdriffieldradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 87a03289-05fe-4e07-8116-7a60b1408237
+  changeuuid: bad15d9e-f0ec-448e-8a74-119a12251abc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-greatest-hits-radio-70s
+  broadcaster: independent
+  name: Greatest Hits Radio 70s
+  streamUrl: https://stream-al.hellorayo.co.uk/ghr70s.aac?aw_0_1st.skey=1602676850&direct=true&rp_source=1
+  bitrate: 47
+  codec: AAC+
+  favicon: https://media.bauerradio.com/image/upload/c_crop,g_custom/v1742817230/brand_manager/stations/vpgvlb3s5roqkyo6cxvf.svg
+  homepage: https://www.hellorayo.co.uk/greatest-hits-radio-70s
+  country: GB
+  status: stream-only
+  stationuuid: 4c6d43e7-b474-440f-be56-d899dd0e757e
+  changeuuid: a035af27-1331-4e5a-819e-4955931fcd97
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-mad-wasp-radio
+  broadcaster: independent
+  name: Mad Wasp Radio
+  streamUrl: https://streaming.radio.co/s8a8d7b49a/listen
+  bitrate: 128
+  codec: MP3
+  favicon: https://pbs.twimg.com/profile_images/1684130478981279744/QqiJhxb9_400x400.jpg
+  homepage: https://madwaspradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 6bd8806e-a450-4e8b-ad59-6d85469821eb
+  changeuuid: 579aee96-ca71-466e-8f85-f6d601781d2e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-mixx-radio-preston
+  broadcaster: independent
+  name: mixx radio preston
+  streamUrl: https://stream-hitsradio.creativedork.com/
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.liveradio.uk/files/images/482949/resized/180x172c/mixx_radio_preston.jpg
+  homepage: https://hitsradio.radioplayer.airsuite.studio/
+  country: GB
+  status: stream-only
+  stationuuid: 6a67b337-da57-4a02-9d08-cd609cf1f727
+  changeuuid: 1711970d-06e0-455f-ae67-860c626d512c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-only-old-skool-radio
+  broadcaster: independent
+  name: Only Old Skool Radio
+  streamUrl: https://listentomystream.com:8036/;?type=http&nocache=107036
+  bitrate: 320
+  codec: MP3
+  favicon: https://onlyoldskoolradio.com/wp-content/uploads/2020/06/cropped-icon1-32x32.png
+  homepage: https://onlyoldskoolradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 113eb10f-4258-44b9-8506-85d406729b28
+  changeuuid: 6683eb81-1c70-4664-8645-64636016b537
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-newquay
+  broadcaster: independent
+  name: Radio Newquay
+  streamUrl: https://s46.myradiostream.com/8816/listen.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://mm.aiircdn.com/479/5b9a5e36391cd.png
+  homepage: https://www.radionewquay.com/
+  country: GB
+  status: stream-only
+  stationuuid: b39e9c3e-596c-4d8d-9bd1-bf823c09ec8b
+  changeuuid: 14bb10f3-4e07-4499-b3fa-a360720685bb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-ninesprings
+  broadcaster: independent
+  name: Radio Ninesprings
+  streamUrl: https://stream.radioninesprings.com/ninesprings-high?_=293441
+  bitrate: 256
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/494/603669b913ade.png
+  homepage: https://www.radioninesprings.com/
+  country: GB
+  status: stream-only
+  stationuuid: 059f3e10-d7bf-4f29-a001-39d853d042cb
+  changeuuid: 21448dd2-c1ad-431f-a009-096d017026b8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-radio
+  broadcaster: independent
+  name: Radio Radio
+  streamUrl: https://c16.radioboss.fm:18014/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://radioradio.fm/grafika/logo1a.png
+  homepage: https://radioradio.fm/
+  country: GB
+  status: stream-only
+  stationuuid: 033b3a5b-93cc-46d2-b7f4-0c381fb800e8
+  changeuuid: 71f03cd7-5bf2-4a1f-8a99-1465b8e3c86e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-rudy
+  broadcaster: independent
+  name: Radio Rudy
+  streamUrl: https://stream-55.zeno.fm/21y1sqfvkm0uv
+  codec: MP3
+  favicon: https://zeno.fm/favicon.ico
+  homepage: https://zeno.fm/radio/radio-rudy/
+  country: GB
+  status: stream-only
+  stationuuid: 5948322a-0634-46e2-97ab-37ae02ff1980
+  changeuuid: 121422aa-1ddb-4d65-9fe8-5f082f9526e5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radiosega-he-aac-v2
+  broadcaster: independent
+  name: RadioSEGA (HE-AAC v2)
+  streamUrl: https://icecast.radiosega.net/live
+  bitrate: 256
+  codec: AAC+
+  favicon: https://www.radiosega.net/_images/template/siteHeader-newlogo_hover.png
+  homepage: https://www.radiosega.net/
+  country: GB
+  status: stream-only
+  stationuuid: b9ee66ff-d196-4bfd-b4b2-2ad87657e2f9
+  changeuuid: 7400daf0-a3a9-4aa1-99ad-a02af2e3bd2a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-retro-soul-radio
+  broadcaster: independent
+  name: Retro Soul Radio
+  streamUrl: https://streaming.galaxywebsolutions.com/stream/retrosoul
+  bitrate: 128
+  codec: MP3
+  favicon: https://static-media.streema.com/media/cache/cf/d9/cfd9303c27dd71c35a2370766d4d1309.jpg
+  homepage: https://www.retrosoulradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 0de4d5eb-53ce-46fa-a20c-73b8300f9c58
+  changeuuid: 63435768-ed19-47c5-bd09-0397f7e809f2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-salisbury-radio
+  broadcaster: independent
+  name: Salisbury Radio
+  streamUrl: https://securestreams6.autopo.st:2139/stream.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://salisburyradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 7d24ec3a-c37a-4a7a-99b3-1e0991ff8041
+  changeuuid: eb9d33c1-5350-4cf6-a1bb-03f17ae5f903
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-vixen-101
+  broadcaster: independent
+  name: Vixen 101
+  streamUrl: https://s33.myradiostream.com:15184/;?type=http
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.vixen101.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 05741225-4a5e-4a61-b90b-30b3ddcf9e78
+  changeuuid: 3fc2f18e-d4f5-43c0-b42c-52e51c8edf69
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-weekend-offender-radio
+  broadcaster: independent
+  name: Weekend Offender Radio
+  streamUrl: https://uk2.internet-radio.com/proxy/weekendoffender?mp=/stream;
+  bitrate: 128
+  codec: MP3
+  favicon: https://weekendoffender.com/cdn/shop/files/android-chrome-512x512.png?crop=center&height=32&v=1699368215&width=32
+  homepage: https://weekendoffender.com/
+  country: GB
+  status: stream-only
+  stationuuid: 2cea2982-7bd7-457f-a599-fc90b5aeea79
+  changeuuid: 98b7ae5d-95ac-4862-9633-714bdde7ecd9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-west-kent-radio
+  broadcaster: independent
+  name: West Kent Radio
+  streamUrl: https://ukwesta.streaming.broadcast.radio/wkcr
+  bitrate: 170
+  codec: MP3
+  favicon: https://www.westkentradio.co.uk/favicon.png
+  homepage: https://www.westkentradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 4dea201f-598f-4794-a25d-5a71058a5ca1
+  changeuuid: 21a4fdb9-2d36-493e-a7d2-a8ce5c411b46
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-xenfm
+  broadcaster: independent
+  name: XenFM
+  streamUrl: https://radio.xenfm.com/listen/xenfm/radio.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://xenfm.com/wp-content/uploads/2020/05/cropped-PythiaArsenicEye.png
+  homepage: https://xenfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: 16c600b5-0e48-4ace-b9bb-5bfc39a757d6
+  changeuuid: b9684799-f420-4c15-aaa0-0f034a9c7217
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-alfred
+  broadcaster: independent
+  name: Alfred
+  streamUrl: https://stream2.hippynet.co.uk:8204/stream
+  bitrate: 160
+  codec: MP3
+  homepage: https://thisisalfred.com/
+  country: GB
+  status: stream-only
+  stationuuid: 0f5816c2-022d-444e-a08f-cfe571a20f7a
+  changeuuid: 5236ca28-30ae-4ed9-95b5-3b772937c270
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-arena-radio
+  broadcaster: independent
+  name: Arena Radio
+  streamUrl: https://stream3.themediasite.co.uk:8318/stream
+  bitrate: 192
+  codec: MP3
+  favicon: https://public-rf-upload.minhawebradio.net/250716/logo/d7351a69a8b11013d475908bf2f562ba.png
+  homepage: http://arenaradio.live/
+  country: GB
+  status: stream-only
+  stationuuid: d72509cc-1ed8-4b2b-84a7-46edbdc22d78
+  changeuuid: 9cddc334-16ad-4af1-883c-3082a3e95f0b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bfbs-aldershot
+  broadcaster: independent
+  name: BFBS Aldershot
+  streamUrl: https://listen-ssvcbfbs.sharp-stream.com/ssvcbfbs13.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://radio.bfbs.com/icons/icon-512x512.png?v=0afec91a27aaa6d57f2b000c6fbe8cac
+  homepage: https://radio.bfbs.com/stations/bfbs-aldershot
+  country: GB
+  status: stream-only
+  stationuuid: 0e3d37da-f614-4998-9e1a-ca7274e4d37e
+  changeuuid: 6f72eac1-82ff-41b4-9ff0-4abdaa7fedd0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-black-country-radio
+  broadcaster: independent
+  name: Black Country Radio
+  streamUrl: https://listen-blackcountryradio.sharp-stream.com/blackcountryradio.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.blackcountryradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 4633eabd-28ea-4a8a-a324-0a45ba184d93
+  changeuuid: 1900e05c-9b1a-4b59-8928-c962614f65e0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-brap-fm
+  broadcaster: independent
+  name: Brap.FM
+  streamUrl: https://radio.brap.fm:8000/radio.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.brap.fm/
+  country: GB
+  status: stream-only
+  stationuuid: 47101fd9-3716-4954-9733-adf9b5091812
+  changeuuid: 3acffda1-5e0a-479a-a37e-21603674d226
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-crop-radio
+  broadcaster: independent
+  name: CROP Radio
+  streamUrl: https://s3.radio.co/sb713b671e/listen
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.cropradio.live/images/favicons/apple-touch-icon.png
+  homepage: https://www.cropradio.live/
+  country: GB
+  status: stream-only
+  stationuuid: 8880fed6-295b-4257-89e3-a7c75034780b
+  changeuuid: f11ad245-68a5-4a02-8da1-4dedfb47d72a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-cutters-choice
+  broadcaster: independent
+  name: Cutters Choice
+  streamUrl: https://cutters-choice-radio.radiocult.fm/stream
+  bitrate: 320
+  codec: MP3
+  homepage: https://www.cutterschoiceradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 70cf8648-f02a-40a1-a285-228369a4fae7
+  changeuuid: 9cca1fe5-353c-4897-94a4-ee7d68ddaebc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-dundee-radio-club
+  broadcaster: independent
+  name: Dundee Radio Club
+  streamUrl: https://dundee-radio-club.radiocult.fm/stream
+  bitrate: 320
+  codec: MP3
+  homepage: https://dundeeradio.club/
+  country: GB
+  status: stream-only
+  stationuuid: 721286a0-1886-4a06-92e3-2f5be0451ebb
+  changeuuid: 99a216df-4b22-47cc-9142-66b6cc082185
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-flex-fm-101-4
+  broadcaster: independent
+  name: Flex FM 101.4
+  streamUrl: https://a2.asurahosting.com:7400/radio.mp3
+  bitrate: 320
+  codec: MP3
+  favicon: https://upload.wikimedia.org/wikipedia/en/4/40/Flex_FM_London_logo.png
+  homepage: https://flexfm.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 0a885695-4f50-4676-8fab-0e7dff0e4fa9
+  changeuuid: aec33f1f-05af-4faa-baa7-59e0fe1ce43e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-fresh-soundz-radio
+  broadcaster: independent
+  name: Fresh Soundz Radio
+  streamUrl: https://solid48.streamupsolutions.com/proxy/neivwtxt/stream/
+  bitrate: 320
+  codec: MP3
+  favicon: https://static.mytuner.mobi/media/tvos_radios/626/soundz-radio-uk.426d8b6f.jpg
+  homepage: https://www.freshsoundzradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 023bfe22-8ced-42b2-9a6f-f205487b5858
+  changeuuid: 921915b2-bb16-48f1-9b4d-55589f0b1d40
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-frisky-radio-chill
+  broadcaster: independent
+  name: Frisky Radio Chill
+  streamUrl: https://stream.chill.friskyradio.com/
+  bitrate: 96
+  codec: MP3
+  homepage: http://friskyradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: fce5f166-670f-4e51-b8d8-9145110e1435
+  changeuuid: 0532ab5f-a24d-4dcc-890a-97a37764a4c9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-frisky-radio-deep
+  broadcaster: independent
+  name: Frisky Radio Deep
+  streamUrl: https://stream.deep.friskyradio.com/
+  bitrate: 96
+  codec: MP3
+  homepage: http://friskyradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 1e5d470b-7605-4d36-9734-4d34f9f2ebab
+  changeuuid: 53c96069-9ead-4915-9bc9-84feed525038
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-genx-radio
+  broadcaster: independent
+  name: GenX Radio
+  streamUrl: https://s2.radio.co/sf25229e16/low
+  bitrate: 64
+  codec: AAC
+  favicon: https://genxradio.co.uk/wp-content/uploads/2021/11/GenXAsset-3.png
+  homepage: https://genxradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 4519a42f-b4c0-4856-aa49-3a497af7de9a
+  changeuuid: 0f0cd65c-18ea-4218-921c-b64f32877e11
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-gold-dust-radio
+  broadcaster: independent
+  name: Gold Dust Radio
+  streamUrl: https://gold-dust-radio.radiocult.fm/stream
+  bitrate: 192
+  codec: MP3
+  favicon: https://images.squarespace-cdn.com/content/v1/5c80edb83560c31af710d6cc/1610290067018-YNK9FQE7ZGF56JE26AK6/gd-landscape-rgb-2.png?format=1500w
+  homepage: https://www.golddusthub.com/
+  country: GB
+  status: stream-only
+  stationuuid: a4611629-e7ac-4bea-8fda-625c695c1656
+  changeuuid: 91fe7884-ab6b-4874-b4f1-269703b51891
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-gwh
+  broadcaster: independent
+  name: GWH
+  streamUrl: https://carina.streamerr.co/stream/swindonhr
+  bitrate: 128
+  codec: MP3
+  country: GB
+  status: stream-only
+  stationuuid: 4ce780ba-f267-4016-b5ba-7762a3d98cd3
+  changeuuid: 0a5789fb-7c12-4d12-a6bd-639300b6bab4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hbsa-hospital-radio
+  broadcaster: independent
+  name: HBSA Hospital Radio
+  streamUrl: https://solid24.streamupsolutions.com/proxy/zzjcamth?mp=/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://hbsaradio.com/wp-content/themes/topofthehour/images/logo.png
+  homepage: https://hbsaradio.com/#
+  country: GB
+  status: stream-only
+  stationuuid: 220d73f5-268b-45da-b74c-4e9d599ca349
+  changeuuid: e90f6245-f792-48a5-96e6-59fad16cd6de
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-heaven-and-heaven-radio
+  broadcaster: independent
+  name: Heaven and Heaven radio
+  streamUrl: https://eu10.fastcast4u.com:1500/
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.heavenandheavenradio.org/apple-touch-icon.png?v=1721674313144
+  homepage: https://www.heavenandheavenradio.org/
+  country: GB
+  status: stream-only
+  stationuuid: 4c536c2b-8fa7-4a14-baa3-82aed93975ec
+  changeuuid: 957ad0e7-983d-4f5c-85c7-639632c7f915
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hospital-radio-colchester
+  broadcaster: independent
+  name: Hospital Radio Colchester
+  streamUrl: https://streaming.broadcastradio.com:10905/hrcolchester
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/2aa317_7b0e1ad2c28944858946b7a57ede4ab1.png/v1/fill/w_172,h_153,al_c,lg_1,q_85,enc_auto/2aa317_7b0e1ad2c28944858946b7a57ede4ab1.png
+  homepage: https://www.hrcolchester.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 8daf0a5c-fb3f-4f79-ac1b-5fd71be7d662
+  changeuuid: 7db21d63-64a5-4ba3-bb46-0e3ead7fb34e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-incapable-staircase
+  broadcaster: independent
+  name: Incapable Staircase
+  streamUrl: https://streams.radio.co/s436782ce6/listen
+  bitrate: 128
+  codec: MP3
+  favicon: https://incapablestaircase.com/wp-content/uploads/2024/08/favicon.png
+  homepage: https://www.incapablestaircase.com/
+  country: GB
+  status: stream-only
+  stationuuid: 41fe5c28-d87a-4e71-8a37-87e91597e94d
+  changeuuid: dd5a4757-98d2-4a85-8eab-524329db5d12
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-kizzfm-uk-90-9
+  broadcaster: independent
+  name: KizzFM UK 90.9
+  streamUrl: https://azura.kizzfmuk90-9.com/listen/kizzfmuk/radio.mp3?1689855016244
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.kizzfmuk90-9.com/
+  country: GB
+  status: stream-only
+  stationuuid: 1db0f955-aefa-4535-9811-748d1ee9db73
+  changeuuid: a7af9736-1af2-4075-b402-809de4555cbb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-lofi-hiphop-chillsky
+  broadcaster: independent
+  name: Lofi hiphop - chillsky
+  streamUrl: https://chill.radioca.st/stream
+  bitrate: 128
+  codec: MP3
+  homepage: https://chillsky.com/
+  country: GB
+  status: stream-only
+  stationuuid: 72f7fc65-a1ec-4e13-93f4-639363d2ff9a
+  changeuuid: cf60d3d8-04b1-4cea-93d6-004adf7d1608
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-london-romanian-radio
+  broadcaster: independent
+  name: London Romanian Radio
+  streamUrl: https://play.lrradio.uk/
+  bitrate: 64
+  codec: AAC
+  favicon: https://lrradio.uk/img/logo.png
+  homepage: https://lrradio.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 76c14813-a09a-480d-85c5-44ae3c6eda54
+  changeuuid: f40925d8-3c29-4464-82cb-aaff2a9f8ce3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-loose-fm
+  broadcaster: independent
+  name: Loose FM
+  streamUrl: https://loosefm.radiocult.fm/stream
+  bitrate: 320
+  codec: MP3
+  favicon: https://www.google.com/s2/favicons?sz=256&domain_url=https%3A%2F%2Fwww.loose.fm%2F
+  homepage: https://www.loose.fm/
+  country: GB
+  status: stream-only
+  stationuuid: 073b7b41-31c8-4f69-92e0-64ec9548af31
+  changeuuid: 8906fdc4-aef2-41bc-a245-49a85cdd5d60
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-mystery-radio
+  broadcaster: independent
+  name: Mystery Radio
+  streamUrl: https://streaming06.liveboxstream.uk/proxy/rokstar9/stream
+  bitrate: 48
+  codec: MP3
+  favicon: https://www2.rokitradio.com/_next/image?url=%2Fimages%2Fchannels%2Fmystery.jpg&w=128&q=75
+  homepage: https://www2.rokitradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 4f3ccf20-cc5a-465d-ba2e-0ecaa75fb5f2
+  changeuuid: 31a5a62a-69cc-405c-81da-9435171fc6d8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-p4ppp-radio
+  broadcaster: independent
+  name: P4PPP Radio
+  streamUrl: https://stream.zeno.fm/hgc7mcknqpuuv
+  codec: AAC
+  favicon: https://zeno.fm/_next/image/?url=https%3A%2F%2Fimages.zeno.fm%2F27b-9YErzi8ANXvNMuOlFjdfMRu1P7AJXYaBWpmPZN0%2Frs%3Afit%3A240%3A240%2Fg%3Ace%3A0%3A0%2FaHR0cHM6Ly9zdHJlYW0tdG9vbHMuemVub21lZGlhLmNvbS9jb250ZW50L3N0YXRpb25zLzYzZGMzZmRmLTQwYTgtNDFkMS04MzZiLWYyMzgwODdhMTAyMC9pbWFnZS8_dXBkYXRlZD0xNzE3MDYyMzY1MDAw.webp&w=1920&q=100
+  homepage: https://zeno.fm/radio/p4ppp-radio/
+  country: GB
+  status: stream-only
+  stationuuid: 67d1d138-6318-48d3-80c0-e3e9949298b6
+  changeuuid: e1f5fb43-28a8-4b28-947f-80ac8d4ece35
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-cardiff
+  broadcaster: independent
+  name: "Radio Cardiff "
+  streamUrl: https://radiocardiff.radioca.st/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://firebasestorage.googleapis.com/v0/b/radiogalaxy-580f4.appspot.com/o/images%2FIMG_20240909_115752423.jpg?alt=media&token=b344b077-73bc-46dd-9b59-eb196ff15d0f
+  homepage: https://radiocardiff.org/
+  country: GB
+  status: stream-only
+  stationuuid: 6706d898-f7c6-42ad-9e1b-4d473985eca4
+  changeuuid: c9454048-614d-459a-80cb-0c9961420ad9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-grapevine
+  broadcaster: independent
+  name: Radio Grapevine
+  streamUrl: https://streaming06.liveboxstream.uk/proxy/radiogra?mp=/stream
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radiograpevine.com/
+  country: GB
+  status: stream-only
+  stationuuid: 956c474b-36d2-4692-bb8e-b430b35ecc27
+  changeuuid: 3ba9db96-89d7-4b10-a2a6-e384966d2cb0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-seerah
+  broadcaster: independent
+  name: Radio Seerah
+  streamUrl: https://icecast.maxxwave.co.uk/radioseerah
+  bitrate: 80
+  codec: AAC
+  favicon: https://cloud-1de12d.becdn.net/media/iW=274&iH=274&oX=0&oY=0&cW=274&cH=274/0c0eff783969b0e0df546d2b6ec9ca8a/MainLOGO.jpg
+  homepage: https://www.radioseerah.com/
+  country: GB
+  status: stream-only
+  stationuuid: a92b5960-0802-45b4-a286-ae1a9151938e
+  changeuuid: 5e3794da-7b74-4b3a-ac28-a10b4781a139
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-utsav
+  broadcaster: independent
+  name: Radio UTSAV
+  streamUrl: https://icecast.maxxwave.co.uk/utsav
+  bitrate: 80
+  codec: AAC
+  favicon: https://radioutsav.com/wp-content/uploads/2024/09/PHOTO-2024-09-01-11-54-35.jpg
+  homepage: https://radioutsav.com/
+  country: GB
+  status: stream-only
+  stationuuid: cd0c14ff-11b3-47af-8dd3-955e789ecdb4
+  changeuuid: 0d6519b4-af8a-47a9-99b7-99e1ee0a5ad9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radionev-24x7-hit-music-lounge
+  broadcaster: independent
+  name: RadioNev (24x7 hit music lounge)
+  streamUrl: https://a7.asurahosting.com/listen/radionev/radio.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.radionev.com/sitepad-data/uploads/2024/11/512.png
+  homepage: https://www.radionev.com/
+  country: GB
+  status: stream-only
+  stationuuid: 18db4772-1f7d-43ef-9fdf-c50fdbe97a78
+  changeuuid: e529fb57-6b2f-4ede-8009-782acb361c0b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-roch-valley-radio
+  broadcaster: independent
+  name: Roch Valley Radio
+  streamUrl: https://rochvalley.radioca.st/stream?_=723854
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/572/615a03a7cb961.jpg
+  homepage: https://www.rochvalleyradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 9eccde5d-20a7-4d42-a8cf-7edc0aef3473
+  changeuuid: d151a5f9-7c35-4fff-9cdb-3298b66c1ce4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-rotherham-radio
+  broadcaster: independent
+  name: Rotherham Radio
+  streamUrl: https://stream3.themediasite.co.uk:8004/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://play-lh.googleusercontent.com/RcFfsJQvuWz-6ZhsTb7jOjwA6dSS0uy8h926Tgxnn4qDez7qEnBINiU9kqyc_qSvA4Q=w240-h480-rw
+  homepage: https://www.rotherhamradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 25ed3119-2ddc-407e-8f96-227a4dcf40a7
+  changeuuid: 49cd647a-078f-4158-a1c7-b45b791cc753
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-stoke-mandeville-hospital-radio
+  broadcaster: independent
+  name: Stoke Mandeville Hospital Radio
+  streamUrl: https://ukwesta.streaming.broadcast.radio/stoke?1692976686054=
+  codec: MP3
+  favicon: https://www.smhr.co.uk/favicon.ico
+  homepage: https://www.smhr.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 8c52d075-f7a5-4963-a922-09c5fa47272f
+  changeuuid: 00e9f762-e23d-4207-8783-78a1071df05d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-the-richie-allen-show
+  broadcaster: independent
+  name: The Richie Allen Show
+  streamUrl: https://ukwesta.streaming.broadcast.radio/therichieallenshow
+  codec: MP3
+  homepage: https://richieallen.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 35a2aa8b-a8c6-41c3-95fe-2e0857223095
+  changeuuid: 48cffd2c-8378-49e0-80bc-93d3fc7bb24d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-vintage-radio-wirral
+  broadcaster: independent
+  name: Vintage Radio Wirral
+  streamUrl: https://streaming04.liveboxstream.uk/proxy/vintager?mp=/stream
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.vintageradio.org.uk/sitepad-data/uploads/2024/11/WhatsApp-Image-2024-10-09-at-16.44.13_8902e262.jpg
+  homepage: https://www.vintageradio.org.uk/
+  country: GB
+  status: stream-only
+  stationuuid: bbd26799-7129-4620-9e46-49677e3fe320
+  changeuuid: 55bfe336-46a3-47cc-bdde-6a732f8008b5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-beat-geeks-radio
+  broadcaster: independent
+  name: Beat Geeks Radio
+  streamUrl: https://broadcast.shoutstream.co.uk:8050/stream
+  bitrate: 128
+  codec: AAC+
+  favicon: https://img1.wsimg.com/isteam/ip/bae4931a-2ea8-4815-9a46-4271f6de2b79/logo%20large.png/:/rs=w:400,h:400,cg:true,m/cr=w:400,h:400/qt=q:95
+  homepage: https://beatgeeksradio.com/#5f139bdd-e5cd-420c-a57c-c7075e626746
+  country: GB
+  status: stream-only
+  stationuuid: 8b219ccf-914c-4822-ad96-245f7e0a7c63
+  changeuuid: b4af40c7-2008-41da-9f6d-66fac0efd54c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-beat-route-radio
+  broadcaster: independent
+  name: Beat Route Radio
+  streamUrl: https://beatrouteradio.radioca.st/autodj
+  bitrate: 128
+  codec: MP3
+  favicon: https://firebasestorage.googleapis.com/v0/b/radiogalaxy-580f4.appspot.com/o/images%2FIMG_20240909_160637684.jpg?alt=media&token=e0d32581-2089-4058-9d80-01279c52b1cc
+  homepage: https://beatrouteradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: beae5ddc-ed22-4c5a-bbfa-cbf0815b794b
+  changeuuid: 6e51621b-8261-4ed3-80c4-db879e815044
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-blue-in-green-radio
+  broadcaster: independent
+  name: "Blue-in-Green:RADIO"
+  streamUrl: https://stream.radio.co/s9e1625f13/listen
+  bitrate: 128
+  codec: MP3
+  favicon: http://4.bp.blogspot.com/-aeCJDMfXnVM/WKWDZV4LOuI/AAAAAAAABxI/QPsmN8EWUBgPXVlN3hE9Q2EyypmA9WWfQCK4B/s400/BinGRadio%2BBW.png
+  homepage: http://www.blueingreenradio.com/?m=1
+  country: GB
+  status: stream-only
+  stationuuid: 0fb72765-2bab-4242-b635-ac8bae673676
+  changeuuid: 450ad6d3-e218-401b-9635-5197300bcf1c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-capital-xtra-reloaded
+  broadcaster: independent
+  name: Capital Xtra Reloaded
+  streamUrl: https://media-ice.musicradio.com/CapitalXTRAReloadedMP3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.capitalxtra.com/reloaded/
+  country: GB
+  status: stream-only
+  stationuuid: 10ceb226-550d-41ce-84e9-df7f33729c84
+  changeuuid: 63f5ebe1-8674-4d1e-a360-3b84fda5b292
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-charlie-mason-radio
+  broadcaster: independent
+  name: Charlie Mason Radio
+  streamUrl: https://s9.reliastream.com/proxy/charlie1/stream
+  bitrate: 320
+  codec: MP3
+  homepage: https://charliemasonradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: aaa2710d-6598-4691-8cf8-a73c1c023a8a
+  changeuuid: 2c0f018c-c418-4104-8d2d-1f7faf96192d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-colin-mogagabe
+  broadcaster: independent
+  name: Colin Mogagabe
+  streamUrl: https://music-station.live/listen/crw_radio/radio.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.music-station.live/static/uploads/crw_radio/album_art.1721666882.png
+  homepage: https://music-station.live/public/crw_radio
+  country: GB
+  status: stream-only
+  stationuuid: b059116f-12b9-4ecb-9a6c-4195f5c141c2
+  changeuuid: cd868afe-3467-4efb-a6e3-424ee61d4452
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-conquest-hospital-radio
+  broadcaster: independent
+  name: Conquest Hospital Radio
+  streamUrl: https://chrconquest.radioca.st/radio.mp3
+  bitrate: 160
+  codec: MP3
+  favicon: https://conquesthospitalradio.co.uk/wp-content/uploads/2021/07/950291C2-2ECB-460D-A667-30F09D405480.jpeg
+  homepage: https://conquesthospitalradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 6b595df4-22e1-4731-b820-6a9ace4e99f5
+  changeuuid: a5447740-64c1-42a1-8871-5984a32b4b68
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-crmk
+  broadcaster: independent
+  name: CRMK
+  streamUrl: https://stream.radio.co/sdfcc41b7a/listen
+  bitrate: 192
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/2f38db_822606c0d74d443cbca64a25e47899b5~mv2.png/v1/fill/w_109,h_109,al_c,q_85,usm_0.66_1.00_0.01,enc_auto/Untitled.png
+  homepage: https://www.crmk.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: a58bf7d6-ae56-4c62-8613-a1d45dc5fab3
+  changeuuid: 005ddfe0-7982-49fe-bb44-be210a7794c6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-deephouse-fm
+  broadcaster: independent
+  name: deephouse.fm
+  streamUrl: https://altair.streamerr.co:8124/stream
+  bitrate: 192
+  codec: MP3
+  favicon: https://deephouse.fm/wp-content/uploads/2025/12/Deep-House-FM-Logo.jpg
+  homepage: https://deephouse.fm/
+  country: GB
+  status: stream-only
+  stationuuid: b55bdebb-54b5-4fdf-9078-d750612fcda1
+  changeuuid: 0f6bbb52-1e86-4fcb-acbb-44a6814c84a5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-doncaster-radio
+  broadcaster: independent
+  name: Doncaster Radio
+  streamUrl: https://stream1.themediasite.co.uk:8008/stream
+  bitrate: 192
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/493/64b694df58f95.png
+  homepage: https://www.doncasterradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 37618117-b106-45e1-9a62-a7c385ee580b
+  changeuuid: 0cff368b-ed50-4420-b1e0-aac194ca5257
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-drystone-radio
+  broadcaster: independent
+  name: Drystone Radio
+  streamUrl: https://uksoutha.streaming.broadcast.radio/drystoneradio?1724596500437=
+  codec: MP3
+  homepage: https://www.drystoneradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: b137a456-40e1-46fa-b840-482fc100d10a
+  changeuuid: 6f22b398-6306-4ec5-b719-6e98f90a3eca
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-eden-fm-107-5
+  broadcaster: independent
+  name: Eden Fm 107.5
+  streamUrl: https://eu4.fastcast4u.com/proxy/edenfmlt?mp=/1
+  bitrate: 128
+  codec: AAC+
+  favicon: https://fastcast4u.com/player/edenfmlt/_user/logo/e/edenfmlt/ch0.jpg
+  homepage: http://www.edenfm.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 13e826d0-62ac-478e-9447-2c35a1b94bff
+  changeuuid: 877eff34-0e1e-4fdc-b4ed-d45f746042ff
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-fishnet-radio
+  broadcaster: independent
+  name: Fishnet Radio
+  streamUrl: https://stream.radio.co/s74e130a62/listen
+  bitrate: 192
+  codec: MP3
+  favicon: https://static.mytuner.mobi/media/tvos_radios/151/fishnet-radio.6ea1e90b.png
+  homepage: https://www.fishnetradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 5efbf78b-7543-4405-9ade-f2561735f807
+  changeuuid: f42c40ca-633a-48e6-829f-f273db91e693
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-fix-radio
+  broadcaster: independent
+  name: Fix Radio
+  streamUrl: https://n06a-eu.rcs.revma.com/gnys6kxst8tvv
+  codec: AAC
+  favicon: https://mmo.aiircdn.com/203/623068c8b2091.png
+  homepage: https://www.fixradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: f1beb3ef-0410-47ef-a137-0430b1f8beb6
+  changeuuid: 6e7a995a-6712-47d2-a585-c684f9e764b6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-fosse-107
+  broadcaster: independent
+  name: Fosse 107
+  streamUrl: https://icecast.maxxwave.co.uk/fossehinckleyhq
+  bitrate: 80
+  codec: AAC
+  favicon: https://mm.aiircdn.com/375/59372c77cd002.png
+  homepage: https://www.fosse107.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 39a42811-79fe-44ed-a4cc-392ef2a6d774
+  changeuuid: 1a5d6672-3dee-42f6-9272-d6d45ce68fb3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-frisk-radio-groove-northeast
+  broadcaster: independent
+  name: frisk radio groove northeast
+  streamUrl: https://www.friskradio.com:8443/stream21
+  codec: AAC
+  homepage: https://www.friskradio.com/?station=4un
+  country: GB
+  status: stream-only
+  stationuuid: de8dea11-4dc3-48df-b229-44b0bed9f921
+  changeuuid: 13680e0d-c6f0-4e4b-b1c9-76898eb8033d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hailsham-fm
+  broadcaster: independent
+  name: Hailsham FM
+  streamUrl: https://s21.myradiostream.com/:10716/listen.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.hailshamfm.com/wp-content/uploads/2021/03/Hailsham-95.9FM-logo-NO-STRAP.png
+  homepage: https://www.hailshamfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: 0637f4cc-4c57-4ccf-80b3-1aeda062c197
+  changeuuid: 762b5481-d2f7-4244-b429-b6477e6d84c5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hearme-movie-soundtracks-radio
+  broadcaster: independent
+  name: "Hearme Movie Soundtracks Radio "
+  streamUrl: https://radio.hearme.fm:8074/stream
+  codec: MP3
+  favicon: https://hearme.fm/wp-content/uploads/2024/06/2024-Redrafted-Transparent-Box-No-Text-1-1024x1024.png
+  homepage: https://hearme.fm/radio/movie-soundtracks/
+  country: GB
+  status: stream-only
+  stationuuid: da9a3558-135c-466c-a8bc-4eca5433ff0c
+  changeuuid: 4c13cda0-9e51-4d0e-bd28-4522b81d8edc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-johnstone-sound
+  broadcaster: independent
+  name: Johnstone Sound
+  streamUrl: https://stream1.themediasite.co.uk:8084/;
+  bitrate: 320
+  codec: MP3
+  homepage: https://johnstonesound.com/
+  country: GB
+  status: stream-only
+  stationuuid: 0a87202d-0fdd-40f5-8a15-bedc48bb9ed4
+  changeuuid: 94fc7147-2577-428b-8ee8-ae1327dd1f91
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-konflict-radio
+  broadcaster: independent
+  name: Konflict Radio
+  streamUrl: https://uk3.internet-radio.com/proxy/konflictradio?mp=/stream
+  bitrate: 320
+  codec: MP3
+  favicon: https://konflict-radio.com/images/krlogo.png
+  homepage: https://konflict-radio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 07fc81e9-58e4-4097-90e4-e4022712d984
+  changeuuid: ad40e826-f510-4388-888d-bc2d2b7fdb8a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-mersey-radio
+  broadcaster: independent
+  name: Mersey Radio
+  streamUrl: https://stream.shoutcastservices.com/proxy/merseyradio/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://merseyradio.co.uk/wp-content/uploads/2023/03/cropped-logo.png
+  homepage: https://merseyradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: a38650f3-7691-4a5e-9475-0d549d3679b5
+  changeuuid: f5ae74dc-f148-4a36-ae9b-9e148098de15
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-mid-downs-radio
+  broadcaster: independent
+  name: Mid Downs Radio
+  streamUrl: https://listen-mdr.sharp-stream.com/mdr.mp3
+  bitrate: 65
+  codec: MP3
+  homepage: https://www.mdr.org.uk/
+  country: GB
+  status: stream-only
+  stationuuid: de4ca30c-690a-4ac4-b123-fdbf0655349d
+  changeuuid: 9e9e15ac-b508-49bc-ae98-1214d11b65f1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-ocean-city-radio
+  broadcaster: independent
+  name: Ocean City Radio
+  streamUrl: https://s3.radio.co/se9877d32a/listen#.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://oceancityradio.co.uk/favicon.ico
+  homepage: https://oceancityradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: d14f6873-f99f-4b41-8194-fd46e27d6f66
+  changeuuid: a9bf42a9-1f7f-400c-a0a2-80822288236c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-outreach-dance
+  broadcaster: independent
+  name: Outreach Dance
+  streamUrl: https://live.ukrp.tv/outreachdance.aac
+  bitrate: 32
+  codec: AAC
+  homepage: https://www.outreachdance.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: aaaf4c25-8173-4838-82a3-e2300e5cf58d
+  changeuuid: a0b26a7d-5e15-490d-8eba-001acfdd78a3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-overton-radio
+  broadcaster: independent
+  name: Overton Radio
+  streamUrl: https://securestreams6.autopo.st:2506/stream
+  bitrate: 192
+  codec: MP3
+  favicon: https://overtonradio.com/wp-content/uploads/2023/07/1-1-1024x1024.png
+  homepage: https://www.overtonradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 7d701a61-820a-4c19-988f-421e7ffd78d7
+  changeuuid: 375b78d8-3364-4789-bba6-0c55460dfb0d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-enrg
+  broadcaster: independent
+  name: Radio ENRG
+  streamUrl: https://edge.mixlr.com/channel/xssdg
+  codec: MP3
+  favicon: https://i0.wp.com/radioenrg.com/wp-content/uploads/2020/06/radio-enrg-triangle-black-10.png
+  homepage: https://radioenrg.com/
+  country: GB
+  status: stream-only
+  stationuuid: 065a9594-4b93-4dad-a65b-cdb55adf9f0f
+  changeuuid: bcfd63fc-6db0-42e9-99c7-3e3cc1333a78
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-leyland
+  broadcaster: independent
+  name: Radio Leyland
+  streamUrl: https://streaming06.liveboxstream.uk/proxy/leyland2?mp=/stream
+  bitrate: 128
+  codec: MP3
+  homepage: https://radioleyland.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 53d6f35f-debd-479d-aa7c-61ccbf30ab54
+  changeuuid: 34c9a20b-2f87-41a6-9e1e-1d077e1bbd1c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-warneford
+  broadcaster: independent
+  name: Radio Warneford
+  streamUrl: https://uk7.internet-radio.com/proxy/radiowarneford?mp=/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.radiowarneford.com/wp-content/uploads/2023/11/rw-logo-2023-50th-400.png
+  homepage: https://www.radiowarneford.com/
+  country: GB
+  status: stream-only
+  stationuuid: 6b8928ad-5b12-4949-a552-959d4be265d4
+  changeuuid: 4cc06dbd-8548-4d32-a161-fd4415d466a4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-rother-radio-rotherham-sheffield
+  broadcaster: independent
+  name: "Rother Radio (Rotherham & Sheffield)"
+  streamUrl: https://streaming06.liveboxstream.uk/proxy/hitmusic?mp=/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://static.mytuner.mobi/media/tvos_radios/594/rother-radio.cc31313e.png
+  homepage: https://www.rotherradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: c68edb9c-dbc8-409d-891e-400ece56c982
+  changeuuid: c1fe57f4-2fd0-46f1-85fd-3292d3d9936b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-rustfm
+  broadcaster: independent
+  name: RustFM
+  streamUrl: https://listen.rustfm.com/listen/rustfm/radio.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://rustfm.com/assets/images/logo_wr.png
+  homepage: https://rustfm.com/#home
+  country: GB
+  status: stream-only
+  stationuuid: 47d46a2f-7bf6-4c7e-a776-b4a788047911
+  changeuuid: 7a32eafb-85dc-418a-a8c6-26d1a4ee25d4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-soundart-radio
+  broadcaster: independent
+  name: Soundart Radio
+  streamUrl: https://radio.canstream.co.uk:8134/live.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.soundartradio.org.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 161201f8-ae58-4f44-806b-4f8c8b90c853
+  changeuuid: 223111c6-6de7-4a66-b0bd-68f392f79d44
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-storm-radio
+  broadcaster: independent
+  name: Storm Radio
+  streamUrl: https://streaming.radio.co/s6df48fd88/listen
+  bitrate: 192
+  codec: MP3
+  favicon: https://img1.wsimg.com/isteam/ip/73788d98-eb15-4545-b89e-02e21d7c3eb9/STORM%20HEADER%20NEW%20A11.jpg/:/rs=w:902,h:273
+  homepage: https://stormfm.uk/home
+  country: GB
+  status: stream-only
+  stationuuid: 25c33875-d263-40c4-a4b4-79bcd0afa8a1
+  changeuuid: 960d0373-e156-4852-a955-0225bd986fd4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-the-sound-lab
+  broadcaster: independent
+  name: The Sound Lab
+  streamUrl: https://s4.radio.co/s0fc46103b/listen
+  bitrate: 192
+  codec: MP3
+  favicon: https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSa6ZgnMpbK8OK1EtUIYciHuysU3-zw2_NdOsB053eHdXnyMpkK9N2JYvHFRVdfsVnggKs&usqp=CAU
+  homepage: https://www.thesoundlabuk.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 9aea8bfd-f3ca-4829-b51d-bd440739c547
+  changeuuid: 21c2bdd2-3b0e-4295-bee6-c54d06f0f14d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-urban-all-in-1-radio
+  broadcaster: independent
+  name: Urban All In 1 Radio
+  streamUrl: https://stream.urbanallin1radio.co.uk/radio.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: https://urbanallin1radio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: e637a363-bc10-466b-960e-21ee86a9ecf0
+  changeuuid: 66ca0a70-a6dd-49cf-a5fe-95c24fcb7d19
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-capital-the-uk-s-no-1-hit-music-station
+  broadcaster: independent
+  name: " CAPITAL - The UK's No.1 Hit Music Station"
+  streamUrl: https://media-ssl.musicradio.com/CapitalUK
+  bitrate: 48
+  codec: AAC
+  favicon: https://cdn-profiles.tunein.com/s241396/images/logod.jpg
+  homepage: https://www.capitalfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: 4ad5bdc7-01e5-47c9-a1f9-751671b4707e
+  changeuuid: 96da73cc-8600-451b-a552-27626cbf5f64
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-capital-dance-the-uk-s-official-dance-station
+  broadcaster: independent
+  name: " CAPITAL DANCE: The UK's Official Dance Station"
+  streamUrl: https://media-ssl.musicradio.com/CapitalDance
+  bitrate: 48
+  codec: AAC
+  favicon: https://cdn-profiles.tunein.com/s309497/images/logod.jpg
+  homepage: https://www.capitaldance.com/
+  country: GB
+  status: stream-only
+  stationuuid: 5d50b9af-852d-43eb-89dd-b9b934e3f551
+  changeuuid: 9a218de4-7693-4ffd-9c06-741070295b02
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-kiss-xtra-black-music-culture
+  broadcaster: independent
+  name: " KISS XTRA: Black Music & Culture"
+  streamUrl: https://live-bauerkiss.sharp-stream.com/kissfresh.aac?direct=true&aw_0_1st.skey=1602676850&rp_source=1&=&&___cb=60456375243858
+  bitrate: 47
+  codec: AAC+
+  favicon: https://cdn-profiles.tunein.com/s198663/images/logod.png
+  homepage: https://www.hellorayo.co.uk/kiss-xtra
+  country: GB
+  status: stream-only
+  stationuuid: abb48ea5-7aaf-460c-bf04-7fe3b7f10bb7
+  changeuuid: bfceeb0d-0762-4309-8016-fae15ae42ac0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-96-3-seahaven-fm
+  broadcaster: independent
+  name: "96.3 Seahaven FM"
+  streamUrl: https://stream1.hippynet.co.uk:8107/stream?_=526570
+  bitrate: 170
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/892/63854c57a853f.png
+  homepage: https://www.seahavenfm.radio/
+  country: GB
+  status: stream-only
+  stationuuid: 042bb509-22e7-4eb8-9d7b-d69caf2ae57d
+  changeuuid: 5a82993c-d175-4856-91f8-105206480363
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-ajk-radio
+  broadcaster: independent
+  name: AJK Radio
+  streamUrl: https://solid41.streamupsolutions.com/proxy/wzbznkee/stream
+  bitrate: 320
+  codec: MP3
+  homepage: https://ajkradio.net/
+  country: GB
+  status: stream-only
+  stationuuid: ac8f3667-da06-449f-b876-e96b0e35b9d5
+  changeuuid: edd07e72-52ac-44a6-b6c1-a8e0bb3ad7a9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-arystation-beyond-reality
+  broadcaster: independent
+  name: AryStation - Beyond Reality
+  streamUrl: https://a11.asurahosting.com:8740/radio.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: https://radio.metachitect.com/
+  country: GB
+  status: stream-only
+  stationuuid: f9c3a3e4-06c9-4082-bb8f-c195a8837789
+  changeuuid: cde14b2a-4082-4cba-8d92-6e9527165f41
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bbc-cwr
+  broadcaster: independent
+  name: BBC CWR
+  streamUrl: https://as-hls-ww-live.akamaized.net/pool_79805333/live/ww/bbc_radio_coventry_warwickshire/bbc_radio_coventry_warwickshire.isml/bbc_radio_coventry_warwickshire-audio%3d96000.norewind.m3u8
+  codec: UNKNOWN
+  favicon: https://sounds.files.bbci.co.uk/3.9.4/networks/bbc_radio_coventry_warwickshire/colour_default.svg
+  homepage: https://www.bbc.co.uk/sounds/play/live/bbc_radio_coventry_warwickshire
+  country: GB
+  status: stream-only
+  stationuuid: 6c2699fb-de31-443d-b1a7-4249f45f4fc0
+  changeuuid: 770d0d1c-753a-4084-a0bc-708cefb1b8e3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bbc-radio-cambridge
+  broadcaster: independent
+  name: BBC Radio Cambridge
+  streamUrl: https://as-hls-ww-live.akamaized.net/pool_21074581/live/ww/bbc_radio_cambridge/bbc_radio_cambridge.isml/dash/bbc_radio_cambridge-audio%3d96000.norewind.m3u8
+  codec: UNKNOWN
+  favicon: https://sounds.files.bbci.co.uk/3.9.4/networks/bbc_radio_cambridge/colour_default.svg
+  homepage: https://www.bbc.co.uk/sounds/play/live/bbc_radio_cambridge
+  country: GB
+  status: stream-only
+  stationuuid: 69af9796-8391-4f32-bb58-ddc0a7673014
+  changeuuid: f431597d-e4e5-4b2b-b696-a8867c0d9b83
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-brown-student-community-radio
+  broadcaster: independent
+  name: "BROWN STUDENT & COMMUNITY RADIO"
+  streamUrl: https://listen.bsrlive.com/bsrmp3?1729748097161
+  bitrate: 128
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/39c7bc_eb82f27fe4d8402986e669cdbca13c4d~mv2.png/v1/fill/w_84,h_69,al_c,q_85,usm_0.66_1.00_0.01,enc_auto/39c7bc_eb82f27fe4d8402986e669cdbca13c4d~mv2.png
+  homepage: https://www.bsrlive.com/
+  country: GB
+  status: stream-only
+  stationuuid: f9ce7fb0-8db1-4cec-ba5b-6403ee483985
+  changeuuid: 94e95716-5b6b-4004-93c6-17085806901f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-cannock-chase-radio-fm
+  broadcaster: independent
+  name: Cannock Chase Radio FM
+  streamUrl: https://streaming.broadcast.radio/cannockchase?1712410831388=
+  codec: MP3
+  favicon: https://i0.wp.com/www.cannockchaseradio.co.uk/wp-content/uploads/2020/11/mobile-app-VER2.png?fit=1820%2C1120&ssl=1
+  homepage: https://www.cannockchaseradio.co.uk/#
+  country: GB
+  status: stream-only
+  stationuuid: 18da8249-0f65-4a29-b7aa-61239c7c44f5
+  changeuuid: ca72216a-92bf-467a-9acf-40fb8c17d920
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-celtic-music-radio
+  broadcaster: independent
+  name: Celtic Music Radio
+  streamUrl: https://uksoutha.streaming.broadcast.radio/celtic
+  codec: MP3
+  favicon: https://www.celticmusicradio.net/wp-content/uploads/2021/03/cropped-CMR-Logo-New-Ross-New-again-morse-correct.jpg
+  homepage: https://www.celticmusicradio.net/
+  country: GB
+  status: stream-only
+  stationuuid: 39e5d255-c3ad-4f81-9957-a1ceb59a3488
+  changeuuid: 89a98268-af26-469f-bd07-2a2a2c97f4cd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-crystal-love-radio
+  broadcaster: independent
+  name: Crystal Love Radio
+  streamUrl: https://betelgeuse.nucast.co.uk:8034/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://crystalloveradio.com/wp-content/uploads/2022/08/Crystallove-favi.jpg
+  homepage: https://crystalloveradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 39803846-5236-4951-b0e9-0f89fca438ab
+  changeuuid: 428b857a-324a-4760-8a6c-8799be5c9ead
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-daz-in-the-hat-radio
+  broadcaster: independent
+  name: Daz In The Hat Radio
+  streamUrl: https://s5.radio.co/s367c77774/listen
+  bitrate: 128
+  codec: MP3
+  favicon: https://assets.zyrosite.com/cdn-cgi/image/format=auto,w=238,fit=crop,q=95/Y4LlnV0PrgfegPw5/daz-in-the-hat-edited-logo-m2Wb7PBjx2ie7lwk.jpg
+  homepage: https://dazinthehat.com/
+  country: GB
+  status: stream-only
+  stationuuid: e6a82efc-59e5-42e8-bdce-ab0363596626
+  changeuuid: 1a8c93a8-6662-4c58-977d-7f4804da409c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-dean-radio
+  broadcaster: independent
+  name: Dean Radio
+  streamUrl: https://radio.forestmedia.co.uk/deanradio
+  bitrate: 128
+  codec: MP3
+  favicon: https://deanradio.co.uk/favicon.ico
+  homepage: https://deanradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: e2c6b5eb-08af-48b6-9f80-59f3ce14b6f6
+  changeuuid: a2f7d165-41f5-477c-aa96-7979d197f4cd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-dune-radio
+  broadcaster: independent
+  name: Dune Radio
+  streamUrl: https://stream.aiir.com/3phqulqckaguv?_=981158
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/192/649d16201b02a.png
+  homepage: https://www.duneradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 6597d969-eff4-424d-b2d5-37b25fd10285
+  changeuuid: 894586ff-6bdf-49c8-927e-3b9d32dbf335
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-first-radio-bounce-northeast
+  broadcaster: independent
+  name: "First radio bounce northeast "
+  streamUrl: https://www.friskradio.com:8443/stream41
+  codec: AAC
+  homepage: https://www.friskradio.com/?station=7
+  country: GB
+  status: stream-only
+  stationuuid: 67e86bb1-0f24-4bad-9ab8-007187c03ef0
+  changeuuid: 7a401e35-6b9a-498c-a180-ae31486ed3d0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-fuse-fm
+  broadcaster: independent
+  name: Fuse FM
+  streamUrl: https://streaming.radio.co/s53051f118/low
+  bitrate: 64
+  codec: MP3
+  favicon: https://fusefm.co.uk/wp-content/themes/yootheme/cache/1f/Logo-Transparent-1fa9e60d.webp
+  homepage: https://fusefm.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 243bae90-3218-4eab-897d-061d0e07e056
+  changeuuid: 6969502b-a44f-4bba-b34e-d4c1207ef8ba
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-global-breakfast-radio
+  broadcaster: independent
+  name: Global Breakfast Radio
+  streamUrl: https://globalbreakfastradio.com:8443/stream
+  codec: MP3
+  favicon: https://www.globalbreakfastradio.com/images/global-breakfast-radio.png
+  homepage: https://www.globalbreakfastradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 1b59e89b-7028-4710-8909-c6fe662adac1
+  changeuuid: b609b462-f24a-4742-b5a7-b72379e7c551
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hits-hull-east-york
+  broadcaster: independent
+  name: "Hits hull & East York"
+  streamUrl: https://listen-nation.sharp-stream.com/hull.mp3?aw_0_1st.playerid=BMUK_html5
+  bitrate: 128
+  codec: MP3
+  homepage: https://hellorayo.co.uk/hits-radio/
+  country: GB
+  status: stream-only
+  stationuuid: 3e41c90a-171f-4a17-a1c0-3516aa898d4a
+  changeuuid: 361ce3d6-40a1-4606-b0a8-3511075b48b7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-homemade-radio
+  broadcaster: independent
+  name: Homemade Radio
+  streamUrl: https://homemaderadio-brianager.radioca.st/;
+  bitrate: 320
+  codec: MP3
+  favicon: https://static.vecteezy.com/system/resources/thumbnails/001/933/723/small/radio-online-neon-signs-style-text-free-vector.jpg
+  homepage: https://homemade-radio.com/
+  country: GB
+  status: stream-only
+  stationuuid: acc196b2-0ad5-4024-840a-79283d590cf2
+  changeuuid: d07de684-2acd-4b32-8c09-8e3bfae488ba
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-house-radio-net
+  broadcaster: independent
+  name: House Radio Net
+  streamUrl: https://server.houseradio.net:8000/stream
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.houseradio.net/
+  country: GB
+  status: stream-only
+  stationuuid: 2e66059f-7c92-43bf-bbbf-6d92372e8d22
+  changeuuid: 7e2614bc-3df6-4c2b-9ef6-29c949a9ae81
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-keep-106
+  broadcaster: independent
+  name: KeeP 106
+  streamUrl: https://solid9.streamupsolutions.com/proxy/djcohrzp?mp=/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://keep106.com/wp-content/uploads/2020/02/imageedit_5_8575205827.png
+  homepage: https://keep106.com/
+  country: GB
+  status: stream-only
+  stationuuid: da5266f1-558a-4a5b-9911-d21b43e21c9c
+  changeuuid: 2c0f1faa-cf49-4160-86ae-3d558aef114d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-kfm-radio
+  broadcaster: independent
+  name: KFM Radio
+  streamUrl: https://s2.radio.co/s367e90f45/listen
+  bitrate: 128
+  codec: MP3
+  favicon: https://i0.wp.com/kfmradio.co.uk/wp-content/uploads/2022/09/KFM-logob-200.png?fit=200102&amp;ssl=1
+  homepage: https://kfmradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 35431197-daf1-4347-a71b-1aacf49336fd
+  changeuuid: edd791f4-b49c-4286-a57c-95c2a918bfae
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-lincs-sound
+  broadcaster: independent
+  name: Lincs Sound
+  streamUrl: https://stream.aiir.com/ubrzdpuap28vv
+  codec: AAC
+  favicon: https://mmo.aiircdn.com/2033/6861243b23677.jpg
+  homepage: https://www.lincssound.com/
+  country: GB
+  status: stream-only
+  stationuuid: 620a1ecc-3aae-47e9-bda8-63e263e9d552
+  changeuuid: 1382320d-98ac-4e37-b132-25b2d8373e17
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-love-will-save-the-day
+  broadcaster: independent
+  name: Love Will Save The Day
+  streamUrl: https://lovewillsavetheday.out.airtime.pro/lovewillsavetheday_a
+  bitrate: 128
+  codec: MP3
+  homepage: https://lovewillsavetheday.fm/
+  country: GB
+  status: stream-only
+  stationuuid: e9e6e838-a649-4b03-b955-0cf42be7c696
+  changeuuid: f84f1b14-b573-4906-88c8-3da9714b5f75
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-lushstarr-radio
+  broadcaster: independent
+  name: LushStarr Radio
+  streamUrl: https://cdn.voscast.com/resources/?key=5d34553745888466d26fc1cc83166d78&c=wmp
+  codec: UNKNOWN
+  favicon: https://compiled.ams3.cdn.digitaloceanspaces.com/profile_images/0FDEUXEQompwot5vyQTaBHD1y4M50wpAv2Pd9osJ.jpg
+  homepage: http://www.lushstarr.com/
+  country: GB
+  status: stream-only
+  stationuuid: f17a4cbf-132c-4370-8537-ef5b5cf77c79
+  changeuuid: 338859f7-2e91-42a5-890a-0fefac0d4511
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-mode-radio-london
+  broadcaster: independent
+  name: Mode Radio London
+  streamUrl: https://mode-london.radiocult.fm/stream
+  bitrate: 320
+  codec: MP3
+  homepage: https://mode.london/
+  country: GB
+  status: stream-only
+  stationuuid: 1aeda665-088f-45b1-abb4-f18c195bf24f
+  changeuuid: b77f474c-7b5e-4e8f-9366-b5a390c0fd69
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-only-hits-radio
+  broadcaster: independent
+  name: Only Hits Radio
+  streamUrl: https://stream4.themediasite.co.uk:8210/stream?_=328882
+  bitrate: 192
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/2016/68090c0a5a354.png
+  homepage: https://www.onlyhitsradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: c3a7c298-2af6-4bd9-a103-82876753178e
+  changeuuid: d09ad8c2-73c0-4106-b9e7-dee980e12152
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-prodigies-radio
+  broadcaster: independent
+  name: Prodigies Radio
+  streamUrl: https://polaris.nucast.co.uk:7580/stream
+  bitrate: 320
+  codec: MP3
+  homepage: https://polaris.nucast.co.uk/custom-player/7580#
+  country: GB
+  status: stream-only
+  stationuuid: d8f83528-d24c-4931-a45e-3e84900f6571
+  changeuuid: c03ebbe4-e4ec-40c1-964e-8068ab1ce1ac
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-frimley-park
+  broadcaster: independent
+  name: Radio Frimley Park
+  streamUrl: https://frimleypark.radioca.st/stream?icy=http
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.radiofrimleypark.co.uk/icons/favicon-256.png
+  homepage: https://www.radiofrimleypark.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 60d706f1-4d4e-48b8-b51e-e967eb8ff50c
+  changeuuid: 33f1d37a-2533-4423-8c10-8697a4ca58d4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-horton
+  broadcaster: independent
+  name: Radio Horton
+  streamUrl: https://radiohorton.radioca.st/;
+  bitrate: 128
+  codec: MP3
+  homepage: https://radiohorton.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 9894afea-8272-4be6-bc85-845913d54753
+  changeuuid: da3dfd6c-e5d8-4e5e-9a0b-7fa9f0b770da
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-north-angus
+  broadcaster: independent
+  name: Radio North Angus
+  streamUrl: https://uk3-vn.mixstream.net/8192/listen.mp3
+  bitrate: 48
+  codec: MP3
+  favicon: https://radionorthangus.co.uk/wp-content/uploads/2024/02/resize-homer.bk_.png-150x150.webp
+  homepage: https://radionorthangus.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 48a5cfff-edb9-4537-a686-526620663428
+  changeuuid: d884ba0e-c2d4-4c80-a73d-4208ed7f1c93
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-northumberland
+  broadcaster: independent
+  name: Radio Northumberland
+  streamUrl: https://northumberland.radioca.st/;
+  bitrate: 128
+  codec: MP3
+  favicon: https://cdn.instant.audio/images/logos/internetradiouk-com/northumberland.png
+  homepage: https://radionorthumberland.com/
+  country: GB
+  status: stream-only
+  stationuuid: 7e02f816-5237-48c2-850b-e4ba63a09181
+  changeuuid: eaa8a939-441c-46e5-966d-a0b8dee6fccb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-scarborough
+  broadcaster: independent
+  name: Radio Scarborough
+  streamUrl: https://s3.radio.co/s201b7a9d0/listen
+  bitrate: 64
+  codec: MP3
+  favicon: https://radioscarborough.com/wp-content/uploads/2023/01/cropped-Site-Icon-Final-32x32.png
+  homepage: https://radioscarborough.com/
+  country: GB
+  status: stream-only
+  stationuuid: 38b1773b-00f9-4add-98e7-d235ac6dd909
+  changeuuid: 4edde119-def8-49c7-bde2-648e7397a525
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-seahaven-fm-eastbourne
+  broadcaster: independent
+  name: Seahaven FM - Eastbourne
+  streamUrl: https://stream4.hippynet.co.uk:8002/stream?_=201701
+  bitrate: 170
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/892/63c550fe44a02.png
+  homepage: https://www.seahavenfm.radio/
+  country: GB
+  status: stream-only
+  stationuuid: 1717822e-1c1b-45ac-8054-286e33c47508
+  changeuuid: f5dd77f9-a87a-4860-9481-3ca8ebc2549f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-sine-fm
+  broadcaster: independent
+  name: Sine FM
+  streamUrl: https://uksoutha.streaming.broadcast.radio/sinefm?1716196689781=
+  codec: MP3
+  favicon: https://www.sinefm.com/wp-content/uploads/2019/11/sine-fm-logo-new-800.png
+  homepage: https://www.sinefm.com/
+  country: GB
+  status: stream-only
+  stationuuid: 89c3a2f7-4fe9-43b1-b078-d361dc0efd2a
+  changeuuid: e1f78ccb-b82e-449f-8a85-eccadf598653
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-skylab-radio
+  broadcaster: independent
+  name: Skylab Radio
+  streamUrl: https://uksoutha.streaming.broadcast.radio:29690/skylab-radio-limited
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/c558e3_a1b2627549444e919504fa15988a9f57~mv2.png/v1/fill/w_198,h_184,al_c,q_85,usm_0.66_1.00_0.01,enc_avif,quality_auto/c558e3_a1b2627549444e919504fa15988a9f57~mv2.png
+  homepage: https://uksoutha.streaming.broadcast.radio:29690/skylab-radio-limited
+  country: GB
+  status: stream-only
+  stationuuid: 24273571-703e-4373-b715-d7e7680d7599
+  changeuuid: 33062efc-d027-4e67-b07e-5f4d906f54ca
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-smooth-west-midlands
+  broadcaster: independent
+  name: Smooth West Midlands
+  streamUrl: https://media-ice.musicradio.com/SmoothWestMidsMP3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.smoothradio.com/westmids/assets_v4r/smooth/img/favicon32x32.png
+  homepage: https://www.smoothradio.com/westmids/
+  country: GB
+  status: stream-only
+  stationuuid: 82c9c402-34f2-42c9-8c85-2fc390f78f1c
+  changeuuid: 046f6672-1ee8-4aa7-b1bc-f183cff1206d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-source-fm
+  broadcaster: independent
+  name: Source FM
+  streamUrl: https://radio.canstream.co.uk:8144/live.mp3?1724162896961=
+  bitrate: 110
+  codec: MP3
+  favicon: https://api.broadcast.radio/api/image/d3661645-0ece-409b-b583-8d74b59c4bee.png?g=center&w=600&h=600&c=true
+  homepage: https://www.thesourcefm.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 6ab88aab-c71d-4008-81a3-ff3579f7e86e
+  changeuuid: faef1ef6-d096-415a-afa0-e01fd681f05b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-stu-allan-radio
+  broadcaster: independent
+  name: Stu Allan Radio
+  streamUrl: https://stream.stuallan.com/stream1
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.stuallan.com/
+  country: GB
+  status: stream-only
+  stationuuid: dde42b52-9dec-49ff-b49f-8dbf59085393
+  changeuuid: 68b9ff68-864a-4631-95d0-00e90dd05231
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-w-b-r-we-black-radio
+  broadcaster: independent
+  name: W.B.R. We Black Radio
+  streamUrl: https://s4.radio.co/safcfabd03/listen
+  bitrate: 192
+  codec: AAC
+  favicon: https://weblackradio.org/images/1534de6bf1609559b708e82ef57c76b2.png
+  homepage: https://weblackradio.org/
+  country: GB
+  status: stream-only
+  stationuuid: 37a34dcc-3cb0-4d58-a0ee-cb90aa1dd901
+  changeuuid: 8285840c-c1a0-453f-b6c6-a8eccf489919
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-banitamaxxradio
+  broadcaster: independent
+  name: BanitaMaxxRadio
+  streamUrl: https://ssl-1.radiohost.pl:9454/stream192
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.banitamaxx.pl/
+  country: GB
+  status: stream-only
+  stationuuid: e5ab1040-0166-4601-9463-11757da92006
+  changeuuid: 7e623f98-e2e2-498c-a714-7e4ea12a2be5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bath-sound
+  broadcaster: independent
+  name: Bath Sound
+  streamUrl: https://uksoutha.streaming.broadcast.radio/bathhr
+  codec: MP3
+  favicon: https://bathsound.radio/imgs/bs.png
+  homepage: https://bathsound.radio/
+  country: GB
+  status: stream-only
+  stationuuid: bc93004d-2fbd-4594-b82a-a45b79530d49
+  changeuuid: 23995508-6243-4fc2-8a87-998ccc61dab9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bbc-essex
+  broadcaster: independent
+  name: BBC Essex
+  streamUrl: https://as-hls-ww-live.akamaized.net/pool_23657270/live/ww/bbc_radio_essex/bbc_radio_essex.isml/bbc_radio_essex-audio%3d96000.norewind.m3u8
+  codec: UNKNOWN
+  favicon: https://sounds.files.bbci.co.uk/3.9.4/networks/bbc_radio_essex/colour_default.svg
+  homepage: https://www.bbc.co.uk/sounds/play/live/bbc_radio_essex
+  country: GB
+  status: stream-only
+  stationuuid: 2219b9dd-7385-4e3e-ab8b-2c76a2bce90e
+  changeuuid: f383d93f-d3bf-4227-a256-4d397e2aabd9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-blastfm-internet-radio-station
+  broadcaster: independent
+  name: BlastFM Internet Radio Station
+  streamUrl: https://blastfm.net:8000/live
+  bitrate: 320
+  codec: MP3
+  favicon: https://blastfmsocial.media/stations/logo/blastfm.jpg
+  homepage: https://blastfmsocial.media/BlastFMRadio
+  country: GB
+  status: stream-only
+  stationuuid: 094d7d86-e509-4f20-a4d4-ece206c1bca2
+  changeuuid: b78f797f-07c0-491f-b073-fcb6b9f611db
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-chiltern-voice-fm
+  broadcaster: independent
+  name: Chiltern Voice FM
+  streamUrl: https://radio.entertainmenttechnologies.co.uk:8020/chilternvoice.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.chilternvoice.fm/wp-content/uploads/2024/02/Chiltern-Voice-Header-Logo-340x156-1.png
+  homepage: https://www.chilternvoice.fm/
+  country: GB
+  status: stream-only
+  stationuuid: 86982463-f289-4336-af13-9bf77a151196
+  changeuuid: 9aaecfcc-785d-43f7-ba9a-40be08bf97e6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-chon-98-1
+  broadcaster: independent
+  name: CHON 98.1
+  streamUrl: https://stream.chonfm.com:8042/stream
+  bitrate: 73
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/209/5fd529540c0f8.gif
+  homepage: https://www.chonfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: f263c982-81c9-49a1-bfee-9966907600ae
+  changeuuid: 6ac7dd99-44d9-4109-aee1-9850762110d8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-country-gospel-radio
+  broadcaster: independent
+  name: Country Gospel Radio
+  streamUrl: https://solid24.streamupsolutions.com/proxy/agtzpadc/stream
+  bitrate: 128
+  codec: MP3
+  homepage: https://countrygospelradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: c82c3825-934e-44a6-bbb6-df26d1b463ab
+  changeuuid: 02d665d7-404d-4873-a376-acf96ec9ef02
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-east-point-radio
+  broadcaster: independent
+  name: East Point Radio
+  streamUrl: https://streaming.radio.co/s3c76b154e/listen
+  bitrate: 128
+  codec: MP3
+  favicon: https://cdn.onlineradiobox.com/img/l/7/64737.v7.png
+  homepage: https://eastpointradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: effe5195-2465-4f05-a985-6bb1139feae5
+  changeuuid: 0c332535-dcb5-412b-a636-dafbf42d338b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-essex-radio
+  broadcaster: independent
+  name: Essex Radio
+  streamUrl: https://stream.essex.radio:8060/radio.mp3
+  bitrate: 128
+  codec: AAC
+  favicon: https://essex.radio/logo.png
+  homepage: https://essex.radio/
+  country: GB
+  status: stream-only
+  stationuuid: ec33435b-edb1-414b-8b77-6130d8980685
+  changeuuid: 05f9af57-fadb-4d5c-8af0-7e1464b6f387
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-fcr-plymouth
+  broadcaster: independent
+  name: FCR Plymouth
+  streamUrl: https://streams.radio.co/sde86bbbbf/low
+  bitrate: 64
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/0ff480_674875e451e6439dba6219a3aad51f2b%7Emv2.png/v1/fill/w_180%2Ch_180%2Clg_1%2Cusm_0.66_1.00_0.01/0ff480_674875e451e6439dba6219a3aad51f2b%7Emv2.png
+  homepage: https://www.fcradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 5e3c552a-4be6-4092-bcd4-c8d38fcd791e
+  changeuuid: 13032fff-0186-4dcd-a1a0-39b614b15049
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-frisky-radio
+  broadcaster: independent
+  name: Frisky Radio
+  streamUrl: https://stream.frisky.friskyradio.com/
+  bitrate: 96
+  codec: MP3
+  homepage: http://friskyradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 82107bab-3030-4aca-b0e0-6ccf82d7f965
+  changeuuid: 3c3559f2-bb11-42bd-bf23-217ca00caa41
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-frome-fm
+  broadcaster: independent
+  name: Frome FM
+  streamUrl: https://icecast2.bargus.co.uk:8001/fromefm.mp3
+  bitrate: 120
+  codec: MP3
+  favicon: https://cdn.prod.website-files.com/65c3a3799d14b21f3710d0b4/66827a1d55ff35d4200e0849_FromeFMIcon-256.png
+  homepage: https://www.frome.fm/
+  country: GB
+  status: stream-only
+  stationuuid: 7af80d4e-1137-4617-9afc-cd1faa624852
+  changeuuid: 581364a4-a352-40ae-8c8c-cb5bcb0045e4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-green-radio
+  broadcaster: independent
+  name: Green Radio
+  streamUrl: https://gains.reviveradio.net/proxy/greenradio?mp=/stream
+  bitrate: 256
+  codec: MP3
+  homepage: https://greenradiolive.com/
+  country: GB
+  status: stream-only
+  stationuuid: 090a5ec5-11a5-4b36-8a87-edb2bd4f55e7
+  changeuuid: 19be10f2-167a-4e05-9f4c-c65b3949349b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-halesowen-town
+  broadcaster: independent
+  name: Halesowen Town
+  streamUrl: https://s3.radio.co/s75a8968ca/listen
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radiohalesowentown.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 0ec08342-14de-456f-b702-4708973fbb82
+  changeuuid: 4c74c462-d44a-4bef-b400-b61c8b83174c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hereford-fc
+  broadcaster: independent
+  name: Hereford FC
+  streamUrl: https://stream.radio.co/s025ead1b9/listen
+  bitrate: 96
+  codec: MP3
+  favicon: https://www.herefordfc.co.uk/wp-content/uploads/2015/05/RADIO-HEREFORD-FC.png
+  homepage: https://www.herefordfc.co.uk/radio-hereford-fc/
+  country: GB
+  status: stream-only
+  stationuuid: f74496eb-561a-496b-aa23-e83340a290c8
+  changeuuid: a74a0925-fb18-4cce-9d4c-0ded0277ec48
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hits-radio-uk
+  broadcaster: independent
+  name: Hits Radio UK
+  streamUrl: https://stream-al.hellorayo.co.uk/key.aac?aw_0_1st.skey=1602676850&direct=true&rp_source=1
+  bitrate: 47
+  codec: AAC+
+  homepage: https://www.hellorayo.co.uk/hits-radio
+  country: GB
+  status: stream-only
+  stationuuid: 0f8f58d2-07e3-4ddb-af14-918a3e90369a
+  changeuuid: cc8eae61-b0e2-4ef9-8a38-f70be2b0df4c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-jorvik-radio
+  broadcaster: independent
+  name: Jorvik Radio
+  streamUrl: https://uksoutha.streaming.broadcast.radio:24780/jorvikradio?_=21939
+  bitrate: 320
+  codec: AAC
+  favicon: https://mmo.aiircdn.com/533/661fa1000a560.png
+  homepage: https://www.jorvikradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: e6b8ff04-31c5-4062-a466-fd67a8630345
+  changeuuid: 1e24029d-1b3d-47eb-8995-d7144c83e3cf
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-keep-the-faith-internet-radio
+  broadcaster: independent
+  name: Keep The Faith Internet Radio
+  streamUrl: https://mars.streamerr.co/8060/stream
+  bitrate: 320
+  codec: MP3
+  homepage: https://keepthefaithinternetradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: c7633ceb-f221-4750-a020-83f8116ac631
+  changeuuid: bb7d9ad4-0044-4050-9120-b7f8e08219c1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-line-out-radio
+  broadcaster: independent
+  name: Line Out Radio
+  streamUrl: https://play.radioking.io/line-out-radio
+  bitrate: 128
+  codec: MP3
+  favicon: http://lineoutradio.com/wp-content/uploads/2021/06/LINEOUTLOGO-e1623077715840.png
+  homepage: http://lineoutradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 2278ce5d-e587-409a-8fd9-a64b8b67d78b
+  changeuuid: ad49140b-cc22-4e34-b5ed-3a165890a172
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-london-house-radio-ldn-house-radio
+  broadcaster: independent
+  name: London House Radio (LDN House Radio)
+  streamUrl: https://stream.ldnhouseradio.net/listen/live/radio.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://ldnhouseradio.net/wp-content/uploads/2024/06/cropped-logo-round-500-favicon-1-180x180.png
+  homepage: https://ldnhouseradio.net/
+  country: GB
+  status: stream-only
+  stationuuid: 732b0e4d-575e-4bd0-9fc8-a4e9eefa5087
+  changeuuid: 144e1c22-25ef-4e87-abc3-da20ee0bc2b9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-luna-radio-reborn-mp3
+  broadcaster: independent
+  name: Luna Radio Reborn (mp3)
+  streamUrl: https://luna.ponyvillefm.com/listen/lunaradio/radio.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: http://luna.ponyvillefm.com/api/station/lunaradio/art/f3b23e8f636f5abd2dafbafb
+  homepage: https://luna.ponyvillefm.com/public/lunaradio
+  country: GB
+  status: stream-only
+  stationuuid: 29476414-c26c-4e2e-92a9-82fe10d6e64b
+  changeuuid: 9ed05375-68ba-4f53-b8be-4a73590f6c93
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-m4d-radio-mix
+  broadcaster: independent
+  name: M4D Radio Mix
+  streamUrl: https://s2.radio.co/s07cd038f1/listen
+  bitrate: 192
+  codec: MP3
+  favicon: https://m4dradio.com/wp-content/uploads/2020/05/cropped-m4dradiologo.png
+  homepage: https://m4dradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 65d9541a-ce23-4c29-a8ba-b03fcc36b390
+  changeuuid: 91c450e7-ca06-4c64-a4db-30d6f3a8bfb1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-meridian-fm-107
+  broadcaster: independent
+  name: Meridian FM 107
+  streamUrl: https://uksoutha.streaming.broadcast.radio/meridianfm
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.meridianfm.com/favicon.ico?i=423
+  homepage: https://www.meridianfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: 5710512c-33f0-4f8d-900d-8a435291fd17
+  changeuuid: deba5f0e-fcc8-496d-a1d2-b966d5dee97f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-morley-radio
+  broadcaster: independent
+  name: Morley Radio
+  streamUrl: https://s2.radio.co/sb0e9a4581/low
+  bitrate: 64
+  codec: AAC
+  homepage: https://morleyradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 625c8b79-6fc0-40c3-a3a1-d5e4440923fc
+  changeuuid: 906574b0-a4b1-42be-892b-421e15bd7642
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-oc-radio
+  broadcaster: independent
+  name: OC Radio
+  streamUrl: https://stream.digilinkconnect.co.uk:2020/stream/oldhamcollegeradio
+  bitrate: 192
+  codec: AAC
+  homepage: https://www.oldham.ac.uk/college-life/oc-radio/
+  country: GB
+  status: stream-only
+  stationuuid: a3c00e6b-90f5-4451-a50e-34938c9a9ba8
+  changeuuid: bd90faf6-02ec-437f-a743-2b50b04e795e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-osn-fm
+  broadcaster: independent
+  name: OSN.fm
+  streamUrl: https://stream.stuallan.com/stream2
+  bitrate: 128
+  codec: MP3
+  favicon: http://osn.fm/img/OSN-Radio-PNG.png
+  homepage: https://osn.fm/
+  country: GB
+  status: stream-only
+  stationuuid: abb88853-2058-4abf-879a-9f1a75fb077b
+  changeuuid: 9d5c74df-495b-45c0-9d72-d43f3f841304
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-panacea-radio
+  broadcaster: independent
+  name: Panacea Radio
+  streamUrl: https://stream-15.aiir.com/kqwcuxfxcwhtv?zt=eyJhbGciOiJIUzI1NiJ9.eyJzdHJlYW0iOiJrcXdjdXhmeGN3aHR2IiwiaG9zdCI6InN0cmVhbS0xNS5haWlyLmNvbSIsInJ0dGwiOjUsImp0aSI6IjVkMTNteVlIU0FXNE5STXpWNEdZeFEiLCJpYXQiOjE3Njg2MDczMzksImV4cCI6MTc2ODYwNzM5OX0.IvvTX4vVuMyuvTvxJQTRNTahLXGSgOeVK3c4JGax0ds
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/515/64c0e1942de5b.jpg
+  homepage: https://www.panacearadio.net/
+  country: GB
+  status: stream-only
+  stationuuid: 467645a7-06bc-4762-9b2a-128cc9bfb081
+  changeuuid: 207a3f81-8348-486b-819c-c6404df01696
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-persian-vibe-radio
+  broadcaster: independent
+  name: Persian Vibe Radio
+  streamUrl: https://radio.aydayazdani.com/stream
+  bitrate: 192
+  codec: MP3
+  favicon: https://radio.aydayazdani.com/assets/img/pvr-logo.png
+  homepage: https://radio.aydayazdani.com/
+  country: GB
+  status: stream-only
+  stationuuid: e55150cf-f6bd-44ea-9f66-0a00dc88c8f0
+  changeuuid: edef9c50-d859-4c30-80e4-d1319ee0c6f3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-phasefm
+  broadcaster: independent
+  name: PhaseFM
+  streamUrl: https://azuracast.clubhits.uk/listen/phasefm/radio.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://phasefm.co.uk/wp-content/uploads/2025/07/clubhitsuk-variety-mix-mytuner-logo.png
+  homepage: https://phasefm.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: bf450fc3-a276-432c-95c5-98e295cc79a9
+  changeuuid: 03cd7bbe-0ecc-4c5b-ae70-4b194c699c78
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-prince-bishops-hospital-radio
+  broadcaster: independent
+  name: Prince Bishops Hospital Radio
+  streamUrl: https://pbhr.radioca.st/stream
+  bitrate: 48
+  codec: AAC
+  favicon: https://www.pbhr.org.uk/wp-content/uploads/2017/01/logo-mic.png
+  homepage: https://www.pbhr.org.uk/#
+  country: GB
+  status: stream-only
+  stationuuid: 6b563d41-f29d-4639-9731-63fd3811b291
+  changeuuid: 62f46dfb-e596-4c61-9b7d-6d2450d5b4eb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-bronglais
+  broadcaster: independent
+  name: Radio Bronglais
+  streamUrl: https://stream.radiobronglais.cymru/stream?ver=92941
+  bitrate: 128
+  codec: MP3
+  homepage: https://radiobronglais.cymru/
+  country: GB
+  status: stream-only
+  stationuuid: c8855dde-af56-4d94-9940-0c43ef867054
+  changeuuid: 99b8ff2d-97ab-434f-ab8f-14d717c73a49
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-hartlepool
+  broadcaster: independent
+  name: Radio Hartlepool
+  streamUrl: https://server.radiohartlepool.co.uk:8443/hartlepool-mp3
+  bitrate: 64
+  codec: MP3
+  favicon: https://radiohartlepool.co.uk/wp-content/uploads/2023/01/cropped-RHlogo.jpg
+  homepage: https://radiohartlepool.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: ec89e9a0-0d5e-48f6-b735-8d256c400dc6
+  changeuuid: c5a8a888-985e-4092-a396-efc64eb73c53
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-wigwam
+  broadcaster: independent
+  name: Radio Wigwam
+  streamUrl: https://streaming.broadcast.radio/radio-wigwam
+  codec: MP3
+  favicon: https://radiowigwam.co.uk/wp-content/uploads/2024/08/wiwamnewdark.jpg.webp
+  homepage: https://radiowigwam.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: b876aaf5-bd27-4576-927c-802acd73b4ae
+  changeuuid: 99206212-07e7-4962-889b-a64619d6e675
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-wimborne
+  broadcaster: independent
+  name: Radio Wimborne
+  streamUrl: https://radio.canstream.co.uk:8057/live.mp3
+  bitrate: 320
+  codec: MP3
+  homepage: https://www.radiowimborne.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: acf8c0e5-ca3c-4b95-a4f2-ce5b49d5a0d9
+  changeuuid: f6adf3fc-b2c6-49cd-a93f-792fc5798976
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-woking
+  broadcaster: independent
+  name: Radio Woking
+  streamUrl: https://radiowoking.radioca.st/stream?rp_source=1&=&&___cb=821829812672569
+  bitrate: 192
+  codec: MP3
+  favicon: http://www.radiowoking.co.uk/wp-content/uploads/2014/05/radiowokingwebhead7new75x360.gif
+  homepage: https://www.radiowoking.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 51d08647-970d-4b50-851a-36a7db5e7ddd
+  changeuuid: 2f1138c0-97f4-49a8-aad6-0ac9a2a785b8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radiorosak
+  broadcaster: independent
+  name: RADIOROSAK
+  streamUrl: https://stream.rcast.net/68127
+  bitrate: 48
+  codec: AAC+
+  homepage: http://radiorosak.com/
+  country: GB
+  status: stream-only
+  stationuuid: 11464b95-3766-44c6-bfdc-4d75ae8e9a5c
+  changeuuid: a55b1c8e-6cd9-4caf-ae14-241503e8e5da
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-ramsgate-radio
+  broadcaster: independent
+  name: Ramsgate Radio
+  streamUrl: https://play.radioking.io/ramsgate-radio1/610934
+  bitrate: 192
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/d883a7_649474a2c070450396a7c3d08a5ce624%7Emv2.png/v1/fill/w_180%2Ch_180%2Clg_1%2Cusm_0.66_1.00_0.01/d883a7_649474a2c070450396a7c3d08a5ce624%7Emv2.png
+  homepage: https://www.ramsgateradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 77076065-4635-4dff-b388-eebe413436b7
+  changeuuid: c7c5f1e4-a540-43cd-984e-e6c571795bda
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-shine-radio
+  broadcaster: independent
+  name: Shine Radio
+  streamUrl: https://listen-petersfield.sharp-stream.com/petersfield.aac
+  bitrate: 96
+  codec: AAC+
+  favicon: https://shineradio.uk/wp-content/uploads/2020/08/shine_logo_primary_d_rgb_01_crop.jpg
+  homepage: https://shineradio.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 351f1709-0c4f-4058-baf1-b63114f75a4d
+  changeuuid: 2ad282e4-dbc7-4560-8864-9462135d0cab
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-smooth-grooving-radio
+  broadcaster: independent
+  name: Smooth Grooving Radio
+  streamUrl: https://sgr.lucasmultimedia.com/stream.ogg
+  bitrate: 128
+  codec: MP3
+  favicon: http://smoothgrooving.com/favicon-1.ico
+  homepage: http://smoothgrooving.com/
+  country: GB
+  status: stream-only
+  stationuuid: 2180fcff-befa-4ab1-bd30-93176bf16355
+  changeuuid: 6b56c14e-fd13-45fe-8268-7f41707b0f49
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-somervalley-fm
+  broadcaster: independent
+  name: Somervalley fm
+  streamUrl: https://stream4.hippynet.co.uk:8014/stream
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.somervalleyfm.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 72ce8ddd-2376-403e-ad7b-1ec618b1a2d1
+  changeuuid: c1135e0c-a130-4a3a-9234-0b0544d5a79a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-southern-roots-radio
+  broadcaster: independent
+  name: Southern Roots Radio
+  streamUrl: https://uksoutha.streaming.broadcast.radio/southern-roots-radio.mp3
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/4a71bd_d0a57c5ed62c4a8fbaee7ce942611b60~mv2.png/v1/fill/w_242,h_242,al_c,q_85,usm_0.66_1.00_0.01,enc_avif,quality_auto/1000022871-Photoroom.png
+  homepage: https://www.southern-roots.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: a5609ff9-523f-4a65-970d-98a0ec729b5e
+  changeuuid: 00bddb73-1570-4a03-8024-5b38f947586e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-spotlight-radio
+  broadcaster: independent
+  name: Spotlight Radio
+  streamUrl: https://stream1.hippynet.co.uk:8075/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://l5.tm-web-01.co.uk/img/fav/favicon-1024-167.png
+  homepage: https://www.spotlightradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 8031b69b-b4e3-402f-bcec-8ee985f29299
+  changeuuid: 14b6efb4-f93c-442d-a81e-25a41ffa87c6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-subcity-radio
+  broadcaster: independent
+  name: Subcity Radio
+  streamUrl: https://stream.subcity.org/listen
+  bitrate: 320
+  codec: MP3
+  favicon: https://f4.bcbits.com/img/a1309017338_10.jpg
+  homepage: https://www.subcity.org/
+  country: GB
+  status: stream-only
+  stationuuid: 2a5af2b2-dc8a-4d1a-91b9-a491022b5f59
+  changeuuid: d8a36509-1417-45a2-8bdb-2166abf752c4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-teenbuzz-radio
+  broadcaster: independent
+  name: Teenbuzz Radio
+  streamUrl: https://streaming.broadcast.radio/teenbuzzradio?1744351024052=
+  codec: MP3
+  favicon: https://teenbuzzradio.com/wp-content/uploads/2020/06/logo.png
+  homepage: https://teenbuzzradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 1d7eb550-4f76-4ad5-a7bc-95b69ef33ce3
+  changeuuid: b4221e7e-e23f-441a-b2f1-b247b2d72110
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-the-gates-radio-station
+  broadcaster: independent
+  name: The Gates Radio Station
+  streamUrl: https://thegatesradio.co.uk/listen/the_gates_radio_station/radio.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.thegates.bolton.sch.uk/images/favicon_2.ico
+  homepage: https://www.thegates.bolton.sch.uk/page/the-gates-radio/135355
+  country: GB
+  status: stream-only
+  stationuuid: b6c8bda6-6827-4564-8544-5d995d44a837
+  changeuuid: 091d219c-fd96-41fb-a467-0bb8264fb792
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-the-void-underground-music-radio
+  broadcaster: independent
+  name: The Void – Underground Music Radio
+  streamUrl: https://thevoidrad.io/stream320
+  bitrate: 128
+  codec: AAC
+  favicon: https://thevoidrad.io/favicon.ico
+  homepage: https://thevoidrad.io/
+  country: GB
+  status: stream-only
+  stationuuid: 690e7bc2-b96c-400c-951d-d1226a9e7103
+  changeuuid: eb78bff6-8fcd-42b2-a164-9d4495820bed
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-ugnjamz
+  broadcaster: independent
+  name: ugnjamz
+  streamUrl: https://streaming.live365.com/a27539
+  bitrate: 128
+  codec: MP3
+  favicon: https://ugnjamz.com/wp-content/uploads/2020/06/UGN-LOGO.png
+  homepage: https://ugnjamz.com/
+  country: GB
+  status: stream-only
+  stationuuid: 5029176e-8a24-4c75-bdff-37030400251e
+  changeuuid: d1f7ac9e-ae82-4996-ae54-50b7ea512994
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-venture-radio
+  broadcaster: independent
+  name: Venture Radio
+  streamUrl: https://streamz.anytek.co.uk/proxy/tracla00
+  bitrate: 128
+  codec: MP3
+  favicon: https://is1-ssl.mzstatic.com/image/thumb/Music211/v4/03/b0/e2/03b0e211-be78-5e79-815b-dc2961e40f40/13UABIM53820.rgb.jpg/600x600bb.jpg
+  homepage: https://www.ventureradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: fc52f984-2e93-40e0-ace2-2de4a6c851a5
+  changeuuid: c1ee3800-2626-4d9d-9c9b-73ffbb071fff
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-6-towns-radio
+  broadcaster: independent
+  name: "6 Towns Radio"
+  streamUrl: https://stream-14.aiir.com/z7drhoivbpbuv?zt=eyJhbGciOiJIUzI1NiJ9.eyJzdHJlYW0iOiJ6N2RyaG9pdmJwYnV2IiwiaG9zdCI6InN0cmVhbS0xNC5haWlyLmNvbSIsInJ0dGwiOjUsImp0aSI6IjhROHpmZWlKVE1hWi1pdnUxdGRtVXciLCJpYXQiOjE3NjkwMzIxOTcsImV4cCI6MTc2OTAzMjI1N30.Lw7Duueb_YYvm7nI82EU1lRAlrd9NHH1ahB4WANmiaU
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/1209/656101b604916.png
+  homepage: https://www.6towns.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: fc8ba7fc-045b-4d48-abbd-e0ca8af95ae9
+  changeuuid: 5b8e15bd-55a7-49b6-9cad-5cd0cf0bf2f6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bbc-radio-berkshire
+  broadcaster: independent
+  name: BBC Radio Berkshire
+  streamUrl: https://as-hls-ww-live.akamaized.net/pool_64162474/live/ww/bbc_radio_berkshire/bbc_radio_berkshire.isml/dash/bbc_radio_berkshire-audio%3d96000.norewind.m3u8
+  codec: UNKNOWN
+  favicon: https://sounds.files.bbci.co.uk/3.9.4/networks/bbc_radio_berkshire/colour_default.svg
+  homepage: https://www.bbc.co.uk/sounds/play/live/bbc_radio_berkshire
+  country: GB
+  status: stream-only
+  stationuuid: a7ef6a83-6f6a-4d43-9862-f7fc6da34868
+  changeuuid: 12c38b98-0c9f-4192-96a3-dc8a02b26da9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bbc-radio-bristol
+  broadcaster: independent
+  name: BBC Radio Bristol
+  streamUrl: https://as-hls-ww-live.akamaized.net/pool_41858929/live/ww/bbc_radio_bristol/bbc_radio_bristol.isml/dash/bbc_radio_bristol-audio%3d96000.norewind.m3u8
+  codec: UNKNOWN
+  favicon: https://sounds.files.bbci.co.uk/3.9.4/networks/bbc_radio_bristol/colour_default.svg
+  homepage: https://www.bbc.co.uk/sounds/play/live/bbc_radio_bristol
+  country: GB
+  status: stream-only
+  stationuuid: 6fcd453e-eea0-4c84-abb5-4f7a2f5967a1
+  changeuuid: 865ac1d6-8717-416c-b7a1-8378948cf61b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bbc-radio-hereford-and-worcester
+  broadcaster: independent
+  name: BBC Radio Hereford and Worcester
+  streamUrl: https://as-hls-ww-live.akamaized.net/pool_80112859/live/ww/bbc_radio_hereford_worcester/bbc_radio_hereford_worcester.isml/bbc_radio_hereford_worcester-audio%3d96000.norewind.m3u8
+  codec: UNKNOWN
+  favicon: https://sounds.files.bbci.co.uk/3.9.4/networks/bbc_radio_hereford_worcester/colour_default.svg
+  homepage: https://www.bbc.co.uk/sounds/play/live/bbc_radio_hereford_worcester
+  country: GB
+  status: stream-only
+  stationuuid: 5e27d6db-bb84-44d4-a5de-9f79a35cb3fd
+  changeuuid: a8e13aee-63ec-43f6-8b61-4a5b58aaf454
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bombshell-radio
+  broadcaster: independent
+  name: Bombshell Radio
+  streamUrl: https://s8.ssl-stream.com:1175/stream
+  bitrate: 192
+  codec: MP3
+  favicon: https://bombshellradio.com/wp-content/uploads/2025/03/originalFile-bombshell-radio-1-2-370x370.jpg
+  homepage: https://bombshellradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 0ec6e73e-3e92-4b30-bad9-5368855a19f4
+  changeuuid: d7f3d488-415d-4889-bf42-2cb9e0420afb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-broadland-radio
+  broadcaster: independent
+  name: Broadland Radio
+  streamUrl: https://arqiva-broadlandradio-live-a.edge.audiocdn.com/10002_128mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://static.mytuner.mobi/media/tvos_radios/401/broadland.8c715f56.png
+  homepage: https://broadlandradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 6db3261f-5e04-4ba8-b373-8bf4371a52f8
+  changeuuid: 6c2c6d15-05fa-49bb-8bbb-33ee86ffdafc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bucks-radio
+  broadcaster: independent
+  name: Bucks Radio
+  streamUrl: https://n01.radiojar.com/f6mru9artg0uv?_=745309&rj-tok=AAABihJa1SMABODPIDh9C1t79A&rj-ttl=5
+  codec: MP3
+  homepage: https://www.bucks.radio/
+  country: GB
+  status: stream-only
+  stationuuid: e7a31f94-a0f0-4579-b05c-1788b4412b6f
+  changeuuid: 86c49a68-d909-481e-9b10-5ad1c7a23eb0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-burton-radio
+  broadcaster: independent
+  name: Burton Radio
+  streamUrl: https://s9.citrus3.com:8370/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://images.squarespace-cdn.com/content/v1/6589f8f0f6168a1963a4d06a/19ba74fd-da8c-4021-a0a5-f6f52489492c/BR-512.png?format=1500w
+  homepage: https://www.burtonradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: ee6bf032-02b8-4e47-a9bb-5eea57e102ce
+  changeuuid: 86d72a1e-eab1-48b4-b65f-51ff353cde17
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-cheesy-fm
+  broadcaster: independent
+  name: Cheesy FM
+  streamUrl: https://n27a-eu.rcs.revma.com/8ebhfmak44uvv?rj-ttl=5&rj-tok=AAABnbAucYoA8uoxbTFltYIAvg
+  codec: AAC
+  favicon: https://mmo.aiircdn.com/520/61a8cce0e4cbb.jpg
+  homepage: https://www.cheesyfm.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 967986ba-926e-4e9f-87d5-d59bc8a2b2ce
+  changeuuid: fe917c28-5ae1-47df-afd6-a2dbe0dd434d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-dales-radio
+  broadcaster: independent
+  name: Dales Radio
+  streamUrl: https://stream3.themediasite.co.uk:8364/stream?_=690543
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.dalesradio.co/
+  country: GB
+  status: stream-only
+  stationuuid: fbc03689-d06e-4e98-8e9e-cda2e5b16f6d
+  changeuuid: 20ffe501-3f4c-4cb9-bcef-dbaddf1b925e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-drums-radio
+  broadcaster: independent
+  name: Drums Radio
+  streamUrl: https://streams.radio.co/sa75718856/listen
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.drumsradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 2e6c9977-2894-48d2-96ba-433f297d458f
+  changeuuid: ec6b94b1-1775-4ec9-9c23-c88e7da4c9b0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-forest-one
+  broadcaster: independent
+  name: Forest One
+  streamUrl: https://c2.prostream365.com:8010/live
+  bitrate: 128
+  codec: AAC
+  favicon: https://static.mytuner.mobi/media/tvos_radios/469/forest-one.fee679cd.png
+  homepage: https://www.forestradiouk.com/forestone
+  country: GB
+  status: stream-only
+  stationuuid: 5dff8400-38f8-4500-bac7-f65fa9b364d2
+  changeuuid: c084e011-0ea9-4203-a898-3a5a654478b0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-frisky-radio-classics
+  broadcaster: independent
+  name: Frisky Radio Classics
+  streamUrl: https://stream.classics.friskyradio.com/
+  bitrate: 96
+  codec: MP3
+  homepage: http://friskyradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: c30c3ab0-3729-4e82-8f15-d60ad4b22015
+  changeuuid: 796bec5c-3266-4aec-bd01-80eb76d04063
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-genesis-radio-birmingham
+  broadcaster: independent
+  name: Genesis Radio Birmingham
+  streamUrl: https://cast5.my-control-panel.com/proxy/grb/stream
+  bitrate: 128
+  codec: MP3
+  homepage: https://genesisradiobirmingham.com/
+  country: GB
+  status: stream-only
+  stationuuid: 69b2e14a-da22-41f8-bc09-1d31e79c3bd5
+  changeuuid: 29899099-408b-4a2f-84b6-26cad1c6f9a9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-goodnight-sweetheart-radio
+  broadcaster: independent
+  name: Goodnight Sweetheart Radio
+  streamUrl: https://a3.asurahosting.com/listen/goodnight_sweetheart_radio/radio.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: https://a3.my-control-panel.com/station/648
+  country: GB
+  status: stream-only
+  stationuuid: ee787566-73fd-4e5a-95d0-6f41cab6560e
+  changeuuid: 60adee7d-ae8e-4178-b40e-360592aceb02
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-groove-genie-radio
+  broadcaster: independent
+  name: Groove Genie Radio
+  streamUrl: https://groove-genie.co.uk/listen/groove_genie_radio/radio.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://i0.wp.com/groovegenieradio.com/wp-content/uploads/2023/05/Groove-Genie-Radio-Logo-512x512-1.png?resize=370%2C370&ssl=1
+  homepage: https://groovegenieradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 3bd72187-1567-4125-a80c-e206ce33fc62
+  changeuuid: dfa296e6-575c-4afb-a036-3fab6f334721
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-high-peak-1
+  broadcaster: independent
+  name: High Peak 1
+  streamUrl: https://stream3.themediasite.co.uk:8260/stream
+  bitrate: 192
+  codec: MP3
+  favicon: https://highpeak1.co.uk/wp-content/uploads/2024/03/LogoJpg-370x370.jpg
+  homepage: https://highpeak1.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 62de15bc-c199-46fc-8c9b-9b3e20be9f73
+  changeuuid: 0c0f260c-1534-4575-b323-0ec38351e8bf
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hits-radio-london
+  broadcaster: independent
+  name: Hits Radio London
+  streamUrl: https://stream-mz.hellorayo.co.uk/net1london.aac?aw_0_1st.skey=1602676850&direct=true&rp_source=1
+  bitrate: 47
+  codec: AAC+
+  favicon: https://media.bauerradio.com/image/upload/c_crop,g_custom/v1713275588/brand_manager/stations/nbcsqhgitwccojxtwfxn.svg
+  homepage: https://www.hellorayo.co.uk/hits-radio/london
+  country: GB
+  status: stream-only
+  stationuuid: ab6eb0b5-2b70-4412-b226-478945fb5edc
+  changeuuid: b5900e1e-eec7-48b1-9782-adbbe3473ee8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-inside-the-gates-radio
+  broadcaster: independent
+  name: Inside The Gates Radio
+  streamUrl: https://s2.radio.co/s98e7a2900/listen
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.insidethegatesradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 192df41d-f2bd-49ee-b68a-a8485c791992
+  changeuuid: 99d17217-5cfd-4ed8-929d-220f1e7189c8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-itisnow-radio
+  broadcaster: independent
+  name: itisnow Radio
+  streamUrl: https://stream.radio.co/sc41e33712/listen
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.itisnowradio.com/uploads/1/4/5/0/145020825/logo-web.jpg
+  homepage: https://www.itisnowradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 48a01798-4b20-41c5-b2c6-312e74cf6d79
+  changeuuid: c7b5adeb-cbb7-41fa-8c64-6bb0631f772a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-kic-radio
+  broadcaster: independent
+  name: KIC Radio
+  streamUrl: https://stream.aiir.com/nbgvn4hgyrxuv
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/1333/692847fae5e8f.jpg
+  homepage: https://www.kicradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: bea75dee-0290-4e7d-aaa7-138ea7d5d75c
+  changeuuid: b91cbf12-99ba-4877-b1bc-d7519efc6b37
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-laser-gold
+  broadcaster: independent
+  name: Laser Gold
+  streamUrl: https://stream1.hippynet.co.uk:8067/stream
+  bitrate: 128
+  codec: AAC
+  favicon: https://primary.jwwb.nl/public/t/a/i/temp-dozjcpvcaeqpdalqxwlr/205-high.jpg?enable-io=true&crop=1%3A1&width=816
+  homepage: https://www.laserinternational.co.uk/laser-gold
+  country: GB
+  status: stream-only
+  stationuuid: fc39e429-4066-40ae-a799-2e0ab159a69a
+  changeuuid: 37c55fac-de1f-46f4-9c2d-fb142d7977dc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-mix-fm-glasgow
+  broadcaster: independent
+  name: Mix FM - Glasgow
+  streamUrl: https://radio.mixfmonline.com:8443/listen/mix_fm/radio.aac
+  bitrate: 64
+  codec: AAC
+  favicon: https://www.mixfm.pro/wp-content/uploads/2024/06/NEW-LOGO-768x186.png
+  homepage: https://www.mixfmglasgow.com/
+  country: GB
+  status: stream-only
+  stationuuid: ef40f745-b4a2-4df1-a78d-3fe907430882
+  changeuuid: d2fe08eb-85fe-48da-a4bd-500358260e90
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-mondo-radio
+  broadcaster: independent
+  name: Mondo Radio
+  streamUrl: https://streamer.radio.co/s1afcca186/listen
+  bitrate: 96
+  codec: MP3
+  favicon: https://images.squarespace-cdn.com/content/v1/648cf7010ac2fb3561bc2154/5b5a7df2-8c59-49fa-9b71-dca00edfe7ff/favicon.ico?format=100w
+  homepage: https://www.mondo.radio/
+  country: GB
+  status: stream-only
+  stationuuid: 7c093cab-e41d-4981-84ae-5647b9aa5c06
+  changeuuid: 0694914e-7e0d-4c99-a832-b3658b657007
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-motorsport-radio
+  broadcaster: independent
+  name: Motorsport Radio
+  streamUrl: https://streaming.radio.co/sd88832e85/listen
+  bitrate: 128
+  codec: MP3
+  favicon: https://motorsport.radio/wp-content/uploads/2020/05/iTunes-Cover-512px.png
+  homepage: https://motorsport.radio/nowplaying/
+  country: GB
+  status: stream-only
+  stationuuid: cb6da657-0784-4106-a2bc-4842728198bc
+  changeuuid: 74bc4f13-5829-41bb-b6e2-60d03cbfb2c8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-nufc-talk-radio
+  broadcaster: independent
+  name: NUFC Talk Radio
+  streamUrl: https://s4.radio.co/s35505f6df/listen
+  bitrate: 96
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/a2c77b_e4f745f8472e4e36aed9b628816b6e6e~mv2.jpg/v1/fill/w_2500,h_2500,al_c/a2c77b_e4f745f8472e4e36aed9b628816b6e6e~mv2.jpg
+  homepage: https://www.nufctalkradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 88855c97-001d-45fd-b04f-e74a81f61c2a
+  changeuuid: 69f41461-2c70-4bc3-b848-fb370fa044e9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-orryy-live
+  broadcaster: independent
+  name: Orryy Live
+  streamUrl: https://radio.orryy.com/live
+  codec: MP3
+  favicon: https://orryy.com/assets/logo.png
+  homepage: https://orryy.com/live
+  country: GB
+  status: stream-only
+  stationuuid: fed9199c-92ab-44ec-ba15-4ebc77dc9caa
+  changeuuid: 5da07a8e-fbd4-4b8e-b698-45ccc7ccfa1b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-osn-radio-plus
+  broadcaster: independent
+  name: OSN Radio Plus
+  streamUrl: https://stream.stuallan.com/stream3
+  bitrate: 128
+  codec: MP3
+  homepage: https://osn.fm/
+  country: GB
+  status: stream-only
+  stationuuid: bfd46092-629c-475c-830b-ab7b307e816b
+  changeuuid: cd28896a-6e02-4679-962d-1d643f405b85
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-past-perfect-radio
+  broadcaster: independent
+  name: Past Perfect Radio
+  streamUrl: https://s2.xrad.io:9646/;stream/1
+  bitrate: 48
+  codec: AAC+
+  favicon: https://www.pastperfect.com/wp-content/uploads/2023/07/Past-Perfect-Radio-e1688392518104-768x473.png
+  homepage: https://www.pastperfect.com/
+  country: GB
+  status: stream-only
+  stationuuid: f4abf99b-3e7c-4e66-bdfd-f9cf9742ed17
+  changeuuid: 110764d2-cbd1-466b-82c4-51cfba930064
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-premier-gospel
+  broadcaster: independent
+  name: Premier Gospel
+  streamUrl: https://pcr.streamguys1.com/pgospel-96k.aac
+  bitrate: 56
+  codec: AAC
+  homepage: https://www.premier.plus/stations/premier-gospel
+  country: GB
+  status: stream-only
+  stationuuid: 9c39b69f-32df-40c3-8738-07035ca546d2
+  changeuuid: b7522c1a-af40-46d7-b7f0-72c4ec5b2471
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-premier-praise
+  broadcaster: independent
+  name: Premier Praise
+  streamUrl: https://pcr.streamguys1.com/ppeace-96k.aac
+  bitrate: 56
+  codec: AAC
+  homepage: https://www.premier.plus/stations/premier-peace
+  country: GB
+  status: stream-only
+  stationuuid: 140295df-e043-42e0-a80d-ebe848713063
+  changeuuid: c3a41296-7996-42a8-a5ee-0dc6e1cb1891
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-quality-radio
+  broadcaster: independent
+  name: Quality Radio
+  streamUrl: https://uksoutha.streaming.broadcast.radio/quality_FM
+  codec: MP3
+  favicon: https://qualityradio.uk/wp-content/uploads/2022/08/qar-logo-e1661895864614.png
+  homepage: https://qualityradio.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 1c257712-e943-4792-8b56-0ed44a4db316
+  changeuuid: 548426d6-3173-4951-9898-bfa6e12f0184
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-hillingdon
+  broadcaster: independent
+  name: Radio Hillingdon
+  streamUrl: https://streaming.broadcast.radio/hrhillingdonaac?1699805800701=
+  bitrate: 128
+  codec: AAC
+  favicon: https://www.radiohillingdon.com/images/Listen%20Live%20Button%202023.png
+  homepage: https://www.radiohillingdon.com/
+  country: GB
+  status: stream-only
+  stationuuid: 1a751f04-4eeb-412a-a6c6-a1ab58decbe6
+  changeuuid: 0065ecfc-cf84-4a8a-bc7f-eb796ef876a4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-lear
+  broadcaster: independent
+  name: Radio LEAR
+  streamUrl: https://icecast.maxxwave.co.uk/lear
+  bitrate: 80
+  codec: AAC
+  favicon: https://img-284.media.info/i/bg/7/7941-1759585321.webp
+  homepage: https://radiolear.uk/
+  country: GB
+  status: stream-only
+  stationuuid: a3ee6eff-a7cf-4250-948d-99935c2457d7
+  changeuuid: 2db771a2-6133-4561-a862-224476fa1283
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-wester-ross
+  broadcaster: independent
+  name: Radio Wester Ross
+  streamUrl: https://stream.rcs.revma.com/96z3d1qs5bcwv
+  codec: MP3
+  favicon: https://www.radiowesterross.scot/application/files/3917/0852/2702/favicon.ico
+  homepage: https://www.radiowesterross.scot/
+  country: GB
+  status: stream-only
+  stationuuid: d61ddebb-dd6f-40d8-8ce8-bcb6642397c2
+  changeuuid: 0772bae4-7c10-4599-b89d-c38949c9a612
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-xtra
+  broadcaster: independent
+  name: Radio Xtra
+  streamUrl: https://n18a-eu.rcs.revma.com/nye22yatz42vv?rj-ttl=5&rj-tok=AAABm86No4cAj3cUwHekQ5GQLQ
+  codec: MP3
+  favicon: https://radioxtra.co.uk/wp-content/uploads/2023/07/Radio-XTRA-2.svg
+  homepage: https://radioxtra.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 9554c047-5c51-4ce5-a6bb-eb65d61bb228
+  changeuuid: 3dfcb425-30bd-467f-8598-2160b3ec358d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radiowave
+  broadcaster: independent
+  name: RadioWave
+  streamUrl: https://1.radiowave.eu/listen/test/aacHQ
+  bitrate: 320
+  codec: AAC
+  favicon: https://radiowave.eu/static/uploads/browser_icon/192.1743030143.png
+  homepage: https://radiowave.eu/public/test
+  country: GB
+  status: stream-only
+  stationuuid: 8bdfe6a8-fd46-4c2f-bb73-b730bb95a30f
+  changeuuid: e26f3d70-b574-4ddc-89ba-4b6a097ecb5d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-reiver-fm-scottish-borders-radio
+  broadcaster: independent
+  name: "Reiver FM – Scottish Borders Radio "
+  streamUrl: https://s10.myradiostream.com/35820/listen.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: https://reiverfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: 9ae16b8c-40fc-4c62-939c-9d4c2fb8be37
+  changeuuid: 2429469d-de01-4b57-88bb-b36afd646cd7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-rutland-and-stamford-sound
+  broadcaster: independent
+  name: Rutland and Stamford Sound
+  streamUrl: https://stream.aiir.com/lqeblzjduoduv
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/500/6035405e0d05a.png
+  homepage: https://www.rutlandandstamfordsound.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: a383a5b1-5a8c-4178-9885-ea527b3cdcce
+  changeuuid: 98bbf302-395e-43ff-be78-8ba55fee80dd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-slim-radio
+  broadcaster: independent
+  name: Slim Radio
+  streamUrl: https://a2.asurahosting.com:6260/radio.mp3
+  bitrate: 320
+  codec: MP3
+  favicon: https://www.slimradio.co.uk
+  homepage: http://www.slimradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 6a2fe382-636f-4423-b30c-ba51d2388c3a
+  changeuuid: 810f3c1c-91fa-4a21-90c2-0418e0e838c5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-spark-fm
+  broadcaster: independent
+  name: Spark FM
+  streamUrl: https://stream1.hippynet.co.uk:8117/live.mp3
+  bitrate: 320
+  codec: MP3
+  homepage: https://www.sparksunderland.com/
+  country: GB
+  status: stream-only
+  stationuuid: a0a6e01e-c70e-4ddd-b274-766e99424716
+  changeuuid: 995cf6a5-6c10-4fd7-8cc3-8f2e9a2309ae
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-td1-radio
+  broadcaster: independent
+  name: TD1 Radio
+  streamUrl: https://streaming.mbc.scot/listen/td1_radio/radio.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.td1radio.scot/
+  country: GB
+  status: stream-only
+  stationuuid: d15ad933-7ee3-40d2-8b8c-01b6ff675e3e
+  changeuuid: b081a056-3770-4b81-8131-00d50f335eda
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-the-cat-107-9
+  broadcaster: independent
+  name: The Cat 107.9
+  streamUrl: https://uksoutha.streaming.broadcast.radio/thecatcloud?1769875744264=
+  codec: MP3
+  favicon: https://thecat.radio/favicon.ico?i=5365
+  homepage: https://thecat.radio/
+  country: GB
+  status: stream-only
+  stationuuid: 1a5bf21a-e67a-44ee-82ea-b9ac2376ef2b
+  changeuuid: 1878d7c0-aae9-4b76-95c5-a8eba5cda147
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-triphop-radio
+  broadcaster: independent
+  name: TripHop.Radio
+  streamUrl: https://live.triphop.radio/
+  bitrate: 128
+  codec: MP3
+  favicon: https://pages.register.radio/uploads/triphop-radio-69d395851f50d.png
+  homepage: https://www.triphop.radio/
+  country: GB
+  status: stream-only
+  stationuuid: 72612036-9d94-46a7-b0ff-7a1061a62867
+  changeuuid: 2d969a48-2afe-46a6-affe-5d76099986c1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-truck-beat-fm
+  broadcaster: independent
+  name: Truck Beat FM
+  streamUrl: https://streamer.radio.co/s895c9762a/listen
+  bitrate: 128
+  codec: MP3
+  homepage: https://truck-beat-fm.github.io/Truck-Beat-FM-radio/index.html
+  country: GB
+  status: stream-only
+  stationuuid: 8fcb2319-f3b7-4766-9d7f-e9d8642c2440
+  changeuuid: d1fc5632-3c94-44e1-8b2a-b941c2bd6b35
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-vdub-radio
+  broadcaster: independent
+  name: VDub Radio
+  streamUrl: https://s2.radio.co/s6fb3318ac/listen
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.vdubradio.com/uploads/1/2/3/2/123248749/new-2024-aerial-line-x-1200_orig.jpg
+  homepage: https://www.vdubradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 73c0d87f-a547-47f7-a6fd-0a2738558db8
+  changeuuid: a142065b-5af0-4b99-8b2c-00ddb8af33b2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-vibe-1
+  broadcaster: independent
+  name: Vibe 1
+  streamUrl: https://stream3.themediasite.co.uk:8106/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQX-73EE6UPXYWRfGsZ6WkesAy6ef2fwE3pSA&s
+  homepage: https://www.vibe1.uk/
+  country: GB
+  status: stream-only
+  stationuuid: f81b8923-98cc-437d-94ee-7d50dd1b91bd
+  changeuuid: 85a4e6b0-f927-4f37-af8e-937d69f46ec2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-weald-radio
+  broadcaster: independent
+  name: Weald Radio
+  streamUrl: https://uksoutha.streaming.broadcast.radio/oastradio
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/2225/687d0e4b722ce.jpg
+  homepage: https://www.wealdradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 10f6f8f2-00c8-48d3-ada4-f7bd2298a8bb
+  changeuuid: 56452f82-e799-44cf-b595-db62e67e21de
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-word-central-radio
+  broadcaster: independent
+  name: Word Central Radio
+  streamUrl: https://play.radioking.io/word-central-radio/707122
+  bitrate: 192
+  codec: MP3
+  favicon: https://image.radioking.io/radios/643897/logo/1cf1f955-b76c-4d78-a4ea-5af7c21909c5.jpeg
+  homepage: https://wordcentralradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 53f2d51f-01b8-4f11-b6ad-8f5f1d76856a
+  changeuuid: e425f4bb-5f6b-4e0a-8c8e-1941f7f862b3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-2day-mix-radio
+  broadcaster: independent
+  name: "2day mix radio"
+  streamUrl: https://2day.2daymixradio.org:8000/radio.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: https://2daymixradio.org/
+  country: GB
+  status: stream-only
+  stationuuid: c67374fe-b34a-479f-a644-b97d410026fb
+  changeuuid: 847fb7f3-b67b-4b0f-9b0a-c4ef53cef0b4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-arp-radio
+  broadcaster: independent
+  name: ARP Radio
+  streamUrl: https://arpradio.com:8443/listen/arp_radio/arp.mp3
+  bitrate: 320
+  codec: MP3
+  homepage: https://arpradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 2dd9ec68-b0e7-47c8-bc52-86579a8de0af
+  changeuuid: 8c1226b7-4477-4cad-b534-17d80bdbd38f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-ashdown-radio
+  broadcaster: independent
+  name: Ashdown Radio
+  streamUrl: https://streaming.broadcast.radio/uckfieldfmmp3?_=365639
+  bitrate: 128
+  codec: MP3
+  favicon: https://mmo.aiircdn.com/592/61d2dbf595ad9.png
+  homepage: https://www.ashdownradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 24afa5b0-9e7f-4264-b139-9a9c72bf6950
+  changeuuid: c40c7e2c-b94e-44f4-a5fd-7fc61d38e3ab
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bexhill-radio
+  broadcaster: independent
+  name: Bexhill Radio
+  streamUrl: https://a13.asurahosting.com/listen/bexhill_radio/radio.mp3
+  bitrate: 320
+  codec: MP3
+  favicon: https://bexhillradio.com/wp-content/uploads/2025/11/PHOTO-2025-08-04-19-38-26.jpg
+  homepage: https://bexhillradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: e3eb1f35-9f15-4a06-ae06-14786eccd01a
+  changeuuid: bc30ace8-cddb-4297-b999-a8a1744ace1d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bounce-nation-radio
+  broadcaster: independent
+  name: Bounce Nation Radio
+  streamUrl: https://stream.stuallan.com/stream4
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.stuallan.com/
+  country: GB
+  status: stream-only
+  stationuuid: 47aaaaf4-0549-46e5-bd20-75b3c8b7702d
+  changeuuid: 6fb2a0db-cad9-41c9-9351-0bcf5c351e69
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-bournemouth-one
+  broadcaster: independent
+  name: Bournemouth One
+  streamUrl: https://n10a-eu.rcs.revma.com/bq0p6qbnpucwv?rj-ttl=5&rj-tok=AAABm8kwEu0ATCenU6Ba4CGEmg
+  codec: AAC
+  favicon: https://mmo.aiircdn.com/743/6773b4fd7db3a.png
+  homepage: https://www.bournemouthone.com/
+  country: GB
+  status: stream-only
+  stationuuid: 3976ed63-6e97-458e-acc5-29d0bb55c0ff
+  changeuuid: b1db0f38-c9a5-41b0-a2af-755c1484cf35
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-branchfm
+  broadcaster: independent
+  name: BranchFM
+  streamUrl: https://s11.ssl-stream.com/ssl/branchfm?mp=%2Fstream&rp_source=1&=&&___cb=797689455893916
+  bitrate: 192
+  codec: MP3
+  homepage: https://branchfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: 451a9871-c303-446b-9f7e-21d16b9af29a
+  changeuuid: f89b3aab-a323-4ff6-af41-f6a77a71322d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-castle-radio
+  broadcaster: independent
+  name: Castle Radio
+  streamUrl: https://c36.radioboss.fm:8114/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.castleradio.co.uk/set1.png
+  homepage: https://www.castleradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: c98ba9c4-27ed-4996-b8ff-cf704ba273f2
+  changeuuid: cda31509-84cc-4b5f-8bba-9bc0692e4926
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-central-radio
+  broadcaster: independent
+  name: Central Radio
+  streamUrl: https://n33a-eu.rcs.revma.com/aehah7wnpp3vv
+  codec: AAC
+  favicon: https://mmo.aiircdn.com/778/673b04861e76c.png
+  homepage: http://www.central.radio/
+  country: GB
+  status: stream-only
+  stationuuid: eae9e199-dd68-403d-ada3-76726324e654
+  changeuuid: 8ae97c07-ac0b-4f4c-b7b0-ca809fbddc98
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-crucial-sounds-radio
+  broadcaster: independent
+  name: crucial sounds radio
+  streamUrl: https://usa19.fastcast4u.com:9420/stream
+  bitrate: 320
+  codec: MP3
+  homepage: https://crucialsoundsradio.uk/
+  country: GB
+  status: stream-only
+  stationuuid: dc90eff0-4100-45df-923a-0d6e97f407a1
+  changeuuid: abd2c51b-ec5b-4be4-ba3e-fc384580ded3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-da-hub-radio
+  broadcaster: independent
+  name: Da Hub Radio
+  streamUrl: https://stream.dahubradio.co.uk:8848/stream
+  bitrate: 128
+  codec: MP3
+  homepage: https://dahubradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 56e2e57d-0ee3-4865-822c-f37335bdf058
+  changeuuid: cbedb433-3774-4670-ba38-a2ae6f8ddad8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-dork-radio
+  broadcaster: independent
+  name: Dork Radio
+  streamUrl: https://s2.radio.co/s3e57f0675/listen
+  bitrate: 192
+  codec: MP3
+  favicon: https://readdork.com/wp-content/uploads/2025/02/dork_logo_new_nearblack-768x185.webp
+  homepage: https://readdork.com/
+  country: GB
+  status: stream-only
+  stationuuid: 03738ed0-5d6c-45ef-b232-6c09e8c7aba7
+  changeuuid: 2a4c21e7-c973-474b-be74-f3d2a9e58c25
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-eava-fm
+  broadcaster: independent
+  name: EAVA FM
+  streamUrl: https://radio.canstream.co.uk:8000/eavafm.mp3
+  bitrate: 96
+  codec: MP3
+  favicon: https://www.eavafm.com/wp-content/uploads/2021/12/eava_logo_Clear_3400.png
+  homepage: https://www.eavafm.com/
+  country: GB
+  status: stream-only
+  stationuuid: 4808310d-bc75-4a05-a2b1-de9e5eaced99
+  changeuuid: f2be796c-4374-4333-aa6e-0c923cb304c6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-electric-circus
+  broadcaster: independent
+  name: electric circus
+  streamUrl: https://a5.asurahosting.com:7990/radio.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.electriccircus.uk/wp-content/uploads/go-x/u/3c3ed3c4-f457-43f2-b909-fbee7590e08b/image-384x304.jpg
+  homepage: https://www.electriccircus.uk/radio/
+  country: GB
+  status: stream-only
+  stationuuid: 9218802f-1977-430b-b95c-439d1554dc41
+  changeuuid: c9bbbdea-f6be-4154-b790-df6ae19f5a3b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hfm-102-3
+  broadcaster: independent
+  name: HFM 102.3
+  streamUrl: https://listen-harboroughfm.sharp-stream.com/harboroughfm.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://harboroughfm.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 78742a2b-17c8-4105-9525-be7d06d42024
+  changeuuid: 2a55797e-3b88-4a86-b949-57e6411a5521
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-hgv1-radio
+  broadcaster: independent
+  name: HGV1 Radio
+  streamUrl: https://stream4.themediasite.co.uk/stream/hgv1-main
+  bitrate: 192
+  codec: MP3
+  homepage: https://hgvradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 5c919eac-d2af-4766-a883-d7871a6c09f8
+  changeuuid: 201859d7-4a8b-4e2a-a058-61164a9deb4f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-huntingdon-community-radio-hcr-fm
+  broadcaster: independent
+  name: Huntingdon Community Radio - HCR FM
+  streamUrl: https://listen.streamaudio.co/proxy/hcr/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.hcrfm.co.uk/favicon.ico
+  homepage: https://www.hcrfm.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: c077bae1-df52-4aa0-a7e6-67f5ab14528d
+  changeuuid: e3472ecd-8282-4661-ba1e-9eb900666766
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-indie-soul-radio
+  broadcaster: independent
+  name: Indie Soul Radio
+  streamUrl: https://s2.citrus3.com:8404/stream
+  bitrate: 128
+  codec: AAC
+  homepage: https://www.indiesoulradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: ccf3396a-40e3-4541-887a-89f5b1f879ee
+  changeuuid: 0ae61f30-9210-49cd-90de-fc7dbe2f53e7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-kick-radio
+  broadcaster: independent
+  name: KICK RADIO
+  streamUrl: https://cast4.my-control-panel.com/proxy/edp/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.kickradio.co.uk/public/themes/default/assets/favicon.ico
+  homepage: https://www.kickradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 2388821a-0d0b-4f09-ae2c-6f6fe3bc06b3
+  changeuuid: 097e866a-09d6-4577-95da-a6d46a8a0867
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-laser-dance
+  broadcaster: independent
+  name: Laser Dance
+  streamUrl: https://stream.airwavebroadcast.com:8010/laserdancehq
+  bitrate: 128
+  codec: AAC
+  favicon: https://primary.jwwb.nl/public/t/a/i/temp-dozjcpvcaeqpdalqxwlr/315-high.jpg?enable-io=true&width=1252
+  homepage: https://www.laserinternational.co.uk/laser-dance
+  country: GB
+  status: stream-only
+  stationuuid: 436a5a1d-d267-4893-b036-c59df79043fd
+  changeuuid: 5c09d18c-5e84-45fe-a03f-cdf2616fec08
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-laser-hot-hits
+  broadcaster: independent
+  name: Laser Hot Hits
+  streamUrl: https://stream.airwavebroadcast.com:8040/laserhq
+  bitrate: 256
+  codec: MP3
+  favicon: https://primary.jwwb.nl/public/t/a/i/temp-dozjcpvcaeqpdalqxwlr/225-high.png?enable-io=true&width=816
+  homepage: https://www.laserinternational.co.uk/laser-hot-hits-international
+  country: GB
+  status: stream-only
+  stationuuid: 1b3d1f50-f8dd-4ebd-9faf-cae04788b218
+  changeuuid: cba24311-7608-42d6-ae7b-ede45b9137c8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-love-da-beat-radio
+  broadcaster: independent
+  name: Love Da Beat Radio
+  streamUrl: https://love-da-beat-radio-cf8d1146.radiocult.fm/stream
+  bitrate: 160
+  codec: MP3
+  homepage: https://www.lovedabeatradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: bb2d8310-f52c-4848-ad93-0bbb1b0b915b
+  changeuuid: fafcff7a-c41b-41de-bdb9-3c8a2621631d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-lyme-out-live
+  broadcaster: independent
+  name: lyme out live
+  streamUrl: https://centova87.shoutcastservices.com/proxy/lymeout/stream
+  bitrate: 128
+  codec: MP3
+  favicon: null
+  homepage: https://centova87.shoutcastservices.com/proxy/lymeout/stream
+  country: GB
+  status: stream-only
+  stationuuid: 5e0b938c-94b8-41e8-a408-1b4f46119461
+  changeuuid: 27bc7bcd-6f7c-414a-bfa3-03bec986b875
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-mearns-fm
+  broadcaster: independent
+  name: Mearns FM
+  streamUrl: https://stream2.hippynet.co.uk:8002/lowquality
+  bitrate: 96
+  codec: MP3
+  favicon: https://www.mearnsfm.org.uk/wp-content/uploads/2020/06/imageedit_5_7574751306.png
+  homepage: https://www.mearnsfm.org.uk/
+  country: GB
+  status: stream-only
+  stationuuid: a83511ac-92ad-4879-b1ff-6dd9a4c2c78b
+  changeuuid: 2ff12e1b-b6e9-4f22-8aa2-11aaf9eb0e84
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-nitro-fm
+  broadcaster: independent
+  name: nitro-FM
+  streamUrl: https://radio.nitro-server.uk/listen/nitrohost/radio.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: https://radio.nitro-server.uk/listen/nitrohost/
+  country: GB
+  status: stream-only
+  stationuuid: fc0d1031-cca4-4c23-9408-c0ec7690a8b0
+  changeuuid: 763f481e-cd3d-4bf9-8fad-8d82e8989721
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-outreach-radio
+  broadcaster: independent
+  name: Outreach Radio
+  streamUrl: https://live.ukrp.tv/outreachradio.aac
+  bitrate: 32
+  codec: AAC
+  favicon: https://cdn.outreachradio.co.uk/wp-content/uploads/2020/11/cropped-logo_website.jpg
+  homepage: https://www.outreachradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: de298f25-06ef-4114-8043-fa0dd75ff8c8
+  changeuuid: 671ff294-4510-4d7a-a0ea-5707f2006baa
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-piestream
+  broadcaster: independent
+  name: Piestream
+  streamUrl: https://radio.psymusic.co.uk/listen/piestream/hifi.mp3
+  bitrate: 320
+  codec: AAC
+  favicon: https://psymusic.co.uk/images/alien-head32.png
+  homepage: https://www.psymusic.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 3903eac2-5061-45e5-89a3-8a7ec183e8e4
+  changeuuid: 18b5bd28-ebf8-4197-bd3b-a631bd5fdf0e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-polish-radio-london
+  broadcaster: independent
+  name: Polish Radio London
+  streamUrl: https://n19a-eu.rcs.revma.com/prfmwmwy768uv?rj-ttl=5&rj-tok=AAABnQg2ZmsA5RX2yPMR7AlE5w
+  codec: AAC
+  homepage: https://prl24.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 9d3e2fad-cae9-48cb-90f1-11c7bef8a8ab
+  changeuuid: c5dec87f-7c16-4497-9dd2-609cfd94bb83
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-camarthenshire
+  broadcaster: independent
+  name: Radio Camarthenshire
+  streamUrl: https://listen-nation.sharp-stream.com/tccarmarthenshire.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://upload.wikimedia.org/wikipedia/commons/thumb/a/ac/Radiocarmar.png/250px-Radiocarmar.png
+  homepage: https://www.nationplayer.com/radio-carmarthenshire/
+  country: GB
+  status: stream-only
+  stationuuid: 5bd70f6e-b7a5-4f3b-ab52-0ac20f7e9624
+  changeuuid: 70745837-8d1a-46ba-909f-2dce9e277ed7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radio-victory
+  broadcaster: independent
+  name: Radio Victory
+  streamUrl: https://stream3.themediasite.co.uk:8380/stream
+  bitrate: 256
+  codec: MP3
+  homepage: https://radiovictory.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 956ed88f-2766-4f6a-9bf0-f3a9b697ca34
+  changeuuid: 6999f498-f764-4c80-8cdd-7475281f9625
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-radiowave-eu
+  broadcaster: independent
+  name: Radiowave.eu
+  streamUrl: https://radiowave.eu/hls/test/live.m3u8
+  bitrate: 211
+  codec: AAC
+  favicon: https://radiowave.eu/static/uploads/browser_icon/192.1743030143.png
+  homepage: https://radiowave.eu/
+  country: GB
+  status: stream-only
+  stationuuid: b2f27b98-05c5-45a2-a457-54cae21c406a
+  changeuuid: 5eb820b7-b9e1-4d79-96f8-3667595f5ae4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-raiders-radio
+  broadcaster: independent
+  name: Raiders Radio
+  streamUrl: https://s2.citrus3.com:8464/stream
+  bitrate: 128
+  codec: AAC
+  favicon: https://raidersradio.co.uk/favicon.png
+  homepage: https://raidersradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 8e46e90a-9bbc-4d47-a82a-61dfb14a57ef
+  changeuuid: 15ce1a48-8e8f-4f58-a644-b4e044cfb129
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-retrobyte-radio
+  broadcaster: independent
+  name: RetroByte Radio
+  streamUrl: https://retrobytesradio.radioca.st/stream
+  bitrate: 320
+  codec: MP3
+  homepage: https://www.retrobyteradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: f3d2c5ca-970f-43e9-aab9-e1bc7b74041d
+  changeuuid: a480c506-b944-4488-8d1f-77d2a42a89fc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-rtm-fm
+  broadcaster: independent
+  name: RTM.FM
+  streamUrl: https://streams.radio.co/s3d2f05f8f/listen
+  bitrate: 128
+  codec: MP3
+  favicon: https://rtm.fm/favicon.png
+  homepage: https://rtm.fm/
+  country: GB
+  status: stream-only
+  stationuuid: a0a43edc-544d-47b2-8980-2ab7c946c2e8
+  changeuuid: 71371581-dfce-4a54-926f-d7074ccbe0ae
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-selecta-radio-uk
+  broadcaster: independent
+  name: Selecta Radio UK
+  streamUrl: https://streaming.live365.com/a40232
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.selectaradiouk.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 38c91628-48d5-4768-b975-3383493f5284
+  changeuuid: 5a1bda14-1bdd-45f3-8fb8-ba3a599e7b5d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-sle-radio-one
+  broadcaster: independent
+  name: SLE RADIO ONE
+  streamUrl: https://sleradiogroup.com/listen/sle_radio_1/sleone.mp3
+  bitrate: 256
+  codec: AAC
+  favicon: https://sleradio.com/station1.png
+  homepage: https://sleradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 982ee37b-0dd5-4acb-94e6-bc2575e38893
+  changeuuid: 1e8a7b6b-ef8a-4712-9bf5-07a27ab26b1e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-sle-radio-rave
+  broadcaster: independent
+  name: SLE RADIO RAVE
+  streamUrl: https://sleradiogroup.com/listen/sle_radio_rave/radio.mp3
+  bitrate: 256
+  codec: MP3
+  favicon: https://sleradio.com/station-rave.png
+  homepage: https://sleradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: 09a754eb-863e-4299-9ee7-eef21c5eff74
+  changeuuid: 2a7ed47f-ace8-496d-b958-d9c1d1bcf878
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-smooth-tyne-wear
+  broadcaster: independent
+  name: "Smooth Tyne & Wear"
+  streamUrl: https://media-ice.musicradio.com/SmoothNorthEastNMP3
+  bitrate: 128
+  codec: MP3
+  favicon: http://www.smoothradio.com/assets_v4r/smooth/img/favicon-196x196.png
+  homepage: https://www.smoothradio.com/
+  country: GB
+  status: stream-only
+  stationuuid: da2ecfd9-4e07-45c3-be0a-999e01487e54
+  changeuuid: 34764d79-d16c-4925-bffd-1f9c2aa50b12
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-toby-s-tunes
+  broadcaster: independent
+  name: "Toby's Tunes"
+  streamUrl: https://stream.aiir.com/he5hocuryqbvv
+  codec: AAC
+  homepage: https://classichits.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: b3574205-b8ad-41ea-aad8-1dd6cbbef903
+  changeuuid: c4f4c90d-f898-4e67-b989-1b3ec80484ba
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-toohotradio-net
+  broadcaster: independent
+  name: TooHotRadio.net
+  streamUrl: https://stream.toohotradio.net/128
+  bitrate: 128
+  codec: MP3
+  favicon: https://toohotradio.net/resize/toohot2.png?w=180
+  homepage: https://toohotradio.net/#
+  country: GB
+  status: stream-only
+  stationuuid: b6fa0be8-846a-4279-80b2-c39d2e4d6e17
+  changeuuid: f0963878-a4f6-4e5d-9221-2075875573e4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-ttns
+  broadcaster: independent
+  name: TTNS
+  streamUrl: https://listen.thethursdaynightshow.com/live
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.thethursdaynightshow.com/
+  country: GB
+  status: stream-only
+  stationuuid: e925e09e-623a-4dff-b7b4-99de76089dba
+  changeuuid: 7040fef5-1c6f-4a35-9c36-a784e9afa430
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-tuneskool-radio
+  broadcaster: independent
+  name: Tuneskool Radio
+  streamUrl: https://c18.radioboss.fm:8423/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://tuneskoolradio.co.uk/wp-content/uploads/2024/01/Tune_school_radio-768x384.jpg
+  homepage: https://tuneskoolradio.co.uk/
+  country: GB
+  status: stream-only
+  stationuuid: 63e45e24-fc7e-4d69-bcaa-6c3e9b7fc342
+  changeuuid: 86cd1f0a-46c7-4552-b9d5-fba8eb840dae
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-xpression-fm
+  broadcaster: independent
+  name: Xpression FM
+  streamUrl: https://streaming.broadcastradio.com:10855/xpression
+  bitrate: 128
+  codec: MP3
+  favicon: http://www.xpression.fm/uploads/3/7/0/6/37062627/image-removebg-preview.png
+  homepage: http://www.xpression.fm/
+  country: GB
+  status: stream-only
+  stationuuid: 7a89ade9-cae3-4a36-ae1b-5ce7a497b63d
+  changeuuid: acfab051-b6a2-4a37-9d85-f08d1190e6fa
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: gb-zack-fm
+  broadcaster: independent
+  name: Zack FM
+  streamUrl: https://s2.streamer1.com/listen/zackfm/zackTEST.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.zackfm.com/templates/joomla3_005/images/logo.png
+  homepage: https://www.zackfm.com/
+  country: GB
+  status: stream-only
+  stationuuid: 7df157a2-7a65-4dea-9278-af66f9d8292c
+  changeuuid: 41226e84-b7ac-44ba-b7b8-1a9e4e67cf44
+  reviewedAt: "2026-05-04"

--- a/data/stations.yaml
+++ b/data/stations.yaml
@@ -60114,3 +60114,6124 @@
   stationuuid: 7c4ef4d1-0595-43e1-9f26-0b815f1c5b96
   changeuuid: 1d358ce2-e722-4899-82d4-826d8d8fe608
   reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-armisa
+  broadcaster: independent
+  name: Radio Armisa
+  streamUrl: https://onair.armisa.it/listen/armisa/radio.mp3
+  bitrate: 192
+  codec: AAC
+  favicon: https://armisa.it/assets/favicon/android-chrome-512x512.png
+  homepage: https://armisa.it/
+  country: IT
+  status: stream-only
+  stationuuid: 83dcfac4-b3c3-4731-afc1-a80dd271dffa
+  changeuuid: 30506ba5-50a0-4d28-8f33-176521aba3ca
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-70-80-hits-hq
+  broadcaster: independent
+  name: "70 80 Hits HQ"
+  streamUrl: https://nr8.newradio.it:19574/stream
+  bitrate: 320
+  codec: MP3
+  homepage: https://www.70-80.it/
+  country: IT
+  status: stream-only
+  stationuuid: 44c862a3-27e7-4d88-be66-4c70a642bb38
+  changeuuid: d2a49aeb-c641-4ad3-9beb-28b30e1f9268
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-classic-hits-radio-italia
+  broadcaster: independent
+  name: CLASSIC HITS RADIO Italia
+  streamUrl: https://classichitsradio.streamingmedia.it/play
+  bitrate: 192
+  codec: AAC+
+  homepage: http://classichits.radio/italy/
+  country: IT
+  status: stream-only
+  stationuuid: ae6a44a0-2ae6-421f-b66b-d2700c8f92e8
+  changeuuid: 277ce2ea-80ec-40af-90d9-b00f78a03a7c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-italia-italia-70
+  broadcaster: independent
+  name: ITALIA Italia 70
+  streamUrl: https://icy.unitedradio.it/um020.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: http://www.unitedmusic.it/
+  country: IT
+  status: stream-only
+  stationuuid: f428a295-760d-11ea-b1cf-52543be04c81
+  changeuuid: e628a226-52b6-493f-bab7-1a32ab97e3a0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-italia-italia-80
+  broadcaster: independent
+  name: ITALIA Italia 80
+  streamUrl: https://icy.unitedradio.it/um016.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: http://www.unitedmusic.it/
+  country: IT
+  status: stream-only
+  stationuuid: c229f726-760d-11ea-b1cf-52543be04c81
+  changeuuid: 9c697250-52f8-477c-8ca9-ac7bded445da
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-sportiva
+  broadcaster: independent
+  name: "Radio Sportiva "
+  streamUrl: https://sportiva.inmystream.it/stream/sportiva
+  bitrate: 36
+  codec: AAC+
+  favicon: https://www.radiosportiva.com/wp-content/uploads/2021/09/logo-radiosportiva-white.svg
+  homepage: https://www.radiosportiva.com/
+  country: IT
+  status: stream-only
+  stationuuid: 9ff8c9b6-34d5-4457-befd-bdad9c218217
+  changeuuid: 8487b04d-79f6-41b1-a2e2-7bcebf0a050d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-new-hits-radio-italia
+  broadcaster: independent
+  name: NEW HITS RADIO Italia
+  streamUrl: https://newhitsradio.streamingmedia.it/play
+  bitrate: 320
+  codec: MP3
+  homepage: https://newhits.radio/
+  country: IT
+  status: stream-only
+  stationuuid: 079f5cb5-c17a-412e-b242-15b22123162b
+  changeuuid: 11d6ce76-197a-4242-8c0e-af9ed97c7115
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-sei-italia
+  broadcaster: independent
+  name: Radio Sei (Italia)
+  streamUrl: https://icecast.ithost.it/radiosei.ogg
+  bitrate: 32
+  codec: AAC+
+  favicon: https://upload.wikimedia.org/wikipedia/commons/thumb/e/ec/Soccer_ball.svg/480px-Soccer_ball.svg.png
+  homepage: https://www.radiosei.it/
+  country: IT
+  status: stream-only
+  stationuuid: 22d0e6ba-6090-40ed-91d8-be21dd57362a
+  changeuuid: 10e282a9-8808-4730-bd37-f2d4e38a10e7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-retesport-italia
+  broadcaster: independent
+  name: Retesport (Italia)
+  streamUrl: https://icecast.ithost.it/retesport.ogg
+  bitrate: 48
+  codec: AAC+
+  favicon: https://upload.wikimedia.org/wikipedia/commons/thumb/e/ec/Soccer_ball.svg/480px-Soccer_ball.svg.png
+  homepage: https://www.retesport.it/
+  country: IT
+  status: stream-only
+  stationuuid: 2e9d860d-017a-4edf-81c2-e81804749a4b
+  changeuuid: dc66d34d-f441-4184-98f7-0e7d591fb2cc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-mana-mana-sport-roma
+  broadcaster: independent
+  name: Radio Manà Manà Sport Roma
+  streamUrl: https://stream10.xdevel.com/audio2s975363-2142/stream/icecast.audio
+  codec: AAC+
+  homepage: https://www.manamanasportroma.it/
+  country: IT
+  status: stream-only
+  stationuuid: 32c1aa82-c639-4c73-9236-948bbda511d7
+  changeuuid: 63cd847c-fbc9-4156-8545-70834877fdf1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-italian-radio-only-romantic-italian-music
+  broadcaster: independent
+  name: ITALIAN RADIO - Only (romantic) Italian Music
+  streamUrl: https://italianradio.streamingmedia.it/play
+  bitrate: 96
+  codec: AAC+
+  homepage: http://italian.radio/
+  country: IT
+  status: stream-only
+  stationuuid: 5a492e5f-48fc-4ad2-891b-e53c70499228
+  changeuuid: eb5a8592-5fd8-4713-8af7-df985884c412
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-virgin-radio-rockstar-rolling-stones
+  broadcaster: independent
+  name: "Virgin Radio Rockstar: Rolling Stones"
+  streamUrl: https://icy.unitedradio.it/VirginSpecialEvent.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.virginradio.it/sezioni/1855/Music-Star-Rolling-Stones
+  country: IT
+  status: stream-only
+  stationuuid: 4c584e2c-aaad-485e-976c-5f200cca6fe3
+  changeuuid: f02045fc-d381-4a61-b2ae-5a80ceb1fbc1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-lolli-radio-italia
+  broadcaster: independent
+  name: Lolli Radio Italia
+  streamUrl: https://stream.lolliradio.net/lolli_italia.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: http://www.lolliradio.net/wp-content/uploads/2016/02/logo_italia-150x150.jpg
+  homepage: http://lolliradio.net/
+  country: IT
+  status: stream-only
+  stationuuid: 9624172b-0601-11e8-ae97-52543be04c81
+  changeuuid: 6e979322-3b33-4af4-8a37-e09b34a19268
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-70-80-disco-funk-modernsoul-e-boogie
+  broadcaster: independent
+  name: "70 80 Disco Funk ModernSoul e Boogie"
+  streamUrl: https://discofunk.streamingmedia.it/play
+  bitrate: 192
+  codec: MP3
+  homepage: https://funky.radio/disco/
+  country: IT
+  status: stream-only
+  stationuuid: 4df24bb0-2794-498f-bdc0-0c3d6b71ed95
+  changeuuid: b567188e-3287-4716-b31d-580c2a9d01b8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-lattemiele
+  broadcaster: independent
+  name: Lattemiele
+  streamUrl: https://sr15.inmystream.it:8000/stream
+  bitrate: 256
+  codec: MP3
+  favicon: https://www.lattemiele.com/wp-content/uploads/2020/07/cropped-logo-autore-lm-32x32.png
+  homepage: https://lattemiele.com/
+  country: IT
+  status: stream-only
+  stationuuid: 9536cb64-9345-4ddb-b84c-cc34f511a965
+  changeuuid: 3e2614f5-17b0-4254-a6ca-fb0df32879c2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-rds-relax
+  broadcaster: independent
+  name: RDS Relax
+  streamUrl: https://stream.rds.radio/audio/rdsrelax.stream_aac/playlist.m3u8
+  bitrate: 128
+  codec: AAC
+  homepage: https://rdsrelax.it/
+  country: IT
+  status: stream-only
+  stationuuid: 42932f35-f4f2-11e8-a471-52543be04c81
+  changeuuid: 6efa5faf-c55b-441b-bd2c-d19722e54f31
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-romanista
+  broadcaster: independent
+  name: Radio Romanista
+  streamUrl: https://romanista.newradio.it/stream
+  bitrate: 64
+  codec: AAC+
+  homepage: https://www.radioromanista.it/
+  country: IT
+  status: stream-only
+  stationuuid: cb74060e-8b0b-45f0-8e6b-e2f8c6c1a152
+  changeuuid: 4debdb0e-9beb-4e24-8909-447b7f756874
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-rtr-99-canale-pooh
+  broadcaster: independent
+  name: RTR 99 Canale Pooh
+  streamUrl: https://rtr99.fluidstream.eu/rtr99_pooh.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.rtr99.it/onair/CanalePooh/OnAir.jpg?x=9f2sj07zxxhpl2i1aocli
+  homepage: https://www.rtr99.it/
+  country: IT
+  status: stream-only
+  stationuuid: 14274755-9b92-4dcb-8dee-d474bfc8a8fd
+  changeuuid: 20dafc72-2c94-46bf-9077-e5827d1d398e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-romantica-radio
+  broadcaster: independent
+  name: ROMANTICA-RADIO
+  streamUrl: https://vetrina.multi-radio.com/romanticaradio
+  bitrate: 64
+  codec: AAC+
+  favicon: https://romanticaradio.it/wp-content/uploads/2022/05/cropped-favicon_romantica-180x180.png
+  homepage: https://www.romanticaradio.it/
+  country: IT
+  status: stream-only
+  stationuuid: af6b114a-5c13-426e-b667-f58a9bd79b92
+  changeuuid: ef439835-2a44-42d6-9583-d7d8a0d56f5a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-70-80-90-marche
+  broadcaster: independent
+  name: " Radio 70 80 90 Marche"
+  streamUrl: https://rblive.it:8020/radio.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.radio708090.it/
+  country: IT
+  status: stream-only
+  stationuuid: a27fc1f0-bcdc-4079-9f73-ae444c045ddc
+  changeuuid: 99e5779a-9e87-4d1a-aa89-f7b30443d8c3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-neu-radio
+  broadcaster: independent
+  name: NEU RADIO
+  streamUrl: https://nr9.newradio.it/proxy/ebaruffa?mp=/stream
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.neuradio.it/
+  country: IT
+  status: stream-only
+  stationuuid: 4d712fdb-596c-495a-80eb-6c0cf2c3e649
+  changeuuid: a045f5f3-99c2-4a12-bb95-3797efad6f3e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-energy-classic-italy
+  broadcaster: independent
+  name: _Radio Energy Classic (Italy)
+  streamUrl: https://gmusto3.radioca.st/stream
+  bitrate: 224
+  codec: MP3
+  favicon: https://www.radioenergy.to/favicon.ico
+  homepage: https://www.radioenergy.to/
+  country: IT
+  status: stream-only
+  stationuuid: 0f5f71e2-ee63-4054-9d0d-18f2e106b37d
+  changeuuid: 0e3c3f5c-e9bb-433d-85b8-928d5afe4aa9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-bianconera
+  broadcaster: independent
+  name: Radio Bianconera
+  streamUrl: https://stream.tmwradio.com/bianconera.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: http://players.fluidstream.it/RadioBiancoNera/icon.png
+  homepage: http://www.radiobianconera.com/
+  country: IT
+  status: stream-only
+  stationuuid: 69aff725-522c-11e9-a4d7-52543be04c81
+  changeuuid: f6f54a81-f5d0-4461-92bb-fa86a52583a9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-80-afro
+  broadcaster: independent
+  name: Radio 80 Afro
+  streamUrl: https://sphera.fluidstream.eu/r80_afro.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.radio80.it/wp-content/uploads/2015/02/logo-radio80-1.ico
+  homepage: https://www.radio80.it/
+  country: IT
+  status: stream-only
+  stationuuid: 85a96041-5734-43de-a351-9edddc88afd0
+  changeuuid: 03926651-ba3e-4b85-a519-7f0ac1404a01
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-one-dance
+  broadcaster: independent
+  name: One Dance
+  streamUrl: https://ice04.fluidstream.net/rn1_2.aac
+  bitrate: 128
+  codec: AAC
+  homepage: https://onedance.fm/
+  country: IT
+  status: stream-only
+  stationuuid: 7a67fe09-ab18-11e9-88f4-52543be04c81
+  changeuuid: 9a96cd73-964b-4475-8944-240eea006aca
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-italiana
+  broadcaster: independent
+  name: RADIO ITALIANA
+  streamUrl: https://radiorossini.stream.laut.fm/radiorossini
+  bitrate: 128
+  codec: MP3
+  favicon: https://cdn.sedo.com/c7r/assets/static/images/icons/apple-touch-icon.png
+  homepage: https://radioitaliana.it/
+  country: IT
+  status: stream-only
+  stationuuid: 164740d3-86ac-48d5-b622-20c91ff0b576
+  changeuuid: 30d2b309-36a3-42fd-a4da-73897d64a820
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-subasio
+  broadcaster: independent
+  name: RADIO SUBASIO
+  streamUrl: https://icy.unitedradio.it/Subasio.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.radiosubasio.it/wp-content/themes/radiosubasiov2/assets/images/logo-radio-subasio.png
+  homepage: https://www.radiosubasio.it/
+  country: IT
+  status: stream-only
+  stationuuid: 2a921377-d27d-4fc8-acd0-f7dee943c7f8
+  changeuuid: 61d5f95e-a123-4f99-a7e5-4e2ad373e496
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-freccia
+  broadcaster: independent
+  name: Radio Freccia
+  streamUrl: https://dd782ed59e2a4e86aabf6fc508674b59.msvdn.net/live/S3160845/0tuSetc8UFkF/playlist_audio.m3u8
+  bitrate: 192
+  codec: AAC
+  favicon: https://cloud.radiofreccia.it/assets/www.radiofreccia.it/1.0.43/img/logo/android-icon-192x192.png
+  homepage: https://www.radiofreccia.it/
+  country: IT
+  status: stream-only
+  stationuuid: b25710a3-fb1b-4aa7-ba81-142ee6f5bea9
+  changeuuid: 5f7c294c-6baa-4a9f-95c9-b8087552d067
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-italia-hits-italia
+  broadcaster: independent
+  name: ITALIA Hits Italia
+  streamUrl: https://icy.unitedradio.it/um011.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: http://www.unitedmusic.it/
+  country: IT
+  status: stream-only
+  stationuuid: c2851dfc-760c-11ea-b1cf-52543be04c81
+  changeuuid: 73e72461-7184-4b03-bf62-1003c7ec53e9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-capital-it
+  broadcaster: independent
+  name: Radio Capital IT
+  streamUrl: https://streamcdnr8-4c4b867c89244861ac216426883d1ad0.msvdn.net/radiocapital/radiocapital/play1.m3u8
+  codec: UNKNOWN
+  favicon: https://upload.wikimedia.org/wikipedia/it/thumb/3/38/Radio_Capital_logo_%282020%29.svg/1200px-Radio_Capital_logo_%282020%29.svg.png
+  homepage: https://www.capital.it/
+  country: IT
+  status: stream-only
+  stationuuid: a89028bc-0cef-4228-9fce-5c91039aca94
+  changeuuid: b841f064-c48a-4df6-a5d0-5f3ca8101606
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-lolli-radio-dance
+  broadcaster: independent
+  name: Lolli Radio Dance
+  streamUrl: https://stream.lolliradio.net/lolli_dance.mp3
+  codec: MP3
+  favicon: http://www.lolliradio.net/wp-content/uploads/2016/02/logo_dance-150x150.jpg
+  homepage: http://www.lolliradio.net/
+  country: IT
+  status: stream-only
+  stationuuid: 960e5e12-0601-11e8-ae97-52543be04c81
+  changeuuid: 7d270bd8-b82d-45cb-b07e-66437724e74d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-italia-italia-90
+  broadcaster: independent
+  name: ITALIA Italia 90
+  streamUrl: https://icy.unitedradio.it/um018.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: http://www.unitedmusic.it/
+  country: IT
+  status: stream-only
+  stationuuid: 8533fd37-760d-11ea-b1cf-52543be04c81
+  changeuuid: 4fa9bc5b-9fe0-4025-a3c2-0c0e610c488d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-virgin-radio-rockstar-queen
+  broadcaster: independent
+  name: "Virgin Radio Rockstar: Queen"
+  streamUrl: https://icy.unitedradio.it/Virgin_05.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.virginradio.it/sezioni/1981/music-star-queen
+  country: IT
+  status: stream-only
+  stationuuid: 81cb9f67-9d78-4f8e-8c5c-62003e13c121
+  changeuuid: 637d7ce6-23c3-4c80-b377-faed0c2066c4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-rmc-music-star-george-michael
+  broadcaster: independent
+  name: RMC Music Star George Michael
+  streamUrl: https://icy.unitedradio.it/MusicStarPrince.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radiomontecarlo.net/sezioni/11757/music-star-george-michael
+  country: IT
+  status: stream-only
+  stationuuid: a0effe99-2ef9-4515-8e3b-55bce69966f7
+  changeuuid: 60a84cc9-386c-4f0e-96b1-4923f15a1ece
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-capital-funky-town
+  broadcaster: independent
+  name: Radio Capital Funky Town
+  streamUrl: https://4c4b867c89244861ac216426883d1ad0.msvdn.net/radiocapitalfunkytown/radiocapitalfunkytown/master_ma.m3u8
+  bitrate: 122
+  codec: AAC+
+  favicon: https://cdn.gelestatic.it/capital/sites/2/2016/11/webradio-funkytown2-320x320.jpg
+  homepage: https://www.capital.it/
+  country: IT
+  status: stream-only
+  stationuuid: 571ecf3e-f348-4bdb-b30d-31e2a20e8fe9
+  changeuuid: a859cf28-28de-4b46-a278-beb920299319
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-giornale-radio
+  broadcaster: independent
+  name: Giornale Radio
+  streamUrl: https://gr.fluidstream.eu/gr1.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://giornaleradio.fm/apple-touch-icon.png
+  homepage: https://giornaleradio.fm/
+  country: IT
+  status: stream-only
+  stationuuid: d50de3ae-0aa8-46b6-9c1e-c4759d53ce22
+  changeuuid: f350d640-b638-470d-b0f3-63d66c7ed777
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-company
+  broadcaster: independent
+  name: Radio Company
+  streamUrl: https://sphera.fluidstream.eu/company.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://www.radiocompany.com/wp-content/uploads/fbrfg/apple-touch-icon.png
+  homepage: https://www.radiocompany.com/
+  country: IT
+  status: stream-only
+  stationuuid: dc23adb6-dcf0-4744-bfa6-5a30cba6fa2b
+  changeuuid: c23ef01d-ae35-480b-83f8-1430457813a9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-united-music-italia-2000
+  broadcaster: independent
+  name: United Music Italia 2000
+  streamUrl: https://icy.unitedradio.it/um013.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.unitedmusic.com/favicon_6.ico?v=1722509814047
+  homepage: https://www.unitedmusic.com/
+  country: IT
+  status: stream-only
+  stationuuid: ed5388e2-d071-4369-af0c-d09a2e26c952
+  changeuuid: 7a063b8c-abf5-4dd5-acb5-bd951c16c809
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-50s-60s-retro-hits
+  broadcaster: independent
+  name: " 50s 60s RETRO HITS"
+  streamUrl: https://stream.zeno.fm/pxzwykxbluitv
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/f361b3_ea9b293c1b80488d97f24981e7c6c1d3~mv2.jpg
+  homepage: https://zeno.fm/radio/50s-60s-retro-hits/
+  country: IT
+  status: stream-only
+  stationuuid: 5532c4d9-616e-4d62-a49f-984a13e3189c
+  changeuuid: 1bb9f1c9-0645-43e3-99f0-8b94c43607aa
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-dumdum
+  broadcaster: independent
+  name: DumDUM
+  streamUrl: https://sr11.inmystream.it/proxy/dumdumradio
+  bitrate: 320
+  codec: MP3
+  favicon: https://www.dumdumrepublic.com/images/favicon-96x96.png
+  homepage: https://www.dumdumrepublic.com/it/radio-it/in-ascolto
+  country: IT
+  status: stream-only
+  stationuuid: fed3b0da-e61a-4b6d-8ba5-4f7b99d407a6
+  changeuuid: 9f433383-03aa-4b63-baf0-84a4a84a340c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-italia-italia-60
+  broadcaster: independent
+  name: ITALIA Italia 60
+  streamUrl: https://icy.unitedradio.it/um014.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: http://www.unitedmusic.it/
+  country: IT
+  status: stream-only
+  stationuuid: 25b1ffe1-760e-11ea-b1cf-52543be04c81
+  changeuuid: 784f4abc-b2a5-4d90-9436-eb15a6c0de98
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-italia-anni-60
+  broadcaster: independent
+  name: Radio Italia anni 60
+  streamUrl: https://str01.fluidstream.net/anni60.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radioitaliaanni60.it/
+  country: IT
+  status: stream-only
+  stationuuid: 6cde51f1-c733-4170-99d6-483fa4c63f1d
+  changeuuid: 2003302d-3227-457b-b5c2-4e73a3688f85
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-cavolo
+  broadcaster: independent
+  name: Radio Cavolo
+  streamUrl: https://radiocavolo.org/stream
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.radiocavolo.org/wp-content/uploads/2020/10/cropped-radio-cavolo-logo-white-background-300x300-1-180x180.png
+  homepage: https://www.radiocavolo.org/
+  country: IT
+  status: stream-only
+  stationuuid: 77ff2da8-6fd2-11ea-b1cf-52543be04c81
+  changeuuid: ba326bd9-13ed-4f75-b816-a745f22c28f6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-raisport
+  broadcaster: independent
+  name: Radio RaiSport
+  streamUrl: https://icecdn-19d24861e90342cc8decb03c24c8a419.msvdn.net/icecastRelay/S74167340/mmNY37FME5Zl/icecast
+  bitrate: 256
+  codec: MP3
+  favicon: https://static.mytuner.mobi/media/tvos_radios/ramgajabuhqm.jpg
+  homepage: https://www.raiplaysound.it/radio1sport
+  country: IT
+  status: stream-only
+  stationuuid: 30494962-3178-42e2-9b3e-60aa397f83d9
+  changeuuid: a8275d81-566a-47fc-a0d4-b079bd971e5e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-lifegate-radio
+  broadcaster: independent
+  name: LifeGate Radio
+  streamUrl: https://router.xdevel.com/audio0s975809-345/stream/icecast.audio
+  codec: MP3
+  favicon: https://www.fm-world.it/wp-content/uploads/2019/04/liferadio.png
+  homepage: https://www.lifegate.it/lifegate-radio
+  country: IT
+  status: stream-only
+  stationuuid: 467ec5d2-ea2a-4f7c-839a-69db2c365409
+  changeuuid: aaeb73a5-12f2-41be-b151-a0b5a0f413ca
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-forever-80
+  broadcaster: independent
+  name: FOREVER 80
+  streamUrl: https://stream.laut.fm/forever80
+  bitrate: 128
+  codec: MP3
+  homepage: https://forever80.altervista.org/
+  country: IT
+  status: stream-only
+  stationuuid: 05d5a867-deea-4957-a810-7eefcaf508cd
+  changeuuid: ed36592c-a5ad-4839-ab6c-94bf88afe599
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-crc
+  broadcaster: independent
+  name: Radio CRC
+  streamUrl: https://stream9.xdevel.com/audio2s975936-745/stream/icecast.audio
+  codec: MP3
+  favicon: https://crcnews.it/favicon.ico
+  homepage: https://crcnews.it/
+  country: IT
+  status: stream-only
+  stationuuid: 3b5f5ea9-2134-4426-b6c2-9b3e41a002aa
+  changeuuid: 210c66d1-0780-4985-9381-2284681283e0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-rtr-99-canzoni-e-parole-fuori-dal-coro
+  broadcaster: independent
+  name: RTR 99 Canzoni e parole fuori dal coro
+  streamUrl: https://rtr99.fluidstream.eu/rtr99.mp3?FLID=3
+  bitrate: 128
+  codec: MP3
+  homepage: https://rtr99.it/
+  country: IT
+  status: stream-only
+  stationuuid: 63b7ed83-da88-4d58-9118-efe1d37dc4f3
+  changeuuid: 42372549-2104-410e-9bfb-28772cd2590d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-italia-millenials-italy
+  broadcaster: independent
+  name: ITALIA Millenials Italy
+  streamUrl: https://icy.unitedradio.it/um021.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: http://www.unitedmusic.it/
+  country: IT
+  status: stream-only
+  stationuuid: edd1eb94-760e-11ea-b1cf-52543be04c81
+  changeuuid: eb542bfc-c325-4e76-8fec-7d4018ebc2af
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-rmc-music-star-pino-daniele
+  broadcaster: independent
+  name: RMC Music Star Pino Daniele
+  streamUrl: https://icy.unitedradio.it/Daniele.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radiomontecarlo.net/sezioni/10487/music-star-pino-daniele
+  country: IT
+  status: stream-only
+  stationuuid: c3493c19-add2-4cc1-acd0-8591fb2e6a76
+  changeuuid: 9159d211-6d85-4686-8324-8d0f2de2513d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-radicale
+  broadcaster: independent
+  name: Radio Radicale
+  streamUrl: https://live.radioradicale.it/live.mp3
+  codec: MP3
+  favicon: https://www.radioradicale.it/sites/www.radioradicale.it/files/favicon_0.ico
+  homepage: https://www.radioradicale.it/
+  country: IT
+  status: stream-only
+  stationuuid: 74cb9de6-d8c8-4295-a73c-aa6d3ced4ec8
+  changeuuid: 1beacbb4-63ff-4890-9e35-eaf7e81cdf3b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-relax-italia
+  broadcaster: independent
+  name: RADIO RELAX Italia
+  streamUrl: https://radiorelax.streamingmedia.it/play
+  bitrate: 192
+  codec: AAC+
+  homepage: https://radiorel.ax/
+  country: IT
+  status: stream-only
+  stationuuid: 8f159e64-9fc5-4cac-948f-c6dd303d78d2
+  changeuuid: 992204de-5be6-4b4d-94cd-f9f385cd1384
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-gamma-radio-golden-hits
+  broadcaster: independent
+  name: Gamma Radio - Golden Hits
+  streamUrl: https://rn2.fluidstream.eu/gammaradio.mp3?FLID=1&type=.mp3
+  bitrate: 256
+  codec: MP3
+  homepage: https://www.gammaradio.it/
+  country: IT
+  status: stream-only
+  stationuuid: 3f5f4fde-e7c8-48dd-bec6-969886292a48
+  changeuuid: fc17ac88-2920-423e-9933-eaae6c0d72e7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-italia-amore
+  broadcaster: independent
+  name: ITALIA Amore
+  streamUrl: https://icy.unitedradio.it/um012.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: http://www.unitedmusic.it/
+  country: IT
+  status: stream-only
+  stationuuid: 12405b91-760d-11ea-b1cf-52543be04c81
+  changeuuid: eae0a472-61ae-4b67-9015-8a5d0d362411
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-music-star-franco-battiato
+  broadcaster: independent
+  name: Music Star Franco Battiato
+  streamUrl: https://icy.unitedradio.it/um057.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radiomontecarlo.net/sezioni/12144/music-star-franco-battiato
+  country: IT
+  status: stream-only
+  stationuuid: 38767341-e305-4b48-9251-d833ba561dd9
+  changeuuid: 58df4c80-271e-48d2-ba56-1dd770e2bc52
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-italia-sanremo
+  broadcaster: independent
+  name: Radio Italia Sanremo
+  streamUrl: https://stream4.xdevel.com/audio2s976608-1381/stream/icecast.audio
+  codec: AAC+
+  favicon: https://www.radioitalia.it/images/logo-webradio-sanremo.png
+  homepage: https://www.radioitalia.it/
+  country: IT
+  status: stream-only
+  stationuuid: 3f4fc0e0-d771-4a56-acec-da43180a352b
+  changeuuid: 7c2eceaa-28e5-4dde-a22b-6d04e4b4e83b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-rmc-r-b
+  broadcaster: independent
+  name: "RMC R&B"
+  streamUrl: https://icy.unitedradio.it/rmcweb003
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radiomontecarlo.net/sezioni/12052/radio-monte-carlo-r-b
+  country: IT
+  status: stream-only
+  stationuuid: 04284ca0-3852-46cc-b6f7-8a28b82c0587
+  changeuuid: 486cc55f-ab15-4869-bf5f-0f4811f4bb59
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-rete-radio-azzurra
+  broadcaster: independent
+  name: rete radio azzurra
+  streamUrl: https://reteradioazzurra.radioca.st/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.reteradioazzurra.it/
+  homepage: https://www.reteradioazzurra.it/
+  country: IT
+  status: stream-only
+  stationuuid: 86b7c416-5e84-4b61-b88e-17b21be94967
+  changeuuid: 5945edf4-d1a3-4934-842f-2c7ee7d18ca1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-70-80-90-dance-marche
+  broadcaster: independent
+  name: Radio 70 80 90 Dance Marche
+  streamUrl: https://rblive.it:8060/radio.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.radio708090.it/diretta-dance/
+  country: IT
+  status: stream-only
+  stationuuid: 5e698557-ac9b-4cff-b7c2-125ac70c8b03
+  changeuuid: 994c635a-f2d1-47b7-8764-ee71deece8fe
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-italia-viva-napoli
+  broadcaster: independent
+  name: ITALIA Viva Napoli
+  streamUrl: https://icy.unitedradio.it/um017.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: http://www.unitedmusic.it/
+  country: IT
+  status: stream-only
+  stationuuid: 51b0f78f-760f-11ea-b1cf-52543be04c81
+  changeuuid: 4a98f7d6-6238-4bad-ac38-a8e6aea7fca5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-globo-vintage
+  broadcaster: independent
+  name: Globo Vintage
+  streamUrl: https://m100.newradio.it/m100-64
+  bitrate: 96
+  codec: AAC+
+  favicon: https://static.wixstatic.com/media/cb9577_389d27d8f1214dfba6d28a9381d7ccdc%7emv2.png/v1/fill/w_180%2ch_180%2clg_1%2cusm_0.66_1.00_0.01/cb9577_389d27d8f1214dfba6d28a9381d7ccdc%7emv2.png
+  homepage: http://www.globovintage.it/
+  country: IT
+  status: stream-only
+  stationuuid: bfcf9b2d-b008-420b-a342-b868aee01e19
+  changeuuid: fe8c5edc-ae55-4347-bad5-72fd1c9d65a2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-popolare
+  broadcaster: independent
+  name: Radio Popolare
+  streamUrl: https://livex.radiopopolare.it/radiopop2
+  bitrate: 64
+  codec: AAC+
+  homepage: https://www.radiopopolare.it/
+  country: IT
+  status: stream-only
+  stationuuid: cdbe6306-c69f-420a-9a43-137e5b9c16ad
+  changeuuid: 4ca45b53-14c0-4cf7-b967-e26ccabe5b20
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-tmw-radio
+  broadcaster: independent
+  name: TMW Radio
+  streamUrl: https://stream.tmwradio.com/tmw.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://www.tmwradio.com/template/tmwradio.com/default/favicon/favicon144.png
+  homepage: https://www.tmwradio.com/
+  country: IT
+  status: stream-only
+  stationuuid: 5a96524a-5cde-11ea-be63-52543be04c81
+  changeuuid: 4456389c-7008-476a-b9fe-8c08f4458cce
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-deegay-pop-dance
+  broadcaster: independent
+  name: "DeeGay Pop & Dance"
+  streamUrl: https://stream.deegay.fm/deegay1.mp3
+  codec: MP3
+  homepage: https://www.deegay.fm/
+  country: IT
+  status: stream-only
+  stationuuid: e98dc9e0-c582-4a8e-a90c-e14add53ed0f
+  changeuuid: d7aceb72-1103-4e62-bd16-78c8176def74
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-lolli-radio-hits
+  broadcaster: independent
+  name: Lolli Radio Hits
+  streamUrl: https://stream.lolliradio.net/lolli_hits.mp3
+  codec: MP3
+  favicon: http://www.lolliradio.net/wp-content/uploads/2016/02/logo_hits-150x150.jpg
+  homepage: http://www.lolliradio.net/
+  country: IT
+  status: stream-only
+  stationuuid: 960e5fae-0601-11e8-ae97-52543be04c81
+  changeuuid: 587888f0-4551-4251-aa49-b605dac6934b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-100-nu-disco-central-radio
+  broadcaster: independent
+  name: " # 100 NU-DISCO CENTRAL RADIO"
+  streamUrl: https://stream.zeno.fm/jqhhzffjynbuv
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/f361b3_66f56cd8d2f44aed871cfd62bf70af65~mv2.jpg
+  homepage: https://zeno.fm/radio/100-nu-disco-central-radio/
+  country: IT
+  status: stream-only
+  stationuuid: 68df3c3b-d0e5-4290-8a5e-364a33e2d334
+  changeuuid: 8ad81eb7-c114-4584-b9e2-2af908094b87
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-deejay-80
+  broadcaster: independent
+  name: Deejay 80
+  streamUrl: https://4c4b867c89244861ac216426883d1ad0.msvdn.net/webradio/deejay80/playlist.m3u8
+  bitrate: 128
+  codec: AAC
+  favicon: https://www.deejay.it/favicon.ico
+  homepage: https://www.deejay.it/
+  country: IT
+  status: stream-only
+  stationuuid: ae0354a3-a57c-477d-8dc9-8bd4464aedbd
+  changeuuid: 29616a5f-b5b6-4cae-bd2a-aeaac65276cd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-italia-rock-italiano
+  broadcaster: independent
+  name: ITALIA Rock Italiano
+  streamUrl: https://icy.unitedradio.it/um076.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: http://www.unitedmusic.it/
+  country: IT
+  status: stream-only
+  stationuuid: 5cf3bd5f-760e-11ea-b1cf-52543be04c81
+  changeuuid: e554f381-e57d-4ba8-9c16-dfdafdc0a5b2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-nature-radio-sleep
+  broadcaster: independent
+  name: NATURE RADIO SLEEP
+  streamUrl: https://az1.mediacp.eu/listen/natureradiosleep/radio.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://d1ujqdpfgkvqfi.cloudfront.net/favicon-generator/htdocs/favicons/2025-03-01/fb714c8d8238b02673a9ee2b018528af.ico.png
+  homepage: https://natureradiosleep.weebly.com/
+  country: IT
+  status: stream-only
+  stationuuid: 77eaf32d-241f-4f25-b7d6-347783cd4471
+  changeuuid: e897700d-69f0-4a39-97fc-2e871cf16754
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-deegay-classic
+  broadcaster: independent
+  name: DeeGay Classic
+  streamUrl: https://stream.deegay.fm/deegay2.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://play5.newradio.it/contents/uploads/logo-43441.png
+  homepage: https://www.deegay.fm/
+  country: IT
+  status: stream-only
+  stationuuid: aedb966a-69d2-4d72-afe1-61e66b6c3711
+  changeuuid: 79a108f3-11f1-460e-8e1d-e2ee5ec3b079
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-virgin-radio-rockstar-bon-jovi
+  broadcaster: independent
+  name: "Virgin Radio Rockstar: Bon Jovi"
+  streamUrl: https://icy.unitedradio.it/um1027.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.virginradio.it/sezioni/12080/rockstar-bon-jovi
+  country: IT
+  status: stream-only
+  stationuuid: 7cf450b4-2b1d-4aaf-af19-5d1efb7ce95d
+  changeuuid: 9fc97018-f704-445d-8d44-30b395dfc681
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-funky-radio
+  broadcaster: independent
+  name: Funky Radio
+  streamUrl: https://funkyradio.streamingmedia.it/play.mp3
+  bitrate: 320
+  codec: MP3
+  favicon: https://funky.radio/wp-content/uploads/2024/05/funky.radio_logo_300x300.webp
+  homepage: https://funky.radio/
+  country: IT
+  status: stream-only
+  stationuuid: 737d604c-df80-4886-8883-538febcb4189
+  changeuuid: cb6408bb-16db-41fb-8060-ed18db3e0ff0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-giornale-radio-ultima-ora
+  broadcaster: independent
+  name: Giornale Radio Ultima Ora
+  streamUrl: https://gr.fluidstream.eu/gr2.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: https://giornaleradio.fm/radio-tematiche/giornale-radio-ultima-ora.html
+  country: IT
+  status: stream-only
+  stationuuid: fa80ca1a-24a7-4b01-85d7-2b5417c73b74
+  changeuuid: 59eeda48-62ea-49d0-b1ca-c36821d80edc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-easy-rock
+  broadcaster: independent
+  name: Radio Easy Rock
+  streamUrl: https://sphera.fluidstream.eu/easyrock.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://www.radioeasyrock.it/wp-content/uploads/2023/01/radio-easy-rock-logo-1.png
+  homepage: https://www.radioeasyrock.it/
+  country: IT
+  status: stream-only
+  stationuuid: eb3657fa-7156-453d-843c-ba26768cca6e
+  changeuuid: e2fea7e3-6076-454d-ae75-e4d9f2820695
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-rmc-acoustic
+  broadcaster: independent
+  name: RMC Acoustic
+  streamUrl: https://icy.unitedradio.it/rmcweb016
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radiomontecarlo.net/sezioni/11911/radio-monte-carlo-acoustic
+  country: IT
+  status: stream-only
+  stationuuid: 3265e40f-ccfc-442f-9619-d91d56d4c9b1
+  changeuuid: ef80632e-1370-4218-82f5-3693451c7ef7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-deegay-club
+  broadcaster: independent
+  name: DeeGay Club
+  streamUrl: https://stream.deegay.fm/deegay3.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.deegay.fm/favicon.ico
+  homepage: https://www.deegay.fm/
+  country: IT
+  status: stream-only
+  stationuuid: aa0c4df3-e693-4120-ae62-3ac84aaa8543
+  changeuuid: d124d04e-5262-4f73-8055-97db76d65e94
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-venezia
+  broadcaster: independent
+  name: Radio Venezia
+  streamUrl: https://audio.streamshow.it/proxy/rveradiocheballa?mp
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.veneziaradiotv.it/
+  country: IT
+  status: stream-only
+  stationuuid: f05a57ae-bd8d-4681-9c3c-5bc396492747
+  changeuuid: 423fdba5-9378-4457-b313-fc51e9156047
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-rai-radiodue
+  broadcaster: independent
+  name: Rai RadioDue
+  streamUrl: https://icecdn-19d24861e90342cc8decb03c24c8a419.msvdn.net/icecastRelay/S35942484/yp5F67151K92/icecast
+  bitrate: 256
+  codec: MP3
+  homepage: https://www.raiplaysound.it/radio2
+  country: IT
+  status: stream-only
+  stationuuid: e610c4ad-1989-498e-8234-a5ca6f23b40b
+  changeuuid: 1ecc9de1-2e69-4ecd-bb18-3ebcfe4b8e19
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-rmc-music-star-coldplay
+  broadcaster: independent
+  name: RMC Music Star Coldplay
+  streamUrl: https://icy.unitedradio.it/ColdPlay.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radiomontecarlo.net/sezioni/10489/music-star-coldplay
+  country: IT
+  status: stream-only
+  stationuuid: 3a032cb4-e9fd-4c49-92dc-3d0e194c95a3
+  changeuuid: bd035a58-9ee2-49ba-baff-69e5b3d862bb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-bandito
+  broadcaster: independent
+  name: Radio Bandito
+  streamUrl: https://s2.radio.co/s8add5b3eb/listen
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.radiobandito.it/wp-content/uploads/2022/04/cropped-cropped-rb-180x180.png
+  homepage: https://radiobandito.it/
+  country: IT
+  status: stream-only
+  stationuuid: c8f34992-4f1d-44d3-a521-0e7895355f4f
+  changeuuid: 1b85f59a-8e84-4a9d-8e56-7037f9f2ce15
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-italia-anni-60-emilia-romagna-e-marche
+  broadcaster: independent
+  name: Radio Italia Anni 60 (Emilia-Romagna e Marche)
+  streamUrl: https://ice04.fluidstream.net/ria60_bo.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://radioitaliaannisessanta.it/templates/enar/images/favicon/apple-touch-icon-120x120.png
+  homepage: https://radioitaliaannisessanta.it/
+  country: IT
+  status: stream-only
+  stationuuid: e2bba5e4-671e-4d79-abfc-ea9d80429a6e
+  changeuuid: 6d81847b-aee0-4100-8802-d37a9a709f34
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-lolli-radio-happy-station
+  broadcaster: independent
+  name: Lolli Radio Happy Station
+  streamUrl: https://stream.lolliradio.net/lolli_happy.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: http://www.lolliradio.net/wp-content/uploads/2016/02/logo_happy-150x150.jpg
+  homepage: http://www.lolliradio.net/
+  country: IT
+  status: stream-only
+  stationuuid: 960e5edf-0601-11e8-ae97-52543be04c81
+  changeuuid: 716d9240-8f02-45af-a46f-ededf84921a1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-70-80-90
+  broadcaster: independent
+  name: "70 80 90"
+  streamUrl: https://rblive.it:8170/radio.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.radio708090.it/wp-content/uploads/2021/10/708090-160-150x150.png
+  homepage: https://www.radio708090.it/
+  country: IT
+  status: stream-only
+  stationuuid: e81cf293-174e-4936-b3cb-db62decedacd
+  changeuuid: a79c1486-5929-4997-9a39-313bc7424c64
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-electro-lounge
+  broadcaster: independent
+  name: Electro Lounge
+  streamUrl: https://electrolounge.stream.laut.fm/electrolounge?pl=m3u&t302=2026-01-14_23-25-32&uuid=4a7f7217-7b1e-45d3-8bd7-ee9f329c080e
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.electrolounge.eu/
+  country: IT
+  status: stream-only
+  stationuuid: f768db9e-bb3e-4b2c-b61a-dabc83f80afa
+  changeuuid: 8cdd1b4f-47c0-4038-a96c-7214090915dd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-rtl-102-5-best
+  broadcaster: independent
+  name: RTL 102.5 Best
+  streamUrl: https://streamingv2.shoutcast.com/rtl-1025-best
+  bitrate: 256
+  codec: MP3
+  favicon: https://cloud.rtl.it/assets/play.rtl.it/2.1.5/img/logo/favicon-96x96.png
+  homepage: https://play.rtl.it/live/2/best/
+  country: IT
+  status: stream-only
+  stationuuid: b0440b72-887a-4fe6-9d8a-5ffaa95f9935
+  changeuuid: 768c06c2-688d-4da2-a17f-54372e703d60
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-milano-xr
+  broadcaster: independent
+  name: Milano XR
+  streamUrl: https://milanoxr.gatesweb.info:8443/live
+  bitrate: 96
+  codec: AAC+
+  favicon: https://milanoxr.gatesweb.info:8443/milanoxr_logo-300-sq.jpg
+  homepage: http://milanoxr.weebly.com/
+  country: IT
+  status: stream-only
+  stationuuid: ab8ad709-f711-11e8-a471-52543be04c81
+  changeuuid: e47e3bd2-a729-44e9-8173-b07e2c861a19
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-easy-network-jazz-soul
+  broadcaster: independent
+  name: "Easy Network Jazz & Soul"
+  streamUrl: https://sphera.fluidstream.eu/easy_jazz.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.easynetwork.fm/
+  country: IT
+  status: stream-only
+  stationuuid: 69acf0e5-5fcb-41c0-940a-c0bb931fdfd5
+  changeuuid: 127d2a6b-4b9e-43d2-90d4-dad216210d25
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-venice-classic-radio-auditorium
+  broadcaster: independent
+  name: Venice Classic Radio Auditorium
+  streamUrl: https://uk2.streamingpulse.com/ssl/vcr2
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.veniceclassicradio.eu/
+  country: IT
+  status: stream-only
+  stationuuid: 4517523d-6fb7-4e1b-9b1a-22fcae079099
+  changeuuid: 78032281-c3dc-4410-a62e-4712364fd1b4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-china-fm-fm89-5
+  broadcaster: independent
+  name: 华夏之声China FM·意大利罗马FM89.5
+  streamUrl: https://radioserver12.profesionalhosting.com/proxy/pkg152492/stream
+  bitrate: 160
+  codec: AAC+
+  homepage: https://chinafm.es/
+  country: IT
+  status: stream-only
+  stationuuid: 5b71769e-5f69-4dfd-bc30-481d567278ce
+  changeuuid: c96d9698-273a-4fda-aa9c-bda255afbf81
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-bruno-pentasport-fiorentina
+  broadcaster: independent
+  name: "\tRadio Bruno Pentasport Fiorentina"
+  streamUrl: https://stream3.xdevel.com/audio6s975355-281/stream/icecast.audio
+  codec: AAC+
+  favicon: https://www.radiobruno.it/wp-content/uploads/2023/10/logo-148-90-black1.png
+  homepage: http://www.radiobrunotoscana.it/
+  country: IT
+  status: stream-only
+  stationuuid: 0c6860fd-dfec-469d-9ef7-48711c43d465
+  changeuuid: e8166f4c-e1d5-4a25-b544-b6764c077c6f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-rmc-music-star-zucchero
+  broadcaster: independent
+  name: RMC Music Star Zucchero
+  streamUrl: https://icy.unitedradio.it/Zucchero.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radiomontecarlo.net/sezioni/10492/music-star-zucchero
+  country: IT
+  status: stream-only
+  stationuuid: c6f4f114-6e99-4db0-999f-8cc80eeda712
+  changeuuid: 2cac1594-0269-4f39-9cdb-62561e0528b5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-olympia
+  broadcaster: independent
+  name: Radio Olympia
+  streamUrl: https://sr6.inmystream.it/proxy/radiosonica2?mp=/stream
+  bitrate: 32
+  codec: AAC+
+  favicon: https://www.radioolympia.it/favicon.png
+  homepage: https://www.radioolympia.it/
+  country: IT
+  status: stream-only
+  stationuuid: c81214db-2625-4d5c-8c39-b79ee8e6c923
+  changeuuid: f46aa675-49e3-4ad0-906f-af7cfbdf616d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-deejay-suona-italia
+  broadcaster: independent
+  name: Deejay Suona Italia
+  streamUrl: https://4c4b867c89244861ac216426883d1ad0.msvdn.net/webradio/deejaysuonaitalia/playlist.m3u8
+  bitrate: 128
+  codec: AAC
+  favicon: https://cdn.gelestatic.it/deejay/sites/2/2015/05/webradio_deejay_suona_italia-320x320.png
+  homepage: https://www.deejay.it/
+  country: IT
+  status: stream-only
+  stationuuid: ad330c56-0bf6-4a60-9da6-8f95bb3e46dd
+  changeuuid: 45db0869-da60-4555-8fb0-58eb712856db
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-margherita
+  broadcaster: independent
+  name: "\tRadio Margherita "
+  streamUrl: https://streaming.radiomargherita.com/stream/radiomargherita
+  bitrate: 320
+  codec: MP3
+  favicon: http://www.radiomargherita.com/favicon.ico
+  homepage: http://www.radiomargherita.com/
+  country: IT
+  status: stream-only
+  stationuuid: 259504da-522f-4668-8f0f-9746756959cf
+  changeuuid: 0e8ca6d3-5a21-443c-9c5a-92e462ccfc13
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-giornale-radio-la-dolce-vita
+  broadcaster: independent
+  name: Giornale Radio La Dolce Vita
+  streamUrl: https://gr.fluidstream.eu/gr7.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://giornaleradio.fm/radio-tematiche/giornale-radio-dolce-la-vita.html
+  country: IT
+  status: stream-only
+  stationuuid: d1a0717c-09b8-4d72-8413-53db61b80f43
+  changeuuid: d2def21f-c375-4597-984b-79ca1ef58278
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-rai-isoradio
+  broadcaster: independent
+  name: Rai Isoradio
+  streamUrl: https://icecdn-19d24861e90342cc8decb03c24c8a419.msvdn.net/icecastRelay/S3822289/9T4F68Q3TT4m/icecast
+  bitrate: 256
+  codec: MP3
+  favicon: https://www.raiplaysound.it/assets/img/canali/logo-raiisoradio.svg
+  homepage: https://www.raiplaysound.it/isoradio
+  country: IT
+  status: stream-only
+  stationuuid: edbfa8f0-73b3-44e9-97cc-f687e2893aa8
+  changeuuid: eefd9cfe-c588-41b5-ba49-b600e08e9858
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-rock
+  broadcaster: independent
+  name: Radio Rock
+  streamUrl: https://onlineradiobox.com/json/it/radiorock/play?platform=web
+  bitrate: 64
+  codec: AAC
+  homepage: http://www.radiorock.it/
+  country: IT
+  status: stream-only
+  stationuuid: 349f2f7e-3f30-4a67-a3a4-82f30394c0c6
+  changeuuid: 5dbdb25d-9dbc-401d-adfa-b5e5ad4c4ee1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-rouge-italy
+  broadcaster: independent
+  name: " Radio Rouge Italy"
+  streamUrl: https://nl1.streamingpulse.com/ssl/radiorougeitaly
+  bitrate: 320
+  codec: MP3
+  homepage: https://radiorouge.com/
+  country: IT
+  status: stream-only
+  stationuuid: 07ee48b6-cd55-4557-b569-8b717841b2e9
+  changeuuid: 591c36bb-76a2-44c3-83d9-394d5e82183c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-lolli-radio-soft
+  broadcaster: independent
+  name: Lolli Radio Soft
+  streamUrl: https://stream.lolliradio.net/lolli_soft.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: http://lolliradio.net/
+  country: IT
+  status: stream-only
+  stationuuid: 9611fe5d-0601-11e8-ae97-52543be04c81
+  changeuuid: 40db3eaa-7c15-4fb6-a7fb-094633019589
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-rmc-music-star-tiziano-ferro
+  broadcaster: independent
+  name: RMC Music Star Tiziano Ferro
+  streamUrl: https://icy.unitedradio.it/Ferro.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radiomontecarlo.net/sezioni/10491/music-star-tiziano-ferro
+  country: IT
+  status: stream-only
+  stationuuid: d57a80dc-904b-49fc-82d1-986381b5afd2
+  changeuuid: e1a9c973-caba-4a11-9e77-2bc4b074f590
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-gedi-radio-capital-funky-town
+  broadcaster: independent
+  name: GEDI - Radio Capital Funky Town
+  streamUrl: https://streamcdnr11-4c4b867c89244861ac216426883d1ad0.msvdn.net/radiocapitalfunkytown/radiocapitalfunkytown/play1.m3u8
+  codec: UNKNOWN
+  favicon: https://www.capital.it/wp-content/themes/network-capital/favicon.ico
+  homepage: https://www.capital.it/webradio/03/
+  country: IT
+  status: stream-only
+  stationuuid: 1627892b-c68d-4d0b-9688-92b748764ef0
+  changeuuid: 30a59a1e-ce2b-42da-9f02-7d1ef702cc6f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-capital-music
+  broadcaster: independent
+  name: Radio Capital Music
+  streamUrl: https://4c4b867c89244861ac216426883d1ad0.msvdn.net/webradio/capitalmusic/playlist.m3u8
+  bitrate: 128
+  codec: AAC
+  favicon: https://cdn.gelestatic.it/capital/sites/2/2016/11/webradio-music-320x320.jpg
+  homepage: https://www.capital.it/
+  country: IT
+  status: stream-only
+  stationuuid: 7a7db53d-ac80-4e26-a6c4-bf706657709f
+  changeuuid: 2570bea1-8487-42a7-b79b-0f7424296d9f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-onda-d-urto
+  broadcaster: independent
+  name: "Radio Onda d'urto"
+  streamUrl: https://hochimin.urtostream.org:8443/radiondadurto.mp3
+  bitrate: 80
+  codec: MP3
+  homepage: https://www.radiondadurto.org/
+  country: IT
+  status: stream-only
+  stationuuid: abe84722-1ff1-471a-b048-7f761b2056a0
+  changeuuid: e97057f2-04b6-49f8-8c38-b15ed3d07059
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-discoradio
+  broadcaster: independent
+  name: Discoradio
+  streamUrl: https://stream.discoradio.radio/audio/disco.stream_aac64/chunklist.m3u8
+  codec: UNKNOWN
+  country: IT
+  status: stream-only
+  stationuuid: 29535b8e-f58e-4d93-b354-b82b0d254cb5
+  changeuuid: ee5a5d7c-e127-4570-8d5d-f9b478c4d535
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-united-music-cinema
+  broadcaster: independent
+  name: United Music Cinema
+  streamUrl: https://icy.unitedradio.it/um058.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.unitedmusic.com/
+  country: IT
+  status: stream-only
+  stationuuid: b95c4f97-d4c2-4f66-9a86-8d0e9ba5f6e0
+  changeuuid: d19bcf70-02a7-44d0-ba36-5cd7b88e3dfb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-deejay-30-songs
+  broadcaster: independent
+  name: Deejay 30 Songs
+  streamUrl: https://4c4b867c89244861ac216426883d1ad0.msvdn.net/radiodeejay30songs/radiodeejay30songs/master_ma.m3u8
+  bitrate: 122
+  codec: AAC+
+  favicon: http://cdn.gelestatic.it/deejay/www/2015/05/webradio_30_songs.png
+  homepage: https://www.deejay.it/webradio/06/
+  country: IT
+  status: stream-only
+  stationuuid: 2c806fe7-67de-4bc4-9a53-1b2920ca4b81
+  changeuuid: 2efaed12-077e-49d6-9432-34934267f4e0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-capital-w-l-italia
+  broadcaster: independent
+  name: "Radio Capital W L'Italia"
+  streamUrl: https://4c4b867c89244861ac216426883d1ad0.msvdn.net/webradio/capitalwitalia/playlist.m3u8
+  bitrate: 128
+  codec: AAC
+  favicon: https://cdn.gelestatic.it/capital/sites/2/2016/11/webradio-vivalitalia-320x320.jpg
+  homepage: https://www.capital.it/
+  country: IT
+  status: stream-only
+  stationuuid: ccdd09af-a0dd-4277-88b6-0f3564d88d29
+  changeuuid: 4558a0ff-faa9-4447-b9e3-2a0a55558f31
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-pulcinella
+  broadcaster: independent
+  name: RADIO PULCINELLA
+  streamUrl: https://stream.zeno.fm/9dve9gmfakhvv
+  codec: MP3
+  homepage: https://stream.zeno.fm/
+  country: IT
+  status: stream-only
+  stationuuid: 05677169-036d-4704-a32d-9361f842acc7
+  changeuuid: 861b8209-9bc2-47be-bc00-2587b66fd5fa
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-international
+  broadcaster: independent
+  name: Radio International
+  streamUrl: https://ice08.fluidstream.net/fluid813.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.radiointernationalstore.it/wp-content/uploads/2021/01/cropped-74939-television-media-youtube-streaming-live-broadcasting-radio-180x180.png
+  homepage: https://www.radiointernationalstore.it/
+  country: IT
+  status: stream-only
+  stationuuid: 753bf35e-1be2-438c-9c15-39dc305d0d52
+  changeuuid: bfe80391-3919-4ba3-8aeb-79d914946297
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-dimensione-relax
+  broadcaster: independent
+  name: RADIO DIMENSIONE RELAX
+  streamUrl: https://az1.mediacp.eu/listen/radiodimensionerelax/radio.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://favicon-generator.org/favicon-generator/htdocs/favicons/2025-01-13/a46c8e118c24923aa862f46d62f93152.ico.png
+  homepage: https://rdastation.it/
+  country: IT
+  status: stream-only
+  stationuuid: d7a0a800-b461-44f0-a444-058e10f27e7c
+  changeuuid: 7be2e7fd-20d5-4ef9-9477-d8462bff9586
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-rmc-music-star-jovanotti
+  broadcaster: independent
+  name: RMC Music Star Jovanotti
+  streamUrl: https://icy.unitedradio.it/Jovanotti.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radiomontecarlo.net/sezioni/10493/music-star-jovanotti
+  country: IT
+  status: stream-only
+  stationuuid: 2e7eea21-77d1-43b3-83e5-cd7c11e12eb2
+  changeuuid: 650c6f68-b2a1-43d0-938d-3db80a847e6b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-lifegate-radio-blues
+  broadcaster: independent
+  name: LifeGate Radio Blues
+  streamUrl: https://router.xdevel.com/audio3s975809-348/stream/icecast.audio
+  codec: MP3
+  favicon: https://www.lifegate.it/app/themes/lifegate-2020/dist/images/apple-touch-icon.png
+  homepage: https://www.lifegate.it/lifegate-radio
+  country: IT
+  status: stream-only
+  stationuuid: e773d65c-4cad-45fa-808d-2f152aed1ee4
+  changeuuid: 262466e9-65ab-48c6-9071-e0c7e427529d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-deejay-time
+  broadcaster: independent
+  name: Deejay Time
+  streamUrl: https://4c4b867c89244861ac216426883d1ad0.msvdn.net/webradio/deejaytime/playlist.m3u8
+  bitrate: 128
+  codec: AAC
+  favicon: https://cdn.gelestatic.it/deejay/sites/2/2015/05/webradio_deejay_time-320x320.png
+  homepage: https://www.deejay.it/
+  country: IT
+  status: stream-only
+  stationuuid: 02d0b200-ac03-4351-a3ae-7c853340ebd6
+  changeuuid: b8383d72-15df-4892-a2f3-20c8af356659
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-napoli-doc
+  broadcaster: independent
+  name: Radio Napoli Doc
+  streamUrl: https://ice08.fluidstream.net/RadioNapoli.aac
+  bitrate: 64
+  codec: AAC
+  homepage: https://online-radio.eu/radio/27319-radio-napoli-doc
+  country: IT
+  status: stream-only
+  stationuuid: 75c74370-fa71-43e7-bc51-7732cd36aa1b
+  changeuuid: 856bb3d5-a135-4c98-af55-2b745827822e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-rai-radio3classica
+  broadcaster: independent
+  name: Rai Radio3Classica
+  streamUrl: https://icecdn-19d24861e90342cc8decb03c24c8a419.msvdn.net/icecastRelay/S53422322/bTdUFhYMnnra/icecast
+  bitrate: 256
+  codec: MP3
+  favicon: https://www.raiplaysound.it/assets/img/canali/logo-rairadio3classica.svg
+  homepage: https://www.raiplaysound.it/radio3classica
+  country: IT
+  status: stream-only
+  stationuuid: 6273ed0d-ce22-4cd9-84bd-c5ace0a402c2
+  changeuuid: 8bde60bf-24d5-408d-87e2-63e48ef251be
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-rai-radio-classica-322-kb-s
+  broadcaster: independent
+  name: Rai Radio Classica (322 kb/s)
+  streamUrl: https://radiotreclassica-live.akamaized.net/hls/live/2032595/radiotreclassica/radiotreclassica/playlist.m3u8
+  bitrate: 320
+  codec: AAC
+  favicon: https://upload.wikimedia.org/wikipedia/commons/thumb/f/fd/Rai_Radio_3_-_Logo_2017.svg/2880px-Rai_Radio_3_-_Logo_2017.svg.png
+  homepage: https://www.raiplaysound.it/radio3
+  country: IT
+  status: stream-only
+  stationuuid: 5c9c937e-3363-42c4-90e6-31a2c4992e41
+  changeuuid: 993796a8-f918-4c24-be9e-ee5f3b0276ec
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-kiss-kiss-disco-party
+  broadcaster: independent
+  name: Radio Kiss Kiss Disco Party
+  streamUrl: https://kk.fluidstream.eu/kk_discoparty.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://kisskiss.it/wp-content/uploads/elementor/thumbs/discoparty-pn2hglt9od540vyjui55frxmsrj4cmhi5s4v32izak.png
+  homepage: https://kisskiss.it/webradio/kiss-kiss-disco-party/
+  country: IT
+  status: stream-only
+  stationuuid: 56dced92-aa5e-4594-930f-3ddf524f5bcb
+  changeuuid: 027670fd-9985-4690-b38e-a4eb3f743d4b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-nbc-milano
+  broadcaster: independent
+  name: NBC Milano
+  streamUrl: https://nr7.newradio.it:19350/stream
+  bitrate: 256
+  codec: MP3
+  favicon: https://www.70-80.it/wp-content/uploads/2020/03/logo-70-80-75x75.jpg
+  homepage: https://www.nbcmilano.it/
+  country: IT
+  status: stream-only
+  stationuuid: 473af0de-e9c8-41eb-bd45-47be38592e6c
+  changeuuid: eb7db47f-9d20-494e-bf99-5217508e1799
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-dimensione-suono-soft
+  broadcaster: independent
+  name: Dimensione Suono Soft
+  streamUrl: https://stream.dimensionesuonosoft.radio/audio/dssc.stream_aac64/playlist.m3u8
+  bitrate: 64
+  codec: AAC
+  favicon: https://www.radio.de/images/broadcasts/25/0f/117624/1/c300.png
+  homepage: https://www.dimensionesuonosoft.it/
+  country: IT
+  status: stream-only
+  stationuuid: f03eb972-1ff7-4b98-9095-f7fcb135a7be
+  changeuuid: 12a8c468-0bc7-4aa2-8037-8ad89e22e8c0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-gemini
+  broadcaster: independent
+  name: Radio Gemini
+  streamUrl: https://geminione.it/proxy/gemini/stream
+  bitrate: 128
+  codec: AAC+
+  homepage: http://www.radiogemini.net/
+  country: IT
+  status: stream-only
+  stationuuid: 70890285-e40f-40fb-b4d8-9ff6f254927b
+  changeuuid: 9fd28c23-4ee0-4afa-81bd-dfaabc9183f8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio54
+  broadcaster: independent
+  name: Radio54
+  streamUrl: https://nr7.newradio.it/proxy/radiosol?mp=/stream
+  bitrate: 320
+  codec: MP3
+  homepage: https://www.radio54.it/
+  country: IT
+  status: stream-only
+  stationuuid: d01f170e-3623-4612-a6dd-03a35e68c207
+  changeuuid: 32a70736-66fd-42a4-a51c-0822b1e677a0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-musica-jazz-radio
+  broadcaster: independent
+  name: Musica Jazz Radio
+  streamUrl: https://ice16.fluidstream.net/mjr.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://musicajazz.it/wp-content/uploads/logo-120.png
+  homepage: https://www.musicajazz.it/radio/
+  country: IT
+  status: stream-only
+  stationuuid: 03bf6559-d0bb-43f1-9ad0-cf7b0a6ee035
+  changeuuid: c3596127-2353-40e8-98d3-b4442701d63c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-padova-history-italia
+  broadcaster: independent
+  name: Radio Padova History Italia
+  streamUrl: https://sphera.fluidstream.eu/rpd_hita.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.radiopadova.com/history-italia/android-icon-192x192.png
+  homepage: https://www.radiopadova.com/
+  country: IT
+  status: stream-only
+  stationuuid: 98e79f6b-8f54-4698-badd-e384ec58877f
+  changeuuid: 194803b1-b4c9-4f50-a933-92f9670e7c58
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-forever-90
+  broadcaster: independent
+  name: FOREVER 90
+  streamUrl: https://stream.laut.fm/forever90
+  bitrate: 128
+  codec: MP3
+  favicon: https://forever80.altervista.org/wp-content/uploads/2020/01/FOREVER-90-dance-pop-320x207.jpg
+  homepage: https://forever80.altervista.org/
+  country: IT
+  status: stream-only
+  stationuuid: b930d44d-7fb6-416b-b637-590a81220da4
+  changeuuid: f03a3fe6-89cc-4c61-9ee6-d4151a5e1207
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-forever-70
+  broadcaster: independent
+  name: FOREVER 70
+  streamUrl: https://stream.laut.fm/forever70
+  bitrate: 128
+  codec: MP3
+  favicon: https://forever80.altervista.org/wp-content/uploads/2020/01/FOREVER-70-DANCE-POP-320x207.jpg
+  homepage: https://forever80.altervista.org/
+  country: IT
+  status: stream-only
+  stationuuid: ac6091b9-49bc-4768-b4dc-46051a4ecea2
+  changeuuid: 8737a39f-ef71-4afa-a607-cbe778dde467
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-digitalia-ricordi
+  broadcaster: independent
+  name: Radio Digitalia - Ricordi
+  streamUrl: https://radiodigitalia-ricordi.stream.laut.fm/radiodigitalia-ricordi?t302=2021-06-10_16-57-30&uuid=8aef2612-2637-4877-8c1b-d3d775186258
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radiodigitalia.net/
+  country: IT
+  status: stream-only
+  stationuuid: 0bf9e338-d081-45fc-ac5e-8850f4480958
+  changeuuid: 14010548-aa78-4425-a9ff-5b7382f79ab3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-marte
+  broadcaster: independent
+  name: Radio Marte
+  streamUrl: https://stream1.xdevel.com/audio0s975753-313/stream/icecast.audio
+  codec: MP3
+  country: IT
+  status: stream-only
+  stationuuid: 3c07f666-302e-4fc1-b95c-12c28023d68d
+  changeuuid: 6fa1fd00-ef5c-44e3-871d-0eba3c5e1243
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-volami-nel-cuore
+  broadcaster: independent
+  name: Radio Volami nel Cuore
+  streamUrl: https://rci.canaleitalia.tv:8009/;
+  codec: AAC
+  favicon: https://canaleitalia.it/wp-content/uploads/2021/07/radio-volami-nel-cuore-ascolta.jpg
+  homepage: https://canaleitalia.it/radio/radio-volami-nel-cuore/
+  country: IT
+  status: stream-only
+  stationuuid: c787b546-f486-4df6-8c5c-344c9bb8b9f5
+  changeuuid: bce1539a-928a-4f41-9c2b-4907a39f714c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-company-stile-italiano
+  broadcaster: independent
+  name: Radio Company Stile Italiano
+  streamUrl: https://sphera.fluidstream.eu/companyitalia.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.radiocompany.com/wp-content/uploads/fbrfg/apple-touch-icon.png
+  homepage: https://www.radiocompany.com/
+  country: IT
+  status: stream-only
+  stationuuid: 56afd25c-9fca-445c-b4f6-024fb4a6fdfe
+  changeuuid: 1564e5d6-9329-4076-ad1e-cb3601682154
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-cuore
+  broadcaster: independent
+  name: Radio Cuore
+  streamUrl: https://stream10.xdevel.com/audio32s975552-1839/stream/icecast.audio
+  codec: MP3
+  favicon: https://www.radiocuore.it/public/favicon.png
+  homepage: https://www.radiocuore.it/
+  country: IT
+  status: stream-only
+  stationuuid: 4a6651f6-095b-4ab5-94d9-613562ed7f09
+  changeuuid: 4e788723-b403-4fd3-86bb-6d42df47c95f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-company-reggaetown
+  broadcaster: independent
+  name: Radio Company Reggaetown
+  streamUrl: https://sphera.fluidstream.eu/companyreggaetown.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.radiocompany.com/wp-content/uploads/fbrfg/apple-touch-icon.png
+  homepage: https://www.radiocompany.com/
+  country: IT
+  status: stream-only
+  stationuuid: ad4c68e3-d0d7-4141-aa1a-1d4564f6747f
+  changeuuid: f6de7241-f3d1-4be9-80e8-08dae0f56bfd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-italia-news-24
+  broadcaster: independent
+  name: Italia News 24
+  streamUrl: https://stream6.xdevel.com/audio6s975889-649/stream/icecast.audio
+  codec: MP3
+  homepage: https://www.italianews24.news/
+  country: IT
+  status: stream-only
+  stationuuid: 5a56c267-a891-49b9-b54a-ca4890585f84
+  changeuuid: 75bee174-123e-47ff-8b31-95c0b4a3abc7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-nerazzurra
+  broadcaster: independent
+  name: Radio Nerazzurra
+  streamUrl: https://api.spreaker.com/v2/episodes/18631166/stream
+  codec: MP3
+  favicon: https://www.radionerazzurra.it/whitelabel/radio-2374497684802285/img/apple-touch-icon.png
+  homepage: https://www.radionerazzurra.it/
+  country: IT
+  status: stream-only
+  stationuuid: 30bfedec-2c67-11ea-aa0c-52543be04c81
+  changeuuid: 732ccc2e-4c69-45c3-aa16-bf611870b9c1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-bruno-made-in-italy
+  broadcaster: independent
+  name: Radio Bruno - Made in Italy
+  streamUrl: https://stream2.xdevel.com/audio1s975355-54/stream/icecast.audio
+  codec: AAC+
+  favicon: https://www.radiobruno.it/wp-content/uploads/2019/11/made-in-italy.jpg
+  homepage: https://www.radiobruno.it/
+  country: IT
+  status: stream-only
+  stationuuid: 57c2fbb7-4f55-4857-8cb0-876f07809a38
+  changeuuid: 1c96a2e9-e36b-4dd7-91d4-02402525de88
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-laziale
+  broadcaster: independent
+  name: "Radio Laziale "
+  streamUrl: https://router.xdevel.com/video5s975363-2398/stream/playlist.m3u8
+  bitrate: 4811
+  codec: AAC,H.264
+  favicon: https://www.cusanomediaplay.it/apple-icon-120x120.png
+  homepage: https://www.cusanomediaplay.it/
+  country: IT
+  status: stream-only
+  stationuuid: 81e1a845-076c-4ee5-8f21-6329c064805d
+  changeuuid: d0225a3c-5e24-43b6-99ea-ff1efeeb8b4e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-italo-sound-radio
+  broadcaster: independent
+  name: Italo Sound Radio
+  streamUrl: https://icecast.italosound.com/italosound
+  bitrate: 192
+  codec: MP3
+  favicon: https://italosound.com/sites/all/themes/framework/apple-touch-icon.png
+  homepage: https://italosound.com/
+  country: IT
+  status: stream-only
+  stationuuid: e5d0c4bd-16fe-4fd4-96f8-4c7b78ac1c2c
+  changeuuid: a6958a41-1067-4d18-8b95-5270ed1aa0c5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-elettrica
+  broadcaster: independent
+  name: Radio Elettrica
+  streamUrl: https://nr8.newradio.it/proxy/apselett?mp=/stream
+  bitrate: 256
+  codec: MP3
+  favicon: https://www.radioelettrica.it/wp-content/uploads/2018/10/cropped-icon-1-180x180.png
+  homepage: https://www.radioelettrica.it/
+  country: IT
+  status: stream-only
+  stationuuid: f7848de3-debe-4b9d-87ae-5f34f4c88140
+  changeuuid: 18c8630e-27c8-436f-8b7b-ca28bf784869
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-105-miami
+  broadcaster: independent
+  name: "105 Miami"
+  streamUrl: https://icy.unitedradio.it/105Miami.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.105.net/sezioni/748/105-miami
+  country: IT
+  status: stream-only
+  stationuuid: 849c65bc-f3dd-4aeb-abaa-3d4316387b67
+  changeuuid: dae18eef-0769-40d4-9878-fbead3dfa25f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-italia-radio-festival
+  broadcaster: independent
+  name: ITALIA Radio Festival
+  streamUrl: https://icy.unitedradio.it/um073.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: http://www.unitedmusic.it/
+  country: IT
+  status: stream-only
+  stationuuid: 90186e4d-760e-11ea-b1cf-52543be04c81
+  changeuuid: f5c57c37-4801-424e-9ddd-5de6285bbece
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-jungle-planet-radio
+  broadcaster: independent
+  name: Jungle Planet Radio
+  streamUrl: https://phoebe.streamerr.co:3650/;?type=http&nocache=1739137731
+  bitrate: 320
+  codec: MP3
+  favicon: https://jungleplanetradio.com/wp-content/uploads/2023/09/JPR-round-B-1.png
+  homepage: https://jungleplanetradio.com/
+  country: IT
+  status: stream-only
+  stationuuid: 3dff0ca7-e8d7-4966-a37f-2d754819af6b
+  changeuuid: 1e39aeb1-8df6-4c4d-920f-edf009dd02c5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-musica-disco-n-dance
+  broadcaster: independent
+  name: Radio Musica Disco ‘N’ Dance
+  streamUrl: https://nrf1.newradio.it:9516/stream
+  bitrate: 96
+  codec: AAC+
+  favicon: https://cdn-profiles.tunein.com/s199160/images/logod.png?t=637523968370000000
+  homepage: https://radiomusicatv.it/
+  country: IT
+  status: stream-only
+  stationuuid: e38308e9-1193-4bce-8e09-101361c383ed
+  changeuuid: f280cfa7-ea9b-4fe2-8f7c-ea780068a86a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-forever-80-pop
+  broadcaster: independent
+  name: FOREVER 80-POP
+  streamUrl: https://stream.laut.fm/forever80-pop
+  bitrate: 128
+  codec: MP3
+  homepage: https://forever80.altervista.org/
+  country: IT
+  status: stream-only
+  stationuuid: f9718255-6fcc-4ab8-82fa-12e96f827e70
+  changeuuid: 90a90f8d-f995-4107-b722-0b43a408ad22
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-lolli-radio-soul
+  broadcaster: independent
+  name: Lolli Radio Soul
+  streamUrl: https://stream.lolliradio.net/lolli_soul.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.lolliradio.net/
+  country: IT
+  status: stream-only
+  stationuuid: 6725dd92-f7a9-4482-9b66-f89955dcf449
+  changeuuid: c37695ee-1d64-40ef-8252-598a87610196
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-capital-classic-rock
+  broadcaster: independent
+  name: Radio Capital Classic Rock
+  streamUrl: https://4c4b867c89244861ac216426883d1ad0.msvdn.net/webradio/capitalclassicrock/playlist.m3u8
+  bitrate: 128
+  codec: AAC
+  favicon: https://cdn.gelestatic.it/capital/sites/2/2016/11/webradio-classicrock-320x320.jpg
+  homepage: https://www.capital.it/
+  country: IT
+  status: stream-only
+  stationuuid: 6b2e0fad-6f57-4464-83ae-d68981e11504
+  changeuuid: 1aa24b04-c72d-47c5-ae88-e045a1c8465c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-legends
+  broadcaster: independent
+  name: Radio Legends
+  streamUrl: https://ssl.audio1.meway.tv/proxy/radiolegends?mp=/stream
+  bitrate: 192
+  codec: MP3
+  favicon: https://radiolegends.com/wp-content/uploads/2022/10/cropped-radiolegends-logo-150x150.png
+  homepage: https://radiolegends.com/
+  country: IT
+  status: stream-only
+  stationuuid: 533035b4-6352-4775-b7e0-4e7657e47dce
+  changeuuid: 6139d20e-ed56-4610-b4fb-13f194845c90
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-cortina
+  broadcaster: independent
+  name: Radio Cortina
+  streamUrl: https://streaming1.radiodatanet.it:8050/stream
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radiocortina.it/
+  country: IT
+  status: stream-only
+  stationuuid: cdec338f-6d94-4837-b4c2-87a27a1d8bb6
+  changeuuid: c9d7db4d-5cbf-4b5e-b3c1-35bc9b9dbf88
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-linea-italia
+  broadcaster: independent
+  name: Radio Linea Italia
+  streamUrl: https://rblive.it:8110//radio.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.radiolinea.it/
+  country: IT
+  status: stream-only
+  stationuuid: 5c387af4-6181-4610-9a6d-fc60d2cf30b7
+  changeuuid: aa1c2007-11b5-4871-b80c-3e28abf9afd7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-united-music-piano
+  broadcaster: independent
+  name: united music piano
+  streamUrl: https://icy.unitedradio.it/um077.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.unitedmusic.com/favicon_6.ico?v=1558694480199
+  homepage: https://www.unitedmusic.com/
+  country: IT
+  status: stream-only
+  stationuuid: 8bb171e6-689f-4041-bbb5-4d95d70576e4
+  changeuuid: eff30b08-9f6a-4bb5-9c74-d0cd14bf0c0d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-rouge-country-hits
+  broadcaster: independent
+  name: Radio Rouge Country Hits
+  streamUrl: https://uk1.streamingpulse.com/ssl/RadioRougeCountry
+  bitrate: 128
+  codec: MP3
+  homepage: https://radiorouge.com/
+  country: IT
+  status: stream-only
+  stationuuid: d5219eaf-3423-4429-8279-0c6f5ba435fd
+  changeuuid: c5985c63-c640-4423-a971-0624dd75d852
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-fred-film-radio-italiano
+  broadcaster: independent
+  name: Fred Film Radio(italiano)
+  streamUrl: https://s10.webradio-hosting.com/proxy/fredradioit/stream
+  bitrate: 128
+  codec: MP3
+  homepage: http://www.fred.fm/
+  country: IT
+  status: stream-only
+  stationuuid: ff97ca68-d11f-4c3d-ad11-1a770abd1772
+  changeuuid: c01536d8-4b6c-4660-adfa-1d0481796e67
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-classica
+  broadcaster: independent
+  name: Radio Classica
+  streamUrl: https://stream10.xdevel.com/audio0s978096-2470/stream/icecast.audio
+  codec: MP3
+  favicon: https://www.radioclassica.fm/img/logo_classica.png
+  homepage: https://www.radioclassica.fm/
+  country: IT
+  status: stream-only
+  stationuuid: 10489554-90f5-4525-ac45-bd0346ef2f12
+  changeuuid: 2147ff66-0bc8-4e84-b52e-a6901fb47872
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-hit-fm
+  broadcaster: independent
+  name: Radio Hit FM
+  streamUrl: https://stream1.xdevel.com/audio0s975632-244/stream/icecast.audio
+  codec: AAC+
+  favicon: https://radiohitfm.it/favicon.ico
+  homepage: https://radiohitfm.it/
+  country: IT
+  status: stream-only
+  stationuuid: 27d86794-a680-4a24-b394-a28e693d8748
+  changeuuid: 456e0c51-1330-4445-8d22-71bd74604d43
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-italia
+  broadcaster: independent
+  name: Radio Italia
+  streamUrl: https://radioitaliasmi.akamaized.net/hls/live/2093120/RISMI/master.m3u8
+  bitrate: 98
+  codec: AAC
+  favicon: https://www.radioitalia.it/images/logo-radioitalia-200.png
+  homepage: https://www.radioitalia.it/
+  country: IT
+  status: stream-only
+  stationuuid: f4a651c0-6ba6-4845-838f-095aff86a67e
+  changeuuid: 4b25fa14-74ef-4d55-9d13-24d02405d6df
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-kiss-kiss-la-notte-vola
+  broadcaster: independent
+  name: Radio Kiss Kiss La Notte Vola
+  streamUrl: https://kk.fluidstream.eu/kk_notte.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://kisskiss.it/wp-content/uploads/2022/07/cropped-favicon-new-kisskiss-180x180.png
+  homepage: https://kisskiss.it/webradio/web-radio-kisskiss-la-notte-vola/
+  country: IT
+  status: stream-only
+  stationuuid: ba0f61a6-878c-41e8-b31d-259f8339f03b
+  changeuuid: 7df2e252-6426-437e-8c55-e5e57d043a11
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-deejay-one-love
+  broadcaster: independent
+  name: Deejay One Love
+  streamUrl: https://4c4b867c89244861ac216426883d1ad0.msvdn.net/webradio/deejayonelove/playlist.m3u8
+  bitrate: 128
+  codec: AAC
+  favicon: https://cdn.gelestatic.it/deejay/sites/2/2016/02/webradio_deejay_one_love-320x320.png
+  homepage: https://www.deejay.it/
+  country: IT
+  status: stream-only
+  stationuuid: 5eb7ecb7-20c1-4c32-af8f-a566505c90cd
+  changeuuid: 18cee22f-2aca-49f8-a835-8cff1667813f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-precisa-i-piu-trasmessi-dal-1975-ad-oggi
+  broadcaster: independent
+  name: RADIO PRECISA I più trasmessi dal 1975 ad oggi
+  streamUrl: https://rprecisa.radioca.st/radioprecisa
+  bitrate: 128
+  codec: MP3
+  homepage: http://www.radioprecisa.it/
+  country: IT
+  status: stream-only
+  stationuuid: 2a10785b-7aea-4f70-8b0a-aa9c7b9259da
+  changeuuid: 34e348a3-2aab-4a19-8751-ee7ea9f8bdd6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-mambo
+  broadcaster: independent
+  name: Radio Mambo
+  streamUrl: https://mambo.newradio.it/stream
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.mambo.it/
+  country: IT
+  status: stream-only
+  stationuuid: b46e8ec3-f784-4a94-b852-3b59236b79bf
+  changeuuid: 3733ab8e-99d6-4414-8b73-3f82c3e3d8f5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-skyline-jazz
+  broadcaster: independent
+  name: Skyline Jazz
+  streamUrl: https://rblive.it:8030/radio.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.skyline.it/
+  country: IT
+  status: stream-only
+  stationuuid: 39a5836b-fbf7-4021-b946-26243cbb00c1
+  changeuuid: 0a80a415-e463-4a27-a571-63cebd4b8175
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-rock-106-6
+  broadcaster: independent
+  name: Radio Rock 106.6
+  streamUrl: https://rrock.fluidstream.eu/radiorock.aac
+  bitrate: 64
+  codec: AAC
+  favicon: https://radiorock.it/wp-content/uploads/2017/01/diretta-copia-370x370.jpg
+  homepage: https://radiorock.it/
+  country: IT
+  status: stream-only
+  stationuuid: 24c13b56-d669-4127-98b3-b0b1c22b4676
+  changeuuid: 8a61038d-abc0-455f-b175-0e91cd777ebe
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-subasio-xl
+  broadcaster: independent
+  name: Subasio XL
+  streamUrl: https://icy.unitedradio.it/SubasioXL.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radiosubasio.it/
+  country: IT
+  status: stream-only
+  stationuuid: 9bbb9d63-b38d-4ce2-8a52-0f5363b32d71
+  changeuuid: 293d53f7-9448-4acc-a609-473001d79be2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-raitg
+  broadcaster: independent
+  name: RAITG
+  streamUrl: https://tgrcampania-live.akamaized.net/hls/live/2025562/tgrcampania/tgrcampania/playlist.m3u8
+  bitrate: 1868
+  codec: AAC
+  favicon: https://www.rainews.it/dl/rainews/images/favicon.png
+  homepage: https://www.rainews.it/
+  country: IT
+  status: stream-only
+  stationuuid: 2a4ece26-2d7f-49ba-8321-de62842fdc17
+  changeuuid: 8f675bb1-3a28-4cef-a3d0-b53dce934f78
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-number-one
+  broadcaster: independent
+  name: Radio Number One
+  streamUrl: https://rn1.fluidstream.eu/rn1.mp3
+  bitrate: 256
+  codec: MP3
+  homepage: https://radionumberone.it/
+  country: IT
+  status: stream-only
+  stationuuid: 1bc7b156-abcc-454d-b0cd-102f9c8df9d0
+  changeuuid: 0a3c46ec-b8a8-43d0-83be-c8005e38d345
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-saba-sound
+  broadcaster: independent
+  name: Radio Saba Sound
+  streamUrl: https://stream3.xdevel.com/audio0s975496-187/stream/icecast.audio
+  codec: AAC+
+  favicon: https://radiosabasound.com/wp-content/uploads/2020/06/cropped-logo1-180x180.png
+  homepage: https://www.radiosabasound.com/
+  country: IT
+  status: stream-only
+  stationuuid: 15522ffa-f610-4048-8183-3c51d6054e21
+  changeuuid: 1222b8b4-6c7b-4ad5-a622-9e1d0af62239
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-wow-black
+  broadcaster: independent
+  name: Radio WoW Black
+  streamUrl: https://sphera.fluidstream.eu/rwow_black.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://radiowow.com/wp-content/uploads/2024/09/cropped-radio-wow-180x180.png
+  homepage: https://radiowow.com/
+  country: IT
+  status: stream-only
+  stationuuid: b5ea4f76-4b5b-4313-b7b7-c07fc3cfc520
+  changeuuid: af439a70-6105-426d-8abd-e4a6a4df0bd2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-bruno-gold
+  broadcaster: independent
+  name: Radio Bruno Gold
+  streamUrl: https://stream2.xdevel.com/audio2s975355-55/stream/icecast.audio
+  codec: AAC+
+  country: IT
+  status: stream-only
+  stationuuid: c7dde51d-ea16-45f3-9133-b67b713ebe91
+  changeuuid: 75f69ed7-2283-4342-a269-fdb3203cfc30
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-company-global-house
+  broadcaster: independent
+  name: Radio Company Global House
+  streamUrl: https://sphera.fluidstream.eu/companyhouse.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.radiocompany.com/wp-content/uploads/fbrfg/apple-touch-icon.png
+  homepage: https://www.radiocompany.com/
+  country: IT
+  status: stream-only
+  stationuuid: 098edf0b-8f49-4919-b768-bdfb354a67ea
+  changeuuid: 8fb1043d-3489-474c-90e2-f80eafe94bdc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-padova-history
+  broadcaster: independent
+  name: Radio Padova History
+  streamUrl: https://sphera.fluidstream.eu/rpd_history.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.radiopadova.com/history/android-icon-192x192.png
+  homepage: https://www.radiopadova.com/
+  country: IT
+  status: stream-only
+  stationuuid: 8181132f-6e58-4e8d-ba62-ae6f63a81376
+  changeuuid: 9b5edcb1-9723-4568-b2d7-2476017cf699
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-stella-toscana
+  broadcaster: independent
+  name: Radio Stella Toscana
+  streamUrl: https://stream4.xdevel.com/audio0s975906-620/stream/icecast.audio
+  codec: MP3
+  homepage: https://radiostella.it/
+  country: IT
+  status: stream-only
+  stationuuid: c64bbba6-98b3-4b21-917c-d677a1715cb1
+  changeuuid: b93b9059-ca2b-4ab3-94ab-714b5bee5dd3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-zouk-emotion
+  broadcaster: independent
+  name: RADIO ZOUK EMOTION
+  streamUrl: https://stream.radiozoukemotion.com/rze
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radiozoukemotion.com/
+  country: IT
+  status: stream-only
+  stationuuid: a5030d63-70fa-40c8-a12f-1a92ab5b07c1
+  changeuuid: 11cd9fc9-660a-4e6d-97c1-a7959f3e2d20
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-relax-radio
+  broadcaster: independent
+  name: Relax Radio
+  streamUrl: https://stream3.xdevel.com/audio8s975388-108/stream/icecast.audio
+  codec: MP3
+  homepage: https://www.musiclubwebradio.com/home/
+  country: IT
+  status: stream-only
+  stationuuid: db8391be-7a63-45e3-8b1c-fd056dbf50b4
+  changeuuid: a6ffd453-63a9-4d32-abbc-c6a1fad9a0d4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-esercito
+  broadcaster: independent
+  name: Radio Esercito
+  streamUrl: https://radio.esercito.difesa.it:8000/stream
+  codec: MP3
+  homepage: https://www.esercito.difesa.it/radio-esercito
+  country: IT
+  status: stream-only
+  stationuuid: fcd414e7-06c7-49d6-8fda-cfc42487a236
+  changeuuid: ad08ee6d-8be6-484b-8c8d-6c4702d4440b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-rai-tg3
+  broadcaster: independent
+  name: RAI TG3
+  streamUrl: https://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=668461
+  bitrate: 1985
+  codec: AAC
+  homepage: https://www.rainews.it/
+  country: IT
+  status: stream-only
+  stationuuid: f84d2c60-7473-4634-b0c0-6c4f4bbb73bd
+  changeuuid: 6703619a-99ac-463b-b4b9-53acfe426eb1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-80s-remix-radio
+  broadcaster: independent
+  name: "80s Remix Radio"
+  streamUrl: https://a10.asurahosting.com:8350/radio.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://a10.asurahosting.com/static/uploads/80s_remix_radio/album_art.1730307872.jpg
+  homepage: https://a10.my-control-panel.com/public/80s_remix_radio
+  country: IT
+  status: stream-only
+  stationuuid: 032ffade-d50c-4281-8f7c-5272271619f7
+  changeuuid: 7822116c-27a1-4da7-8c09-1b68b0392dcb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-rock-n-roll-radio
+  broadcaster: independent
+  name: "Rock'n'Roll Radio"
+  streamUrl: https://nr14.newradio.it:8643/stream?ext=.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://cdn-radiotime-logos.tunein.com/s126487d.png
+  homepage: https://www.rocknrollradio.it/
+  country: IT
+  status: stream-only
+  stationuuid: 4e38277d-8ce1-40d4-8a80-be484e0b3f14
+  changeuuid: 244b832a-955a-4b31-94d5-b9a03eba3630
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-urban-radio
+  broadcaster: independent
+  name: Urban Radio
+  streamUrl: https://nr3.newradio.it:18100/stream
+  bitrate: 192
+  codec: MP3
+  favicon: https://urbanradio.it/wp-content/uploads/2022/05/cropped-favicon-180x180.png
+  homepage: https://www.urbanradio.it/
+  country: IT
+  status: stream-only
+  stationuuid: 87d9091c-5560-4cd8-8a7b-b00b11b98f2d
+  changeuuid: c08d444b-a220-48a8-8ea6-7eb73ea9ad39
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-funky-radio-classic-funk-only
+  broadcaster: independent
+  name: Funky Radio - Classic Funk Only
+  streamUrl: https://my.streamingmedia.it/listen/discofunk/play
+  bitrate: 192
+  codec: MP3
+  favicon: https://funky.radio/wp-content/uploads/2024/05/funky.radio_logo_300x300.webp
+  homepage: https://funky.radio/
+  country: IT
+  status: stream-only
+  stationuuid: 1ba0c4d1-4ea7-4346-8b07-90bed63b8539
+  changeuuid: 7b5fa78e-6a63-48c7-be10-6e6e67b606cb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-viniles-radio
+  broadcaster: independent
+  name: Viniles Radio
+  streamUrl: https://s3.radio.co/sfaf3f1f4a/listen
+  bitrate: 128
+  codec: MP3
+  homepage: https://vinilesradio.it/
+  country: IT
+  status: stream-only
+  stationuuid: 56568d0e-7ce3-4ac8-9f7c-ffb55327cfa4
+  changeuuid: 81fef737-ceba-4712-946b-d500f7b345b5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-futura-fm-hd-ogg
+  broadcaster: independent
+  name: Futura FM (HD OGG)
+  streamUrl: https://futura.fm/stream.ogg
+  bitrate: 1500
+  codec: OGG
+  favicon: https://futura.fm/song-metadata/cover/undefined
+  homepage: https://futura.fm/
+  country: IT
+  status: stream-only
+  stationuuid: 6bb402a8-0b23-4143-bc36-d7fee37a0139
+  changeuuid: e9068f98-488f-48b1-b7c6-09367dcb0776
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-60-70-80
+  broadcaster: independent
+  name: Radio 60 70 80
+  streamUrl: https://ice.studiopiu.net/607080.aac
+  bitrate: 48
+  codec: AAC
+  favicon: https://www.607080.it/wp-content/uploads/2017/11/Logo-SB.png
+  homepage: https://www.607080.it/
+  country: IT
+  status: stream-only
+  stationuuid: 3bbc371b-7899-4f6e-9e79-6da4d696c819
+  changeuuid: e208eabb-2606-41c5-acfd-df5957a27c41
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-antenna-uno-rock-station
+  broadcaster: independent
+  name: Radio Antenna Uno Rock Station
+  streamUrl: https://sr11.inmystream.it/proxy/associa9?mp=/stream
+  bitrate: 192
+  codec: MP3
+  favicon: http://www.radioantenna1.com/wp-content/themes/Elite/images/logonuovo.jpg
+  homepage: http://www.radioantenna1.com/
+  country: IT
+  status: stream-only
+  stationuuid: 2ed9fe39-62df-4484-9473-24c0621a5de8
+  changeuuid: 2db3e333-555b-408c-9c46-6f60815a09a4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radiouno
+  broadcaster: independent
+  name: RadioUno
+  streamUrl: https://streamcdng2-8e7439fdb1694c8da3a0fd63e4dda518.msvdn.net/radiounoita1/hls/radiounoita1_320/chunklist.m3u8
+  codec: UNKNOWN
+  favicon: https://www.raiplaysound.it/assets/img/canali/logo-rairadio1.svg
+  homepage: https://www.raiplaysound.it/
+  country: IT
+  status: stream-only
+  stationuuid: 81c5b62c-769b-4343-b326-36f986d0ed31
+  changeuuid: a3062b94-8470-49ad-b9b3-2a70a26e98d2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-capital-soft
+  broadcaster: independent
+  name: Radio Capital Soft
+  streamUrl: https://4c4b867c89244861ac216426883d1ad0.msvdn.net/webradio/capitalsoft/playlist.m3u8
+  bitrate: 128
+  codec: AAC
+  favicon: https://cdn.gelestatic.it/capital/sites/2/2016/11/webradio-soft-320x320.jpg
+  homepage: https://www.capital.it/
+  country: IT
+  status: stream-only
+  stationuuid: 6f48bb10-f3cf-41da-9985-15630e84cf40
+  changeuuid: a5827d5f-e836-4dc1-961b-da621c3db72a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-dreamland
+  broadcaster: independent
+  name: Radio Dreamland
+  streamUrl: https://dreamsiteradiocp3.com/proxy/dreamland?mp=/stream
+  bitrate: 128
+  codec: MP3
+  homepage: http://www.radiodreamland.it/
+  country: IT
+  status: stream-only
+  stationuuid: 9febcbf6-990d-4c98-9645-58707b092945
+  changeuuid: 61834f24-130d-48d1-880a-14ecc0b2a918
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-delfino
+  broadcaster: independent
+  name: Radio Delfino
+  streamUrl: https://nr8.newradio.it/proxy/emaamo00?mp=/stream
+  bitrate: 96
+  codec: AAC+
+  favicon: https://www.radiodelfino.com/wp-content/uploads/2022/10/305398753_463061192502259_7843286858231192740_n.ico
+  homepage: https://radiodelfino.com/
+  country: IT
+  status: stream-only
+  stationuuid: 1eaa95b8-0732-4558-97fc-3953db407f7d
+  changeuuid: 8190bda2-8ea0-4718-923d-740136c4caeb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-podcast
+  broadcaster: independent
+  name: RADIO PODCAST
+  streamUrl: https://gr.fluidstream.eu/gr6.mp3?FLID=1
+  bitrate: 192
+  codec: MP3
+  favicon: https://radiopodcast.fm/favicon.ico
+  homepage: https://radiopodcast.fm/
+  country: IT
+  status: stream-only
+  stationuuid: 2a5f9ef6-d176-43eb-8362-dfec433fab8e
+  changeuuid: 47eefc5d-7fb2-46fa-b709-76510e2a27dd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-rtr99
+  broadcaster: independent
+  name: Rtr99
+  streamUrl: https://rtr99.fluidstream.eu/rtr99.aac
+  bitrate: 128
+  codec: AAC
+  favicon: https://www.rtr99.it/wp-content/uploads/2016/03/logo_facebook.png
+  homepage: http://www.rtr99.it/
+  country: IT
+  status: stream-only
+  stationuuid: aa76f1fc-b885-487b-9010-7f15213c79b3
+  changeuuid: d5ba0a4b-fd77-4472-b5ad-fa79d593e7b5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-capital-tivu
+  broadcaster: independent
+  name: Radio Capital TiVù
+  streamUrl: https://4c4b867c89244861ac216426883d1ad0.msvdn.net/live/S35394734/Z6U2wGoDYANk/playlist.m3u8
+  bitrate: 2658
+  codec: AAC
+  homepage: https://www.capital.it/tv/
+  country: IT
+  status: stream-only
+  stationuuid: fe49a52e-8985-44cd-bbce-745fe0ee2874
+  changeuuid: efa45e27-0a0b-446f-8fc0-a795fe8aace6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-italia-dance-music
+  broadcaster: independent
+  name: Italia Dance Music
+  streamUrl: https://sr2.inmystream.it:18032/stream2
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.italiadancemusic.com/it/sites/default/files/logo.png
+  homepage: https://www.italiadancemusic.com/it/
+  country: IT
+  status: stream-only
+  stationuuid: 81671e14-bd14-4a6d-8490-f087ac9826bd
+  changeuuid: ce4b2ee6-247c-455a-ac06-26403f1cf3e3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-time-dance-fm
+  broadcaster: independent
+  name: Time Dance FM
+  streamUrl: https://eu8.fastcast4u.com/proxy/timedancefm?mp=/1
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.timedancefm.it/wp-content/uploads/2023/02/TIME_DANCE_FM_3.png
+  homepage: https://www.timedancefm.it/
+  country: IT
+  status: stream-only
+  stationuuid: 4297a1bc-86d2-4ea5-a073-393e02fbef22
+  changeuuid: ded27e4d-f4c2-445e-876c-27f39f85686b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-canale-italia
+  broadcaster: independent
+  name: Canale Italia+
+  streamUrl: https://rci.canaleitalia.tv:8005/;
+  codec: AAC
+  favicon: https://canaleitalia.it/wp-content/uploads/2022/06/logo-canale-italia-streaming.png
+  homepage: https://canaleitalia.it/radio/radio-canale-italia/
+  country: IT
+  status: stream-only
+  stationuuid: 5a4906a8-9842-40e0-9a5a-36959cc1e7d7
+  changeuuid: 4916995d-232c-40db-ad7c-f0c6d6c073d2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-padova-christmas
+  broadcaster: independent
+  name: Radio Padova Christmas
+  streamUrl: https://sphera.fluidstream.eu/rpd_christmas.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.radiopadova.com/wp-content/uploads/2022/05/cropped-radio-padova-icona-180x180.png
+  homepage: https://www.radiopadova.com/
+  country: IT
+  status: stream-only
+  stationuuid: c5f57e07-7590-4c75-a236-dfcb690957a4
+  changeuuid: 091866c4-8f72-4c61-b2e0-1e3f81a78784
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-rmc-radio-bau-co
+  broadcaster: independent
+  name: "RMC Radio Bau & Co"
+  streamUrl: https://icy.unitedradio.it/RadioBAU.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radiomontecarlo.net/sezioni/10494/radio-bau-co
+  country: IT
+  status: stream-only
+  stationuuid: 58d62e4f-cd09-4a79-b9b2-8b317f5fd5c4
+  changeuuid: 45881740-eefa-4c97-9d27-55cc0680c6be
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-company-90
+  broadcaster: independent
+  name: Radio Company 90
+  streamUrl: https://sphera.fluidstream.eu/company90.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.radiocompany.com/
+  country: IT
+  status: stream-only
+  stationuuid: dd3e0202-7b5e-49ea-b2fc-b9280daf00c5
+  changeuuid: 1a861c7a-2a5b-4248-bef7-e555d76ce78f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-studio-nord-80-energia
+  broadcaster: independent
+  name: Radio Studio Nord 80 Energia
+  streamUrl: https://nr6.newradio.it:19393/;
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.rsn.it/
+  country: IT
+  status: stream-only
+  stationuuid: 5d45c128-ed15-48cd-aa3f-47ce12fa37ea
+  changeuuid: a7a9b0d9-506d-494f-adc9-cd34edf0557f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-bruno-top-40
+  broadcaster: independent
+  name: Radio Bruno Top 40
+  streamUrl: https://stream2.xdevel.com/audio0s975355-53/stream/icecast.audio
+  codec: AAC+
+  homepage: https://www.radiobruno.it/web-radio/radio-bruno-top-40/
+  country: IT
+  status: stream-only
+  stationuuid: 360289b2-b9f9-414d-a659-2dc2e76e2c49
+  changeuuid: 94bfb882-315f-43e9-9df5-6fb7b087e78b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-soul-radio
+  broadcaster: independent
+  name: SOUL RADIO
+  streamUrl: https://listen.soulradio.it/it
+  bitrate: 192
+  codec: AAC+
+  homepage: https://soulradio.it/
+  country: IT
+  status: stream-only
+  stationuuid: 9392329d-2db6-4cd6-8bea-65b960fbeee0
+  changeuuid: d5eacd48-dc22-4582-b714-576177dad22b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-rocket-radio-1
+  broadcaster: independent
+  name: Rocket Radio 1
+  streamUrl: https://stream.radiojar.com/nvvyes7gud5tv
+  codec: MP3
+  favicon: https://images.squarespace-cdn.com/content/v1/53d6c3efe4b07a1cdbbae414/1520288879144-STBAF8R3I9C523AUA4LS/favicon.ico?format=100w
+  homepage: https://rocketradiolive.com/
+  country: IT
+  status: stream-only
+  stationuuid: 850be23c-3c26-4dbf-955a-02b139d39a5f
+  changeuuid: b57912eb-8f4d-47ba-a827-4b9a063738b1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-spore
+  broadcaster: independent
+  name: Spore
+  streamUrl: https://stream.radiospore.oziosi.org:8003/spore.ogg
+  codec: OGG
+  favicon: https://radiospore.oziosi.org/user/themes/quark/images/logo/logoprova2.png
+  homepage: http://upstream.radiospore.oziosi.org:8000/spore.ogg
+  country: IT
+  status: stream-only
+  stationuuid: b3c31d8c-9312-491b-b2d1-3b933f98a261
+  changeuuid: d185cf1b-f4eb-469d-8f71-b691556f72d5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-news
+  broadcaster: independent
+  name: Radio News
+  streamUrl: https://stream5.xdevel.com/audio5s975889-479/stream/icecast.audio
+  codec: MP3
+  homepage: https://www.italianews24.news/
+  country: IT
+  status: stream-only
+  stationuuid: e1b95431-4a67-4908-8197-4fa16c89de03
+  changeuuid: 4fb25256-8b3c-48c2-af6c-ea40f396df5c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-sintony
+  broadcaster: independent
+  name: Radio Sintony
+  streamUrl: https://stream5.xdevel.com/audio0s976204-1069/stream/icecast.audio
+  codec: MP3
+  favicon: https://sintony.it/images/logo_sintony2.png
+  homepage: https://www.sintony.it/
+  country: IT
+  status: stream-only
+  stationuuid: 03274531-3ede-4780-8466-bd023684a581
+  changeuuid: aba82f6c-c3d9-420a-baa8-195550caacd3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-rete-toscana-classica
+  broadcaster: independent
+  name: Rete Toscana Classica
+  streamUrl: https://nr12.newradio.it/stream/8744
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.retetoscanaclassica.it/wp-content/themes/rtc/assets/content/img/logo.png
+  homepage: https://www.retetoscanaclassica.it/
+  country: IT
+  status: stream-only
+  stationuuid: fc05569b-0b17-4586-87be-f9248bb36300
+  changeuuid: 3a3e413e-4049-4b83-a70e-86cc9863cd68
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-kiss-kiss-history-lounge
+  broadcaster: independent
+  name: Kiss Kiss History Lounge
+  streamUrl: https://kk.fluidstream.eu/kk_history_lounge.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://kisskiss.it/wp-content/uploads/elementor/thumbs/history_lounge-pqfun57h0y154wockpdaik12g4hic80slnznyc9zqk.png
+  homepage: https://kisskiss.it/webradio/la-web-radio-kiss-kiss-history-lounge/
+  country: IT
+  status: stream-only
+  stationuuid: 42608dbc-995f-4f31-8a72-b24620622c6f
+  changeuuid: 9881576b-6e79-43f7-b3c3-65ec27cc189e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-seisei-vintage
+  broadcaster: independent
+  name: Radio SeiSei Vintage
+  streamUrl: https://ice02.fluidstream.net/fluid02_8360.aac
+  bitrate: 64
+  codec: AAC+
+  homepage: https://www.seiseivintage.it/
+  country: IT
+  status: stream-only
+  stationuuid: ce8c28d6-c885-444a-9bcf-0dbe887707d3
+  changeuuid: f74af2f9-f5ce-4baa-bf98-5acfa195d935
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-skyline-soul
+  broadcaster: independent
+  name: Radio Skyline Soul
+  streamUrl: https://rblive.it:8040/radio.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.skyline.it/
+  country: IT
+  status: stream-only
+  stationuuid: 1bffdceb-5283-44c2-a0d8-08f11977c2ff
+  changeuuid: e19df5a4-8bfe-4db8-9781-748cd7ab5252
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-classica-bresciana
+  broadcaster: independent
+  name: Radio Classica Bresciana
+  streamUrl: https://nmcdn-3177cee185284d2990021eccc8b06ae6.msvdn.net/icecastRelay/S66374741/yNMp1W7wbgWY/icecast
+  codec: AAC+
+  favicon: https://servizi.bresciaonline.it/radioclassica/radioclassicabresciana.png
+  homepage: https://www.radioclassicabresciana.it/
+  country: IT
+  status: stream-only
+  stationuuid: 27ad0282-a343-4f2a-ae53-652a25f7eeea
+  changeuuid: ddc96cbb-8738-4dc5-9687-33f23e3530e1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-rock-italia
+  broadcaster: independent
+  name: Radio Rock Italia
+  streamUrl: https://rrock.fluidstream.eu/radiorock_ita.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://radiorock.it/wp-content/uploads/2023/02/radiorockitalia-770x770.jpg
+  homepage: https://radiorock.it/
+  country: IT
+  status: stream-only
+  stationuuid: 5ddb136a-ec26-417c-b5ad-e9d6a71ce3b3
+  changeuuid: 4eec545b-e78a-4abe-a34c-ab2c0010910a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-70-80-it
+  broadcaster: independent
+  name: "70-80.it"
+  streamUrl: https://onair18.xdevel.com/proxy/7080it?mp=/stream
+  bitrate: 320
+  codec: MP3
+  favicon: https://www.70-80.it/wp-content/uploads/2020/03/logo-7080-new.webp
+  homepage: https://www.70-80.it/
+  country: IT
+  status: stream-only
+  stationuuid: ca839a3b-1e0d-40e6-9131-3f15071dcd07
+  changeuuid: d8dda015-34a0-4635-8123-af5921983b96
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-cooperativa-padova-right
+  broadcaster: independent
+  name: Radio Cooperativa Padova right
+  streamUrl: https://de4.streamingpulse.com/ssl/7013
+  bitrate: 96
+  codec: MP3
+  homepage: https://www.radiocooperativa.org/3/index.php
+  country: IT
+  status: stream-only
+  stationuuid: 51636653-4203-4251-a584-d84f69409758
+  changeuuid: c746c1a2-5faf-41b7-802d-70aa97c45482
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-padova-country
+  broadcaster: independent
+  name: Radio Padova Country
+  streamUrl: https://sphera.fluidstream.eu/rpd_country.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.radiopadova.com/wp-content/uploads/2022/05/cropped-radio-padova-icona-180x180.png
+  homepage: https://www.radiopadova.com/
+  country: IT
+  status: stream-only
+  stationuuid: 425da6c2-0d90-4181-aa07-1cff2a943ada
+  changeuuid: 86771be4-b372-4f1f-9847-df07f917bd8f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-easy-network-classic
+  broadcaster: independent
+  name: Easy Network Classic
+  streamUrl: https://sphera.fluidstream.eu/easy_classica.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.easynetwork.fm/
+  country: IT
+  status: stream-only
+  stationuuid: 08ac365c-4524-49ab-ad31-834831a5c025
+  changeuuid: 88ffad38-04e4-4249-b177-1483758f9706
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-deejay-gasolina
+  broadcaster: independent
+  name: Deejay Gasolina
+  streamUrl: https://4c4b867c89244861ac216426883d1ad0.msvdn.net/webradio/deejaygasolina/playlist.m3u8
+  bitrate: 128
+  codec: AAC
+  favicon: https://cdn.gelestatic.it/deejay/sites/2/2016/03/webradio_deejay_gasolina-320x320.png
+  homepage: https://www.deejay.it/
+  country: IT
+  status: stream-only
+  stationuuid: 34b474bd-a9ca-42a5-860a-dbba246adfe4
+  changeuuid: 97274bfe-32f0-453d-a031-a64e7225f552
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-cafe-roma-lounge
+  broadcaster: independent
+  name: Cafe Roma Lounge
+  streamUrl: https://stream.laut.fm/cafe-roma-lounge
+  bitrate: 128
+  codec: MP3
+  homepage: https://info201774.wixsite.com/caferomalounge
+  country: IT
+  status: stream-only
+  stationuuid: 6fe11e7f-2ba4-4c68-8294-228f938c353c
+  changeuuid: 8e65fe10-df46-4b5e-9e9d-806ec55b6fa2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-mediterranea
+  broadcaster: independent
+  name: Radio Mediterranea
+  streamUrl: https://stream.radiomediterranea.com:8160/lounge.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radiomediterranea.com/
+  country: IT
+  status: stream-only
+  stationuuid: 4e3ff0db-6076-4ede-8f4a-50e11ba4693f
+  changeuuid: 72b757bf-9a01-408b-9612-ea953c30984a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-deejay-one-two-one-two
+  broadcaster: independent
+  name: Deejay One Two One Two
+  streamUrl: https://4c4b867c89244861ac216426883d1ad0.msvdn.net/webradio/deejayonetwoonetwo/playlist.m3u8
+  bitrate: 128
+  codec: AAC
+  favicon: https://cdn.gelestatic.it/deejay/sites/2/2015/05/webradio_one_two-320x320.png
+  homepage: https://www.deejay.it/
+  country: IT
+  status: stream-only
+  stationuuid: 4a22109c-4ec4-4a93-93e7-d334da23484d
+  changeuuid: 678c8cbe-a7f0-453f-9aaa-447867a3ef7f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-italia-auditorium
+  broadcaster: independent
+  name: ITALIA Auditorium
+  streamUrl: https://icy.unitedradio.it/um015.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: http://www.unitedmusic.it/
+  country: IT
+  status: stream-only
+  stationuuid: bc34bbc3-760e-11ea-b1cf-52543be04c81
+  changeuuid: 1ce4e9ef-b80b-455f-90ac-9ce5530963f3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-banda-larga
+  broadcaster: independent
+  name: Radio Banda Larga
+  streamUrl: https://rblmedia.out.airtime.pro/rblmedia_a
+  bitrate: 192
+  codec: MP3
+  favicon: https://rbl.media/favicon.ico
+  homepage: https://rbl.media/en
+  country: IT
+  status: stream-only
+  stationuuid: e4f598cb-9164-4028-a9a7-e673b4202fe5
+  changeuuid: bdba8ec9-d8f2-4bfc-b6d6-d87ffb355746
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-rtr-99-radio-pop-e-rock
+  broadcaster: independent
+  name: RTR 99 Radio Pop e Rock
+  streamUrl: https://rtr99.fluidstream.eu/rtr99_poprock.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.rtr99.it/onair/PopRock/OnAir.jpg?x=d19xo2mvx08g75jst1trz
+  homepage: https://rtr99.it/
+  country: IT
+  status: stream-only
+  stationuuid: 2a61c501-8ff7-4b16-a3c3-fef1773e4de7
+  changeuuid: a122d146-05db-46ed-8012-d7924a095e73
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-bruno-brescia
+  broadcaster: independent
+  name: Radio Bruno Brescia
+  streamUrl: https://stream1.xdevel.com/audio1s975758-318/stream/icecast.audio
+  codec: AAC+
+  favicon: https://www.radiobrunobrescia.it/favicon.ico
+  homepage: https://www.radiobrunobrescia.it/
+  country: IT
+  status: stream-only
+  stationuuid: 259b18cd-cbd8-4758-95a9-c5d88ca3e51b
+  changeuuid: 0c99cf35-e23a-4f87-b203-116618cd225e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-musica-disco-fever
+  broadcaster: independent
+  name: Radio Musica Disco Fever
+  streamUrl: https://gcarrstream2-danidi01.radioca.st/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://static2.mytuner.mobi/media/tvos_radios/tz6dwkzktbup.png
+  homepage: https://www.radiomusicatv.it/
+  country: IT
+  status: stream-only
+  stationuuid: e4a89bd9-9e46-4fd7-93da-f111c5e48cf7
+  changeuuid: 30290927-6edc-4667-b7fe-debf9cfa4477
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-deejay-on-the-road
+  broadcaster: independent
+  name: Deejay On The Road
+  streamUrl: https://4c4b867c89244861ac216426883d1ad0.msvdn.net/webradio/deejayontheroad/playlist.m3u8
+  bitrate: 128
+  codec: AAC
+  favicon: https://cdn.gelestatic.it/deejay/sites/2/2015/05/webradio_deejay_on_the_road-320x320.png
+  homepage: https://www.deejay.it/
+  country: IT
+  status: stream-only
+  stationuuid: c6d44c0b-418e-4c0b-b7cb-4de22ce40f44
+  changeuuid: 177c8549-a144-406f-8b0f-39391caeaecc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-ciccio-riccio
+  broadcaster: independent
+  name: Radio Ciccio Riccio
+  streamUrl: https://stream5.xdevel.com/audio0s975942-758/stream/icecast.audio
+  codec: MP3
+  homepage: http://www.ciccioriccio.it/
+  country: IT
+  status: stream-only
+  stationuuid: 8be2bccd-5494-41dc-ae1e-fddd52f7e640
+  changeuuid: 8297a9e0-022c-477a-a8dc-257a1cc488fa
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-rsc-radio-studio-centrale
+  broadcaster: independent
+  name: RSC Radio Studio Centrale
+  streamUrl: https://stream.studiocentrale.it/radio/8020/radio.mp3?_=1
+  bitrate: 320
+  codec: MP3
+  homepage: https://www.studiocentrale.it/
+  country: IT
+  status: stream-only
+  stationuuid: 238369ef-bffa-4e5e-941b-630923423b35
+  changeuuid: e6ab9012-97fd-4406-ac95-fa20ab05237a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-evangelo-piemonte
+  broadcaster: independent
+  name: RADIO EVANGELO PIEMONTE
+  streamUrl: https://dreamsiteradiocp3.com/proxy/radioevangelo?mp=/stream
+  bitrate: 128
+  codec: MP3
+  homepage: https://radioevangelo.it/
+  country: IT
+  status: stream-only
+  stationuuid: 34d59beb-fdc5-455e-937c-8c0914605645
+  changeuuid: dad76b28-68c5-404a-a108-1bf924ab742e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-rossini
+  broadcaster: independent
+  name: Radio Rossini
+  streamUrl: https://stream.laut.fm/radiorossini
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radiorossini.com/
+  country: IT
+  status: stream-only
+  stationuuid: b40962ab-4b63-4dad-9221-a3586775e4a7
+  changeuuid: 3c0a0dd0-9b02-4ba9-a002-548826188288
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-deejay-4-christmas
+  broadcaster: independent
+  name: Deejay 4 Christmas
+  streamUrl: https://4c4b867c89244861ac216426883d1ad0.msvdn.net/webradio/deejay80/live.m3u8
+  codec: UNKNOWN
+  favicon: https://www.deejay.it/favicon.ico
+  homepage: https://www.deejay.it/webradio/01/
+  country: IT
+  status: stream-only
+  stationuuid: 6d1ef60e-e5a7-4be9-9dbb-3465bc0006a5
+  changeuuid: 956bbc22-e16f-42e7-ad05-02b73779d8f4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-quar
+  broadcaster: independent
+  name: Radio Quar
+  streamUrl: https://radioquar.com/radio/8000/radio320.mp3
+  bitrate: 320
+  codec: MP3
+  homepage: https://radioquar.com/public/radio_quar
+  country: IT
+  status: stream-only
+  stationuuid: 34dcb38d-9cdb-48c9-97e8-e75f00455ff9
+  changeuuid: 0f2da3f4-0836-4e24-ab83-3ce83faa956e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-rtl-102-5-disco
+  broadcaster: independent
+  name: RTL 102.5 Disco
+  streamUrl: https://dd782ed59e2a4e86aabf6fc508674b59.msvdn.net/live/S51100361/Sz3kCA55PrRh/playlist_audio.m3u8
+  bitrate: 192
+  codec: AAC
+  favicon: https://cloud.rtl.it/assets/www.rtl.it/3.0.64/img/logo/favicon-96x96.png
+  homepage: https://play.rtl.it/live/21/rtl-1025-doc-tv/
+  country: IT
+  status: stream-only
+  stationuuid: 3f49bd02-5f8b-468b-88b0-c7bcdfd8291a
+  changeuuid: 8db416ae-0c31-4a91-80a3-1c8565fa540e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-core-de-roma
+  broadcaster: independent
+  name: Radio Core de Roma
+  streamUrl: https://sr14.inmystream.it:8210/stream
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radiocorederoma.it/
+  country: IT
+  status: stream-only
+  stationuuid: b4a1a38c-0473-4f1c-a4c1-d55099686b5f
+  changeuuid: c4f3ea71-6291-4466-b493-cba12d7488d2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-maria-italy
+  broadcaster: independent
+  name: Radio Maria Italy
+  streamUrl: https://dreamsiteradiocp4.com/proxy/rmitaliamontecarlo?mp=/stream
+  bitrate: 64
+  codec: AAC+
+  homepage: https://radiomaria.it/
+  country: IT
+  status: stream-only
+  stationuuid: e76db104-6f04-4b90-92a1-cbdfe3e35180
+  changeuuid: 49b65947-9cfd-4edb-8e4e-5d6b0b5bef9f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-piterpan-hq
+  broadcaster: independent
+  name: Radio Piterpan (HQ)
+  streamUrl: https://ice02.fluidstream.net/piterpan.mp3?FLID=1&type=.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.piterpan.it/
+  country: IT
+  status: stream-only
+  stationuuid: cfccfb63-9002-4171-a521-4fb5bc673df1
+  changeuuid: f229f12e-d7ec-4650-97ad-074ed1e4f902
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-company-fitness
+  broadcaster: independent
+  name: Radio Company Fitness
+  streamUrl: https://sphera.fluidstream.eu/companyfitness.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.radiocompany.com/fitness/android-icon-192x192.png
+  homepage: https://www.radiocompany.com/
+  country: IT
+  status: stream-only
+  stationuuid: cd791756-9bf1-4408-ac9c-c64c09cbd457
+  changeuuid: 0f113ec5-4740-4e27-b7ac-32df92216b7d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-raheem
+  broadcaster: independent
+  name: Radio Raheem
+  streamUrl: https://radioraheem.out.airtime.pro/radioraheem_a
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.radioraheem.it/wp-content/themes/gds-vue/meta/favicon.ico
+  homepage: https://www.radioraheem.it/
+  country: IT
+  status: stream-only
+  stationuuid: a1c99f81-f8d1-4f6d-b9e3-714763a72b7d
+  changeuuid: 0ffff0dd-fdab-4ac5-98c5-664d8cfba42b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-gedi-radio-capital-classic-rock
+  broadcaster: independent
+  name: GEDI - Radio Capital Classic Rock
+  streamUrl: https://streamcdnr3-4c4b867c89244861ac216426883d1ad0.msvdn.net/webradio/capitalclassicrock/playlist.m3u8
+  bitrate: 128
+  codec: AAC
+  homepage: https://www.capital.it/webradio/02/
+  country: IT
+  status: stream-only
+  stationuuid: bb4b71ef-f046-488b-a4cf-26e1fbb37cfa
+  changeuuid: ca8ff37f-4b4c-44ac-8f55-5c07bb0f1200
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radioattivita
+  broadcaster: independent
+  name: Radioattività
+  streamUrl: https://nr5.newradio.it/proxy/finmedia?mp=/stream
+  codec: MP3
+  favicon: https://radioattivita.com/favicon.ico
+  homepage: https://radioattivita.com/
+  country: IT
+  status: stream-only
+  stationuuid: 9ee8b937-bfba-4ad7-b98d-4739c9ba3683
+  changeuuid: 1839dab3-28d2-4597-a672-436b68d774a9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-gedi-radio-capital-w-l-italia
+  broadcaster: independent
+  name: "GEDI - Radio Capital W L'Italia"
+  streamUrl: https://streamcdnr15-4c4b867c89244861ac216426883d1ad0.msvdn.net/webradio/capitalwitalia/playlist.m3u8
+  bitrate: 128
+  codec: AAC
+  favicon: https://cdn.gelestatic.it/capital/sites/2/2016/11/webradio-vivalitalia-640x334.jpg
+  homepage: https://www.capital.it/webradio/04/
+  country: IT
+  status: stream-only
+  stationuuid: 491d0dd6-7157-4bfd-89a1-2c9defc373ad
+  changeuuid: 317de852-1ef7-42cb-ac80-e65821471859
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-underground-italia
+  broadcaster: independent
+  name: "Radio Underground Italia "
+  streamUrl: https://nr14.newradio.it:8707/stream
+  bitrate: 128
+  codec: AAC+
+  favicon: https://radio-streaming.it/assets/image/radio/180/logo_con_scritta.jpg
+  homepage: https://radiounderground.it/
+  country: IT
+  status: stream-only
+  stationuuid: d74c1aaf-9987-4fd3-9f86-1c6607b42569
+  changeuuid: 1f1330ac-6d24-444e-a179-cd34b9e705b6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-aci-radio
+  broadcaster: independent
+  name: Aci Radio
+  streamUrl: https://sphera.fluidstream.eu/company.mp3?FLID=1
+  bitrate: 128
+  codec: MP3
+  homepage: http://www.aci.it/
+  country: IT
+  status: stream-only
+  stationuuid: af64b00c-c987-4dcd-a5f4-316270df0393
+  changeuuid: dab30dee-5572-4e93-96aa-16a97a843826
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-forever-rock
+  broadcaster: independent
+  name: FOREVER ROCK
+  streamUrl: https://stream.laut.fm/foreverrock
+  bitrate: 128
+  codec: MP3
+  homepage: https://forever80.altervista.org/
+  country: IT
+  status: stream-only
+  stationuuid: 403bfc3c-bc95-4633-8e72-d4897480d40d
+  changeuuid: fcb320d2-2c68-4411-a3ef-cfab3cae4cac
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-kolbe-la-voce-di-maria-regina-dell-amore
+  broadcaster: independent
+  name: "Radio Kolbe - La voce di Maria Regina dell'Amore"
+  streamUrl: https://uk2.streamingpulse.com/ssl/kolbe
+  bitrate: 96
+  codec: AAC+
+  favicon: https://www.radiokolbe.it/__ovh/common/img/favicon.ico
+  homepage: https://www.radiokolbe.it/
+  country: IT
+  status: stream-only
+  stationuuid: 69b17e13-e756-433d-ad17-8ee8e7b91cd9
+  changeuuid: f2ed3ae9-a704-42e1-94f0-9514cc01d7b0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-linea-love
+  broadcaster: independent
+  name: Radio Linea Love
+  streamUrl: https://rblive.it:8120//radio.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.radiolinea.it/
+  country: IT
+  status: stream-only
+  stationuuid: 9d063596-df61-47a7-a6c0-d621d7174ebb
+  changeuuid: e87bb855-6474-4e64-8a9c-8e5175dc22a7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-skyline
+  broadcaster: independent
+  name: Radio Skyline
+  streamUrl: https://rblive.it:8010/radio.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.skyline.it/
+  country: IT
+  status: stream-only
+  stationuuid: 2cfcf114-81f7-4ca7-ab47-c14d1273ce41
+  changeuuid: fad447c2-afaa-4c80-8e91-705155442350
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-primocanale-tv
+  broadcaster: independent
+  name: Primocanale TV
+  streamUrl: https://msh0203.stream.seeweb.it/live/flv:stream2.sdp/chunklist_w1626804143.m3u8
+  codec: UNKNOWN
+  favicon: https://primocanale.it/favicon.ico
+  homepage: https://primocanale.it/
+  country: IT
+  status: stream-only
+  stationuuid: 19902011-9715-4b1c-98af-c0e219b1ccba
+  changeuuid: 28c06350-c4e7-4a5e-a4e8-2c56f917c43e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-cron
+  broadcaster: independent
+  name: Radio Cron
+  streamUrl: https://cron.stream.laut.fm/cron
+  bitrate: 128
+  codec: MP3
+  favicon: https://radiocron.altervista.org/wp-content/uploads/2021/03/cropped-radio-cron-512-180x180.png
+  homepage: https://radiocron.altervista.org/
+  country: IT
+  status: stream-only
+  stationuuid: e30a8e44-e9a6-4d5d-9af5-836e2ac54a68
+  changeuuid: 7fa63700-98a2-481d-b0ce-06545ca789de
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-veneto-radio
+  broadcaster: independent
+  name: Veneto Radio
+  streamUrl: https://sr11.inmystream.it/proxy/paolo1?mp=/stream
+  bitrate: 256
+  codec: MP3
+  favicon: https://www.venetoradio.com/wp-content/uploads/2021/06/live.gif
+  homepage: https://www.venetoradio.it/
+  country: IT
+  status: stream-only
+  stationuuid: 319b72a5-04bc-46ac-bebb-2a32bb8642fe
+  changeuuid: 21dc9fb4-08de-4ff2-ac42-7ffec5042c1f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-dee-jay-full-time-radio
+  broadcaster: independent
+  name: dee Jay full time radio
+  streamUrl: https://djft.radioca.st/
+  bitrate: 96
+  codec: MP3
+  country: IT
+  status: stream-only
+  stationuuid: d6a8e39c-1cb2-4d14-85bd-638006ab6c0c
+  changeuuid: e2ff70c6-f4f8-48f6-9935-370b329dbd16
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-comozero
+  broadcaster: independent
+  name: Radio ComoZero
+  streamUrl: https://sr14.inmystream.it/stream/freedom
+  bitrate: 128
+  codec: MP3
+  favicon: https://comozero.it/wp-content/uploads/favicon.png
+  homepage: https://comozero.it/
+  country: IT
+  status: stream-only
+  stationuuid: ce898b30-0356-4397-818f-7d43db518107
+  changeuuid: 2b2d7338-697f-4fb3-a785-c6d4c8f84cda
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-70-80-90-rock
+  broadcaster: independent
+  name: Radio 70 80 90 Rock
+  streamUrl: https://rblive.it:8090/radio.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.radio708090.it/wp-content/uploads/2021/10/708090-ROCK-160-1.png
+  homepage: https://www.radio708090.it/
+  country: IT
+  status: stream-only
+  stationuuid: e6a3d34c-870a-4db7-9c47-6c7ddd7a38cd
+  changeuuid: e2d04c90-5f71-452e-a125-4adb70d4605e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-alta-italy
+  broadcaster: independent
+  name: Radio Alta Italy
+  streamUrl: https://live.radioalta.it/stream.mp3
+  bitrate: 320
+  codec: MP3
+  favicon: https://cdn-profiles.tunein.com/s25078/images/logod.jpg?t=638325351480000000
+  homepage: https://www.bergamotv.it/radiolive/
+  country: IT
+  status: stream-only
+  stationuuid: 6a10e6e7-5e0d-43c9-b4f0-16211d991425
+  changeuuid: 9d9f54ce-d953-4433-b721-ceef2cedc2a1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-firenze-95-4
+  broadcaster: independent
+  name: Radio Firenze 95.4
+  streamUrl: https://sr14.inmystream.it/stream/radiofirenze/stream
+  bitrate: 192
+  codec: MP3
+  country: IT
+  status: stream-only
+  stationuuid: e047831f-8b38-4709-b1b3-bb982f4e23a5
+  changeuuid: b9a2a802-b2a4-45b0-84a9-63bcda02c9a4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-san-luchino
+  broadcaster: independent
+  name: Radio San Luchino
+  streamUrl: https://ssl.audio1.meway.tv/proxy/sanluchino?mp=/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.radiosanluchino.it/wp-content/uploads/2020/09/logoblu3.jpg
+  homepage: https://www.radiosanluchino.it/
+  country: IT
+  status: stream-only
+  stationuuid: dd4d7fa9-6827-43ef-99e8-e8835c2e74d6
+  changeuuid: 7eb9e848-b297-4721-beb2-de258471baa9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-studio-104
+  broadcaster: independent
+  name: Radio Studio 104
+  streamUrl: https://onair7.xdevel.com/proxy/xautocloud_v8ss_1328?mp=/;1/
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.radiostudio104.com/wp-content/uploads/2025/06/104-logo.png
+  homepage: https://www.radiostudio104.com/
+  country: IT
+  status: stream-only
+  stationuuid: adf1e7d8-ba4c-4fbb-9a65-95e1597f8d91
+  changeuuid: 2d8236b9-d27e-4734-9f30-14d5d5097913
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-megamix80
+  broadcaster: independent
+  name: megamix80
+  streamUrl: https://centova.ipstream.it/proxy/megamix80/stream
+  bitrate: 192
+  codec: MP3
+  favicon: null
+  homepage: http://ntova.ipstream.it/
+  country: IT
+  status: stream-only
+  stationuuid: 4c299f07-c91a-4cc0-b524-43b3712e774d
+  changeuuid: 3359da38-dbd9-4e0b-b241-f92cd68d9450
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-linea-sport-energy
+  broadcaster: independent
+  name: Radio Linea Sport Energy
+  streamUrl: https://rblive.it:8130/radio.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.radiolinea.it/diretta-sport/
+  country: IT
+  status: stream-only
+  stationuuid: b9a3cc1d-db42-46d9-9973-b9d30b8f462f
+  changeuuid: 398a80aa-4c33-4b1b-8ee0-cf706ef43125
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-antenna-web-assisi
+  broadcaster: independent
+  name: _Antenna Web Assisi
+  streamUrl: https://italiavera.radioca.st/stream?type=http&nocache=296
+  bitrate: 320
+  codec: MP3
+  favicon: https://antennaweb.it/wp-content/uploads/2023/08/rap180-100x100.png
+  homepage: http://www.antennaradio.it/
+  country: IT
+  status: stream-only
+  stationuuid: eddaaf11-bfbc-4c27-872c-bf72de11efa6
+  changeuuid: 62802646-5bb2-40a9-9978-475522e7026a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-energy-chill
+  broadcaster: independent
+  name: Radio Energy Chill
+  streamUrl: https://gmusto5.radioca.st/mp3
+  bitrate: 224
+  codec: MP3
+  favicon: https://radioenergy.to/play/tmp/images/logo.1714720179.png
+  homepage: https://radioenergy.to/
+  country: IT
+  status: stream-only
+  stationuuid: e8d17cc7-1ad1-4005-a27d-107728304098
+  changeuuid: 8537d0bb-ce3b-418a-b23f-8458ead0ba24
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-fresh
+  broadcaster: independent
+  name: Radio Fresh
+  streamUrl: https://radiofresh.radioca.st/stream
+  bitrate: 96
+  codec: MP3
+  favicon: https://www.radiofresh.it/wp-content/uploads/2020/08/Logo-Radio-Fresh-68pxH.png
+  homepage: https://www.radiofresh.it/
+  country: IT
+  status: stream-only
+  stationuuid: e21f8ed8-3606-4ed5-838c-6fbd2a0b024d
+  changeuuid: 45aaf5ac-deab-4ba8-bcc0-6878f64b8002
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-l-olgiata
+  broadcaster: independent
+  name: "Radio l'Olgiata"
+  streamUrl: https://olgiata-danidi01.radioca.st/stream.mp3/
+  bitrate: 128
+  codec: MP3
+  favicon: http://www.radiololgiata.net/images/iconaiphone.ico
+  homepage: http://www.radiololgiata.net/
+  country: IT
+  status: stream-only
+  stationuuid: 7ca3c65b-bd64-48c2-aec7-f5f633cd4078
+  changeuuid: bc3f895f-a1e9-4fca-8828-ba09809b7643
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-romeo-juliet
+  broadcaster: independent
+  name: "Radio Romeo & Juliet"
+  streamUrl: https://onair7.xdevel.com/proxy/xautocloud_vovi_2030?mp=/;1/
+  bitrate: 192
+  codec: MP3
+  favicon: https://static3.inonda.com/2030/RES/player/5ViwscqTCV-cover-600,600.png
+  homepage: https://radioromeoandjuliet.it/
+  country: IT
+  status: stream-only
+  stationuuid: 48bc6966-eb20-4305-8232-8788f3136d4f
+  changeuuid: aa696c3e-a048-4f83-93c0-6f39fca7a52f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-rouge-fm
+  broadcaster: independent
+  name: Radio Rouge FM
+  streamUrl: https://nl1.streamingpulse.com/ssl/radiorouge993
+  bitrate: 320
+  codec: MP3
+  homepage: https://radiorouge.com/
+  country: IT
+  status: stream-only
+  stationuuid: f68464fd-7616-4a8f-b450-0621e3851666
+  changeuuid: 54470d52-23e0-4da1-b80d-db410a3c2b4b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-rds-next
+  broadcaster: independent
+  name: RDS Next
+  streamUrl: https://stream.rds.radio/audio/rdsnext.stream_aac/playlist.m3u8
+  bitrate: 128
+  codec: AAC
+  favicon: https://www.rds.it/next-web-radio/wp-content/uploads/fbrfg/apple-touch-icon.png
+  homepage: https://www.rds.it/next-web-radio/
+  country: IT
+  status: stream-only
+  stationuuid: ac4b6dbe-f990-46e7-95a7-7deb3b579742
+  changeuuid: eb62a056-611a-4153-a691-6fad5b64860a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-deejay-tropical-pizza
+  broadcaster: independent
+  name: Deejay Tropical Pizza
+  streamUrl: https://4c4b867c89244861ac216426883d1ad0.msvdn.net/webradio/deejaytropicalpizza/playlist.m3u8
+  bitrate: 128
+  codec: AAC
+  favicon: https://cdn.gelestatic.it/deejay/sites/2/2015/05/webradio_tropical-320x320.png
+  homepage: https://www.deejay.it/
+  country: IT
+  status: stream-only
+  stationuuid: b1628f4d-89e6-44d0-b270-638e4cbdba4f
+  changeuuid: 12e60349-6b6e-40b0-9829-2181d9a8d7d1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-inblu2000
+  broadcaster: independent
+  name: Radio InBlu2000
+  streamUrl: https://www.radioinblu.it/live-stream/inblu2000-playlist.m3u8
+  bitrate: 128
+  codec: AAC
+  homepage: https://www.radioinblu.it/
+  country: IT
+  status: stream-only
+  stationuuid: 872f3ec0-db9b-4225-b1df-e29068ae6567
+  changeuuid: 98c6ea6c-1847-4670-9b8a-6646c562a0ef
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-ram-power-102-7
+  broadcaster: independent
+  name: Ram Power 102.7
+  streamUrl: https://stream.ram.radio/audio/ram.stream_aac64/chunklist.m3u8
+  codec: UNKNOWN
+  favicon: https://gitlab.com/alexby306/host-images/-/raw/main/rampower.png
+  homepage: https://www.rampower.it/
+  country: IT
+  status: stream-only
+  stationuuid: a2934367-5e6b-4729-81e0-6ed3d5708551
+  changeuuid: 317b13a7-1a58-4078-bf64-160d43d6f3c8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-repubblic-rock-radio
+  broadcaster: independent
+  name: Repubblic Rock Radio
+  streamUrl: https://repubblicrockradio.stream.laut.fm/repubblicrockradio?ref=web-app&start_time=1632920059398&t302=2021-09-29_14-54-19&uuid=58cf1184-76b2-4e9c-bd17-1b7b88500313
+  bitrate: 128
+  codec: MP3
+  homepage: https://repubblicrock.altervista.org/
+  country: IT
+  status: stream-only
+  stationuuid: 26af083e-8d19-4f82-a40c-68daca3f1edd
+  changeuuid: 377e113d-acea-4f35-bb25-a7c4a52a6be2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-dimensione-suono-roma
+  broadcaster: independent
+  name: Dimensione Suono Roma
+  streamUrl: https://stream.dimensionesuonoroma.radio/audio/dsr.stream_aac64/playlist.m3u8
+  bitrate: 64
+  codec: AAC
+  favicon: https://www.dimensionesuonoroma.it/wp-content/themes/rds-dsr/icons/favicon-196x196.png
+  homepage: https://www.dimensionesuonoroma.it/
+  country: IT
+  status: stream-only
+  stationuuid: d5e27912-6201-4684-813d-6dd1f90fc127
+  changeuuid: 59833b01-2a11-406e-9034-543c128899dc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-cecchetto
+  broadcaster: independent
+  name: Radio Cecchetto
+  streamUrl: https://eu10.fastcast4u.com:3420/
+  bitrate: 128
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/45e16d_6f30cb2becf740a9b406dded11ff23a3%7emv2.png/v1/fill/w_180%2ch_180%2clg_1%2cusm_0.66_1.00_0.01/45e16d_6f30cb2becf740a9b406dded11ff23a3%7emv2.png
+  homepage: https://www.radiocecchetto.it/
+  country: IT
+  status: stream-only
+  stationuuid: 18827714-4709-467a-9568-1ba3519ce96b
+  changeuuid: 924be4cf-a70a-497a-bd35-5906dfdeee09
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-company-rock
+  broadcaster: independent
+  name: Radio Company Rock
+  streamUrl: https://sphera.fluidstream.eu/companyrock.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.radiocompany.com/
+  country: IT
+  status: stream-only
+  stationuuid: 974a7cdf-dd80-47db-bb8f-5d8fe3736f14
+  changeuuid: 1b7606ef-405f-45c6-a907-cd4d8ac95288
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-lady
+  broadcaster: independent
+  name: Radio Lady
+  streamUrl: https://ice05.fluidstream.net/fluid0507.mp3?FLID=1&type=.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.radiolady.it/wp-content/uploads/2020/02/cropped-radio_lady_testa-set19.png
+  homepage: https://www.radiolady.it/
+  country: IT
+  status: stream-only
+  stationuuid: f74da297-67d0-4676-a446-245fe1afede0
+  changeuuid: e86241af-5e6e-4078-921f-d5eb445a7e8a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-tour
+  broadcaster: independent
+  name: RADIO TOUR
+  streamUrl: https://radiotour.streamingmedia.it/play.mp3
+  bitrate: 192
+  codec: AAC+
+  favicon: https://drive.google.com/file/d/1mN5LPpmY5fJjXIHIg8rB5F7Gd0PODAM3/view?usp=sharing
+  homepage: http://radiotour.fm/
+  country: IT
+  status: stream-only
+  stationuuid: f166597f-1398-4377-9c6e-c52c94a8e438
+  changeuuid: ada05b14-c03b-4b94-bbf1-5a51558c029b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-toradio
+  broadcaster: independent
+  name: TOradio
+  streamUrl: https://nr5.newradio.it/proxy/fsrls?mp=/stream
+  bitrate: 192
+  codec: MP3
+  homepage: https://toradio.it/
+  country: IT
+  status: stream-only
+  stationuuid: bfe7258b-f0c3-4bbb-b97d-bb894f183c68
+  changeuuid: 275fffdd-60e3-4dc7-a277-10e189b28546
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-garganofm
+  broadcaster: independent
+  name: GarganoFM
+  streamUrl: https://onlineradiobox.com/json/it/gargano/play?platform=web
+  codec: AAC+
+  favicon: https://www.garganofm.com/wp-content/uploads/2019/10/cropped-gfm-1-180x180.jpg.webp
+  homepage: https://www.garganofm.com/
+  country: IT
+  status: stream-only
+  stationuuid: c9f59053-68e8-4b6d-b40b-3f34dafb843e
+  changeuuid: 78a8e781-fb0a-4c79-95a9-2b2b17e314b9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-emotions
+  broadcaster: independent
+  name: Radio emotions
+  streamUrl: https://sr13.inmystream.it/proxy/radioemotions
+  bitrate: 320
+  codec: MP3
+  favicon: https://www.radioemotions.net/wp-content/uploads/elementor/thumbs/huawei-1-e1609262248368-p0l7rbomrm3f93qkumlw58oayrbokcs4u652uaifb4.png
+  homepage: https://www.radioemotions.net/
+  country: IT
+  status: stream-only
+  stationuuid: 38b6f8c8-2560-48b7-b53b-8e3d92bfcd36
+  changeuuid: eb4cc764-5997-47bf-b592-91f248493985
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-parma
+  broadcaster: independent
+  name: Radio Parma
+  streamUrl: https://ice05.fluidstream.net/radioparma.aac
+  bitrate: 64
+  codec: AAC
+  country: IT
+  status: stream-only
+  stationuuid: d9e800aa-7151-4253-b1ca-6cfeda01ee79
+  changeuuid: b1f78ac4-2048-41e5-8526-edd6a05e92c4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-rtl-102-5-news
+  broadcaster: independent
+  name: RTL 102.5 news
+  streamUrl: https://dd782ed59e2a4e86aabf6fc508674b59.msvdn.net/live/S38122967/aJMOUBAFc2Bc/playlist_audio.m3u8
+  bitrate: 192
+  codec: AAC
+  country: IT
+  status: stream-only
+  stationuuid: 78f39bc1-7180-4214-8195-3201ccfadd60
+  changeuuid: eb2039c9-044a-4de7-bb3d-5db63dc8ca3e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-dancefloor-90s
+  broadcaster: independent
+  name: Radio Dancefloor 90s
+  streamUrl: https://audio.radiodancefloor.it/dancefloor.mp3
+  bitrate: 96
+  codec: MP3
+  favicon: https://firebasestorage.googleapis.com/v0/b/radiogalaxy-580f4.appspot.com/o/images%2FIMG_20240601_155330797.jpg?alt=media&token=9b200358-04d4-4adb-847f-664d6bf837ca
+  homepage: https://www.radiodancefloor.it/
+  country: IT
+  status: stream-only
+  stationuuid: bf036b3a-082f-4a8b-a35a-5b5d8efd7b91
+  changeuuid: 62559b47-7632-4203-a164-1d25421748d6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-meravigliosa
+  broadcaster: independent
+  name: Radio Meravigliosa
+  streamUrl: https://sr11.inmystream.it/proxy/meravigliosa?mp=/
+  bitrate: 192
+  codec: MP3
+  favicon: http://www.radiomeravigliosa.it/favicon.ico
+  homepage: http://www.radiomeravigliosa.it/
+  country: IT
+  status: stream-only
+  stationuuid: 5f6f8641-9009-4b18-a40d-25470b7b86f8
+  changeuuid: 03896c2a-5a1d-4666-b0eb-c8220ba5b891
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-trapena
+  broadcaster: independent
+  name: Radio Trapena
+  streamUrl: https://stream-177.zeno.fm/ytxxawhz67zuv?zt=eyJhbGciOiJIUzI1NiJ9.eyJzdHJlYW0iOiJ5dHh4YXdoejY3enV2IiwiaG9zdCI6InN0cmVhbS0xNzcuemVuby5mbSIsInRtIjpmYWxzZSwicnR0bCI6NSwianRpIjoiYi1XNjhJUU1RaDJETnlvWk1ra1NJUSIsImlhdCI6MTc2ODQ0NzA4MiwiZXhwIjoxNzY4NDQ3MTQyfQ.hwc0kDMs_H8bi4XAFJY3BvbjcnaSD22pJ5OCYlqTMd0
+  codec: MP3
+  homepage: https://zeno.fm/radio/RadioTrapena/
+  country: IT
+  status: stream-only
+  stationuuid: 4e9126d2-ee1f-4e46-90e0-35c50000035b
+  changeuuid: a4d30269-5b28-496a-bb89-0b3983767263
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-rdr-rainbow-diversamente-radio
+  broadcaster: independent
+  name: RDR Rainbow Diversamente Radio
+  streamUrl: https://rdrtv.radioca.st/stream
+  bitrate: 128
+  codec: MP3
+  homepage: https://rainboweb.blogspot.com/
+  country: IT
+  status: stream-only
+  stationuuid: 5a02738d-c5df-450d-89a8-24b5e5547f6a
+  changeuuid: db2562dc-1293-452c-aefa-85b0785a092e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-gedi-deejay-suona-italia
+  broadcaster: independent
+  name: GEDI - Deejay Suona Italia
+  streamUrl: https://streamcdnr13-4c4b867c89244861ac216426883d1ad0.msvdn.net/webradio/deejaysuonaitalia/playlist.m3u8
+  bitrate: 128
+  codec: AAC
+  favicon: https://cdn.gelestatic.it/deejay/sites/2/2015/05/webradio_deejay_suona_italia.png
+  homepage: https://www.deejay.it/webradio/07/
+  country: IT
+  status: stream-only
+  stationuuid: 9f7ea722-1e65-4f0e-8b4f-27303e4f8bdc
+  changeuuid: a3ab522b-2a68-4e2d-9610-c7f8b3f9d7cc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-108-web
+  broadcaster: independent
+  name: Radio 108 Web
+  streamUrl: https://onair7.xdevel.com/proxy/xautocloud_ab42_890?mp=/;mp3/;
+  bitrate: 128
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/10c032_313726babc364862a55f4a96bf36c38b%7emv2.png/v1/fill/w_180%2ch_180%2clg_1%2cusm_0.66_1.00_0.01/10c032_313726babc364862a55f4a96bf36c38b%7emv2.png
+  homepage: https://www.radio108web.com/
+  country: IT
+  status: stream-only
+  stationuuid: 7fb40f09-990a-45b2-b6e3-2302b4c154cc
+  changeuuid: 4c9885b6-e550-45ae-87a6-f1e0580049c4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-capital-funkytown
+  broadcaster: independent
+  name: RADIO CAPITAL FUNKYTOWN
+  streamUrl: https://4c4b867c89244861ac216426883d1ad0.msvdn.net/radiocapitalfunkytownbck/radiocapitalfunkytownbck/play1.m3u8
+  codec: UNKNOWN
+  homepage: https://www.capital.it/webradio/
+  country: IT
+  status: stream-only
+  stationuuid: faba97cb-f925-4773-bef7-6ea7c9a883c7
+  changeuuid: b6aa8268-6bed-4e4b-bd6b-5997d83d1fae
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-cassino-stereo
+  broadcaster: independent
+  name: Radio Cassino Stereo
+  streamUrl: https://radiocassino.radioca.st/;
+  bitrate: 128
+  codec: AAC+
+  favicon: https://www.inmystream.app/player2/rcs.png
+  homepage: https://www.radiocassinostereo.com/
+  country: IT
+  status: stream-only
+  stationuuid: 57d508e8-044c-4f88-b3c7-c107974e9b37
+  changeuuid: 8747b73a-bd0f-4955-aafd-0c8de849a01a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-citta-fujiko
+  broadcaster: independent
+  name: Radio Città Fujiko
+  streamUrl: https://streaming.radiocittafujiko.it:8000/rcf.ogg
+  codec: OGG
+  favicon: https://www.radiocittafujiko.it/wp-content/uploads/2019/09/logo_quadro_fondo_bianco_x600_53ce3a61a3ca7d6763e94a5372f74e98.jpg
+  homepage: https://www.radiocittafujiko.it/
+  country: IT
+  status: stream-only
+  stationuuid: 39dff6b5-b58b-4e2e-a700-500a0f716cb6
+  changeuuid: 40afb943-7102-4c99-b63f-4174dfab3089
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-base-venezia
+  broadcaster: independent
+  name: Radio Base Venezia
+  streamUrl: https://sr11.inmystream.it/proxy/radiobase?mp=/stream
+  bitrate: 128
+  codec: MP3
+  homepage: https://radiobasevenezia.net/
+  country: IT
+  status: stream-only
+  stationuuid: a2c4432a-46d1-445d-b2b2-f971f57d4742
+  changeuuid: e32e95a1-72e5-4b3a-9f68-eafa98786e74
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-centrale-montorio-al-vomano
+  broadcaster: independent
+  name: Radio Centrale - Montorio al Vomano
+  streamUrl: https://s1.forstream.it:8070/radiocentrale.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: http://offline.radiocentrale.info/streaming/base_streaming.png
+  homepage: http://offline.radiocentrale.info/
+  country: IT
+  status: stream-only
+  stationuuid: d48e1114-a33f-4dd9-a700-c7fc0545b805
+  changeuuid: 0fd8976b-a794-41ff-ab75-bca5020dd4e8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-gioconda
+  broadcaster: independent
+  name: Radio Gioconda
+  streamUrl: https://eu7.fastcast4u.com/proxy/radiofvg?mp=/;
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.radiogioconda.it/wp-content/uploads/2018/06/favicon-150x150.png
+  homepage: https://radiogioconda.it/
+  country: IT
+  status: stream-only
+  stationuuid: a7d6d855-2843-4af9-b283-c5f6d5d0b596
+  changeuuid: a0b39922-11a5-49d3-918e-3ca7f10f2690
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-italia-cina-tv
+  broadcaster: independent
+  name: Radio Italia Cina TV 意大利中国电台电视频道
+  streamUrl: https://585b674743bbb.streamlock.net/9054/9054/playlist.m3u8
+  bitrate: 1566
+  codec: AAC,H.264
+  favicon: https://www.radioitaliacina.com/wp-content/uploads/radio-italia-cina-logo.jpg
+  homepage: https://www.radioitaliacina.com/
+  country: IT
+  status: stream-only
+  stationuuid: 5dc6ee6b-476b-4c29-94b5-137a97b3b878
+  changeuuid: 18a81241-8d08-4480-9fd6-3216ee19b968
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-supersound
+  broadcaster: independent
+  name: Radio Supersound
+  streamUrl: https://ssl2.azotosolutions.com:1010/1.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.radiosupersound.it/wp-content/uploads/revslider/rss-homepage/radio_super_sound_logo_slider.png
+  homepage: https://www.radiosupersound.it/
+  country: IT
+  status: stream-only
+  stationuuid: 5de8d041-9826-4869-bb3a-64851aa118a6
+  changeuuid: e5398b5d-725b-439c-a805-3b9155408eca
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-love-fm
+  broadcaster: independent
+  name: Love FM
+  streamUrl: https://rh.fluidstream.eu/lovefm.mp3?FLID=1
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.lovefm.it/national-radio.htm
+  country: IT
+  status: stream-only
+  stationuuid: 99697308-29c5-4929-9054-2b9ed0726827
+  changeuuid: 5ad8610c-4ba8-46dd-b09b-2b7ae83aaf4c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-bias
+  broadcaster: independent
+  name: Radio Bias
+  streamUrl: https://admin.biasradio.com/listen/bias_radio/live
+  bitrate: 320
+  codec: MP3
+  favicon: https://biasradio.com/wp-content/uploads/2024/06/Radio-Bias150.png
+  homepage: https://biasradio.com/
+  country: IT
+  status: stream-only
+  stationuuid: b5a9aec8-7e13-42df-b7d5-b472a673e77e
+  changeuuid: a5183f11-bada-43bc-97b8-969786a7342d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-bruno
+  broadcaster: independent
+  name: Radio Bruno
+  streamUrl: https://router.xdevel.com/audio4s975355-254/stream/icecast.audio
+  codec: AAC+
+  homepage: https://www.radiobruno.it/
+  country: IT
+  status: stream-only
+  stationuuid: c7f2c02b-a024-4b21-b307-a2fcc4ed3fbb
+  changeuuid: c3589e95-c7e6-41fa-a9f5-38ac219bcafa
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-villa-immacolata
+  broadcaster: independent
+  name: Radio Villa Immacolata
+  streamUrl: https://radiocast.cloud/listen/relays_villaimmacolata/radio.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://villaimmacolata.net/images/stories/articoli/logo1.JPG
+  homepage: https://villaimmacolata.net/
+  country: IT
+  status: stream-only
+  stationuuid: 5c84a3be-cb85-4e44-af05-fdbf20fc0df9
+  changeuuid: f44ea883-c2a2-41a1-a9e2-f8ef98fa38ec
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-gedi-radio-capital-music
+  broadcaster: independent
+  name: GEDI - Radio Capital Music
+  streamUrl: https://streamcdnr16-4c4b867c89244861ac216426883d1ad0.msvdn.net/webradio/capitalmusic/playlist.m3u8
+  bitrate: 128
+  codec: AAC
+  favicon: https://cdn.gelestatic.it/capital/sites/2/2016/11/webradio-music-1200x1200.jpg
+  homepage: https://www.capital.it/webradio/01/
+  country: IT
+  status: stream-only
+  stationuuid: 595880fa-1724-4d82-bb95-287a94c0c05e
+  changeuuid: 05e44110-1878-48a6-b215-84a1bf14ea9f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-globo-solo-le-migliori
+  broadcaster: independent
+  name: "Radio Globo | Solo le migliori"
+  streamUrl: https://globo.newradio.it/globorm64
+  bitrate: 128
+  codec: MP3
+  homepage: https://radioglobo.it/
+  country: IT
+  status: stream-only
+  stationuuid: 1a79e996-8263-4e65-9d39-6e0e38dc6df4
+  changeuuid: 82659e2e-eba4-4f95-bda3-593c99863393
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-kiss-kiss-soft
+  broadcaster: independent
+  name: Kiss Kiss Soft
+  streamUrl: https://kk.fluidstream.eu/kk_soft.mp3?id=OJi2H7QVWz&FLID=1
+  bitrate: 128
+  codec: MP3
+  favicon: https://kisskissnapoli.it/wp-content/uploads/elementor/thumbs/kisskiss_soft-py8k5n1kmyquvj2avlt6g9u4jw0aqotxl1cp0wme5o.png
+  homepage: https://kisskissnapoli.it/webradio/kiss-kiss-soft/
+  country: IT
+  status: stream-only
+  stationuuid: 9399d131-22e2-479e-8540-e30ea86d5746
+  changeuuid: 67b482d8-7d41-4408-9417-5e801943f2c5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-pfarrradio-kaltern-caldaro
+  broadcaster: independent
+  name: Pfarrradio Kaltern-Caldaro
+  streamUrl: https://radiocast.cloud/radio/8110/radio.mp3?1603457029
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.pfarrei-kaltern.it/de/pfarrliche-medien/pfarrsender
+  country: IT
+  status: stream-only
+  stationuuid: 0d946998-ea34-4a6e-b0bc-572806e902ae
+  changeuuid: 3a17d101-d0a8-44f4-a278-e27f0c95378f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-dance-anni-90
+  broadcaster: independent
+  name: RADIO DANCE anni 90
+  streamUrl: https://radiodance.streamingmedia.it/it.aac
+  bitrate: 320
+  codec: AAC+
+  favicon: https://www.radio.dance/logo_radiodance90s_512.png
+  homepage: https://www.radio.dance/
+  country: IT
+  status: stream-only
+  stationuuid: 5c300571-e688-4e58-89b7-aba261f8cdc3
+  changeuuid: a6017c8f-e7e1-441d-b0eb-6434d219ecf3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radiolina
+  broadcaster: independent
+  name: Radiolina
+  streamUrl: https://streaming.shoutcast.com/radiolina
+  bitrate: 192
+  codec: MP3
+  favicon: https://radiolina.it/wp-content/uploads/2021/10/cropped-Radiolina150x150-192x192.png
+  homepage: https://radiolina.it/
+  country: IT
+  status: stream-only
+  stationuuid: b77649d5-b04f-4de7-95f3-08c3ef140bea
+  changeuuid: 08727992-2354-4cb1-ad4d-281859bff209
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-rvs-radio-villa-sound
+  broadcaster: independent
+  name: RVS Radio Villa Sound
+  streamUrl: https://eu4.fastcast4u.com/proxy/lmarengo?mp=/;
+  bitrate: 96
+  codec: MP3
+  homepage: http://www.villasound.net/
+  country: IT
+  status: stream-only
+  stationuuid: 595e3085-33b2-11ea-afca-52543be04c81
+  changeuuid: 577d96a1-552d-40de-95c2-c07bcf8597cb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-happy-station
+  broadcaster: independent
+  name: "Happy Station "
+  streamUrl: https://rtr99.fluidstream.eu/rtr99_happy_hq.aac
+  bitrate: 128
+  codec: AAC
+  homepage: https://happystation.radio/
+  country: IT
+  status: stream-only
+  stationuuid: 4111878b-139f-452f-b4b2-8d7aec5aca39
+  changeuuid: bf6e0eec-2291-465b-b9e9-94a2fe2251d0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-loredana-berte
+  broadcaster: independent
+  name: Loredana Berte
+  streamUrl: https://stream.zeno.fm/34avuktawp8uv
+  codec: MP3
+  favicon: https://zeno.fm/favicon.ico
+  homepage: https://zeno.fm/radio/web-radio-network-le-sorelle-berte/
+  country: IT
+  status: stream-only
+  stationuuid: 9cf88c7a-f54e-4c1b-9c33-146ec1c9919c
+  changeuuid: 8fdd60be-7074-492a-875a-804867ba1258
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-studio-nord-rock-cafe
+  broadcaster: independent
+  name: Radio Studio Nord Rock Cafè
+  streamUrl: https://nr6.newradio.it:19363/;
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.rsn.it/
+  country: IT
+  status: stream-only
+  stationuuid: 4ab27ec8-f498-4ef1-ab42-0754048fd7fe
+  changeuuid: d5da262b-5775-4db0-b511-e628e656aa09
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-utopia-firenze
+  broadcaster: independent
+  name: Radio Utopia Firenze
+  streamUrl: https://nr12.newradio.it:8624/stream?ext=.mp3
+  bitrate: 256
+  codec: MP3
+  favicon: https://www.radioutopia.biz/radio-utopia.png
+  homepage: https://www.radioutopia.biz/
+  country: IT
+  status: stream-only
+  stationuuid: 17af7c92-1828-42ad-bef9-346ef3f67133
+  changeuuid: 7e049dbe-4251-4261-85b8-19374e804739
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-margherita-giovane
+  broadcaster: independent
+  name: Margherita Giovane
+  streamUrl: https://streaming.radiomargherita.com/stream/radiomargheritagiovane
+  bitrate: 320
+  codec: MP3
+  homepage: https://www.radiomargherita.com/
+  country: IT
+  status: stream-only
+  stationuuid: 21473115-77b4-4624-89b7-e23d686d46fb
+  changeuuid: 5b9d0946-b56e-47ad-9eab-89ef1204cee5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-amica-biella
+  broadcaster: independent
+  name: "Radio Amica, Biella"
+  streamUrl: https://s10.myradiostream.com/35674/listen.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radioamica.net/
+  country: IT
+  status: stream-only
+  stationuuid: 615ce604-7489-4f5a-bad5-cfc9daa46e17
+  changeuuid: 17c61178-a97c-48fc-9f15-bca2acce1031
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-cittadella
+  broadcaster: independent
+  name: Radio Cittadella
+  streamUrl: https://nr14.newradio.it:8960/stream?ext=.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.radiocittadella.it/favicon.ico
+  homepage: https://www.radiocittadella.it/
+  country: IT
+  status: stream-only
+  stationuuid: d55b8e4e-16fb-431e-9797-c39415499e73
+  changeuuid: 9bdd23e3-fefe-4fab-a6f8-1c53d6963d8b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-linetti-deejay-linus-wfm
+  broadcaster: independent
+  name: Radio Linetti (Deejay Linus WFM)
+  streamUrl: https://streamcdnr11-4c4b867c89244861ac216426883d1ad0.msvdn.net/webradio/deejaywfmlinus/live.m3u8
+  codec: UNKNOWN
+  favicon: https://cdn.gelestatic.it/deejay/sites/2/2019/04/linetti-320x320.png
+  homepage: https://www.deejay.it/
+  country: IT
+  status: stream-only
+  stationuuid: 72e22c32-ec22-4afa-b1cb-fe55d1875ec7
+  changeuuid: 2fa6ed40-14d8-400b-bd1b-94451865ac53
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-studio-nord
+  broadcaster: independent
+  name: Radio Studio Nord
+  streamUrl: https://nr6.newradio.it:19104/;
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.rsn.it/
+  country: IT
+  status: stream-only
+  stationuuid: 9f74b68d-1e4f-4d80-9191-c5da9527bab3
+  changeuuid: a91d48dd-4659-4a1a-9f14-26e743e02dcd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-volere-e-volare
+  broadcaster: independent
+  name: Radio volere e volare
+  streamUrl: https://bay1.streamfm.it:8010/aacp
+  bitrate: 64
+  codec: AAC
+  homepage: https://radiolive.online/radio-volere-e-volare/
+  country: IT
+  status: stream-only
+  stationuuid: 959bda56-8742-4f8a-ab98-a2c71530eb09
+  changeuuid: f21d7b69-d9f0-442a-a70b-ef0174a026e3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-rds-avola
+  broadcaster: independent
+  name: RDS Avola
+  streamUrl: https://be.server89.com:10989/stream.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.rdsavola.it/img/core-img/favicon.ico
+  homepage: https://www.rdsavola.it/
+  country: IT
+  status: stream-only
+  stationuuid: 107d8676-e76b-499d-b007-84db997a93e5
+  changeuuid: 5412fa6b-045c-4aec-9c94-d6fc4b4ffa62
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-franco-califano
+  broadcaster: independent
+  name: Franco Califano
+  streamUrl: https://stream-39.zeno.fm/tcfbbvcdvp8uv?zs=k4Ch0DfKQh2hoqKasxb-3g
+  codec: MP3
+  homepage: https://zeno.fm/radio/web-radio-network-franco-califano/
+  country: IT
+  status: stream-only
+  stationuuid: 567ab2a7-ed58-478f-b7eb-facbc82ac2f5
+  changeuuid: e0e69cbe-1ec4-48b1-8260-e4b363fa7c01
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-amore-italia
+  broadcaster: independent
+  name: Radio Amore Italia
+  streamUrl: https://stream10.xdevel.com/audio6s977886-2320/stream/icecast.audio
+  codec: MP3
+  favicon: https://www.grupporadioamore.it/images/stories/loghi/radio_amore_italia.jpg
+  homepage: https://www.grupporadioamore.it/
+  country: IT
+  status: stream-only
+  stationuuid: 2dc68b3e-3430-4526-a79e-823644c3f307
+  changeuuid: 0e90da4a-7842-49e6-9ff2-eceaf5b10d4c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-capital-xmas
+  broadcaster: independent
+  name: RADIO Capital XMAS
+  streamUrl: https://4c4b867c89244861ac216426883d1ad0.msvdn.net/webradio/capitalsoft/live.m3u8
+  codec: UNKNOWN
+  favicon: https://www.capital.it/wp-content/themes/network-capital/favicon.ico
+  homepage: https://www.capital.it/web%20radio/05/
+  country: IT
+  status: stream-only
+  stationuuid: f3027779-feee-421b-8bdf-e0118293605c
+  changeuuid: 1c0f2314-9097-406b-a032-4866c82c044e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-citta-aperta
+  broadcaster: independent
+  name: Radio Città Aperta
+  streamUrl: https://be.server89.com/8020/stream
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radiocittaperta.it/
+  country: IT
+  status: stream-only
+  stationuuid: 85cbdf64-ca05-44d2-a6f8-f5eedb9acd02
+  changeuuid: e6c0305d-2379-441a-b5e9-28b28273676f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-easy-network
+  broadcaster: independent
+  name: Radio Easy Network
+  streamUrl: https://sphera.fluidstream.eu/easy.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: https://www.easynetwork.fm/wp-content/uploads/2016/07/logo-radio-easy-network-nerp.png
+  homepage: https://www.easynetwork.fm/
+  country: IT
+  status: stream-only
+  stationuuid: 8bf4ce60-702d-4325-9abf-a69f8a703dd3
+  changeuuid: 5926ef99-654a-4cce-b576-c24c6998450e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-gelosa
+  broadcaster: independent
+  name: Radio Gelosa
+  streamUrl: https://ice02.fluidstream.net/gelosa.mp3?FLID=1&type=.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radiogelosa.it/ascolta-radio-gelosa/
+  country: IT
+  status: stream-only
+  stationuuid: f4fea212-6b61-4e9c-85c2-26d9fbac2c7c
+  changeuuid: 75982722-6f0f-46a3-bdba-f17f2d33819b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-ricordi
+  broadcaster: independent
+  name: "Radio Ricordi "
+  streamUrl: https://stream1.xdevel.com/audio2s975889-476/stream/icecast.audio
+  codec: MP3
+  favicon: https://www.adn24.it/favicon.ico
+  homepage: https://www.adn24.it/radio-ricordi/radio-ricordi-live-streaming/
+  country: IT
+  status: stream-only
+  stationuuid: 0a35a3ca-3a72-49ed-9c05-81328afc5175
+  changeuuid: e2e3559d-82c3-4224-95c9-92d7f354146e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-sud-orientale-rso
+  broadcaster: independent
+  name: Radio Sud Orientale RSO
+  streamUrl: https://nrf1.newradio.it/stream/9750
+  bitrate: 96
+  codec: MP3
+  favicon: https://www.rsoradio.it/images/sponsor/banner4.jpg
+  homepage: https://rsoradio.it/
+  country: IT
+  status: stream-only
+  stationuuid: e10278bb-64a4-4f6d-9f58-9797382db3e3
+  changeuuid: 8b661a95-b94a-48ae-92ce-64d811908be0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-wow-latin
+  broadcaster: independent
+  name: Radio WoW Latin
+  streamUrl: https://sphera.fluidstream.eu/rwow_latin.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://radiowow.com/wp-content/uploads/2024/09/cropped-radio-wow-180x180.png
+  homepage: https://radiowow.com/
+  country: IT
+  status: stream-only
+  stationuuid: fe0c3a6b-2b6a-49b8-9f9d-5cdd5587dd48
+  changeuuid: abfad70b-0074-4792-b66b-e7c2f6fa99c1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radiogamma5
+  broadcaster: independent
+  name: RADIOGAMMA5
+  streamUrl: https://ice05.fluidstream.net/fluid0510.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: http://www.radiogammacinque.it/favicon.ico
+  homepage: http://www.radiogammacinque.it/
+  country: IT
+  status: stream-only
+  stationuuid: 9b6b2f2f-d645-4487-b836-689d3d2d717f
+  changeuuid: 2a63a07f-8e02-42df-b1f4-8d4aeebdb5fa
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-rtr99-happy-station
+  broadcaster: independent
+  name: Rtr99 Happy Station
+  streamUrl: https://rtr99.fluidstream.eu/rtr99_happy.aac
+  bitrate: 64
+  codec: AAC
+  homepage: http://www.happystation.radio/
+  country: IT
+  status: stream-only
+  stationuuid: 1d8d0f61-f017-4df5-8478-ceaf2233e291
+  changeuuid: 54df2513-5af6-4416-b571-f422c23080da
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-aci
+  broadcaster: independent
+  name: ACI
+  streamUrl: https://nr7.newradio.it:19353/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.luceverde.it/favicons/apple-touch-icon.png
+  homepage: https://www.luceverde.it/radio.html
+  country: IT
+  status: stream-only
+  stationuuid: 07645528-ff52-493b-8b8f-dac446e3787a
+  changeuuid: 3739c62e-47bd-435b-ba59-7c1820231bee
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-alto-jonio-raj
+  broadcaster: independent
+  name: Radio Alto Jonio - RAJ
+  streamUrl: https://stream1.xdevel.com/audio0s975781-332/stream/icecast.audio
+  codec: MP3
+  favicon: https://www.facebook.com/favicon.ico
+  homepage: https://www.facebook.com/radioaltojonio
+  country: IT
+  status: stream-only
+  stationuuid: f3fb8d3e-e1c8-47b6-aa8d-eb3a6f265440
+  changeuuid: fefa7c85-80fe-45a2-b970-fd866eba8d6a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-kiss-kiss-1
+  broadcaster: independent
+  name: Radio Kiss Kiss + 1
+  streamUrl: https://kk.fluidstream.eu/KissKiss1.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://kisskiss.it/wp-content/uploads/2022/04/1.png
+  homepage: http://www.kisskiss.it/
+  country: IT
+  status: stream-only
+  stationuuid: 3191f13e-8ca0-4639-a30f-ac4b2f0bde92
+  changeuuid: 863bcff5-9d82-42c6-85ce-2417a43ec21a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-leopolda
+  broadcaster: independent
+  name: Radio Leopolda
+  streamUrl: https://onair7.xdevel.com/proxy/xautocloud_ohfs_1545?mp=/stream
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.radioleopolda.it/favicon.ico
+  homepage: https://www.radioleopolda.it/
+  country: IT
+  status: stream-only
+  stationuuid: 5591ca1b-9369-4159-a666-dc97dca16d43
+  changeuuid: 5b345815-c218-4f27-af86-7b7d15dde693
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-linea-young-generation
+  broadcaster: independent
+  name: Radio Linea Young Generation
+  streamUrl: https://rblive.it:8140/radio.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.radiolinea.it/favicon.ico
+  homepage: https://www.radiolinea.it/diretta-young-generation/
+  country: IT
+  status: stream-only
+  stationuuid: b0ecc8d7-00e5-4256-916d-0d9c73d92f59
+  changeuuid: a53c0ba8-f9ff-4f16-8d55-13c97c252a8b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-max-partenope
+  broadcaster: independent
+  name: Radio Max Partenope
+  streamUrl: https://stream.zeno.fm/zmygsdxpks8uv
+  codec: MP3
+  homepage: https://zeno.fm/radio/radio-max-partenope/
+  country: IT
+  status: stream-only
+  stationuuid: 4ad1814f-2415-4a80-bc28-3307d0effd10
+  changeuuid: 98961c58-9f97-4218-96a5-058ba7e7a716
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-star-92e5
+  broadcaster: independent
+  name: Radio Star 92e5
+  streamUrl: https://vramacciv2-danidi01.radioca.st/stream
+  bitrate: 96
+  codec: AAC+
+  favicon: http://www.radiostar92e5.it/favicon.ico
+  homepage: http://www.radiostar92e5.it/
+  country: IT
+  status: stream-only
+  stationuuid: 31dcf37f-eb42-4225-8afa-0889fe98af84
+  changeuuid: 52ba306b-3e54-4e19-90dd-02074da741a8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radioreload-it
+  broadcaster: independent
+  name: RadioReload.it
+  streamUrl: https://stream3.xdevel.com/audio0s975522-197/stream/icecast.audio
+  bitrate: 128
+  codec: MP3
+  favicon: https://mytuner.global.ssl.fastly.net/media/tvos_radios/72cjm2r4d33m.png
+  homepage: https://www.radioreload.it/
+  country: IT
+  status: stream-only
+  stationuuid: 2d419438-3d54-4523-8be0-f838cc0e7330
+  changeuuid: 24221c37-c62b-4d3d-9494-e837d5b95763
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-holy-family
+  broadcaster: independent
+  name: "Holy Family "
+  streamUrl: https://mercury.reliastream.com/proxy/fratel?mp=/stream
+  bitrate: 24
+  codec: MP3
+  homepage: https://aeron.ning.com/
+  country: IT
+  status: stream-only
+  stationuuid: d2ac5a2b-6831-49e0-abb7-cf04895a127e
+  changeuuid: 925c024d-c273-4797-a903-8f2e36c3d48f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-nation-70s
+  broadcaster: independent
+  name: Nation 70s
+  streamUrl: https://listen-nation.sharp-stream.com/nationradio70s.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: null
+  homepage: https://listen-nation.sharp-stream.com/nationradio70s.mp3
+  country: IT
+  status: stream-only
+  stationuuid: a25fad6d-2a11-40ac-a239-75612cbe79f1
+  changeuuid: 3eb9c55b-4093-4bd1-b96b-fd8dbf068b06
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-crossover-disco
+  broadcaster: independent
+  name: RADIO CROSSOVER DISCO
+  streamUrl: https://sp4.server89.com/8002/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://radiocrossoverdisco.com/wp-content/uploads/2024/02/logo-senza-sfondo.png?w=559
+  homepage: https://radiocrossoverdisco.com/
+  country: IT
+  status: stream-only
+  stationuuid: 5df7e2bb-6704-4d6f-b438-65c5a3aefd4f
+  changeuuid: f6a63264-fec5-4ee0-8dbb-47ec4262ac73
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-linea-drive
+  broadcaster: independent
+  name: Radio Linea Drive
+  streamUrl: https://rblive.it:8100//radio.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.radiolinea.it/diretta-drive/
+  country: IT
+  status: stream-only
+  stationuuid: b58f4362-76a2-4d96-8465-b5328533714e
+  changeuuid: 00cbcc99-f372-4a36-85f6-6d75e452d0db
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-yes
+  broadcaster: independent
+  name: Radio YES
+  streamUrl: https://stream1.aswifi.it/radioyes/live/index.m3u8
+  codec: UNKNOWN
+  favicon: https://i0.wp.com/yesmagazine.it/wp-content/uploads/2020/04/image3.jpeg
+  homepage: https://yesmagazine.it/radio-yes-dab/
+  country: IT
+  status: stream-only
+  stationuuid: a2d25046-4641-4ff9-b3a7-ff8328d474a7
+  changeuuid: 1e8df15f-41e7-4060-8472-09876d324dbb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-stazione-playlist
+  broadcaster: independent
+  name: Stazione Playlist
+  streamUrl: https://stream.zeno.fm/5fnppy0ag0hvv
+  codec: MP3
+  homepage: https://stjoseph.ning.com/
+  country: IT
+  status: stream-only
+  stationuuid: 8d7fb56e-d911-49a4-aa8b-c67b5e6e64a1
+  changeuuid: f0de3436-5c5b-455e-9d74-2457239d9a8e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-gedi-radio-capital-soft
+  broadcaster: independent
+  name: GEDI - Radio Capital Soft
+  streamUrl: https://streamcdnr14-4c4b867c89244861ac216426883d1ad0.msvdn.net/webradio/capitalsoft/playlist.m3u8
+  bitrate: 128
+  codec: AAC
+  favicon: https://cdn.gelestatic.it/capital/sites/2/2019/06/webradio-radio-capital-soft-1200x627.jpg
+  homepage: https://www.capital.it/webradio/05/
+  country: IT
+  status: stream-only
+  stationuuid: 274ddf0d-3b8b-4a2d-a2af-1ec6c095b80c
+  changeuuid: a890d7e2-db40-41ec-82df-41741f6a70dd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-hybrid-radio
+  broadcaster: independent
+  name: Hybrid Radio
+  streamUrl: https://nr9.newradio.it/proxy/content?mp=/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.radiohybrid.net/favicon.ico
+  homepage: https://www.radiohybrid.net/
+  country: IT
+  status: stream-only
+  stationuuid: 1c418f87-98cd-47ca-ac37-2bbfdead6716
+  changeuuid: 143a4b8b-7ced-45ee-9238-94e7f24cab7b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-dj-goku24
+  broadcaster: independent
+  name: Radio DJ Goku24
+  streamUrl: https://stream-152.zeno.fm/b2d9xxu8khruv
+  codec: MP3
+  homepage: https://djgoku24.it/
+  country: IT
+  status: stream-only
+  stationuuid: 25324155-cc0c-498b-bc8f-098bba36d542
+  changeuuid: c7ad4dc0-0b49-42e7-afe8-34b4d57f88b5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-polignano-web
+  broadcaster: independent
+  name: radio polignano web
+  streamUrl: https://sp3.server89.com:7018/
+  bitrate: 128
+  codec: MP3
+  homepage: https://sp3.server89.com:7018/;
+  country: IT
+  status: stream-only
+  stationuuid: 18711d23-9eb1-4793-a042-081ec12a18c6
+  changeuuid: 1d97d7c7-ba81-4868-96ba-47b211e07f7f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-sole-luna
+  broadcaster: independent
+  name: RADIO SOLE LUNA
+  streamUrl: https://cast3.server89.com/radio/8040/radio.mp3
+  bitrate: 320
+  codec: MP3
+  favicon: https://www.wix.com/favicon.ico
+  homepage: https://radiosoleluna.wixsite.com/shaky-micio
+  country: IT
+  status: stream-only
+  stationuuid: 9c6d746a-0493-4042-b811-6ca25ed801eb
+  changeuuid: 3368ae11-22d9-46ea-971f-f54a0779bf11
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-art-of-music-web-radio
+  broadcaster: independent
+  name: ART OF MUSIC • Web Radio
+  streamUrl: https://sr6.inmystream.it/proxy/artofmusic?mp=/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://artofmusic.fm/resources/apple-touch-icon.png
+  homepage: https://artofmusic.fm/
+  country: IT
+  status: stream-only
+  stationuuid: 42a44cad-d39d-46d2-b1d7-a130d70af74d
+  changeuuid: 71d2077d-3e00-4bf2-b646-10abf80e774f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-controradio
+  broadcaster: independent
+  name: Controradio
+  streamUrl: https://s4.yesstreaming.net:17199/stream
+  bitrate: 256
+  codec: MP3
+  favicon: https://www.controradio.it/wp-content/uploads/2021/09/cropped-favicon-32x32.png
+  homepage: https://www.controradio.it/
+  country: IT
+  status: stream-only
+  stationuuid: a08f5f5a-b392-4615-b0f4-c0fb43575a60
+  changeuuid: f1f85531-a8b0-4848-8cf1-06f714c31003
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-ala
+  broadcaster: independent
+  name: Radio Ala
+  streamUrl: https://cast.radioala.it:8443/stream?type=.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.radioala.it/
+  country: IT
+  status: stream-only
+  stationuuid: b874b62d-70c1-480a-86f7-32583807856e
+  changeuuid: 4f10d367-363f-4a20-889a-c3df766f3ca3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-dancefloor-90-s
+  broadcaster: independent
+  name: "Radio Dancefloor - 90's"
+  streamUrl: https://audio.radiodancefloor.it/live128k.mp3
+  codec: MP3
+  favicon: https://www.radiodancefloor.it/wp-content/uploads/2021/09/logo_2022_mobile.png
+  homepage: https://www.radiodancefloor.it/
+  country: IT
+  status: stream-only
+  stationuuid: cdc9b539-bd1b-4545-a488-6526e1ba080b
+  changeuuid: 5f831b90-ccf4-4f40-abc1-371d6e5817e3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-poderosa
+  broadcaster: independent
+  name: Radio Poderosa
+  streamUrl: https://s5.radio.co/sf025b6002/listen
+  bitrate: 128
+  codec: MP3
+  homepage: https://radiopoderosa.org/
+  country: IT
+  status: stream-only
+  stationuuid: 7b3800ff-d0dc-4523-987e-7e36efc49b47
+  changeuuid: b4b82407-42a0-495e-a6ff-de6125ab7765
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-sicilia-express
+  broadcaster: independent
+  name: RADIO SICILIA EXPRESS
+  streamUrl: https://ssl3.azotosolutions.com:1052/stream
+  bitrate: 128
+  codec: MP3
+  homepage: https://azotosolutions.com/player/radiosiciliaexpress/
+  country: IT
+  status: stream-only
+  stationuuid: 434b818a-bbbc-43a3-b791-e95c45353464
+  changeuuid: 018e0657-39be-47a1-980f-182de8fed764
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-vomero
+  broadcaster: independent
+  name: "Radio Vomero "
+  streamUrl: https://free.rcast.net/67426
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radiovomero.it/
+  country: IT
+  status: stream-only
+  stationuuid: 1fe676d9-7ee6-4fab-8aa1-9c3d3b1f670d
+  changeuuid: 7ddb3337-4ca3-47ae-83cb-7b2d31ef76a1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-rin-italia-network
+  broadcaster: independent
+  name: RIN Italia Network
+  streamUrl: https://nr15.newradio.it:9100/stream
+  bitrate: 128
+  codec: MP3
+  homepage: https://rinitalianetwork.com/
+  country: IT
+  status: stream-only
+  stationuuid: f1c53003-8b3e-4ee8-8979-e0e2baf28030
+  changeuuid: 510c45e9-d303-41de-aa61-4ef37393ff37
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-rtr-99-story
+  broadcaster: independent
+  name: RTR 99 Story
+  streamUrl: https://rtr99.fluidstream.eu/rtr99_story.mp3?id=lJNQvCT7kq&FLID=1&aw_0_req.gdpr=true&listenerid=05cf4c0e10ce1fd7d4c8ca2a37c45d16&awparams=companionAds%3Atrue
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.rtr99.it/story/
+  country: IT
+  status: stream-only
+  stationuuid: 6803e942-41a9-449a-a002-55377056abd6
+  changeuuid: aa95dbe0-9543-4b78-bd3b-520fa81ab8f6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-zak-radio-sicilia
+  broadcaster: independent
+  name: Zak Radio Sicilia
+  streamUrl: https://zakradiosicilia.radioca.st/stream#.mp3
+  bitrate: 96
+  codec: MP3
+  homepage: https://www.zakradio.ne/
+  country: IT
+  status: stream-only
+  stationuuid: 6ce65595-e355-4c4f-83fa-7128a89e9d5b
+  changeuuid: eabb1db4-f499-429d-809f-efa485ceeff9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-105-story
+  broadcaster: independent
+  name: "105 Story"
+  streamUrl: https://icy.unitedradio.it/105Story.mp3?aw_0_req.userConsentV2=&listenerId=e01becbe77271731a6ab06043a29ef98
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.105.net/sezioni/739/105-story
+  country: IT
+  status: stream-only
+  stationuuid: 10521105-6237-4f1e-9854-6f3aded33781
+  changeuuid: 7e4dc544-2222-40eb-9781-2138c384a261
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-bru-zane-classical-radio
+  broadcaster: independent
+  name: Bru Zane Classical Radio
+  streamUrl: https://uk2.streamingpulse.com/ssl/bzr?v=20200621
+  bitrate: 128
+  codec: MP3
+  favicon: https://bru-zane.com/wp-content/uploads/2019/09/logo-small.png
+  homepage: https://bru-zane.com/classical-radio/
+  country: IT
+  status: stream-only
+  stationuuid: 6c1ed21c-bb69-4d0d-8640-802da635c003
+  changeuuid: 325ea8d0-5939-4529-b885-cbc4454a8ab0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-combo-radio
+  broadcaster: independent
+  name: Combo Radio
+  streamUrl: https://s2.radio.co/sed646842d/listen
+  bitrate: 192
+  codec: MP3
+  homepage: https://thisiscombo.com/
+  country: IT
+  status: stream-only
+  stationuuid: 94695a71-65ad-4f44-85c1-d5cd4a3ba58a
+  changeuuid: 8fe9b3af-6807-4a6a-a6f1-50e8bddc5ab4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-united-hip-hop
+  broadcaster: independent
+  name: United Hip Hop
+  streamUrl: https://icy.unitedradio.it/um049.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://unitedradio.it/
+  country: IT
+  status: stream-only
+  stationuuid: d276ca4e-a88a-499f-9ae7-2bd9e0aa33db
+  changeuuid: f12c8740-7af5-45b7-8302-ac8ff3dab1df
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-2000
+  broadcaster: independent
+  name: Radio 2000
+  streamUrl: https://stream.radio2000.it/
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.radio2000.it/wp-content/uploads/2017/11/cropped-radio2000_logo-2-270x270.png
+  homepage: https://www.radio2000.it/
+  country: IT
+  status: stream-only
+  stationuuid: ae4a6839-328e-4719-ae25-0fd0b547a20c
+  changeuuid: 806c1b2b-8320-4ad8-97d5-69efb03cc3d3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-macomer-centrale
+  broadcaster: independent
+  name: Radio Macomer Centrale
+  streamUrl: https://usa1-vn.mixstream.net/:8014/listen.mp3
+  bitrate: 96
+  codec: AAC+
+  homepage: https://www.radiomacomer.com/
+  country: IT
+  status: stream-only
+  stationuuid: 489294af-76bb-451a-afc9-e5f3fd734287
+  changeuuid: f4c546be-185e-4fee-92b8-40111036dc6c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-v2-beat-italy
+  broadcaster: independent
+  name: V2 Beat Italy
+  streamUrl: https://de1se01.v2beat.live/icecast.audio
+  bitrate: 128
+  codec: AAC+
+  homepage: https://www.vibee.tv/
+  country: IT
+  status: stream-only
+  stationuuid: ed661c20-3546-4501-bf9c-89e468a8477d
+  changeuuid: c9948d09-6de9-4ead-a231-79f58a0e745d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-dj-osso-radio
+  broadcaster: independent
+  name: DJ Osso Radio
+  streamUrl: https://stream.rcs.revma.com/x3ab37sgn7uvv
+  codec: MP3
+  homepage: https://www.djossoradio.it/
+  country: IT
+  status: stream-only
+  stationuuid: 9fd24138-a782-4719-ab8a-cf8b43d657d2
+  changeuuid: 77c0f3e5-2e2e-435f-a40d-cc9926621c14
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-ms-hit-radio
+  broadcaster: independent
+  name: MS Hit Radio
+  streamUrl: https://mshit-radio.stream.laut.fm/mshit-radio?ref=radiode&t302=2020-10-27_18-44-16&uuid=df04811c-7724-4496-89b7-cd02544437ed
+  bitrate: 128
+  codec: MP3
+  homepage: https://mshit-radio.stream.laut.fm/
+  country: IT
+  status: stream-only
+  stationuuid: b1c01327-1b3c-49fc-8544-b0116b485d96
+  changeuuid: 9d7de499-2534-4bbe-9bb6-6dbf0e01365c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radiospeaker-it
+  broadcaster: independent
+  name: RADIOSPEAKER.IT
+  streamUrl: https://nr5.newradio.it/proxy/webradfest?mp=/stream2
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.radiospeaker.it/wp-content/themes/radiospeaker/images/player-cover.png
+  homepage: https://radiospeaker.it/
+  country: IT
+  status: stream-only
+  stationuuid: 2524f42e-f9b2-4a0c-b4d7-4bd6eef5c4be
+  changeuuid: c4b0cce8-e4d5-4efd-9b14-d563c23189fe
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-lifegate
+  broadcaster: independent
+  name: lifegate
+  streamUrl: https://stream2.xdevel.com/audio0s975809-423/stream/icecast.audio
+  codec: MP3
+  homepage: https://www.lifegate.it/
+  country: IT
+  status: stream-only
+  stationuuid: f2847b14-8a7b-4f93-a381-99628ee723ef
+  changeuuid: fde31fce-adba-4a3d-afcc-93c0d10bf3c2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-m2o-originals-radio
+  broadcaster: independent
+  name: m2o originals radio
+  streamUrl: https://stream.laut.fm/m2o-originals-radio
+  bitrate: 128
+  codec: MP3
+  favicon: https://static.wixstatic.com/media/b9d036_d21d18b1eff34d019064204ad012c786~mv2.png
+  homepage: https://m2ooriginals.wixsite.com/my-site
+  country: IT
+  status: stream-only
+  stationuuid: ae5ab591-f05b-4724-98c1-1a383e75d5da
+  changeuuid: a16cbb04-6ac0-46af-8b9d-0c75b114a03f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-90-s-4-you
+  broadcaster: independent
+  name: "Radio 90's 4 You"
+  streamUrl: https://streamsrv2.nets-sr.com:8004/stream
+  bitrate: 192
+  codec: AAC
+  homepage: https://www.radiocity4you.it/
+  country: IT
+  status: stream-only
+  stationuuid: f3db0318-0018-4dfd-a6a9-7842a27132cf
+  changeuuid: ac3dd2f3-c127-436a-b6c3-1f07a809c318
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-flyweb
+  broadcaster: independent
+  name: Radio Flyweb
+  streamUrl: https://nrf1.newradio.it:9930/?ver=413378
+  bitrate: 96
+  codec: AAC+
+  favicon: https://www.radioflyweb.it/wp-content/uploads/2022/05/Logo_radioflyweb_95x70.png
+  homepage: https://www.radioflyweb.it/
+  country: IT
+  status: stream-only
+  stationuuid: ec3b773f-8d71-4f6e-886d-68cc0c70740b
+  changeuuid: 437c243b-17f0-4ff7-b0d4-4090ee13e8ef
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-planet-music
+  broadcaster: independent
+  name: Radio Planet Music
+  streamUrl: https://ns3156088.ip-51-89-96.eu:2000/stream/RadioPlanetMusic
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.radioplanetmusic.it/favicon.ico
+  homepage: https://www.radioplanetmusic.it/
+  country: IT
+  status: stream-only
+  stationuuid: 5418a2fc-0d4a-4d82-8174-941d14a196a0
+  changeuuid: 5ec45c2e-1675-4e2c-ba45-f675c779cfab
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-station-one
+  broadcaster: independent
+  name: Radio Station One
+  streamUrl: https://sr10.inmystream.it/proxy/bwrso?mp=/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.stationone.it/wp-content/uploads/2021/12/cropped-cropped-Logo-Station-One-Radio-300.png
+  homepage: https://www.stationone.it/
+  country: IT
+  status: stream-only
+  stationuuid: 1fe3e755-51ea-413c-98cf-0c68acb579dc
+  changeuuid: 2b1af86d-8940-4c1a-8a55-83f844c57311
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-rigiriamo-web-radio
+  broadcaster: independent
+  name: Rigiriamo Web Radio
+  streamUrl: https://onair7.xdevel.com/proxy/xautocloud_zswr_1060?mp=/;stream/;
+  bitrate: 128
+  codec: MP3
+  favicon: https://rigiriamo.it/wp-content/uploads/2024/01/rigira-con-noi-2.png
+  homepage: https://rigiriamo.it/
+  country: IT
+  status: stream-only
+  stationuuid: b09292a5-e185-451a-ba5b-5cb830c547f0
+  changeuuid: 00e27a7f-448d-4851-8c89-9e8bc60cc604
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-mongrando-radio-italia
+  broadcaster: independent
+  name: Mongrando Radio Italia
+  streamUrl: https://a7.asurahosting.com:7000/radio.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://sites.google.com/view/radiomongrando/home-page
+  country: IT
+  status: stream-only
+  stationuuid: ac8ab75c-a56e-463c-8cd1-a6cd3b19f4de
+  changeuuid: 4e5527ee-89c7-4eee-8c34-b385ea314793
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-party-radio
+  broadcaster: independent
+  name: Party Radio
+  streamUrl: https://stream12.top-ix.org/partygroove2
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.fastmediasnc.it/party_radio/
+  country: IT
+  status: stream-only
+  stationuuid: 7b320046-cc06-404e-8c25-15c261b57668
+  changeuuid: 88fae931-8feb-4ac0-a794-3097e3776626
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-fusion-italia
+  broadcaster: independent
+  name: Radio Fusion Italia
+  streamUrl: https://www.shoutcastitalia.com/proxy/fusion?mp=/stream
+  bitrate: 128
+  codec: MP3
+  homepage: https://radiofusion.it/
+  country: IT
+  status: stream-only
+  stationuuid: 5d96e3e3-416e-4dd9-b861-58c9b5587e6a
+  changeuuid: 12e6d04e-db56-4c00-8ef8-5920892eb670
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-omega-sound
+  broadcaster: independent
+  name: Radio Omega Sound
+  streamUrl: https://nr9.newradio.it/proxy/radioome?mp=/stream
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radioomega.it/
+  country: IT
+  status: stream-only
+  stationuuid: 6a13313a-fd7e-46d3-a0cc-9950b5fbe8ff
+  changeuuid: b682845a-65ed-4cc2-8898-ef4de74514d6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-roma-mobilita
+  broadcaster: independent
+  name: Radio Roma mobilità
+  streamUrl: https://nr9.newradio.it:19021/stream?ext=.mp3
+  bitrate: 128
+  codec: MP3
+  country: IT
+  status: stream-only
+  stationuuid: 6f2b201c-8618-4760-b09d-4164633e78e1
+  changeuuid: eb155a15-12cf-4b24-9af2-80040791750e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-studio-delta-la-piu
+  broadcaster: independent
+  name: Radio Studio Delta - la piu
+  streamUrl: https://rsd.streamingmedia.it/play.mp3
+  bitrate: 192
+  codec: MP3
+  favicon: https://radiostudiodelta.it/wp-content/uploads/2014/08/mobile-logo-rsd.png
+  homepage: https://www.radiostudiodelta.it/
+  country: IT
+  status: stream-only
+  stationuuid: b06955b3-2465-45be-854c-c8d0af2207d3
+  changeuuid: 6747ccf7-4554-4ca1-aea6-5ec6851fffea
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-suby
+  broadcaster: independent
+  name: Radio Suby
+  streamUrl: https://icy.unitedradio.it/Suby.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radiosubasio.it/player/#!/channel/2
+  country: IT
+  status: stream-only
+  stationuuid: 2e237816-280c-44a7-9093-79a84de8cd97
+  changeuuid: 2acc2557-1380-4cdc-a759-29457947a55d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-amore-blu
+  broadcaster: independent
+  name: Radio Amore Blu
+  streamUrl: https://stream10.xdevel.com/audio4s977886-2318/stream/icecast.audio
+  codec: MP3
+  favicon: https://www.grupporadioamore.it/images/stories/loghi/radio_amore_blu.jpg
+  homepage: https://www.grupporadioamore.it/
+  country: IT
+  status: stream-only
+  stationuuid: 17326e5e-ee2f-43e7-918e-6eba222159fd
+  changeuuid: 15952ba1-633e-4a5a-8239-c61bd17fd3e8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-caos-italia
+  broadcaster: independent
+  name: Radio Caos Italia
+  streamUrl: https://sr14.inmystream.it/stream/radiocaos
+  bitrate: 128
+  codec: AAC+
+  homepage: https://radiocaositalia.it/
+  country: IT
+  status: stream-only
+  stationuuid: f6690b18-c8c5-4e78-834e-6e8a56ba2e14
+  changeuuid: 7db58e9f-c805-4a8c-9221-7f437dec3f31
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-energy-is-on-flac
+  broadcaster: independent
+  name: Radio Energy Is On (Flac)
+  streamUrl: https://stream.radioenergy.to/stream
+  bitrate: 1536
+  codec: OGG
+  favicon: https://radioenergy.to/wp-content/uploads/2018/03/LogoEnergy.png
+  homepage: https://radioenergy.to/
+  country: IT
+  status: stream-only
+  stationuuid: 10d0abaa-1305-4482-a5b6-af3060c01075
+  changeuuid: 444c2874-3436-40a1-b243-7eff73bea427
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-erre18
+  broadcaster: independent
+  name: Radio ERRE18
+  streamUrl: https://player.erre18.com:8010/radioerre18.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: https://erre18.com/
+  country: IT
+  status: stream-only
+  stationuuid: 39ca20b8-1cd3-484a-8f56-ffa63b18490c
+  changeuuid: fcf6a3b8-50cb-44a9-a21d-d777586b513d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-gattopardo
+  broadcaster: independent
+  name: RADIO GATTOPARDO
+  streamUrl: https://sr11.inmystream.it/proxy/radiogattopardo?mp=/stream&1700931042510
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radiogattopardo.it/
+  country: IT
+  status: stream-only
+  stationuuid: 1a885f9e-3b01-419d-bd01-732e7543839c
+  changeuuid: b064fba2-2988-41c7-bcdc-de6585ee2c45
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-soffio
+  broadcaster: independent
+  name: Radio Soffio
+  streamUrl: https://sr2.inmystream.it/proxy/radiosoffio/stream
+  bitrate: 128
+  codec: AAC+
+  favicon: https://www.radiosoffio.it/wp-content/uploads/2021/09/logo-e1631203629175-150x150.png
+  homepage: https://www.radiosoffio.it/
+  country: IT
+  status: stream-only
+  stationuuid: efccd376-b2b9-4068-a1ad-93b73fd903b0
+  changeuuid: 4700a38b-715a-4344-b7dd-0061bae55c98
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-teleradio1
+  broadcaster: independent
+  name: "TeleRadio1 "
+  streamUrl: https://stream.laut.fm/teleradio1
+  bitrate: 128
+  codec: MP3
+  favicon: https://teleradio1.com/favicon.ico
+  homepage: https://teleradio1.com/
+  country: IT
+  status: stream-only
+  stationuuid: c487ed32-07d7-4999-a370-27537b0e5d7e
+  changeuuid: f048b191-57ce-49e7-a959-888938beda78
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-grs-gruppo-radio-sperone
+  broadcaster: independent
+  name: GRS - Gruppo Radio Sperone
+  streamUrl: https://onair7.xdevel.com/proxy/xautocloud_luge_1982?mp=/;1/
+  bitrate: 320
+  codec: MP3
+  favicon: https://grupporadiosperone.it/wp-content/uploads/2022/07/LogoCompleto-Quadrato-BGBlack.jpg
+  homepage: https://grupporadiosperone.it/
+  country: IT
+  status: stream-only
+  stationuuid: 01a765f1-6980-4776-a942-245e624d8f05
+  changeuuid: 00babcff-86b6-488d-93b2-08a69e24a609
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-amore
+  broadcaster: independent
+  name: Radio Amore
+  streamUrl: https://stream10.xdevel.com/audio8s977886-2322/stream/icecast.audio
+  codec: MP3
+  favicon: https://www.grupporadioamore.it/images/stories/loghi/radio_amore.jpg
+  homepage: https://www.grupporadioamore.it/
+  country: IT
+  status: stream-only
+  stationuuid: ea908a2e-8b09-4bc4-b435-0d3cdfcc92fe
+  changeuuid: c3ed2489-e2cf-46f8-8c52-fed5afc3c014
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-capital-30-songs
+  broadcaster: independent
+  name: radio Capital 30 songs
+  streamUrl: https://4c4b867c89244861ac216426883d1ad0.msvdn.net/radiodeejay30songs/radiodeejay30songs/play1.m3u8
+  codec: UNKNOWN
+  country: IT
+  status: stream-only
+  stationuuid: d968c44c-c2a1-472c-96fb-e63c620a0ad8
+  changeuuid: 8193dcda-0859-4307-be12-a5168a3f7cde
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-gioiosa-marina
+  broadcaster: independent
+  name: Radio Gioiosa Marina
+  streamUrl: https://sr7.inmystream.it/proxy/radiogioiosamarina?mp=/stream
+  bitrate: 192
+  codec: MP3
+  favicon: https://www.radiogioiosamarina.it/wp-content/uploads/2024/06/favicon.png
+  homepage: https://www.radiogioiosamarina.it/
+  country: IT
+  status: stream-only
+  stationuuid: 956605b9-95dc-43c0-9937-81319dd61397
+  changeuuid: 2d9b556e-ee0c-450f-ba26-c8b508314494
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-gold-wonderland
+  broadcaster: independent
+  name: RADIO GOLD WONDERLAND
+  streamUrl: https://ad1.xdevel.com/radiogoldwl
+  bitrate: 192
+  codec: MP3
+  country: IT
+  status: stream-only
+  stationuuid: 88ee8c9f-56a0-4711-b4fc-5f82d77eee7f
+  changeuuid: 25238e82-2954-4cff-9fb2-67898bdb8845
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-latina
+  broadcaster: independent
+  name: RADIO LATINA
+  streamUrl: https://media.velcom.it:8014/radiolatina
+  bitrate: 256
+  codec: MP3
+  favicon: https://www.radiolatina.it/wp-content/uploads/2023/05/Radio-Latina-logo-sito.png
+  homepage: https://www.radiolatina.it/
+  country: IT
+  status: stream-only
+  stationuuid: ce0a1889-569b-422f-accb-d33a4744f83b
+  changeuuid: 0d999c8f-0e6f-4a4f-b24c-36ed0ad12ae5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-laziale-88-100-fm
+  broadcaster: independent
+  name: Radio Laziale 88.100 FM
+  streamUrl: https://stream9.xdevel.com/audio3s975363-2397/stream/icecast.audio
+  codec: AAC+
+  homepage: https://www.radiolaziale.com/
+  country: IT
+  status: stream-only
+  stationuuid: 76d47259-f487-4dc3-9a13-ce96b3f28fa1
+  changeuuid: 85bd1a1e-b773-4c05-9eca-6190e1cf39d4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-olbia-web
+  broadcaster: independent
+  name: RADIO OLBIA WEB
+  streamUrl: https://nrf1.newradio.it:10026/stream
+  bitrate: 96
+  codec: AAC+
+  favicon: https://static.wixstatic.com/media/d6d54a_fdd52cdf89174685a44168e8d1c7dc19~mv2.png/v1/fill/w_121,h_121,al_c,q_85,usm_0.66_1.00_0.01,enc_auto/default%202_edited.png
+  homepage: https://www.radioolbiaweb.it/
+  country: IT
+  status: stream-only
+  stationuuid: 68cba36a-576b-40de-b82f-2623ca56ac6b
+  changeuuid: e5494040-3eec-4ac1-9b22-7f6310137fdd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-sole-vittoria
+  broadcaster: independent
+  name: Radio Sole Vittoria
+  streamUrl: https://radiosole-fellini.radioca.st/
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.radiosole.eu/images/favicon_radiosole.png
+  homepage: https://www.radiosole.eu/
+  country: IT
+  status: stream-only
+  stationuuid: 3a7c409a-ca9e-4bfd-87b5-96cd0bbb8e65
+  changeuuid: d39c7dff-e01b-4b6a-8911-2664a904a57c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-gedi-deejay-gasolina
+  broadcaster: independent
+  name: GEDI - Deejay Gasolina
+  streamUrl: https://streamcdnr7-4c4b867c89244861ac216426883d1ad0.msvdn.net/webradio/deejaygasolina/playlist.m3u8
+  bitrate: 128
+  codec: AAC
+  favicon: https://cdn.gelestatic.it/deejay/sites/2/2016/03/webradio_deejay_gasolina.png
+  homepage: https://www.deejay.it/webradio/08/
+  country: IT
+  status: stream-only
+  stationuuid: f2ca4d6b-674e-4239-b9b0-f0929236bb77
+  changeuuid: 5e569af8-bda3-4dde-9ebe-51eaff2a3f33
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-nettuno-bologna-uno
+  broadcaster: independent
+  name: NETTUNO BOLOGNA UNO
+  streamUrl: https://audio6.nemostream.tv/proxy/nettunobologna1ice1/stream
+  bitrate: 96
+  codec: AAC
+  favicon: https://www.fm-world.it/wp-content/uploads/2020/09/WhatsApp-Image-2020-09-11-at-23.46.25.jpeg.webp
+  homepage: http://www.radiobolognauno.it/
+  country: IT
+  status: stream-only
+  stationuuid: 2c1011da-f343-4da5-9fe4-0acde448ca74
+  changeuuid: cb235de3-b2c9-45db-94e2-afd252b37965
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-al-serv-della-divina-misericordia
+  broadcaster: independent
+  name: Radio al Serv della Divina Misericordia
+  streamUrl: https://nr9.newradio.it/proxy/mpalmisa?mp=/stream?ext=.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.apostolegc.net/ita/radio/
+  country: IT
+  status: stream-only
+  stationuuid: 27cbe141-f5a3-4676-9dd5-1eba3469c781
+  changeuuid: 67b06623-8747-47de-8fd0-b40c01b7f8e7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-amica-partinico
+  broadcaster: independent
+  name: Radio Amica Partinico
+  streamUrl: https://nr12.newradio.it/stream/8676/stream
+  bitrate: 128
+  codec: MP3
+  homepage: https://www.radioamica.it/
+  country: IT
+  status: stream-only
+  stationuuid: 819798ed-2590-47eb-aef6-978f53bf7eb5
+  changeuuid: fb4fe8f9-3b53-4b1d-83de-e06899e85b2b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-diva-fm
+  broadcaster: independent
+  name: Radio Diva FM
+  streamUrl: https://stream10.xdevel.com/audio0s977410-1985/stream/icecast.audio?1727095495120
+  codec: MP3
+  homepage: http://www.radiodiva.it/
+  country: IT
+  status: stream-only
+  stationuuid: a66409d4-dc57-4ed8-8b64-6b891dcc66e9
+  changeuuid: 2826c134-f5ed-4f14-a476-ab2ddfd9e01c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-lombardia
+  broadcaster: independent
+  name: Radio Lombardia
+  streamUrl: https://stream6.xdevel.com/audio0s976574-1328/stream/icecast.audio
+  codec: MP3
+  favicon: https://www.radiolombardia.it/wp-content/uploads/2024/05/LOGO_bianco-1-1024x1024.png
+  homepage: https://www.radiolombardia.it/
+  country: IT
+  status: stream-only
+  stationuuid: 2dbb1c08-fb63-4ec4-80de-54c4b9a5dd13
+  changeuuid: 29f946f7-8bf5-4064-a5ba-7774ad2cc1ce
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-mille-baci
+  broadcaster: independent
+  name: Radio Mille Baci
+  streamUrl: https://stream-154.zeno.fm/6qzpb1exszzuv
+  codec: MP3
+  homepage: https://radiomillebaci.com/
+  country: IT
+  status: stream-only
+  stationuuid: fea9656d-86a8-464a-b31f-429ae62dd7bc
+  changeuuid: bf4a89b6-be96-4f5a-95fb-30bf3d071956
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-monte-carlo-fm
+  broadcaster: independent
+  name: Radio Monte Carlo FM
+  streamUrl: https://icy.unitedradio.it/RMC.aac
+  bitrate: 96
+  codec: AAC+
+  favicon: https://img-api.cloud.mediaset.net/api/images/rd/v1/ita/aHR0cHM6Ly9yYWRpbzMub21ueXMuY29tL3dwLWNvbnRlbnQvdXBsb2Fkcy8yMDI1LzA2L2RlZmF1bHQtMS5qcGc/-/0/0?r=91587740ec678bd2765cf54837744f04
+  homepage: https://www.radiomontecarlo.net/radio-onair/
+  country: IT
+  status: stream-only
+  stationuuid: 6c1388c5-bb0f-41fa-bf07-af836268e8d8
+  changeuuid: 6118ca16-a5fd-4258-96f6-76028b31c75a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-musica-tuttaunaltramusica
+  broadcaster: independent
+  name: Radio Musica TuttaUnAltraMusica
+  streamUrl: https://nrf1.newradio.it:10434/stream
+  bitrate: 96
+  codec: AAC+
+  favicon: https://cdn-profiles.tunein.com/s303872/images/logod.jpg?t=637806298200000000
+  homepage: https://radiomusicatv.it/
+  country: IT
+  status: stream-only
+  stationuuid: 1e06cb41-007a-42bc-8fa6-d3b521f9f11a
+  changeuuid: 760b60af-2b4c-4d6a-b1ab-d5733a3997c7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-play-emotions
+  broadcaster: independent
+  name: Radio Play Emotions
+  streamUrl: https://www.shoutcastitalia.com/proxy/playemotions?mp=/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.playemotions.it/wp-content/uploads/2022/12/pngegg.png
+  homepage: http://www.playemotions.it/#
+  country: IT
+  status: stream-only
+  stationuuid: df42511b-d962-4d7e-92f1-d3a3f98a737a
+  changeuuid: 6581eb1f-5761-4caf-827c-e999d49de529
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-pret-a-porter
+  broadcaster: independent
+  name: Radio Pret a Porter
+  streamUrl: https://onair7.xdevel.com/proxy/xautocloud_ammg_1275?mp=/;1/
+  bitrate: 320
+  codec: MP3
+  homepage: https://www.radiopretaporter.com/
+  country: IT
+  status: stream-only
+  stationuuid: 8dc96e4e-273f-4f1e-a38e-f0502e5d5aa7
+  changeuuid: 68ee429b-1318-49fd-b6d7-0346eb0e8c44
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-sacra-famiglia
+  broadcaster: independent
+  name: RADIO SACRA FAMIGLIA
+  streamUrl: https://nr6.newradio.it/proxy/aieconlu?mp=/stream
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.radiosacrafamiglia.it/
+  country: IT
+  status: stream-only
+  stationuuid: 1a01e453-921f-4539-a0d6-1720a7c07e28
+  changeuuid: 599eefcc-11ca-4ad1-90d1-20a42176a3b5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-sunbeat
+  broadcaster: independent
+  name: Radio Sunbeat
+  streamUrl: https://stream.rcs.revma.com/5tbxc6f39yuvv
+  codec: MP3
+  homepage: https://radiosunbeat.com/
+  country: IT
+  status: stream-only
+  stationuuid: 50487a4e-29ca-4a5e-97ba-745d7e9f5833
+  changeuuid: 25eac4b1-bcf1-4359-adb5-a2f9af9da03c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-valle-camonica
+  broadcaster: independent
+  name: Radio Valle Camonica
+  streamUrl: https://onair20.xdevel.com/proxy/vallecamonica?mp=/;stream/;
+  bitrate: 256
+  codec: MP3
+  favicon: https://new.radiovallecamonica.it/wp-content/uploads/2023/03/logo_new.png
+  homepage: https://new.radiovallecamonica.it/
+  country: IT
+  status: stream-only
+  stationuuid: e5289c52-6969-4dd1-bcf9-1e10e6e9aa11
+  changeuuid: 0b3e861e-c59a-4931-939f-b3b6adf62e35
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radioradio
+  broadcaster: independent
+  name: Radioradio
+  streamUrl: https://sr6.inmystream.it/proxy/rrshout?mp=/stream
+  bitrate: 64
+  codec: AAC+
+  homepage: https://www.radioradio.it/
+  country: IT
+  status: stream-only
+  stationuuid: 4db8710a-8cab-4c63-9b67-420c637a5fad
+  changeuuid: a8a43479-879c-479e-9df9-6e92d75c14c2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-rft-movida-club
+  broadcaster: independent
+  name: RFT Movida Club
+  streamUrl: https://streaming.smartradio.ch:8505/stream
+  bitrate: 48
+  codec: AAC+
+  favicon: https://radioticino.com/wp-content/uploads/2019/09/RFT-Movida-Club-300x300.png
+  homepage: https://radioticino.com/rft-movida/
+  country: IT
+  status: stream-only
+  stationuuid: 0b60f67c-6e94-42a6-adb0-d0ca58d216ab
+  changeuuid: 750e325a-9e93-40c7-8e60-1041b6d41525
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-soloanni80
+  broadcaster: independent
+  name: SoloAnni80
+  streamUrl: https://stream.laut.fm/soloanni80
+  bitrate: 128
+  codec: MP3
+  favicon: https://soloanni80.blogspot.com/favicon.ico
+  homepage: https://soloanni80.blogspot.com/
+  country: IT
+  status: stream-only
+  stationuuid: 183f6fe0-a75b-4c46-808a-b3453b7d1cef
+  changeuuid: b5e63a97-6428-42e7-b7bf-5df20b08ff75
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-sorriso
+  broadcaster: independent
+  name: Sorriso
+  streamUrl: https://klasse1.fluidstream.eu/sorriso?FLID=1&type=.aac
+  bitrate: 64
+  codec: AAC+
+  homepage: https://www.sorrriso.it/
+  country: IT
+  status: stream-only
+  stationuuid: a6d66851-5902-4241-aa69-20ed34b4c2b9
+  changeuuid: bb91a822-b9fd-4102-bbb8-130cf478ce61
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-virgin-radio-rock-ballads
+  broadcaster: independent
+  name: Virgin Radio Rock Ballads
+  streamUrl: https://icy.unitedradio.it/Virgin_06.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://img-api.cloud.mediaset.net/api/images/rd/v1/ita/aHR0cHM6Ly93d3cudmlyZ2lucmFkaW8uaXQvd3AtY29udGVudC91cGxvYWRzLzIwMjUvMTEvV2VicmFkaW8tVmlyZ2luLTIwMjAtUm9ja0JhbGxhZHMtMTU4ODA2MjM0NzE4NXBuZy12aXJnaW5fcmFkaW9fcm9ja19iYWxsYWRzLnBuZw/-/0/0?r=11acbeadd748211a27a11f42433abe6a
+  homepage: https://www.virginradio.it/web-radio/virgin-radio-rock-ballads/
+  country: IT
+  status: stream-only
+  stationuuid: ae34a504-b882-409d-8040-7a9cb9ec2329
+  changeuuid: 6f60f328-cef4-4e0b-91a1-55d0051228da
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-ac3x-radio
+  broadcaster: independent
+  name: AC3X Radio
+  streamUrl: https://ac3xradio.com/liveaac
+  codec: AAC
+  favicon: https://ac3xradio.com/logo.png
+  homepage: https://ac3xradio.com/
+  country: IT
+  status: stream-only
+  stationuuid: 3f48a699-9e4b-405a-97a7-3f8f95d9a2a8
+  changeuuid: a17526a0-56b2-4674-aadb-d1006af94c25
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-die-antenne
+  broadcaster: independent
+  name: Die Antenne
+  streamUrl: https://stream.radio2000.it/antenne
+  bitrate: 192
+  codec: MP3
+  homepage: https://www.dieantenne.it/
+  country: IT
+  status: stream-only
+  stationuuid: ca389e28-b591-4be4-bdfc-ff3e2735d50a
+  changeuuid: e5e1c8fb-a81d-4557-ac73-ee417e8739fb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-giglio-rosso
+  broadcaster: independent
+  name: RADIO GIGLIO ROSSO
+  streamUrl: https://nr14.newradio.it:8823/stream?ext=.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.radiogigliorosso.it/wp-content/uploads/2023/01/logowhite2-768x902.png
+  homepage: https://www.radiogigliorosso.it/
+  country: IT
+  status: stream-only
+  stationuuid: b7185139-3860-4067-9dde-88f9eacc4b24
+  changeuuid: 81e946f5-e3b1-461c-8e0a-3b0c2670e74f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-like
+  broadcaster: independent
+  name: Radio Like
+  streamUrl: https://ice43.fluidstream.net/antenna2.mp3?FLID=1&type=.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://players.fluidstream.it/RadioAntenna2/images/logo320.png
+  homepage: https://www.radiolike.it/
+  country: IT
+  status: stream-only
+  stationuuid: e0edded2-3882-405e-b624-d815523c03aa
+  changeuuid: f3c5a005-fb26-48c3-96c1-cc3078e284da
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-monte-carlo-80
+  broadcaster: independent
+  name: Radio Monte Carlo 80
+  streamUrl: https://icy.unitedradio.it/rmcweb008
+  bitrate: 128
+  codec: MP3
+  favicon: https://img-api.cloud.mediaset.net/api/images/rd/v1/ita/aHR0cHM6Ly9yYWRpbzMub21ueXMuY29tL3dwLWNvbnRlbnQvdXBsb2Fkcy8yMDI1LzEwL1JNQ184MF9XZWJSYWRpby0xNjAxNTI3NzM2NzYzLTIuanBnLXJtY184MC0yLmpwZw/-/0/0?r=1b99011b2b5c550c59f7eefa09dd81b6
+  homepage: https://www.radiomontecarlo.net/web-radio/radio-monte-carlo-80/
+  country: IT
+  status: stream-only
+  stationuuid: 173e656d-e94b-46a7-b4a0-aac7b41006f8
+  changeuuid: f9fb30da-3fff-48ce-87ff-af703781804f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-replay-news-italiano
+  broadcaster: independent
+  name: REPLAY NEWS - Italiano
+  streamUrl: https://replaynewsit.ice.infomaniak.ch/replaynewsit-128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.publicsante.com/BIENVENU/LOGO%20REPLAY%20NEWS-IT.png
+  homepage: https://www.replaynews.net/
+  country: IT
+  status: stream-only
+  stationuuid: db6ad5ca-db5b-4d1b-ad1c-816ca70b23ca
+  changeuuid: bd241030-6ce9-41ee-9ebe-afc75895ccac
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-rv-1-superhit
+  broadcaster: independent
+  name: Rv 1 Superhit
+  streamUrl: https://rv1-superhit.stream.laut.fm/rv1-superhit
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.rv1.it/images/Rv1-SuperHIT_317x315.png
+  homepage: https://www.rv1.it/rv1-superhit.php
+  country: IT
+  status: stream-only
+  stationuuid: 7dad4a7d-8fa3-43c0-baf7-93eaf58efb98
+  changeuuid: c9754e87-0e7d-4795-8f5f-3d29d8d04de8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-studio-100-radio
+  broadcaster: independent
+  name: Studio 100 Radio
+  streamUrl: https://s16.myradiostream.com:5626/;
+  bitrate: 96
+  codec: MP3
+  homepage: http://www.radiostudio100.com/
+  country: IT
+  status: stream-only
+  stationuuid: ef657f97-98fc-4b83-9383-122bc26201b4
+  changeuuid: 418458b1-6466-4205-81cd-14837fb138f8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-bussola-24-radiobussola-radiobussola24
+  broadcaster: independent
+  name: "Radio Bussola 24 (RadioBussola, RadioBussola24)"
+  streamUrl: https://radiobussola24.radioca.st/stream
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.radiobussola.it/app/player/images/icon.png
+  homepage: https://www.radiobussola.it/
+  country: IT
+  status: stream-only
+  stationuuid: 76ea3d5f-16d9-40d5-be36-8329f2a740fc
+  changeuuid: 2aab8040-6af4-4ba5-aa57-2c9ad3c79ca2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-meano
+  broadcaster: independent
+  name: Radio Meano
+  streamUrl: https://meteomeano.stream.laut.fm/meteomeano?.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: https://laut.fm/meteomeano
+  country: IT
+  status: stream-only
+  stationuuid: 9b97ead9-17a5-4c65-90f1-419fa9a02560
+  changeuuid: 86666202-e8f3-4404-8508-c6d5735bb336
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-monte-carlo-disco-funk
+  broadcaster: independent
+  name: Radio Monte Carlo Disco Funk
+  streamUrl: https://icy.unitedradio.it/rmcweb025
+  bitrate: 128
+  codec: MP3
+  favicon: https://img-api.cloud.mediaset.net/api/images/rd/v1/ita/aHR0cHM6Ly9yYWRpbzMub21ueXMuY29tL3dwLWNvbnRlbnQvdXBsb2Fkcy8yMDI1LzEwL1JNQ19ESVNDT0ZVTktfV2ViUmFkaW8tMTYwMTUyODAyNzQ1MC0yLmpwZy1yYWRpb19tb250ZV9jYXJsb19kaXNjb19mdW5rLTIuanBn/-/0/0?r=feb9fbd1bba1b43ee74ae2046068ed2f
+  homepage: https://www.radiomontecarlo.net/web-radio/radio-monte-carlo-disco-funk/
+  country: IT
+  status: stream-only
+  stationuuid: f215e3f4-6f2b-4279-98e6-7c304a159fa7
+  changeuuid: e6e37239-c383-4ac3-a79e-1c3435011a98
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-divina-fm
+  broadcaster: independent
+  name: Divina FM
+  streamUrl: https://maurizi1.radioca.st/stream.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.divinafm.it//wp-content/uploads/logo.png
+  homepage: https://www.divinafm.it/
+  country: IT
+  status: stream-only
+  stationuuid: 3e68f6bd-023a-4d25-adab-4e6e52fb6ede
+  changeuuid: 67d58e5b-945c-4ba0-ab93-2fe3e96d6d63
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-free-radio-conselve
+  broadcaster: independent
+  name: Free Radio Conselve
+  streamUrl: https://ice17.fluidstream.net/conselve.mp3?FLID=M
+  bitrate: 192
+  codec: MP3
+  favicon: https://players.fluidstream.it/Conselve/images/512.jpg
+  homepage: https://freeradioconselve.it/
+  country: IT
+  status: stream-only
+  stationuuid: d3b632f1-b39f-458c-9ee8-79e645f0b0a9
+  changeuuid: 17321850-b29c-46c4-90c0-47d998023675
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-nostream
+  broadcaster: independent
+  name: NoStream
+  streamUrl: https://nostream.mastodon.uno/hls/0/stream.m3u8
+  codec: UNKNOWN
+  homepage: https://nostream.mastodon.uno/#
+  country: IT
+  status: stream-only
+  stationuuid: 6ec57cc2-d00b-44b1-93d7-86afa0393af8
+  changeuuid: b08f68a6-6fff-4b8f-8687-dadeea60a2b7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radio-rf101
+  broadcaster: independent
+  name: Radio RF101
+  streamUrl: https://rf101.radioca.st/
+  bitrate: 256
+  codec: AAC+
+  homepage: https://www.rf101.it/
+  country: IT
+  status: stream-only
+  stationuuid: 94f52041-96d7-42d2-9e46-3ada1d6c1e6b
+  changeuuid: 5a11c745-ce77-43de-8600-740b80e39a2c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-hey-dj-radio
+  broadcaster: independent
+  name: HEY DJ RADIO
+  streamUrl: https://nr3.newradio.it:18303/stream?ver=777128
+  bitrate: 128
+  codec: MP3
+  favicon: https://www.heydjradio.com/new/wp-content/uploads/2018/11/heyDJ_logo_index_small.png
+  homepage: https://www.heydjradio.com/
+  country: IT
+  status: stream-only
+  stationuuid: 9db676f4-6315-4846-b790-f11eda598ec1
+  changeuuid: c34b92d8-e687-4e1c-bbd7-bd80a470890e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: it-radioattivainformazione
+  broadcaster: independent
+  name: RadioAttivaInformazione
+  streamUrl: https://radioattiva.duckdns.org/hls/radioattivainformazione/live.m3u8
+  bitrate: 52
+  codec: AAC
+  homepage: https://radioattivainformazione.it/
+  country: IT
+  status: stream-only
+  stationuuid: a81c1349-a1bf-4b9c-ba55-e7bdff3a645b
+  changeuuid: 2d05e7c6-3841-44d1-986f-fae751ff9d18
+  reviewedAt: "2026-05-04"

--- a/public/stations.json
+++ b/public/stations.json
@@ -47008,6 +47008,12777 @@
         16.3876
       ],
       "status": "stream-only"
+    },
+    {
+      "id": "gb-tmm-1",
+      "name": "TMM 1",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-msmn.sharp-stream.com/nme1.mp3",
+      "homepage": "https://www.themusicmachine.co.uk/",
+      "country": "GB",
+      "tags": [
+        "alternative",
+        "alternative rock",
+        "garage",
+        "indie",
+        "indie pop",
+        "indie rock"
+      ],
+      "favicon": "https://cdn-profiles.tunein.com/s159857/images/logod.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-heart-70s",
+      "name": "Heart 70s",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ssl.musicradio.com/Heart70sMP3",
+      "homepage": "https://www.heart.co.uk/70s",
+      "country": "GB",
+      "tags": [
+        "70s",
+        "national",
+        "pop",
+        "public radio",
+        "variety"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-heart-dance",
+      "name": "Heart Dance",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ssl.musicradio.com/HeartDanceMP3",
+      "homepage": "https://www.heart.co.uk/dance",
+      "country": "GB",
+      "tags": [
+        "dance",
+        "national",
+        "pop",
+        "public radio",
+        "variety"
+      ],
+      "favicon": "https://www.heart.co.uk/assets_v4r/heart/img/favicon-196x196.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-tmm-2",
+      "name": "TMM 2",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-msmn.sharp-stream.com/nme2.mp3",
+      "homepage": "https://www.themusicmachine.co.uk/",
+      "country": "GB",
+      "tags": [
+        "alternative",
+        "hiphop",
+        "electronic"
+      ],
+      "favicon": "https://cdn-profiles.tunein.com/s155539/images/logod.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-love-radio-only-love-songs-70s80s90s",
+      "name": "LOVE.radio Only Love Songs 70s80s90s",
+      "broadcaster": "independent",
+      "streamUrl": "https://loveradio.streamingmedia.it/england",
+      "homepage": "https://love.radio/",
+      "country": "GB",
+      "tags": [
+        "love",
+        "love songs",
+        "lovesongs",
+        "romantic"
+      ],
+      "bitrate": 192,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bbc-news-hd-720p",
+      "name": "BBC News HD (720P)",
+      "broadcaster": "independent",
+      "streamUrl": "https://vs-hls-push-ww-live.akamaized.net/x=4/i=urn:bbc:pips:service:bbc_news_channel_hd/t=3840/v=pv14/b=5070016/main.m3u8",
+      "homepage": "https://bbc.co.uk/news",
+      "country": "GB",
+      "tags": [
+        "england",
+        "english",
+        "london",
+        "news",
+        "uk",
+        "world news"
+      ],
+      "favicon": "https://upload.wikimedia.org/wikipedia/en/thumb/2/24/BBC_News_HD_Logo.svg/2560px-BBC_News_HD_Logo.svg.png",
+      "codec": "UNKNOWN",
+      "geo": [
+        51.5007,
+        -0.1246
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-exclusively-dire-straits",
+      "name": "Exclusively Dire Straits",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.exclusive.radio/er/direstraits/icecast.audio",
+      "homepage": "https://exclusive.radio/",
+      "country": "GB",
+      "tags": [
+        "rock"
+      ],
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-virgin-radio-chilled",
+      "name": "Virgin Radio Chilled",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.virginradio.co.uk/stream-chilled?aw_0_1st.platform=vr-web",
+      "homepage": "https://virginradio.co.uk/radioplayer/live/virginradio-player-chilled.html",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-seva-novgorodsev",
+      "name": "Радио Сева (Radio Seva Novgorodsev)",
+      "broadcaster": "independent",
+      "streamUrl": "https://seva.ru/radio/stream",
+      "homepage": "https://seva.ru/",
+      "country": "GB",
+      "tags": [
+        "music",
+        "rock",
+        "talk",
+        "музыка",
+        "разговорное",
+        "рок"
+      ],
+      "favicon": "https://seva.ru/radio/radio.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-tmm-2-hq",
+      "name": "TMM 2 (HQ)",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-msmn.sharp-stream.com/nme2high.mp3",
+      "homepage": "https://www.themusicmachine.co.uk/",
+      "country": "GB",
+      "tags": [
+        "alternative",
+        "hiphop",
+        "electronic"
+      ],
+      "favicon": "https://cdn-profiles.tunein.com/s155539/images/logod.png",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-exclusively-supertramp",
+      "name": "Exclusively Supertramp",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.exclusive.radio/er/supertramp/icecast.audio",
+      "homepage": "https://exclusive.radio/",
+      "country": "GB",
+      "tags": [
+        "rock"
+      ],
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-britcom-2-pumpkin-fm",
+      "name": "BritCom 2 - Pumpkin FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast2.asurahosting.com/proxy/britcom2/stream",
+      "homepage": "https://pumpkinfm.com/",
+      "country": "GB",
+      "tags": [
+        "british comedy",
+        "comedy",
+        "old time radio"
+      ],
+      "favicon": "https://pumpkinfm.com/wp-content/uploads/2019/02/BritComTwo300x300.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-exclusively-ac-dc",
+      "name": "Exclusively AC/DC",
+      "broadcaster": "independent",
+      "streamUrl": "https://nl4.mystreaming.net/er/acdc/icecast.audio",
+      "homepage": "https://play.exclusive.radio/",
+      "country": "GB",
+      "tags": [
+        "classic rock"
+      ],
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-sky-news-uk",
+      "name": "sky news UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://tunein.cdnstream1.com/3688_96.mp3?aw_0_1st.skey=1718490659&aw_0_1st.abtest=&aw_0_1st.stationId=s2583&aw_0_1st.premium=false&source=TuneIn&aw_0_1st.platform=tunein&aw_0_1st.genre_id=g255&aw_0_1st.class=talk&aw_0_1st.ads_partner_alias=ce.Other&aw_0_azn.planguage=en",
+      "homepage": "https://news.sky.com/",
+      "country": "GB",
+      "favicon": "https://news.sky.com/resources/apple-touch-icon.png?v=2",
+      "bitrate": 96,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-soul-radio-only-classic-soul",
+      "name": "SOUL RADIO Only Classic Soul",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.soulradio.uk/uk",
+      "homepage": "https://soulradio.uk/",
+      "country": "GB",
+      "tags": [
+        "50s",
+        "60s",
+        "70s",
+        "classic soul",
+        "oldies",
+        "soul"
+      ],
+      "bitrate": 192,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-teenage-kicks-radio",
+      "name": "Teenage Kicks Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://onlineradiobox.com/json/fr/teenagekicks/play",
+      "homepage": "https://teenagekicksradio.blogspot.com/",
+      "country": "GB",
+      "tags": [
+        "new wave",
+        "pop and electronic music from the late 70s and the 80s",
+        "punk"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-house-nation-uk",
+      "name": "House Nation UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.radio.co/s06bd9d805/listen",
+      "homepage": "https://housenationuk.com/",
+      "country": "GB",
+      "tags": [
+        "house"
+      ],
+      "favicon": "https://static.mytuner.mobi/media/tvos_radios/aWa7xGKfBh.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-strange-radio-pumpkin-fm",
+      "name": "Strange Radio - Pumpkin FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast2.asurahosting.com/proxy/strangeradio/stream",
+      "homepage": "https://pumpkinfm.com/",
+      "country": "GB",
+      "tags": [
+        "horror stories",
+        "mystery",
+        "sci-fi",
+        "science fiction",
+        "scifi",
+        "space"
+      ],
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-x-classic-rock",
+      "name": "Radio X Classic Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ice.musicradio.com/RadioXClassicRockMP3",
+      "homepage": "https://www.radiox.co.uk/",
+      "country": "GB",
+      "tags": [
+        "classic rock",
+        "rock"
+      ],
+      "favicon": "https://i.imgur.com/eBIsjQw.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-britcom-1-british-comedy-radio-pumpkin-fm-otrn",
+      "name": "BritCom 1 - British Comedy Radio  (Pumpkin FM OTRN)",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast2.asurahosting.com/proxy/britcom1/stream",
+      "homepage": "https://britishcomedyradio.org/",
+      "country": "GB",
+      "favicon": "https://pumpkinfm.com/wp-content/uploads/2019/02/BritComOne300x300.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-happy-hardcore",
+      "name": "Happy Hardcore",
+      "broadcaster": "independent",
+      "streamUrl": "https://audio-edge-3mayu.fra.h.radiomast.io/73055724-1141-41e2-a69b-24a6ca96c8e7",
+      "homepage": "https://www.happyhardcore.com/",
+      "country": "GB",
+      "tags": [
+        "dj mixes",
+        "electronic",
+        "hardcore",
+        "oldskool hardcore"
+      ],
+      "bitrate": 256,
+      "codec": "MP3",
+      "geo": [
+        51.4814,
+        -0.3186
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-kniteforce-radio",
+      "name": "Kniteforce Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://kniteforce.out.airtime.pro/kniteforce_a",
+      "homepage": "https://kniteforce-radio.com/",
+      "country": "GB",
+      "tags": [
+        "drum & bass",
+        "hardcore",
+        "jungle"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-slow-focus-nts",
+      "name": "Slow Focus | NTS",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-mixtape-geo.ntslive.net/mixtape",
+      "homepage": "https://www.nts.live/infinite-mixtapes/slow-focus",
+      "country": "GB",
+      "tags": [
+        "ambient",
+        "drone",
+        "relaxing"
+      ],
+      "favicon": "https://www.nts.live/apple-touch-icon.png?v=47re43rrzb",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-rokit-radio-science-fiction",
+      "name": "ROKit Radio Science Fiction",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming05.liveboxstream.uk/proxy/roksta12/stream",
+      "homepage": "https://rokitradio.com/",
+      "country": "GB",
+      "tags": [
+        "action",
+        "drama",
+        "old time radio",
+        "otr",
+        "radio shows",
+        "science fiction"
+      ],
+      "favicon": "https://rokitradio.com/images/channels/scifi.jpg",
+      "bitrate": 48,
+      "codec": "MP3",
+      "geo": [
+        51.5069,
+        -0.1225
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-britcom-3-british-comedy-radio-pumpkin-fm-otrn",
+      "name": "BritCom 3 - British Comedy Radio (Pumpkin FM OTRN)",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast2.asurahosting.com/proxy/britcom3/stream",
+      "homepage": "https://britishcomedyradio.org/",
+      "country": "GB",
+      "favicon": "https://pumpkinfm.com/wp-content/uploads/2023/02/BritComThreeNew300x300-3.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-fun-kids",
+      "name": "Fun Kids",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-funkids.sharp-stream.com/funkids.mp3",
+      "homepage": "https://www.funkidslive.com/",
+      "country": "GB",
+      "tags": [
+        "kids"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.5197,
+        -0.1173
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hearme-classic-hard-rock",
+      "name": "HearMe - Classic Hard Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.hearme.fm:8250/stream",
+      "homepage": "https://hearme.fm/",
+      "country": "GB",
+      "tags": [
+        "classic hard rock"
+      ],
+      "codec": "MP3",
+      "geo": [
+        53.5403,
+        -1.0547
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-uk-bass-radio",
+      "name": "UK Bass Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.ukbassradio.com/stream",
+      "homepage": "https://www.ukbassradio.com/",
+      "country": "GB",
+      "tags": [
+        "breakbeat hardcore",
+        "drum and bass",
+        "drumfunk",
+        "dubstep",
+        "garage",
+        "hardcore"
+      ],
+      "favicon": "https://www.ukbassradio.com/wp-content/uploads/2021/03/cropped-thumbnail_ukbass-radio5.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-box-uk",
+      "name": "box uk",
+      "broadcaster": "independent",
+      "streamUrl": "https://boxstream.danceradiouk.com/stream",
+      "homepage": "https://boxuk.danceradiouk.com/",
+      "country": "GB",
+      "favicon": "https://boxuk.danceradiouk.com/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-now-70s",
+      "name": "Now 70s",
+      "broadcaster": "independent",
+      "streamUrl": "https://lightning-now70s-samsungnz.amagi.tv/playlist.m3u8",
+      "homepage": "https://nowmusic.com/",
+      "country": "GB",
+      "tags": [
+        "1970s",
+        "70s",
+        "classic hits",
+        "retro"
+      ],
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/c/cd/NOW_70s.png",
+      "bitrate": 1020,
+      "codec": "AAC,H.264",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-capital-chill",
+      "name": "Capital Chill",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ssl.musicradio.com/CapitalChill",
+      "homepage": "https://capitalchill.co.uk/",
+      "country": "GB",
+      "tags": [
+        "chill",
+        "chilled"
+      ],
+      "bitrate": 48,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-rokit-radio-british-comedy-1",
+      "name": "ROKit Radio : British Comedy 1",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming04.liveboxstream.uk/proxy/roksta14/stream",
+      "homepage": "https://rokitradio.com/",
+      "country": "GB",
+      "tags": [
+        "comedy",
+        "old time radio",
+        "otr",
+        "radio shows",
+        "u.k. comedy"
+      ],
+      "favicon": "https://rokitradio.com/images/channels/british_comedy_1.jpg",
+      "bitrate": 48,
+      "codec": "MP3",
+      "geo": [
+        51.5068,
+        -0.1228
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-eric-clapton",
+      "name": "Eric Clapton ",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.exclusive.radio/er/ericclapton/icecast.audio",
+      "homepage": "https://tunein.com/artist/Eric-Clapton-m473626/",
+      "country": "GB",
+      "tags": [
+        "international"
+      ],
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0a/Eric_Clapton_-_Royal_Albert_Hall_-_Wednesday_24th_May_2017_EricClaptonRAH240517-30_%2834987232355%29_%28cropped%29.jpg/1200px-Eric_Clapton_-_Royal_Albert_Hall_-_Wednesday_24th_May_2017_EricClaptonRAH240517-30_%2834987232355%29_%28cropped%29.jpg",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-classic-fm-calm",
+      "name": "Classic FM Calm",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ice.musicradio.com/ClassicFMCalmMP3",
+      "homepage": "https://www.classicfm.com/calm/",
+      "country": "GB",
+      "tags": [
+        "classical",
+        "romantic"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-house-music-radio",
+      "name": "House Music Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://uk4-vn.mixstream.net/8128/listen.mp3",
+      "homepage": "https://www.housemusicradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "deep house",
+        "house"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-smooth-relax",
+      "name": "Smooth Relax",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.thisisdax.com/SmoothRelaxMP3",
+      "homepage": "https://www.smoothradio.com/relax/",
+      "country": "GB",
+      "tags": [
+        "easy listening",
+        "relaxing"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-diva-radio-funk-disco-music-paradise",
+      "name": "Diva Radio - Funk & Disco Music Paradise",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.deevaradio.net:10443/divaradiofunk",
+      "homepage": "https://deevaradio.net/",
+      "country": "GB",
+      "tags": [
+        "boogie",
+        "disco",
+        "funk",
+        "r'n'b",
+        "rap",
+        "soul"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.3366,
+        -0.0293
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-nation-60s",
+      "name": "Nation 60s",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-nation.sharp-stream.com/nation60s.mp3",
+      "homepage": "http://www.nationradio.com/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-100-hip-hop-nts",
+      "name": "100% Hip Hop | NTS",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-mixtape-geo.ntslive.net/mixtape2",
+      "homepage": "https://www.nts.live/infinite-mixtapes/100-percent-hip-hop",
+      "country": "GB",
+      "tags": [
+        "hip-hop"
+      ],
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-danceradiouk-dance-uk",
+      "name": "DanceRadioUK - Dance UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://dancestream.danceradiouk.com/stream/1/",
+      "homepage": "https://danceradiouk.com/",
+      "country": "GB",
+      "tags": [
+        "dance"
+      ],
+      "favicon": "https://www.danceradiouk.com/wp-content/uploads/2021/02/druk300-150x150.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-naim-jazz-flac",
+      "name": "Naim Jazz [flac]",
+      "broadcaster": "independent",
+      "streamUrl": "https://mscp3.live-streams.nl:8342/jazz-flac.flac",
+      "homepage": "https://www.naimaudio.com/new-naim-radio",
+      "country": "GB",
+      "favicon": "https://www.naimaudio.com/build/assets/apple-touch-icon-2a4e35a0.png",
+      "bitrate": 128,
+      "codec": "OGG",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-kool-fm",
+      "name": "Kool FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://admin.stream.rinse.fm/proxy/kool/stream",
+      "homepage": "https://rinse.fm/channels/kool/",
+      "country": "GB",
+      "tags": [
+        "breakbeat",
+        "dancefloor",
+        "drum and bass",
+        "jump up",
+        "jungle",
+        "jungle hardcore"
+      ],
+      "favicon": "https://pbs.twimg.com/profile_images/1638236080674578434/Hbww_nFm_400x400.jpg",
+      "bitrate": 128,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-virgin-radio-anthems",
+      "name": "Virgin Radio Anthems",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.virginradio.co.uk/stream-anthems",
+      "homepage": "https://virginradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "anthems",
+        "national"
+      ],
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-rokit-radio-british-comedy-2",
+      "name": "ROKit Radio : British Comedy 2",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming05.liveboxstream.uk/proxy/jondreas/stream",
+      "homepage": "https://rokitradio.com/",
+      "country": "GB",
+      "tags": [
+        "comedy",
+        "old time radio",
+        "otr",
+        "radio shows",
+        "u.k. comedy"
+      ],
+      "favicon": "https://rokitradio.com/favicon.ico",
+      "bitrate": 48,
+      "codec": "MP3",
+      "geo": [
+        51.5071,
+        -0.1228
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-classic-fm-hd",
+      "name": "Classic FM HD",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice-sov.musicradio.com/ClassicFMHD?hdauth=:2000000000:a290d4b39a16153061d4c743008b9fe8d424a7e5ec6469d40acf51fdcd336e80",
+      "homepage": "https://www.classicfm.com/",
+      "country": "GB",
+      "tags": [
+        "classical"
+      ],
+      "favicon": "https://is1-ssl.mzstatic.com/image/thumb/Purple116/v4/bd/a7/bf/bda7bf4f-16e9-6b60-0d87-a39d432b505e/AppIcon-1x_U007emarketing-0-7-0-85-220.png/492x0w.webp",
+      "bitrate": 192,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-boom-radio-uk",
+      "name": "Boom Radio UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-boomradio.sharp-stream.com/65_boom_radio_live_192",
+      "homepage": "https://www.boomradiouk.com/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/460/5fb3bb6151ee4.png",
+      "bitrate": 256,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-street-sounds-radio",
+      "name": "Street Sounds Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.broadcastradio.com:10525/streetsd",
+      "homepage": "https://www.streetsoundsradio.com/",
+      "country": "GB",
+      "tags": [
+        "funk",
+        "jazz"
+      ],
+      "codec": "MP3",
+      "geo": [
+        51.7192,
+        0.4757
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-45-radio",
+      "name": "45 Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream1.themediasite.co.uk:7009/stream",
+      "homepage": "https://www.my45radio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "60s",
+        "70s",
+        "80s",
+        "90s"
+      ],
+      "favicon": "https://www.my45radio.co.uk/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bbc-for-australasia",
+      "name": "BBC for Australasia",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.live.vc.bbcmedia.co.uk/bbc_world_service_australasia",
+      "homepage": "https://bbc.co.uk/",
+      "country": "GB",
+      "tags": [
+        "news"
+      ],
+      "favicon": "https://bbc.co.uk/favicon.ico",
+      "bitrate": 56,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-smooth-country",
+      "name": "Smooth Country",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ssl.musicradio.com/SmoothCountry",
+      "homepage": "https://www.smoothradio.com/country/",
+      "country": "GB",
+      "tags": [
+        "country",
+        "country music"
+      ],
+      "favicon": "https://www.smoothradio.com/assets_v4r/smooth/img/favicon-196x196.png",
+      "bitrate": 48,
+      "codec": "AAC",
+      "geo": [
+        51.5306,
+        -0.022
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hypedem-reggae-radio",
+      "name": "HypeDem Reggae Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://mrwolfman2.radioca.st/;",
+      "homepage": "https://hypedem-radio.com/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-london-music-radio",
+      "name": "London Music Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiobossrelay.radioca.st/stream",
+      "homepage": "https://londonmusicradio.com/",
+      "country": "GB",
+      "favicon": "https://londonmusicradio.com/wp-content/uploads/2017/04/thumbnail_Logo2-2-copyY-copy-black-e1519168864488.jpg",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-kiss-uk",
+      "name": "KISS UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://live-kiss.sharp-stream.com/kiss100.mp3",
+      "homepage": "https://kissfmuk.com/",
+      "country": "GB",
+      "tags": [
+        "bauer radio",
+        "kiss",
+        "kiss fm",
+        "pop"
+      ],
+      "favicon": "https://media.bauerradio.com/image/upload/c_crop,g_custom/v1678797505/brand_manager/stations/mahvph4fqjmnp4y8d6wt.png",
+      "bitrate": 112,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-essex",
+      "name": "Radio Essex",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.aiir.com/ujzy590c3stvv",
+      "homepage": "https://www.radioessex.com/",
+      "country": "GB",
+      "tags": [
+        "contemporary hits radio",
+        "pop",
+        "top 40 hits"
+      ],
+      "favicon": "https://mmo.aiircdn.com/339/67698698b4c61.png",
+      "codec": "MP3",
+      "geo": [
+        51.5408,
+        0.6908
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-rinse-uk",
+      "name": "Rinse UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://admin.stream.rinse.fm/proxy/rinse_uk/stream",
+      "homepage": "https://www.rinse.fm/channels/uk/",
+      "country": "GB",
+      "tags": [
+        "dance music",
+        "dubstep",
+        "garage",
+        "grime",
+        "house",
+        "jungle"
+      ],
+      "favicon": "https://i1.sndcdn.com/avatars-HFUM5iVBOYInWEED-oro7Vg-t200x200.jpg",
+      "bitrate": 128,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-classic-fm-movies",
+      "name": "Classic FM Movies",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ice.musicradio.com/ClassicFMMoviesMP3",
+      "homepage": "https://www.classicfm.com/movies/",
+      "country": "GB",
+      "tags": [
+        "classical",
+        "film score",
+        "movies"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-intamixx-80s-90s-radio-uk",
+      "name": "Intamixx 80s 90s Radio UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.intamixx.uk:8443/radio2",
+      "homepage": "https://80s.intamixx.uk/",
+      "country": "GB",
+      "tags": [
+        "80s",
+        "90s",
+        "dance",
+        "drum and bass",
+        "electronic",
+        "funk"
+      ],
+      "favicon": "https://80s.intamixx.uk/images/imc8090.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.1788,
+        -0.3079
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-cruiseone-radio",
+      "name": "CruiseOne Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://solid24.streamupsolutions.com/proxy/cmxicxxx?mp=/256kbps",
+      "homepage": "https://cruiseoneradio.net/",
+      "country": "GB",
+      "tags": [
+        "electronic",
+        "indie",
+        "indie rock",
+        "pop",
+        "rock"
+      ],
+      "favicon": "https://i1.sndcdn.com/avatars-000037533466-mgfbsp-t500x500.jpg",
+      "bitrate": 256,
+      "codec": "MP3",
+      "geo": [
+        51.4552,
+        -2.5931
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-kicks-fm",
+      "name": "KICKS fm",
+      "broadcaster": "independent",
+      "streamUrl": "https://s6.citrus3.com:8452/stream",
+      "homepage": "https://www.kicks.fm/",
+      "country": "GB",
+      "tags": [
+        "general"
+      ],
+      "bitrate": 160,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-expansions-nts",
+      "name": "Expansions | NTS",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-mixtape-geo.ntslive.net/mixtape3",
+      "homepage": "https://www.nts.live/infinite-mixtapes/expansions",
+      "country": "GB",
+      "tags": [
+        "jazz"
+      ],
+      "favicon": "https://www.nts.live/apple-touch-icon.png?v=47re43rrzb",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-energy-fm-dance-music-radio",
+      "name": "Energy FM - Dance Music Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.streemlion.com:1875/stream",
+      "homepage": "https://www.energyfm.co.uk/",
+      "country": "GB",
+      "tags": [
+        "dance",
+        "house",
+        "trance"
+      ],
+      "favicon": "https://cdn.onlineradiobox.com/img/logo/9/35209.v3.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-1940s-radio-hs-pumpkin-fm",
+      "name": "1940s Radio HS - Pumpkin FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast2.asurahosting.com/proxy/1940sradio/stream",
+      "homepage": "https://pumpkinfm.com/",
+      "country": "GB",
+      "tags": [
+        "1930s",
+        "1940s",
+        "1950s",
+        "40s",
+        "50s",
+        "big band"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-davide-of-mimic",
+      "name": "Davide of MIMIC",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming04.liveboxstream.uk/proxy/davideof?mp=/stream",
+      "homepage": "https://www.davideofmimic.com/",
+      "country": "GB",
+      "tags": [
+        "classical"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-classic-fm-essential-classical",
+      "name": "Classic FM Essential Classical",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.thisisdax.com/ClassicFM-M-Essential",
+      "homepage": "https://www.classicfm.com/",
+      "country": "GB",
+      "tags": [
+        "classical"
+      ],
+      "favicon": "https://www.radio.de/images/broadcasts/a1/f8/126083/1/c300.png",
+      "bitrate": 48,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-psychedelicized-radio",
+      "name": "Psychedelicized Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast1.asurahosting.com/proxy/psychedelicized/stream",
+      "homepage": "https://psychedelicized.com/",
+      "country": "GB",
+      "tags": [
+        "psychedelic rock"
+      ],
+      "favicon": "https://cdn-radiotime-logos.tunein.com/s155704q.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-dire-straits",
+      "name": "Dire Straits",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.pcradio.ru/dire_straits-hi",
+      "homepage": "https://pcradio.ru/",
+      "country": "GB",
+      "tags": [
+        "discography"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-gold-london",
+      "name": "Gold London",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ssl.musicradio.com/Gold?isLoggedIn=false&dax_version=release_2019&dax_player=GlobalPlayer&dax_platform=Web&aisDelivery=streaming&listenerid=1612127423858_0.6253666805372976&aw_0_1st.playerid=GlobalPlayer&aw_0_1st.skey=1612127423&aw_0_req.userConsentV2=CPA5x3uPA5x3uAGABCENBLCgAAAAAAAAAATIAAAAAAAA.YAAAAAAAAAAA",
+      "homepage": "https://media-ssl.musicradio.com/Gold?isLoggedIn=false&dax_version=release_2019&dax_player=GlobalPlayer&dax_platform=Web&aisDelivery=streaming&listenerid=1612127423858_0.6253666805372976&aw_0_1st.playerid=GlobalPlayer&aw_0_1st.skey=1612127423&aw_0_req.userConsentV2=CPA5x3uPA5x3uAGABCENBLCgAAAAAAAAAATIAAAAAAAA.YAAAAAAAAAAA",
+      "country": "GB",
+      "favicon": "https://media-ssl.musicradio.com/favicon.ico",
+      "bitrate": 48,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-greatest-hits-non-stop",
+      "name": "Greatest Hits Non-Stop",
+      "broadcaster": "independent",
+      "streamUrl": "https://s8.myradiostream.com/58238//listen.mp3",
+      "homepage": "https://greatesthitsnonstop.com/",
+      "country": "GB",
+      "favicon": "https://greatesthitsnonstop.com/wp-content/uploads/2020/02/GHNS_512-1.png",
+      "bitrate": 160,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-reprezent-radio",
+      "name": "Reprezent Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.canstream.co.uk:8022/live.mp3",
+      "homepage": "https://www.reprezentradio.org.uk/",
+      "country": "GB",
+      "tags": [
+        "music",
+        "grime",
+        "hiphop",
+        "electronic"
+      ],
+      "favicon": "https://cdn.prod.website-files.com/62bc4b9b51f455e9a386fdd1/62be3ea967ffbeb32ccfe453_android-chrome-256x256.png",
+      "bitrate": 256,
+      "codec": "MP3",
+      "geo": [
+        51.4634,
+        -0.1123
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-naim-radio-320k-aac",
+      "name": "Naim Radio [320k aac]",
+      "broadcaster": "independent",
+      "streamUrl": "https://mscp3.live-streams.nl:8362/high.aac",
+      "homepage": "https://www.naimaudio.com/radio/player",
+      "country": "GB",
+      "favicon": "https://www.naimaudio.com/build/assets/apple-touch-icon-2a4e35a0.png",
+      "bitrate": 320,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-box-uk-radio",
+      "name": "Box UK Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://boxstream.danceradiouk.com/stream/1/stream.mp3",
+      "homepage": "https://www.danceradiouk.com/",
+      "country": "GB",
+      "favicon": "https://www.danceradiouk.com/players/files/images/albumart/13040-BoxUK-300.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-classic-fm-video-game-music",
+      "name": "Classic FM Video Game Music",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.thisisdax.com/ClassicFM-M-Gaming",
+      "homepage": "https://www.classicfm.com/",
+      "country": "GB",
+      "tags": [
+        "classical"
+      ],
+      "favicon": "https://www.classicfm.com/assets_v4r/classic/img/favicon-196x196.png",
+      "bitrate": 48,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bbc-arabic",
+      "name": "BBC Arabic ",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.live.vc.bbcmedia.co.uk/bbc_arabic_radio",
+      "homepage": "https://stream.live.vc.bbcmedia.co.uk/",
+      "country": "GB",
+      "tags": [
+        "news"
+      ],
+      "bitrate": 56,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-birdsong-radio",
+      "name": "Birdsong Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://a1.radio.co/s5c5da6a36/listen",
+      "homepage": "https://www.birdsong.fm/",
+      "country": "GB",
+      "favicon": "https://images.radio.co/station_logos/s5c5da6a36.20240717025356.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-4-to-the-floor-nts",
+      "name": "4 To The Floor | NTS",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-mixtape-geo.ntslive.net/mixtape5",
+      "homepage": "https://www.nts.live/infinite-mixtapes/4-to-the-floor",
+      "country": "GB",
+      "tags": [
+        "disco",
+        "house",
+        "techno"
+      ],
+      "favicon": "https://www.nts.live/apple-touch-icon.png?v=47re43rrzb",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-truckstopradio",
+      "name": "TruckStopRadio",
+      "broadcaster": "independent",
+      "streamUrl": "https://oreo.truckstopradio.co.uk/radio/8000/radio.mp3",
+      "homepage": "https://truckstopradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://truckstopradio.co.uk/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-x",
+      "name": "Radio X",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ssl.musicradio.com/RadioXLondonMP3",
+      "homepage": "https://www.radiox.co.uk/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-the-english-909-radio",
+      "name": "The English 909 Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.radioking.com/play/the-english-909",
+      "homepage": "https://english909.com/",
+      "country": "GB",
+      "favicon": "https://www.google.co.uk/search?q=the+english+909+radio+favicon&tbm=isch&ved=2ahUKEwjy5ois1dX6AhVYgc4BHX2PCx8Q2-cCegQIABAA&oq=the+english+909+radio+favicon&gs_lcp=CgNpbWcQAzoECCMQJ1CSB1jdRWC8SGgAcAB4AIABR4gBmASSAQE5mAEAoAEBqgELZ3dzLXdpei1pbWfAAQE&sclient=img&ei=jBBEY_LwF9iCur4P_Z6u-AE&authuser=0&bih=711&biw=1431&hl=en-GB#imgrc=BAdZB6F91SYoWM",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-rokit-radio-comedy-gold",
+      "name": "ROKit Radio : Comedy Gold",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming06.liveboxstream.uk/proxy/rokstar8/stream",
+      "homepage": "https://rokitradio.com/",
+      "country": "GB",
+      "tags": [
+        "comedy",
+        "old time radio",
+        "otr",
+        "radio shows"
+      ],
+      "favicon": "https://rokitradio.com/images/channels/comedy_gold.jpg",
+      "bitrate": 48,
+      "codec": "MP3",
+      "geo": [
+        51.507,
+        -0.1228
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-just-house-music",
+      "name": "Just House Music",
+      "broadcaster": "independent",
+      "streamUrl": "https://justhousemusic.radioca.st/stream",
+      "homepage": "https://justhousemusic.co.uk/",
+      "country": "GB",
+      "favicon": "https://cdn-profiles.tunein.com/s293430/images/logod.png?t=638095610890000000",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.4964,
+        -0.1305
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-england-pumpkin-fm",
+      "name": "Radio England - Pumpkin FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast2.asurahosting.com/proxy/radioengland/stream",
+      "homepage": "https://pumpkinfm.com/",
+      "country": "GB",
+      "tags": [
+        "1940s",
+        "1950s",
+        "40s",
+        "50s",
+        "british comedy",
+        "comedy"
+      ],
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-dandelion-radio",
+      "name": "Dandelion Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://solid41.streamupsolutions.com/proxy/bqbyzdhi?mp=/stream",
+      "homepage": "http://www.dandelionradio.com/",
+      "country": "GB",
+      "tags": [
+        "alternative",
+        "indie",
+        "eclectic",
+        "john peel"
+      ],
+      "favicon": "http://www.dandelionradio.com/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-jfsr-jazz-funk-soul-radio",
+      "name": "JFSR - Jazz Funk Soul Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.radio.co/s22ae5a8a6/listen",
+      "homepage": "https://jfsr.co.uk/",
+      "country": "GB",
+      "tags": [
+        "funk",
+        "jazz",
+        "soul"
+      ],
+      "favicon": "https://jfsr.co.uk/wp-content/uploads/2020/08/cropped-JFSR-Favicon-300x300.png",
+      "bitrate": 320,
+      "codec": "AAC",
+      "geo": [
+        55.0985,
+        -2.9443
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-totally-80s-radio",
+      "name": "Totally 80s Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ukstream.radiohost.co.uk/listen/totally_80s_radio/radio.mp3",
+      "homepage": "https://www.totally80sradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://lh3.googleusercontent.com/YJxyM8-pCOf0oai9UTisHiudRJ1ni2Xt3s7DdPYQKp_oMCuHBn75zpZMSpFd_CBt6PdCKjlOWk9ToqItZPzcrlcgtMXK_h0k=s500",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-now-80s",
+      "name": "Now 80s",
+      "broadcaster": "independent",
+      "streamUrl": "https://lightning-now80s-samsunguk.amagi.tv/playlist.m3u8",
+      "homepage": "https://nowmusic.com/",
+      "country": "GB",
+      "tags": [
+        "1980s",
+        "80s",
+        "classic hits",
+        "retro"
+      ],
+      "bitrate": 1020,
+      "codec": "AAC,H.264",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-poolside-nts",
+      "name": "Poolside | NTS",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-mixtape-geo.ntslive.net/mixtape4",
+      "homepage": "https://www.nts.live/infinite-mixtapes/poolside",
+      "country": "GB",
+      "tags": [
+        "poolside",
+        "soul"
+      ],
+      "favicon": "https://www.nts.live/favicon.ico",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-rokit-radio-classic-old-time-radio-shows",
+      "name": "ROKit Radio : Classic Old Time Radio Shows",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming04.liveboxstream.uk/proxy/roksta18/stream",
+      "homepage": "https://rokitradio.com/",
+      "country": "GB",
+      "tags": [
+        "comedy",
+        "drama",
+        "old time radio",
+        "otr",
+        "radio shows",
+        "sitcom"
+      ],
+      "favicon": "https://rokitradio.com/images/channels/old_time_gold.jpg",
+      "bitrate": 48,
+      "codec": "MP3",
+      "geo": [
+        51.5074,
+        -0.1244
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-fsn-world-news",
+      "name": "FSN World News",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.fsnradionews.com/FSNNews/FSNWorldNews.mp3",
+      "homepage": "https://www.featurestorynews.com/",
+      "country": "GB",
+      "tags": [
+        "news",
+        "world news"
+      ],
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-24-7-disco",
+      "name": "24-7 Disco",
+      "broadcaster": "independent",
+      "streamUrl": "https://antares.dribbcast.com/proxy/s8190/stream",
+      "homepage": "https://24-7nicheradio.com/audiogallery/24-7-disco/",
+      "country": "GB",
+      "favicon": "https://24-7nicheradio.com/wp-content/uploads/2017/04/xDisco.jpg.pagespeed.ic.Z0Vjw3zxU-.webp",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-tonic-ska-radio",
+      "name": "Tonic Ska Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://eu10.fastcast4u.com/tonicska",
+      "homepage": "https://www.tonicskaradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "ska"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.5074,
+        -0.1276
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-crime-incorporated-pumpkin-fm",
+      "name": "Crime Incorporated - Pumpkin FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast2.asurahosting.com/proxy/crimeinc/stream",
+      "homepage": "https://pumpkinfm.com/",
+      "country": "GB",
+      "tags": [
+        "crime",
+        "detective",
+        "mystery",
+        "old time radio",
+        "police",
+        "suspense"
+      ],
+      "favicon": "https://pumpkinfm.com/wp-content/uploads/2019/02/CrimeInc300x300.jpg",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-aah-classical-radio-bach",
+      "name": "Aah Classical Radio - Bach",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.hearme.fm:9040/stream",
+      "homepage": "http://classical.aahradio.com/channel/bach/",
+      "country": "GB",
+      "tags": [
+        "classical"
+      ],
+      "favicon": "http://img.sedoparking.com/templates/logos/sedo_logo.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-rokit-radio-adventure-stories",
+      "name": "ROKit Radio : Adventure Stories",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming06.liveboxstream.uk/proxy/rokstar7/stream",
+      "homepage": "https://rokitradio.com/",
+      "country": "GB",
+      "tags": [
+        "adventure",
+        "old time radio",
+        "otr",
+        "radio shows"
+      ],
+      "favicon": "https://rokitradio.com/images/channels/adventure_stories.jpg",
+      "bitrate": 48,
+      "codec": "MP3",
+      "geo": [
+        51.5075,
+        -0.1239
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-the-tube-nts",
+      "name": "The Tube | NTS",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-mixtape-geo.ntslive.net/mixtape26",
+      "homepage": "https://www.nts.live/infinite-mixtapes/the-tube",
+      "country": "GB",
+      "tags": [
+        "avant-garde",
+        "industrial",
+        "minimal wave",
+        "post-punk"
+      ],
+      "favicon": "https://www.nts.live/apple-touch-icon.png?v=47re43rrzb",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-flashback-radio",
+      "name": "Flashback Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.flashbackcentral.co.uk/radio/8000/apple",
+      "homepage": "https://www.flashbackradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "00s",
+        "90s",
+        "dance",
+        "pop",
+        "rock"
+      ],
+      "favicon": "https://irp.cdn-website.com/d8990fde/site_favicon_16_1654769166393.ico",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-memory-lane-nts",
+      "name": "Memory Lane | NTS",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-mixtape-geo.ntslive.net/mixtape6",
+      "homepage": "https://www.nts.live/infinite-mixtapes/memory-lane",
+      "country": "GB",
+      "tags": [
+        "garage rock",
+        "psychedelic",
+        "soul"
+      ],
+      "favicon": "https://www.nts.live/favicon.ico",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-pink-floyd",
+      "name": "Pink Floyd",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.pcradio.ru/Pink_Floyd-hi",
+      "homepage": "https://pcradio.ru/",
+      "country": "GB",
+      "tags": [
+        "discography"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-tmm-1-hq",
+      "name": "TMM 1 (HQ)",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-msmn.sharp-stream.com/nme1high.mp3",
+      "homepage": "https://www.themusicmachine.co.uk/",
+      "country": "GB",
+      "tags": [
+        "alternative",
+        "alternative rock",
+        "garage",
+        "indie",
+        "indie pop",
+        "indie rock"
+      ],
+      "favicon": "https://cdn-profiles.tunein.com/s159857/images/logod.png",
+      "bitrate": 256,
+      "codec": "MP3",
+      "geo": [
+        51.5015,
+        -0.1305
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-actual-radio",
+      "name": "Actual Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://securestreams.autopo.st:1174/;",
+      "homepage": "https://actualradio.com/",
+      "country": "GB",
+      "tags": [
+        "80s",
+        "classic hits",
+        "oldies"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-subtle-radio",
+      "name": "Subtle Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://subtle.out.airtime.pro/subtle_a",
+      "homepage": "https://www.subtleradio.com/",
+      "country": "GB",
+      "tags": [
+        "community radio",
+        "music",
+        "variety"
+      ],
+      "favicon": "https://www.subtleradio.com/wp-content/uploads/2022/11/favicon.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-field-recordings-nts",
+      "name": "Field Recordings | NTS",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-mixtape-geo.ntslive.net/mixtape23",
+      "homepage": "https://www.nts.live/infinite-mixtapes/field-recordings",
+      "country": "GB",
+      "tags": [
+        "field recording"
+      ],
+      "favicon": "https://www.nts.live/apple-touch-icon.png?v=47re43rrzb",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-soho-radio-london",
+      "name": "Soho Radio London",
+      "broadcaster": "independent",
+      "streamUrl": "https://sohoradiomusic.doughunt.co.uk:8010/128mp3",
+      "homepage": "https://sohoradiolondon.com/",
+      "country": "GB",
+      "tags": [
+        "culture",
+        "eclectic",
+        "variety"
+      ],
+      "favicon": "https://sohoradiolondon.com/wp-content/themes/sohoradio-jan-2023/build/images/favicons/sohoradio-192x192.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-labyrinth-nts",
+      "name": "Labyrinth | NTS",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-mixtape-geo.ntslive.net/mixtape31",
+      "homepage": "https://www.nts.live/infinite-mixtapes/labyrinth",
+      "country": "GB",
+      "tags": [
+        "breaks",
+        "techno"
+      ],
+      "favicon": "https://www.nts.live/apple-touch-icon.png?v=47re43rrzb",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-the-voice-of-doom",
+      "name": "The Voice Of Doom",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.galaxywebsolutions.com:9046/stream",
+      "homepage": "https://www.thevoiceofdoom.com/",
+      "country": "GB",
+      "tags": [
+        "death metal",
+        "doom metal",
+        "gothic metal",
+        "metal",
+        "symphonic metal"
+      ],
+      "bitrate": 320,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-dnbradio-com",
+      "name": "DnBRadio.com",
+      "broadcaster": "independent",
+      "streamUrl": "https://fw.dnbradio.com/dnbradio_main.mp3",
+      "homepage": "https://dnbradio.com/",
+      "country": "GB",
+      "favicon": "https://dnbradio.com/img/logotags.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-gen-x-radio",
+      "name": "Gen X Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.radio.co/sf25229e16/listen",
+      "homepage": "https://genxradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "00s",
+        "10s",
+        "20s",
+        "60s",
+        "70s",
+        "80s"
+      ],
+      "favicon": "https://genxradio.co.uk/wp-content/uploads/2021/11/cropped-GenXAsset-9-192x192.png",
+      "bitrate": 320,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-house-fusion-radio-uk",
+      "name": "House Fusion Radio (UK)",
+      "broadcaster": "independent",
+      "streamUrl": "https://housefusionradiouk.out.airtime.pro/housefusionradiouk_a",
+      "homepage": "https://house-fusion-radio5.webnode.co.uk/",
+      "country": "GB",
+      "tags": [
+        "chillout",
+        "deep",
+        "disco",
+        "funky",
+        "house",
+        "old skool"
+      ],
+      "favicon": "https://d1di2lzuh97fh2.cloudfront.net/files/1j/1j3/1j3767.ico?ph=a9529f376f",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-the-british-home-front-radio-service",
+      "name": "The British Home Front Radio Service",
+      "broadcaster": "independent",
+      "streamUrl": "https://solid24.streamupsolutions.com/proxy/mmpplqiv?mp=/;type=mp3",
+      "homepage": "http://www.1940sukradio.co.uk/BHFR/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-heart-musicals",
+      "name": "Heart Musicals",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ice.musicradio.com/HeartMusicalsMP3",
+      "homepage": "https://www.heart.co.uk/musicals/",
+      "country": "GB",
+      "tags": [
+        "movies",
+        "musicals"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-boogaloo-radio",
+      "name": "Boogaloo Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streams.radio.co/sb88c742f0/listen",
+      "homepage": "https://boogalooradio.com/",
+      "country": "GB",
+      "tags": [
+        "brit pop",
+        "indie rock"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.5764,
+        -0.1436
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-easy-50s",
+      "name": "Easy 50s",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.exclusive.radio/uber/easy50/icecast.audio",
+      "homepage": "https://easy.radio/station/47/658",
+      "country": "GB",
+      "favicon": "https://manager.uber.radio/static/uploads/station/45f6ba11-a495-4500-abae-41c0b999df6c.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-mi-soul",
+      "name": "Mi-Soul ",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-misoul.sharp-stream.com/462_mi_soul_128_mp3",
+      "homepage": "https://mi-soul.com/",
+      "country": "GB",
+      "favicon": "https://upload.wikimedia.org/wikipedia/en/thumb/c/cc/Mi-Soul_logo.png/220px-Mi-Soul_logo.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-liquid-dnb",
+      "name": "Liquid DnB",
+      "broadcaster": "independent",
+      "streamUrl": "https://antares.dribbcast.com/proxy/dave1/stream/",
+      "homepage": "https://liquid-dnb.com/",
+      "country": "GB",
+      "tags": [
+        "dnb",
+        "liquid dnb"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bbc-radio-one",
+      "name": "BBC Radio One",
+      "broadcaster": "independent",
+      "streamUrl": "https://a.files.bbci.co.uk/ms6/live/3441A116-B12E-4D2F-ACA8-C1984642FA4B/audio/simulcast/hls/nonuk/audio_syndication_low_sbr_v1/aks/bbc_radio_one.m3u8",
+      "homepage": "http://www.bbc.co.uk/radio1",
+      "country": "GB",
+      "favicon": "https://cdn-radiotime-logos.tunein.com/s24939q.png",
+      "bitrate": 101,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-funkuradio",
+      "name": "FunkURadio",
+      "broadcaster": "independent",
+      "streamUrl": "https://furfmcou.radioca.st/stream",
+      "homepage": "http://www.funkuradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "70s",
+        "80s",
+        "disco",
+        "funk",
+        "jazz",
+        "rare groove"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-american-gold-pumpkin-fm",
+      "name": "American Gold - Pumpkin FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast2.asurahosting.com/proxy/americangold/stream",
+      "homepage": "https://pumpkinfm.com/",
+      "country": "GB",
+      "tags": [
+        "1940s",
+        "1950s",
+        "1960s",
+        "american",
+        "cabaret",
+        "old time radio"
+      ],
+      "favicon": "https://pumpkinfm.com/wp-content/uploads/2021/01/AmericanGold300x300.jpg",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-diva-radio-disco",
+      "name": "Diva Radio Disco",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.deevaradio.net:10443/divaradiodisco",
+      "homepage": "https://deevaradio.net/",
+      "country": "GB",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.5032,
+        -0.0787
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-dubplate-fm-dub-bass",
+      "name": "Dubplate.fm Dub &Bass",
+      "broadcaster": "independent",
+      "streamUrl": "https://sc2.dubplate.fm/radio/8000/dubandbass/uhifi",
+      "homepage": "https://dubplate.fm/dub-and-bass-radio",
+      "country": "GB",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-neon-radio-80s-90s-pop-dance",
+      "name": "Neon Radio - 80s & 90s Pop & Dance",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.flashbackcentral.co.uk/radio/8050/tunein.mp3",
+      "homepage": "https://www.neonradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "hits 80s",
+        "hits 90s",
+        "pop music"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-ozzy-osbourne",
+      "name": "Ozzy Osbourne",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.pcradio.ru/ozzy_osbourne-hi",
+      "homepage": "https://pcradio.ru/",
+      "country": "GB",
+      "tags": [
+        "discography"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-heart-south-wales",
+      "name": "Heart South Wales",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ssl.musicradio.com/HeartSouthWalesMP3",
+      "homepage": "https://www.heart.co.uk/southwales",
+      "country": "GB",
+      "tags": [
+        "adult contemporary",
+        "pop",
+        "public radio",
+        "south wales",
+        "variety"
+      ],
+      "favicon": "https://www.heart.co.uk/assets_v4r/heart/img/favicon-196x196.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-central-24",
+      "name": "Radio Central 24",
+      "broadcaster": "independent",
+      "streamUrl": "https://casper.radioca.st/;",
+      "homepage": "http://radiocentral24.com/",
+      "country": "GB",
+      "tags": [
+        "bhangra",
+        "bollywood",
+        "pakistani"
+      ],
+      "favicon": "http://radiocentral24.com/assets/images/transparent-121x64.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-one-world-radio-tomorrowland-anthems",
+      "name": "One World Radio - Tomorrowland Anthems",
+      "broadcaster": "independent",
+      "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/OWR_DAB.mp3",
+      "homepage": "https://www.tomorrowland.com/home/radio",
+      "country": "GB",
+      "tags": [
+        "dance",
+        "edm",
+        "electronic"
+      ],
+      "favicon": "https://www.tomorrowland.com/home/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-total-soul-uk-192kb-mp3",
+      "name": "Total Soul (UK) 192kb mp3",
+      "broadcaster": "independent",
+      "streamUrl": "https://onair7.xdevel.com/proxy/xautocloud_atvn_1069?mp=/;1/",
+      "homepage": "https://www.totalsoul.co.uk/",
+      "country": "GB",
+      "tags": [
+        "80's",
+        "disco",
+        "soul"
+      ],
+      "favicon": "https://mmo.aiircdn.com/440/66d2d8d6d54ea.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-i-like-it-oldskool",
+      "name": "I Like It Oldskool",
+      "broadcaster": "independent",
+      "streamUrl": "https://ilikeitoldskool.radioca.st/stream",
+      "homepage": "https://ilikeitoldskool.co.uk/",
+      "country": "GB",
+      "tags": [
+        "dance",
+        "hardcore",
+        "house",
+        "jungle",
+        "uk garage"
+      ],
+      "favicon": "https://ilikeitoldskool.co.uk/favicon.ico",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-select-radio",
+      "name": "Select Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming05.liveboxstream.uk/proxy/selectr1/stream",
+      "homepage": "https://selectradioapp.com/",
+      "country": "GB",
+      "favicon": "https://selectradioapp.com/wp-content/uploads/2023/11/cropped-selecticon-180x180.png",
+      "bitrate": 128,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hot-radio",
+      "name": "Hot Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream1.hippynet.co.uk/stream/hotradio/dorset",
+      "homepage": "https://www.hot.radio/",
+      "country": "GB",
+      "tags": [
+        "00s",
+        "2000s",
+        "2010s",
+        "2020s",
+        "bournemouth",
+        "community"
+      ],
+      "favicon": "https://mmo.aiircdn.com/406/601068617960a.png",
+      "bitrate": 160,
+      "codec": "MP3",
+      "geo": [
+        50.737,
+        -1.9505
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-heart-xmas",
+      "name": "Heart Xmas",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ssl.musicradio.com/HeartXmas",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "GB",
+      "tags": [
+        "international"
+      ],
+      "bitrate": 48,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-lite-radio",
+      "name": "Lite Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ais-sa2.cdnstream1.com/2382_128.mp3?rp_source=1&=&&___cb=212916936695709",
+      "homepage": "https://www.literadio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "soft adult contemporary"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-trancetechnic-radio",
+      "name": "Trancetechnic Radio ",
+      "broadcaster": "independent",
+      "streamUrl": "https://s11.ssl-stream.com/ssl/trancete?mp=/stream",
+      "homepage": "http://www.trancetechnic.uk/",
+      "country": "GB",
+      "tags": [
+        "acid house",
+        "techno",
+        "trance",
+        "trancetechnic",
+        "trancetechnic radio"
+      ],
+      "favicon": "http://img.sedoparking.com/templates/logos/sedo_logo.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-easy-radio",
+      "name": "Easy Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-nation.sharp-stream.com/breezyradiouk.mp3",
+      "homepage": "https://www.nationplayer.com/easy-radio-south/",
+      "country": "GB",
+      "tags": [
+        "easy",
+        "easy listening"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-kaos-sound-pink-floyd-radio",
+      "name": "KAOS Sound  - Pink Floyd Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s3.myradiostream.com/:59506/stream/1/",
+      "homepage": "https://kaos-sound.co.uk/mrsdocs/home.html",
+      "country": "GB",
+      "tags": [
+        "classic rock",
+        "rock"
+      ],
+      "favicon": "https://cdn-profiles.tunein.com/s140303/images/logog.png?t=160685",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-netil-radio",
+      "name": "Netil Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://netilradio.out.airtime.pro/netilradio_a",
+      "homepage": "http://netilradio.com/",
+      "country": "GB",
+      "tags": [
+        "ambient",
+        "beats",
+        "breaks",
+        "disco",
+        "electro",
+        "electronic"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-rokit-radio-classic-crime-and-suspense",
+      "name": "ROKit Radio : Classic Crime and Suspense",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming04.liveboxstream.uk/proxy/roksta17/stream",
+      "homepage": "https://rokitradio.com/",
+      "country": "GB",
+      "tags": [
+        "crime",
+        "old time radio",
+        "otr",
+        "radio shows",
+        "suspense"
+      ],
+      "favicon": "https://rokitradio.com/favicon.ico",
+      "bitrate": 48,
+      "codec": "MP3",
+      "geo": [
+        51.5075,
+        -0.1221
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-psychedelic-secret-radio",
+      "name": "Psychedelic Secret radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://solid48.streamupsolutions.com/proxy/bglsokon?mp=/=stream",
+      "homepage": "https://www.psychedelicsecretsradio.com/?m=1",
+      "country": "GB",
+      "favicon": "https://www.psychedelicsecretsradio.com/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-x-90s",
+      "name": "Radio X 90s",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ice.musicradio.com/RadioX90sMP3",
+      "homepage": "https://www.radiox.co.uk/90s/",
+      "country": "GB",
+      "tags": [
+        "90s",
+        "alternative",
+        "indie rock"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bfbs-beats",
+      "name": "BFBS Beats",
+      "broadcaster": "independent",
+      "streamUrl": "https://edge-audio-01-cr.sharp-stream.com/ssvcbfbs20.aac?device=bfbs_beats",
+      "homepage": "https://www.forces.net/",
+      "country": "GB",
+      "tags": [
+        "beats",
+        "bfbs",
+        "charts",
+        "electro",
+        "hits",
+        "pop dance"
+      ],
+      "favicon": "https://www.forces.net/themes/custom/forcesnet_2020/favicon.ico",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-feelings-nts",
+      "name": "Feelings | NTS",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-mixtape-geo.ntslive.net/mixtape27",
+      "homepage": "https://www.nts.live/infinite-mixtapes/feelings",
+      "country": "GB",
+      "tags": [
+        "boogie",
+        "disco",
+        "doo-wop",
+        "gospel",
+        "soul"
+      ],
+      "favicon": "https://www.nts.live/apple-touch-icon.png?v=47re43rrzb",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-classic-fm-hall-of-fame",
+      "name": "Classic FM Hall of Fame",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.thisisdax.com/ClassicFM-M-HOF",
+      "homepage": "https://www.classicfm.com/",
+      "country": "GB",
+      "tags": [
+        "classical"
+      ],
+      "favicon": "https://www.radio.de/images/broadcasts/a1/f8/126083/1/c300.png",
+      "bitrate": 48,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-nu-disco-funk-radio",
+      "name": "Nu Disco Funk Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://my.radiolize.com/radio/8090/radio.mp3",
+      "homepage": "https://nu-disco-funk-radio.com/",
+      "country": "GB",
+      "tags": [
+        "deep house",
+        "disco",
+        "electric",
+        "funk"
+      ],
+      "favicon": "https://uk.radio.net/300/nudiscofunkradio.jpeg?version=b5b29e74fa5bb43b3b8a3e9d27349a94",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-britasia-radio",
+      "name": "BritAsia Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s4.radio.co/sfefce156f/listen",
+      "homepage": "https://britasia.tv/radio/",
+      "country": "GB",
+      "favicon": "https://britasia.tv/wp-content/uploads/2021/01/britasia-radio-logo.jpg",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-mystery-train-radio",
+      "name": "Mystery Train Radio ",
+      "broadcaster": "independent",
+      "streamUrl": "https://streamer.radio.co/sf662f27c0/listen",
+      "homepage": "https://www.mysterytrainradio.com/",
+      "country": "GB",
+      "tags": [
+        "americana",
+        "blues",
+        "eclectic",
+        "folk",
+        "indie",
+        "rock"
+      ],
+      "bitrate": 192,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-judas-priest",
+      "name": "Judas Priest",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.pcradio.ru/judas_priest-hi",
+      "homepage": "https://pcradio.ru/",
+      "country": "GB",
+      "tags": [
+        "discography"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-smooth-radio-suffolk",
+      "name": "Smooth Radio (Suffolk)",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ssl.musicradio.com/SmoothSuffolk",
+      "homepage": "https://www.smoothradio.com/suffolk/",
+      "country": "GB",
+      "tags": [
+        "adult contemporary",
+        "chill",
+        "chillout",
+        "oldies",
+        "smooth"
+      ],
+      "favicon": "https://www.smoothradio.com/assets_v4r/smooth/img/favicon-196x196.png",
+      "bitrate": 48,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-led-zeppelin",
+      "name": "Led Zeppelin",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.pcradio.ru/Led_Zeppelin-hi",
+      "homepage": "https://pcradio.ru/",
+      "country": "GB",
+      "tags": [
+        "discography"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-smooth-christmas",
+      "name": "Smooth Christmas",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ice.musicradio.com/SmoothXmasMP3",
+      "homepage": "https://www.smoothradio.com/news/christmas/",
+      "country": "GB",
+      "tags": [
+        "christmas music"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-boot-boy-radio",
+      "name": "Boot Boy Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming04.liveboxstream.uk/proxy/dwain?mp=/stream",
+      "homepage": "https://bootboyradio.net/",
+      "country": "GB",
+      "tags": [
+        "punk",
+        "reggae",
+        "ska",
+        "soul"
+      ],
+      "favicon": "https://bootboyradio.net/wp-content/uploads/2021/02/cropped-900logosquare-192x192.jpg",
+      "bitrate": 192,
+      "codec": "AAC+",
+      "geo": [
+        52.4785,
+        1.7551
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-boom-light",
+      "name": "Boom Light",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-boomradio.sharp-stream.com/65_boom_light_128_mp3",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "GB",
+      "tags": [
+        "decades"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-solar-radio",
+      "name": "Solar Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-msmn.sharp-stream.com/solarlow.mp3",
+      "homepage": "https://solarradio.com/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-twr-uk",
+      "name": "TWR UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://direct.sharp-stream.com/twruk.mp3",
+      "homepage": "https://www.twr.org.uk/",
+      "country": "GB",
+      "tags": [
+        "christian"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-malvern-radio-international-pumpkin-fm",
+      "name": "Malvern Radio International - Pumpkin FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast2.asurahosting.com/proxy/radiomalvernint/stream",
+      "homepage": "https://pumpkinfm.com/",
+      "country": "GB",
+      "tags": [
+        "classical baroque",
+        "classical music",
+        "opera",
+        "symphony"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        52.1074,
+        -2.3384
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-gold-radio-uk",
+      "name": "Gold Radio UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ice.musicradio.com/GoldMP3",
+      "homepage": "https://www.goldradio.com/?page=2",
+      "country": "GB",
+      "tags": [
+        "golden oldies",
+        "pop"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-heart-fm-birmingham",
+      "name": "Heart FM (Birmingham)",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ssl.musicradio.com/HeartWestMids?isLoggedIn=true&dax_version=release_4140&dax_player=GlobalPlayer&dax_platform=Web&delivery_type=streaming&aw_0_req.userConsentV2=CPytTYAPytTYAAGABCENATEoAP_AAAGAAAwIGMpF7D5VZWFC-OZ5YKsAMYhXQMCAIuQQCASAA-ABCAKQIIQGgmAQFASgBAAKAQAAIAJBAAIECAAQCQAAAAAAAACAAAAABAAIAAAAgAAAAAAIAAAGAAAAAAAIgAAAEAAAmAwAAIIAAADgkBkABAACwAKgAcAA8ACAAGQANAAeQBDAEQAJgATwAqgB-AEIAKUAW4AwwB7AD9AIGAVcAxQCkQF5hAAoADwASAA_AHOApsMABAU2IAAgAkFQAQAhjIAIAQx0BwABYAFQAOAAgABkADQAHkAQwBEACYAE8AKoAXQAxAB-AFGAKUAW4AwwBogD2AH6AQMAjoBVwCxAGKAReAvMcAOAAQAA8AC4AJAAcgA_AHOAQgAiIBFgCMgKQAU2AvohAIAAWAEMAJgAVQAxAClAKuAYogADAAQAOcAsRKAcAAgABYAHAAeABEACYAFUAMQAowBbgFXAMUAi8BeZIAIABcAHIA1ADMlIC4ACwAKgAcABAADIAGgAPIAhgCIAEwAJ4AUgAqgBiAD8AKMAUoAtwBogD9AI6AVcBF4C8ygA8AC4AJAAcgA_ADaANQAc4BFgCxAF1AMUAa8BSACmwF9A.YAAAAAAAAAAA&dax_listenerid=824C2FA8EC1A06EF990BEDF6BE300A70&gigya_id=aca49a64b4254a8ab5a088cd031e7efe&nlsid=1c499bb707f2fc48cfd210acda4433d0",
+      "homepage": "https://www.heart.co.uk/westmids/",
+      "country": "GB",
+      "bitrate": 48,
+      "codec": "AAC",
+      "geo": [
+        52.4881,
+        -1.8492
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-bloodstream",
+      "name": "Radio Bloodstream",
+      "broadcaster": "independent",
+      "streamUrl": "https://uk1.internet-radio.com/proxy/bloodstream?mp=/stream",
+      "homepage": "https://www.radiobloodstream.com/en/",
+      "country": "GB",
+      "tags": [
+        "hard rock",
+        "heavy metal",
+        "rock"
+      ],
+      "favicon": "https://www.radiobloodstream.com/favicon.ico",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-monocle-radio",
+      "name": "Monocle Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/MONOCLE_24.mp3",
+      "homepage": "https://monocle.com/radio/",
+      "country": "GB",
+      "tags": [
+        "culture",
+        "design",
+        "entrepreneurship",
+        "global",
+        "live shows",
+        "news"
+      ],
+      "favicon": "https://pbs.twimg.com/profile_images/1641728752236281856/zeIa6wPU_400x400.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-atlantic-252",
+      "name": "Atlantic 252",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream4.themediasite.co.uk:8042/",
+      "homepage": "https://www.atlantic252radio.com/",
+      "country": "GB",
+      "tags": [
+        "90s",
+        "dance",
+        "hits",
+        "pop"
+      ],
+      "favicon": "https://play-lh.googleusercontent.com/kIp3BTHaetEyZcMXvOzQ41i15fTZkShTAhpmjS-643non9AxqB45R1--DyU1PbFV=w240-h480-rw",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-24-7-blues-radio",
+      "name": "24/7 Blues Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ec3.yesstreaming.net:3685/stream",
+      "homepage": "https://www.247onlineradio.com/24-7-online-radio-group-stations/24-7-blues-radio/",
+      "country": "GB",
+      "tags": [
+        "blues"
+      ],
+      "favicon": "https://www.247onlineradio.com/wp-content/uploads/2023/04/247-Blues-Radio.jpg",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-forest-gold",
+      "name": "Forest Gold",
+      "broadcaster": "independent",
+      "streamUrl": "https://c2.prostream365.com:8000/live",
+      "homepage": "https://www.forestgoldradio.com/",
+      "country": "GB",
+      "tags": [
+        "classic hits",
+        "golden oldies",
+        "goldies",
+        "oldies"
+      ],
+      "favicon": "https://www.forestgoldradio.com/favicon.ico",
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        51.6978,
+        0.1099
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-news-radio-uk",
+      "name": "News Radio UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.aiir.com/clcb6m0k9shvv",
+      "homepage": "https://newsradiouk.co.uk/",
+      "country": "GB",
+      "tags": [
+        "information",
+        "news",
+        "talk"
+      ],
+      "favicon": "https://newsradiouk.co.uk/wp-content/uploads/2022/06/Facebook-profile.png",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-sheet-music-nts",
+      "name": "Sheet Music | NTS",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-mixtape-geo.ntslive.net/mixtape35",
+      "homepage": "https://www.nts.live/infinite-mixtapes/sheet-music",
+      "country": "GB",
+      "tags": [
+        "classical"
+      ],
+      "favicon": "https://www.nts.live/apple-touch-icon.png?v=47re43rrzb",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-chocolate-radio",
+      "name": "Chocolate Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radio.co/sa7336b687/listen?ver=712690",
+      "homepage": "https://chocolate-radio.com/",
+      "country": "GB",
+      "tags": [
+        "r&b/urban"
+      ],
+      "bitrate": 192,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-nation-radio-wales",
+      "name": "Nation Radio Wales",
+      "broadcaster": "independent",
+      "streamUrl": "https://edge-ads-05-gos2.sharp-stream.com/tcnationi.aac",
+      "homepage": "https://nationradio.wales/",
+      "country": "GB",
+      "tags": [
+        "contemporary"
+      ],
+      "bitrate": 48,
+      "codec": "AAC+",
+      "geo": [
+        51.482,
+        -3.1771
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-rockin50s-radio",
+      "name": "Rockin50s Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://eu10.fastcast4u.com/rockin50s",
+      "homepage": "https://rockin50s.uk/",
+      "country": "GB",
+      "favicon": "https://rockin50s.uk/images/site/site_logo2small.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-uk-bass",
+      "name": "UK Bass",
+      "broadcaster": "independent",
+      "streamUrl": "https://ukbassradio.com/stream",
+      "homepage": "https://ukbassradio.com/",
+      "country": "GB",
+      "tags": [
+        "drum and bass",
+        "neurofunk",
+        "uk bass"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-dancefmlive-trance",
+      "name": "DanceFMLive Trance",
+      "broadcaster": "independent",
+      "streamUrl": "https://broadcast.dancefmlive.com/radio/8010/radio.mp3",
+      "homepage": "https://www.dancefmlive.com/",
+      "country": "GB",
+      "tags": [
+        "trance"
+      ],
+      "favicon": "https://www.dancefmlive.com/wp-content/uploads/2021/02/trance.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-divine-radio-london",
+      "name": "Divine Radio London",
+      "broadcaster": "independent",
+      "streamUrl": "https://uk2.internet-radio.com/proxy/divinestream?mp=/stream",
+      "homepage": "https://www.divineradiolondon.co.uk/",
+      "country": "GB",
+      "tags": [
+        "dj mixes",
+        "electronic",
+        "underground"
+      ],
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-smooth-soul",
+      "name": "Smooth Soul",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ice.musicradio.com/SmoothSoulMP3",
+      "homepage": "https://www.smoothradio.com/soul/",
+      "country": "GB",
+      "tags": [
+        "motown",
+        "soul"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bolton-fm",
+      "name": "Bolton FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.canstream.co.uk:8083/live.mp3",
+      "homepage": "https://www.boltonfm.com/",
+      "country": "GB",
+      "tags": [
+        "community",
+        "local"
+      ],
+      "favicon": "https://www.boltonfm.com/bfm_website_logos/BFM_Logos/BoltonFM-Logo-square.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        53.5765,
+        -2.4324
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-sweat-nts",
+      "name": "Sweat | NTS",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-mixtape-geo.ntslive.net/mixtape24",
+      "homepage": "https://www.nts.live/infinite-mixtapes/sweat",
+      "country": "GB",
+      "tags": [
+        "party"
+      ],
+      "favicon": "https://www.nts.live/apple-touch-icon.png?v=47re43rrzb",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-dclm-radio",
+      "name": "DCLM Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://airtime.dclm.org/radio/8000/live",
+      "homepage": "https://radio.dclm.org/",
+      "country": "GB",
+      "favicon": "https://radio.dclm.org/assets/img/favicon.png",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-5-rivers-radio",
+      "name": "5 Rivers radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://onlineradiobox.com/json/uk/5rivers/play?platform=web",
+      "homepage": "https://onlineradiobox.com/json/uk/5rivers/play?platform=web",
+      "country": "GB",
+      "tags": [
+        "music"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bradford-asian-radio",
+      "name": "Bradford Asian Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast1.asurahosting.com/proxy/bradford/stream",
+      "homepage": "https://cast1.asurahosting.com/proxy/bradford/stream",
+      "country": "GB",
+      "tags": [
+        "music"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-swu-fm",
+      "name": "SWU FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://admin.stream.rinse.fm/proxy/swu/stream",
+      "homepage": "https://rinse.fm/channels/swu/",
+      "country": "GB",
+      "tags": [
+        "dnb",
+        "drum and bass",
+        "house",
+        "jungle",
+        "mixed",
+        "techno"
+      ],
+      "favicon": "https://rinse.fm/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.4409,
+        -2.6003
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-brmb-radio",
+      "name": "BRMB Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.canstream.co.uk:8147/live.mp3",
+      "homepage": "https://www.brmbradio.com/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/1111/64a34bf89acd7.png",
+      "bitrate": 160,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-resonance-104-4fm",
+      "name": "Resonance 104.4FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.resonance.fm/resonance?rp_source=1&=&&___cb=309691324386261",
+      "homepage": "https://www.resonancefm.com/",
+      "country": "GB",
+      "favicon": "https://www.resonancefm.com/assets/logo-a79206a34394173ba3e41d66a3388f4c.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-foundation-fm",
+      "name": "Foundation FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://streamer.radio.co/s0628bdd53/listen",
+      "homepage": "https://foundation.fm/",
+      "country": "GB",
+      "tags": [
+        "community radio",
+        "electronic",
+        "hip-hop",
+        "indie",
+        "jazz"
+      ],
+      "favicon": "https://foundation.fm/images/favicon/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-maria-england",
+      "name": "Radio Maria England",
+      "broadcaster": "independent",
+      "streamUrl": "https://dreamsiteradiocp5.com/proxy/rmengland?mp=/stream",
+      "homepage": "https://radiomariaengland.uk/",
+      "country": "GB",
+      "tags": [
+        "religious"
+      ],
+      "bitrate": 48,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bloop-london-radio-channel-4-music-only-themed-s",
+      "name": "Bloop London Radio (channel 4) - MUSIC ONLY THEMED STREAM.  NATURAL HIGH. DRENCHED IN GROOVES, AN ORGANIC JOURNEY OF BEATS DEDICATED TO MOVING YOUR ASS.",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.canstream.co.uk:8058/live.mp3",
+      "homepage": "https://blooplondon.com/",
+      "country": "GB",
+      "tags": [
+        "electronic",
+        "grooves"
+      ],
+      "favicon": "https://blooplondon.com/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-heart-00s",
+      "name": "Heart 00s",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ssl.musicradio.com/Heart00sMP3",
+      "homepage": "https://media-ssl.musicradio.com/Heart00sMP3",
+      "country": "GB",
+      "tags": [
+        "pop"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hearme-beethoven",
+      "name": "HearMe-Beethoven",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.hearme.fm:9050/stream",
+      "homepage": "http://www.hearme.fm/",
+      "country": "GB",
+      "tags": [
+        "classical"
+      ],
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hot-gold",
+      "name": "Hot Gold",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream1.hippynet.co.uk/stream/hotgold/dorset",
+      "homepage": "https://www.hotgold.radio/",
+      "country": "GB",
+      "tags": [
+        "70s",
+        "80s",
+        "90s",
+        "bournemouth",
+        "community",
+        "community radio"
+      ],
+      "favicon": "https://mmo.aiircdn.com/406/61940c9fa5f84.png",
+      "bitrate": 160,
+      "codec": "MP3",
+      "geo": [
+        50.737,
+        -1.9505
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-the-prodigy",
+      "name": "The Prodigy",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.pcradio.ru/The_Prodigy-hi",
+      "homepage": "https://pcradio.ru/",
+      "country": "GB",
+      "tags": [
+        "discography"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-ram-fm-80s-hit-radio",
+      "name": "Ram FM 80s Hit Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://usa1-vn.mixstream.net/8084/listen.mp3",
+      "homepage": "https://ramfm.org/",
+      "country": "GB",
+      "tags": [
+        "70s",
+        "80s",
+        "90s",
+        "eighties"
+      ],
+      "favicon": "https://ramfm.org/favicon.ico",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-capital-fm-london",
+      "name": "Capital FM London",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ssl.musicradio.com/CapitalMP3",
+      "homepage": "https://capitalfm.com/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-rokit-radio-saturn-x-radio-shows",
+      "name": "ROKit Radio : Saturn-X Radio Shows",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming05.liveboxstream.uk/proxy/jondre03/stream",
+      "homepage": "https://rokitradio.com/",
+      "country": "GB",
+      "tags": [
+        "adventure",
+        "old time radio",
+        "otr",
+        "radio shows",
+        "science fiction",
+        "scifi"
+      ],
+      "favicon": "https://rokitradio.com/favicon.ico",
+      "bitrate": 48,
+      "codec": "MP3",
+      "geo": [
+        51.507,
+        -0.1227
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-totalrock-radio",
+      "name": "TotalRock Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s3.citrus3.com:8056/stream",
+      "homepage": "https://totalrock.com/",
+      "country": "GB",
+      "tags": [
+        "metal",
+        "music",
+        "rock"
+      ],
+      "favicon": "https://scontent.fcgk8-1.fna.fbcdn.net/v/t1.18169-9/11400985_1602513246663466_6035298720034077887_n.jpg?stp=cp0_dst-jpg_e15_fr_q65&_nc_cat=108&ccb=1-7&_nc_sid=7aed08&efg=eyJpIjoiYiJ9&_nc_eui2=AeEETQvQCq6lHutRRfK171iMKMnkfCxBQUgoyeR8LEFBSC8L74DpSPHz7DvwVuHvpZkIi6qJ0_1acvrVbfekHQL9&_nc_ohc=Oo7DzNH7oTMAX_ZluE8&tn=I4UqcoMHerbAkKms&_nc_ht=scontent.fcgk8-1.fna&oh=00_AfBCXINd2TGpeja3jEiHkpvCmVAH0sxg6_Q39XWj5iRvUA&oe=6407F56B",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-asian-star-radio",
+      "name": "Asian Star Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.canstream.co.uk:9067/live.mp3",
+      "homepage": "https://radio.canstream.co.uk:9067/live.mp3",
+      "country": "GB",
+      "tags": [
+        "music"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-4tunesfm",
+      "name": "4TunesFM",
+      "broadcaster": "independent",
+      "streamUrl": "https://c30.radioboss.fm:18274/stream",
+      "homepage": "https://links.4tunefm.co.uk/",
+      "country": "GB",
+      "tags": [
+        "jazz",
+        "reggae"
+      ],
+      "favicon": "https://assets.production.linktr.ee/profiles/_next/static/logo-assets/apple-icon-120x120.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.4042,
+        -0.0853
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-gb-news",
+      "name": "GB News",
+      "broadcaster": "independent",
+      "streamUrl": "https://amg01076-lightningintern-gbnews-samsunguk-0lu52.amagi.tv/playlist/amg01076-lightningintern-gbnews-samsunguk/playlist.m3u8",
+      "homepage": "https://superradio.cc/",
+      "country": "GB",
+      "tags": [
+        "gbn",
+        "news",
+        "tv"
+      ],
+      "bitrate": 1020,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-heart-fm",
+      "name": "Heart FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ssl.musicradio.com/HeartUK",
+      "homepage": "https://www.heart.co.uk/london/radio/",
+      "country": "GB",
+      "favicon": "https://cdn-profiles.tunein.com/s320841/images/logod.jpg?t=638651487420000000",
+      "bitrate": 48,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hot-hits-uk-com",
+      "name": "Hot Hits UK.com",
+      "broadcaster": "independent",
+      "streamUrl": "https://443-1.autopo.st/54/stream.mp3",
+      "homepage": "https://www.hothitsuk.com/",
+      "country": "GB",
+      "tags": [
+        "contemporary hits",
+        "dance music",
+        "edm",
+        "top40"
+      ],
+      "favicon": "https://hothitsuk.com/wp-content/uploads/2020/09/HHUK-3D-transparent-300-x-200.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.5043,
+        -0.1099
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-rokit-radio-american-classic-radio-shows",
+      "name": "ROKit Radio : American Classic Radio Shows",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming05.liveboxstream.uk/proxy/jondre01/stream",
+      "homepage": "https://rokitradio.com/",
+      "country": "GB",
+      "tags": [
+        "old time radio",
+        "otr",
+        "radio show"
+      ],
+      "favicon": "https://rokitradio.com/images/channels/american_classics.jpg",
+      "bitrate": 48,
+      "codec": "MP3",
+      "geo": [
+        51.5074,
+        -0.1221
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-heart-80s",
+      "name": "Radio Heart 80s",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice-sov.musicradio.com/Heart80sMP3",
+      "homepage": "https://www.heart.co.uk/80s",
+      "country": "GB",
+      "tags": [
+        "80s",
+        "classic hits",
+        "oldies"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-rafa-bible-radio-english",
+      "name": "Rafa Bible Radio English",
+      "broadcaster": "independent",
+      "streamUrl": "https://gains.reviveradio.net/proxy/rafabibleradioeng?mp=/stream",
+      "homepage": "http://www.rafaradio.com/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-faza",
+      "name": "Radio Faza",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiocast.cr8tive-digital.com/radiofaza",
+      "homepage": "https://radiofaza.co.uk/",
+      "country": "GB",
+      "favicon": "https://radiofaza.co.uk/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-smooth-80s",
+      "name": "Smooth 80s",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ice.musicradio.com/Smooth80sMP3",
+      "homepage": "https://www.smoothradio.com/80s/",
+      "country": "GB",
+      "tags": [
+        "80s"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-sunrise-radio",
+      "name": "Sunrise Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://direct.sharp-stream.com/sunriseradio.mp3",
+      "homepage": "https://www.sunriseradio.com/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-calm-n-chill-radio",
+      "name": "Calm N Chill Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.zeno.fm/yvcddifycietv",
+      "homepage": "https://theresmarty.pages.dev/",
+      "country": "GB",
+      "tags": [
+        "calm",
+        "chill",
+        "sleep",
+        "relax"
+      ],
+      "favicon": "https://cloud-4shg5daq1-hack-club-bot.vercel.app/0calm_n_chill_radio_logo.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-nazareth",
+      "name": "Nazareth",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.pcradio.ru/Nazareth-hi",
+      "homepage": "https://pcradio.ru/",
+      "country": "GB",
+      "tags": [
+        "discography"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-lyca-dil-se-radio",
+      "name": "Lyca Dil se radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://edge-ads-03-gos2.sharp-stream.com/1035.mp3",
+      "homepage": "https://edge-ads-03-gos2.sharp-stream.com/1035.mp3",
+      "country": "GB",
+      "tags": [
+        "music"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-old-skool-rave-tapes",
+      "name": "Old Skool Rave Tapes",
+      "broadcaster": "independent",
+      "streamUrl": "https://azuracast.oldskoolravetapes.co.uk/listen/old_skool_rave_tapes/backup?refresh=1744812055358",
+      "homepage": "https://oldskoolravetapes.co.uk/",
+      "country": "GB",
+      "tags": [
+        "old skool"
+      ],
+      "favicon": "https://oldskoolravetapes.co.uk/wp-content/uploads/2023/02/Old-Skool-Rave-Tapes-New-512.jpg",
+      "bitrate": 96,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-24-7-edm-radio",
+      "name": "24/7 EDM Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ec6.yesstreaming.net:1455/stream",
+      "homepage": "https://www.247onlineradio.com/24-7-edm-radio/",
+      "country": "GB",
+      "tags": [
+        "edm",
+        "electronic dance music"
+      ],
+      "favicon": "https://www.247onlineradio.com/wp-content/uploads/2023/04/247-EDM-Radio.jpg",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-24-7-jazz-radio",
+      "name": "24/7 Jazz Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ec3.yesstreaming.net:3455/stream",
+      "homepage": "https://www.247onlineradio.com/24-7-jazz-radio/",
+      "country": "GB",
+      "tags": [
+        "jazz"
+      ],
+      "favicon": "https://www.247onlineradio.com/wp-content/uploads/2020/02/247-Jazz-Radio.jpg",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-oldskool-uk",
+      "name": "Oldskool UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://usa10.fastcast4u.com:8880/",
+      "homepage": "https://www.oldskool.uk/",
+      "country": "GB",
+      "tags": [
+        "dnb",
+        "hardcore",
+        "house",
+        "jungle",
+        "rave",
+        "techno"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-now-rock",
+      "name": "Now Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://lightning-now90s-samsungnz.amagi.tv/playlist.m3u8",
+      "homepage": "https://nowmusic.com/",
+      "country": "GB",
+      "tags": [
+        "alternative rock",
+        "classic rock",
+        "pop rock",
+        "rock"
+      ],
+      "bitrate": 1020,
+      "codec": "AAC,H.264",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-the-beatles",
+      "name": "The Beatles",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.pcradio.ru/The_Beatles-hi",
+      "homepage": "https://pcradio.ru/radio",
+      "country": "GB",
+      "tags": [
+        "discography"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-80s-rhythm",
+      "name": "80s Rhythm",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.mybroadbandradio.com/80srhythmhq/",
+      "homepage": "https://www.80srhythm.com/",
+      "country": "GB",
+      "tags": [
+        "80s",
+        "dance",
+        "new wave",
+        "pop",
+        "rock"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-globl-funk-radio",
+      "name": "Globl Funk Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://securestreams2.autopo.st:1148/stream",
+      "homepage": "https://www.globalfunkradio.com/",
+      "country": "GB",
+      "tags": [
+        "bass",
+        "disco",
+        "electro",
+        "funk",
+        "hip-hop"
+      ],
+      "favicon": "https://www.globalfunkradio.com/favicon/128x128.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-the-sounds-of-gta-nts",
+      "name": "The Sounds of GTA | NTS",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-mixtape-geo.ntslive.net/mixtape33",
+      "homepage": "https://www.nts.live/infinite-mixtapes/the-sound-of-gta",
+      "country": "GB",
+      "tags": [
+        "videogames"
+      ],
+      "favicon": "https://www.nts.live/favicon.ico",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bbc-radio-leeds",
+      "name": "BBC Radio Leeds",
+      "broadcaster": "independent",
+      "streamUrl": "https://as-hls-ww-live.akamaized.net/pool_50115440/live/ww/bbc_radio_leeds/bbc_radio_leeds.isml/bbc_radio_leeds-audio%3d96000.norewind.m3u8",
+      "homepage": "https://www.bbc.co.uk/schedules/p00fzl7w",
+      "country": "GB",
+      "tags": [
+        "various"
+      ],
+      "favicon": "https://sounds.files.bbci.co.uk/3.5.0/services/bbc_radio_leeds/blocks-colour_600x600.png",
+      "codec": "UNKNOWN",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bristol-sound-webradio",
+      "name": "Bristol Sound Webradio",
+      "broadcaster": "independent",
+      "streamUrl": "https://thebristolsoundwebradio.stream.laut.fm/thebristolsoundwebradio",
+      "homepage": "https://bristol-sound-webradio.tumblr.com/LISTEN",
+      "country": "GB",
+      "tags": [
+        "bristol",
+        "chillout",
+        "downtempo",
+        "trip-hop",
+        "triphop"
+      ],
+      "favicon": "https://64.media.tumblr.com/8d23b78c8346101f620e06d5ce5e7165/tumblr_pmqf9sPig21uq8z6lo1_r2_400.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-venture-radio-pumpkin-fm",
+      "name": "Venture Radio - Pumpkin FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast2.asurahosting.com/proxy/ventureradio/stream",
+      "homepage": "https://pumpkinfm.com/",
+      "country": "GB",
+      "tags": [
+        "adventure",
+        "cowboys",
+        "gunfighter",
+        "gunslingers",
+        "indians",
+        "westerns"
+      ],
+      "favicon": "https://pumpkinfm.com/wp-content/uploads/2019/02/VentureRadio300x300.jpg",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-infrared-fm",
+      "name": "Infrared.fm",
+      "broadcaster": "independent",
+      "streamUrl": "https://carol.epichosts.co.uk:8232/live.mp3",
+      "homepage": "http://infrared.fm/",
+      "country": "GB",
+      "tags": [
+        "breaks",
+        "drum & bass",
+        "hardcore",
+        "jungle"
+      ],
+      "favicon": "http://infrared.fm/favicon.ico",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-revolution-radio-one",
+      "name": "Revolution Radio One",
+      "broadcaster": "independent",
+      "streamUrl": "https://visual.shoutca.st/stream/revolutionone/stream",
+      "homepage": "https://revolutionradio.online/revolutionone",
+      "country": "GB",
+      "tags": [
+        "rock"
+      ],
+      "favicon": "https://static.wixstatic.com/media/a4f5c5_466d1b7b03424018be005a100fda1990%7emv2_d_1726_1562_s_2.png/v1/fill/w_180%2ch_180%2clg_1%2cusm_0.66_1.00_0.01/a4f5c5_466d1b7b03424018be005a100fda1990%7emv2_d_1726_1562_s_2.png",
+      "bitrate": 320,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-deep-purple",
+      "name": "Deep Purple",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.pcradio.ru/Deep_purple-hi",
+      "homepage": "https://pcradio.ru/",
+      "country": "GB",
+      "tags": [
+        "discography"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hearme-60s-rock",
+      "name": "HearMe - 60s Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.hearme.fm:8230/stream",
+      "homepage": "https://hearme.fm/",
+      "country": "GB",
+      "tags": [
+        "60s rock",
+        "60’s rock"
+      ],
+      "codec": "MP3",
+      "geo": [
+        54.3678,
+        -3.1641
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-xl-uk-radio",
+      "name": "XL:UK Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s3.radio.co/s113a5dc46/listen",
+      "homepage": "https://www.xlukradio.com/",
+      "country": "GB",
+      "tags": [
+        "afrobeat",
+        "asian urban hits",
+        "bhangra",
+        "bollywood",
+        "dance",
+        "dance hall"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.6185,
+        -3.943
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bbc-radio-nottingham",
+      "name": "BBC Radio Nottingham",
+      "broadcaster": "independent",
+      "streamUrl": "https://a.files.bbci.co.uk/ms6/live/3441A116-B12E-4D2F-ACA8-C1984642FA4B/audio/simulcast/hls/nonuk/audio_syndication_low_sbr_v1/aks/bbc_radio_nottingham.m3u8",
+      "homepage": "https://www.radio-uk.co.uk/bbc-radio-nottingham",
+      "country": "GB",
+      "favicon": "https://static.mytuner.mobi/media/tvos_radios/U3M5n4tQDu.png",
+      "bitrate": 101,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-https-www-differentdrumz-co-uk",
+      "name": "https://www.differentdrumz.co.uk/",
+      "broadcaster": "independent",
+      "streamUrl": "https://differentdrumz.radioca.st/stream%20;",
+      "homepage": "https://www.differentdrumz.co.uk/",
+      "country": "GB",
+      "favicon": "https://www.differentdrumz.co.uk/wp-content/uploads/2016/02/Tune-In-Pic.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-the-pit-nts",
+      "name": "The Pit | NTS",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-mixtape-geo.ntslive.net/mixtape34",
+      "homepage": "https://www.nts.live/infinite-mixtapes/the-pit",
+      "country": "GB",
+      "tags": [
+        "black metal",
+        "metal",
+        "thrash metal"
+      ],
+      "favicon": "https://www.nts.live/favicon.ico",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-classic-fm-music-for-pets",
+      "name": "Classic FM Music For Pets",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ssl.musicradio.com/ClassicFM-M-Pets",
+      "homepage": "https://www.classicfm.com/lifestyle/pets/",
+      "country": "GB",
+      "tags": [
+        "classic"
+      ],
+      "bitrate": 48,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-smooth-chill-focus",
+      "name": "Smooth Chill Focus",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ssl.musicradio.com/SmoothChill-M-Concentration?",
+      "homepage": "https://www.radio-uk.co.uk/chill",
+      "country": "GB",
+      "bitrate": 48,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-dance-anthems-radio",
+      "name": "Dance Anthems Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream3.themediasite.co.uk/stream/danceanthems",
+      "homepage": "https://www.danceanthemsradio.com/",
+      "country": "GB",
+      "tags": [
+        "00s",
+        "90s",
+        "anthems",
+        "dance",
+        "old skool"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-love-soul-radio-london",
+      "name": "Love Soul Radio London",
+      "broadcaster": "independent",
+      "streamUrl": "https://s1.citrus3.com:8018/stream",
+      "homepage": "https://lovesoulradiolondon.org/",
+      "country": "GB",
+      "favicon": "https://static.thenounproject.com/png/128478-200.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-24-7-scifi-radio",
+      "name": "24/7 SciFi Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ec6.yesstreaming.net:1465/stream",
+      "homepage": "https://www.247onlineradio.com/24-7-online-radio-group-stations/24-7-scifi-radio/",
+      "country": "GB",
+      "tags": [
+        "ambient",
+        "new age",
+        "sci-fi"
+      ],
+      "favicon": "https://www.247onlineradio.com/wp-content/uploads/2023/04/2019-08-24-16.30.25-scaled.jpg",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-rainbow",
+      "name": "Rainbow",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.pcradio.ru/Rainbow-hi",
+      "homepage": "https://pcradio.ru/",
+      "country": "GB",
+      "tags": [
+        "discography"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-itch-fm",
+      "name": "Itch.FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.radio.co/s264858a04/listen",
+      "homepage": "https://www.itch.fm/",
+      "country": "GB",
+      "tags": [
+        "hiphop"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-otaku-nts",
+      "name": "Otaku | NTS",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-mixtape-geo.ntslive.net/mixtape36",
+      "homepage": "https://www.nts.live/infinite-mixtapes/otaku",
+      "country": "GB",
+      "tags": [
+        "anime",
+        "soundtracks",
+        "videogame music"
+      ],
+      "favicon": "https://www.nts.live/favicon.ico",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-dance-classics-uk",
+      "name": "Dance Classics UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream4.themediasite.co.uk/stream/danceclassics",
+      "homepage": "http://www.danceclassics.co.uk/",
+      "country": "GB",
+      "tags": [
+        "90s",
+        "dance"
+      ],
+      "favicon": "https://static2.mytuner.mobi/media/tvos_radios/ku8qxjlffvfr.png",
+      "bitrate": 192,
+      "codec": "AAC",
+      "geo": [
+        51.7016,
+        -3.0409
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-dragon-radio",
+      "name": "Dragon Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-nation.sharp-stream.com/tcnationdigital.mp3",
+      "homepage": "https://www.nationplayer.com/dragon-radio/",
+      "country": "GB",
+      "tags": [
+        "pop"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.4586,
+        -3.4464
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-malvern-radio-jrs-pumpkin-fm",
+      "name": "Malvern Radio JRS - Pumpkin FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast2.asurahosting.com/proxy/malvernradiojrs/stream",
+      "homepage": "https://pumpkinfm.com/",
+      "country": "GB",
+      "tags": [
+        "big band",
+        "jazz",
+        "ragtime",
+        "swing"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        52.1157,
+        -2.3284
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-playback-uk",
+      "name": "Playback UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://chilledstreaming.com:8650/mobile.mp3",
+      "homepage": "https://www.playbackuk.com/",
+      "country": "GB",
+      "tags": [
+        "dnb",
+        "house",
+        "jungle",
+        "uk garage"
+      ],
+      "favicon": "https://www.playbackuk.com/wp-content/uploads/2021/01/cropped-pbuk-123-192x192.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-dance-90s",
+      "name": "RADIO DANCE 90s",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiodance.streamingmedia.it/uk.aac",
+      "homepage": "https://www.radio.dance/",
+      "country": "GB",
+      "favicon": "https://www.radio.dance/logo_radiodance90s_512.png",
+      "bitrate": 320,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-simulator-radio",
+      "name": "Simulator Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://simulatorradio.stream/stream.mp3",
+      "homepage": "https://simulatorradio.com/",
+      "country": "GB",
+      "tags": [
+        "commercial free",
+        "community",
+        "gaming",
+        "top 40"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-powerhouse-radio",
+      "name": "Powerhouse Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.broadcastradio.com:11065/powerhouse",
+      "homepage": "https://powerhouseradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "christian",
+        "christian contemporary",
+        "christian praise&worship"
+      ],
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-salaam-radio",
+      "name": "Salaam Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.canstream.co.uk:8005/live.mp3",
+      "homepage": "https://www.salaamradio.co.uk/#",
+      "country": "GB",
+      "favicon": "https://storage.googleapis.com/salaamradio-live/landing-page/_ui/media/logo.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-go-radio-glasgow",
+      "name": "Go Radio Glasgow",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.broadcastradio.com:8252/goradio",
+      "homepage": "https://thisisgo.co.uk/",
+      "country": "GB",
+      "favicon": "https://thisisgo.co.uk/wp-content/uploads/2023/04/go-logo.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-jazz-fm91",
+      "name": "JAZZ.FM91",
+      "broadcaster": "independent",
+      "streamUrl": "https://jazzfm91.streamb.live/SB00009",
+      "homepage": "https://jazz.fm/",
+      "country": "GB",
+      "tags": [
+        "jazz"
+      ],
+      "bitrate": 131,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-premier-christian-radio",
+      "name": "Premier Christian Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://pcr.streamguys1.com/pcrnational-96k.aac",
+      "homepage": "https://www.premier.plus/stations/premier-christian-radio",
+      "country": "GB",
+      "favicon": "https://www.premier.plus/images/common/logo-animated-50ms.gif",
+      "bitrate": 56,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-xpression-fm-bollywood",
+      "name": "Xpression FM Bollywood",
+      "broadcaster": "independent",
+      "streamUrl": "https://casper.radioca.st/",
+      "homepage": "https://casper.radioca.st/",
+      "country": "GB",
+      "tags": [
+        "music"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-rustradio",
+      "name": "RustRadio",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.rustradio.co.uk:8443/stream",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "GB",
+      "tags": [
+        "metal"
+      ],
+      "favicon": "https://rustradio.co.uk/images/RRDefault.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        51.685,
+        -4.182
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-the-mix-radio-80s",
+      "name": "The Mix Radio 80s",
+      "broadcaster": "independent",
+      "streamUrl": "https://tmr80s.radioca.st/stream",
+      "homepage": "https://www.themixradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "1980s",
+        "80s",
+        "classic rock",
+        "pop",
+        "pop music",
+        "pop rock"
+      ],
+      "favicon": "https://static.mytuner.mobi/media/tvos_radios/390/the-mix-radio-80s.dd4413ea.png",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-fred-film-radio-28-education",
+      "name": "Fred Film Radio-28 Education",
+      "broadcaster": "independent",
+      "streamUrl": "https://s10.webradio-hosting.com/proxy/fredradioedu/stream",
+      "homepage": "https://www.fred.fm/",
+      "country": "GB",
+      "tags": [
+        "culture",
+        "film"
+      ],
+      "favicon": "https://www.fred.fm/wp-content/uploads/2014/12/Fred-Logo_trasp_-copia.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-like-anthems",
+      "name": "Like Anthems",
+      "broadcaster": "independent",
+      "streamUrl": "https://likeradiostream.com/likeanthemsaac",
+      "homepage": "https://like.radio/",
+      "country": "GB",
+      "tags": [
+        "00s",
+        "90s",
+        "dance",
+        "pop"
+      ],
+      "bitrate": 48,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-smokie",
+      "name": "Smokie",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.pcradio.ru/smokie-hi",
+      "homepage": "https://pcradio.ru/",
+      "country": "GB",
+      "tags": [
+        "discography"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-24-7-bossa-nova-radio",
+      "name": "24/7 Bossa Nova Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ec6.yesstreaming.net:1605/stream",
+      "homepage": "https://www.247onlineradio.com/24-7-online-radio-group-stations/24-7-bossa-nova-radio/",
+      "country": "GB",
+      "tags": [
+        "bossa nova",
+        "smooth jazz"
+      ],
+      "favicon": "https://www.247onlineradio.com/wp-content/uploads/2023/04/247-Bossa-Nova-Radio.jpg",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-fred-film-radio-english",
+      "name": "FRED FILM RADIO English",
+      "broadcaster": "independent",
+      "streamUrl": "https://s10.webradio-hosting.com/proxy/fredradioen/stream",
+      "homepage": "https://www.fred.fm/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-progzilla-radio",
+      "name": "Progzilla_Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.progzilla.com/main",
+      "homepage": "http://www.progzilla.com/",
+      "country": "GB",
+      "tags": [
+        "progressive rock"
+      ],
+      "favicon": "http://www.progzilla.com/favicon.ico",
+      "bitrate": 52,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-24-7-nature-radio",
+      "name": "24/7 Nature Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ec3.yesstreaming.net:3545/stream",
+      "homepage": "https://www.247natureradio.com/",
+      "country": "GB",
+      "tags": [
+        "environment",
+        "nature"
+      ],
+      "favicon": "https://www.getmeradio.com/stations/247natureradio-4493/logos/512x512.png",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-dance-uk",
+      "name": "Dance UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://dancestream.danceradiouk.com/stream/1/stream.mp3",
+      "homepage": "https://www.danceradiouk.com/",
+      "country": "GB",
+      "favicon": "https://danceradiouk.com/players/files/images/albumart/13040-DanceUK-300.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-heart-wiltshire",
+      "name": "Heart Wiltshire",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ssl.musicradio.com/HeartWiltshireMP3",
+      "homepage": "https://www.heart.co.uk/wiltshire/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-house-fm",
+      "name": "House FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://uksoutha.streaming.broadcast.radio:19920/housefm",
+      "homepage": "https://hse.fm/",
+      "country": "GB",
+      "tags": [
+        "deep house",
+        "house",
+        "soulful house"
+      ],
+      "favicon": "https://hse.fm/cdn/shop/files/logo_on_content_c7615023-6bff-4bf9-8841-9a9916b5a3b0_2500x.png?v=1615321261",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.4916,
+        -0.1346
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-uk-health-radio",
+      "name": "UK Health Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.radio.co/s8e535ff20/listen",
+      "homepage": "https://ukhealthradio.com/",
+      "country": "GB",
+      "favicon": "https://ukhealthradio.com/wp-content/themes/ukhealthradio_new/assets/img/ukhealthdario_logo.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-capital-anthems",
+      "name": "Capital Anthems",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ice.musicradio.com/CapitalAnthemsMP3",
+      "homepage": "https://www.capitalfm.com/anthems/",
+      "country": "GB",
+      "tags": [
+        "adult contemporary",
+        "anthems",
+        "pop"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-easylistening-com",
+      "name": "EasyListening.com",
+      "broadcaster": "independent",
+      "streamUrl": "https://easylistening.out.airtime.pro/easylistening_a",
+      "homepage": "https://www.easylistening.com/",
+      "country": "GB",
+      "favicon": "https://static.wixstatic.com/media/7c2261_da98addc261649d699647544ae301897~mv2.jpg/v1/fill/w_488,h_88,al_c,lg_1,q_80,enc_auto/7c2261_da98addc261649d699647544ae301897~mv2.jpg",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-fred-film-radio-extra",
+      "name": "Fred Film Radio Extra",
+      "broadcaster": "independent",
+      "streamUrl": "https://s10.webradio-hosting.com/proxy/fredradioec/stream",
+      "homepage": "http://www.fred.fm/",
+      "country": "GB",
+      "tags": [
+        "culture",
+        "film",
+        "movie"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-intamixx-desi-radio-uk",
+      "name": "Intamixx Desi Radio UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.intamixx.uk:8443/radio1",
+      "homepage": "https://radio.intamixx.uk/#hero",
+      "country": "GB",
+      "favicon": "https://radio.intamixx.uk/images/intamixx.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-totally-wired-radio",
+      "name": "Totally Wired Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://totallywired.out.airtime.pro/totallywired_a",
+      "homepage": "https://totallywiredradio.com/",
+      "country": "GB",
+      "tags": [
+        "adult contemporary",
+        "jazz",
+        "soul"
+      ],
+      "favicon": "https://totallywiredradio.com/radio/wp-content/uploads/2019/04/TWR-fb.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-great-yorkshire-radio",
+      "name": "Great Yorkshire Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream1.superstreaming.co.uk/proxy/greatyorkshire/stream",
+      "homepage": "https://greatyorkshireradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://greatyorkshireradio.co.uk/images/GYRWEBLOGO.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-ram-fm-80s-hit-radio-2",
+      "name": "RAM FM - 80s Hit Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://cc6.beheerstream.com/proxy/ramfm?mp=/stream",
+      "homepage": "https://ramfm.org/",
+      "country": "GB",
+      "tags": [
+        "80s"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-rap-house-infinite-mixtapes-nts",
+      "name": "Rap House - Infinite Mixtapes | NTS",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-mixtape-geo.ntslive.net/mixtape22",
+      "homepage": "https://www.nts.live/infinite-mixtapes/rap-house",
+      "country": "GB",
+      "tags": [
+        "drill",
+        "rap",
+        "trap"
+      ],
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-planet-rock-where-rock-lives",
+      "name": " PLANET ROCK: Where Rock Lives",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-mz.hellorayo.co.uk/planetrock.aac?direct=true&aw_0_1st.playerid=BMUK_Airable&aw_0_1st.skey=6778249992",
+      "homepage": "https://www.hellorayo.co.uk/planet-rock",
+      "country": "GB",
+      "tags": [
+        "bauer radio",
+        "classic rock",
+        "dab",
+        "digital radio",
+        "england",
+        "europe"
+      ],
+      "favicon": "https://cdn-profiles.tunein.com/s2377/images/logod.png",
+      "bitrate": 47,
+      "codec": "AAC+",
+      "geo": [
+        51.5085,
+        -0.1284
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-107-8-black-diamond-fm",
+      "name": "107.8 Black Diamond FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast-s.bdfm.radio/blackdiamondfm?icecast",
+      "homepage": "https://www.blackdiamondfm.com/",
+      "country": "GB",
+      "tags": [
+        "107.8",
+        "107.8 fm",
+        "country",
+        "music",
+        "regge",
+        "reggeton"
+      ],
+      "favicon": "https://www.blackdiamondfm.com/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-lcrfm-103-6-lincoln",
+      "name": "LCRFM 103.6 Lincoln",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.broadcast.radio/lincoln",
+      "homepage": "https://lcrlincoln.com/",
+      "country": "GB",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-noods-radio",
+      "name": "Noods Radio ",
+      "broadcaster": "independent",
+      "streamUrl": "https://noods-radio.radiocult.fm/stream",
+      "homepage": "http://www.noodsradio.com/",
+      "country": "GB",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-power-of-worship-radio",
+      "name": "Power of Worship Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://fwd.autopo.st/powerofworshipradio?_=484910",
+      "homepage": "https://www.powerofworship.net/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/177/664992e2268f6.png",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-r5k-radio",
+      "name": "R5K Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.r5k.net/",
+      "homepage": "https://r5k.uk/",
+      "country": "GB",
+      "tags": [
+        "edm"
+      ],
+      "favicon": "http://radio.r5k.uk/wp-content/uploads/2024/09/R-Black-Glow.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-riverside-radio",
+      "name": "Riverside Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming04.liveboxstream.uk/proxy/mtunstil?mp=/stream",
+      "homepage": "https://riversideradio.com/",
+      "country": "GB",
+      "tags": [
+        "arts",
+        "culture",
+        "local radio",
+        "music news",
+        "variety"
+      ],
+      "bitrate": 64,
+      "codec": "AAC+",
+      "geo": [
+        51.4744,
+        -0.1529
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-capital-fm-birmingham",
+      "name": "Capital FM (Birmingham)",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ice.musicradio.com/CapitalBirminghamMP3",
+      "homepage": "https://tunein.com/radio/Capital-Birmingham-1022-s25008/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        52.4654,
+        -1.8828
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hereme-2000s-pop",
+      "name": "Hereme 2000s pop",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.hearme.fm:8040/stream",
+      "homepage": "https://hearme.fm/",
+      "country": "GB",
+      "tags": [
+        "2000's",
+        "pop",
+        "pop music"
+      ],
+      "codec": "MP3",
+      "geo": [
+        52.6964,
+        -2.8125
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-one-world-radio",
+      "name": "One World Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/OWR_INTERNATIONAL.mp3",
+      "homepage": "https://global.tomorrowland.com/",
+      "country": "GB",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-northsea-uk",
+      "name": "Radio Northsea UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://listentomystream.com:8008/;",
+      "homepage": "https://www.rniradio.net/",
+      "country": "GB",
+      "tags": [
+        "60s",
+        "70s",
+        "80s",
+        "90s",
+        "offshore",
+        "pop"
+      ],
+      "favicon": "https://i1.sndcdn.com/artworks-000172944490-2m076q-t500x500.jpg",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-24-7-lounge-radio",
+      "name": "24/7 Lounge Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ec3.yesstreaming.net:3665/stream",
+      "homepage": "https://www.247onlineradio.com/24-7-online-radio-group-stations/24-7-lounge-radio/",
+      "country": "GB",
+      "tags": [
+        "blues",
+        "chillout",
+        "jazz",
+        "lounge"
+      ],
+      "favicon": "https://www.247onlineradio.com/wp-content/uploads/2023/04/247-Lounge-Radio.jpg",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-quantum-radio",
+      "name": "qUAntUm RaDio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.erb.pw/listen/subspace/radio.mp3",
+      "homepage": "https://radio.erb.pw/public/subspace",
+      "country": "GB",
+      "tags": [
+        "chiptune",
+        "chiptunes"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-taiyabah-masjid",
+      "name": "Taiyabah Masjid",
+      "broadcaster": "independent",
+      "streamUrl": "https://taiyabahmbolton.radioca.st/stream",
+      "homepage": "https://www.taiyabahmasjid.com/",
+      "country": "GB",
+      "tags": [
+        "islamic",
+        "masjid",
+        "mosque",
+        "religion",
+        "religious"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        53.592,
+        -2.4314
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-awaz-fm",
+      "name": "Awaz FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://uksoutha.streaming.broadcast.radio/awazfm?1709527674574=",
+      "homepage": "https://www.awazfm.co.uk/",
+      "country": "GB",
+      "favicon": "https://api.broadcast.radio/api/image/feb85d15-2e18-45a7-b50a-e35b957f7d5a.png?g=center&w=600&h=600&c=true",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-crackers-radio",
+      "name": "Crackers Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://crackersfresh.radioca.st/;",
+      "homepage": "https://www.crackersradio.com/",
+      "country": "GB",
+      "tags": [
+        "disco & jazz",
+        "funk",
+        "soul"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        51.4238,
+        0.0591
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-xl-1296",
+      "name": "Radio XL 1296",
+      "broadcaster": "independent",
+      "streamUrl": "https://xlradio.co.uk:8000/",
+      "homepage": "https://xlradio.co.uk:8000/",
+      "country": "GB",
+      "tags": [
+        "music"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-97-country-fm",
+      "name": "97 Country FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://vistaradio.streamb.live/SB00040?=&&___cb=491767877535127",
+      "homepage": "https://www.myprincegeorgenow.com/on-air/countryfm/",
+      "country": "GB",
+      "favicon": "https://www.myprincegeorgenow.com/wp-content/uploads/2021/05/mynow-icon.png",
+      "bitrate": 57,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hearme-70s-rock",
+      "name": "HearMe - 70s Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.hearme.fm:8240/stream",
+      "homepage": "https://hearme.fm/",
+      "country": "GB",
+      "tags": [
+        "70s rock",
+        "70’s rock"
+      ],
+      "codec": "MP3",
+      "geo": [
+        52.2682,
+        -0.7031
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-regal-radio",
+      "name": "Regal Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.regalradio.net/stream.mp3",
+      "homepage": "https://www.regalradio.net/",
+      "country": "GB",
+      "tags": [
+        "blues",
+        "community radio",
+        "interview",
+        "local music",
+        "local radio",
+        "music"
+      ],
+      "favicon": "https://www.regalradio.net/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-soulpower-radio-com",
+      "name": "SOULPOWER-RADIO.COM",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.radio.co/sb0964023c/listen",
+      "homepage": "https://soulpower-radio.com/",
+      "country": "GB",
+      "tags": [
+        "funk",
+        "jazz",
+        "soul"
+      ],
+      "favicon": "https://www.enomcentral.com/favicon.ico?v=1731000855",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        52.5333,
+        -1.6211
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-masjid-e-salaam-bolton",
+      "name": "Masjid E Salaam Bolton",
+      "broadcaster": "independent",
+      "streamUrl": "https://msalaambolton.radioca.st/Stream",
+      "homepage": "https://www.masjidesalaam.com/",
+      "country": "GB",
+      "bitrate": 56,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-sanskar-radio",
+      "name": "Sanskar Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.canstream.co.uk:8024/live.mp3",
+      "homepage": "http://sanskarradio.com/",
+      "country": "GB",
+      "favicon": "http://sanskarradio.com/wp-content/uploads/2018/10/logo-01.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-the-ambientscape-project",
+      "name": "The Ambientscape Project",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/504205/stream/561655",
+      "homepage": "https://www.ambientscape.com/radio",
+      "country": "GB",
+      "favicon": "https://lh3.googleusercontent.com/nl0-E_ry5_Nrnfl2EH1BfXZPxrajs0E4g1d6d2ApEAvm_6WUhnfGxWVPRV940ey0KuTLes7AddVA88dk1PlvRQw7gJPcuQ=s120",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-big-l",
+      "name": "Big L",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.streamer1.com/listen/bigl/biglTEST.mp3",
+      "homepage": "https://www.bigl.co.uk/",
+      "country": "GB",
+      "favicon": "https://www.bigl.co.uk/images/icon-2.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-do-you-radio",
+      "name": "Do You Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://doyouworld.out.airtime.pro/doyouworld_a",
+      "homepage": "https://doyou.world/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-fred-film-radio-entertainment",
+      "name": "Fred Film Radio Entertainment",
+      "broadcaster": "independent",
+      "streamUrl": "https://s10.webradio-hosting.com/proxy/fredenter/stream",
+      "homepage": "http://www.fred.fm/",
+      "country": "GB",
+      "tags": [
+        "culture",
+        "film",
+        "movie"
+      ],
+      "favicon": "http://www.fred.fm/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-shine-879",
+      "name": "Shine 879",
+      "broadcaster": "independent",
+      "streamUrl": "https://s3.radio.co/sd4abfe69e/listen",
+      "homepage": "https://shinedab.com/",
+      "country": "GB",
+      "tags": [
+        "dance",
+        "house",
+        "uk garage"
+      ],
+      "favicon": "https://shinedab.com/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-worldwide-fm",
+      "name": "Worldwide FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://worldwide-fm.radiocult.fm/stream",
+      "homepage": "https://www.worldwidefm.net/",
+      "country": "GB",
+      "tags": [
+        "electronica",
+        "jazz",
+        "progressive",
+        "underground music",
+        "world music"
+      ],
+      "favicon": "https://scontent-fra5-2.xx.fbcdn.net/v/t39.30808-1/450237294_942043604601681_3306132891557988504_n.jpg?stp=dst-jpg_s200x200_tt6&_nc_cat=109&ccb=1-7&_nc_sid=2d3e12&_nc_ohc=Ur-AWGYdJIEQ7kNvwHfsWWi&_nc_oc=Adn31I1juFGVfOprAsE1UsSz-7_H0ISFLok1gNrhmWqzfmlI6AbPJgNZB15dkduTEq4&_nc_zt=24&_nc_ht=scontent-fra5-2.xx&_nc_gid=60spXN55S49um4k8ceAfcA&oh=00_AfrO3IOBFCxwn4Bqxc2mOFTcigubLSqRjTY1N2cfbWsvxg&oe=696ED4DC",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-100-8-home-radio",
+      "name": "100.8 Home Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://uksoutha.streaming.broadcast.radio/home?1721747577077=",
+      "homepage": "https://www.homeradio.org/",
+      "country": "GB",
+      "favicon": "https://api.broadcast.radio/api/image/7ed6bffb-6808-4c08-8576-6132efe7bd78.png?g=center",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-jazz-london-radio",
+      "name": "Jazz London radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.canstream.co.uk:8075/live.aac",
+      "homepage": "https://www.jazzlondonradio.com/",
+      "country": "GB",
+      "tags": [
+        "jazz"
+      ],
+      "favicon": "https://www.jazzlondonradio.com/images/favicon.ico",
+      "bitrate": 64,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-naim-classical",
+      "name": "Naim classical",
+      "broadcaster": "independent",
+      "streamUrl": "https://mscp3.live-streams.nl:8252/class-flac.flac",
+      "homepage": "https://www.naimaudio.com/",
+      "country": "GB",
+      "favicon": "https://www.naimaudio.com/build/assets/apple-touch-icon-2a4e35a0.png",
+      "bitrate": 128,
+      "codec": "OGG",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-isle-of-wight-radio",
+      "name": "Isle of Wight Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.xrad.io:9598/listen.mp3?=&&___cb=275280937051671",
+      "homepage": "https://www.iwradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/386/5ec2a4d8bc430.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-rokit-radio-1940s-radio",
+      "name": "Rokit Radio 1940s Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming06.liveboxstream.uk/proxy/roksta13/stream",
+      "homepage": "https://www2.rokitradio.com/",
+      "country": "GB",
+      "favicon": "https://www2.rokitradio.com/_next/image?url=%2Fimages%2Fchannels%2F1940s.jpg&w=128&q=75",
+      "bitrate": 48,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-university-radio-york",
+      "name": "University Radio York",
+      "broadcaster": "independent",
+      "streamUrl": "https://audio.ury.org.uk/live-high",
+      "homepage": "https://ury.org.uk/",
+      "country": "GB",
+      "tags": [
+        "student radio"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-90s-2000s-more",
+      "name": "90s 2000s & More",
+      "broadcaster": "independent",
+      "streamUrl": "https://lunar.citrus3.com:8162/stream",
+      "homepage": "https://lunar.citrus3.com:2020/public/90s2000sandmore",
+      "country": "GB",
+      "tags": [
+        "00s",
+        "10s",
+        "80s",
+        "90s",
+        "hits",
+        "pop"
+      ],
+      "favicon": "https://lunar.citrus3.com:2020/pub/90s2000sandmore/background.jpg",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-golden-decades-radio",
+      "name": "Golden Decades Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.live365.com/a99471",
+      "homepage": "https://www.goldendecadesradio.net/",
+      "country": "GB",
+      "tags": [
+        "70s",
+        "80s",
+        "90s",
+        "pop",
+        "rock"
+      ],
+      "favicon": "https://www.goldendecadesradio.net/favicin.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        54.8945,
+        -2.9357
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hospital-radio-norwich",
+      "name": "Hospital Radio Norwich",
+      "broadcaster": "independent",
+      "streamUrl": "https://hospita1.radioca.st/;",
+      "homepage": "https://hospitalradionorwich.co.uk/",
+      "country": "GB",
+      "tags": [
+        "classical",
+        "comedy",
+        "country",
+        "eighties",
+        "fifties",
+        "folk"
+      ],
+      "bitrate": 96,
+      "codec": "MP3",
+      "geo": [
+        52.6158,
+        1.2183
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-real-roots-radio",
+      "name": "Real roots radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streams.radio.co/s1df61e0af/listen",
+      "homepage": "https://realrootsradio.net/",
+      "country": "GB",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-sunshine-radio-online-uk",
+      "name": "Sunshine Radio Online UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream1.themediasite.co.uk/8036/stream",
+      "homepage": "https://sunshineradioonline.co.uk/",
+      "country": "GB",
+      "tags": [
+        "music"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-this-is-the-coast",
+      "name": "This is the Coast",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.broadcastradio.com:10765/thisisthecoast",
+      "homepage": "https://www.thisisthecoast.co.uk/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/428/6192188de6d51.png",
+      "codec": "MP3",
+      "geo": [
+        54.2797,
+        -0.3936
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-24-7-classical-radio",
+      "name": "24/7 Classical Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ec3.yesstreaming.net:3615/stream",
+      "homepage": "https://www.247onlineradio.com/classical-radio/",
+      "country": "GB",
+      "favicon": "https://usercontent.one/wp/www.247onlineradio.com/wp-content/uploads/2019/10/Classical-Radio-logo.jpg",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-belters-radio",
+      "name": "Belters Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://uk2.internet-radio.com/proxy/belters?mp=/live",
+      "homepage": "https://www.belter-radio.com/",
+      "country": "GB",
+      "tags": [
+        "alternative",
+        "indie rock"
+      ],
+      "favicon": "https://seeded-session-images.scdn.co/v2/img/122/secondary/artist/6Q7SW1I96IGwqBDhIm55oj/en",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-original-106",
+      "name": "Original 106",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-original.sharp-stream.com/original106.mp3",
+      "homepage": "https://www.originalfm.com/",
+      "country": "GB",
+      "tags": [
+        "adult contemporary",
+        "pop music",
+        "top 40"
+      ],
+      "favicon": "https://mmo.aiircdn.com/11/62090e452aff2.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        57.1464,
+        -2.0956
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-the-buzz",
+      "name": "The Buzz",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming05.liveboxstream.uk/proxy/kookyinc/stream",
+      "homepage": "https://www.thisisthebuzz.com/",
+      "country": "GB",
+      "tags": [
+        "80s",
+        "90s",
+        "pop",
+        "rock"
+      ],
+      "favicon": "https://media.licdn.com/dms/image/D5622AQGpwL9LyKlbdg/feedshare-shrink_800/0/1697466642566?e=2147483647&v=beta&t=aYyFGOmG4uUzv7nHS5wNnENGiObuOXs9dZ6gzAG6zrM",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-aaja-radio-channel-2",
+      "name": "Aaja Radio | Channel 2",
+      "broadcaster": "independent",
+      "streamUrl": "https://aaja-2.radiocult.fm/stream",
+      "homepage": "https://aajamusic.com/radio",
+      "country": "GB",
+      "tags": [
+        "music",
+        "variety",
+        "eclectic"
+      ],
+      "favicon": "https://aajamusic.com/_nuxt/icons/icon_64x64.fafdcd.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.4761,
+        -0.0226
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-classical-radio-international",
+      "name": "CLASSICAL RADIO INTERNATIONAL",
+      "broadcaster": "independent",
+      "streamUrl": "https://ec3.yesstreaming.net:3625/stream",
+      "homepage": "https://www.247onlineradio.com/classical-radio-international/",
+      "country": "GB",
+      "tags": [
+        "classical music"
+      ],
+      "favicon": "https://www.247onlineradio.com/wp-content/uploads/2019/01/Classical-Radio-logo.png",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-clyde-built-radio",
+      "name": "Clyde Built Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://clydebuiltradio.out.airtime.pro/clydebuiltradio_a",
+      "homepage": "https://www.clydebuiltradio.com/",
+      "country": "GB",
+      "tags": [
+        "arts",
+        "community radio",
+        "culture",
+        "local music",
+        "music",
+        "non-profit"
+      ],
+      "favicon": "https://www.clydebuiltradio.com/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-crucial-hip-hop-and-electro",
+      "name": "Crucial Hip Hop and Electro",
+      "broadcaster": "independent",
+      "streamUrl": "https://uksoutha.streaming.broadcast.radio/crucial",
+      "homepage": "https://www.streetsoundsradio.com/",
+      "country": "GB",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-dirty-radio-for-underworld-fans",
+      "name": "Dirty Radio for Underworld Fans",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.dirty.radio/stream",
+      "homepage": "https://dirty.radio/",
+      "country": "GB",
+      "tags": [
+        "electronica",
+        "house",
+        "idm"
+      ],
+      "bitrate": 64,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-maritime-radio",
+      "name": "maritime radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://mediacp.nkpa.co.uk/stream/maritime%E2%80%8B/MRMP3",
+      "homepage": "https://www.maritimeradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/1353/65d08095711fe.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-cdnx-radio",
+      "name": "CDNX Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.cdnx.co.uk/proxy/cx128mp3?mp=/stream&=&&___cb=870564735813642",
+      "homepage": "https://www.camdenmarket.com/journal/cdnx-radio",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.5398,
+        -0.1362
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hearme-love-songs",
+      "name": "HearMe - Love songs",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.hearme.fm:8140/stream",
+      "homepage": "https://hearme.fm/",
+      "country": "GB",
+      "tags": [
+        "love songs"
+      ],
+      "codec": "MP3",
+      "geo": [
+        52.2682,
+        0.3516
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-christmas",
+      "name": "Radio Christmas",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.radiochristmas.co.uk/RadioChristmas",
+      "homepage": "https://radiochristmas.co.uk/",
+      "country": "GB",
+      "favicon": "https://radiochristmas.co.uk/favicon.ico",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-resonance-extra",
+      "name": "Resonance Extra",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.resonance.fm/resonance-extra",
+      "homepage": "https://extra.resonance.fm/",
+      "country": "GB",
+      "favicon": "https://extra.resonance.fm/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-xtra-hot",
+      "name": "Xtra Hot",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream1.hippynet.co.uk/stream/xtrahot/live",
+      "homepage": "https://www.xtrahot.radio/",
+      "country": "GB",
+      "tags": [
+        "bournemouth",
+        "community",
+        "community radio",
+        "dorset",
+        "funk",
+        "garage"
+      ],
+      "favicon": "https://mmo.aiircdn.com/406/63e29f650517e.png",
+      "bitrate": 160,
+      "codec": "MP3",
+      "geo": [
+        50.737,
+        -1.9505
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-centreforce-883",
+      "name": "Centreforce 883",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.centreforceradio.com/96",
+      "homepage": "https://www.centreforceradio.com/",
+      "country": "GB",
+      "bitrate": 96,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-coffee-morning",
+      "name": "Coffee Morning",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-the.musicradio.com/Global-M-CoffeeMorning",
+      "homepage": "https://global.com/global-player",
+      "country": "GB",
+      "tags": [
+        "global",
+        "heart",
+        "live playlist",
+        "media-the",
+        "smooth",
+        "uk"
+      ],
+      "favicon": "https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse4.mm.bing.net%2Fth%3Fid%3DOIP.urcOy5KLidgx_JRwHUewewAAAA%26pid%3DApi&f=1&ipt=52c4c14b37a85c76dcb3d11f83b678bf7eddd5574cb09cd4839d7e64110eb25d&ipo=images",
+      "bitrate": 48,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hardrock-hell",
+      "name": "Hardrock Hell",
+      "broadcaster": "independent",
+      "streamUrl": "https://s3.radio.co/s1f74e2763/listen",
+      "homepage": "https://hardrockhellradio.com/",
+      "country": "GB",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        52.6311,
+        1.2909
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hearme-classic-rock",
+      "name": "HearMe - Classic Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.hearme.fm:8270/stream",
+      "homepage": "https://hearme.fm/",
+      "country": "GB",
+      "tags": [
+        "classic rock"
+      ],
+      "codec": "MP3",
+      "geo": [
+        50.9584,
+        -1.4062
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-louder-than-war",
+      "name": "Louder Than War",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.radio.co/sab795a38d/listen",
+      "homepage": "https://louderthanwar.com/",
+      "country": "GB",
+      "tags": [
+        "punk postpunk"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-movedahouse",
+      "name": "MoveDaHouse",
+      "broadcaster": "independent",
+      "streamUrl": "https://uk7.internet-radio.com/proxy/movedahouse?mp=//stream",
+      "homepage": "https://www.movedahouse.com/",
+      "country": "GB",
+      "favicon": "https://www.movedahouse.com/wp-content/uploads/2018/01/mdh-172x172.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-smooth-bristol-and-bath",
+      "name": "Smooth Bristol and Bath",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-the.musicradio.com/SmoothBristolMP3",
+      "homepage": "https://www.smoothradio.com/bristol/",
+      "country": "GB",
+      "tags": [
+        "smooth"
+      ],
+      "favicon": "http://www.smoothradio.com/assets_v4r/smooth/img/favicon-196x196.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-jambo-radio",
+      "name": "Jambo! Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream3.themediasite.co.uk:8130/stream",
+      "homepage": "https://jamboradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://jamboradio.co.uk/wp-content/uploads/2019/10/cropped-Jambo-Logo-1-192x192.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-power-ace-radio",
+      "name": "Power Ace Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://music-station.live/radio/8030/radio.mp3",
+      "homepage": "https://www.poweraceradio.com/",
+      "country": "GB",
+      "tags": [
+        "afrobeats",
+        "easy listening",
+        "jazz",
+        "reggae",
+        "reggaetón",
+        "soul"
+      ],
+      "favicon": "https://www.poweraceradio.com/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-rstv-dance",
+      "name": "RSTV Dance",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiozender.mpbnetwerken.nl/rstvdance.mp3",
+      "homepage": "https://dance.rstvnetworks.com/",
+      "country": "GB",
+      "tags": [
+        "dance music"
+      ],
+      "favicon": "https://radiodns.mpbnl.nl/logos/rstv/dance.png",
+      "bitrate": 384,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-aaja-radio-channel-1",
+      "name": "Aaja Radio | Channel 1",
+      "broadcaster": "independent",
+      "streamUrl": "https://aaja.radiocult.fm/stream",
+      "homepage": "https://aajamusic.com/radio",
+      "country": "GB",
+      "tags": [
+        "music",
+        "variety",
+        "eclectic"
+      ],
+      "favicon": "https://aajamusic.com/_nuxt/icons/icon_64x64.fafdcd.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.4761,
+        -0.0226
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bikers-hangout-radio",
+      "name": "Bikers Hangout Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radio.co/s803057ca0/listen",
+      "homepage": "https://www.bikershangout.co.uk/bikers-hangout-radio",
+      "country": "GB",
+      "favicon": "https://static.wixstatic.com/media/21bad3_49d2ec0019f24f83bffacbce6787fd0a%7emv2.png/v1/fill/w_180%2ch_180%2clg_1%2cusm_0.66_1.00_0.01/21bad3_49d2ec0019f24f83bffacbce6787fd0a%7emv2.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bluesradio-uk",
+      "name": "BluesRadio UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming06.liveboxstream.uk/proxy/david125/stream",
+      "homepage": "http://www.bluesradio.co.uk/index.php",
+      "country": "GB",
+      "tags": [
+        "blues"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bar-latina-radio",
+      "name": "Bar Latina Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.citrus3.com:2000/stream/barlatinaradio",
+      "homepage": "https://www.barlatina.com/",
+      "country": "GB",
+      "tags": [
+        "bachata",
+        "kizomba",
+        "latin",
+        "regaeton",
+        "salsa"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        51.5135,
+        -0.1346
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-black-metal-radio",
+      "name": "Black Metal Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://das-edge16-live365-dal02.cdnstream.com/a05584",
+      "homepage": "https://live365.com/station/BLACK-METAL-RADIO-a05584",
+      "country": "GB",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-naim-radio",
+      "name": "Naim Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://mscp3.live-streams.nl:8362/flac.flac",
+      "homepage": "https://www.naimaudio.com/",
+      "country": "GB",
+      "tags": [
+        "various"
+      ],
+      "favicon": "https://www.naimaudio.com/build/assets/apple-touch-icon-2a4e35a0.png",
+      "bitrate": 160,
+      "codec": "OGG",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-big-beat-brighton",
+      "name": "Big Beat Brighton",
+      "broadcaster": "independent",
+      "streamUrl": "https://s4.citrus3.com:8366/stream",
+      "homepage": "https://big-beat-brighton.ueniweb.com/",
+      "country": "GB",
+      "tags": [
+        "classic hits",
+        "oldies",
+        "pop"
+      ],
+      "bitrate": 256,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-brown-noise-radio",
+      "name": "Brown Noise Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://uk1.internet-radio.com/proxy/brownnoise?mp=/stream;",
+      "homepage": "https://www.brownnoiseradio.com/",
+      "country": "GB",
+      "favicon": "https://static.wixstatic.com/media/996eee_494ede18f9684a0898e0fc38dc06869b%7Emv2.jpg/v1/fill/w_180%2Ch_180%2Clg_1%2Cusm_0.66_1.00_0.01/996eee_494ede18f9684a0898e0fc38dc06869b%7Emv2.jpg",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-heart-10s",
+      "name": "Heart 10s",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ice.musicradio.com/Heart10sMP3",
+      "homepage": "https://www.heart.co.uk/10s/",
+      "country": "GB",
+      "tags": [
+        "10s",
+        "2010s",
+        "adult contemporary"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-majestic-jukebox-radio",
+      "name": "Majestic Jukebox Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://uk3.internet-radio.com/proxy/majesticjukebox/live",
+      "homepage": "https://www.majesticjukeboxradio.com/",
+      "country": "GB",
+      "tags": [
+        "60s",
+        "70s",
+        "oldies",
+        "rocknroll"
+      ],
+      "favicon": "https://static.wixstatic.com/media/83e446_a77f5ab906b7455689b82789c523e616~mv2.jpg/v1/fit/w_2500,h_1330,al_c/83e446_a77f5ab906b7455689b82789c523e616~mv2.jpg",
+      "bitrate": 16,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-x-chilled",
+      "name": "Radio X Chilled",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ice.musicradio.com/RadioXChilledMP3",
+      "homepage": "https://www.radiox.co.uk/chilled/",
+      "country": "GB",
+      "tags": [
+        "alternative",
+        "chilled",
+        "indie rock"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-sabotage",
+      "name": "Sabotage",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/634/stream/2282",
+      "homepage": "https://welove.radio/radio/sabotage/",
+      "country": "GB",
+      "tags": [
+        "alternative indie rock"
+      ],
+      "favicon": "https://t4.ftcdn.net/jpg/04/69/34/51/360_F_469345184_YlmdPahjiPXs133mjIZf98YgZ5g8ZFSN.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-60-north-radio",
+      "name": "60 North Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://cdn1.zetcast.net/stream",
+      "homepage": "https://60north.radio/",
+      "country": "GB",
+      "favicon": "https://60north.radio/wp-content/uploads/2020/06/60n-radio-app-icon-108x108-1.jpeg",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-dance-revolution",
+      "name": "Dance Revolution",
+      "broadcaster": "independent",
+      "streamUrl": "https://s5.radio.co/s89dcf578d/listen",
+      "homepage": "https://dancerevradio.com/",
+      "country": "GB",
+      "favicon": "http://dancerevradio.com/wp-content/uploads/2024/01/asset-10360-1.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-ekr-retro-rock",
+      "name": "EKR Retro Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming06.liveboxstream.uk/proxy/eastken4?mp=/stream",
+      "homepage": "https://ekrdigital.com/retro-rock/",
+      "country": "GB",
+      "tags": [
+        "70s",
+        "80s",
+        "retro",
+        "rock"
+      ],
+      "favicon": "https://ekrdigital.com/wp-content/themes/ekr-digital-radio/img/icons/retro-rock_180.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-electric-lion-radio-london",
+      "name": "Electric Lion Radio London",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming04.liveboxstream.uk/proxy/electric?mp=/stream",
+      "homepage": "https://electriclionradio.com/",
+      "country": "GB",
+      "favicon": "https://electriclionradio.com/resources/Electric%20Lion.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hearme-trance",
+      "name": "HearMe - trance",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.hearme.fm:8100/stream",
+      "homepage": "https://hearme.fm/",
+      "country": "GB",
+      "tags": [
+        "trance"
+      ],
+      "codec": "MP3",
+      "geo": [
+        53.9561,
+        -1.7578
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-intamixx",
+      "name": "Intamixx",
+      "broadcaster": "independent",
+      "streamUrl": "https://intamixx.no-ip.com:8002/;",
+      "homepage": "https://radio.intamixx.uk/",
+      "country": "GB",
+      "tags": [
+        "bhangra",
+        "desi"
+      ],
+      "favicon": "https://radio.intamixx.uk/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-nostalgia-central",
+      "name": "Nostalgia Central",
+      "broadcaster": "independent",
+      "streamUrl": "https://s5.radio.co/s6211fbeed/listen",
+      "homepage": "https://ncradio.com/",
+      "country": "GB",
+      "tags": [
+        "1950s",
+        "1960s",
+        "1970s",
+        "1980s",
+        "1990s",
+        "nostalgic"
+      ],
+      "favicon": "http://ncradio.com/wp-content/uploads/2024/08/nclogo.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        53.0614,
+        -5.2515
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-xtra-dance",
+      "name": "Radio Xtra Dance",
+      "broadcaster": "independent",
+      "streamUrl": "https://c30.radioboss.fm:8613/stream",
+      "homepage": "https://radioxtra.co.uk/xtra-dance/",
+      "country": "GB",
+      "tags": [
+        "00s dance",
+        "10s dance",
+        "90s dance",
+        "commercial free",
+        "dance music",
+        "news free"
+      ],
+      "favicon": "https://radioxtra.co.uk/wp-content/uploads/2023/07/xTRA-DANCE-B-150x150-1.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-soul-roots-radio",
+      "name": "Soul Roots Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streams.radio.co/sbdfc075c0/listen",
+      "homepage": "https://soulrootsradio.com/",
+      "country": "GB",
+      "favicon": "https://soulrootsradio.com/wp-content/uploads/2022/08/Soul-Roots-Header-Logo.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-ace-cafe-radio",
+      "name": "Ace Cafe Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/69079/stream/106852",
+      "homepage": "https://acecafe.com/ace-cafe-radio/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.8584,
+        0.0875
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-get-ready-to-rock",
+      "name": "Get Ready to Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://streamer.radio.co/s24ae1285c/listen",
+      "homepage": "http://getreadytorockradio.com/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-healthcare-now-radio",
+      "name": "Healthcare Now Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://healthcarenowradio.out.airtime.pro/healthcarenowradio_a",
+      "homepage": "https://www.healthcarenowradio.com/",
+      "country": "GB",
+      "favicon": "https://www.healthcarenowradio.com/wp-content/uploads/2017/12/HCNR-websiteheader-636.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-sd-radio",
+      "name": "SD Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://mystation.micast.media/radio/8020/radio.mp3",
+      "homepage": "https://sdradiouk.co.uk/",
+      "country": "GB",
+      "tags": [
+        "dance",
+        "dnb",
+        "drum and bass",
+        "grime",
+        "hip hop",
+        "house"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        53.702,
+        -1.7857
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-ambur-radio",
+      "name": "Ambur Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.garden/api/ara/content/listen/FEBrvDEk/channel.mp3?1743950367875",
+      "homepage": "https://amburfm.co.uk/",
+      "country": "GB",
+      "favicon": "https://amburfm.co.uk/wp-content/uploads/2020/04/logo-ambur-original-composite-cropped.jpg.pagespeed.ce.wm1b2kWhy7.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-box-radio-dreamscapes",
+      "name": "Box radio dreamscapes",
+      "broadcaster": "independent",
+      "streamUrl": "https://boxradio-edge-00.streamafrica.net/dreamscapes",
+      "homepage": "https://boxradio.net/opendata",
+      "country": "GB",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-ehfm",
+      "name": "EHFM",
+      "broadcaster": "independent",
+      "streamUrl": "https://ehfm.out.airtime.pro/ehfm_a",
+      "homepage": "https://www.ehfm.live/",
+      "country": "GB",
+      "tags": [
+        "community radio",
+        "edinburgh"
+      ],
+      "favicon": "https://static.mytuner.mobi/media/tvos_radios/lbvlm87gg7bp.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-fresh-fm-radio-london",
+      "name": "Fresh Fm Radio London",
+      "broadcaster": "independent",
+      "streamUrl": "https://eu4.fastcast4u.com/proxy/blacka?mp=/1",
+      "homepage": "https://freshfmradiolondon.com/",
+      "country": "GB",
+      "tags": [
+        "dub",
+        "lovers rock reggae",
+        "reggae",
+        "roots",
+        "uk"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.5024,
+        -0.1154
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-gaydio-london",
+      "name": "Gaydio London",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-gaydio.sharp-stream.com/472_gaydio_london_128_mp3",
+      "homepage": "https://www.gaydio.co.uk/london/",
+      "country": "GB",
+      "tags": [
+        "chat",
+        "gaydio",
+        "pop music"
+      ],
+      "favicon": "https://mmo.aiircdn.com/20/664f572bc2e7c.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.5063,
+        -0.1286
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-heart-love",
+      "name": "Heart Love",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ice.musicradio.com/HeartLoveMP3",
+      "homepage": "https://www.heart.co.uk/love/",
+      "country": "GB",
+      "tags": [
+        "adult contemporary",
+        "love songs",
+        "middle of the road"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-pure-beat-radio",
+      "name": "Pure Beat Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast6.asurahosting.com/proxy/purebeat/stream",
+      "homepage": "http://purebeatradio.co.uk/",
+      "country": "GB",
+      "favicon": "http://purebeatradio.co.uk/gallery/favicons/favicon-120x120.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-24-7-cafe-radio",
+      "name": "24/7 Cafe Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ec6.yesstreaming.net:1555/stream",
+      "homepage": "https://www.247caferadio.com/",
+      "country": "GB",
+      "favicon": "https://www.247caferadio.com/wp-content/uploads/2020/11/cropped-247-Cafe-Radio.jpg",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-dejavufm",
+      "name": "dejavufm",
+      "broadcaster": "independent",
+      "streamUrl": "https://dejavufm.radioca.st/;",
+      "homepage": "https://dejavufm.com/",
+      "country": "GB",
+      "tags": [
+        "underground"
+      ],
+      "favicon": "https://i2.wp.com/dejavufm.com/wp-content/uploads/deja-pic-logo-.jpg?fit=600%2C600&ssl=1",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-energy-fm-classic-dance-and-the-best-new-music",
+      "name": "ENERGY FM - classic dance and the best new music",
+      "broadcaster": "independent",
+      "streamUrl": "https://s1.myradiostream.com/8838/listen.mp3",
+      "homepage": "https://www.energyfm.co.uk/",
+      "country": "GB",
+      "favicon": "https://www.energyfm.co.uk/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-funky-corner-radio-uk",
+      "name": "Funky Corner Radio UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://ais-sa2.cdnstream1.com/2447_192.mp3",
+      "homepage": "https://funkycorner.uk/",
+      "country": "GB",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-soul-rhythms-radio-uk",
+      "name": "Soul Rhythms Radio UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://a7.asurahosting.com:8230/radio.mp3",
+      "homepage": "https://soulrhythmsradio.com/home/",
+      "country": "GB",
+      "tags": [
+        "afrobeats",
+        "alternative / indie",
+        "classic jazz",
+        "disco",
+        "funk",
+        "funky house"
+      ],
+      "favicon": "https://soulrhythmsradio.com/wp-content/uploads/2023/12/SRR-LOGOTHIS_ONE.jpg",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        51.4964,
+        -0.1514
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-switch-fm-london",
+      "name": "Switch FM London",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.switchfm.co.uk/listen/switchfm/switchfm.mp3",
+      "homepage": "https://switchfm.co.uk/",
+      "country": "GB",
+      "favicon": "https://switchfm.co.uk/assets/img/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-teamsport-radio",
+      "name": "Teamsport Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://uksouth1.juiceboxradio.com/tsradionational",
+      "homepage": "http://teamsportradio.com/",
+      "country": "GB",
+      "bitrate": 96,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-80s-zoom",
+      "name": "80s Zoom",
+      "broadcaster": "independent",
+      "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/SAM03AAC226_SC.mp3",
+      "homepage": "http://www.80szoom.com/",
+      "country": "GB",
+      "tags": [
+        "128 kbit/s",
+        "192kbps",
+        "1980s",
+        "24/7",
+        "256 kbit/s",
+        "256 kbps"
+      ],
+      "favicon": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTzUFC8MX_VPOLHcB32vggZZhwC928NeErEyQ&s.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.5307,
+        -0.1223
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bloop-london-radio-live4",
+      "name": "Bloop London Radio - live4",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.canstream.co.uk:8058/live4.mp3",
+      "homepage": "https://blooplondon.com/",
+      "country": "GB",
+      "tags": [
+        "electronic"
+      ],
+      "favicon": "https://blooplondon.com/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-d3ep-radio",
+      "name": "D3EP Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast.d3ep.com:8008/192?v=1726246823",
+      "homepage": "https://d3ep.com/",
+      "country": "GB",
+      "favicon": "https://d3ep.com/assets/images/topbar-logo.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.9153,
+        -1.7853
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-heart-bristol",
+      "name": "Heart Bristol",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ssl.musicradio.com/HeartBristol?",
+      "homepage": "https://www.heart.co.uk/bristol/",
+      "country": "GB",
+      "tags": [
+        "pop music"
+      ],
+      "favicon": "https://www.heart.co.uk/assets_v4r/dist/combined/img/logos/bristol.png",
+      "bitrate": 48,
+      "codec": "AAC",
+      "geo": [
+        51.451,
+        -2.5828
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-point-blank-fm",
+      "name": "Point Blank FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://pointblankradio.co.uk/stream.mp3?latency=high",
+      "homepage": "https://www.pointblankradio.com/",
+      "country": "GB",
+      "favicon": "https://www.pointblankradio.com/wp-content/uploads/2022/11/Primary-logo.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-scifi-radio",
+      "name": "SCIFI.radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://station.kryptonradio.com:8080/stream",
+      "homepage": "http://scifi.radio/",
+      "country": "GB",
+      "favicon": "https://i0.wp.com/scifi.radio/wp-content/uploads/2021/02/cropped-scifiradio-b-512x512-1.png?fit=180%2C180&ssl=1",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-cbn-television",
+      "name": "CBN-Television",
+      "broadcaster": "independent",
+      "streamUrl": "https://5790d294af2dc.streamlock.net/CBNVI/CBNVI/playlist.m3u8",
+      "homepage": "https://www.cbnvirginislands.com/cbn-tv",
+      "country": "GB",
+      "favicon": "https://static.wixstatic.com/media/a79bb4_69234cd7684d43fa85e3b8d0c18fe9ee~mv2.png/v1/fill/w_167,h_57,al_c,lg_1,q_85,enc_auto/a79bb4_69234cd7684d43fa85e3b8d0c18fe9ee~mv2.png",
+      "bitrate": 2032,
+      "codec": "AAC,H.264",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-london-soul-radio",
+      "name": "London Soul Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://londonsoulradio.out.airtime.pro/londonsoulradio_a",
+      "homepage": "https://www.thesouloflondonradio.com/",
+      "country": "GB",
+      "favicon": "https://cdn-profiles.tunein.com/s137728/images/logod.jpg?t=637190405260000000",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-moon-phase-radio",
+      "name": "Moon Phase Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://dc1.serverse.com/proxy/dnutqhxl/stream",
+      "homepage": "http://moonphaseradio.uk/",
+      "country": "GB",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-queen",
+      "name": "Queen",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.pcradio.ru/Queen-hi",
+      "homepage": "https://pcradio.ru/",
+      "country": "GB",
+      "tags": [
+        "discography"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-fred-film-radio-27-industry",
+      "name": "Fred Film Radio-27 INDUSTRY",
+      "broadcaster": "independent",
+      "streamUrl": "https://s10.webradio-hosting.com/proxy/fredradioind/stream",
+      "homepage": "https://www.fred.fm/",
+      "country": "GB",
+      "tags": [
+        "film"
+      ],
+      "favicon": "https://www.fred.fm/wp-content/uploads/2014/12/Fred-Logo_trasp_-copia.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-greatest-hits-radio",
+      "name": "Greatest Hits Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-mz.hellorayo.co.uk/net2westmidlands.aac?aw_0_1st.skey=1602676850&direct=true&rp_source=1",
+      "homepage": "https://www.hellorayo.co.uk/greatest-hits/west-midlands",
+      "country": "GB",
+      "favicon": "https://assets.planetradio.co.uk/img/ConfigWebHeaderLogoSVGImageUrl/381.svg?ver=1545132394",
+      "bitrate": 48,
+      "codec": "AAC+",
+      "geo": [
+        52.2785,
+        -1.7069
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hearme-2020s-pop-music",
+      "name": "HearMe - 2020s Pop Music",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.hearme.fm:8000/stream",
+      "homepage": "https://hearme.fm/",
+      "country": "GB",
+      "tags": [
+        "2020s pop music"
+      ],
+      "codec": "MP3",
+      "geo": [
+        53.1204,
+        -2.4609
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-x-00s",
+      "name": "Radio X 00s",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ice.musicradio.com/RadioX00sMP3",
+      "homepage": "https://www.radiox.co.uk/00s/",
+      "country": "GB",
+      "tags": [
+        "00s",
+        "2000s",
+        "alternative",
+        "indie rock"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radiohead",
+      "name": "Radiohead",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.pcradio.ru/radiohead-hi",
+      "homepage": "https://pcradio.ru/",
+      "country": "GB",
+      "tags": [
+        "discography"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-replay-news-english-news-radio-every-5-minutes",
+      "name": "REPLAY NEWS - English           News radio every 5 minutes",
+      "broadcaster": "independent",
+      "streamUrl": "https://replaynewsen.ice.infomaniak.ch/replaynewsen-128.mp3",
+      "homepage": "https://www.replaynews.net/",
+      "country": "GB",
+      "tags": [
+        "information",
+        "news"
+      ],
+      "favicon": "https://www.publicsante.com/BIENVENU/LOGO%20REPLAY%20NEWS-EN.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-sab-radio-folkestone-uk",
+      "name": "SAB RADIO FOLKESTONE UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://spectrum.radioca.st/stream",
+      "homepage": "https://shepwayspectrumarts.co.uk/",
+      "country": "GB",
+      "tags": [
+        "other",
+        "special"
+      ],
+      "favicon": "https://shepwayspectrumarts.co.uk/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-sam-fm-hampshire",
+      "name": "SAM FM Hampshire",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-nation.sharp-stream.com/samfmhampshire.aac",
+      "homepage": "https://hellorayo.co.uk/greatest-hits/",
+      "country": "GB",
+      "tags": [
+        "32 kbps",
+        "aac",
+        "classic hits"
+      ],
+      "favicon": "https://hellorayo.co.uk/tesla/static/favicons/rayo/favicon.svg",
+      "bitrate": 48,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-ujima-radio",
+      "name": "Ujima Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.canstream.co.uk:8037/live.mp3",
+      "homepage": "https://radio.canstream.co.uk:8037/live.mp3",
+      "country": "GB",
+      "tags": [
+        "african music",
+        "blues",
+        "caribbean music",
+        "community radio",
+        "local talk",
+        "political talk"
+      ],
+      "favicon": "https://www.ujimaradio.com/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.4572,
+        -2.5925
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-beyond-radio",
+      "name": "Beyond Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.beyondradio.co.uk/radio/8000/high",
+      "homepage": "https://www.beyondradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/458/61aa613685fdd.png",
+      "bitrate": 192,
+      "codec": "AAC",
+      "geo": [
+        54.0339,
+        -2.7914
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-box-office-radio",
+      "name": "Box Office Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.citrus3.com:8400/stream",
+      "homepage": "https://boxofficeradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "broadway",
+        "film music",
+        "musical",
+        "musicals",
+        "showtunes",
+        "soundtrack"
+      ],
+      "favicon": "https://raw.githubusercontent.com/AusIPTV/IPTVLogos/master/Box_Office_Radio.png",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-british-tamil-radio",
+      "name": "British Tamil Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://hello.citrus3.com:8188/stream",
+      "homepage": "https://www.bitronline.com/",
+      "country": "GB",
+      "favicon": "https://www.bitronline.com/wp-content/uploads/2023/12/cropped-logo_radio_main-1-300x300.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-chunt-fm",
+      "name": "Chunt FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://fm.chunt.org/stream",
+      "homepage": "https://chunt.org/",
+      "country": "GB",
+      "tags": [
+        "ambient",
+        "disco",
+        "drum and bass",
+        "house",
+        "jungle",
+        "soul"
+      ],
+      "favicon": "https://chunt.org/images/logo_fishe_calm_256.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hearme-1990s-pop-music",
+      "name": "HearMe - 1990s pop music",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.hearme.fm:8050/stream",
+      "homepage": "https://hearme.fm/",
+      "country": "GB",
+      "tags": [
+        "1990s",
+        "pop",
+        "pop music"
+      ],
+      "codec": "MP3",
+      "geo": [
+        52.4828,
+        -0.7031
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-heckington-living-community-radio",
+      "name": "Heckington Living Community Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.live365.com/a52107",
+      "homepage": "http://www.heckingtonliving.co.uk/heckington-living-community-radio/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        52.9818,
+        -0.2998
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-jazz-radio-international",
+      "name": "JAZZ RADIO INTERNATIONAL",
+      "broadcaster": "independent",
+      "streamUrl": "https://ec3.yesstreaming.net:1815/stream",
+      "homepage": "https://www.247onlineradio.com/jazz-radio-international/",
+      "country": "GB",
+      "tags": [
+        "jazz"
+      ],
+      "favicon": "https://www.247onlineradio.com/wp-content/uploads/2015/07/JIR-logo.jpg",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-laser-558",
+      "name": "Laser 558",
+      "broadcaster": "independent",
+      "streamUrl": "https://s6.autopo.st/proxy/stfkrnfr?mp=/stream",
+      "homepage": "https://laser558.live/",
+      "country": "GB",
+      "tags": [
+        "80s"
+      ],
+      "favicon": "https://i0.wp.com/laser558.live/wp-content/uploads/2023/06/cropped-820eb3aa2e08a58fcf16db6aebbbdcb4_2000x.png?fit=180%2c180&#038;ssl=1",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-nation-classic-hits",
+      "name": "Nation Classic Hits",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-nation.sharp-stream.com/nationparty.mp3",
+      "homepage": "https://www.nationplayer.com/nation-classic-hits/",
+      "country": "GB",
+      "tags": [
+        "adult contemporary",
+        "classic hits",
+        "oldies"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-angel-radio",
+      "name": "Angel Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://edge.clrmedia.co.uk/angel_hb",
+      "homepage": "https://www.angelradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://static.wixstatic.com/media/d58553_797ec55eb22b47f38dd7203577e49e5e%7emv2.png/v1/fill/w_180%2ch_180%2clg_1%2cusm_0.66_1.00_0.01/d58553_797ec55eb22b47f38dd7203577e49e5e%7emv2.png",
+      "bitrate": 96,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hearme-classic-eurodisco",
+      "name": "HearMe - Classic EuroDisco",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.hearme.fm:9810/stream",
+      "homepage": "https://hearme.fm/radio/classic-eurodisco/",
+      "country": "GB",
+      "favicon": "https://hearme.fm/wp-content/uploads/2024/06/2024-Redrafted-Transparent-Box-No-Text-1-1024x1024.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hot-fm-uk",
+      "name": "Hot FM UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://hotfmuk.radioca.st/;",
+      "homepage": "https://www.hotfm.org.uk/",
+      "country": "GB",
+      "tags": [
+        "music 70s 80s 90s",
+        "pop"
+      ],
+      "favicon": "https://static.mytuner.mobi/media/tvos_radios/3tbgbthvw26v.webp",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-mellow-mountain-radio",
+      "name": "Mellow Mountain Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://owncast.mellowmountainradio.com/hls/stream.m3u8",
+      "homepage": "https://www.mellowmountainradio.com/",
+      "country": "GB",
+      "favicon": "https://irp.cdn-website.com/5e4cb10b/site_favicon_16_1715929040005.ico",
+      "bitrate": 1108,
+      "codec": "AAC,H.264",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-north-manchester-fm",
+      "name": "North Manchester FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.canstream.co.uk:8061/live.mp3",
+      "homepage": "https://northmanchester.fm/",
+      "country": "GB",
+      "tags": [
+        "community"
+      ],
+      "favicon": "https://northmanchester.fm/wp-content/uploads/2011/08/nmfm10661.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-poprockradiouk",
+      "name": "PopRockRadioUK",
+      "broadcaster": "independent",
+      "streamUrl": "https://popradiouk.out.airtime.pro/popradiouk_a",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "GB",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-stones-live-the-24-7-maidstone-united-radio-stat",
+      "name": "Stones Live! - The 24/7 Maidstone United Radio Station",
+      "broadcaster": "independent",
+      "streamUrl": "https://uk5.internet-radio.com/proxy/stoneslive?mp=/stream;",
+      "homepage": "https://www.stoneslive.com/",
+      "country": "GB",
+      "favicon": "https://www.stoneslive.com/wp-content/uploads/2015/07/julystoneslive.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-the-christmas-station",
+      "name": "The Christmas Station",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radio.co/s63541ce9b/listen",
+      "homepage": "https://thechristmasstation.org/",
+      "country": "GB",
+      "favicon": "https://thechristmasstation.org/images/stationlogo.webp",
+      "bitrate": 64,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-wey-valley",
+      "name": "Wey Valley",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.readyformed.com:8443/wey1",
+      "homepage": "https://www.weyvalleyradio.uk/l",
+      "country": "GB",
+      "tags": [
+        "easy listening",
+        "pop"
+      ],
+      "favicon": "https://www.weyvalleyradio.uk/favicon.ico",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-kisstory-non-stop-old-skool-anthems",
+      "name": " KISSTORY: Non-Stop Old Skool & Anthems",
+      "broadcaster": "independent",
+      "streamUrl": "https://live-bauerkiss.sharp-stream.com/kisstory.aac?direct=true&aw_0_1st.playerid=BMUK_Airable&aw_0_1st.skey=6778249992",
+      "homepage": "https://www.hellorayo.co.uk/kisstory",
+      "country": "GB",
+      "tags": [
+        "anthems",
+        "bauer radio",
+        "classics",
+        "dance anthems",
+        "dance classics",
+        "england"
+      ],
+      "favicon": "https://cdn-profiles.tunein.com/s77960/images/logod.png",
+      "bitrate": 48,
+      "codec": "AAC+",
+      "geo": [
+        51.5082,
+        -0.1285
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-24-7-london-radio-royalty-free-music",
+      "name": "24/7 London Radio - Royalty Free Music",
+      "broadcaster": "independent",
+      "streamUrl": "https://ec3.yesstreaming.net:3645/stream",
+      "homepage": "https://www.247londonradio.com/royalty-free-music/",
+      "country": "GB",
+      "tags": [
+        "24/7",
+        "free",
+        "london",
+        "royalty free"
+      ],
+      "favicon": "https://usercontent.one/wp/www.247londonradio.com/wp-content/uploads/2020/02/cropped-247-london-Radio-Logo.jpg",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-cj-carlos",
+      "name": "CJ Carlos",
+      "broadcaster": "independent",
+      "streamUrl": "https://s3.radio.co/sf2bda8390/listen",
+      "homepage": "https://cjcarlosevents.co.uk/",
+      "country": "GB",
+      "tags": [
+        "r&b/urban"
+      ],
+      "bitrate": 192,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-gamingnow-radio",
+      "name": "GamingNow Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://media01.gamingnow.net:8010/",
+      "homepage": "https://gamingnow.net/radio/",
+      "country": "GB",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-in2beats",
+      "name": "in2Beats",
+      "broadcaster": "independent",
+      "streamUrl": "https://in2radio.co.uk/IN2MP3",
+      "homepage": "https://in2beats.com/",
+      "country": "GB",
+      "tags": [
+        "classic soul"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-laser-558-classic",
+      "name": "Laser 558 Classic",
+      "broadcaster": "independent",
+      "streamUrl": "https://s6.autopo.st/proxy/neffjohd?mp=/stream",
+      "homepage": "https://laser558.live/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-ribblefm",
+      "name": "RibbleFM",
+      "broadcaster": "independent",
+      "streamUrl": "https://uksouth.streaming.broadcast.radio/ribblefm",
+      "homepage": "https://ribblefm.com/",
+      "country": "GB",
+      "favicon": "https://ribblefm.com/wp-content/uploads/2023/02/ribblefm-logo.webp",
+      "codec": "MP3",
+      "geo": [
+        53.8506,
+        -2.3758
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-starpoint-radio",
+      "name": "Starpoint Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream2.hippynet.co.uk/stream/starpointradiohigh",
+      "homepage": "http://www.starpointradio.com/",
+      "country": "GB",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-uk-national-radio",
+      "name": "UK National Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://das-edge14-live365-dal02.cdnstream.com/a80402",
+      "homepage": "https://www.uknationalradio.com/",
+      "country": "GB",
+      "tags": [
+        "00s",
+        "10s",
+        "60s",
+        "70s",
+        "80s",
+        "90s"
+      ],
+      "favicon": "https://media.live365.com/download/119460ab-eb43-4fca-a482-eadc9c4d9ef0.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-1btn",
+      "name": "1BTN",
+      "broadcaster": "independent",
+      "streamUrl": "https://edge.clrmedia.co.uk/obfm_mp3",
+      "homepage": "https://1btn.fm/",
+      "country": "GB",
+      "tags": [
+        "electronic",
+        "funk",
+        "house",
+        "reggae",
+        "soul"
+      ],
+      "codec": "MP3",
+      "geo": [
+        50.8262,
+        -0.1611
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-24-7-restaurant-radio",
+      "name": "24/7 Restaurant Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ec6.yesstreaming.net:1655/stream",
+      "homepage": "https://www.247restaurantradio.com/",
+      "country": "GB",
+      "favicon": "https://usercontent.one/wp/www.247restaurantradio.com/wp-content/uploads/2021/04/cropped-247-Restaurant-Radio.jpg",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-alpha-wave-radio",
+      "name": "Alpha Wave Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://listentomystream.com:8068/stream",
+      "homepage": "https://www.alphawaveradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://static.wixstatic.com/media/a8d0cc_272a834a431540a6a4bc2c9a7f652ec0~mv2.png/v1/fill/w_123,h_123,al_c,q_85,usm_0.66_1.00_0.01,enc_auto/Bright%20Blue.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bbc-radio-tees",
+      "name": "BBC Radio Tees",
+      "broadcaster": "independent",
+      "streamUrl": "https://a.files.bbci.co.uk/ms6/live/3441A116-B12E-4D2F-ACA8-C1984642FA4B/audio/simulcast/hls/nonuk/pc_hd_abr_v2/aks/bbc_tees.m3u8",
+      "homepage": "https://www.bbc.co.uk/radiotees/",
+      "country": "GB",
+      "favicon": "https://static.files.bbci.co.uk/sounds/web/sounds-web/img/sounds-apple-touch-icon.ead169771d.png",
+      "bitrate": 101,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-beware-the-radio",
+      "name": "Beware! The Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://bewaretheradio.out.airtime.pro/bewaretheradio_a",
+      "homepage": "https://www.bewaretheradio.com/",
+      "country": "GB",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-fred-film-radio-mandarin",
+      "name": "FRED FILM RADIO Mandarin",
+      "broadcaster": "independent",
+      "streamUrl": "https://s10.webradio-hosting.com/proxy/fredradiocn/stream/1/",
+      "homepage": "https://www.fred.fm/",
+      "country": "GB",
+      "favicon": "https://www.fred.fm/wp-content/uploads/2014/12/Fred-Logo_trasp_-copia.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hearme-2010s-pop-music",
+      "name": "HearMe 2010s pop music",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.hearme.fm:8030/stream",
+      "homepage": "https://hearme.fm/",
+      "country": "GB",
+      "codec": "MP3",
+      "geo": [
+        52.6964,
+        -2.4609
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-ostm-radio",
+      "name": "OSTM Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.zeno.fm/1vx25xbdmzzuv",
+      "homepage": "https://www.ostm.co.uk/",
+      "country": "GB",
+      "tags": [
+        "alternative",
+        "alternative rock",
+        "indie",
+        "indie rock",
+        "rock"
+      ],
+      "favicon": "https://www.ostm.co.uk/img/favicon.ico",
+      "codec": "MP3",
+      "geo": [
+        53.4726,
+        -2.2996
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-capital-nottinghamshire",
+      "name": "Capital (Nottinghamshire)",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ice.musicradio.com/CapitalNottinghamshireMP3",
+      "homepage": "https://www.capitalfm.com/",
+      "country": "GB",
+      "tags": [
+        "top 40"
+      ],
+      "favicon": "https://www.capitalfm.com/assets_v4r/capital/img/favicon-196x196.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-caravan-radio",
+      "name": "Caravan Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream4.themediasite.co.uk:8044/stream?_=456752",
+      "homepage": "https://www.caravanradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "pop",
+        "rock"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-cosmic-fuzz-fm",
+      "name": "COSMIC FUZZ FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://26343.live.streamtheworld.com/SAM04AAC335_SC",
+      "homepage": "https://cosmicfuzzfm.com/",
+      "country": "GB",
+      "favicon": "https://img1.wsimg.com/isteam/ip/a07df4e6-3874-46a7-b088-6a4e68a6123b/blob-6f3a7d7.png/:/cr=t:0%25,l:0%25,w:100%25,h:100%25/rs=w:806,h:403",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-galaxy-of-stars",
+      "name": "Galaxy of Stars ",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ssl.musicradio.com/Global-M-GalaxyStars",
+      "homepage": "https://www.globalplayer.com/playlists/2SWmn/",
+      "country": "GB",
+      "tags": [
+        "dance",
+        "urban"
+      ],
+      "favicon": "https://images.globalplayer.com/images/595200?width=450&signature=8QhLiiKoeaxJMt_Zc6w4S9Wekz0=",
+      "bitrate": 48,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-magic-classical",
+      "name": "Magic Classical",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-mz.hellorayo.co.uk/scala.aac",
+      "homepage": "https://www.hellorayo.co.uk/magic-classical",
+      "country": "GB",
+      "tags": [
+        "classical music"
+      ],
+      "bitrate": 48,
+      "codec": "AAC+",
+      "geo": [
+        51.4786,
+        -0.1978
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-ssradio",
+      "name": "SSRadio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ssradiol.radioca.st/listen.mp3",
+      "homepage": "https://ssradio.com/",
+      "country": "GB",
+      "tags": [
+        "deep house",
+        "funky house",
+        "house",
+        "soulful house"
+      ],
+      "favicon": "https://ssradio.com/wp-content/themes/ssradio/images/ssrDeepLogo.gif",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-the-people-s-radio-a-star-citizen-community-radi",
+      "name": "The People's Radio - A Star Citizen Community Radio Station",
+      "broadcaster": "independent",
+      "streamUrl": "https://us1.streamingpulse.com/ssl/7058",
+      "homepage": "https://thepeoplesradio.space/",
+      "country": "GB",
+      "favicon": "https://us7.streamingpulse.com/4232/tmp/images/logo.1632318369.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-winchester-radio",
+      "name": "Winchester Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://winchest.radioca.st/stream?rp_source=1&=&&___cb=427101946874329",
+      "homepage": "http://winchester.radio/",
+      "country": "GB",
+      "favicon": "https://www.hampshirehospitals.nhs.uk/application/files/5715/9741/0233/WinchRadio-portrait250x109.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-virgin-radio-uk-rock-n-roll-radio-from-the-top-o",
+      "name": " VIRGIN RADIO UK: Rock‘n’Roll Radio From The Top Of The Tower",
+      "broadcaster": "independent",
+      "streamUrl": "https://virgin.live.stream.broadcasting.news/stream",
+      "homepage": "https://virginradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "dab",
+        "digital radio",
+        "england",
+        "english",
+        "europe",
+        "london"
+      ],
+      "favicon": "https://cdn-profiles.tunein.com/s266113/images/logod.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        51.5072,
+        -0.1269
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-24-7-seawaves-radio",
+      "name": "24/7 Seawaves Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ec6.yesstreaming.net:1505/stream",
+      "homepage": "https://www.247natureradio.com/24-7-seawaves-radio/",
+      "country": "GB",
+      "tags": [
+        "meditation",
+        "nature",
+        "relaxation",
+        "seawaves"
+      ],
+      "favicon": "https://www.247natureradio.com/wp-content/uploads/2021/09/247-Seawaves-Radio.jpg",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-big-barn-radio",
+      "name": "BIG BARN RADIO",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.radio.co/s04214ea9a/listen",
+      "homepage": "https://bigbarnradio.com/",
+      "country": "GB",
+      "tags": [
+        "pop"
+      ],
+      "favicon": "https://www.wix.com/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-broradio",
+      "name": "broradio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.broadcastradio.com:8422/brorad?=&&___cb=380218828489260",
+      "homepage": "https://www.broradio.fm/",
+      "country": "GB",
+      "tags": [
+        "community radio",
+        "local news",
+        "music",
+        "welsh language"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-burgess-hill-radio",
+      "name": "Burgess Hill Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.broadcastradio.com:9312/burgesshillradio",
+      "homepage": "https://www.burgesshillradio.co.uk/",
+      "country": "GB",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-heritage-chart-radio",
+      "name": "Heritage Chart Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s4.radio.co/sd5b175766/listen",
+      "homepage": "https://www.heritagechart.co.uk/",
+      "country": "GB",
+      "tags": [
+        "heritage"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-jingle-ark-jingle-jukebox",
+      "name": "Jingle Ark Jingle Jukebox",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.zeno.fm/6q0ftbdzk2zuv",
+      "homepage": "https://zeno.fm/radio/jingle-ark-classics/",
+      "country": "GB",
+      "favicon": "https://zeno.fm/static/icons/apple-icon-120x120.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-music-galaxy-radio",
+      "name": "Music Galaxy Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://eu10.fastcast4u.com/themusi2",
+      "homepage": "https://www.themusicgalaxyradio.com/",
+      "country": "GB",
+      "tags": [
+        "country",
+        "djs",
+        "funk",
+        "hip-hop",
+        "jazz",
+        "reggae"
+      ],
+      "favicon": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRl5H_571Uc9TPjudUTSRXY6Kme_1deY38X0r8gWVmn1YclbOUPbBC3exlC4gEOZEs05r0&usqp=CAU",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-retro-mix-radio",
+      "name": "Retro Mix Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.retromixradio.co.uk/radio48",
+      "homepage": "https://www.retromixradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "70s",
+        "80s",
+        "90s"
+      ],
+      "bitrate": 48,
+      "codec": "AAC+",
+      "geo": [
+        51.5754,
+        0.4752
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-sheppey-fm-92-2",
+      "name": "Sheppey FM 92.2",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming05.liveboxstream.uk/proxy/sheppeyf?mp=/stream",
+      "homepage": "https://sheppeyfm.org.uk/",
+      "country": "GB",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-your-hits-digital",
+      "name": "Your Hits Digital",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-yourhitsdigital.creativedork.com/",
+      "homepage": "https://www.yourhitsdigital.com/",
+      "country": "GB",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-242-radio",
+      "name": "242 Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://uk7.internet-radio.com/proxy/242radio?mp=/stream&1705137844878",
+      "homepage": "https://www.242radio.com/",
+      "country": "GB",
+      "favicon": "https://www.242radio.com/index_htm_files/17903@2x.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-apocalypse-radio",
+      "name": "Apocalypse Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiopanel.scoobynetworks.uk:10990/stream?type=http&nocache=28",
+      "homepage": "https://apocalypse-radio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "dance",
+        "dj remix",
+        "house",
+        "techno",
+        "trance"
+      ],
+      "bitrate": 320,
+      "codec": "AAC+",
+      "geo": [
+        52.4426,
+        -1.8402
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bfbs-uk",
+      "name": "BFBS UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-ssvcbfbs.sharp-stream.com/ssvcbfbs1.aac",
+      "homepage": "https://radio.bfbs.com/stations/bfbs-uk",
+      "country": "GB",
+      "favicon": "https://radio.bfbs.com/icons/icon-512x512.png?v=0afec91a27aaa6d57f2b000c6fbe8cac",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bloomberg-uk",
+      "name": "Bloomberg UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://bloomberg-live-prod-us-east-1.s3.amazonaws.com/rad/Channel-RAD-AWS-virginia-1/Source-RadUK-96-1_live.m3u8",
+      "homepage": "https://www.bloomberg.com/audio",
+      "country": "GB",
+      "tags": [
+        "business",
+        "news",
+        "ridwan",
+        "talk",
+        "world news"
+      ],
+      "favicon": "https://www.bloomberg.com/favicon.ico",
+      "codec": "UNKNOWN",
+      "geo": [
+        52.0957,
+        -0.4216
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-frisk-guilty-pleasures",
+      "name": "Frisk Guilty Pleasures",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.friskradio.com:8443/stream31",
+      "homepage": "https://www.friskradio.com/?station=6#station-select-panel",
+      "country": "GB",
+      "favicon": "https://management.friskradio.com:7000/stations/logo?id=6",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-inverness-hospital-radio",
+      "name": "Inverness Hospital Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://uksoutha.streaming.broadcast.radio/invernesshr?1699799769753=",
+      "homepage": "https://www.invernesshospitalradio.co.uk/",
+      "country": "GB",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-nation-xmas",
+      "name": "Nation Xmas",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-nation.sharp-stream.com/nationxmas.mp3",
+      "homepage": "https://www.nationplayer.com/nation-xmas/",
+      "country": "GB",
+      "tags": [
+        "christmas",
+        "christmas music",
+        "christmas songs"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-ocean-youth-radio",
+      "name": "Ocean Youth Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radio.co/s7bb9c4fc8/low",
+      "homepage": "https://www.oceanyouth.co.uk/",
+      "country": "GB",
+      "favicon": "https://images.squarespace-cdn.com/content/v1/63b306b5c427c63f7ac443bb/a113998f-ade6-40ba-9e52-0ee49b945a1d/02_OYLogoWhite.png?format=1500w",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-groovy",
+      "name": "Radio Groovy",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radio.co/s560edbdb7/listen",
+      "homepage": "https://www.radiogroovy.com/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-101-8-wcr-fm",
+      "name": "101.8 WCR FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream3.themediasite.co.uk:8312/stream?_=580911",
+      "homepage": "https://www.wcrfm.com/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        52.5833,
+        -2.1296
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-24-7-country-walks-radio",
+      "name": "24/7 Country Walks Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ec6.yesstreaming.net:1585/stream",
+      "homepage": "https://www.247onlineradio.com/24-7-online-radio-group-stations/24-7-country-walks-radio/",
+      "country": "GB",
+      "tags": [
+        "environnement",
+        "meditation",
+        "nature",
+        "relaxation"
+      ],
+      "favicon": "https://www.247onlineradio.com/wp-content/uploads/2023/04/247-Country-Walks.jpg",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-crystal-107-4-fm",
+      "name": "Crystal 107.4 FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://crystalfm-radiohosting2.radioca.st/stream",
+      "homepage": "https://www.crystalfm.co.uk/",
+      "country": "GB",
+      "tags": [
+        "cultural",
+        "eclectic programming",
+        "folk music"
+      ],
+      "favicon": "https://www.crystalfm.co.uk/index_htm_files/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-liverpool-live-radio",
+      "name": "Liverpool Live Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.aiir.com/xbmvsamvpnluv",
+      "homepage": "https://www.liverpoolliveradio.com/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/417/5f8022222baf6.png",
+      "codec": "MP3",
+      "geo": [
+        53.3954,
+        -2.9825
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-mechanical-music-radio",
+      "name": "Mechanical Music Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://global.citrus3.com:2020/stream/mechanicalmusicradio",
+      "homepage": "https://www.mechanicalmusicradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://www.mechanicalmusicradio.co.uk/uploads/1/1/3/3/1133045/google-play-store-featured-section.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-buena-vida",
+      "name": "Radio Buena Vida",
+      "broadcaster": "independent",
+      "streamUrl": "https://s4.radio.co/s69b281ac0/listen",
+      "homepage": "https://buenavida.co.uk/",
+      "country": "GB",
+      "tags": [
+        "community radio",
+        "music"
+      ],
+      "favicon": "https://buenavida.co.uk/wp-content/uploads/2022/08/Small-logo-for-Soundcloud.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        55.8341,
+        -4.2655
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-newark",
+      "name": "Radio Newark",
+      "broadcaster": "independent",
+      "streamUrl": "https://streamer.radionewark.com/",
+      "homepage": "https://radionewark.org/",
+      "country": "GB",
+      "favicon": "https://radionewark.org/images/favicon/apple-touch-icon.png",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-sabras-radio",
+      "name": "Sabras Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.canstream.co.uk:8025/live.mp3?_=596083",
+      "homepage": "https://www.sabrasradio.com/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/232/6460ea059133d.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-24-7-spa-radio",
+      "name": "24/7 Spa Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ec6.yesstreaming.net:2915/stream",
+      "homepage": "https://www.247sparadio.com/",
+      "country": "GB",
+      "favicon": "https://usercontent.one/wp/www.247sparadio.com/wp-content/uploads/2021/04/cropped-247-Spa-Radio.jpg",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-95-6-brfm",
+      "name": "95.6 BRFM",
+      "broadcaster": "independent",
+      "streamUrl": "https://mediacp.nkpa.co.uk/stream/Brfm/BrfmMP3",
+      "homepage": "https://brfm.net/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-banita-maxx-radio",
+      "name": "Banita Maxx Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.zeno.fm/z5artz4g2wzuv",
+      "homepage": "https://banitamaxx.pl/",
+      "country": "GB",
+      "tags": [
+        "edm",
+        "hardstyle",
+        "polish",
+        "trance"
+      ],
+      "codec": "MP3",
+      "geo": [
+        51.6829,
+        -0.4036
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-dance-radio-uk",
+      "name": "Dance Radio UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://dancestream.danceradiouk.com/",
+      "homepage": "https://www.danceradiouk.com/",
+      "country": "GB",
+      "tags": [
+        "80's",
+        "pop",
+        "top-40"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-fenland-youth-radio",
+      "name": "Fenland Youth Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.broadcastradio.com:10445/youngtech",
+      "homepage": "https://www.fenlandyouthradio.com/",
+      "country": "GB",
+      "tags": [
+        "community"
+      ],
+      "favicon": "https://irp.cdn-website.com/546fca48/site_favicon_16_1630357525872.ico",
+      "codec": "UNKNOWN",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-forest-fm",
+      "name": "Forest FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.canstream.co.uk:8146/live.mp3",
+      "homepage": "https://forestfm.co.uk/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-iconicextra",
+      "name": "IconicExtra",
+      "broadcaster": "independent",
+      "streamUrl": "https://ukbeatz.radioca.st/stream",
+      "homepage": "https://www.iconicextra.com/",
+      "country": "GB",
+      "favicon": "https://www.iconicextra.com/wp-content/uploads/2020/06/cropped-logo_redo1cl-180x180.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-insanity-radio",
+      "name": "Insanity Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.cor.insanityradio.com/insanity.flac",
+      "homepage": "https://insanityradio.com/",
+      "country": "GB",
+      "codec": "OGG",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-mix-92-6",
+      "name": "Mix 92.6",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream4.hippynet.co.uk/stream/8012/stream",
+      "homepage": "https://mix926.com/",
+      "country": "GB",
+      "tags": [
+        "community radio"
+      ],
+      "favicon": "https://mix926.com/favicon.ico",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-music-box-radio",
+      "name": "Music Box Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://uk5.internet-radio.com/proxy/musicboxradio?mp=/stream",
+      "homepage": "https://www.musicboxradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "community radio",
+        "eclectic",
+        "music"
+      ],
+      "favicon": "https://www.musicboxradio.co.uk/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-nr1-drum-and-bass-radio",
+      "name": "NR1 Drum and Bass Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.listen-nr1dnb.com/listen/nr1_dnb_radio/radio.mp3",
+      "homepage": "https://listen.nr1dnb.com/",
+      "country": "GB",
+      "tags": [
+        "dnb",
+        "drum and bass",
+        "electronic",
+        "jungle"
+      ],
+      "favicon": "https://listen.nr1dnb.com/icons/icon-512.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-powerstream",
+      "name": "PowerStream",
+      "broadcaster": "independent",
+      "streamUrl": "https://my.powerstream.live/1985/stream",
+      "homepage": "https://dj-stream.com/",
+      "country": "GB",
+      "favicon": "https://dj-stream.com/favicon.ico",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-west-middlesex",
+      "name": "Radio West Middlesex",
+      "broadcaster": "independent",
+      "streamUrl": "https://uk6.internet-radio.com/proxy/radiowestmiddlesex?mp=/stream;",
+      "homepage": "http://radiowestmiddlesex.org.uk/",
+      "country": "GB",
+      "favicon": "http://radiowestmiddlesex.org.uk/wordpress/wp-content/themes/RWMTheme4/images/page.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-thornbury-radio",
+      "name": "Thornbury Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s42.myradiostream.com/29400/listen.mp3?_=135900",
+      "homepage": "https://www.thornbury.radio/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/222/5f4659d5167b4.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-vintage-radio-birkenhead",
+      "name": "Vintage Radio birkenhead",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming04.liveboxstream.uk/proxy/vintager/stream",
+      "homepage": "https://www.vintageradio.org.uk/#",
+      "country": "GB",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-voices",
+      "name": "Voices",
+      "broadcaster": "independent",
+      "streamUrl": "https://voicesradio.out.airtime.pro/voicesradio_a",
+      "homepage": "https://www.voicesradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://www.voicesradio.co.uk/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.5361,
+        -0.1261
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-we-get-lifted-radio-wglr-192k-mp3",
+      "name": "We Get Lifted Radio (WGLR) 192k mp3",
+      "broadcaster": "independent",
+      "streamUrl": "https://s3.radio.co/sa80d22794/listen",
+      "homepage": "https://wegetliftedradio.com/",
+      "country": "GB",
+      "tags": [
+        "deep house",
+        "deep techno",
+        "edm",
+        "tech house"
+      ],
+      "favicon": "https://www.wegetliftedradio.com/wp-content/uploads/2020/03/cropped-WGLR-HEADER-1-1-1-600x343.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-britcom-4",
+      "name": "Britcom 4",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast2.asurahosting.com/proxy/britcom4/stream.mp3",
+      "homepage": "https://pumpkinfm.com/",
+      "country": "GB",
+      "tags": [
+        "comedy"
+      ],
+      "favicon": "https://pumpkinfm.com/wp-content/uploads/2022/03/pfmnewlogoSmall.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-cam-fm-97-2",
+      "name": "Cam FM 97.2",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.camfm.co.uk/camfm",
+      "homepage": "https://www.camfm.co.uk/",
+      "country": "GB",
+      "favicon": "https://www.camfm.co.uk/media/images/default_thumb.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-fantasy-radio-devizes",
+      "name": "Fantasy Radio (Devizes)",
+      "broadcaster": "independent",
+      "streamUrl": "https://server.fantasyradio.co.uk/fantasyradio",
+      "homepage": "https://www.fantasyradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "classic hits",
+        "community radio",
+        "hot adult contemporary",
+        "local radio"
+      ],
+      "favicon": "https://www.fantasyradio.co.uk/files/9414/1236/5176/fbthumb.png",
+      "bitrate": 256,
+      "codec": "MP3",
+      "geo": [
+        51.3525,
+        -1.996
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-island-time-infinite-mixtapes-nts",
+      "name": "Island Time - Infinite Mixtapes | NTS",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-mixtape-geo.ntslive.net/mixtape21",
+      "homepage": "https://www.nts.live/infinite-mixtapes/island-time",
+      "country": "GB",
+      "tags": [
+        "dub",
+        "reggae"
+      ],
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-kennet-radio",
+      "name": "Kennet Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.kennetradio.com/64.aac",
+      "homepage": "https://kennetradio.com/",
+      "country": "GB",
+      "favicon": "https://kennetradio.com/wp-content/uploads/2021/05/kr_square_150.png",
+      "bitrate": 48,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-mkfm",
+      "name": "MKFM",
+      "broadcaster": "independent",
+      "streamUrl": "https://mkfmradioplayer2.radioca.st/;stream.nsv?=&&___cb=838498533391580",
+      "homepage": "https://www.mkfm.com/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/171/6367c3f242240.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-northwich",
+      "name": "Radio Northwich",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radio.co/s98163f694/listen",
+      "homepage": "https://www.radionorthwich.co.uk/",
+      "country": "GB",
+      "tags": [
+        "local information",
+        "local music",
+        "local news",
+        "local programming",
+        "local radio",
+        "local talk"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        53.2627,
+        -2.5116
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-reform-radio",
+      "name": "Reform Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://testform.out.airtime.pro/testform_a",
+      "homepage": "https://www.reformradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "music",
+        "variety"
+      ],
+      "favicon": "https://www.reformradio.co.uk/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        53.4781,
+        -2.2565
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-smash-hits-radio-retro",
+      "name": "Smash hits radio retro",
+      "broadcaster": "independent",
+      "streamUrl": "https://s3.radio.co/s802363087/listen",
+      "homepage": "https://s3.radio.co/s802363087/listen",
+      "country": "GB",
+      "tags": [
+        "retro hits"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        -35.8329,
+        11.5342
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-sunny-g-community-radio",
+      "name": "Sunny G Community Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming06.liveboxstream.uk/proxy/gary1?mp=/stream",
+      "homepage": "https://www.sunnyg.org/",
+      "country": "GB",
+      "tags": [
+        "community"
+      ],
+      "favicon": "https://static.wixstatic.com/media/3455a1_7e4ecdcdcf7344fe88ca9633cc48aae4~mv2.png/v1/fill/w_315,h_315,al_c,lg_1,q_85,enc_auto/Sunny_G_logo%20(no%20background).png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        55.8595,
+        -4.2576
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-york-hospital-radio",
+      "name": "York Hospital Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream1.superstreaming.co.uk/proxy/yorkhospradio/stream",
+      "homepage": "http://www.yorkhospitalradio.com/#",
+      "country": "GB",
+      "favicon": "https://yorkhospitalradio.com/wp-content/uploads/2024/01/cropped-yhr-site-logo-180x180.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-kiss-the-best-vibes-energy",
+      "name": " KISS - The Best Vibes & Energy",
+      "broadcaster": "independent",
+      "streamUrl": "https://live-bauerkiss.sharp-stream.com/kissnational.aac?direct=true&aw_0_1st.skey=1602676850&rp_source=1&=&&___cb=60456375243858",
+      "homepage": "https://www.hellorayo.co.uk/kiss",
+      "country": "GB",
+      "tags": [
+        "dab",
+        "dance",
+        "dance music",
+        "digital radio",
+        "edm",
+        "england"
+      ],
+      "favicon": "https://cdn-profiles.tunein.com/s6004/images/logod.png",
+      "bitrate": 47,
+      "codec": "AAC+",
+      "geo": [
+        51.5078,
+        -0.1265
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-kiss-dance-the-biggest-dance-anthems-24-7",
+      "name": " KISS DANCE: The Biggest Dance Anthems 24/7",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-kiss.hellorayo.co.uk/kissdance.aac?direct=true&aw_0_1st.skey=1602676850&rp_source=1&=&&___cb=60456375243858",
+      "homepage": "https://www.hellorayo.co.uk/kiss-dance",
+      "country": "GB",
+      "tags": [
+        "anthems",
+        "bauer radio",
+        "club dance",
+        "dab",
+        "dab+",
+        "dance"
+      ],
+      "favicon": "https://cdn-profiles.tunein.com/s321341/images/logod.png",
+      "bitrate": 127,
+      "codec": "AAC",
+      "geo": [
+        51.5078,
+        -0.1275
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-100-whatever-westcountry",
+      "name": "100% Whatever Westcountry",
+      "broadcaster": "independent",
+      "streamUrl": "https://dh1-sanityradio.radioca.st/stream",
+      "homepage": "https://whateverwestcountry.com/",
+      "country": "GB",
+      "favicon": "https://whateverwestcountry.com/wp-content/uploads/2020/06/WHATEVER-WEST-GRN.png",
+      "codec": "MP3",
+      "geo": [
+        51.3272,
+        -2.958
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-academy-fm-folkestone",
+      "name": "Academy FM Folkestone",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.xrad.io:9480/;stream/1",
+      "homepage": "https://www.radiofolkestone.com/",
+      "country": "GB",
+      "favicon": "https://static.wixstatic.com/media/2a383b_fd22a81897514de18547bdf81eb202de~mv2.png/v1/fill/w_84,h_75,al_c,q_85,usm_0.66_1.00_0.01,enc_auto/Wordpress%20Transparent.png",
+      "bitrate": 48,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bhbn-radio",
+      "name": "BHBN Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://uksoutha.streaming.broadcast.radio/stream/9400/BHBN?1699801420380=",
+      "homepage": "https://www.bhbn.net/",
+      "country": "GB",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-brooklands-radio",
+      "name": "Brooklands Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream4.hippynet.co.uk/stream/brooklandsradio",
+      "homepage": "https://www.brooklandsradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "community radio",
+        "local news",
+        "local talk",
+        "pop music"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.3721,
+        -0.4602
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-caresound-radio",
+      "name": "CareSound Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.broadcast.radio/perth?1699803359553=",
+      "homepage": "https://caresound.radio/",
+      "country": "GB",
+      "favicon": "https://caresound.radio/wp-content/uploads/CSR-Full-Colour-Round-Gradient-150px.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-clubland-radio-uk",
+      "name": "Clubland Radio UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.radio.co/sf1cecf191/listen",
+      "homepage": "https://clublandradiouk.co.uk/",
+      "country": "GB",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/3/33563.v13.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-def-leppard",
+      "name": "Def Leppard",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.pcradio.ru/def_leppard-hi",
+      "homepage": "https://pcradio.ru/",
+      "country": "GB",
+      "tags": [
+        "discography"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-dnbradio-atmospheric",
+      "name": "DnBRadio Atmospheric",
+      "broadcaster": "independent",
+      "streamUrl": "https://azura.drmnbss.org/listen/plushrecs/radio.mp3",
+      "homepage": "https://dnbradio.com/?channel=plushrecs&autoplay=0",
+      "country": "GB",
+      "favicon": "https://www.google.com/s2/favicons?sz=256&domain_url=https%3A%2F%2Fdnbradio.com%2F%3Fchannel%3Dplushrecs%26autoplay%3D0",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-frisk-radio-uk",
+      "name": "Frisk Radio UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.friskradio.com:8443/stream11",
+      "homepage": "https://www.friskradio.com/",
+      "country": "GB",
+      "tags": [
+        "dance",
+        "deep house",
+        "pop"
+      ],
+      "favicon": "https://management.friskradio.com:7000/stations/logo?id=1",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-grampian-hospital-radio",
+      "name": "Grampian Hospital Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://uksoutha.streaming.broadcast.radio/ghr?1699804401378=",
+      "homepage": "https://www.grampianhospitalradio.org/",
+      "country": "GB",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-greatest-hits-radio-60s",
+      "name": "Greatest Hits Radio 60s",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-al.hellorayo.co.uk/ghr60s.aac?aw_0_1st.skey=1602676850&direct=true&rp_source=1",
+      "homepage": "https://www.hellorayo.co.uk/greatest-hits-60s",
+      "country": "GB",
+      "tags": [
+        "greatest hits"
+      ],
+      "favicon": "https://media.bauerradio.com/image/upload/c_crop,g_custom/v1725015216/brand_manager/stations/pqnbvpmvgj7jnsopgpix.svg",
+      "bitrate": 48,
+      "codec": "AAC+",
+      "geo": [
+        50.9613,
+        0.1162
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hwd-hospital-radio",
+      "name": "HWD Hospital Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming04.liveboxstream.uk/proxy/hwdhospi?mp=/stream",
+      "homepage": "https://www.hwdhospitalradio.com/",
+      "country": "GB",
+      "favicon": "https://www.hwdhospitalradio.com/images/logo.png",
+      "bitrate": 112,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-one-world-radio-daybreak-session",
+      "name": "One World Radio - Daybreak Session",
+      "broadcaster": "independent",
+      "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/OWR_DAYBREAK_ADP.aac",
+      "homepage": "https://www.tomorrowland.com/home/radio",
+      "country": "GB",
+      "favicon": "https://www.tomorrowland.com/home/apple-touch-icon.png",
+      "bitrate": 256,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-pure-radio",
+      "name": "Pure Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://kathy.torontocast.com:4825/stream",
+      "homepage": "https://listentopure.uk/",
+      "country": "GB",
+      "tags": [
+        "adult alternative",
+        "britpop",
+        "rock"
+      ],
+      "favicon": "https://listentopure.uk/wp-content/uploads/2023/02/cropped-cropped-pure-logo-23-150.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-rominimal-radio",
+      "name": "ROminimal Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://r4.rominimal.club/listen/rominimal.club/radio2.m4a",
+      "homepage": "https://rominimal.club/",
+      "country": "GB",
+      "tags": [
+        "deep minimal",
+        "electronic",
+        "microhouse",
+        "minimal techno",
+        "minimal techno mixes",
+        "rominimal"
+      ],
+      "favicon": "https://rominimal.club/images/logo.png",
+      "bitrate": 320,
+      "codec": "AAC",
+      "geo": [
+        51.5074,
+        -0.1278
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-soar-sound",
+      "name": "Soar Sound",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.maxxwave.co.uk/soarsound",
+      "homepage": "https://www.soarsound.uk/",
+      "country": "GB",
+      "favicon": "https://i0.wp.com/www.soarsound.uk/wp-content/uploads/2024/03/cropped-SoarLogoFinal-Favicon-e1710351771330.png?fit=150%2C146&ssl=1",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-white-cliffs-radio",
+      "name": "White Cliffs Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.whitecliffsradio.co.uk/",
+      "homepage": "https://www.whitecliffsradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://images.whitecliffsradio.co.uk/wcr_logo_new_r.webp",
+      "codec": "MP3",
+      "geo": [
+        51.1251,
+        1.3134
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-wrexham-premier-radio",
+      "name": "Wrexham Premier Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://uksoutha.streaming.broadcast.radio/premier?1709519917408=",
+      "homepage": "https://www.premier-radio.co.uk/",
+      "country": "GB",
+      "favicon": "https://www.premier-radio.co.uk/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bcfm-93-2",
+      "name": "BCfm 93.2",
+      "broadcaster": "independent",
+      "streamUrl": "https://bcfmradiomain.radioca.st/live.mp3",
+      "homepage": "https://www.bcfmradio.com/",
+      "country": "GB",
+      "tags": [
+        "bristol",
+        "rock"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.4445,
+        -2.5856
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-belfast-89",
+      "name": "Belfast 89",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.broadcast.radio/belfastfm",
+      "homepage": "https://www.belfast89.com/",
+      "country": "GB",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bouncy-vibes-radio",
+      "name": "Bouncy Vibes Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://bouncy-host.co.uk/radio/8000/radio.mp3",
+      "homepage": "https://bouncy-vibes.co.uk/",
+      "country": "GB",
+      "favicon": "https://bouncy-vibes.co.uk/images/favicon.ico",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-drama-radio",
+      "name": "Drama Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming06.liveboxstream.uk/proxy/roksta10/stream",
+      "homepage": "https://www2.rokitradio.com/",
+      "country": "GB",
+      "favicon": "https://www2.rokitradio.com/_next/image?url=%2Fimages%2Fchannels%2Fdrama.jpg&w=128&q=75",
+      "bitrate": 48,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-heart-west-midlands",
+      "name": "Heart West Midlands",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ice.musicradio.com/HeartWestMidsMP3",
+      "homepage": "https://www.heart.co.uk/westmids/",
+      "country": "GB",
+      "tags": [
+        "pop",
+        "rock"
+      ],
+      "favicon": "http://www.heart.co.uk/assets_v4r/heart/img/favicon-196x196.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-lazy-gold",
+      "name": "Lazy Gold",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-lazyradio.creativedork.com/",
+      "homepage": "https://www.lazygold.co.uk/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-memory-lane-radio",
+      "name": "Memory Lane Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://memorylaneradio.radioca.st/;",
+      "homepage": "https://memorylaneradio.co.uk/",
+      "country": "GB",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-pure-west-radio",
+      "name": "Pure West Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://uksoutha.streaming.broadcast.radio/stream/8580/purewest",
+      "homepage": "https://www.purewestradio.com/",
+      "country": "GB",
+      "tags": [
+        "local radio",
+        "pop",
+        "pop music",
+        "south wales"
+      ],
+      "favicon": "https://www.purewestradio.com/media/jjvja3hb/pure-west-radio-450x450.png",
+      "bitrate": 256,
+      "codec": "MP3",
+      "geo": [
+        51.8014,
+        -4.9721
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-red-rose-radio",
+      "name": "Red Rose Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.red-roseradio.co.uk:8008/stream?_=520468",
+      "homepage": "https://www.redroseradio.uk/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/1552/6680100859da1.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-sister-midnight-fm",
+      "name": "Sister Midnight FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radio.co/s35e4926a1/listen",
+      "homepage": "https://radio.sistermidnight.org/",
+      "country": "GB",
+      "tags": [
+        "music",
+        "non-commercial",
+        "variety"
+      ],
+      "favicon": "https://radio.sistermidnight.org/favicons/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-soul-connexion-radio",
+      "name": "Soul Connexion Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.soulconnexionradio.com/1045",
+      "homepage": "https://www.soulconnexionradio.com/",
+      "country": "GB",
+      "tags": [
+        "classic soul",
+        "disco",
+        "funk",
+        "jazz-funk",
+        "modern soul",
+        "nu disco"
+      ],
+      "favicon": "https://static.wixstatic.com/media/1cdeb2_d480bb8158f4469284f543e790063616%7Emv2.jpg/v1/fill/w_192%2Ch_192%2Clg_1%2Cusm_0.66_1.00_0.01/1cdeb2_d480bb8158f4469284f543e790063616%7Emv2.jpg",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-24-7-online-radio",
+      "name": "24/7 Online Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ec3.yesstreaming.net:3585/stream",
+      "homepage": "https://www.247onlineradio.com/24-7-online-radio/",
+      "country": "GB",
+      "tags": [
+        "chillout",
+        "easy listening",
+        "independent artists",
+        "lounge"
+      ],
+      "favicon": "https://usercontent.one/wp/www.247onlineradio.com/wp-content/uploads/2020/02/247-Online-Radio-Station-Logo.jpg",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-deal-radio",
+      "name": "Deal Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.radio.co/sa44aa697f/listen",
+      "homepage": "https://www.dealradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "eclectic"
+      ],
+      "favicon": "https://dev.dealradio.co.uk/wp-content/uploads/2020/06/Small-redblue.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-greatest-hits-radio-80s",
+      "name": "Greatest Hits Radio 80s",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-al.hellorayo.co.uk/ghr80s.aac?aw_0_1st.skey=1602676850&direct=true&rp_source=1",
+      "homepage": "https://www.hellorayo.co.uk/greatest-hits-radio-80s",
+      "country": "GB",
+      "tags": [
+        "80s",
+        "greatest hits"
+      ],
+      "favicon": "https://media.bauerradio.com/image/upload/c_crop,g_custom/v1741162714/brand_manager/stations/tmeuw7bt9gwnbkuxpjab.png",
+      "bitrate": 47,
+      "codec": "AAC+",
+      "geo": [
+        51.2725,
+        -0.173
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-margate-radio",
+      "name": "Margate Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://margate-radio.radiocult.fm/stream",
+      "homepage": "https://margateradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://images.squarespace-cdn.com/content/v1/55dccc18e4b080417ce5fafa/1585823097541-KVKK0PO2RTI5SZC6YLWF/MargateRadio_White_72dpi.png?format=1500w",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-midlands-radio",
+      "name": "Midlands Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-153.zeno.fm/2mn7tdzkug0uv",
+      "homepage": "https://www.radio-uk.co.uk/midlands-radio-80s",
+      "country": "GB",
+      "tags": [
+        "1980s",
+        "pop"
+      ],
+      "favicon": "https://static.mytuner.mobi/media/tvos_radios/CXYgFMyE7u.jpg",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-now-radio-80s",
+      "name": "NOW Radio 80s",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.zeno.fm/ihij6rdighvtv",
+      "homepage": "https://www.mynowradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "80's",
+        "80s"
+      ],
+      "favicon": "https://www.mynowradio.co.uk/wp-content/uploads/2023/12/NOW-Radio-90s-1-scaled.jpg",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-jupiter",
+      "name": "Radio Jupiter",
+      "broadcaster": "independent",
+      "streamUrl": "https://s10.myradiostream.com/:7946/listen.mp3?nocache=1686498616",
+      "homepage": "https://www.radiojupiter.studio/",
+      "country": "GB",
+      "tags": [
+        "adult contemporary",
+        "pop",
+        "rock"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.2748,
+        1.1623
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio2funky",
+      "name": "Radio2Funky",
+      "broadcaster": "independent",
+      "streamUrl": "https://s6.citrus3.com:8006/stream",
+      "homepage": "https://radio2funky.co.uk/",
+      "country": "GB",
+      "favicon": "https://radio2funky.co.uk/wp-content/uploads/2023/04/DAB-logo-new.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-rainbow-radio-wales",
+      "name": "Rainbow Radio Wales",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.zeno.fm/dtbgwan9sd0uv",
+      "homepage": "https://rainbowradio.uk/",
+      "country": "GB",
+      "favicon": "http://rainbowradio.uk/wp-content/uploads/2024/07/7h5TKbvAqe__1_-removebg-preview.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-southampton-hospital-radio",
+      "name": "Southampton Hospital Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s6.autopo.st/proxy/shrinternet?mp=/stream",
+      "homepage": "https://www.sohba.org/",
+      "country": "GB",
+      "favicon": "https://www.sohba.org/static/35df7ec86d.android-icon-192x192.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-yo1-radio",
+      "name": "Yo1 Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream1.themediasite.co.uk:8026/;?_=215164",
+      "homepage": "https://www.yo1radio.co.uk/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/706/6311ef9a56ac6.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-kisstory-r-b-the-hottest-r-b-tracks-from-kisstor",
+      "name": " KISSTORY R&B: The Hottest R&B tracks from KISSTORY",
+      "broadcaster": "independent",
+      "streamUrl": "https://live-bauerkiss.sharp-stream.com/kisstoryrb.aac?direct=true&aw_0_1st.playerid=BMUK_Airable&aw_0_1st.skey=6778249992",
+      "homepage": "https://www.hellorayo.co.uk/kisstory-rnb",
+      "country": "GB",
+      "tags": [
+        "anthems",
+        "bauer radio",
+        "black music",
+        "classics",
+        "england",
+        "europe"
+      ],
+      "favicon": "https://cdn-profiles.tunein.com/s333201/images/logod.png",
+      "bitrate": 127,
+      "codec": "AAC",
+      "geo": [
+        51.5095,
+        -0.1281
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-air-gay-radio",
+      "name": "Air Gay Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ecmanager.pro-fhi.net:2655/stream",
+      "homepage": "https://www.airgayradio.net/",
+      "country": "GB",
+      "favicon": "https://www.airgayradio.net/wp-content/uploads/2020/06/qr-code.png",
+      "bitrate": 64,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-amber-radio",
+      "name": "Amber Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream3.themediasite.co.uk:8240/listen.mp3?sid=3",
+      "homepage": "https://amber.radio/",
+      "country": "GB",
+      "favicon": "https://amber.radio/wp-content/uploads/2022/12/Amber-Radio-Logo-Assets_Original-Clear-Background.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-armagh-city-radio",
+      "name": "Armagh City Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://acrlive.radioca.st/stream?type=http&nocache=1702573713796",
+      "homepage": "https://www.armaghcityradio.com/",
+      "country": "GB",
+      "favicon": "https://static.wixstatic.com/media/3bc95e_9e8eb3dcdc8c4162b6516cc4f1a781c6~mv2.png/v1/fill/w_522,h_530,al_c,q_85,usm_0.66_1.00_0.01,enc_auto/A-only-PNG.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-aycliffe-radio",
+      "name": "Aycliffe Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://solid41.streamupsolutions.com/proxy/catidbxp?mp=/;type=mp3",
+      "homepage": "https://www.ayclifferadio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "local radio"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-countryline-radio",
+      "name": "CountryLine Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-chriscountry.sharp-stream.com/chriscountry.mp3",
+      "homepage": "https://www.countryline.radio/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-edge-1",
+      "name": "Edge 1",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.aiir.com/8dhvgxm1kbvuv",
+      "homepage": "https://edgeradio.co.uk/edge1",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/703/666adc84d05bb.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hifi-prime",
+      "name": "HiFi Prime",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.cloudrad.io/5913/8160",
+      "homepage": "https://hifiradio.net/",
+      "country": "GB",
+      "favicon": "http://hifiradio.net/wp-content/uploads/2023/09/prime-crop.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hospital-radio-chelmsford",
+      "name": "Hospital Radio Chelmsford",
+      "broadcaster": "independent",
+      "streamUrl": "https://solid55.streamupsolutions.com/proxy/mmbdfslu?mp=//stream",
+      "homepage": "https://www.hrc.org.uk/",
+      "country": "GB",
+      "favicon": "https://lirp.cdn-website.com/b164d775/dms3rep/multi/opt/IMG_0007-432w.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hospital-radio-plymouth",
+      "name": "Hospital Radio Plymouth",
+      "broadcaster": "independent",
+      "streamUrl": "https://hospitalradioplymouth.radioca.st/stream",
+      "homepage": "https://www.hospitalradioplymouth.org.uk/",
+      "country": "GB",
+      "favicon": "https://www.hospitalradioplymouth.org.uk/wp-content/uploads/2020/06/HRP-LogoNEWTRANS-100px-e1630450570740.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-juice-liverpool",
+      "name": "Juice Liverpool",
+      "broadcaster": "independent",
+      "streamUrl": "https://uksouth1.juiceboxradio.com/JuiceLiverpool",
+      "homepage": "https://juiceliverpool.co.uk/",
+      "country": "GB",
+      "favicon": "https://juiceliverpool.co.uk/assets/img/favicons/favicon-196x196.png",
+      "bitrate": 96,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-kaos-sound",
+      "name": "Kaos Sound",
+      "broadcaster": "independent",
+      "streamUrl": "https://s3.myradiostream.com:59506/stream",
+      "homepage": "https://kaos-sound.co.uk/mrsdocs/home.html",
+      "country": "GB",
+      "tags": [
+        "rock"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-lyca-gold-2",
+      "name": "Lyca Gold 2",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-lycaradio.sharp-stream.com/lyca_gold_2.mp3",
+      "homepage": "https://lycaradio.com/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-mdog-radio",
+      "name": "Mdog Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream2.hippynet.co.uk/stream/8212",
+      "homepage": "https://www.facebook.com/people/Mdog-Radio/100083286139973/",
+      "country": "GB",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        54.5682,
+        -5.9354
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-neon-radio",
+      "name": "Neon Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.flashbackcentral.co.uk/radio/8050/radio.mp3",
+      "homepage": "https://www.neonradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://images.leadconnectorhq.com/image/f_webp/q_80/r_480/u_https://assets.cdn.filesafe.space/dCZ3DwdyoW0OEpmHJlYP/media/66bb37b0e49a8129bd748aa2.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-northants-1",
+      "name": "Northants 1",
+      "broadcaster": "independent",
+      "streamUrl": "https://solid41.streamupsolutions.com/proxy/svdkgaiq/stream?icecast",
+      "homepage": "https://northants1.co.uk/",
+      "country": "GB",
+      "tags": [
+        "00's",
+        "10's",
+        "20's",
+        "chart",
+        "hit music",
+        "pop"
+      ],
+      "favicon": "https://northants1.co.uk/wp-content/uploads/2022/12/Northants-_1_-Symbol-Red.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        52.3946,
+        -0.7299
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-park-radio",
+      "name": "Park Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s32.myradiostream.com/18756/listen.mp3",
+      "homepage": "https://parkradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "community",
+        "diss",
+        "radio"
+      ],
+      "bitrate": 96,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-waters",
+      "name": "Radio Waters",
+      "broadcaster": "independent",
+      "streamUrl": "https://uk5.internet-radio.com/proxy/radiowaters/stream",
+      "homepage": "https://www.radiowaters.co.uk/",
+      "country": "GB",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-rhubarb-radio",
+      "name": "Rhubarb Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://securestreams2.autopo.st:1234/stream#.mp3?1702339792481",
+      "homepage": "https://www.rhubarbradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "local radio",
+        "music",
+        "pop music"
+      ],
+      "bitrate": 160,
+      "codec": "MP3",
+      "geo": [
+        53.6879,
+        -1.5768
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-university-radio-falmer",
+      "name": "University Radio Falmer",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-urfonline.sharp-stream.com/urfonline.mp3?nocache=0.1868666957825399",
+      "homepage": "https://www.urfonline.com/",
+      "country": "GB",
+      "tags": [
+        "music",
+        "talk",
+        "university",
+        "university radio"
+      ],
+      "favicon": "https://www.urfonline.com/favicon-256x256.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.8644,
+        -0.0885
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-zero-radio",
+      "name": "Zero Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://uk7.internet-radio.com/proxy/0radio?mp=%2Flive&1731415265701",
+      "homepage": "https://www.zeroradio.co.uk/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bailrigg-fm",
+      "name": "Bailrigg FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.bailriggfm.co.uk/listen/bfm/128.mp3",
+      "homepage": "https://bailriggfm.co.uk/",
+      "country": "GB",
+      "favicon": "https://bailriggfm.co.uk/wp-content/uploads/2020/06/cropped-Bailrigg-Mini-Logo-red-background-192x192.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-derby-sound",
+      "name": "Derby Sound",
+      "broadcaster": "independent",
+      "streamUrl": "https://uk7.internet-radio.com/proxy/in2derbyradio?mp=%2Fstream%3B",
+      "homepage": "https://www.derbysound.org.uk/",
+      "country": "GB",
+      "favicon": "https://www.derbysound.org.uk/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-frisk-radio",
+      "name": "FRISK Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.friskradio.com:8443/stream1",
+      "homepage": "https://www.friskradio.com/#station-select-panel",
+      "country": "GB",
+      "favicon": "https://www.friskradio.com/application/assets/images/favicon/64.png",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hearme-00s-rock",
+      "name": "HearMe - 00s rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.hearme.fm:8130/stream",
+      "homepage": "https://hearme.fm/",
+      "country": "GB",
+      "tags": [
+        "00s rock",
+        "00’s rock"
+      ],
+      "favicon": "https://hearme.fm/favicon.ico",
+      "codec": "MP3",
+      "geo": [
+        54.5721,
+        -2.8125
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hearme-80s-rock",
+      "name": "Hearme - 80s rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.hearme.fm:8310/stream",
+      "homepage": "https://hearme.fm/",
+      "country": "GB",
+      "tags": [
+        "80d rock",
+        "80’s rock"
+      ],
+      "codec": "MP3",
+      "geo": [
+        52.6964,
+        -2.4609
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hospital-radio-glamorgan",
+      "name": "Hospital Radio Glamorgan",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.broadcastradio.com:8002/glamorg?1725024804656=",
+      "homepage": "https://www.radioglamorgan.com/",
+      "country": "GB",
+      "favicon": "https://api.broadcast.radio/api/image/d57d29e6-9c41-4875-8cc9-952e32e08310.png?g=center",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-leeds-student-radio",
+      "name": "Leeds Student Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.radio.co/seb5cdba5b/listen",
+      "homepage": "https://www.thisislsr.com/",
+      "country": "GB",
+      "favicon": "https://static.wixstatic.com/media/316c00_def14e5b8c604227b2fa666a3a15fa2d~mv2.png/v1/fill/w_105,h_107,al_c,q_85,usm_0.66_1.00_0.01,enc_auto/LSR%20Logo.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-alty",
+      "name": "Radio Alty",
+      "broadcaster": "independent",
+      "streamUrl": "https://streams.radio.co/s4d51ef3bf/listen",
+      "homepage": "https://www.radioalty.co.uk/",
+      "country": "GB",
+      "favicon": "https://www.radioalty.co.uk/uploads/1/3/1/5/131514373/published/radio-alty-rgb-master-logo-transparent-bkground.png?1702248957",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        53.384,
+        -2.3545
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-cherwell",
+      "name": "Radio Cherwell",
+      "broadcaster": "independent",
+      "streamUrl": "https://uk6.internet-radio.com/proxy/cherwell?mp=/stream",
+      "homepage": "https://radiocherwell.com/",
+      "country": "GB",
+      "favicon": "https://radiocherwell.com/wp-content/uploads/2019/05/RC_LOGO_RGB-150x115.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-redhill-mp3",
+      "name": "Radio Redhill mp3",
+      "broadcaster": "independent",
+      "streamUrl": "https://radioredhill.uk/stream/live.mp3",
+      "homepage": "https://radioredhill.uk/",
+      "country": "GB",
+      "favicon": "https://radioredhill.uk/favicon.png",
+      "bitrate": 160,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-rare-groove-radio",
+      "name": "Rare Groove Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://a9.asurahosting.com:7950/radio.mp3",
+      "homepage": "https://raregrooveradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://assets.zyrosite.com/cdn-cgi/image/format=auto,w=268,fit=crop,q=95/Yyv7QeD1ZgiXyg7m/rgr-logo-YNqrVzg7QMF85M1n.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-satsang-radio",
+      "name": "Satsang Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.maxxwave.co.uk/satsang",
+      "homepage": "https://satsangradio.com/",
+      "country": "GB",
+      "favicon": "https://images.squarespace-cdn.com/content/v1/6801621b014aea65690810ca/e422d15b-d3ab-43d3-97d7-8695fe43a7df/Screenshot+2025-07-30+at+22.34.52.png?format=1500w",
+      "bitrate": 80,
+      "codec": "AAC",
+      "geo": [
+        52.645,
+        -1.1219
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-stirling-community-radio",
+      "name": "Stirling Community Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.broadcastradio.com:11855/castlesound?8852",
+      "homepage": "https://stirlingcommunity.radio/",
+      "country": "GB",
+      "favicon": "https://stirlingcommunity.radio/images/radio/player/logo-1715587272.webp",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-the-big-top-40-show-sundays-4-7pm",
+      "name": "The Big Top 40 Show (SUNDAYS 4 - 7PM)",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.thisisdax.com/BigTop40",
+      "homepage": "https://www.bigtop40.com/",
+      "country": "GB",
+      "tags": [
+        "music",
+        "pop"
+      ],
+      "favicon": "https://www.bigtop40.com/assets_v4r/bigtop40/img/logos/large.png",
+      "bitrate": 48,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-time-2-chill-radio",
+      "name": "Time 2 Chill Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ec6.yesstreaming.net:3615/stream",
+      "homepage": "https://www.time2chill.co.uk/radio",
+      "country": "GB",
+      "tags": [
+        "chillout",
+        "downtempo",
+        "lounge",
+        "new age"
+      ],
+      "favicon": "https://static.wixstatic.com/media/55ed4f_f43016b1c5784b71b344cd4504914340~mv2.png/v1/crop/x_0,y_342,w_1920,h_1376/fill/w_548,h_396,al_c,q_85,usm_0.66_1.00_0.01,enc_avif,quality_auto/hammock-icon_edited.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        53.3111,
+        0.2864
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-trust-am-hospital-radio",
+      "name": "Trust AM Hospital Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.galaxywebsolutions.com:9034/stream",
+      "homepage": "https://trustam.com/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-wave-community-radio",
+      "name": "Wave Community Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming06.liveboxstream.uk/proxy/piraten1?mp=/stream",
+      "homepage": "https://wavewsm.co.uk/",
+      "country": "GB",
+      "favicon": "https://wavewsm.co.uk/wp-content/uploads/2023/06/cropped-wavelogo-1.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-95-6-b-radio",
+      "name": "95.6 B Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.aiir.com/t4k624qg11kuv?_=802765",
+      "homepage": "https://www.bradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/347/62b4dc758ba9d.jpg",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bedrock-radio",
+      "name": "Bedrock Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s40.myradiostream.com:16652/bedrockradio",
+      "homepage": "https://www.bedrockradio.org.uk/",
+      "country": "GB",
+      "favicon": "https://i0.wp.com/www.bedrockradio.org.uk/wp-content/uploads/2019/06/alternate-logo-white.png?resize=300%2C135&ssl=1",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-blastfm-indie-radio-station",
+      "name": "BlastFM Indie Radio Station",
+      "broadcaster": "independent",
+      "streamUrl": "https://blast-indie-radio.com:8000/live",
+      "homepage": "https://blastfmsocial.media/BlastIndie",
+      "country": "GB",
+      "favicon": "https://blastfmsocial.media/upload/photos/2019/08/e1Yzi7QNBg2Lw32vvghN_30_e2c846377ca16726ad65724674b98d3e_avatar.jpg?cache=0",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-care-radio",
+      "name": "Care Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-careradio.sharp-stream.com/120_care_radio_128_mp3",
+      "homepage": "https://www.careradio.org/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/590/620694edbfb9e.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-central-radio-north-west",
+      "name": "Central Radio North West",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.central.radio/listen/web/high",
+      "homepage": "https://www.central.radio/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/778/673b04861e76c.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        53.7354,
+        -2.6807
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-delite-radio",
+      "name": "Delite Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.deliteonline.com/live320",
+      "homepage": "http://www.deliteradio.com/",
+      "country": "GB",
+      "favicon": "http://www.deliteradio.com/upload/players/62fb755a427c40.95586069.jpg",
+      "bitrate": 512,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-gems-top-40",
+      "name": "GEMS  TOP 40",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.gemsradio.net:8000/;",
+      "homepage": "https://www.gemsradio.net/",
+      "country": "GB",
+      "favicon": "https://www.gemsradio.net/wp-content/uploads/2021/10/cropped-Gems-Radio-icon-180x180.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-glitterbeam-italia",
+      "name": "GlitterBeam Italia",
+      "broadcaster": "independent",
+      "streamUrl": "https://quincy.torontocast.com:1740/stream",
+      "homepage": "https://www.glitterbeam.net/",
+      "country": "GB",
+      "tags": [
+        "lgbt",
+        "lgbtqia+",
+        "pop"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-glitterbeam-radio",
+      "name": "GlitterBeam Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ukwesta.streaming.broadcast.radio:17810/glitterbeam",
+      "homepage": "https://www.glitterbeam.co.uk/",
+      "country": "GB",
+      "favicon": "https://usercontent.one/wp/www.glitterbeam.co.uk/wp-content/uploads/2023/09/GBRECSMALL4.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-global-pride",
+      "name": "Global Pride",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-sov.musicradio.com/Global-M-Pride",
+      "homepage": "https://global.com/global-player",
+      "country": "GB",
+      "tags": [
+        "global",
+        "heart",
+        "media-sov",
+        "pride",
+        "uk"
+      ],
+      "favicon": "https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse2.mm.bing.net%2Fth%3Fid%3DOIP.cmoF-nf5byb4GKWOVoVefAAAAA%26pid%3DApi&f=1&ipt=fb8665bb588c291de9ed9bd2765e62613792e1203899f9a45f639d973e894cf7&ipo=images",
+      "bitrate": 48,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-great-driffield-radio",
+      "name": "Great Driffield Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream1.superstreaming.co.uk/proxy/greatdriffield/stream?rp_source=1&=&&___cb=720015281299521",
+      "homepage": "https://greatdriffieldradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://greatdriffieldradio.co.uk/wp-content/uploads/2023/12/gdr-150x150.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-greatest-hits-radio-70s",
+      "name": "Greatest Hits Radio 70s",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-al.hellorayo.co.uk/ghr70s.aac?aw_0_1st.skey=1602676850&direct=true&rp_source=1",
+      "homepage": "https://www.hellorayo.co.uk/greatest-hits-radio-70s",
+      "country": "GB",
+      "tags": [
+        "70s"
+      ],
+      "favicon": "https://media.bauerradio.com/image/upload/c_crop,g_custom/v1742817230/brand_manager/stations/vpgvlb3s5roqkyo6cxvf.svg",
+      "bitrate": 47,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-mad-wasp-radio",
+      "name": "Mad Wasp Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.radio.co/s8a8d7b49a/listen",
+      "homepage": "https://madwaspradio.com/",
+      "country": "GB",
+      "tags": [
+        "alternative",
+        "eclectic",
+        "freeform"
+      ],
+      "favicon": "https://pbs.twimg.com/profile_images/1684130478981279744/QqiJhxb9_400x400.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.4609,
+        -0.126
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-mixx-radio-preston",
+      "name": "mixx radio preston",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-hitsradio.creativedork.com/",
+      "homepage": "https://hitsradio.radioplayer.airsuite.studio/",
+      "country": "GB",
+      "favicon": "https://www.liveradio.uk/files/images/482949/resized/180x172c/mixx_radio_preston.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-only-old-skool-radio",
+      "name": "Only Old Skool Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://listentomystream.com:8036/;?type=http&nocache=107036",
+      "homepage": "https://onlyoldskoolradio.com/",
+      "country": "GB",
+      "favicon": "https://onlyoldskoolradio.com/wp-content/uploads/2020/06/cropped-icon1-32x32.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-newquay",
+      "name": "Radio Newquay",
+      "broadcaster": "independent",
+      "streamUrl": "https://s46.myradiostream.com/8816/listen.mp3",
+      "homepage": "https://www.radionewquay.com/",
+      "country": "GB",
+      "favicon": "https://mm.aiircdn.com/479/5b9a5e36391cd.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-ninesprings",
+      "name": "Radio Ninesprings",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radioninesprings.com/ninesprings-high?_=293441",
+      "homepage": "https://www.radioninesprings.com/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/494/603669b913ade.png",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-radio",
+      "name": "Radio Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://c16.radioboss.fm:18014/stream",
+      "homepage": "https://radioradio.fm/",
+      "country": "GB",
+      "tags": [
+        "pop",
+        "rock"
+      ],
+      "favicon": "https://radioradio.fm/grafika/logo1a.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-rudy",
+      "name": "Radio Rudy",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-55.zeno.fm/21y1sqfvkm0uv",
+      "homepage": "https://zeno.fm/radio/radio-rudy/",
+      "country": "GB",
+      "favicon": "https://zeno.fm/favicon.ico",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radiosega-he-aac-v2",
+      "name": "RadioSEGA (HE-AAC v2)",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.radiosega.net/live",
+      "homepage": "https://www.radiosega.net/",
+      "country": "GB",
+      "tags": [
+        "video game music"
+      ],
+      "favicon": "https://www.radiosega.net/_images/template/siteHeader-newlogo_hover.png",
+      "bitrate": 256,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-retro-soul-radio",
+      "name": "Retro Soul Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.galaxywebsolutions.com/stream/retrosoul",
+      "homepage": "https://www.retrosoulradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "disco",
+        "funk",
+        "jazz",
+        "soul"
+      ],
+      "favicon": "https://static-media.streema.com/media/cache/cf/d9/cfd9303c27dd71c35a2370766d4d1309.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-salisbury-radio",
+      "name": "Salisbury Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://securestreams6.autopo.st:2139/stream.mp3",
+      "homepage": "https://salisburyradio.co.uk/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-vixen-101",
+      "name": "Vixen 101",
+      "broadcaster": "independent",
+      "streamUrl": "https://s33.myradiostream.com:15184/;?type=http",
+      "homepage": "https://www.vixen101.co.uk/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-weekend-offender-radio",
+      "name": "Weekend Offender Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://uk2.internet-radio.com/proxy/weekendoffender?mp=/stream;",
+      "homepage": "https://weekendoffender.com/",
+      "country": "GB",
+      "favicon": "https://weekendoffender.com/cdn/shop/files/android-chrome-512x512.png?crop=center&height=32&v=1699368215&width=32",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-west-kent-radio",
+      "name": "West Kent Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ukwesta.streaming.broadcast.radio/wkcr",
+      "homepage": "https://www.westkentradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://www.westkentradio.co.uk/favicon.png",
+      "bitrate": 170,
+      "codec": "MP3",
+      "geo": [
+        51.1381,
+        0.2656
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-xenfm",
+      "name": "XenFM",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.xenfm.com/listen/xenfm/radio.mp3",
+      "homepage": "https://xenfm.com/",
+      "country": "GB",
+      "tags": [
+        "dnb",
+        "drum & bass",
+        "dubstep",
+        "edm",
+        "liquid",
+        "melodic"
+      ],
+      "favicon": "https://xenfm.com/wp-content/uploads/2020/05/cropped-PythiaArsenicEye.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.832,
+        -0.1428
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-alfred",
+      "name": "Alfred",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream2.hippynet.co.uk:8204/stream",
+      "homepage": "https://thisisalfred.com/",
+      "country": "GB",
+      "tags": [
+        "community news"
+      ],
+      "bitrate": 160,
+      "codec": "MP3",
+      "geo": [
+        51.0079,
+        -2.1927
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-arena-radio",
+      "name": "Arena Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream3.themediasite.co.uk:8318/stream",
+      "homepage": "http://arenaradio.live/",
+      "country": "GB",
+      "favicon": "https://public-rf-upload.minhawebradio.net/250716/logo/d7351a69a8b11013d475908bf2f562ba.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bfbs-aldershot",
+      "name": "BFBS Aldershot",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-ssvcbfbs.sharp-stream.com/ssvcbfbs13.aac",
+      "homepage": "https://radio.bfbs.com/stations/bfbs-aldershot",
+      "country": "GB",
+      "favicon": "https://radio.bfbs.com/icons/icon-512x512.png?v=0afec91a27aaa6d57f2b000c6fbe8cac",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-black-country-radio",
+      "name": "Black Country Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-blackcountryradio.sharp-stream.com/blackcountryradio.mp3",
+      "homepage": "https://www.blackcountryradio.co.uk/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-brap-fm",
+      "name": "Brap.FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.brap.fm:8000/radio.mp3",
+      "homepage": "https://www.brap.fm/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-crop-radio",
+      "name": "CROP Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s3.radio.co/sb713b671e/listen",
+      "homepage": "https://www.cropradio.live/",
+      "country": "GB",
+      "tags": [
+        "community radio",
+        "music",
+        "underground",
+        "variety"
+      ],
+      "favicon": "https://www.cropradio.live/images/favicons/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-cutters-choice",
+      "name": "Cutters Choice",
+      "broadcaster": "independent",
+      "streamUrl": "https://cutters-choice-radio.radiocult.fm/stream",
+      "homepage": "https://www.cutterschoiceradio.com/",
+      "country": "GB",
+      "tags": [
+        "dance",
+        "electronic",
+        "indie",
+        "ska"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-dundee-radio-club",
+      "name": "Dundee Radio Club",
+      "broadcaster": "independent",
+      "streamUrl": "https://dundee-radio-club.radiocult.fm/stream",
+      "homepage": "https://dundeeradio.club/",
+      "country": "GB",
+      "tags": [
+        "community radio",
+        "field recordings",
+        "music",
+        "podcasts",
+        "soundscape"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        56.4615,
+        -2.9701
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-flex-fm-101-4",
+      "name": "Flex FM 101.4",
+      "broadcaster": "independent",
+      "streamUrl": "https://a2.asurahosting.com:7400/radio.mp3",
+      "homepage": "https://flexfm.co.uk/",
+      "country": "GB",
+      "tags": [
+        "dance",
+        "drum and bass",
+        "edm",
+        "garage",
+        "uk"
+      ],
+      "favicon": "https://upload.wikimedia.org/wikipedia/en/4/40/Flex_FM_London_logo.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-fresh-soundz-radio",
+      "name": "Fresh Soundz Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://solid48.streamupsolutions.com/proxy/neivwtxt/stream/",
+      "homepage": "https://www.freshsoundzradio.com/",
+      "country": "GB",
+      "tags": [
+        "dj",
+        "house"
+      ],
+      "favicon": "https://static.mytuner.mobi/media/tvos_radios/626/soundz-radio-uk.426d8b6f.jpg",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-frisky-radio-chill",
+      "name": "Frisky Radio Chill",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.chill.friskyradio.com/",
+      "homepage": "http://friskyradio.com/",
+      "country": "GB",
+      "bitrate": 96,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-frisky-radio-deep",
+      "name": "Frisky Radio Deep",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.deep.friskyradio.com/",
+      "homepage": "http://friskyradio.com/",
+      "country": "GB",
+      "bitrate": 96,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-genx-radio",
+      "name": "GenX Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.radio.co/sf25229e16/low",
+      "homepage": "https://genxradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://genxradio.co.uk/wp-content/uploads/2021/11/GenXAsset-3.png",
+      "bitrate": 64,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-gold-dust-radio",
+      "name": "Gold Dust Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://gold-dust-radio.radiocult.fm/stream",
+      "homepage": "https://www.golddusthub.com/",
+      "country": "GB",
+      "favicon": "https://images.squarespace-cdn.com/content/v1/5c80edb83560c31af710d6cc/1610290067018-YNK9FQE7ZGF56JE26AK6/gd-landscape-rgb-2.png?format=1500w",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-gwh",
+      "name": "GWH",
+      "broadcaster": "independent",
+      "streamUrl": "https://carina.streamerr.co/stream/swindonhr",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hbsa-hospital-radio",
+      "name": "HBSA Hospital Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://solid24.streamupsolutions.com/proxy/zzjcamth?mp=/stream",
+      "homepage": "https://hbsaradio.com/#",
+      "country": "GB",
+      "favicon": "https://hbsaradio.com/wp-content/themes/topofthehour/images/logo.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-heaven-and-heaven-radio",
+      "name": "Heaven and Heaven radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://eu10.fastcast4u.com:1500/",
+      "homepage": "https://www.heavenandheavenradio.org/",
+      "country": "GB",
+      "favicon": "https://www.heavenandheavenradio.org/apple-touch-icon.png?v=1721674313144",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hospital-radio-colchester",
+      "name": "Hospital Radio Colchester",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.broadcastradio.com:10905/hrcolchester",
+      "homepage": "https://www.hrcolchester.co.uk/",
+      "country": "GB",
+      "favicon": "https://static.wixstatic.com/media/2aa317_7b0e1ad2c28944858946b7a57ede4ab1.png/v1/fill/w_172,h_153,al_c,lg_1,q_85,enc_auto/2aa317_7b0e1ad2c28944858946b7a57ede4ab1.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-incapable-staircase",
+      "name": "Incapable Staircase",
+      "broadcaster": "independent",
+      "streamUrl": "https://streams.radio.co/s436782ce6/listen",
+      "homepage": "https://www.incapablestaircase.com/",
+      "country": "GB",
+      "tags": [
+        "ambient",
+        "disco",
+        "djs",
+        "funk",
+        "indie"
+      ],
+      "favicon": "https://incapablestaircase.com/wp-content/uploads/2024/08/favicon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-kizzfm-uk-90-9",
+      "name": "KizzFM UK 90.9",
+      "broadcaster": "independent",
+      "streamUrl": "https://azura.kizzfmuk90-9.com/listen/kizzfmuk/radio.mp3?1689855016244",
+      "homepage": "https://www.kizzfmuk90-9.com/",
+      "country": "GB",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-lofi-hiphop-chillsky",
+      "name": "Lofi hiphop - chillsky",
+      "broadcaster": "independent",
+      "streamUrl": "https://chill.radioca.st/stream",
+      "homepage": "https://chillsky.com/",
+      "country": "GB",
+      "tags": [
+        "beats",
+        "chillout",
+        "lofi hip hop"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.5136,
+        -0.1237
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-london-romanian-radio",
+      "name": "London Romanian Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://play.lrradio.uk/",
+      "homepage": "https://lrradio.uk/",
+      "country": "GB",
+      "tags": [
+        "hot ac",
+        "pop",
+        "top 40"
+      ],
+      "favicon": "https://lrradio.uk/img/logo.png",
+      "bitrate": 64,
+      "codec": "AAC",
+      "geo": [
+        51.5708,
+        -0.2455
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-loose-fm",
+      "name": "Loose FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://loosefm.radiocult.fm/stream",
+      "homepage": "https://www.loose.fm/",
+      "country": "GB",
+      "tags": [
+        "eclectic",
+        "electronic",
+        "experimental"
+      ],
+      "favicon": "https://www.google.com/s2/favicons?sz=256&domain_url=https%3A%2F%2Fwww.loose.fm%2F",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        51.4995,
+        0.0062
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-mystery-radio",
+      "name": "Mystery Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming06.liveboxstream.uk/proxy/rokstar9/stream",
+      "homepage": "https://www2.rokitradio.com/",
+      "country": "GB",
+      "favicon": "https://www2.rokitradio.com/_next/image?url=%2Fimages%2Fchannels%2Fmystery.jpg&w=128&q=75",
+      "bitrate": 48,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-p4ppp-radio",
+      "name": "P4PPP Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.zeno.fm/hgc7mcknqpuuv",
+      "homepage": "https://zeno.fm/radio/p4ppp-radio/",
+      "country": "GB",
+      "tags": [
+        "digital health",
+        "health",
+        "peace",
+        "people",
+        "planet"
+      ],
+      "favicon": "https://zeno.fm/_next/image/?url=https%3A%2F%2Fimages.zeno.fm%2F27b-9YErzi8ANXvNMuOlFjdfMRu1P7AJXYaBWpmPZN0%2Frs%3Afit%3A240%3A240%2Fg%3Ace%3A0%3A0%2FaHR0cHM6Ly9zdHJlYW0tdG9vbHMuemVub21lZGlhLmNvbS9jb250ZW50L3N0YXRpb25zLzYzZGMzZmRmLTQwYTgtNDFkMS04MzZiLWYyMzgwODdhMTAyMC9pbWFnZS8_dXBkYXRlZD0xNzE3MDYyMzY1MDAw.webp&w=1920&q=100",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-cardiff",
+      "name": "Radio Cardiff ",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiocardiff.radioca.st/stream",
+      "homepage": "https://radiocardiff.org/",
+      "country": "GB",
+      "favicon": "https://firebasestorage.googleapis.com/v0/b/radiogalaxy-580f4.appspot.com/o/images%2FIMG_20240909_115752423.jpg?alt=media&token=b344b077-73bc-46dd-9b59-eb196ff15d0f",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-grapevine",
+      "name": "Radio Grapevine",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming06.liveboxstream.uk/proxy/radiogra?mp=/stream",
+      "homepage": "https://www.radiograpevine.com/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-seerah",
+      "name": "Radio Seerah",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.maxxwave.co.uk/radioseerah",
+      "homepage": "https://www.radioseerah.com/",
+      "country": "GB",
+      "favicon": "https://cloud-1de12d.becdn.net/media/iW=274&iH=274&oX=0&oY=0&cW=274&cH=274/0c0eff783969b0e0df546d2b6ec9ca8a/MainLOGO.jpg",
+      "bitrate": 80,
+      "codec": "AAC",
+      "geo": [
+        52.6341,
+        -1.1133
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-utsav",
+      "name": "Radio UTSAV",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.maxxwave.co.uk/utsav",
+      "homepage": "https://radioutsav.com/",
+      "country": "GB",
+      "favicon": "https://radioutsav.com/wp-content/uploads/2024/09/PHOTO-2024-09-01-11-54-35.jpg",
+      "bitrate": 80,
+      "codec": "AAC",
+      "geo": [
+        52.6562,
+        -1.1181
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radionev-24x7-hit-music-lounge",
+      "name": "RadioNev (24x7 hit music lounge)",
+      "broadcaster": "independent",
+      "streamUrl": "https://a7.asurahosting.com/listen/radionev/radio.mp3",
+      "homepage": "https://www.radionev.com/",
+      "country": "GB",
+      "favicon": "https://www.radionev.com/sitepad-data/uploads/2024/11/512.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-roch-valley-radio",
+      "name": "Roch Valley Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://rochvalley.radioca.st/stream?_=723854",
+      "homepage": "https://www.rochvalleyradio.com/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/572/615a03a7cb961.jpg",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-rotherham-radio",
+      "name": "Rotherham Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream3.themediasite.co.uk:8004/stream",
+      "homepage": "https://www.rotherhamradio.com/",
+      "country": "GB",
+      "favicon": "https://play-lh.googleusercontent.com/RcFfsJQvuWz-6ZhsTb7jOjwA6dSS0uy8h926Tgxnn4qDez7qEnBINiU9kqyc_qSvA4Q=w240-h480-rw",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        53.3795,
+        -1.5138
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-stoke-mandeville-hospital-radio",
+      "name": "Stoke Mandeville Hospital Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ukwesta.streaming.broadcast.radio/stoke?1692976686054=",
+      "homepage": "https://www.smhr.co.uk/",
+      "country": "GB",
+      "tags": [
+        "hospital radio"
+      ],
+      "favicon": "https://www.smhr.co.uk/favicon.ico",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-the-richie-allen-show",
+      "name": "The Richie Allen Show",
+      "broadcaster": "independent",
+      "streamUrl": "https://ukwesta.streaming.broadcast.radio/therichieallenshow",
+      "homepage": "https://richieallen.co.uk/",
+      "country": "GB",
+      "codec": "MP3",
+      "geo": [
+        53.5078,
+        -2.3043
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-vintage-radio-wirral",
+      "name": "Vintage Radio Wirral",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming04.liveboxstream.uk/proxy/vintager?mp=/stream",
+      "homepage": "https://www.vintageradio.org.uk/",
+      "country": "GB",
+      "favicon": "https://www.vintageradio.org.uk/sitepad-data/uploads/2024/11/WhatsApp-Image-2024-10-09-at-16.44.13_8902e262.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-beat-geeks-radio",
+      "name": "Beat Geeks Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://broadcast.shoutstream.co.uk:8050/stream",
+      "homepage": "https://beatgeeksradio.com/#5f139bdd-e5cd-420c-a57c-c7075e626746",
+      "country": "GB",
+      "favicon": "https://img1.wsimg.com/isteam/ip/bae4931a-2ea8-4815-9a46-4271f6de2b79/logo%20large.png/:/rs=w:400,h:400,cg:true,m/cr=w:400,h:400/qt=q:95",
+      "bitrate": 128,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-beat-route-radio",
+      "name": "Beat Route Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://beatrouteradio.radioca.st/autodj",
+      "homepage": "https://beatrouteradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://firebasestorage.googleapis.com/v0/b/radiogalaxy-580f4.appspot.com/o/images%2FIMG_20240909_160637684.jpg?alt=media&token=e0d32581-2089-4058-9d80-01279c52b1cc",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-blue-in-green-radio",
+      "name": "Blue-in-Green:RADIO",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radio.co/s9e1625f13/listen",
+      "homepage": "http://www.blueingreenradio.com/?m=1",
+      "country": "GB",
+      "favicon": "http://4.bp.blogspot.com/-aeCJDMfXnVM/WKWDZV4LOuI/AAAAAAAABxI/QPsmN8EWUBgPXVlN3hE9Q2EyypmA9WWfQCK4B/s400/BinGRadio%2BBW.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-capital-xtra-reloaded",
+      "name": "Capital Xtra Reloaded",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ice.musicradio.com/CapitalXTRAReloadedMP3",
+      "homepage": "https://www.capitalxtra.com/reloaded/",
+      "country": "GB",
+      "tags": [
+        "non-stop old skool & anthems"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.5102,
+        -0.1286
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-charlie-mason-radio",
+      "name": "Charlie Mason Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s9.reliastream.com/proxy/charlie1/stream",
+      "homepage": "https://charliemasonradio.com/",
+      "country": "GB",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-colin-mogagabe",
+      "name": "Colin Mogagabe",
+      "broadcaster": "independent",
+      "streamUrl": "https://music-station.live/listen/crw_radio/radio.mp3",
+      "homepage": "https://music-station.live/public/crw_radio",
+      "country": "GB",
+      "favicon": "https://www.music-station.live/static/uploads/crw_radio/album_art.1721666882.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.3814,
+        0.5224
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-conquest-hospital-radio",
+      "name": "Conquest Hospital Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://chrconquest.radioca.st/radio.mp3",
+      "homepage": "https://conquesthospitalradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://conquesthospitalradio.co.uk/wp-content/uploads/2021/07/950291C2-2ECB-460D-A667-30F09D405480.jpeg",
+      "bitrate": 160,
+      "codec": "MP3",
+      "geo": [
+        50.8549,
+        0.5811
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-crmk",
+      "name": "CRMK",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radio.co/sdfcc41b7a/listen",
+      "homepage": "https://www.crmk.co.uk/",
+      "country": "GB",
+      "tags": [
+        "pop"
+      ],
+      "favicon": "https://static.wixstatic.com/media/2f38db_822606c0d74d443cbca64a25e47899b5~mv2.png/v1/fill/w_109,h_109,al_c,q_85,usm_0.66_1.00_0.01,enc_auto/Untitled.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        52.0809,
+        -0.7229
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-deephouse-fm",
+      "name": "deephouse.fm",
+      "broadcaster": "independent",
+      "streamUrl": "https://altair.streamerr.co:8124/stream",
+      "homepage": "https://deephouse.fm/",
+      "country": "GB",
+      "tags": [
+        "deep house",
+        "house"
+      ],
+      "favicon": "https://deephouse.fm/wp-content/uploads/2025/12/Deep-House-FM-Logo.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-doncaster-radio",
+      "name": "Doncaster Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream1.themediasite.co.uk:8008/stream",
+      "homepage": "https://www.doncasterradio.com/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/493/64b694df58f95.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-drystone-radio",
+      "name": "Drystone Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://uksoutha.streaming.broadcast.radio/drystoneradio?1724596500437=",
+      "homepage": "https://www.drystoneradio.com/",
+      "country": "GB",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-eden-fm-107-5",
+      "name": "Eden Fm 107.5",
+      "broadcaster": "independent",
+      "streamUrl": "https://eu4.fastcast4u.com/proxy/edenfmlt?mp=/1",
+      "homepage": "http://www.edenfm.co.uk/",
+      "country": "GB",
+      "favicon": "https://fastcast4u.com/player/edenfmlt/_user/logo/e/edenfmlt/ch0.jpg",
+      "bitrate": 128,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-fishnet-radio",
+      "name": "Fishnet Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radio.co/s74e130a62/listen",
+      "homepage": "https://www.fishnetradio.com/",
+      "country": "GB",
+      "tags": [
+        "alternative",
+        "soul"
+      ],
+      "favicon": "https://static.mytuner.mobi/media/tvos_radios/151/fishnet-radio.6ea1e90b.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-fix-radio",
+      "name": "Fix Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://n06a-eu.rcs.revma.com/gnys6kxst8tvv",
+      "homepage": "https://www.fixradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/203/623068c8b2091.png",
+      "codec": "AAC",
+      "geo": [
+        51.4862,
+        -0.1188
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-fosse-107",
+      "name": "Fosse 107",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.maxxwave.co.uk/fossehinckleyhq",
+      "homepage": "https://www.fosse107.co.uk/",
+      "country": "GB",
+      "tags": [
+        "80s",
+        "90s",
+        "local news",
+        "news",
+        "rock"
+      ],
+      "favicon": "https://mm.aiircdn.com/375/59372c77cd002.png",
+      "bitrate": 80,
+      "codec": "AAC",
+      "geo": [
+        52.5408,
+        -1.376
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-frisk-radio-groove-northeast",
+      "name": "frisk radio groove northeast",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.friskradio.com:8443/stream21",
+      "homepage": "https://www.friskradio.com/?station=4un",
+      "country": "GB",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hailsham-fm",
+      "name": "Hailsham FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://s21.myradiostream.com/:10716/listen.mp3",
+      "homepage": "https://www.hailshamfm.com/",
+      "country": "GB",
+      "tags": [
+        "local radio"
+      ],
+      "favicon": "https://www.hailshamfm.com/wp-content/uploads/2021/03/Hailsham-95.9FM-logo-NO-STRAP.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.8628,
+        0.2595
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hearme-movie-soundtracks-radio",
+      "name": "Hearme Movie Soundtracks Radio ",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.hearme.fm:8074/stream",
+      "homepage": "https://hearme.fm/radio/movie-soundtracks/",
+      "country": "GB",
+      "tags": [
+        "soundtracks"
+      ],
+      "favicon": "https://hearme.fm/wp-content/uploads/2024/06/2024-Redrafted-Transparent-Box-No-Text-1-1024x1024.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-johnstone-sound",
+      "name": "Johnstone Sound",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream1.themediasite.co.uk:8084/;",
+      "homepage": "https://johnstonesound.com/",
+      "country": "GB",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        55.8359,
+        -4.5085
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-konflict-radio",
+      "name": "Konflict Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://uk3.internet-radio.com/proxy/konflictradio?mp=/stream",
+      "homepage": "https://konflict-radio.com/",
+      "country": "GB",
+      "tags": [
+        "dnb"
+      ],
+      "favicon": "https://konflict-radio.com/images/krlogo.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-mersey-radio",
+      "name": "Mersey Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.shoutcastservices.com/proxy/merseyradio/stream",
+      "homepage": "https://merseyradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://merseyradio.co.uk/wp-content/uploads/2023/03/cropped-logo.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-mid-downs-radio",
+      "name": "Mid Downs Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-mdr.sharp-stream.com/mdr.mp3",
+      "homepage": "https://www.mdr.org.uk/",
+      "country": "GB",
+      "tags": [
+        "hospital radio"
+      ],
+      "bitrate": 65,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-ocean-city-radio",
+      "name": "Ocean City Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s3.radio.co/se9877d32a/listen#.mp3",
+      "homepage": "https://oceancityradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "various"
+      ],
+      "favicon": "https://oceancityradio.co.uk/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-outreach-dance",
+      "name": "Outreach Dance",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.ukrp.tv/outreachdance.aac",
+      "homepage": "https://www.outreachdance.co.uk/",
+      "country": "GB",
+      "bitrate": 32,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-overton-radio",
+      "name": "Overton Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://securestreams6.autopo.st:2506/stream",
+      "homepage": "https://www.overtonradio.com/",
+      "country": "GB",
+      "favicon": "https://overtonradio.com/wp-content/uploads/2023/07/1-1-1024x1024.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-enrg",
+      "name": "Radio ENRG",
+      "broadcaster": "independent",
+      "streamUrl": "https://edge.mixlr.com/channel/xssdg",
+      "homepage": "https://radioenrg.com/",
+      "country": "GB",
+      "tags": [
+        "alternative",
+        "edinburgh",
+        "pop",
+        "rock",
+        "sport",
+        "student"
+      ],
+      "favicon": "https://i0.wp.com/radioenrg.com/wp-content/uploads/2020/06/radio-enrg-triangle-black-10.png",
+      "codec": "MP3",
+      "geo": [
+        55.9334,
+        -3.214
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-leyland",
+      "name": "Radio Leyland",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming06.liveboxstream.uk/proxy/leyland2?mp=/stream",
+      "homepage": "https://radioleyland.co.uk/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        53.6902,
+        -2.6987
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-warneford",
+      "name": "Radio Warneford",
+      "broadcaster": "independent",
+      "streamUrl": "https://uk7.internet-radio.com/proxy/radiowarneford?mp=/stream",
+      "homepage": "https://www.radiowarneford.com/",
+      "country": "GB",
+      "favicon": "https://www.radiowarneford.com/wp-content/uploads/2023/11/rw-logo-2023-50th-400.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-rother-radio-rotherham-sheffield",
+      "name": "Rother Radio (Rotherham & Sheffield)",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming06.liveboxstream.uk/proxy/hitmusic?mp=/stream",
+      "homepage": "https://www.rotherradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://static.mytuner.mobi/media/tvos_radios/594/rother-radio.cc31313e.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        53.3794,
+        -1.5138
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-rustfm",
+      "name": "RustFM",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.rustfm.com/listen/rustfm/radio.mp3",
+      "homepage": "https://rustfm.com/#home",
+      "country": "GB",
+      "favicon": "https://rustfm.com/assets/images/logo_wr.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-soundart-radio",
+      "name": "Soundart Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.canstream.co.uk:8134/live.mp3",
+      "homepage": "https://www.soundartradio.org.uk/",
+      "country": "GB",
+      "tags": [
+        "diy",
+        "experimental",
+        "experimental electronic music",
+        "field recordings",
+        "soundart"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-storm-radio",
+      "name": "Storm Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.radio.co/s6df48fd88/listen",
+      "homepage": "https://stormfm.uk/home",
+      "country": "GB",
+      "favicon": "https://img1.wsimg.com/isteam/ip/73788d98-eb15-4545-b89e-02e21d7c3eb9/STORM%20HEADER%20NEW%20A11.jpg/:/rs=w:902,h:273",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-the-sound-lab",
+      "name": "The Sound Lab",
+      "broadcaster": "independent",
+      "streamUrl": "https://s4.radio.co/s0fc46103b/listen",
+      "homepage": "https://www.thesoundlabuk.co.uk/",
+      "country": "GB",
+      "tags": [
+        "indie",
+        "pop"
+      ],
+      "favicon": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSa6ZgnMpbK8OK1EtUIYciHuysU3-zw2_NdOsB053eHdXnyMpkK9N2JYvHFRVdfsVnggKs&usqp=CAU",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-urban-all-in-1-radio",
+      "name": "Urban All In 1 Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.urbanallin1radio.co.uk/radio.mp3",
+      "homepage": "https://urbanallin1radio.co.uk/",
+      "country": "GB",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-capital-the-uk-s-no-1-hit-music-station",
+      "name": " CAPITAL - The UK's No.1 Hit Music Station",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ssl.musicradio.com/CapitalUK",
+      "homepage": "https://www.capitalfm.com/",
+      "country": "GB",
+      "tags": [
+        "capital",
+        "capital fm",
+        "contemporary hits radio",
+        "dab+",
+        "england",
+        "entertainment"
+      ],
+      "favicon": "https://cdn-profiles.tunein.com/s241396/images/logod.jpg",
+      "bitrate": 48,
+      "codec": "AAC",
+      "geo": [
+        51.5089,
+        -0.1272
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-capital-dance-the-uk-s-official-dance-station",
+      "name": " CAPITAL DANCE: The UK's Official Dance Station",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ssl.musicradio.com/CapitalDance",
+      "homepage": "https://www.capitaldance.com/",
+      "country": "GB",
+      "tags": [
+        "capital",
+        "capital dance",
+        "dab+",
+        "dance",
+        "dance music",
+        "edm"
+      ],
+      "favicon": "https://cdn-profiles.tunein.com/s309497/images/logod.jpg",
+      "bitrate": 48,
+      "codec": "AAC",
+      "geo": [
+        51.5082,
+        -0.1281
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-kiss-xtra-black-music-culture",
+      "name": " KISS XTRA: Black Music & Culture",
+      "broadcaster": "independent",
+      "streamUrl": "https://live-bauerkiss.sharp-stream.com/kissfresh.aac?direct=true&aw_0_1st.skey=1602676850&rp_source=1&=&&___cb=60456375243858",
+      "homepage": "https://www.hellorayo.co.uk/kiss-xtra",
+      "country": "GB",
+      "tags": [
+        "bauer radio",
+        "contemporary r&b",
+        "dab",
+        "digital radio",
+        "england",
+        "entertainment"
+      ],
+      "favicon": "https://cdn-profiles.tunein.com/s198663/images/logod.png",
+      "bitrate": 47,
+      "codec": "AAC+",
+      "geo": [
+        51.5082,
+        -0.1275
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-96-3-seahaven-fm",
+      "name": "96.3 Seahaven FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream1.hippynet.co.uk:8107/stream?_=526570",
+      "homepage": "https://www.seahavenfm.radio/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/892/63854c57a853f.png",
+      "bitrate": 170,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-ajk-radio",
+      "name": "AJK Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://solid41.streamupsolutions.com/proxy/wzbznkee/stream",
+      "homepage": "https://ajkradio.net/",
+      "country": "GB",
+      "tags": [
+        "eclectic"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-arystation-beyond-reality",
+      "name": "AryStation - Beyond Reality",
+      "broadcaster": "independent",
+      "streamUrl": "https://a11.asurahosting.com:8740/radio.mp3",
+      "homepage": "https://radio.metachitect.com/",
+      "country": "GB",
+      "tags": [
+        "all genres",
+        "country",
+        "hardstyle",
+        "hiphop",
+        "jazz",
+        "podcasts"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bbc-cwr",
+      "name": "BBC CWR",
+      "broadcaster": "independent",
+      "streamUrl": "https://as-hls-ww-live.akamaized.net/pool_79805333/live/ww/bbc_radio_coventry_warwickshire/bbc_radio_coventry_warwickshire.isml/bbc_radio_coventry_warwickshire-audio%3d96000.norewind.m3u8",
+      "homepage": "https://www.bbc.co.uk/sounds/play/live/bbc_radio_coventry_warwickshire",
+      "country": "GB",
+      "favicon": "https://sounds.files.bbci.co.uk/3.9.4/networks/bbc_radio_coventry_warwickshire/colour_default.svg",
+      "codec": "UNKNOWN",
+      "geo": [
+        52.4124,
+        -1.509
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bbc-radio-cambridge",
+      "name": "BBC Radio Cambridge",
+      "broadcaster": "independent",
+      "streamUrl": "https://as-hls-ww-live.akamaized.net/pool_21074581/live/ww/bbc_radio_cambridge/bbc_radio_cambridge.isml/dash/bbc_radio_cambridge-audio%3d96000.norewind.m3u8",
+      "homepage": "https://www.bbc.co.uk/sounds/play/live/bbc_radio_cambridge",
+      "country": "GB",
+      "tags": [
+        "cambridge"
+      ],
+      "favicon": "https://sounds.files.bbci.co.uk/3.9.4/networks/bbc_radio_cambridge/colour_default.svg",
+      "codec": "UNKNOWN",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-brown-student-community-radio",
+      "name": "BROWN STUDENT & COMMUNITY RADIO",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.bsrlive.com/bsrmp3?1729748097161",
+      "homepage": "https://www.bsrlive.com/",
+      "country": "GB",
+      "favicon": "https://static.wixstatic.com/media/39c7bc_eb82f27fe4d8402986e669cdbca13c4d~mv2.png/v1/fill/w_84,h_69,al_c,q_85,usm_0.66_1.00_0.01,enc_auto/39c7bc_eb82f27fe4d8402986e669cdbca13c4d~mv2.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-cannock-chase-radio-fm",
+      "name": "Cannock Chase Radio FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.broadcast.radio/cannockchase?1712410831388=",
+      "homepage": "https://www.cannockchaseradio.co.uk/#",
+      "country": "GB",
+      "favicon": "https://i0.wp.com/www.cannockchaseradio.co.uk/wp-content/uploads/2020/11/mobile-app-VER2.png?fit=1820%2C1120&ssl=1",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-celtic-music-radio",
+      "name": "Celtic Music Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://uksoutha.streaming.broadcast.radio/celtic",
+      "homepage": "https://www.celticmusicradio.net/",
+      "country": "GB",
+      "tags": [
+        "americana",
+        "celtic",
+        "community",
+        "contemporary folk",
+        "listener supported",
+        "roots"
+      ],
+      "favicon": "https://www.celticmusicradio.net/wp-content/uploads/2021/03/cropped-CMR-Logo-New-Ross-New-again-morse-correct.jpg",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-crystal-love-radio",
+      "name": "Crystal Love Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://betelgeuse.nucast.co.uk:8034/stream",
+      "homepage": "https://crystalloveradio.com/",
+      "country": "GB",
+      "favicon": "https://crystalloveradio.com/wp-content/uploads/2022/08/Crystallove-favi.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-daz-in-the-hat-radio",
+      "name": "Daz In The Hat Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s5.radio.co/s367c77774/listen",
+      "homepage": "https://dazinthehat.com/",
+      "country": "GB",
+      "favicon": "https://assets.zyrosite.com/cdn-cgi/image/format=auto,w=238,fit=crop,q=95/Y4LlnV0PrgfegPw5/daz-in-the-hat-edited-logo-m2Wb7PBjx2ie7lwk.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-dean-radio",
+      "name": "Dean Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.forestmedia.co.uk/deanradio",
+      "homepage": "https://deanradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "local radio",
+        "pop",
+        "pop music"
+      ],
+      "favicon": "https://deanradio.co.uk/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.825,
+        -2.5012
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-dune-radio",
+      "name": "Dune Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.aiir.com/3phqulqckaguv?_=981158",
+      "homepage": "https://www.duneradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/192/649d16201b02a.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-first-radio-bounce-northeast",
+      "name": "First radio bounce northeast ",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.friskradio.com:8443/stream41",
+      "homepage": "https://www.friskradio.com/?station=7",
+      "country": "GB",
+      "tags": [
+        "club dance"
+      ],
+      "codec": "AAC",
+      "geo": [
+        54.826,
+        -1.5381
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-fuse-fm",
+      "name": "Fuse FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.radio.co/s53051f118/low",
+      "homepage": "https://fusefm.co.uk/",
+      "country": "GB",
+      "favicon": "https://fusefm.co.uk/wp-content/themes/yootheme/cache/1f/Logo-Transparent-1fa9e60d.webp",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-global-breakfast-radio",
+      "name": "Global Breakfast Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://globalbreakfastradio.com:8443/stream",
+      "homepage": "https://www.globalbreakfastradio.com/",
+      "country": "GB",
+      "favicon": "https://www.globalbreakfastradio.com/images/global-breakfast-radio.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hits-hull-east-york",
+      "name": "Hits hull & East York",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-nation.sharp-stream.com/hull.mp3?aw_0_1st.playerid=BMUK_html5",
+      "homepage": "https://hellorayo.co.uk/hits-radio/",
+      "country": "GB",
+      "tags": [
+        "pop music"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        53.1204,
+        -3.8672
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-homemade-radio",
+      "name": "Homemade Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://homemaderadio-brianager.radioca.st/;",
+      "homepage": "https://homemade-radio.com/",
+      "country": "GB",
+      "tags": [
+        "adult contemporary",
+        "blues",
+        "classic rock",
+        "indie",
+        "rock"
+      ],
+      "favicon": "https://static.vecteezy.com/system/resources/thumbnails/001/933/723/small/radio-online-neon-signs-style-text-free-vector.jpg",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-house-radio-net",
+      "name": "House Radio Net",
+      "broadcaster": "independent",
+      "streamUrl": "https://server.houseradio.net:8000/stream",
+      "homepage": "https://www.houseradio.net/",
+      "country": "GB",
+      "tags": [
+        "club",
+        "dance",
+        "deep house",
+        "electronic",
+        "house",
+        "progressive house"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.5047,
+        -0.1051
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-keep-106",
+      "name": "KeeP 106",
+      "broadcaster": "independent",
+      "streamUrl": "https://solid9.streamupsolutions.com/proxy/djcohrzp?mp=/stream",
+      "homepage": "https://keep106.com/",
+      "country": "GB",
+      "favicon": "https://keep106.com/wp-content/uploads/2020/02/imageedit_5_8575205827.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-kfm-radio",
+      "name": "KFM Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.radio.co/s367e90f45/listen",
+      "homepage": "https://kfmradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "multi"
+      ],
+      "favicon": "https://i0.wp.com/kfmradio.co.uk/wp-content/uploads/2022/09/KFM-logob-200.png?fit=200102&amp;ssl=1",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        53.4084,
+        -2.1612
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-lincs-sound",
+      "name": "Lincs Sound",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.aiir.com/ubrzdpuap28vv",
+      "homepage": "https://www.lincssound.com/",
+      "country": "GB",
+      "tags": [
+        "classic hits",
+        "hot adult contemporary",
+        "pop",
+        "top hits"
+      ],
+      "favicon": "https://mmo.aiircdn.com/2033/6861243b23677.jpg",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-love-will-save-the-day",
+      "name": "Love Will Save The Day",
+      "broadcaster": "independent",
+      "streamUrl": "https://lovewillsavetheday.out.airtime.pro/lovewillsavetheday_a",
+      "homepage": "https://lovewillsavetheday.fm/",
+      "country": "GB",
+      "tags": [
+        "house"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-lushstarr-radio",
+      "name": "LushStarr Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://cdn.voscast.com/resources/?key=5d34553745888466d26fc1cc83166d78&c=wmp",
+      "homepage": "http://www.lushstarr.com/",
+      "country": "GB",
+      "favicon": "https://compiled.ams3.cdn.digitaloceanspaces.com/profile_images/0FDEUXEQompwot5vyQTaBHD1y4M50wpAv2Pd9osJ.jpg",
+      "codec": "UNKNOWN",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-mode-radio-london",
+      "name": "Mode Radio London",
+      "broadcaster": "independent",
+      "streamUrl": "https://mode-london.radiocult.fm/stream",
+      "homepage": "https://mode.london/",
+      "country": "GB",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-only-hits-radio",
+      "name": "Only Hits Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream4.themediasite.co.uk:8210/stream?_=328882",
+      "homepage": "https://www.onlyhitsradio.com/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/2016/68090c0a5a354.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-prodigies-radio",
+      "name": "Prodigies Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://polaris.nucast.co.uk:7580/stream",
+      "homepage": "https://polaris.nucast.co.uk/custom-player/7580#",
+      "country": "GB",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-frimley-park",
+      "name": "Radio Frimley Park",
+      "broadcaster": "independent",
+      "streamUrl": "https://frimleypark.radioca.st/stream?icy=http",
+      "homepage": "https://www.radiofrimleypark.co.uk/",
+      "country": "GB",
+      "favicon": "https://www.radiofrimleypark.co.uk/icons/favicon-256.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-horton",
+      "name": "Radio Horton",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiohorton.radioca.st/;",
+      "homepage": "https://radiohorton.co.uk/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-north-angus",
+      "name": "Radio North Angus",
+      "broadcaster": "independent",
+      "streamUrl": "https://uk3-vn.mixstream.net/8192/listen.mp3",
+      "homepage": "https://radionorthangus.co.uk/",
+      "country": "GB",
+      "favicon": "https://radionorthangus.co.uk/wp-content/uploads/2024/02/resize-homer.bk_.png-150x150.webp",
+      "bitrate": 48,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-northumberland",
+      "name": "Radio Northumberland",
+      "broadcaster": "independent",
+      "streamUrl": "https://northumberland.radioca.st/;",
+      "homepage": "https://radionorthumberland.com/",
+      "country": "GB",
+      "favicon": "https://cdn.instant.audio/images/logos/internetradiouk-com/northumberland.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-scarborough",
+      "name": "Radio Scarborough",
+      "broadcaster": "independent",
+      "streamUrl": "https://s3.radio.co/s201b7a9d0/listen",
+      "homepage": "https://radioscarborough.com/",
+      "country": "GB",
+      "tags": [
+        "community radio"
+      ],
+      "favicon": "https://radioscarborough.com/wp-content/uploads/2023/01/cropped-Site-Icon-Final-32x32.png",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-seahaven-fm-eastbourne",
+      "name": "Seahaven FM - Eastbourne",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream4.hippynet.co.uk:8002/stream?_=201701",
+      "homepage": "https://www.seahavenfm.radio/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/892/63c550fe44a02.png",
+      "bitrate": 170,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-sine-fm",
+      "name": "Sine FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://uksoutha.streaming.broadcast.radio/sinefm?1716196689781=",
+      "homepage": "https://www.sinefm.com/",
+      "country": "GB",
+      "favicon": "https://www.sinefm.com/wp-content/uploads/2019/11/sine-fm-logo-new-800.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-skylab-radio",
+      "name": "Skylab Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://uksoutha.streaming.broadcast.radio:29690/skylab-radio-limited",
+      "homepage": "https://uksoutha.streaming.broadcast.radio:29690/skylab-radio-limited",
+      "country": "GB",
+      "favicon": "https://static.wixstatic.com/media/c558e3_a1b2627549444e919504fa15988a9f57~mv2.png/v1/fill/w_198,h_184,al_c,q_85,usm_0.66_1.00_0.01,enc_avif,quality_auto/c558e3_a1b2627549444e919504fa15988a9f57~mv2.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-smooth-west-midlands",
+      "name": "Smooth West Midlands",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ice.musicradio.com/SmoothWestMidsMP3",
+      "homepage": "https://www.smoothradio.com/westmids/",
+      "country": "GB",
+      "favicon": "https://www.smoothradio.com/westmids/assets_v4r/smooth/img/favicon32x32.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-source-fm",
+      "name": "Source FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.canstream.co.uk:8144/live.mp3?1724162896961=",
+      "homepage": "https://www.thesourcefm.co.uk/",
+      "country": "GB",
+      "favicon": "https://api.broadcast.radio/api/image/d3661645-0ece-409b-b583-8d74b59c4bee.png?g=center&w=600&h=600&c=true",
+      "bitrate": 110,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-stu-allan-radio",
+      "name": "Stu Allan Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.stuallan.com/stream1",
+      "homepage": "https://www.stuallan.com/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-w-b-r-we-black-radio",
+      "name": "W.B.R. We Black Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s4.radio.co/safcfabd03/listen",
+      "homepage": "https://weblackradio.org/",
+      "country": "GB",
+      "favicon": "https://weblackradio.org/images/1534de6bf1609559b708e82ef57c76b2.png",
+      "bitrate": 192,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-banitamaxxradio",
+      "name": "BanitaMaxxRadio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ssl-1.radiohost.pl:9454/stream192",
+      "homepage": "https://www.banitamaxx.pl/",
+      "country": "GB",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bath-sound",
+      "name": "Bath Sound",
+      "broadcaster": "independent",
+      "streamUrl": "https://uksoutha.streaming.broadcast.radio/bathhr",
+      "homepage": "https://bathsound.radio/",
+      "country": "GB",
+      "favicon": "https://bathsound.radio/imgs/bs.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bbc-essex",
+      "name": "BBC Essex",
+      "broadcaster": "independent",
+      "streamUrl": "https://as-hls-ww-live.akamaized.net/pool_23657270/live/ww/bbc_radio_essex/bbc_radio_essex.isml/bbc_radio_essex-audio%3d96000.norewind.m3u8",
+      "homepage": "https://www.bbc.co.uk/sounds/play/live/bbc_radio_essex",
+      "country": "GB",
+      "favicon": "https://sounds.files.bbci.co.uk/3.9.4/networks/bbc_radio_essex/colour_default.svg",
+      "codec": "UNKNOWN",
+      "geo": [
+        51.5846,
+        0.7835
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-blastfm-internet-radio-station",
+      "name": "BlastFM Internet Radio Station",
+      "broadcaster": "independent",
+      "streamUrl": "https://blastfm.net:8000/live",
+      "homepage": "https://blastfmsocial.media/BlastFMRadio",
+      "country": "GB",
+      "favicon": "https://blastfmsocial.media/stations/logo/blastfm.jpg",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-chiltern-voice-fm",
+      "name": "Chiltern Voice FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.entertainmenttechnologies.co.uk:8020/chilternvoice.mp3",
+      "homepage": "https://www.chilternvoice.fm/",
+      "country": "GB",
+      "favicon": "https://www.chilternvoice.fm/wp-content/uploads/2024/02/Chiltern-Voice-Header-Logo-340x156-1.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-chon-98-1",
+      "name": "CHON 98.1",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.chonfm.com:8042/stream",
+      "homepage": "https://www.chonfm.com/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/209/5fd529540c0f8.gif",
+      "bitrate": 73,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-country-gospel-radio",
+      "name": "Country Gospel Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://solid24.streamupsolutions.com/proxy/agtzpadc/stream",
+      "homepage": "https://countrygospelradio.com/",
+      "country": "GB",
+      "tags": [
+        "bluegrass gospel",
+        "christian",
+        "country",
+        "country gospel",
+        "southern gospel"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-east-point-radio",
+      "name": "East Point Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.radio.co/s3c76b154e/listen",
+      "homepage": "https://eastpointradio.com/",
+      "country": "GB",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/7/64737.v7.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-essex-radio",
+      "name": "Essex Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.essex.radio:8060/radio.mp3",
+      "homepage": "https://essex.radio/",
+      "country": "GB",
+      "favicon": "https://essex.radio/logo.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-fcr-plymouth",
+      "name": "FCR Plymouth",
+      "broadcaster": "independent",
+      "streamUrl": "https://streams.radio.co/sde86bbbbf/low",
+      "homepage": "https://www.fcradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://static.wixstatic.com/media/0ff480_674875e451e6439dba6219a3aad51f2b%7Emv2.png/v1/fill/w_180%2Ch_180%2Clg_1%2Cusm_0.66_1.00_0.01/0ff480_674875e451e6439dba6219a3aad51f2b%7Emv2.png",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-frisky-radio",
+      "name": "Frisky Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.frisky.friskyradio.com/",
+      "homepage": "http://friskyradio.com/",
+      "country": "GB",
+      "bitrate": 96,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-frome-fm",
+      "name": "Frome FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast2.bargus.co.uk:8001/fromefm.mp3",
+      "homepage": "https://www.frome.fm/",
+      "country": "GB",
+      "favicon": "https://cdn.prod.website-files.com/65c3a3799d14b21f3710d0b4/66827a1d55ff35d4200e0849_FromeFMIcon-256.png",
+      "bitrate": 120,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-green-radio",
+      "name": "Green Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://gains.reviveradio.net/proxy/greenradio?mp=/stream",
+      "homepage": "https://greenradiolive.com/",
+      "country": "GB",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-halesowen-town",
+      "name": "Halesowen Town",
+      "broadcaster": "independent",
+      "streamUrl": "https://s3.radio.co/s75a8968ca/listen",
+      "homepage": "https://www.radiohalesowentown.co.uk/",
+      "country": "GB",
+      "tags": [
+        "sport"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hereford-fc",
+      "name": "Hereford FC",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radio.co/s025ead1b9/listen",
+      "homepage": "https://www.herefordfc.co.uk/radio-hereford-fc/",
+      "country": "GB",
+      "tags": [
+        "edgar street",
+        "hereford fc",
+        "hereford united",
+        "the bulls"
+      ],
+      "favicon": "https://www.herefordfc.co.uk/wp-content/uploads/2015/05/RADIO-HEREFORD-FC.png",
+      "bitrate": 96,
+      "codec": "MP3",
+      "geo": [
+        52.0606,
+        -2.7179
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hits-radio-uk",
+      "name": "Hits Radio UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-al.hellorayo.co.uk/key.aac?aw_0_1st.skey=1602676850&direct=true&rp_source=1",
+      "homepage": "https://www.hellorayo.co.uk/hits-radio",
+      "country": "GB",
+      "bitrate": 47,
+      "codec": "AAC+",
+      "geo": [
+        53.8288,
+        -2.3455
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-jorvik-radio",
+      "name": "Jorvik Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://uksoutha.streaming.broadcast.radio:24780/jorvikradio?_=21939",
+      "homepage": "https://www.jorvikradio.com/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/533/661fa1000a560.png",
+      "bitrate": 320,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-keep-the-faith-internet-radio",
+      "name": "Keep The Faith Internet Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://mars.streamerr.co/8060/stream",
+      "homepage": "https://keepthefaithinternetradio.co.uk/",
+      "country": "GB",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-line-out-radio",
+      "name": "Line Out Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://play.radioking.io/line-out-radio",
+      "homepage": "http://lineoutradio.com/",
+      "country": "GB",
+      "favicon": "http://lineoutradio.com/wp-content/uploads/2021/06/LINEOUTLOGO-e1623077715840.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-london-house-radio-ldn-house-radio",
+      "name": "London House Radio (LDN House Radio)",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.ldnhouseradio.net/listen/live/radio.mp3",
+      "homepage": "https://ldnhouseradio.net/",
+      "country": "GB",
+      "favicon": "https://ldnhouseradio.net/wp-content/uploads/2024/06/cropped-logo-round-500-favicon-1-180x180.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-luna-radio-reborn-mp3",
+      "name": "Luna Radio Reborn (mp3)",
+      "broadcaster": "independent",
+      "streamUrl": "https://luna.ponyvillefm.com/listen/lunaradio/radio.mp3",
+      "homepage": "https://luna.ponyvillefm.com/public/lunaradio",
+      "country": "GB",
+      "favicon": "http://luna.ponyvillefm.com/api/station/lunaradio/art/f3b23e8f636f5abd2dafbafb",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-m4d-radio-mix",
+      "name": "M4D Radio Mix",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.radio.co/s07cd038f1/listen",
+      "homepage": "https://m4dradio.com/",
+      "country": "GB",
+      "favicon": "https://m4dradio.com/wp-content/uploads/2020/05/cropped-m4dradiologo.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-meridian-fm-107",
+      "name": "Meridian FM 107",
+      "broadcaster": "independent",
+      "streamUrl": "https://uksoutha.streaming.broadcast.radio/meridianfm",
+      "homepage": "https://www.meridianfm.com/",
+      "country": "GB",
+      "tags": [
+        "community radio"
+      ],
+      "favicon": "https://www.meridianfm.com/favicon.ico?i=423",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-morley-radio",
+      "name": "Morley Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.radio.co/sb0e9a4581/low",
+      "homepage": "https://morleyradio.co.uk/",
+      "country": "GB",
+      "bitrate": 64,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-oc-radio",
+      "name": "OC Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.digilinkconnect.co.uk:2020/stream/oldhamcollegeradio",
+      "homepage": "https://www.oldham.ac.uk/college-life/oc-radio/",
+      "country": "GB",
+      "tags": [
+        "chart",
+        "dance",
+        "hiphop",
+        "indie",
+        "mainstream",
+        "pop"
+      ],
+      "bitrate": 192,
+      "codec": "AAC",
+      "geo": [
+        53.5424,
+        -2.1208
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-osn-fm",
+      "name": "OSN.fm",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.stuallan.com/stream2",
+      "homepage": "https://osn.fm/",
+      "country": "GB",
+      "favicon": "http://osn.fm/img/OSN-Radio-PNG.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-panacea-radio",
+      "name": "Panacea Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-15.aiir.com/kqwcuxfxcwhtv?zt=eyJhbGciOiJIUzI1NiJ9.eyJzdHJlYW0iOiJrcXdjdXhmeGN3aHR2IiwiaG9zdCI6InN0cmVhbS0xNS5haWlyLmNvbSIsInJ0dGwiOjUsImp0aSI6IjVkMTNteVlIU0FXNE5STXpWNEdZeFEiLCJpYXQiOjE3Njg2MDczMzksImV4cCI6MTc2ODYwNzM5OX0.IvvTX4vVuMyuvTvxJQTRNTahLXGSgOeVK3c4JGax0ds",
+      "homepage": "https://www.panacearadio.net/",
+      "country": "GB",
+      "tags": [
+        "funk",
+        "groove",
+        "soul"
+      ],
+      "favicon": "https://mmo.aiircdn.com/515/64c0e1942de5b.jpg",
+      "codec": "MP3",
+      "geo": [
+        53.3845,
+        -2.5905
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-persian-vibe-radio",
+      "name": "Persian Vibe Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.aydayazdani.com/stream",
+      "homepage": "https://radio.aydayazdani.com/",
+      "country": "GB",
+      "tags": [
+        "chill",
+        "farsi music",
+        "farsi pop",
+        "iranian music",
+        "persian music",
+        "persian pop"
+      ],
+      "favicon": "https://radio.aydayazdani.com/assets/img/pvr-logo.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.5074,
+        -0.1278
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-phasefm",
+      "name": "PhaseFM",
+      "broadcaster": "independent",
+      "streamUrl": "https://azuracast.clubhits.uk/listen/phasefm/radio.mp3",
+      "homepage": "https://phasefm.co.uk/",
+      "country": "GB",
+      "favicon": "https://phasefm.co.uk/wp-content/uploads/2025/07/clubhitsuk-variety-mix-mytuner-logo.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-prince-bishops-hospital-radio",
+      "name": "Prince Bishops Hospital Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://pbhr.radioca.st/stream",
+      "homepage": "https://www.pbhr.org.uk/#",
+      "country": "GB",
+      "favicon": "https://www.pbhr.org.uk/wp-content/uploads/2017/01/logo-mic.png",
+      "bitrate": 48,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-bronglais",
+      "name": "Radio Bronglais",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radiobronglais.cymru/stream?ver=92941",
+      "homepage": "https://radiobronglais.cymru/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-hartlepool",
+      "name": "Radio Hartlepool",
+      "broadcaster": "independent",
+      "streamUrl": "https://server.radiohartlepool.co.uk:8443/hartlepool-mp3",
+      "homepage": "https://radiohartlepool.co.uk/",
+      "country": "GB",
+      "favicon": "https://radiohartlepool.co.uk/wp-content/uploads/2023/01/cropped-RHlogo.jpg",
+      "bitrate": 64,
+      "codec": "MP3",
+      "geo": [
+        54.684,
+        -1.2148
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-wigwam",
+      "name": "Radio Wigwam",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.broadcast.radio/radio-wigwam",
+      "homepage": "https://radiowigwam.co.uk/",
+      "country": "GB",
+      "tags": [
+        "indie rock"
+      ],
+      "favicon": "https://radiowigwam.co.uk/wp-content/uploads/2024/08/wiwamnewdark.jpg.webp",
+      "codec": "MP3",
+      "geo": [
+        51.4808,
+        -3.1792
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-wimborne",
+      "name": "Radio Wimborne",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.canstream.co.uk:8057/live.mp3",
+      "homepage": "https://www.radiowimborne.co.uk/",
+      "country": "GB",
+      "tags": [
+        "community radio station"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        50.8014,
+        -1.9863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-woking",
+      "name": "Radio Woking",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiowoking.radioca.st/stream?rp_source=1&=&&___cb=821829812672569",
+      "homepage": "https://www.radiowoking.co.uk/",
+      "country": "GB",
+      "favicon": "http://www.radiowoking.co.uk/wp-content/uploads/2014/05/radiowokingwebhead7new75x360.gif",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radiorosak",
+      "name": "RADIOROSAK",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rcast.net/68127",
+      "homepage": "http://radiorosak.com/",
+      "country": "GB",
+      "bitrate": 48,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-ramsgate-radio",
+      "name": "Ramsgate Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://play.radioking.io/ramsgate-radio1/610934",
+      "homepage": "https://www.ramsgateradio.com/",
+      "country": "GB",
+      "favicon": "https://static.wixstatic.com/media/d883a7_649474a2c070450396a7c3d08a5ce624%7Emv2.png/v1/fill/w_180%2Ch_180%2Clg_1%2Cusm_0.66_1.00_0.01/d883a7_649474a2c070450396a7c3d08a5ce624%7Emv2.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-shine-radio",
+      "name": "Shine Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-petersfield.sharp-stream.com/petersfield.aac",
+      "homepage": "https://shineradio.uk/",
+      "country": "GB",
+      "favicon": "https://shineradio.uk/wp-content/uploads/2020/08/shine_logo_primary_d_rgb_01_crop.jpg",
+      "bitrate": 96,
+      "codec": "AAC+",
+      "geo": [
+        51.0045,
+        -0.9343
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-smooth-grooving-radio",
+      "name": "Smooth Grooving Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://sgr.lucasmultimedia.com/stream.ogg",
+      "homepage": "http://smoothgrooving.com/",
+      "country": "GB",
+      "favicon": "http://smoothgrooving.com/favicon-1.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-somervalley-fm",
+      "name": "Somervalley fm",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream4.hippynet.co.uk:8014/stream",
+      "homepage": "https://www.somervalleyfm.co.uk/",
+      "country": "GB",
+      "tags": [
+        "community radio",
+        "local station",
+        "north east somerset"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.2844,
+        -2.4851
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-southern-roots-radio",
+      "name": "Southern Roots Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://uksoutha.streaming.broadcast.radio/southern-roots-radio.mp3",
+      "homepage": "https://www.southern-roots.co.uk/",
+      "country": "GB",
+      "tags": [
+        "country"
+      ],
+      "favicon": "https://static.wixstatic.com/media/4a71bd_d0a57c5ed62c4a8fbaee7ce942611b60~mv2.png/v1/fill/w_242,h_242,al_c,q_85,usm_0.66_1.00_0.01,enc_avif,quality_auto/1000022871-Photoroom.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-spotlight-radio",
+      "name": "Spotlight Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream1.hippynet.co.uk:8075/stream",
+      "homepage": "https://www.spotlightradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://l5.tm-web-01.co.uk/img/fav/favicon-1024-167.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-subcity-radio",
+      "name": "Subcity Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.subcity.org/listen",
+      "homepage": "https://www.subcity.org/",
+      "country": "GB",
+      "tags": [
+        "freeform",
+        "independent",
+        "university"
+      ],
+      "favicon": "https://f4.bcbits.com/img/a1309017338_10.jpg",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-teenbuzz-radio",
+      "name": "Teenbuzz Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.broadcast.radio/teenbuzzradio?1744351024052=",
+      "homepage": "https://teenbuzzradio.com/",
+      "country": "GB",
+      "favicon": "https://teenbuzzradio.com/wp-content/uploads/2020/06/logo.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-the-gates-radio-station",
+      "name": "The Gates Radio Station",
+      "broadcaster": "independent",
+      "streamUrl": "https://thegatesradio.co.uk/listen/the_gates_radio_station/radio.mp3",
+      "homepage": "https://www.thegates.bolton.sch.uk/page/the-gates-radio/135355",
+      "country": "GB",
+      "favicon": "https://www.thegates.bolton.sch.uk/images/favicon_2.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-the-void-underground-music-radio",
+      "name": "The Void – Underground Music Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://thevoidrad.io/stream320",
+      "homepage": "https://thevoidrad.io/",
+      "country": "GB",
+      "tags": [
+        "dub techno",
+        "microhouse",
+        "minimal",
+        "rominimal"
+      ],
+      "favicon": "https://thevoidrad.io/favicon.ico",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-ugnjamz",
+      "name": "ugnjamz",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.live365.com/a27539",
+      "homepage": "https://ugnjamz.com/",
+      "country": "GB",
+      "tags": [
+        "christian rap",
+        "hip hop",
+        "rap",
+        "ridwan",
+        "urban gospel"
+      ],
+      "favicon": "https://ugnjamz.com/wp-content/uploads/2020/06/UGN-LOGO.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-venture-radio",
+      "name": "Venture Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streamz.anytek.co.uk/proxy/tracla00",
+      "homepage": "https://www.ventureradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "1980s",
+        "80's",
+        "80s",
+        "oldies"
+      ],
+      "favicon": "https://is1-ssl.mzstatic.com/image/thumb/Music211/v4/03/b0/e2/03b0e211-be78-5e79-815b-dc2961e40f40/13UABIM53820.rgb.jpg/600x600bb.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-6-towns-radio",
+      "name": "6 Towns Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-14.aiir.com/z7drhoivbpbuv?zt=eyJhbGciOiJIUzI1NiJ9.eyJzdHJlYW0iOiJ6N2RyaG9pdmJwYnV2IiwiaG9zdCI6InN0cmVhbS0xNC5haWlyLmNvbSIsInJ0dGwiOjUsImp0aSI6IjhROHpmZWlKVE1hWi1pdnUxdGRtVXciLCJpYXQiOjE3NjkwMzIxOTcsImV4cCI6MTc2OTAzMjI1N30.Lw7Duueb_YYvm7nI82EU1lRAlrd9NHH1ahB4WANmiaU",
+      "homepage": "https://www.6towns.co.uk/",
+      "country": "GB",
+      "tags": [
+        "adult contemporary",
+        "classic hits",
+        "local radio",
+        "pop"
+      ],
+      "favicon": "https://mmo.aiircdn.com/1209/656101b604916.png",
+      "codec": "MP3",
+      "geo": [
+        53.0588,
+        -2.2068
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bbc-radio-berkshire",
+      "name": "BBC Radio Berkshire",
+      "broadcaster": "independent",
+      "streamUrl": "https://as-hls-ww-live.akamaized.net/pool_64162474/live/ww/bbc_radio_berkshire/bbc_radio_berkshire.isml/dash/bbc_radio_berkshire-audio%3d96000.norewind.m3u8",
+      "homepage": "https://www.bbc.co.uk/sounds/play/live/bbc_radio_berkshire",
+      "country": "GB",
+      "tags": [
+        "bbc",
+        "berkshire"
+      ],
+      "favicon": "https://sounds.files.bbci.co.uk/3.9.4/networks/bbc_radio_berkshire/colour_default.svg",
+      "codec": "UNKNOWN",
+      "geo": [
+        51.9727,
+        -0.729
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bbc-radio-bristol",
+      "name": "BBC Radio Bristol",
+      "broadcaster": "independent",
+      "streamUrl": "https://as-hls-ww-live.akamaized.net/pool_41858929/live/ww/bbc_radio_bristol/bbc_radio_bristol.isml/dash/bbc_radio_bristol-audio%3d96000.norewind.m3u8",
+      "homepage": "https://www.bbc.co.uk/sounds/play/live/bbc_radio_bristol",
+      "country": "GB",
+      "tags": [
+        "bbc",
+        "bristol"
+      ],
+      "favicon": "https://sounds.files.bbci.co.uk/3.9.4/networks/bbc_radio_bristol/colour_default.svg",
+      "codec": "UNKNOWN",
+      "geo": [
+        52.0437,
+        -2.0636
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bbc-radio-hereford-and-worcester",
+      "name": "BBC Radio Hereford and Worcester",
+      "broadcaster": "independent",
+      "streamUrl": "https://as-hls-ww-live.akamaized.net/pool_80112859/live/ww/bbc_radio_hereford_worcester/bbc_radio_hereford_worcester.isml/bbc_radio_hereford_worcester-audio%3d96000.norewind.m3u8",
+      "homepage": "https://www.bbc.co.uk/sounds/play/live/bbc_radio_hereford_worcester",
+      "country": "GB",
+      "favicon": "https://sounds.files.bbci.co.uk/3.9.4/networks/bbc_radio_hereford_worcester/colour_default.svg",
+      "codec": "UNKNOWN",
+      "geo": [
+        52.1072,
+        -2.4442
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bombshell-radio",
+      "name": "Bombshell Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s8.ssl-stream.com:1175/stream",
+      "homepage": "https://bombshellradio.com/",
+      "country": "GB",
+      "favicon": "https://bombshellradio.com/wp-content/uploads/2025/03/originalFile-bombshell-radio-1-2-370x370.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-broadland-radio",
+      "name": "Broadland Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://arqiva-broadlandradio-live-a.edge.audiocdn.com/10002_128mp3",
+      "homepage": "https://broadlandradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "classic hits",
+        "hits",
+        "hot adult contemporary",
+        "pop"
+      ],
+      "favicon": "https://static.mytuner.mobi/media/tvos_radios/401/broadland.8c715f56.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bucks-radio",
+      "name": "Bucks Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://n01.radiojar.com/f6mru9artg0uv?_=745309&rj-tok=AAABihJa1SMABODPIDh9C1t79A&rj-ttl=5",
+      "homepage": "https://www.bucks.radio/",
+      "country": "GB",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-burton-radio",
+      "name": "Burton Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s9.citrus3.com:8370/stream",
+      "homepage": "https://www.burtonradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://images.squarespace-cdn.com/content/v1/6589f8f0f6168a1963a4d06a/19ba74fd-da8c-4021-a0a5-f6f52489492c/BR-512.png?format=1500w",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-cheesy-fm",
+      "name": "Cheesy FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://n27a-eu.rcs.revma.com/8ebhfmak44uvv?rj-ttl=5&rj-tok=AAABnbAucYoA8uoxbTFltYIAvg",
+      "homepage": "https://www.cheesyfm.co.uk/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/520/61a8cce0e4cbb.jpg",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-dales-radio",
+      "name": "Dales Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream3.themediasite.co.uk:8364/stream?_=690543",
+      "homepage": "https://www.dalesradio.co/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-drums-radio",
+      "name": "Drums Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streams.radio.co/sa75718856/listen",
+      "homepage": "https://www.drumsradio.com/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-forest-one",
+      "name": "Forest One",
+      "broadcaster": "independent",
+      "streamUrl": "https://c2.prostream365.com:8010/live",
+      "homepage": "https://www.forestradiouk.com/forestone",
+      "country": "GB",
+      "favicon": "https://static.mytuner.mobi/media/tvos_radios/469/forest-one.fee679cd.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        51.7061,
+        0.1227
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-frisky-radio-classics",
+      "name": "Frisky Radio Classics",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.classics.friskyradio.com/",
+      "homepage": "http://friskyradio.com/",
+      "country": "GB",
+      "bitrate": 96,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-genesis-radio-birmingham",
+      "name": "Genesis Radio Birmingham",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast5.my-control-panel.com/proxy/grb/stream",
+      "homepage": "https://genesisradiobirmingham.com/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        52.4792,
+        -1.8994
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-goodnight-sweetheart-radio",
+      "name": "Goodnight Sweetheart Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://a3.asurahosting.com/listen/goodnight_sweetheart_radio/radio.mp3",
+      "homepage": "https://a3.my-control-panel.com/station/648",
+      "country": "GB",
+      "tags": [
+        "1990s hits",
+        "music from the 1940s"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-groove-genie-radio",
+      "name": "Groove Genie Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://groove-genie.co.uk/listen/groove_genie_radio/radio.mp3",
+      "homepage": "https://groovegenieradio.com/",
+      "country": "GB",
+      "favicon": "https://i0.wp.com/groovegenieradio.com/wp-content/uploads/2023/05/Groove-Genie-Radio-Logo-512x512-1.png?resize=370%2C370&ssl=1",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-high-peak-1",
+      "name": "High Peak 1",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream3.themediasite.co.uk:8260/stream",
+      "homepage": "https://highpeak1.co.uk/",
+      "country": "GB",
+      "favicon": "https://highpeak1.co.uk/wp-content/uploads/2024/03/LogoJpg-370x370.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hits-radio-london",
+      "name": "Hits Radio London",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-mz.hellorayo.co.uk/net1london.aac?aw_0_1st.skey=1602676850&direct=true&rp_source=1",
+      "homepage": "https://www.hellorayo.co.uk/hits-radio/london",
+      "country": "GB",
+      "favicon": "https://media.bauerradio.com/image/upload/c_crop,g_custom/v1713275588/brand_manager/stations/nbcsqhgitwccojxtwfxn.svg",
+      "bitrate": 47,
+      "codec": "AAC+",
+      "geo": [
+        51.2556,
+        -0.148
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-inside-the-gates-radio",
+      "name": "Inside The Gates Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.radio.co/s98e7a2900/listen",
+      "homepage": "https://www.insidethegatesradio.com/",
+      "country": "GB",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-itisnow-radio",
+      "name": "itisnow Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radio.co/sc41e33712/listen",
+      "homepage": "https://www.itisnowradio.com/",
+      "country": "GB",
+      "favicon": "https://www.itisnowradio.com/uploads/1/4/5/0/145020825/logo-web.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-kic-radio",
+      "name": "KIC Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.aiir.com/nbgvn4hgyrxuv",
+      "homepage": "https://www.kicradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "dance",
+        "hits",
+        "pop",
+        "top 40"
+      ],
+      "favicon": "https://mmo.aiircdn.com/1333/692847fae5e8f.jpg",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-laser-gold",
+      "name": "Laser Gold",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream1.hippynet.co.uk:8067/stream",
+      "homepage": "https://www.laserinternational.co.uk/laser-gold",
+      "country": "GB",
+      "tags": [
+        "classic hits",
+        "oldies",
+        "pop",
+        "rock"
+      ],
+      "favicon": "https://primary.jwwb.nl/public/t/a/i/temp-dozjcpvcaeqpdalqxwlr/205-high.jpg?enable-io=true&crop=1%3A1&width=816",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-mix-fm-glasgow",
+      "name": "Mix FM - Glasgow",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.mixfmonline.com:8443/listen/mix_fm/radio.aac",
+      "homepage": "https://www.mixfmglasgow.com/",
+      "country": "GB",
+      "favicon": "https://www.mixfm.pro/wp-content/uploads/2024/06/NEW-LOGO-768x186.png",
+      "bitrate": 64,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-mondo-radio",
+      "name": "Mondo Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streamer.radio.co/s1afcca186/listen",
+      "homepage": "https://www.mondo.radio/",
+      "country": "GB",
+      "tags": [
+        "community radio",
+        "variety"
+      ],
+      "favicon": "https://images.squarespace-cdn.com/content/v1/648cf7010ac2fb3561bc2154/5b5a7df2-8c59-49fa-9b71-dca00edfe7ff/favicon.ico?format=100w",
+      "bitrate": 96,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-motorsport-radio",
+      "name": "Motorsport Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.radio.co/sd88832e85/listen",
+      "homepage": "https://motorsport.radio/nowplaying/",
+      "country": "GB",
+      "tags": [
+        "motorsport",
+        "pop",
+        "rock"
+      ],
+      "favicon": "https://motorsport.radio/wp-content/uploads/2020/05/iTunes-Cover-512px.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-nufc-talk-radio",
+      "name": "NUFC Talk Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s4.radio.co/s35505f6df/listen",
+      "homepage": "https://www.nufctalkradio.com/",
+      "country": "GB",
+      "tags": [
+        "football",
+        "soccer",
+        "sport",
+        "talk"
+      ],
+      "favicon": "https://static.wixstatic.com/media/a2c77b_e4f745f8472e4e36aed9b628816b6e6e~mv2.jpg/v1/fill/w_2500,h_2500,al_c/a2c77b_e4f745f8472e4e36aed9b628816b6e6e~mv2.jpg",
+      "bitrate": 96,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-orryy-live",
+      "name": "Orryy Live",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.orryy.com/live",
+      "homepage": "https://orryy.com/live",
+      "country": "GB",
+      "tags": [
+        "24/7",
+        "bouncy",
+        "dance",
+        "dj",
+        "electronic",
+        "house"
+      ],
+      "favicon": "https://orryy.com/assets/logo.png",
+      "codec": "MP3",
+      "geo": [
+        55.8642,
+        -4.2518
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-osn-radio-plus",
+      "name": "OSN Radio Plus",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.stuallan.com/stream3",
+      "homepage": "https://osn.fm/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-past-perfect-radio",
+      "name": "Past Perfect Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.xrad.io:9646/;stream/1",
+      "homepage": "https://www.pastperfect.com/",
+      "country": "GB",
+      "favicon": "https://www.pastperfect.com/wp-content/uploads/2023/07/Past-Perfect-Radio-e1688392518104-768x473.png",
+      "bitrate": 48,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-premier-gospel",
+      "name": "Premier Gospel",
+      "broadcaster": "independent",
+      "streamUrl": "https://pcr.streamguys1.com/pgospel-96k.aac",
+      "homepage": "https://www.premier.plus/stations/premier-gospel",
+      "country": "GB",
+      "tags": [
+        "christian",
+        "gospel"
+      ],
+      "bitrate": 56,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-premier-praise",
+      "name": "Premier Praise",
+      "broadcaster": "independent",
+      "streamUrl": "https://pcr.streamguys1.com/ppeace-96k.aac",
+      "homepage": "https://www.premier.plus/stations/premier-peace",
+      "country": "GB",
+      "tags": [
+        "chill",
+        "christian",
+        "peace"
+      ],
+      "bitrate": 56,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-quality-radio",
+      "name": "Quality Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://uksoutha.streaming.broadcast.radio/quality_FM",
+      "homepage": "https://qualityradio.uk/",
+      "country": "GB",
+      "favicon": "https://qualityradio.uk/wp-content/uploads/2022/08/qar-logo-e1661895864614.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-hillingdon",
+      "name": "Radio Hillingdon",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.broadcast.radio/hrhillingdonaac?1699805800701=",
+      "homepage": "https://www.radiohillingdon.com/",
+      "country": "GB",
+      "favicon": "https://www.radiohillingdon.com/images/Listen%20Live%20Button%202023.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-lear",
+      "name": "Radio LEAR",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.maxxwave.co.uk/lear",
+      "homepage": "https://radiolear.uk/",
+      "country": "GB",
+      "tags": [
+        "arts",
+        "culture"
+      ],
+      "favicon": "https://img-284.media.info/i/bg/7/7941-1759585321.webp",
+      "bitrate": 80,
+      "codec": "AAC",
+      "geo": [
+        52.6288,
+        -1.1562
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-wester-ross",
+      "name": "Radio Wester Ross",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rcs.revma.com/96z3d1qs5bcwv",
+      "homepage": "https://www.radiowesterross.scot/",
+      "country": "GB",
+      "tags": [
+        "folklore",
+        "pop"
+      ],
+      "favicon": "https://www.radiowesterross.scot/application/files/3917/0852/2702/favicon.ico",
+      "codec": "MP3",
+      "geo": [
+        57.7309,
+        -5.6994
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-xtra",
+      "name": "Radio Xtra",
+      "broadcaster": "independent",
+      "streamUrl": "https://n18a-eu.rcs.revma.com/nye22yatz42vv?rj-ttl=5&rj-tok=AAABm86No4cAj3cUwHekQ5GQLQ",
+      "homepage": "https://radioxtra.co.uk/",
+      "country": "GB",
+      "tags": [
+        "2000s",
+        "2010s",
+        "2020s",
+        "80s",
+        "90s",
+        "charts"
+      ],
+      "favicon": "https://radioxtra.co.uk/wp-content/uploads/2023/07/Radio-XTRA-2.svg",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radiowave",
+      "name": "RadioWave",
+      "broadcaster": "independent",
+      "streamUrl": "https://1.radiowave.eu/listen/test/aacHQ",
+      "homepage": "https://radiowave.eu/public/test",
+      "country": "GB",
+      "favicon": "https://radiowave.eu/static/uploads/browser_icon/192.1743030143.png",
+      "bitrate": 320,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-reiver-fm-scottish-borders-radio",
+      "name": "Reiver FM – Scottish Borders Radio ",
+      "broadcaster": "independent",
+      "streamUrl": "https://s10.myradiostream.com/35820/listen.mp3",
+      "homepage": "https://reiverfm.com/",
+      "country": "GB",
+      "tags": [
+        "oldies",
+        "pop music",
+        "rock",
+        "soul"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-rutland-and-stamford-sound",
+      "name": "Rutland and Stamford Sound",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.aiir.com/lqeblzjduoduv",
+      "homepage": "https://www.rutlandandstamfordsound.co.uk/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/500/6035405e0d05a.png",
+      "codec": "MP3",
+      "geo": [
+        52.6697,
+        -0.73
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-slim-radio",
+      "name": "Slim Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://a2.asurahosting.com:6260/radio.mp3",
+      "homepage": "http://www.slimradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "deep house",
+        "disco",
+        "funk",
+        "house",
+        "soul",
+        "soulful house"
+      ],
+      "favicon": "https://www.slimradio.co.uk",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        51.4919,
+        0.1208
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-spark-fm",
+      "name": "Spark FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream1.hippynet.co.uk:8117/live.mp3",
+      "homepage": "https://www.sparksunderland.com/",
+      "country": "GB",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        54.9119,
+        -1.3729
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-td1-radio",
+      "name": "TD1 Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.mbc.scot/listen/td1_radio/radio.mp3",
+      "homepage": "https://www.td1radio.scot/",
+      "country": "GB",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-the-cat-107-9",
+      "name": "The Cat 107.9",
+      "broadcaster": "independent",
+      "streamUrl": "https://uksoutha.streaming.broadcast.radio/thecatcloud?1769875744264=",
+      "homepage": "https://thecat.radio/",
+      "country": "GB",
+      "tags": [
+        "community radio",
+        "local radio",
+        "pop"
+      ],
+      "favicon": "https://thecat.radio/favicon.ico?i=5365",
+      "codec": "MP3",
+      "geo": [
+        53.087,
+        -2.4565
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-triphop-radio",
+      "name": "TripHop.Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.triphop.radio/",
+      "homepage": "https://www.triphop.radio/",
+      "country": "GB",
+      "tags": [
+        "chill",
+        "chillout",
+        "downtempo",
+        "electronic",
+        "lounge",
+        "lounge downtempo chillout ambient easy listening"
+      ],
+      "favicon": "https://pages.register.radio/uploads/triphop-radio-69d395851f50d.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-truck-beat-fm",
+      "name": "Truck Beat FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://streamer.radio.co/s895c9762a/listen",
+      "homepage": "https://truck-beat-fm.github.io/Truck-Beat-FM-radio/index.html",
+      "country": "GB",
+      "tags": [
+        "trucking"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-vdub-radio",
+      "name": "VDub Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.radio.co/s6fb3318ac/listen",
+      "homepage": "https://www.vdubradio.com/",
+      "country": "GB",
+      "tags": [
+        "alternative",
+        "funk",
+        "house",
+        "rnb"
+      ],
+      "favicon": "https://www.vdubradio.com/uploads/1/2/3/2/123248749/new-2024-aerial-line-x-1200_orig.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-vibe-1",
+      "name": "Vibe 1",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream3.themediasite.co.uk:8106/stream",
+      "homepage": "https://www.vibe1.uk/",
+      "country": "GB",
+      "favicon": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQX-73EE6UPXYWRfGsZ6WkesAy6ef2fwE3pSA&s",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-weald-radio",
+      "name": "Weald Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://uksoutha.streaming.broadcast.radio/oastradio",
+      "homepage": "https://www.wealdradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "pop"
+      ],
+      "favicon": "https://mmo.aiircdn.com/2225/687d0e4b722ce.jpg",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-word-central-radio",
+      "name": "Word Central Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://play.radioking.io/word-central-radio/707122",
+      "homepage": "https://wordcentralradio.com/",
+      "country": "GB",
+      "favicon": "https://image.radioking.io/radios/643897/logo/1cf1f955-b76c-4d78-a4ea-5af7c21909c5.jpeg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-2day-mix-radio",
+      "name": "2day mix radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://2day.2daymixradio.org:8000/radio.mp3",
+      "homepage": "https://2daymixradio.org/",
+      "country": "GB",
+      "tags": [
+        "00s",
+        "2010s",
+        "2020s",
+        "80s",
+        "90s",
+        "enjoy the moments of our vibes"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-arp-radio",
+      "name": "ARP Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://arpradio.com:8443/listen/arp_radio/arp.mp3",
+      "homepage": "https://arpradio.com/",
+      "country": "GB",
+      "tags": [
+        "dub",
+        "dub techno",
+        "electro",
+        "electronic music",
+        "house",
+        "techno"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        53.8236,
+        -1.4612
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-ashdown-radio",
+      "name": "Ashdown Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.broadcast.radio/uckfieldfmmp3?_=365639",
+      "homepage": "https://www.ashdownradio.com/",
+      "country": "GB",
+      "favicon": "https://mmo.aiircdn.com/592/61d2dbf595ad9.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bexhill-radio",
+      "name": "Bexhill Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://a13.asurahosting.com/listen/bexhill_radio/radio.mp3",
+      "homepage": "https://bexhillradio.com/",
+      "country": "GB",
+      "favicon": "https://bexhillradio.com/wp-content/uploads/2025/11/PHOTO-2025-08-04-19-38-26.jpg",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bounce-nation-radio",
+      "name": "Bounce Nation Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.stuallan.com/stream4",
+      "homepage": "https://www.stuallan.com/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-bournemouth-one",
+      "name": "Bournemouth One",
+      "broadcaster": "independent",
+      "streamUrl": "https://n10a-eu.rcs.revma.com/bq0p6qbnpucwv?rj-ttl=5&rj-tok=AAABm8kwEu0ATCenU6Ba4CGEmg",
+      "homepage": "https://www.bournemouthone.com/",
+      "country": "GB",
+      "tags": [
+        "pop"
+      ],
+      "favicon": "https://mmo.aiircdn.com/743/6773b4fd7db3a.png",
+      "codec": "AAC",
+      "geo": [
+        50.7341,
+        -1.8173
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-branchfm",
+      "name": "BranchFM",
+      "broadcaster": "independent",
+      "streamUrl": "https://s11.ssl-stream.com/ssl/branchfm?mp=%2Fstream&rp_source=1&=&&___cb=797689455893916",
+      "homepage": "https://branchfm.com/",
+      "country": "GB",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-castle-radio",
+      "name": "Castle Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://c36.radioboss.fm:8114/stream",
+      "homepage": "https://www.castleradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://www.castleradio.co.uk/set1.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-central-radio",
+      "name": "Central Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://n33a-eu.rcs.revma.com/aehah7wnpp3vv",
+      "homepage": "http://www.central.radio/",
+      "country": "GB",
+      "tags": [
+        "classic hits",
+        "hot ac",
+        "pop"
+      ],
+      "favicon": "https://mmo.aiircdn.com/778/673b04861e76c.png",
+      "codec": "AAC",
+      "geo": [
+        53.7603,
+        -2.6931
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-crucial-sounds-radio",
+      "name": "crucial sounds radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://usa19.fastcast4u.com:9420/stream",
+      "homepage": "https://crucialsoundsradio.uk/",
+      "country": "GB",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-da-hub-radio",
+      "name": "Da Hub Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.dahubradio.co.uk:8848/stream",
+      "homepage": "https://dahubradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "dancehall",
+        "electronic",
+        "electronic dance music",
+        "house",
+        "r&b/urban"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-dork-radio",
+      "name": "Dork Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.radio.co/s3e57f0675/listen",
+      "homepage": "https://readdork.com/",
+      "country": "GB",
+      "favicon": "https://readdork.com/wp-content/uploads/2025/02/dork_logo_new_nearblack-768x185.webp",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-eava-fm",
+      "name": "EAVA FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.canstream.co.uk:8000/eavafm.mp3",
+      "homepage": "https://www.eavafm.com/",
+      "country": "GB",
+      "favicon": "https://www.eavafm.com/wp-content/uploads/2021/12/eava_logo_Clear_3400.png",
+      "bitrate": 96,
+      "codec": "MP3",
+      "geo": [
+        52.654,
+        -1.1254
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-electric-circus",
+      "name": "electric circus",
+      "broadcaster": "independent",
+      "streamUrl": "https://a5.asurahosting.com:7990/radio.mp3",
+      "homepage": "https://www.electriccircus.uk/radio/",
+      "country": "GB",
+      "favicon": "https://www.electriccircus.uk/wp-content/uploads/go-x/u/3c3ed3c4-f457-43f2-b909-fbee7590e08b/image-384x304.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hfm-102-3",
+      "name": "HFM 102.3",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-harboroughfm.sharp-stream.com/harboroughfm.mp3",
+      "homepage": "https://harboroughfm.co.uk/",
+      "country": "GB",
+      "tags": [
+        "adult contemporary",
+        "community radio",
+        "local radio",
+        "pop"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        52.4799,
+        -0.913
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-hgv1-radio",
+      "name": "HGV1 Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream4.themediasite.co.uk/stream/hgv1-main",
+      "homepage": "https://hgvradio.com/",
+      "country": "GB",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        51.4595,
+        -0.0989
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-huntingdon-community-radio-hcr-fm",
+      "name": "Huntingdon Community Radio - HCR FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.streamaudio.co/proxy/hcr/stream",
+      "homepage": "https://www.hcrfm.co.uk/",
+      "country": "GB",
+      "favicon": "https://www.hcrfm.co.uk/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-indie-soul-radio",
+      "name": "Indie Soul Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.citrus3.com:8404/stream",
+      "homepage": "https://www.indiesoulradio.com/",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-kick-radio",
+      "name": "KICK RADIO",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast4.my-control-panel.com/proxy/edp/stream",
+      "homepage": "https://www.kickradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://www.kickradio.co.uk/public/themes/default/assets/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-laser-dance",
+      "name": "Laser Dance",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.airwavebroadcast.com:8010/laserdancehq",
+      "homepage": "https://www.laserinternational.co.uk/laser-dance",
+      "country": "GB",
+      "tags": [
+        "garage",
+        "house",
+        "live shows",
+        "modern dance",
+        "old school"
+      ],
+      "favicon": "https://primary.jwwb.nl/public/t/a/i/temp-dozjcpvcaeqpdalqxwlr/315-high.jpg?enable-io=true&width=1252",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-laser-hot-hits",
+      "name": "Laser Hot Hits",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.airwavebroadcast.com:8040/laserhq",
+      "homepage": "https://www.laserinternational.co.uk/laser-hot-hits-international",
+      "country": "GB",
+      "tags": [
+        "oldies",
+        "pop",
+        "recent hits",
+        "rock"
+      ],
+      "favicon": "https://primary.jwwb.nl/public/t/a/i/temp-dozjcpvcaeqpdalqxwlr/225-high.png?enable-io=true&width=816",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-love-da-beat-radio",
+      "name": "Love Da Beat Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://love-da-beat-radio-cf8d1146.radiocult.fm/stream",
+      "homepage": "https://www.lovedabeatradio.co.uk/",
+      "country": "GB",
+      "bitrate": 160,
+      "codec": "MP3",
+      "geo": [
+        51.4141,
+        -0.052
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-lyme-out-live",
+      "name": "lyme out live",
+      "broadcaster": "independent",
+      "streamUrl": "https://centova87.shoutcastservices.com/proxy/lymeout/stream",
+      "homepage": "https://centova87.shoutcastservices.com/proxy/lymeout/stream",
+      "country": "GB",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-mearns-fm",
+      "name": "Mearns FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream2.hippynet.co.uk:8002/lowquality",
+      "homepage": "https://www.mearnsfm.org.uk/",
+      "country": "GB",
+      "favicon": "https://www.mearnsfm.org.uk/wp-content/uploads/2020/06/imageedit_5_7574751306.png",
+      "bitrate": 96,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-nitro-fm",
+      "name": "nitro-FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.nitro-server.uk/listen/nitrohost/radio.mp3",
+      "homepage": "https://radio.nitro-server.uk/listen/nitrohost/",
+      "country": "GB",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-outreach-radio",
+      "name": "Outreach Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.ukrp.tv/outreachradio.aac",
+      "homepage": "https://www.outreachradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://cdn.outreachradio.co.uk/wp-content/uploads/2020/11/cropped-logo_website.jpg",
+      "bitrate": 32,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-piestream",
+      "name": "Piestream",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.psymusic.co.uk/listen/piestream/hifi.mp3",
+      "homepage": "https://www.psymusic.co.uk/",
+      "country": "GB",
+      "favicon": "https://psymusic.co.uk/images/alien-head32.png",
+      "bitrate": 320,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-polish-radio-london",
+      "name": "Polish Radio London",
+      "broadcaster": "independent",
+      "streamUrl": "https://n19a-eu.rcs.revma.com/prfmwmwy768uv?rj-ttl=5&rj-tok=AAABnQg2ZmsA5RX2yPMR7AlE5w",
+      "homepage": "https://prl24.co.uk/",
+      "country": "GB",
+      "codec": "AAC",
+      "geo": [
+        51.5009,
+        -0.1159
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-camarthenshire",
+      "name": "Radio Camarthenshire",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-nation.sharp-stream.com/tccarmarthenshire.mp3",
+      "homepage": "https://www.nationplayer.com/radio-carmarthenshire/",
+      "country": "GB",
+      "tags": [
+        "local news",
+        "pop music",
+        "welsh language"
+      ],
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/thumb/a/ac/Radiocarmar.png/250px-Radiocarmar.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.69,
+        -4.1288
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radio-victory",
+      "name": "Radio Victory",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream3.themediasite.co.uk:8380/stream",
+      "homepage": "https://radiovictory.co.uk/",
+      "country": "GB",
+      "bitrate": 256,
+      "codec": "MP3",
+      "geo": [
+        50.8395,
+        -1.0703
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-radiowave-eu",
+      "name": "Radiowave.eu",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiowave.eu/hls/test/live.m3u8",
+      "homepage": "https://radiowave.eu/",
+      "country": "GB",
+      "favicon": "https://radiowave.eu/static/uploads/browser_icon/192.1743030143.png",
+      "bitrate": 211,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-raiders-radio",
+      "name": "Raiders Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.citrus3.com:8464/stream",
+      "homepage": "https://raidersradio.co.uk/",
+      "country": "GB",
+      "tags": [
+        "dnb",
+        "drum and bass",
+        "funky house",
+        "hard house",
+        "hard techno",
+        "house"
+      ],
+      "favicon": "https://raidersradio.co.uk/favicon.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        51.8983,
+        -1.1577
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-retrobyte-radio",
+      "name": "RetroByte Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://retrobytesradio.radioca.st/stream",
+      "homepage": "https://www.retrobyteradio.com/",
+      "country": "GB",
+      "tags": [
+        "retro",
+        "retro games",
+        "soundtracks",
+        "video game music"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        52.8593,
+        -3.0551
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-rtm-fm",
+      "name": "RTM.FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://streams.radio.co/s3d2f05f8f/listen",
+      "homepage": "https://rtm.fm/",
+      "country": "GB",
+      "favicon": "https://rtm.fm/favicon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.4993,
+        0.1091
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-selecta-radio-uk",
+      "name": "Selecta Radio UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.live365.com/a40232",
+      "homepage": "https://www.selectaradiouk.co.uk/",
+      "country": "GB",
+      "tags": [
+        "2tone",
+        "punk",
+        "reggae",
+        "ska"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        52.8699,
+        -1.6344
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-sle-radio-one",
+      "name": "SLE RADIO ONE",
+      "broadcaster": "independent",
+      "streamUrl": "https://sleradiogroup.com/listen/sle_radio_1/sleone.mp3",
+      "homepage": "https://sleradio.com/",
+      "country": "GB",
+      "favicon": "https://sleradio.com/station1.png",
+      "bitrate": 256,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-sle-radio-rave",
+      "name": "SLE RADIO RAVE",
+      "broadcaster": "independent",
+      "streamUrl": "https://sleradiogroup.com/listen/sle_radio_rave/radio.mp3",
+      "homepage": "https://sleradio.com/",
+      "country": "GB",
+      "favicon": "https://sleradio.com/station-rave.png",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-smooth-tyne-wear",
+      "name": "Smooth Tyne & Wear",
+      "broadcaster": "independent",
+      "streamUrl": "https://media-ice.musicradio.com/SmoothNorthEastNMP3",
+      "homepage": "https://www.smoothradio.com/",
+      "country": "GB",
+      "tags": [
+        "easy listening",
+        "newcastle",
+        "smooth"
+      ],
+      "favicon": "http://www.smoothradio.com/assets_v4r/smooth/img/favicon-196x196.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        54.9741,
+        -1.6197
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-toby-s-tunes",
+      "name": "Toby's Tunes",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.aiir.com/he5hocuryqbvv",
+      "homepage": "https://classichits.co.uk/",
+      "country": "GB",
+      "tags": [
+        "classic h"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-toohotradio-net",
+      "name": "TooHotRadio.net",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.toohotradio.net/128",
+      "homepage": "https://toohotradio.net/#",
+      "country": "GB",
+      "favicon": "https://toohotradio.net/resize/toohot2.png?w=180",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-ttns",
+      "name": "TTNS",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.thethursdaynightshow.com/live",
+      "homepage": "https://www.thethursdaynightshow.com/",
+      "country": "GB",
+      "tags": [
+        "eclectic",
+        "f",
+        "jazz"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.8204,
+        -0.1368
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-tuneskool-radio",
+      "name": "Tuneskool Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://c18.radioboss.fm:8423/stream",
+      "homepage": "https://tuneskoolradio.co.uk/",
+      "country": "GB",
+      "favicon": "https://tuneskoolradio.co.uk/wp-content/uploads/2024/01/Tune_school_radio-768x384.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-xpression-fm",
+      "name": "Xpression FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.broadcastradio.com:10855/xpression",
+      "homepage": "http://www.xpression.fm/",
+      "country": "GB",
+      "favicon": "http://www.xpression.fm/uploads/3/7/0/6/37062627/image-removebg-preview.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "gb-zack-fm",
+      "name": "Zack FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.streamer1.com/listen/zackfm/zackTEST.mp3",
+      "homepage": "https://www.zackfm.com/",
+      "country": "GB",
+      "favicon": "https://www.zackfm.com/templates/joomla3_005/images/logo.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
     }
   ]
 }

--- a/public/stations.json
+++ b/public/stations.json
@@ -72128,6 +72128,6456 @@
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
+    },
+    {
+      "id": "it-radio-armisa",
+      "name": "Radio Armisa",
+      "broadcaster": "independent",
+      "streamUrl": "https://onair.armisa.it/listen/armisa/radio.mp3",
+      "homepage": "https://armisa.it/",
+      "country": "IT",
+      "tags": [
+        "anni 80",
+        "anni 90",
+        "balera",
+        "dance",
+        "folk",
+        "italiana"
+      ],
+      "favicon": "https://armisa.it/assets/favicon/android-chrome-512x512.png",
+      "bitrate": 192,
+      "codec": "AAC",
+      "geo": [
+        46.3323,
+        10.2359
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-70-80-hits-hq",
+      "name": "70 80 Hits HQ",
+      "broadcaster": "independent",
+      "streamUrl": "https://nr8.newradio.it:19574/stream",
+      "homepage": "https://www.70-80.it/",
+      "country": "IT",
+      "tags": [
+        "320 kbps",
+        "70",
+        "70 80 hits",
+        "70 80 hits hq",
+        "70 music",
+        "70-80"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-classic-hits-radio-italia",
+      "name": "CLASSIC HITS RADIO Italia",
+      "broadcaster": "independent",
+      "streamUrl": "https://classichitsradio.streamingmedia.it/play",
+      "homepage": "http://classichits.radio/italy/",
+      "country": "IT",
+      "tags": [
+        "1970s",
+        "1980s",
+        "70's",
+        "70s",
+        "70s disco",
+        "80"
+      ],
+      "bitrate": 192,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-italia-italia-70",
+      "name": "ITALIA Italia 70",
+      "broadcaster": "independent",
+      "streamUrl": "https://icy.unitedradio.it/um020.mp3",
+      "homepage": "http://www.unitedmusic.it/",
+      "country": "IT",
+      "tags": [
+        "70s",
+        "italian",
+        "mediaset"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-italia-italia-80",
+      "name": "ITALIA Italia 80",
+      "broadcaster": "independent",
+      "streamUrl": "https://icy.unitedradio.it/um016.mp3",
+      "homepage": "http://www.unitedmusic.it/",
+      "country": "IT",
+      "tags": [
+        "80s",
+        "italian",
+        "mediaset"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-sportiva",
+      "name": "Radio Sportiva ",
+      "broadcaster": "independent",
+      "streamUrl": "https://sportiva.inmystream.it/stream/sportiva",
+      "homepage": "https://www.radiosportiva.com/",
+      "country": "IT",
+      "tags": [
+        "sport"
+      ],
+      "favicon": "https://www.radiosportiva.com/wp-content/uploads/2021/09/logo-radiosportiva-white.svg",
+      "bitrate": 36,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-new-hits-radio-italia",
+      "name": "NEW HITS RADIO Italia",
+      "broadcaster": "independent",
+      "streamUrl": "https://newhitsradio.streamingmedia.it/play",
+      "homepage": "https://newhits.radio/",
+      "country": "IT",
+      "tags": [
+        "hits",
+        "new hits"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-sei-italia",
+      "name": "Radio Sei (Italia)",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.ithost.it/radiosei.ogg",
+      "homepage": "https://www.radiosei.it/",
+      "country": "IT",
+      "tags": [
+        "talk"
+      ],
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/thumb/e/ec/Soccer_ball.svg/480px-Soccer_ball.svg.png",
+      "bitrate": 32,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-retesport-italia",
+      "name": "Retesport (Italia)",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.ithost.it/retesport.ogg",
+      "homepage": "https://www.retesport.it/",
+      "country": "IT",
+      "tags": [
+        "talk"
+      ],
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/thumb/e/ec/Soccer_ball.svg/480px-Soccer_ball.svg.png",
+      "bitrate": 48,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-mana-mana-sport-roma",
+      "name": "Radio Manà Manà Sport Roma",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream10.xdevel.com/audio2s975363-2142/stream/icecast.audio",
+      "homepage": "https://www.manamanasportroma.it/",
+      "country": "IT",
+      "tags": [
+        "as roma",
+        "sports talk"
+      ],
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-italian-radio-only-romantic-italian-music",
+      "name": "ITALIAN RADIO - Only (romantic) Italian Music",
+      "broadcaster": "independent",
+      "streamUrl": "https://italianradio.streamingmedia.it/play",
+      "homepage": "http://italian.radio/",
+      "country": "IT",
+      "tags": [
+        "classic italian pop",
+        "love songs"
+      ],
+      "bitrate": 96,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-virgin-radio-rockstar-rolling-stones",
+      "name": "Virgin Radio Rockstar: Rolling Stones",
+      "broadcaster": "independent",
+      "streamUrl": "https://icy.unitedradio.it/VirginSpecialEvent.mp3",
+      "homepage": "https://www.virginradio.it/sezioni/1855/Music-Star-Rolling-Stones",
+      "country": "IT",
+      "tags": [
+        "blues rock",
+        "hard rock",
+        "mediaset",
+        "rock",
+        "rock and roll",
+        "rolling stones"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-lolli-radio-italia",
+      "name": "Lolli Radio Italia",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.lolliradio.net/lolli_italia.mp3",
+      "homepage": "http://lolliradio.net/",
+      "country": "IT",
+      "tags": [
+        "italian pop"
+      ],
+      "favicon": "http://www.lolliradio.net/wp-content/uploads/2016/02/logo_italia-150x150.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-70-80-disco-funk-modernsoul-e-boogie",
+      "name": "70 80 Disco Funk ModernSoul e Boogie",
+      "broadcaster": "independent",
+      "streamUrl": "https://discofunk.streamingmedia.it/play",
+      "homepage": "https://funky.radio/disco/",
+      "country": "IT",
+      "tags": [
+        "1970s",
+        "1980s",
+        "70's",
+        "70er",
+        "70s",
+        "70s disco"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-lattemiele",
+      "name": "Lattemiele",
+      "broadcaster": "independent",
+      "streamUrl": "https://sr15.inmystream.it:8000/stream",
+      "homepage": "https://lattemiele.com/",
+      "country": "IT",
+      "tags": [
+        "musica italiana"
+      ],
+      "favicon": "https://www.lattemiele.com/wp-content/uploads/2020/07/cropped-logo-autore-lm-32x32.png",
+      "bitrate": 256,
+      "codec": "MP3",
+      "geo": [
+        45.474,
+        9.1736
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-rds-relax",
+      "name": "RDS Relax",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rds.radio/audio/rdsrelax.stream_aac/playlist.m3u8",
+      "homepage": "https://rdsrelax.it/",
+      "country": "IT",
+      "tags": [
+        "easy listening",
+        "relax"
+      ],
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-romanista",
+      "name": "Radio Romanista",
+      "broadcaster": "independent",
+      "streamUrl": "https://romanista.newradio.it/stream",
+      "homepage": "https://www.radioromanista.it/",
+      "country": "IT",
+      "tags": [
+        "roma",
+        "sport",
+        "talk"
+      ],
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-rtr-99-canale-pooh",
+      "name": "RTR 99 Canale Pooh",
+      "broadcaster": "independent",
+      "streamUrl": "https://rtr99.fluidstream.eu/rtr99_pooh.mp3",
+      "homepage": "https://www.rtr99.it/",
+      "country": "IT",
+      "tags": [
+        "italian pop",
+        "pop rock"
+      ],
+      "favicon": "https://www.rtr99.it/onair/CanalePooh/OnAir.jpg?x=9f2sj07zxxhpl2i1aocli",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-romantica-radio",
+      "name": "ROMANTICA-RADIO",
+      "broadcaster": "independent",
+      "streamUrl": "https://vetrina.multi-radio.com/romanticaradio",
+      "homepage": "https://www.romanticaradio.it/",
+      "country": "IT",
+      "favicon": "https://romanticaradio.it/wp-content/uploads/2022/05/cropped-favicon_romantica-180x180.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-70-80-90-marche",
+      "name": " Radio 70 80 90 Marche",
+      "broadcaster": "independent",
+      "streamUrl": "https://rblive.it:8020/radio.mp3",
+      "homepage": "https://www.radio708090.it/",
+      "country": "IT",
+      "tags": [
+        "70s",
+        "80s",
+        "90s",
+        "italy"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-neu-radio",
+      "name": "NEU RADIO",
+      "broadcaster": "independent",
+      "streamUrl": "https://nr9.newradio.it/proxy/ebaruffa?mp=/stream",
+      "homepage": "https://www.neuradio.it/",
+      "country": "IT",
+      "tags": [
+        "afrobeats",
+        "alternative",
+        "ambient",
+        "arts",
+        "beats",
+        "black"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-energy-classic-italy",
+      "name": "_Radio Energy Classic (Italy)",
+      "broadcaster": "independent",
+      "streamUrl": "https://gmusto3.radioca.st/stream",
+      "homepage": "https://www.radioenergy.to/",
+      "country": "IT",
+      "tags": [
+        "70s",
+        "80s",
+        "90s",
+        "classic hits",
+        "classic rock",
+        "disco"
+      ],
+      "favicon": "https://www.radioenergy.to/favicon.ico",
+      "bitrate": 224,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-bianconera",
+      "name": "Radio Bianconera",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.tmwradio.com/bianconera.aac",
+      "homepage": "http://www.radiobianconera.com/",
+      "country": "IT",
+      "tags": [
+        "sport",
+        "talk",
+        "torino"
+      ],
+      "favicon": "http://players.fluidstream.it/RadioBiancoNera/icon.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-80-afro",
+      "name": "Radio 80 Afro",
+      "broadcaster": "independent",
+      "streamUrl": "https://sphera.fluidstream.eu/r80_afro.mp3",
+      "homepage": "https://www.radio80.it/",
+      "country": "IT",
+      "tags": [
+        "disco",
+        "funk",
+        "r&b",
+        "soul"
+      ],
+      "favicon": "https://www.radio80.it/wp-content/uploads/2015/02/logo-radio80-1.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-one-dance",
+      "name": "One Dance",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice04.fluidstream.net/rn1_2.aac",
+      "homepage": "https://onedance.fm/",
+      "country": "IT",
+      "tags": [
+        "dance",
+        "reggaeton"
+      ],
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-italiana",
+      "name": "RADIO ITALIANA",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiorossini.stream.laut.fm/radiorossini",
+      "homepage": "https://radioitaliana.it/",
+      "country": "IT",
+      "favicon": "https://cdn.sedo.com/c7r/assets/static/images/icons/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-subasio",
+      "name": "RADIO SUBASIO",
+      "broadcaster": "independent",
+      "streamUrl": "https://icy.unitedradio.it/Subasio.mp3",
+      "homepage": "https://www.radiosubasio.it/",
+      "country": "IT",
+      "favicon": "https://www.radiosubasio.it/wp-content/themes/radiosubasiov2/assets/images/logo-radio-subasio.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-freccia",
+      "name": "Radio Freccia",
+      "broadcaster": "independent",
+      "streamUrl": "https://dd782ed59e2a4e86aabf6fc508674b59.msvdn.net/live/S3160845/0tuSetc8UFkF/playlist_audio.m3u8",
+      "homepage": "https://www.radiofreccia.it/",
+      "country": "IT",
+      "tags": [
+        "classic rock",
+        "oldies",
+        "rock"
+      ],
+      "favicon": "https://cloud.radiofreccia.it/assets/www.radiofreccia.it/1.0.43/img/logo/android-icon-192x192.png",
+      "bitrate": 192,
+      "codec": "AAC",
+      "geo": [
+        45.5238,
+        9.2658
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-italia-hits-italia",
+      "name": "ITALIA Hits Italia",
+      "broadcaster": "independent",
+      "streamUrl": "https://icy.unitedradio.it/um011.mp3",
+      "homepage": "http://www.unitedmusic.it/",
+      "country": "IT",
+      "tags": [
+        "italian",
+        "mediaset"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-capital-it",
+      "name": "Radio Capital IT",
+      "broadcaster": "independent",
+      "streamUrl": "https://streamcdnr8-4c4b867c89244861ac216426883d1ad0.msvdn.net/radiocapital/radiocapital/play1.m3u8",
+      "homepage": "https://www.capital.it/",
+      "country": "IT",
+      "favicon": "https://upload.wikimedia.org/wikipedia/it/thumb/3/38/Radio_Capital_logo_%282020%29.svg/1200px-Radio_Capital_logo_%282020%29.svg.png",
+      "codec": "UNKNOWN",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-lolli-radio-dance",
+      "name": "Lolli Radio Dance",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.lolliradio.net/lolli_dance.mp3",
+      "homepage": "http://www.lolliradio.net/",
+      "country": "IT",
+      "tags": [
+        "dance",
+        "house"
+      ],
+      "favicon": "http://www.lolliradio.net/wp-content/uploads/2016/02/logo_dance-150x150.jpg",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-italia-italia-90",
+      "name": "ITALIA Italia 90",
+      "broadcaster": "independent",
+      "streamUrl": "https://icy.unitedradio.it/um018.mp3",
+      "homepage": "http://www.unitedmusic.it/",
+      "country": "IT",
+      "tags": [
+        "90s",
+        "italian",
+        "mediaset"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-virgin-radio-rockstar-queen",
+      "name": "Virgin Radio Rockstar: Queen",
+      "broadcaster": "independent",
+      "streamUrl": "https://icy.unitedradio.it/Virgin_05.mp3",
+      "homepage": "https://www.virginradio.it/sezioni/1981/music-star-queen",
+      "country": "IT",
+      "tags": [
+        "art rock",
+        "glam rock",
+        "hard rock",
+        "mediaset",
+        "pop rock",
+        "queen"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-rmc-music-star-george-michael",
+      "name": "RMC Music Star George Michael",
+      "broadcaster": "independent",
+      "streamUrl": "https://icy.unitedradio.it/MusicStarPrince.mp3",
+      "homepage": "https://www.radiomontecarlo.net/sezioni/11757/music-star-george-michael",
+      "country": "IT",
+      "tags": [
+        "pop"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-capital-funky-town",
+      "name": "Radio Capital Funky Town",
+      "broadcaster": "independent",
+      "streamUrl": "https://4c4b867c89244861ac216426883d1ad0.msvdn.net/radiocapitalfunkytown/radiocapitalfunkytown/master_ma.m3u8",
+      "homepage": "https://www.capital.it/",
+      "country": "IT",
+      "tags": [
+        "disco funk",
+        "funk",
+        "funky",
+        "groove",
+        "rare groove"
+      ],
+      "favicon": "https://cdn.gelestatic.it/capital/sites/2/2016/11/webradio-funkytown2-320x320.jpg",
+      "bitrate": 122,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-giornale-radio",
+      "name": "Giornale Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://gr.fluidstream.eu/gr1.mp3",
+      "homepage": "https://giornaleradio.fm/",
+      "country": "IT",
+      "favicon": "https://giornaleradio.fm/apple-touch-icon.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-company",
+      "name": "Radio Company",
+      "broadcaster": "independent",
+      "streamUrl": "https://sphera.fluidstream.eu/company.aac",
+      "homepage": "https://www.radiocompany.com/",
+      "country": "IT",
+      "tags": [
+        "hits",
+        "news"
+      ],
+      "favicon": "https://www.radiocompany.com/wp-content/uploads/fbrfg/apple-touch-icon.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-united-music-italia-2000",
+      "name": "United Music Italia 2000",
+      "broadcaster": "independent",
+      "streamUrl": "https://icy.unitedradio.it/um013.mp3",
+      "homepage": "https://www.unitedmusic.com/",
+      "country": "IT",
+      "tags": [
+        "music non stop",
+        "musica italiana"
+      ],
+      "favicon": "https://www.unitedmusic.com/favicon_6.ico?v=1722509814047",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-50s-60s-retro-hits",
+      "name": " 50s 60s RETRO HITS",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.zeno.fm/pxzwykxbluitv",
+      "homepage": "https://zeno.fm/radio/50s-60s-retro-hits/",
+      "country": "IT",
+      "tags": [
+        "50s",
+        "60s",
+        "classic hits",
+        "classic rock",
+        "community radio",
+        "fm"
+      ],
+      "favicon": "https://static.wixstatic.com/media/f361b3_ea9b293c1b80488d97f24981e7c6c1d3~mv2.jpg",
+      "codec": "MP3",
+      "geo": [
+        41.3583,
+        13.347
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-dumdum",
+      "name": "DumDUM",
+      "broadcaster": "independent",
+      "streamUrl": "https://sr11.inmystream.it/proxy/dumdumradio",
+      "homepage": "https://www.dumdumrepublic.com/it/radio-it/in-ascolto",
+      "country": "IT",
+      "tags": [
+        "indie rock",
+        "instrumental",
+        "organic house"
+      ],
+      "favicon": "https://www.dumdumrepublic.com/images/favicon-96x96.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        40.4057,
+        15.0007
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-italia-italia-60",
+      "name": "ITALIA Italia 60",
+      "broadcaster": "independent",
+      "streamUrl": "https://icy.unitedradio.it/um014.mp3",
+      "homepage": "http://www.unitedmusic.it/",
+      "country": "IT",
+      "tags": [
+        "60s",
+        "italian",
+        "mediaset"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-italia-anni-60",
+      "name": "Radio Italia anni 60",
+      "broadcaster": "independent",
+      "streamUrl": "https://str01.fluidstream.net/anni60.mp3",
+      "homepage": "https://www.radioitaliaanni60.it/",
+      "country": "IT",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-cavolo",
+      "name": "Radio Cavolo",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiocavolo.org/stream",
+      "homepage": "https://www.radiocavolo.org/",
+      "country": "IT",
+      "tags": [
+        "eclectic",
+        "electronic",
+        "pop",
+        "rock",
+        "talk",
+        "university radio"
+      ],
+      "favicon": "https://www.radiocavolo.org/wp-content/uploads/2020/10/cropped-radio-cavolo-logo-white-background-300x300-1-180x180.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-raisport",
+      "name": "Radio RaiSport",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecdn-19d24861e90342cc8decb03c24c8a419.msvdn.net/icecastRelay/S74167340/mmNY37FME5Zl/icecast",
+      "homepage": "https://www.raiplaysound.it/radio1sport",
+      "country": "IT",
+      "favicon": "https://static.mytuner.mobi/media/tvos_radios/ramgajabuhqm.jpg",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-lifegate-radio",
+      "name": "LifeGate Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://router.xdevel.com/audio0s975809-345/stream/icecast.audio",
+      "homepage": "https://www.lifegate.it/lifegate-radio",
+      "country": "IT",
+      "favicon": "https://www.fm-world.it/wp-content/uploads/2019/04/liferadio.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-forever-80",
+      "name": "FOREVER 80",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/forever80",
+      "homepage": "https://forever80.altervista.org/",
+      "country": "IT",
+      "tags": [
+        "80s",
+        "dance"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-crc",
+      "name": "Radio CRC",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream9.xdevel.com/audio2s975936-745/stream/icecast.audio",
+      "homepage": "https://crcnews.it/",
+      "country": "IT",
+      "tags": [
+        "local news",
+        "sport",
+        "sports news",
+        "talk"
+      ],
+      "favicon": "https://crcnews.it/favicon.ico",
+      "codec": "MP3",
+      "geo": [
+        40.8343,
+        14.2458
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-rtr-99-canzoni-e-parole-fuori-dal-coro",
+      "name": "RTR 99 Canzoni e parole fuori dal coro",
+      "broadcaster": "independent",
+      "streamUrl": "https://rtr99.fluidstream.eu/rtr99.mp3?FLID=3",
+      "homepage": "https://rtr99.it/",
+      "country": "IT",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-italia-millenials-italy",
+      "name": "ITALIA Millenials Italy",
+      "broadcaster": "independent",
+      "streamUrl": "https://icy.unitedradio.it/um021.mp3",
+      "homepage": "http://www.unitedmusic.it/",
+      "country": "IT",
+      "tags": [
+        "italian",
+        "mediaset"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-rmc-music-star-pino-daniele",
+      "name": "RMC Music Star Pino Daniele",
+      "broadcaster": "independent",
+      "streamUrl": "https://icy.unitedradio.it/Daniele.mp3",
+      "homepage": "https://www.radiomontecarlo.net/sezioni/10487/music-star-pino-daniele",
+      "country": "IT",
+      "tags": [
+        "italian pop",
+        "pino daniele",
+        "pop"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-radicale",
+      "name": "Radio Radicale",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.radioradicale.it/live.mp3",
+      "homepage": "https://www.radioradicale.it/",
+      "country": "IT",
+      "favicon": "https://www.radioradicale.it/sites/www.radioradicale.it/files/favicon_0.ico",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-relax-italia",
+      "name": "RADIO RELAX Italia",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiorelax.streamingmedia.it/play",
+      "homepage": "https://radiorel.ax/",
+      "country": "IT",
+      "tags": [
+        "80s",
+        "90s",
+        "classic italian pop",
+        "easy listening",
+        "italian music",
+        "italian pop"
+      ],
+      "bitrate": 192,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-gamma-radio-golden-hits",
+      "name": "Gamma Radio - Golden Hits",
+      "broadcaster": "independent",
+      "streamUrl": "https://rn2.fluidstream.eu/gammaradio.mp3?FLID=1&type=.mp3",
+      "homepage": "https://www.gammaradio.it/",
+      "country": "IT",
+      "tags": [
+        "classic hits",
+        "musica anni 70",
+        "musica anni 80"
+      ],
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-italia-amore",
+      "name": "ITALIA Amore",
+      "broadcaster": "independent",
+      "streamUrl": "https://icy.unitedradio.it/um012.mp3",
+      "homepage": "http://www.unitedmusic.it/",
+      "country": "IT",
+      "tags": [
+        "italian",
+        "mediaset"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-music-star-franco-battiato",
+      "name": "Music Star Franco Battiato",
+      "broadcaster": "independent",
+      "streamUrl": "https://icy.unitedradio.it/um057.mp3",
+      "homepage": "https://www.radiomontecarlo.net/sezioni/12144/music-star-franco-battiato",
+      "country": "IT",
+      "tags": [
+        "mediaset",
+        "pop"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-italia-sanremo",
+      "name": "Radio Italia Sanremo",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream4.xdevel.com/audio2s976608-1381/stream/icecast.audio",
+      "homepage": "https://www.radioitalia.it/",
+      "country": "IT",
+      "tags": [
+        "italian pop"
+      ],
+      "favicon": "https://www.radioitalia.it/images/logo-webradio-sanremo.png",
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-rmc-r-b",
+      "name": "RMC R&B",
+      "broadcaster": "independent",
+      "streamUrl": "https://icy.unitedradio.it/rmcweb003",
+      "homepage": "https://www.radiomontecarlo.net/sezioni/12052/radio-monte-carlo-r-b",
+      "country": "IT",
+      "tags": [
+        "r&b"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-rete-radio-azzurra",
+      "name": "rete radio azzurra",
+      "broadcaster": "independent",
+      "streamUrl": "https://reteradioazzurra.radioca.st/stream",
+      "homepage": "https://www.reteradioazzurra.it/",
+      "country": "IT",
+      "favicon": "https://www.reteradioazzurra.it/",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-70-80-90-dance-marche",
+      "name": "Radio 70 80 90 Dance Marche",
+      "broadcaster": "independent",
+      "streamUrl": "https://rblive.it:8060/radio.mp3",
+      "homepage": "https://www.radio708090.it/diretta-dance/",
+      "country": "IT",
+      "tags": [
+        "dance",
+        "oldies"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-italia-viva-napoli",
+      "name": "ITALIA Viva Napoli",
+      "broadcaster": "independent",
+      "streamUrl": "https://icy.unitedradio.it/um017.mp3",
+      "homepage": "http://www.unitedmusic.it/",
+      "country": "IT",
+      "tags": [
+        "italian",
+        "mediaset",
+        "napoli"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-globo-vintage",
+      "name": "Globo Vintage",
+      "broadcaster": "independent",
+      "streamUrl": "https://m100.newradio.it/m100-64",
+      "homepage": "http://www.globovintage.it/",
+      "country": "IT",
+      "tags": [
+        "70s",
+        "80s",
+        "90s",
+        "classic hits",
+        "roma"
+      ],
+      "favicon": "https://static.wixstatic.com/media/cb9577_389d27d8f1214dfba6d28a9381d7ccdc%7emv2.png/v1/fill/w_180%2ch_180%2clg_1%2cusm_0.66_1.00_0.01/cb9577_389d27d8f1214dfba6d28a9381d7ccdc%7emv2.png",
+      "bitrate": 96,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-popolare",
+      "name": "Radio Popolare",
+      "broadcaster": "independent",
+      "streamUrl": "https://livex.radiopopolare.it/radiopop2",
+      "homepage": "https://www.radiopopolare.it/",
+      "country": "IT",
+      "tags": [
+        "network",
+        "popolare"
+      ],
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-tmw-radio",
+      "name": "TMW Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.tmwradio.com/tmw.aac",
+      "homepage": "https://www.tmwradio.com/",
+      "country": "IT",
+      "favicon": "https://www.tmwradio.com/template/tmwradio.com/default/favicon/favicon144.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-deegay-pop-dance",
+      "name": "DeeGay Pop & Dance",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.deegay.fm/deegay1.mp3",
+      "homepage": "https://www.deegay.fm/",
+      "country": "IT",
+      "tags": [
+        "dance",
+        "pop"
+      ],
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-lolli-radio-hits",
+      "name": "Lolli Radio Hits",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.lolliradio.net/lolli_hits.mp3",
+      "homepage": "http://www.lolliradio.net/",
+      "country": "IT",
+      "tags": [
+        "hits",
+        "top 40"
+      ],
+      "favicon": "http://www.lolliradio.net/wp-content/uploads/2016/02/logo_hits-150x150.jpg",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-100-nu-disco-central-radio",
+      "name": " # 100 NU-DISCO CENTRAL RADIO",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.zeno.fm/jqhhzffjynbuv",
+      "homepage": "https://zeno.fm/radio/100-nu-disco-central-radio/",
+      "country": "IT",
+      "tags": [
+        "club dance",
+        "clubbing",
+        "community radio",
+        "dance",
+        "dance hits",
+        "disco"
+      ],
+      "favicon": "https://static.wixstatic.com/media/f361b3_66f56cd8d2f44aed871cfd62bf70af65~mv2.jpg",
+      "codec": "MP3",
+      "geo": [
+        41.8604,
+        12.4426
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-deejay-80",
+      "name": "Deejay 80",
+      "broadcaster": "independent",
+      "streamUrl": "https://4c4b867c89244861ac216426883d1ad0.msvdn.net/webradio/deejay80/playlist.m3u8",
+      "homepage": "https://www.deejay.it/",
+      "country": "IT",
+      "tags": [
+        "1980s",
+        "80 hits",
+        "80's",
+        "80s",
+        "80s rock",
+        "hits 80s"
+      ],
+      "favicon": "https://www.deejay.it/favicon.ico",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-italia-rock-italiano",
+      "name": "ITALIA Rock Italiano",
+      "broadcaster": "independent",
+      "streamUrl": "https://icy.unitedradio.it/um076.mp3",
+      "homepage": "http://www.unitedmusic.it/",
+      "country": "IT",
+      "tags": [
+        "italian",
+        "mediaset",
+        "rock"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-nature-radio-sleep",
+      "name": "NATURE RADIO SLEEP",
+      "broadcaster": "independent",
+      "streamUrl": "https://az1.mediacp.eu/listen/natureradiosleep/radio.mp3",
+      "homepage": "https://natureradiosleep.weebly.com/",
+      "country": "IT",
+      "tags": [
+        "ambient",
+        "bird",
+        "city",
+        "easy listening",
+        "forest",
+        "italy"
+      ],
+      "favicon": "https://d1ujqdpfgkvqfi.cloudfront.net/favicon-generator/htdocs/favicons/2025-03-01/fb714c8d8238b02673a9ee2b018528af.ico.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        41.8184,
+        12.9324
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-deegay-classic",
+      "name": "DeeGay Classic",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.deegay.fm/deegay2.mp3",
+      "homepage": "https://www.deegay.fm/",
+      "country": "IT",
+      "tags": [
+        "classic hits"
+      ],
+      "favicon": "https://play5.newradio.it/contents/uploads/logo-43441.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-virgin-radio-rockstar-bon-jovi",
+      "name": "Virgin Radio Rockstar: Bon Jovi",
+      "broadcaster": "independent",
+      "streamUrl": "https://icy.unitedradio.it/um1027.mp3",
+      "homepage": "https://www.virginradio.it/sezioni/12080/rockstar-bon-jovi",
+      "country": "IT",
+      "tags": [
+        "bon jovi",
+        "mediaset",
+        "rock"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-funky-radio",
+      "name": "Funky Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://funkyradio.streamingmedia.it/play.mp3",
+      "homepage": "https://funky.radio/",
+      "country": "IT",
+      "tags": [
+        "funky"
+      ],
+      "favicon": "https://funky.radio/wp-content/uploads/2024/05/funky.radio_logo_300x300.webp",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        45.4655,
+        9.1956
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-giornale-radio-ultima-ora",
+      "name": "Giornale Radio Ultima Ora",
+      "broadcaster": "independent",
+      "streamUrl": "https://gr.fluidstream.eu/gr2.mp3",
+      "homepage": "https://giornaleradio.fm/radio-tematiche/giornale-radio-ultima-ora.html",
+      "country": "IT",
+      "tags": [
+        "news"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-easy-rock",
+      "name": "Radio Easy Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://sphera.fluidstream.eu/easyrock.aac",
+      "homepage": "https://www.radioeasyrock.it/",
+      "country": "IT",
+      "tags": [
+        "alternative rock",
+        "classic rock",
+        "rock"
+      ],
+      "favicon": "https://www.radioeasyrock.it/wp-content/uploads/2023/01/radio-easy-rock-logo-1.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-rmc-acoustic",
+      "name": "RMC Acoustic",
+      "broadcaster": "independent",
+      "streamUrl": "https://icy.unitedradio.it/rmcweb016",
+      "homepage": "https://www.radiomontecarlo.net/sezioni/11911/radio-monte-carlo-acoustic",
+      "country": "IT",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-deegay-club",
+      "name": "DeeGay Club",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.deegay.fm/deegay3.mp3",
+      "homepage": "https://www.deegay.fm/",
+      "country": "IT",
+      "tags": [
+        "electronic",
+        "house"
+      ],
+      "favicon": "https://www.deegay.fm/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-venezia",
+      "name": "Radio Venezia",
+      "broadcaster": "independent",
+      "streamUrl": "https://audio.streamshow.it/proxy/rveradiocheballa?mp",
+      "homepage": "https://www.veneziaradiotv.it/",
+      "country": "IT",
+      "tags": [
+        "pop"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-rai-radiodue",
+      "name": "Rai RadioDue",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecdn-19d24861e90342cc8decb03c24c8a419.msvdn.net/icecastRelay/S35942484/yp5F67151K92/icecast",
+      "homepage": "https://www.raiplaysound.it/radio2",
+      "country": "IT",
+      "tags": [
+        "pop music"
+      ],
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-rmc-music-star-coldplay",
+      "name": "RMC Music Star Coldplay",
+      "broadcaster": "independent",
+      "streamUrl": "https://icy.unitedradio.it/ColdPlay.mp3",
+      "homepage": "https://www.radiomontecarlo.net/sezioni/10489/music-star-coldplay",
+      "country": "IT",
+      "tags": [
+        "coldplay",
+        "pop"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-bandito",
+      "name": "Radio Bandito",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.radio.co/s8add5b3eb/listen",
+      "homepage": "https://radiobandito.it/",
+      "country": "IT",
+      "favicon": "https://www.radiobandito.it/wp-content/uploads/2022/04/cropped-cropped-rb-180x180.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-italia-anni-60-emilia-romagna-e-marche",
+      "name": "Radio Italia Anni 60 (Emilia-Romagna e Marche)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice04.fluidstream.net/ria60_bo.mp3",
+      "homepage": "https://radioitaliaannisessanta.it/",
+      "country": "IT",
+      "tags": [
+        "60s",
+        "70s",
+        "80s",
+        "90s"
+      ],
+      "favicon": "https://radioitaliaannisessanta.it/templates/enar/images/favicon/apple-touch-icon-120x120.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-lolli-radio-happy-station",
+      "name": "Lolli Radio Happy Station",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.lolliradio.net/lolli_happy.mp3",
+      "homepage": "http://www.lolliradio.net/",
+      "country": "IT",
+      "tags": [
+        "world music"
+      ],
+      "favicon": "http://www.lolliradio.net/wp-content/uploads/2016/02/logo_happy-150x150.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-70-80-90",
+      "name": "70 80 90",
+      "broadcaster": "independent",
+      "streamUrl": "https://rblive.it:8170/radio.mp3",
+      "homepage": "https://www.radio708090.it/",
+      "country": "IT",
+      "tags": [
+        "70's",
+        "70s",
+        "80's",
+        "80s",
+        "90's",
+        "90s"
+      ],
+      "favicon": "https://www.radio708090.it/wp-content/uploads/2021/10/708090-160-150x150.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-electro-lounge",
+      "name": "Electro Lounge",
+      "broadcaster": "independent",
+      "streamUrl": "https://electrolounge.stream.laut.fm/electrolounge?pl=m3u&t302=2026-01-14_23-25-32&uuid=4a7f7217-7b1e-45d3-8bd7-ee9f329c080e",
+      "homepage": "https://www.electrolounge.eu/",
+      "country": "IT",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-rtl-102-5-best",
+      "name": "RTL 102.5 Best",
+      "broadcaster": "independent",
+      "streamUrl": "https://streamingv2.shoutcast.com/rtl-1025-best",
+      "homepage": "https://play.rtl.it/live/2/best/",
+      "country": "IT",
+      "tags": [
+        "best music",
+        "top"
+      ],
+      "favicon": "https://cloud.rtl.it/assets/play.rtl.it/2.1.5/img/logo/favicon-96x96.png",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-milano-xr",
+      "name": "Milano XR",
+      "broadcaster": "independent",
+      "streamUrl": "https://milanoxr.gatesweb.info:8443/live",
+      "homepage": "http://milanoxr.weebly.com/",
+      "country": "IT",
+      "tags": [
+        "alternative rock",
+        "classic rock",
+        "rock"
+      ],
+      "favicon": "https://milanoxr.gatesweb.info:8443/milanoxr_logo-300-sq.jpg",
+      "bitrate": 96,
+      "codec": "AAC+",
+      "geo": [
+        45.4658,
+        9.1678
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-easy-network-jazz-soul",
+      "name": "Easy Network Jazz & Soul",
+      "broadcaster": "independent",
+      "streamUrl": "https://sphera.fluidstream.eu/easy_jazz.mp3",
+      "homepage": "https://www.easynetwork.fm/",
+      "country": "IT",
+      "tags": [
+        "jazz",
+        "padova",
+        "soul"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-venice-classic-radio-auditorium",
+      "name": "Venice Classic Radio Auditorium",
+      "broadcaster": "independent",
+      "streamUrl": "https://uk2.streamingpulse.com/ssl/vcr2",
+      "homepage": "https://www.veniceclassicradio.eu/",
+      "country": "IT",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        45.4364,
+        12.3342
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-china-fm-fm89-5",
+      "name": "华夏之声China FM·意大利罗马FM89.5",
+      "broadcaster": "independent",
+      "streamUrl": "https://radioserver12.profesionalhosting.com/proxy/pkg152492/stream",
+      "homepage": "https://chinafm.es/",
+      "country": "IT",
+      "tags": [
+        "information",
+        "music",
+        "oldies"
+      ],
+      "bitrate": 160,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-bruno-pentasport-fiorentina",
+      "name": "\tRadio Bruno Pentasport Fiorentina",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream3.xdevel.com/audio6s975355-281/stream/icecast.audio",
+      "homepage": "http://www.radiobrunotoscana.it/",
+      "country": "IT",
+      "favicon": "https://www.radiobruno.it/wp-content/uploads/2023/10/logo-148-90-black1.png",
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-rmc-music-star-zucchero",
+      "name": "RMC Music Star Zucchero",
+      "broadcaster": "independent",
+      "streamUrl": "https://icy.unitedradio.it/Zucchero.mp3",
+      "homepage": "https://www.radiomontecarlo.net/sezioni/10492/music-star-zucchero",
+      "country": "IT",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-olympia",
+      "name": "Radio Olympia",
+      "broadcaster": "independent",
+      "streamUrl": "https://sr6.inmystream.it/proxy/radiosonica2?mp=/stream",
+      "homepage": "https://www.radioolympia.it/",
+      "country": "IT",
+      "favicon": "https://www.radioolympia.it/favicon.png",
+      "bitrate": 32,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-deejay-suona-italia",
+      "name": "Deejay Suona Italia",
+      "broadcaster": "independent",
+      "streamUrl": "https://4c4b867c89244861ac216426883d1ad0.msvdn.net/webradio/deejaysuonaitalia/playlist.m3u8",
+      "homepage": "https://www.deejay.it/",
+      "country": "IT",
+      "tags": [
+        "classic italian pop",
+        "italian",
+        "italian music",
+        "italian pop",
+        "italy",
+        "musica italiana"
+      ],
+      "favicon": "https://cdn.gelestatic.it/deejay/sites/2/2015/05/webradio_deejay_suona_italia-320x320.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-margherita",
+      "name": "\tRadio Margherita ",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.radiomargherita.com/stream/radiomargherita",
+      "homepage": "http://www.radiomargherita.com/",
+      "country": "IT",
+      "favicon": "http://www.radiomargherita.com/favicon.ico",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-giornale-radio-la-dolce-vita",
+      "name": "Giornale Radio La Dolce Vita",
+      "broadcaster": "independent",
+      "streamUrl": "https://gr.fluidstream.eu/gr7.mp3",
+      "homepage": "https://giornaleradio.fm/radio-tematiche/giornale-radio-dolce-la-vita.html",
+      "country": "IT",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-rai-isoradio",
+      "name": "Rai Isoradio",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecdn-19d24861e90342cc8decb03c24c8a419.msvdn.net/icecastRelay/S3822289/9T4F68Q3TT4m/icecast",
+      "homepage": "https://www.raiplaysound.it/isoradio",
+      "country": "IT",
+      "tags": [
+        "pop music"
+      ],
+      "favicon": "https://www.raiplaysound.it/assets/img/canali/logo-raiisoradio.svg",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-rock",
+      "name": "Radio Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://onlineradiobox.com/json/it/radiorock/play?platform=web",
+      "homepage": "http://www.radiorock.it/",
+      "country": "IT",
+      "bitrate": 64,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-rouge-italy",
+      "name": " Radio Rouge Italy",
+      "broadcaster": "independent",
+      "streamUrl": "https://nl1.streamingpulse.com/ssl/radiorougeitaly",
+      "homepage": "https://radiorouge.com/",
+      "country": "IT",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        42.5272,
+        14.0625
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-lolli-radio-soft",
+      "name": "Lolli Radio Soft",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.lolliradio.net/lolli_soft.mp3",
+      "homepage": "http://lolliradio.net/",
+      "country": "IT",
+      "tags": [
+        "soft adult contemporary"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-rmc-music-star-tiziano-ferro",
+      "name": "RMC Music Star Tiziano Ferro",
+      "broadcaster": "independent",
+      "streamUrl": "https://icy.unitedradio.it/Ferro.mp3",
+      "homepage": "https://www.radiomontecarlo.net/sezioni/10491/music-star-tiziano-ferro",
+      "country": "IT",
+      "tags": [
+        "italian pop",
+        "pop",
+        "tiziano ferro"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-gedi-radio-capital-funky-town",
+      "name": "GEDI - Radio Capital Funky Town",
+      "broadcaster": "independent",
+      "streamUrl": "https://streamcdnr11-4c4b867c89244861ac216426883d1ad0.msvdn.net/radiocapitalfunkytown/radiocapitalfunkytown/play1.m3u8",
+      "homepage": "https://www.capital.it/webradio/03/",
+      "country": "IT",
+      "tags": [
+        "funk"
+      ],
+      "favicon": "https://www.capital.it/wp-content/themes/network-capital/favicon.ico",
+      "codec": "UNKNOWN",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-capital-music",
+      "name": "Radio Capital Music",
+      "broadcaster": "independent",
+      "streamUrl": "https://4c4b867c89244861ac216426883d1ad0.msvdn.net/webradio/capitalmusic/playlist.m3u8",
+      "homepage": "https://www.capital.it/",
+      "country": "IT",
+      "tags": [
+        "1970s",
+        "1980s",
+        "1990s",
+        "70 80 hits",
+        "70's",
+        "70s"
+      ],
+      "favicon": "https://cdn.gelestatic.it/capital/sites/2/2016/11/webradio-music-320x320.jpg",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-onda-d-urto",
+      "name": "Radio Onda d'urto",
+      "broadcaster": "independent",
+      "streamUrl": "https://hochimin.urtostream.org:8443/radiondadurto.mp3",
+      "homepage": "https://www.radiondadurto.org/",
+      "country": "IT",
+      "bitrate": 80,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-discoradio",
+      "name": "Discoradio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.discoradio.radio/audio/disco.stream_aac64/chunklist.m3u8",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "IT",
+      "tags": [
+        "pop"
+      ],
+      "codec": "UNKNOWN",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-united-music-cinema",
+      "name": "United Music Cinema",
+      "broadcaster": "independent",
+      "streamUrl": "https://icy.unitedradio.it/um058.mp3",
+      "homepage": "https://www.unitedmusic.com/",
+      "country": "IT",
+      "tags": [
+        "cinema",
+        "film music",
+        "soundtrack"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-deejay-30-songs",
+      "name": "Deejay 30 Songs",
+      "broadcaster": "independent",
+      "streamUrl": "https://4c4b867c89244861ac216426883d1ad0.msvdn.net/radiodeejay30songs/radiodeejay30songs/master_ma.m3u8",
+      "homepage": "https://www.deejay.it/webradio/06/",
+      "country": "IT",
+      "tags": [
+        "30son",
+        "webradio"
+      ],
+      "favicon": "http://cdn.gelestatic.it/deejay/www/2015/05/webradio_30_songs.png",
+      "bitrate": 122,
+      "codec": "AAC+",
+      "geo": [
+        45.4639,
+        9.1831
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-capital-w-l-italia",
+      "name": "Radio Capital W L'Italia",
+      "broadcaster": "independent",
+      "streamUrl": "https://4c4b867c89244861ac216426883d1ad0.msvdn.net/webradio/capitalwitalia/playlist.m3u8",
+      "homepage": "https://www.capital.it/",
+      "country": "IT",
+      "tags": [
+        "classic italian pop",
+        "italian",
+        "italian music",
+        "italian oldies",
+        "italian pop",
+        "musica italiana"
+      ],
+      "favicon": "https://cdn.gelestatic.it/capital/sites/2/2016/11/webradio-vivalitalia-320x320.jpg",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-pulcinella",
+      "name": "RADIO PULCINELLA",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.zeno.fm/9dve9gmfakhvv",
+      "homepage": "https://stream.zeno.fm/",
+      "country": "IT",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-international",
+      "name": "Radio International",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice08.fluidstream.net/fluid813.mp3",
+      "homepage": "https://www.radiointernationalstore.it/",
+      "country": "IT",
+      "tags": [
+        "pop music"
+      ],
+      "favicon": "https://www.radiointernationalstore.it/wp-content/uploads/2021/01/cropped-74939-television-media-youtube-streaming-live-broadcasting-radio-180x180.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-dimensione-relax",
+      "name": "RADIO DIMENSIONE RELAX",
+      "broadcaster": "independent",
+      "streamUrl": "https://az1.mediacp.eu/listen/radiodimensionerelax/radio.mp3",
+      "homepage": "https://rdastation.it/",
+      "country": "IT",
+      "tags": [
+        "ambient",
+        "ambient and relaxation music",
+        "ambient lounge",
+        "ambiental",
+        "chillout",
+        "chillout+lounge"
+      ],
+      "favicon": "https://favicon-generator.org/favicon-generator/htdocs/favicons/2025-01-13/a46c8e118c24923aa862f46d62f93152.ico.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        41.774,
+        12.4341
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-rmc-music-star-jovanotti",
+      "name": "RMC Music Star Jovanotti",
+      "broadcaster": "independent",
+      "streamUrl": "https://icy.unitedradio.it/Jovanotti.mp3",
+      "homepage": "https://www.radiomontecarlo.net/sezioni/10493/music-star-jovanotti",
+      "country": "IT",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-lifegate-radio-blues",
+      "name": "LifeGate Radio Blues",
+      "broadcaster": "independent",
+      "streamUrl": "https://router.xdevel.com/audio3s975809-348/stream/icecast.audio",
+      "homepage": "https://www.lifegate.it/lifegate-radio",
+      "country": "IT",
+      "favicon": "https://www.lifegate.it/app/themes/lifegate-2020/dist/images/apple-touch-icon.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-deejay-time",
+      "name": "Deejay Time",
+      "broadcaster": "independent",
+      "streamUrl": "https://4c4b867c89244861ac216426883d1ad0.msvdn.net/webradio/deejaytime/playlist.m3u8",
+      "homepage": "https://www.deejay.it/",
+      "country": "IT",
+      "tags": [
+        "dance",
+        "dance music",
+        "house",
+        "pop dance"
+      ],
+      "favicon": "https://cdn.gelestatic.it/deejay/sites/2/2015/05/webradio_deejay_time-320x320.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-napoli-doc",
+      "name": "Radio Napoli Doc",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice08.fluidstream.net/RadioNapoli.aac",
+      "homepage": "https://online-radio.eu/radio/27319-radio-napoli-doc",
+      "country": "IT",
+      "bitrate": 64,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-rai-radio3classica",
+      "name": "Rai Radio3Classica",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecdn-19d24861e90342cc8decb03c24c8a419.msvdn.net/icecastRelay/S53422322/bTdUFhYMnnra/icecast",
+      "homepage": "https://www.raiplaysound.it/radio3classica",
+      "country": "IT",
+      "favicon": "https://www.raiplaysound.it/assets/img/canali/logo-rairadio3classica.svg",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-rai-radio-classica-322-kb-s",
+      "name": "Rai Radio Classica (322 kb/s)",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiotreclassica-live.akamaized.net/hls/live/2032595/radiotreclassica/radiotreclassica/playlist.m3u8",
+      "homepage": "https://www.raiplaysound.it/radio3",
+      "country": "IT",
+      "tags": [
+        "classical"
+      ],
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/thumb/f/fd/Rai_Radio_3_-_Logo_2017.svg/2880px-Rai_Radio_3_-_Logo_2017.svg.png",
+      "bitrate": 320,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-kiss-kiss-disco-party",
+      "name": "Radio Kiss Kiss Disco Party",
+      "broadcaster": "independent",
+      "streamUrl": "https://kk.fluidstream.eu/kk_discoparty.mp3",
+      "homepage": "https://kisskiss.it/webradio/kiss-kiss-disco-party/",
+      "country": "IT",
+      "favicon": "https://kisskiss.it/wp-content/uploads/elementor/thumbs/discoparty-pn2hglt9od540vyjui55frxmsrj4cmhi5s4v32izak.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-nbc-milano",
+      "name": "NBC Milano",
+      "broadcaster": "independent",
+      "streamUrl": "https://nr7.newradio.it:19350/stream",
+      "homepage": "https://www.nbcmilano.it/",
+      "country": "IT",
+      "tags": [
+        "70",
+        "70 80 hits",
+        "70 hits",
+        "80",
+        "80 hits",
+        "greatest hits"
+      ],
+      "favicon": "https://www.70-80.it/wp-content/uploads/2020/03/logo-70-80-75x75.jpg",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-dimensione-suono-soft",
+      "name": "Dimensione Suono Soft",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.dimensionesuonosoft.radio/audio/dssc.stream_aac64/playlist.m3u8",
+      "homepage": "https://www.dimensionesuonosoft.it/",
+      "country": "IT",
+      "tags": [
+        "soft adult contemporary",
+        "soft pop"
+      ],
+      "favicon": "https://www.radio.de/images/broadcasts/25/0f/117624/1/c300.png",
+      "bitrate": 64,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-gemini",
+      "name": "Radio Gemini",
+      "broadcaster": "independent",
+      "streamUrl": "https://geminione.it/proxy/gemini/stream",
+      "homepage": "http://www.radiogemini.net/",
+      "country": "IT",
+      "bitrate": 128,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio54",
+      "name": "Radio54",
+      "broadcaster": "independent",
+      "streamUrl": "https://nr7.newradio.it/proxy/radiosol?mp=/stream",
+      "homepage": "https://www.radio54.it/",
+      "country": "IT",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        44.7475,
+        10.9799
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-musica-jazz-radio",
+      "name": "Musica Jazz Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice16.fluidstream.net/mjr.mp3",
+      "homepage": "https://www.musicajazz.it/radio/",
+      "country": "IT",
+      "tags": [
+        "jazz"
+      ],
+      "favicon": "https://musicajazz.it/wp-content/uploads/logo-120.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-padova-history-italia",
+      "name": "Radio Padova History Italia",
+      "broadcaster": "independent",
+      "streamUrl": "https://sphera.fluidstream.eu/rpd_hita.mp3",
+      "homepage": "https://www.radiopadova.com/",
+      "country": "IT",
+      "tags": [
+        "italian pop"
+      ],
+      "favicon": "https://www.radiopadova.com/history-italia/android-icon-192x192.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-forever-90",
+      "name": "FOREVER 90",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/forever90",
+      "homepage": "https://forever80.altervista.org/",
+      "country": "IT",
+      "tags": [
+        "90s",
+        "dance",
+        "pop",
+        "rock"
+      ],
+      "favicon": "https://forever80.altervista.org/wp-content/uploads/2020/01/FOREVER-90-dance-pop-320x207.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-forever-70",
+      "name": "FOREVER 70",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/forever70",
+      "homepage": "https://forever80.altervista.org/",
+      "country": "IT",
+      "tags": [
+        "70s",
+        "dance",
+        "pop"
+      ],
+      "favicon": "https://forever80.altervista.org/wp-content/uploads/2020/01/FOREVER-70-DANCE-POP-320x207.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-digitalia-ricordi",
+      "name": "Radio Digitalia - Ricordi",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiodigitalia-ricordi.stream.laut.fm/radiodigitalia-ricordi?t302=2021-06-10_16-57-30&uuid=8aef2612-2637-4877-8c1b-d3d775186258",
+      "homepage": "https://www.radiodigitalia.net/",
+      "country": "IT",
+      "tags": [
+        "60s",
+        "70s",
+        "italian pop",
+        "oldies"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-marte",
+      "name": "Radio Marte",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream1.xdevel.com/audio0s975753-313/stream/icecast.audio",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "IT",
+      "tags": [
+        "pop"
+      ],
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-volami-nel-cuore",
+      "name": "Radio Volami nel Cuore",
+      "broadcaster": "independent",
+      "streamUrl": "https://rci.canaleitalia.tv:8009/;",
+      "homepage": "https://canaleitalia.it/radio/radio-volami-nel-cuore/",
+      "country": "IT",
+      "tags": [
+        "60's",
+        "60s",
+        "70's",
+        "70s",
+        "80's",
+        "80s"
+      ],
+      "favicon": "https://canaleitalia.it/wp-content/uploads/2021/07/radio-volami-nel-cuore-ascolta.jpg",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-company-stile-italiano",
+      "name": "Radio Company Stile Italiano",
+      "broadcaster": "independent",
+      "streamUrl": "https://sphera.fluidstream.eu/companyitalia.mp3",
+      "homepage": "https://www.radiocompany.com/",
+      "country": "IT",
+      "tags": [
+        "italian pop"
+      ],
+      "favicon": "https://www.radiocompany.com/wp-content/uploads/fbrfg/apple-touch-icon.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-cuore",
+      "name": "Radio Cuore",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream10.xdevel.com/audio32s975552-1839/stream/icecast.audio",
+      "homepage": "https://www.radiocuore.it/",
+      "country": "IT",
+      "tags": [
+        "italian music",
+        "italian pop",
+        "musica italiana"
+      ],
+      "favicon": "https://www.radiocuore.it/public/favicon.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-company-reggaetown",
+      "name": "Radio Company Reggaetown",
+      "broadcaster": "independent",
+      "streamUrl": "https://sphera.fluidstream.eu/companyreggaetown.mp3",
+      "homepage": "https://www.radiocompany.com/",
+      "country": "IT",
+      "tags": [
+        "reggaeton"
+      ],
+      "favicon": "https://www.radiocompany.com/wp-content/uploads/fbrfg/apple-touch-icon.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-italia-news-24",
+      "name": "Italia News 24",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream6.xdevel.com/audio6s975889-649/stream/icecast.audio",
+      "homepage": "https://www.italianews24.news/",
+      "country": "IT",
+      "tags": [
+        "music",
+        "news",
+        "talk"
+      ],
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-nerazzurra",
+      "name": "Radio Nerazzurra",
+      "broadcaster": "independent",
+      "streamUrl": "https://api.spreaker.com/v2/episodes/18631166/stream",
+      "homepage": "https://www.radionerazzurra.it/",
+      "country": "IT",
+      "tags": [
+        "milano",
+        "sport",
+        "talk"
+      ],
+      "favicon": "https://www.radionerazzurra.it/whitelabel/radio-2374497684802285/img/apple-touch-icon.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-bruno-made-in-italy",
+      "name": "Radio Bruno - Made in Italy",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream2.xdevel.com/audio1s975355-54/stream/icecast.audio",
+      "homepage": "https://www.radiobruno.it/",
+      "country": "IT",
+      "tags": [
+        "italian pop"
+      ],
+      "favicon": "https://www.radiobruno.it/wp-content/uploads/2019/11/made-in-italy.jpg",
+      "codec": "AAC+",
+      "geo": [
+        42.4105,
+        12.9641
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-laziale",
+      "name": "Radio Laziale ",
+      "broadcaster": "independent",
+      "streamUrl": "https://router.xdevel.com/video5s975363-2398/stream/playlist.m3u8",
+      "homepage": "https://www.cusanomediaplay.it/",
+      "country": "IT",
+      "tags": [
+        "calcio",
+        "lazio",
+        "sports",
+        "sports news"
+      ],
+      "favicon": "https://www.cusanomediaplay.it/apple-icon-120x120.png",
+      "bitrate": 4811,
+      "codec": "AAC,H.264",
+      "geo": [
+        41.9063,
+        12.4818
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-italo-sound-radio",
+      "name": "Italo Sound Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.italosound.com/italosound",
+      "homepage": "https://italosound.com/",
+      "country": "IT",
+      "tags": [
+        "dance",
+        "italo dance"
+      ],
+      "favicon": "https://italosound.com/sites/all/themes/framework/apple-touch-icon.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-elettrica",
+      "name": "Radio Elettrica",
+      "broadcaster": "independent",
+      "streamUrl": "https://nr8.newradio.it/proxy/apselett?mp=/stream",
+      "homepage": "https://www.radioelettrica.it/",
+      "country": "IT",
+      "favicon": "https://www.radioelettrica.it/wp-content/uploads/2018/10/cropped-icon-1-180x180.png",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-105-miami",
+      "name": "105 Miami",
+      "broadcaster": "independent",
+      "streamUrl": "https://icy.unitedradio.it/105Miami.mp3",
+      "homepage": "https://www.105.net/sezioni/748/105-miami",
+      "country": "IT",
+      "tags": [
+        "dance",
+        "house",
+        "rap"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-italia-radio-festival",
+      "name": "ITALIA Radio Festival",
+      "broadcaster": "independent",
+      "streamUrl": "https://icy.unitedradio.it/um073.mp3",
+      "homepage": "http://www.unitedmusic.it/",
+      "country": "IT",
+      "tags": [
+        "italian",
+        "mediaset"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-jungle-planet-radio",
+      "name": "Jungle Planet Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://phoebe.streamerr.co:3650/;?type=http&nocache=1739137731",
+      "homepage": "https://jungleplanetradio.com/",
+      "country": "IT",
+      "tags": [
+        "drum and bass",
+        "jungle",
+        "uk garage"
+      ],
+      "favicon": "https://jungleplanetradio.com/wp-content/uploads/2023/09/JPR-round-B-1.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-musica-disco-n-dance",
+      "name": "Radio Musica Disco ‘N’ Dance",
+      "broadcaster": "independent",
+      "streamUrl": "https://nrf1.newradio.it:9516/stream",
+      "homepage": "https://radiomusicatv.it/",
+      "country": "IT",
+      "favicon": "https://cdn-profiles.tunein.com/s199160/images/logod.png?t=637523968370000000",
+      "bitrate": 96,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-forever-80-pop",
+      "name": "FOREVER 80-POP",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/forever80-pop",
+      "homepage": "https://forever80.altervista.org/",
+      "country": "IT",
+      "tags": [
+        "80s",
+        "pop"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-lolli-radio-soul",
+      "name": "Lolli Radio Soul",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.lolliradio.net/lolli_soul.mp3",
+      "homepage": "https://www.lolliradio.net/",
+      "country": "IT",
+      "tags": [
+        "r&b",
+        "soul"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-capital-classic-rock",
+      "name": "Radio Capital Classic Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://4c4b867c89244861ac216426883d1ad0.msvdn.net/webradio/capitalclassicrock/playlist.m3u8",
+      "homepage": "https://www.capital.it/",
+      "country": "IT",
+      "tags": [
+        "alternative rock",
+        "classic rock",
+        "pop rock",
+        "rock"
+      ],
+      "favicon": "https://cdn.gelestatic.it/capital/sites/2/2016/11/webradio-classicrock-320x320.jpg",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-legends",
+      "name": "Radio Legends",
+      "broadcaster": "independent",
+      "streamUrl": "https://ssl.audio1.meway.tv/proxy/radiolegends?mp=/stream",
+      "homepage": "https://radiolegends.com/",
+      "country": "IT",
+      "tags": [
+        "free jazz",
+        "italian music",
+        "pop music",
+        "pop rock"
+      ],
+      "favicon": "https://radiolegends.com/wp-content/uploads/2022/10/cropped-radiolegends-logo-150x150.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-cortina",
+      "name": "Radio Cortina",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming1.radiodatanet.it:8050/stream",
+      "homepage": "https://www.radiocortina.it/",
+      "country": "IT",
+      "tags": [
+        "local news",
+        "local radio"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-linea-italia",
+      "name": "Radio Linea Italia",
+      "broadcaster": "independent",
+      "streamUrl": "https://rblive.it:8110//radio.mp3",
+      "homepage": "https://www.radiolinea.it/",
+      "country": "IT",
+      "tags": [
+        "italian pop"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-united-music-piano",
+      "name": "united music piano",
+      "broadcaster": "independent",
+      "streamUrl": "https://icy.unitedradio.it/um077.mp3",
+      "homepage": "https://www.unitedmusic.com/",
+      "country": "IT",
+      "tags": [
+        "piano"
+      ],
+      "favicon": "https://www.unitedmusic.com/favicon_6.ico?v=1558694480199",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-rouge-country-hits",
+      "name": "Radio Rouge Country Hits",
+      "broadcaster": "independent",
+      "streamUrl": "https://uk1.streamingpulse.com/ssl/RadioRougeCountry",
+      "homepage": "https://radiorouge.com/",
+      "country": "IT",
+      "tags": [
+        "alternative country",
+        "country"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-fred-film-radio-italiano",
+      "name": "Fred Film Radio(italiano)",
+      "broadcaster": "independent",
+      "streamUrl": "https://s10.webradio-hosting.com/proxy/fredradioit/stream",
+      "homepage": "http://www.fred.fm/",
+      "country": "IT",
+      "tags": [
+        "culture",
+        "film",
+        "movie"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-classica",
+      "name": "Radio Classica",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream10.xdevel.com/audio0s978096-2470/stream/icecast.audio",
+      "homepage": "https://www.radioclassica.fm/",
+      "country": "IT",
+      "tags": [
+        "classical"
+      ],
+      "favicon": "https://www.radioclassica.fm/img/logo_classica.png",
+      "codec": "MP3",
+      "geo": [
+        45.4554,
+        9.2422
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-hit-fm",
+      "name": "Radio Hit FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream1.xdevel.com/audio0s975632-244/stream/icecast.audio",
+      "homepage": "https://radiohitfm.it/",
+      "country": "IT",
+      "favicon": "https://radiohitfm.it/favicon.ico",
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-italia",
+      "name": "Radio Italia",
+      "broadcaster": "independent",
+      "streamUrl": "https://radioitaliasmi.akamaized.net/hls/live/2093120/RISMI/master.m3u8",
+      "homepage": "https://www.radioitalia.it/",
+      "country": "IT",
+      "favicon": "https://www.radioitalia.it/images/logo-radioitalia-200.png",
+      "bitrate": 98,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-kiss-kiss-la-notte-vola",
+      "name": "Radio Kiss Kiss La Notte Vola",
+      "broadcaster": "independent",
+      "streamUrl": "https://kk.fluidstream.eu/kk_notte.mp3",
+      "homepage": "https://kisskiss.it/webradio/web-radio-kisskiss-la-notte-vola/",
+      "country": "IT",
+      "favicon": "https://kisskiss.it/wp-content/uploads/2022/07/cropped-favicon-new-kisskiss-180x180.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-deejay-one-love",
+      "name": "Deejay One Love",
+      "broadcaster": "independent",
+      "streamUrl": "https://4c4b867c89244861ac216426883d1ad0.msvdn.net/webradio/deejayonelove/playlist.m3u8",
+      "homepage": "https://www.deejay.it/",
+      "country": "IT",
+      "tags": [
+        "love",
+        "love songs",
+        "lovesongs"
+      ],
+      "favicon": "https://cdn.gelestatic.it/deejay/sites/2/2016/02/webradio_deejay_one_love-320x320.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-precisa-i-piu-trasmessi-dal-1975-ad-oggi",
+      "name": "RADIO PRECISA I più trasmessi dal 1975 ad oggi",
+      "broadcaster": "independent",
+      "streamUrl": "https://rprecisa.radioca.st/radioprecisa",
+      "homepage": "http://www.radioprecisa.it/",
+      "country": "IT",
+      "tags": [
+        "2000s",
+        "33/45",
+        "70s",
+        "80s",
+        "90s",
+        "adult classic pop"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-mambo",
+      "name": "Radio Mambo",
+      "broadcaster": "independent",
+      "streamUrl": "https://mambo.newradio.it/stream",
+      "homepage": "https://www.mambo.it/",
+      "country": "IT",
+      "tags": [
+        "latin",
+        "roma"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-skyline-jazz",
+      "name": "Skyline Jazz",
+      "broadcaster": "independent",
+      "streamUrl": "https://rblive.it:8030/radio.mp3",
+      "homepage": "https://www.skyline.it/",
+      "country": "IT",
+      "tags": [
+        "jazz"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-rock-106-6",
+      "name": "Radio Rock 106.6",
+      "broadcaster": "independent",
+      "streamUrl": "https://rrock.fluidstream.eu/radiorock.aac",
+      "homepage": "https://radiorock.it/",
+      "country": "IT",
+      "tags": [
+        "rock"
+      ],
+      "favicon": "https://radiorock.it/wp-content/uploads/2017/01/diretta-copia-370x370.jpg",
+      "bitrate": 64,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-subasio-xl",
+      "name": "Subasio XL",
+      "broadcaster": "independent",
+      "streamUrl": "https://icy.unitedradio.it/SubasioXL.mp3",
+      "homepage": "https://www.radiosubasio.it/",
+      "country": "IT",
+      "tags": [
+        "dab+",
+        "italian pop",
+        "mediaset",
+        "no ads",
+        "only music",
+        "pop"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-raitg",
+      "name": "RAITG",
+      "broadcaster": "independent",
+      "streamUrl": "https://tgrcampania-live.akamaized.net/hls/live/2025562/tgrcampania/tgrcampania/playlist.m3u8",
+      "homepage": "https://www.rainews.it/",
+      "country": "IT",
+      "favicon": "https://www.rainews.it/dl/rainews/images/favicon.png",
+      "bitrate": 1868,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-number-one",
+      "name": "Radio Number One",
+      "broadcaster": "independent",
+      "streamUrl": "https://rn1.fluidstream.eu/rn1.mp3",
+      "homepage": "https://radionumberone.it/",
+      "country": "IT",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-saba-sound",
+      "name": "Radio Saba Sound",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream3.xdevel.com/audio0s975496-187/stream/icecast.audio",
+      "homepage": "https://www.radiosabasound.com/",
+      "country": "IT",
+      "tags": [
+        "pop",
+        "san salvo"
+      ],
+      "favicon": "https://radiosabasound.com/wp-content/uploads/2020/06/cropped-logo1-180x180.png",
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-wow-black",
+      "name": "Radio WoW Black",
+      "broadcaster": "independent",
+      "streamUrl": "https://sphera.fluidstream.eu/rwow_black.mp3",
+      "homepage": "https://radiowow.com/",
+      "country": "IT",
+      "tags": [
+        "hiphop",
+        "r&b",
+        "rap",
+        "soul"
+      ],
+      "favicon": "https://radiowow.com/wp-content/uploads/2024/09/cropped-radio-wow-180x180.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-bruno-gold",
+      "name": "Radio Bruno Gold",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream2.xdevel.com/audio2s975355-55/stream/icecast.audio",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "IT",
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-company-global-house",
+      "name": "Radio Company Global House",
+      "broadcaster": "independent",
+      "streamUrl": "https://sphera.fluidstream.eu/companyhouse.mp3",
+      "homepage": "https://www.radiocompany.com/",
+      "country": "IT",
+      "tags": [
+        "electronic",
+        "house"
+      ],
+      "favicon": "https://www.radiocompany.com/wp-content/uploads/fbrfg/apple-touch-icon.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-padova-history",
+      "name": "Radio Padova History",
+      "broadcaster": "independent",
+      "streamUrl": "https://sphera.fluidstream.eu/rpd_history.mp3",
+      "homepage": "https://www.radiopadova.com/",
+      "country": "IT",
+      "tags": [
+        "classic hits"
+      ],
+      "favicon": "https://www.radiopadova.com/history/android-icon-192x192.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-stella-toscana",
+      "name": "Radio Stella Toscana",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream4.xdevel.com/audio0s975906-620/stream/icecast.audio",
+      "homepage": "https://radiostella.it/",
+      "country": "IT",
+      "tags": [
+        "hits",
+        "italian pop",
+        "local news"
+      ],
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-zouk-emotion",
+      "name": "RADIO ZOUK EMOTION",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radiozoukemotion.com/rze",
+      "homepage": "https://www.radiozoukemotion.com/",
+      "country": "IT",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-relax-radio",
+      "name": "Relax Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream3.xdevel.com/audio8s975388-108/stream/icecast.audio",
+      "homepage": "https://www.musiclubwebradio.com/home/",
+      "country": "IT",
+      "tags": [
+        "relax music"
+      ],
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-esercito",
+      "name": "Radio Esercito",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.esercito.difesa.it:8000/stream",
+      "homepage": "https://www.esercito.difesa.it/radio-esercito",
+      "country": "IT",
+      "tags": [
+        "pop music"
+      ],
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-rai-tg3",
+      "name": "RAI TG3",
+      "broadcaster": "independent",
+      "streamUrl": "https://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=668461",
+      "homepage": "https://www.rainews.it/",
+      "country": "IT",
+      "bitrate": 1985,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-80s-remix-radio",
+      "name": "80s Remix Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://a10.asurahosting.com:8350/radio.mp3",
+      "homepage": "https://a10.my-control-panel.com/public/80s_remix_radio",
+      "country": "IT",
+      "tags": [
+        "80's",
+        "80s",
+        "pop",
+        "remix"
+      ],
+      "favicon": "https://a10.asurahosting.com/static/uploads/80s_remix_radio/album_art.1730307872.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        45.3511,
+        9.3619
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-rock-n-roll-radio",
+      "name": "Rock'n'Roll Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://nr14.newradio.it:8643/stream?ext=.mp3",
+      "homepage": "https://www.rocknrollradio.it/",
+      "country": "IT",
+      "tags": [
+        "classic rock",
+        "heavy metal",
+        "rock"
+      ],
+      "favicon": "https://cdn-radiotime-logos.tunein.com/s126487d.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        45.4926,
+        9.2076
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-urban-radio",
+      "name": "Urban Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://nr3.newradio.it:18100/stream",
+      "homepage": "https://www.urbanradio.it/",
+      "country": "IT",
+      "tags": [
+        "hiphop",
+        "rap",
+        "reggae",
+        "reggaeton",
+        "trap",
+        "urban contemporary"
+      ],
+      "favicon": "https://urbanradio.it/wp-content/uploads/2022/05/cropped-favicon-180x180.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-funky-radio-classic-funk-only",
+      "name": "Funky Radio - Classic Funk Only",
+      "broadcaster": "independent",
+      "streamUrl": "https://my.streamingmedia.it/listen/discofunk/play",
+      "homepage": "https://funky.radio/",
+      "country": "IT",
+      "tags": [
+        "70s",
+        "80s",
+        "funk",
+        "funky"
+      ],
+      "favicon": "https://funky.radio/wp-content/uploads/2024/05/funky.radio_logo_300x300.webp",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-viniles-radio",
+      "name": "Viniles Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s3.radio.co/sfaf3f1f4a/listen",
+      "homepage": "https://vinilesradio.it/",
+      "country": "IT",
+      "tags": [
+        "house",
+        "italian",
+        "lounge"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        42.9519,
+        13.8825
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-futura-fm-hd-ogg",
+      "name": "Futura FM (HD OGG)",
+      "broadcaster": "independent",
+      "streamUrl": "https://futura.fm/stream.ogg",
+      "homepage": "https://futura.fm/",
+      "country": "IT",
+      "tags": [
+        "80s",
+        "retro"
+      ],
+      "favicon": "https://futura.fm/song-metadata/cover/undefined",
+      "bitrate": 1500,
+      "codec": "OGG",
+      "geo": [
+        45.8324,
+        9.7423
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-60-70-80",
+      "name": "Radio 60 70 80",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice.studiopiu.net/607080.aac",
+      "homepage": "https://www.607080.it/",
+      "country": "IT",
+      "tags": [
+        "1960s",
+        "1970s",
+        "1980s",
+        "60s",
+        "70s",
+        "80s"
+      ],
+      "favicon": "https://www.607080.it/wp-content/uploads/2017/11/Logo-SB.png",
+      "bitrate": 48,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-antenna-uno-rock-station",
+      "name": "Radio Antenna Uno Rock Station",
+      "broadcaster": "independent",
+      "streamUrl": "https://sr11.inmystream.it/proxy/associa9?mp=/stream",
+      "homepage": "http://www.radioantenna1.com/",
+      "country": "IT",
+      "tags": [
+        "alternative rock",
+        "indie rock"
+      ],
+      "favicon": "http://www.radioantenna1.com/wp-content/themes/Elite/images/logonuovo.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        44.5389,
+        10.8129
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radiouno",
+      "name": "RadioUno",
+      "broadcaster": "independent",
+      "streamUrl": "https://streamcdng2-8e7439fdb1694c8da3a0fd63e4dda518.msvdn.net/radiounoita1/hls/radiounoita1_320/chunklist.m3u8",
+      "homepage": "https://www.raiplaysound.it/",
+      "country": "IT",
+      "favicon": "https://www.raiplaysound.it/assets/img/canali/logo-rairadio1.svg",
+      "codec": "UNKNOWN",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-capital-soft",
+      "name": "Radio Capital Soft",
+      "broadcaster": "independent",
+      "streamUrl": "https://4c4b867c89244861ac216426883d1ad0.msvdn.net/webradio/capitalsoft/playlist.m3u8",
+      "homepage": "https://www.capital.it/",
+      "country": "IT",
+      "tags": [
+        "love",
+        "love songs",
+        "soft",
+        "soft music",
+        "soft pop"
+      ],
+      "favicon": "https://cdn.gelestatic.it/capital/sites/2/2016/11/webradio-soft-320x320.jpg",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-dreamland",
+      "name": "Radio Dreamland",
+      "broadcaster": "independent",
+      "streamUrl": "https://dreamsiteradiocp3.com/proxy/dreamland?mp=/stream",
+      "homepage": "http://www.radiodreamland.it/",
+      "country": "IT",
+      "tags": [
+        "music",
+        "nature",
+        "spiritual",
+        "talk",
+        "torino"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-delfino",
+      "name": "Radio Delfino",
+      "broadcaster": "independent",
+      "streamUrl": "https://nr8.newradio.it/proxy/emaamo00?mp=/stream",
+      "homepage": "https://radiodelfino.com/",
+      "country": "IT",
+      "tags": [
+        "oldies"
+      ],
+      "favicon": "https://www.radiodelfino.com/wp-content/uploads/2022/10/305398753_463061192502259_7843286858231192740_n.ico",
+      "bitrate": 96,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-podcast",
+      "name": "RADIO PODCAST",
+      "broadcaster": "independent",
+      "streamUrl": "https://gr.fluidstream.eu/gr6.mp3?FLID=1",
+      "homepage": "https://radiopodcast.fm/",
+      "country": "IT",
+      "favicon": "https://radiopodcast.fm/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        45.5898,
+        8.9133
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-rtr99",
+      "name": "Rtr99",
+      "broadcaster": "independent",
+      "streamUrl": "https://rtr99.fluidstream.eu/rtr99.aac",
+      "homepage": "http://www.rtr99.it/",
+      "country": "IT",
+      "tags": [
+        "canzoni",
+        "fuori",
+        "parole"
+      ],
+      "favicon": "https://www.rtr99.it/wp-content/uploads/2016/03/logo_facebook.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-capital-tivu",
+      "name": "Radio Capital TiVù",
+      "broadcaster": "independent",
+      "streamUrl": "https://4c4b867c89244861ac216426883d1ad0.msvdn.net/live/S35394734/Z6U2wGoDYANk/playlist.m3u8",
+      "homepage": "https://www.capital.it/tv/",
+      "country": "IT",
+      "tags": [
+        "70s",
+        "80s",
+        "90s",
+        "oldies",
+        "retro"
+      ],
+      "bitrate": 2658,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-italia-dance-music",
+      "name": "Italia Dance Music",
+      "broadcaster": "independent",
+      "streamUrl": "https://sr2.inmystream.it:18032/stream2",
+      "homepage": "https://www.italiadancemusic.com/it/",
+      "country": "IT",
+      "favicon": "https://www.italiadancemusic.com/it/sites/default/files/logo.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-time-dance-fm",
+      "name": "Time Dance FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://eu8.fastcast4u.com/proxy/timedancefm?mp=/1",
+      "homepage": "https://www.timedancefm.it/",
+      "country": "IT",
+      "tags": [
+        "dance"
+      ],
+      "favicon": "https://www.timedancefm.it/wp-content/uploads/2023/02/TIME_DANCE_FM_3.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-canale-italia",
+      "name": "Canale Italia+",
+      "broadcaster": "independent",
+      "streamUrl": "https://rci.canaleitalia.tv:8005/;",
+      "homepage": "https://canaleitalia.it/radio/radio-canale-italia/",
+      "country": "IT",
+      "tags": [
+        "music",
+        "música pop"
+      ],
+      "favicon": "https://canaleitalia.it/wp-content/uploads/2022/06/logo-canale-italia-streaming.png",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-padova-christmas",
+      "name": "Radio Padova Christmas",
+      "broadcaster": "independent",
+      "streamUrl": "https://sphera.fluidstream.eu/rpd_christmas.mp3",
+      "homepage": "https://www.radiopadova.com/",
+      "country": "IT",
+      "tags": [
+        "christmas music"
+      ],
+      "favicon": "https://www.radiopadova.com/wp-content/uploads/2022/05/cropped-radio-padova-icona-180x180.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-rmc-radio-bau-co",
+      "name": "RMC Radio Bau & Co",
+      "broadcaster": "independent",
+      "streamUrl": "https://icy.unitedradio.it/RadioBAU.mp3",
+      "homepage": "https://www.radiomontecarlo.net/sezioni/10494/radio-bau-co",
+      "country": "IT",
+      "tags": [
+        "animals",
+        "pop"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-company-90",
+      "name": "Radio Company 90",
+      "broadcaster": "independent",
+      "streamUrl": "https://sphera.fluidstream.eu/company90.mp3",
+      "homepage": "https://www.radiocompany.com/",
+      "country": "IT",
+      "tags": [
+        "90s"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-studio-nord-80-energia",
+      "name": "Radio Studio Nord 80 Energia",
+      "broadcaster": "independent",
+      "streamUrl": "https://nr6.newradio.it:19393/;",
+      "homepage": "https://www.rsn.it/",
+      "country": "IT",
+      "tags": [
+        "80s",
+        "tolmezzo"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-bruno-top-40",
+      "name": "Radio Bruno Top 40",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream2.xdevel.com/audio0s975355-53/stream/icecast.audio",
+      "homepage": "https://www.radiobruno.it/web-radio/radio-bruno-top-40/",
+      "country": "IT",
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-soul-radio",
+      "name": "SOUL RADIO",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.soulradio.it/it",
+      "homepage": "https://soulradio.it/",
+      "country": "IT",
+      "bitrate": 192,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-rocket-radio-1",
+      "name": "Rocket Radio 1",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radiojar.com/nvvyes7gud5tv",
+      "homepage": "https://rocketradiolive.com/",
+      "country": "IT",
+      "tags": [
+        "ambient",
+        "downtempo",
+        "electro",
+        "electronica",
+        "experimental",
+        "funk"
+      ],
+      "favicon": "https://images.squarespace-cdn.com/content/v1/53d6c3efe4b07a1cdbbae414/1520288879144-STBAF8R3I9C523AUA4LS/favicon.ico?format=100w",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-spore",
+      "name": "Spore",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radiospore.oziosi.org:8003/spore.ogg",
+      "homepage": "http://upstream.radiospore.oziosi.org:8000/spore.ogg",
+      "country": "IT",
+      "tags": [
+        "casino"
+      ],
+      "favicon": "https://radiospore.oziosi.org/user/themes/quark/images/logo/logoprova2.png",
+      "codec": "OGG",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-news",
+      "name": "Radio News",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream5.xdevel.com/audio5s975889-479/stream/icecast.audio",
+      "homepage": "https://www.italianews24.news/",
+      "country": "IT",
+      "tags": [
+        "music",
+        "news",
+        "talk"
+      ],
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-sintony",
+      "name": "Radio Sintony",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream5.xdevel.com/audio0s976204-1069/stream/icecast.audio",
+      "homepage": "https://www.sintony.it/",
+      "country": "IT",
+      "tags": [
+        "news",
+        "pop",
+        "rock"
+      ],
+      "favicon": "https://sintony.it/images/logo_sintony2.png",
+      "codec": "MP3",
+      "geo": [
+        39.2207,
+        9.1168
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-rete-toscana-classica",
+      "name": "Rete Toscana Classica",
+      "broadcaster": "independent",
+      "streamUrl": "https://nr12.newradio.it/stream/8744",
+      "homepage": "https://www.retetoscanaclassica.it/",
+      "country": "IT",
+      "favicon": "https://www.retetoscanaclassica.it/wp-content/themes/rtc/assets/content/img/logo.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-kiss-kiss-history-lounge",
+      "name": "Kiss Kiss History Lounge",
+      "broadcaster": "independent",
+      "streamUrl": "https://kk.fluidstream.eu/kk_history_lounge.mp3",
+      "homepage": "https://kisskiss.it/webradio/la-web-radio-kiss-kiss-history-lounge/",
+      "country": "IT",
+      "favicon": "https://kisskiss.it/wp-content/uploads/elementor/thumbs/history_lounge-pqfun57h0y154wockpdaik12g4hic80slnznyc9zqk.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-seisei-vintage",
+      "name": "Radio SeiSei Vintage",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice02.fluidstream.net/fluid02_8360.aac",
+      "homepage": "https://www.seiseivintage.it/",
+      "country": "IT",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-skyline-soul",
+      "name": "Radio Skyline Soul",
+      "broadcaster": "independent",
+      "streamUrl": "https://rblive.it:8040/radio.mp3",
+      "homepage": "https://www.skyline.it/",
+      "country": "IT",
+      "tags": [
+        "classic soul"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-classica-bresciana",
+      "name": "Radio Classica Bresciana",
+      "broadcaster": "independent",
+      "streamUrl": "https://nmcdn-3177cee185284d2990021eccc8b06ae6.msvdn.net/icecastRelay/S66374741/yNMp1W7wbgWY/icecast",
+      "homepage": "https://www.radioclassicabresciana.it/",
+      "country": "IT",
+      "favicon": "https://servizi.bresciaonline.it/radioclassica/radioclassicabresciana.png",
+      "codec": "AAC+",
+      "geo": [
+        45.5121,
+        10.2173
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-rock-italia",
+      "name": "Radio Rock Italia",
+      "broadcaster": "independent",
+      "streamUrl": "https://rrock.fluidstream.eu/radiorock_ita.mp3",
+      "homepage": "https://radiorock.it/",
+      "country": "IT",
+      "tags": [
+        "italian rock",
+        "musica italiana",
+        "rock",
+        "rock italiano"
+      ],
+      "favicon": "https://radiorock.it/wp-content/uploads/2023/02/radiorockitalia-770x770.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-70-80-it",
+      "name": "70-80.it",
+      "broadcaster": "independent",
+      "streamUrl": "https://onair18.xdevel.com/proxy/7080it?mp=/stream",
+      "homepage": "https://www.70-80.it/",
+      "country": "IT",
+      "tags": [
+        "1970s",
+        "1980s",
+        "70 80 hits",
+        "70s",
+        "80s"
+      ],
+      "favicon": "https://www.70-80.it/wp-content/uploads/2020/03/logo-7080-new.webp",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-cooperativa-padova-right",
+      "name": "Radio Cooperativa Padova right",
+      "broadcaster": "independent",
+      "streamUrl": "https://de4.streamingpulse.com/ssl/7013",
+      "homepage": "https://www.radiocooperativa.org/3/index.php",
+      "country": "IT",
+      "tags": [
+        "misc"
+      ],
+      "bitrate": 96,
+      "codec": "MP3",
+      "geo": [
+        45.3473,
+        11.8678
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-padova-country",
+      "name": "Radio Padova Country",
+      "broadcaster": "independent",
+      "streamUrl": "https://sphera.fluidstream.eu/rpd_country.mp3",
+      "homepage": "https://www.radiopadova.com/",
+      "country": "IT",
+      "tags": [
+        "country"
+      ],
+      "favicon": "https://www.radiopadova.com/wp-content/uploads/2022/05/cropped-radio-padova-icona-180x180.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-easy-network-classic",
+      "name": "Easy Network Classic",
+      "broadcaster": "independent",
+      "streamUrl": "https://sphera.fluidstream.eu/easy_classica.mp3",
+      "homepage": "https://www.easynetwork.fm/",
+      "country": "IT",
+      "tags": [
+        "classical",
+        "padova"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-deejay-gasolina",
+      "name": "Deejay Gasolina",
+      "broadcaster": "independent",
+      "streamUrl": "https://4c4b867c89244861ac216426883d1ad0.msvdn.net/webradio/deejaygasolina/playlist.m3u8",
+      "homepage": "https://www.deejay.it/",
+      "country": "IT",
+      "tags": [
+        "latin",
+        "latin music",
+        "latin pop",
+        "musica latina",
+        "pop latino"
+      ],
+      "favicon": "https://cdn.gelestatic.it/deejay/sites/2/2016/03/webradio_deejay_gasolina-320x320.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-cafe-roma-lounge",
+      "name": "Cafe Roma Lounge",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/cafe-roma-lounge",
+      "homepage": "https://info201774.wixsite.com/caferomalounge",
+      "country": "IT",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-mediterranea",
+      "name": "Radio Mediterranea",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radiomediterranea.com:8160/lounge.mp3",
+      "homepage": "https://www.radiomediterranea.com/",
+      "country": "IT",
+      "tags": [
+        "lounge chillout relax smoothjazz ambient"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        40.3954,
+        18.136
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-deejay-one-two-one-two",
+      "name": "Deejay One Two One Two",
+      "broadcaster": "independent",
+      "streamUrl": "https://4c4b867c89244861ac216426883d1ad0.msvdn.net/webradio/deejayonetwoonetwo/playlist.m3u8",
+      "homepage": "https://www.deejay.it/",
+      "country": "IT",
+      "tags": [
+        "hip hop",
+        "hip-hop",
+        "hip-hop and rap oldies",
+        "hiphop",
+        "rap",
+        "trap"
+      ],
+      "favicon": "https://cdn.gelestatic.it/deejay/sites/2/2015/05/webradio_one_two-320x320.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-italia-auditorium",
+      "name": "ITALIA Auditorium",
+      "broadcaster": "independent",
+      "streamUrl": "https://icy.unitedradio.it/um015.mp3",
+      "homepage": "http://www.unitedmusic.it/",
+      "country": "IT",
+      "tags": [
+        "italian",
+        "mediaset"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-banda-larga",
+      "name": "Radio Banda Larga",
+      "broadcaster": "independent",
+      "streamUrl": "https://rblmedia.out.airtime.pro/rblmedia_a",
+      "homepage": "https://rbl.media/en",
+      "country": "IT",
+      "tags": [
+        "community radio",
+        "dj",
+        "dj sets",
+        "eclectic",
+        "freeform"
+      ],
+      "favicon": "https://rbl.media/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-rtr-99-radio-pop-e-rock",
+      "name": "RTR 99 Radio Pop e Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://rtr99.fluidstream.eu/rtr99_poprock.mp3",
+      "homepage": "https://rtr99.it/",
+      "country": "IT",
+      "tags": [
+        "pop",
+        "pop rock",
+        "rock"
+      ],
+      "favicon": "https://www.rtr99.it/onair/PopRock/OnAir.jpg?x=d19xo2mvx08g75jst1trz",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-bruno-brescia",
+      "name": "Radio Bruno Brescia",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream1.xdevel.com/audio1s975758-318/stream/icecast.audio",
+      "homepage": "https://www.radiobrunobrescia.it/",
+      "country": "IT",
+      "tags": [
+        "pop"
+      ],
+      "favicon": "https://www.radiobrunobrescia.it/favicon.ico",
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-musica-disco-fever",
+      "name": "Radio Musica Disco Fever",
+      "broadcaster": "independent",
+      "streamUrl": "https://gcarrstream2-danidi01.radioca.st/stream",
+      "homepage": "https://www.radiomusicatv.it/",
+      "country": "IT",
+      "favicon": "https://static2.mytuner.mobi/media/tvos_radios/tz6dwkzktbup.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-deejay-on-the-road",
+      "name": "Deejay On The Road",
+      "broadcaster": "independent",
+      "streamUrl": "https://4c4b867c89244861ac216426883d1ad0.msvdn.net/webradio/deejayontheroad/playlist.m3u8",
+      "homepage": "https://www.deejay.it/",
+      "country": "IT",
+      "tags": [
+        "road",
+        "roadtrip"
+      ],
+      "favicon": "https://cdn.gelestatic.it/deejay/sites/2/2015/05/webradio_deejay_on_the_road-320x320.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-ciccio-riccio",
+      "name": "Radio Ciccio Riccio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream5.xdevel.com/audio0s975942-758/stream/icecast.audio",
+      "homepage": "http://www.ciccioriccio.it/",
+      "country": "IT",
+      "tags": [
+        "varied"
+      ],
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-rsc-radio-studio-centrale",
+      "name": "RSC Radio Studio Centrale",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.studiocentrale.it/radio/8020/radio.mp3?_=1",
+      "homepage": "https://www.studiocentrale.it/",
+      "country": "IT",
+      "tags": [
+        "pop music"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        37.4789,
+        15.0526
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-evangelo-piemonte",
+      "name": "RADIO EVANGELO PIEMONTE",
+      "broadcaster": "independent",
+      "streamUrl": "https://dreamsiteradiocp3.com/proxy/radioevangelo?mp=/stream",
+      "homepage": "https://radioevangelo.it/",
+      "country": "IT",
+      "tags": [
+        "christian",
+        "gospel"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-rossini",
+      "name": "Radio Rossini",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/radiorossini",
+      "homepage": "https://www.radiorossini.com/",
+      "country": "IT",
+      "tags": [
+        "anni 60",
+        "anni 70",
+        "italian pop",
+        "italo dance anni 90",
+        "musica anni 80"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-deejay-4-christmas",
+      "name": "Deejay 4 Christmas",
+      "broadcaster": "independent",
+      "streamUrl": "https://4c4b867c89244861ac216426883d1ad0.msvdn.net/webradio/deejay80/live.m3u8",
+      "homepage": "https://www.deejay.it/webradio/01/",
+      "country": "IT",
+      "tags": [
+        "christmas songs",
+        "seasonal"
+      ],
+      "favicon": "https://www.deejay.it/favicon.ico",
+      "codec": "UNKNOWN",
+      "geo": [
+        45.4635,
+        9.1908
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-quar",
+      "name": "Radio Quar",
+      "broadcaster": "independent",
+      "streamUrl": "https://radioquar.com/radio/8000/radio320.mp3",
+      "homepage": "https://radioquar.com/public/radio_quar",
+      "country": "IT",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-rtl-102-5-disco",
+      "name": "RTL 102.5 Disco",
+      "broadcaster": "independent",
+      "streamUrl": "https://dd782ed59e2a4e86aabf6fc508674b59.msvdn.net/live/S51100361/Sz3kCA55PrRh/playlist_audio.m3u8",
+      "homepage": "https://play.rtl.it/live/21/rtl-1025-doc-tv/",
+      "country": "IT",
+      "tags": [
+        "club",
+        "dance",
+        "electronic dance music",
+        "eurodance",
+        "house"
+      ],
+      "favicon": "https://cloud.rtl.it/assets/www.rtl.it/3.0.64/img/logo/favicon-96x96.png",
+      "bitrate": 192,
+      "codec": "AAC",
+      "geo": [
+        45.5236,
+        9.2659
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-core-de-roma",
+      "name": "Radio Core de Roma",
+      "broadcaster": "independent",
+      "streamUrl": "https://sr14.inmystream.it:8210/stream",
+      "homepage": "https://www.radiocorederoma.it/",
+      "country": "IT",
+      "tags": [
+        "folk",
+        "pop",
+        "roma"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-maria-italy",
+      "name": "Radio Maria Italy",
+      "broadcaster": "independent",
+      "streamUrl": "https://dreamsiteradiocp4.com/proxy/rmitaliamontecarlo?mp=/stream",
+      "homepage": "https://radiomaria.it/",
+      "country": "IT",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-piterpan-hq",
+      "name": "Radio Piterpan (HQ)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice02.fluidstream.net/piterpan.mp3?FLID=1&type=.mp3",
+      "homepage": "https://www.piterpan.it/",
+      "country": "IT",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-company-fitness",
+      "name": "Radio Company Fitness",
+      "broadcaster": "independent",
+      "streamUrl": "https://sphera.fluidstream.eu/companyfitness.mp3",
+      "homepage": "https://www.radiocompany.com/",
+      "country": "IT",
+      "tags": [
+        "electronic",
+        "power pop"
+      ],
+      "favicon": "https://www.radiocompany.com/fitness/android-icon-192x192.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-raheem",
+      "name": "Radio Raheem",
+      "broadcaster": "independent",
+      "streamUrl": "https://radioraheem.out.airtime.pro/radioraheem_a",
+      "homepage": "https://www.radioraheem.it/",
+      "country": "IT",
+      "tags": [
+        "ambient",
+        "balearic",
+        "breakbeat",
+        "dancehall",
+        "downtempo",
+        "electronic"
+      ],
+      "favicon": "https://www.radioraheem.it/wp-content/themes/gds-vue/meta/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        45.4725,
+        9.1737
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-gedi-radio-capital-classic-rock",
+      "name": "GEDI - Radio Capital Classic Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://streamcdnr3-4c4b867c89244861ac216426883d1ad0.msvdn.net/webradio/capitalclassicrock/playlist.m3u8",
+      "homepage": "https://www.capital.it/webradio/02/",
+      "country": "IT",
+      "tags": [
+        "rock"
+      ],
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radioattivita",
+      "name": "Radioattività",
+      "broadcaster": "independent",
+      "streamUrl": "https://nr5.newradio.it/proxy/finmedia?mp=/stream",
+      "homepage": "https://radioattivita.com/",
+      "country": "IT",
+      "tags": [
+        "trieste"
+      ],
+      "favicon": "https://radioattivita.com/favicon.ico",
+      "codec": "MP3",
+      "geo": [
+        45.6445,
+        13.7571
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-gedi-radio-capital-w-l-italia",
+      "name": "GEDI - Radio Capital W L'Italia",
+      "broadcaster": "independent",
+      "streamUrl": "https://streamcdnr15-4c4b867c89244861ac216426883d1ad0.msvdn.net/webradio/capitalwitalia/playlist.m3u8",
+      "homepage": "https://www.capital.it/webradio/04/",
+      "country": "IT",
+      "tags": [
+        "pop"
+      ],
+      "favicon": "https://cdn.gelestatic.it/capital/sites/2/2016/11/webradio-vivalitalia-640x334.jpg",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-underground-italia",
+      "name": "Radio Underground Italia ",
+      "broadcaster": "independent",
+      "streamUrl": "https://nr14.newradio.it:8707/stream",
+      "homepage": "https://radiounderground.it/",
+      "country": "IT",
+      "tags": [
+        "underground"
+      ],
+      "favicon": "https://radio-streaming.it/assets/image/radio/180/logo_con_scritta.jpg",
+      "bitrate": 128,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-aci-radio",
+      "name": "Aci Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://sphera.fluidstream.eu/company.mp3?FLID=1",
+      "homepage": "http://www.aci.it/",
+      "country": "IT",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-forever-rock",
+      "name": "FOREVER ROCK",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/foreverrock",
+      "homepage": "https://forever80.altervista.org/",
+      "country": "IT",
+      "tags": [
+        "60s",
+        "70s",
+        "80s",
+        "90s",
+        "pop rock"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-kolbe-la-voce-di-maria-regina-dell-amore",
+      "name": "Radio Kolbe - La voce di Maria Regina dell'Amore",
+      "broadcaster": "independent",
+      "streamUrl": "https://uk2.streamingpulse.com/ssl/kolbe",
+      "homepage": "https://www.radiokolbe.it/",
+      "country": "IT",
+      "tags": [
+        "religion",
+        "spiritual"
+      ],
+      "favicon": "https://www.radiokolbe.it/__ovh/common/img/favicon.ico",
+      "bitrate": 96,
+      "codec": "AAC+",
+      "geo": [
+        45.7241,
+        11.3378
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-linea-love",
+      "name": "Radio Linea Love",
+      "broadcaster": "independent",
+      "streamUrl": "https://rblive.it:8120//radio.mp3",
+      "homepage": "https://www.radiolinea.it/",
+      "country": "IT",
+      "tags": [
+        "love songs"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-skyline",
+      "name": "Radio Skyline",
+      "broadcaster": "independent",
+      "streamUrl": "https://rblive.it:8010/radio.mp3",
+      "homepage": "https://www.skyline.it/",
+      "country": "IT",
+      "tags": [
+        "pop music"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-primocanale-tv",
+      "name": "Primocanale TV",
+      "broadcaster": "independent",
+      "streamUrl": "https://msh0203.stream.seeweb.it/live/flv:stream2.sdp/chunklist_w1626804143.m3u8",
+      "homepage": "https://primocanale.it/",
+      "country": "IT",
+      "tags": [
+        "local news"
+      ],
+      "favicon": "https://primocanale.it/favicon.ico",
+      "codec": "UNKNOWN",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-cron",
+      "name": "Radio Cron",
+      "broadcaster": "independent",
+      "streamUrl": "https://cron.stream.laut.fm/cron",
+      "homepage": "https://radiocron.altervista.org/",
+      "country": "IT",
+      "tags": [
+        "anime",
+        "carpi",
+        "children",
+        "soundtracks"
+      ],
+      "favicon": "https://radiocron.altervista.org/wp-content/uploads/2021/03/cropped-radio-cron-512-180x180.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-veneto-radio",
+      "name": "Veneto Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://sr11.inmystream.it/proxy/paolo1?mp=/stream",
+      "homepage": "https://www.venetoradio.it/",
+      "country": "IT",
+      "tags": [
+        "pop"
+      ],
+      "favicon": "https://www.venetoradio.com/wp-content/uploads/2021/06/live.gif",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-dee-jay-full-time-radio",
+      "name": "dee Jay full time radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://djft.radioca.st/",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "IT",
+      "tags": [
+        "classical"
+      ],
+      "bitrate": 96,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-comozero",
+      "name": "Radio ComoZero",
+      "broadcaster": "independent",
+      "streamUrl": "https://sr14.inmystream.it/stream/freedom",
+      "homepage": "https://comozero.it/",
+      "country": "IT",
+      "favicon": "https://comozero.it/wp-content/uploads/favicon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        45.8118,
+        9.0825
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-70-80-90-rock",
+      "name": "Radio 70 80 90 Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://rblive.it:8090/radio.mp3",
+      "homepage": "https://www.radio708090.it/",
+      "country": "IT",
+      "tags": [
+        "rock"
+      ],
+      "favicon": "https://www.radio708090.it/wp-content/uploads/2021/10/708090-ROCK-160-1.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-alta-italy",
+      "name": "Radio Alta Italy",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.radioalta.it/stream.mp3",
+      "homepage": "https://www.bergamotv.it/radiolive/",
+      "country": "IT",
+      "favicon": "https://cdn-profiles.tunein.com/s25078/images/logod.jpg?t=638325351480000000",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-firenze-95-4",
+      "name": "Radio Firenze 95.4",
+      "broadcaster": "independent",
+      "streamUrl": "https://sr14.inmystream.it/stream/radiofirenze/stream",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "IT",
+      "tags": [
+        "pop"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-san-luchino",
+      "name": "Radio San Luchino",
+      "broadcaster": "independent",
+      "streamUrl": "https://ssl.audio1.meway.tv/proxy/sanluchino?mp=/stream",
+      "homepage": "https://www.radiosanluchino.it/",
+      "country": "IT",
+      "tags": [
+        "musica",
+        "news",
+        "talk"
+      ],
+      "favicon": "https://www.radiosanluchino.it/wp-content/uploads/2020/09/logoblu3.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-studio-104",
+      "name": "Radio Studio 104",
+      "broadcaster": "independent",
+      "streamUrl": "https://onair7.xdevel.com/proxy/xautocloud_v8ss_1328?mp=/;1/",
+      "homepage": "https://www.radiostudio104.com/",
+      "country": "IT",
+      "tags": [
+        "pop",
+        "rock",
+        "soul",
+        "jazz",
+        "funk"
+      ],
+      "favicon": "https://www.radiostudio104.com/wp-content/uploads/2025/06/104-logo.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        38.1167,
+        13.3667
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-megamix80",
+      "name": "megamix80",
+      "broadcaster": "independent",
+      "streamUrl": "https://centova.ipstream.it/proxy/megamix80/stream",
+      "homepage": "http://ntova.ipstream.it/",
+      "country": "IT",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-linea-sport-energy",
+      "name": "Radio Linea Sport Energy",
+      "broadcaster": "independent",
+      "streamUrl": "https://rblive.it:8130/radio.mp3",
+      "homepage": "https://www.radiolinea.it/diretta-sport/",
+      "country": "IT",
+      "tags": [
+        "high energy"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-antenna-web-assisi",
+      "name": "_Antenna Web Assisi",
+      "broadcaster": "independent",
+      "streamUrl": "https://italiavera.radioca.st/stream?type=http&nocache=296",
+      "homepage": "http://www.antennaradio.it/",
+      "country": "IT",
+      "tags": [
+        "assisi",
+        "firenze",
+        "gubbio",
+        "italian",
+        "mp3",
+        "napoli"
+      ],
+      "favicon": "https://antennaweb.it/wp-content/uploads/2023/08/rap180-100x100.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-energy-chill",
+      "name": "Radio Energy Chill",
+      "broadcaster": "independent",
+      "streamUrl": "https://gmusto5.radioca.st/mp3",
+      "homepage": "https://radioenergy.to/",
+      "country": "IT",
+      "tags": [
+        "chill",
+        "chillout",
+        "dance",
+        "easy listening",
+        "edm",
+        "electronic"
+      ],
+      "favicon": "https://radioenergy.to/play/tmp/images/logo.1714720179.png",
+      "bitrate": 224,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-fresh",
+      "name": "Radio Fresh",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiofresh.radioca.st/stream",
+      "homepage": "https://www.radiofresh.it/",
+      "country": "IT",
+      "tags": [
+        "pop music"
+      ],
+      "favicon": "https://www.radiofresh.it/wp-content/uploads/2020/08/Logo-Radio-Fresh-68pxH.png",
+      "bitrate": 96,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-l-olgiata",
+      "name": "Radio l'Olgiata",
+      "broadcaster": "independent",
+      "streamUrl": "https://olgiata-danidi01.radioca.st/stream.mp3/",
+      "homepage": "http://www.radiololgiata.net/",
+      "country": "IT",
+      "favicon": "http://www.radiololgiata.net/images/iconaiphone.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-romeo-juliet",
+      "name": "Radio Romeo & Juliet",
+      "broadcaster": "independent",
+      "streamUrl": "https://onair7.xdevel.com/proxy/xautocloud_vovi_2030?mp=/;1/",
+      "homepage": "https://radioromeoandjuliet.it/",
+      "country": "IT",
+      "tags": [
+        "electronic",
+        "house",
+        "techno"
+      ],
+      "favicon": "https://static3.inonda.com/2030/RES/player/5ViwscqTCV-cover-600,600.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-rouge-fm",
+      "name": "Radio Rouge FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://nl1.streamingpulse.com/ssl/radiorouge993",
+      "homepage": "https://radiorouge.com/",
+      "country": "IT",
+      "tags": [
+        "adult contemporary"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-rds-next",
+      "name": "RDS Next",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rds.radio/audio/rdsnext.stream_aac/playlist.m3u8",
+      "homepage": "https://www.rds.it/next-web-radio/",
+      "country": "IT",
+      "tags": [
+        "pop",
+        "top40"
+      ],
+      "favicon": "https://www.rds.it/next-web-radio/wp-content/uploads/fbrfg/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-deejay-tropical-pizza",
+      "name": "Deejay Tropical Pizza",
+      "broadcaster": "independent",
+      "streamUrl": "https://4c4b867c89244861ac216426883d1ad0.msvdn.net/webradio/deejaytropicalpizza/playlist.m3u8",
+      "homepage": "https://www.deejay.it/",
+      "country": "IT",
+      "tags": [
+        "alternative rock",
+        "classic rock",
+        "pop rock",
+        "rock"
+      ],
+      "favicon": "https://cdn.gelestatic.it/deejay/sites/2/2015/05/webradio_tropical-320x320.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-inblu2000",
+      "name": "Radio InBlu2000",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.radioinblu.it/live-stream/inblu2000-playlist.m3u8",
+      "homepage": "https://www.radioinblu.it/",
+      "country": "IT",
+      "tags": [
+        "religious",
+        "talk"
+      ],
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-ram-power-102-7",
+      "name": "Ram Power 102.7",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.ram.radio/audio/ram.stream_aac64/chunklist.m3u8",
+      "homepage": "https://www.rampower.it/",
+      "country": "IT",
+      "tags": [
+        "adult contemporary",
+        "italian",
+        "pop",
+        "rnb"
+      ],
+      "favicon": "https://gitlab.com/alexby306/host-images/-/raw/main/rampower.png",
+      "codec": "UNKNOWN",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-repubblic-rock-radio",
+      "name": "Repubblic Rock Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://repubblicrockradio.stream.laut.fm/repubblicrockradio?ref=web-app&start_time=1632920059398&t302=2021-09-29_14-54-19&uuid=58cf1184-76b2-4e9c-bd17-1b7b88500313",
+      "homepage": "https://repubblicrock.altervista.org/",
+      "country": "IT",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        44.7847,
+        10.8868
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-dimensione-suono-roma",
+      "name": "Dimensione Suono Roma",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.dimensionesuonoroma.radio/audio/dsr.stream_aac64/playlist.m3u8",
+      "homepage": "https://www.dimensionesuonoroma.it/",
+      "country": "IT",
+      "tags": [
+        "capital",
+        "lazio",
+        "roma"
+      ],
+      "favicon": "https://www.dimensionesuonoroma.it/wp-content/themes/rds-dsr/icons/favicon-196x196.png",
+      "bitrate": 64,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-cecchetto",
+      "name": "Radio Cecchetto",
+      "broadcaster": "independent",
+      "streamUrl": "https://eu10.fastcast4u.com:3420/",
+      "homepage": "https://www.radiocecchetto.it/",
+      "country": "IT",
+      "favicon": "https://static.wixstatic.com/media/45e16d_6f30cb2becf740a9b406dded11ff23a3%7emv2.png/v1/fill/w_180%2ch_180%2clg_1%2cusm_0.66_1.00_0.01/45e16d_6f30cb2becf740a9b406dded11ff23a3%7emv2.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-company-rock",
+      "name": "Radio Company Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://sphera.fluidstream.eu/companyrock.mp3",
+      "homepage": "https://www.radiocompany.com/",
+      "country": "IT",
+      "tags": [
+        "rock"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-lady",
+      "name": "Radio Lady",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice05.fluidstream.net/fluid0507.mp3?FLID=1&type=.mp3",
+      "homepage": "https://www.radiolady.it/",
+      "country": "IT",
+      "favicon": "https://www.radiolady.it/wp-content/uploads/2020/02/cropped-radio_lady_testa-set19.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-tour",
+      "name": "RADIO TOUR",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiotour.streamingmedia.it/play.mp3",
+      "homepage": "http://radiotour.fm/",
+      "country": "IT",
+      "tags": [
+        "anni 70",
+        "anni 80",
+        "anni 90",
+        "classic hits",
+        "musica anni 70",
+        "musica anni 80"
+      ],
+      "favicon": "https://drive.google.com/file/d/1mN5LPpmY5fJjXIHIg8rB5F7Gd0PODAM3/view?usp=sharing",
+      "bitrate": 192,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-toradio",
+      "name": "TOradio",
+      "broadcaster": "independent",
+      "streamUrl": "https://nr5.newradio.it/proxy/fsrls?mp=/stream",
+      "homepage": "https://toradio.it/",
+      "country": "IT",
+      "tags": [
+        "news",
+        "pop",
+        "talk",
+        "top 40",
+        "torino"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-garganofm",
+      "name": "GarganoFM",
+      "broadcaster": "independent",
+      "streamUrl": "https://onlineradiobox.com/json/it/gargano/play?platform=web",
+      "homepage": "https://www.garganofm.com/",
+      "country": "IT",
+      "tags": [
+        "entertainment",
+        "italy",
+        "pop"
+      ],
+      "favicon": "https://www.garganofm.com/wp-content/uploads/2019/10/cropped-gfm-1-180x180.jpg.webp",
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-emotions",
+      "name": "Radio emotions",
+      "broadcaster": "independent",
+      "streamUrl": "https://sr13.inmystream.it/proxy/radioemotions",
+      "homepage": "https://www.radioemotions.net/",
+      "country": "IT",
+      "favicon": "https://www.radioemotions.net/wp-content/uploads/elementor/thumbs/huawei-1-e1609262248368-p0l7rbomrm3f93qkumlw58oayrbokcs4u652uaifb4.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-parma",
+      "name": "Radio Parma",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice05.fluidstream.net/radioparma.aac",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "IT",
+      "tags": [
+        "talk & speech"
+      ],
+      "bitrate": 64,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-rtl-102-5-news",
+      "name": "RTL 102.5 news",
+      "broadcaster": "independent",
+      "streamUrl": "https://dd782ed59e2a4e86aabf6fc508674b59.msvdn.net/live/S38122967/aJMOUBAFc2Bc/playlist_audio.m3u8",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "IT",
+      "tags": [
+        "news"
+      ],
+      "bitrate": 192,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-dancefloor-90s",
+      "name": "Radio Dancefloor 90s",
+      "broadcaster": "independent",
+      "streamUrl": "https://audio.radiodancefloor.it/dancefloor.mp3",
+      "homepage": "https://www.radiodancefloor.it/",
+      "country": "IT",
+      "tags": [
+        "dance",
+        "electronic"
+      ],
+      "favicon": "https://firebasestorage.googleapis.com/v0/b/radiogalaxy-580f4.appspot.com/o/images%2FIMG_20240601_155330797.jpg?alt=media&token=9b200358-04d4-4adb-847f-664d6bf837ca",
+      "bitrate": 96,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-meravigliosa",
+      "name": "Radio Meravigliosa",
+      "broadcaster": "independent",
+      "streamUrl": "https://sr11.inmystream.it/proxy/meravigliosa?mp=/",
+      "homepage": "http://www.radiomeravigliosa.it/",
+      "country": "IT",
+      "favicon": "http://www.radiomeravigliosa.it/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-trapena",
+      "name": "Radio Trapena",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-177.zeno.fm/ytxxawhz67zuv?zt=eyJhbGciOiJIUzI1NiJ9.eyJzdHJlYW0iOiJ5dHh4YXdoejY3enV2IiwiaG9zdCI6InN0cmVhbS0xNzcuemVuby5mbSIsInRtIjpmYWxzZSwicnR0bCI6NSwianRpIjoiYi1XNjhJUU1RaDJETnlvWk1ra1NJUSIsImlhdCI6MTc2ODQ0NzA4MiwiZXhwIjoxNzY4NDQ3MTQyfQ.hwc0kDMs_H8bi4XAFJY3BvbjcnaSD22pJ5OCYlqTMd0",
+      "homepage": "https://zeno.fm/radio/RadioTrapena/",
+      "country": "IT",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-rdr-rainbow-diversamente-radio",
+      "name": "RDR Rainbow Diversamente Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://rdrtv.radioca.st/stream",
+      "homepage": "https://rainboweb.blogspot.com/",
+      "country": "IT",
+      "tags": [
+        "music",
+        "napoli",
+        "talk"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-gedi-deejay-suona-italia",
+      "name": "GEDI - Deejay Suona Italia",
+      "broadcaster": "independent",
+      "streamUrl": "https://streamcdnr13-4c4b867c89244861ac216426883d1ad0.msvdn.net/webradio/deejaysuonaitalia/playlist.m3u8",
+      "homepage": "https://www.deejay.it/webradio/07/",
+      "country": "IT",
+      "tags": [
+        "pop"
+      ],
+      "favicon": "https://cdn.gelestatic.it/deejay/sites/2/2015/05/webradio_deejay_suona_italia.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-108-web",
+      "name": "Radio 108 Web",
+      "broadcaster": "independent",
+      "streamUrl": "https://onair7.xdevel.com/proxy/xautocloud_ab42_890?mp=/;mp3/;",
+      "homepage": "https://www.radio108web.com/",
+      "country": "IT",
+      "tags": [
+        "canale generale di intrattenimento"
+      ],
+      "favicon": "https://static.wixstatic.com/media/10c032_313726babc364862a55f4a96bf36c38b%7emv2.png/v1/fill/w_180%2ch_180%2clg_1%2cusm_0.66_1.00_0.01/10c032_313726babc364862a55f4a96bf36c38b%7emv2.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-capital-funkytown",
+      "name": "RADIO CAPITAL FUNKYTOWN",
+      "broadcaster": "independent",
+      "streamUrl": "https://4c4b867c89244861ac216426883d1ad0.msvdn.net/radiocapitalfunkytownbck/radiocapitalfunkytownbck/play1.m3u8",
+      "homepage": "https://www.capital.it/webradio/",
+      "country": "IT",
+      "codec": "UNKNOWN",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-cassino-stereo",
+      "name": "Radio Cassino Stereo",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiocassino.radioca.st/;",
+      "homepage": "https://www.radiocassinostereo.com/",
+      "country": "IT",
+      "tags": [
+        "hot adult contemporary"
+      ],
+      "favicon": "https://www.inmystream.app/player2/rcs.png",
+      "bitrate": 128,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-citta-fujiko",
+      "name": "Radio Città Fujiko",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.radiocittafujiko.it:8000/rcf.ogg",
+      "homepage": "https://www.radiocittafujiko.it/",
+      "country": "IT",
+      "favicon": "https://www.radiocittafujiko.it/wp-content/uploads/2019/09/logo_quadro_fondo_bianco_x600_53ce3a61a3ca7d6763e94a5372f74e98.jpg",
+      "codec": "OGG",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-base-venezia",
+      "name": "Radio Base Venezia",
+      "broadcaster": "independent",
+      "streamUrl": "https://sr11.inmystream.it/proxy/radiobase?mp=/stream",
+      "homepage": "https://radiobasevenezia.net/",
+      "country": "IT",
+      "tags": [
+        "alternative"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-centrale-montorio-al-vomano",
+      "name": "Radio Centrale - Montorio al Vomano",
+      "broadcaster": "independent",
+      "streamUrl": "https://s1.forstream.it:8070/radiocentrale.mp3",
+      "homepage": "http://offline.radiocentrale.info/",
+      "country": "IT",
+      "tags": [
+        "classic italian pop",
+        "italian pop",
+        "local news",
+        "musica italiana",
+        "pop",
+        "sports news"
+      ],
+      "favicon": "http://offline.radiocentrale.info/streaming/base_streaming.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        42.5831,
+        13.6297
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-gioconda",
+      "name": "Radio Gioconda",
+      "broadcaster": "independent",
+      "streamUrl": "https://eu7.fastcast4u.com/proxy/radiofvg?mp=/;",
+      "homepage": "https://radiogioconda.it/",
+      "country": "IT",
+      "tags": [
+        "hits",
+        "musica italiana",
+        "pop"
+      ],
+      "favicon": "https://www.radiogioconda.it/wp-content/uploads/2018/06/favicon-150x150.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-italia-cina-tv",
+      "name": "Radio Italia Cina TV 意大利中国电台电视频道",
+      "broadcaster": "independent",
+      "streamUrl": "https://585b674743bbb.streamlock.net/9054/9054/playlist.m3u8",
+      "homepage": "https://www.radioitaliacina.com/",
+      "country": "IT",
+      "tags": [
+        "music",
+        "oldies"
+      ],
+      "favicon": "https://www.radioitaliacina.com/wp-content/uploads/radio-italia-cina-logo.jpg",
+      "bitrate": 1566,
+      "codec": "AAC,H.264",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-supersound",
+      "name": "Radio Supersound",
+      "broadcaster": "independent",
+      "streamUrl": "https://ssl2.azotosolutions.com:1010/1.mp3",
+      "homepage": "https://www.radiosupersound.it/",
+      "country": "IT",
+      "tags": [
+        "italian",
+        "pop",
+        "rock"
+      ],
+      "favicon": "https://www.radiosupersound.it/wp-content/uploads/revslider/rss-homepage/radio_super_sound_logo_slider.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-love-fm",
+      "name": "Love FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://rh.fluidstream.eu/lovefm.mp3?FLID=1",
+      "homepage": "https://www.lovefm.it/national-radio.htm",
+      "country": "IT",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-bias",
+      "name": "Radio Bias",
+      "broadcaster": "independent",
+      "streamUrl": "https://admin.biasradio.com/listen/bias_radio/live",
+      "homepage": "https://biasradio.com/",
+      "country": "IT",
+      "favicon": "https://biasradio.com/wp-content/uploads/2024/06/Radio-Bias150.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-bruno",
+      "name": "Radio Bruno",
+      "broadcaster": "independent",
+      "streamUrl": "https://router.xdevel.com/audio4s975355-254/stream/icecast.audio",
+      "homepage": "https://www.radiobruno.it/",
+      "country": "IT",
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-villa-immacolata",
+      "name": "Radio Villa Immacolata",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiocast.cloud/listen/relays_villaimmacolata/radio.mp3",
+      "homepage": "https://villaimmacolata.net/",
+      "country": "IT",
+      "tags": [
+        "religious"
+      ],
+      "favicon": "https://villaimmacolata.net/images/stories/articoli/logo1.JPG",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        45.3242,
+        11.7195
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-gedi-radio-capital-music",
+      "name": "GEDI - Radio Capital Music",
+      "broadcaster": "independent",
+      "streamUrl": "https://streamcdnr16-4c4b867c89244861ac216426883d1ad0.msvdn.net/webradio/capitalmusic/playlist.m3u8",
+      "homepage": "https://www.capital.it/webradio/01/",
+      "country": "IT",
+      "tags": [
+        "pop"
+      ],
+      "favicon": "https://cdn.gelestatic.it/capital/sites/2/2016/11/webradio-music-1200x1200.jpg",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-globo-solo-le-migliori",
+      "name": "Radio Globo | Solo le migliori",
+      "broadcaster": "independent",
+      "streamUrl": "https://globo.newradio.it/globorm64",
+      "homepage": "https://radioglobo.it/",
+      "country": "IT",
+      "tags": [
+        "capital",
+        "lazio",
+        "roma"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        41.8809,
+        12.4942
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-kiss-kiss-soft",
+      "name": "Kiss Kiss Soft",
+      "broadcaster": "independent",
+      "streamUrl": "https://kk.fluidstream.eu/kk_soft.mp3?id=OJi2H7QVWz&FLID=1",
+      "homepage": "https://kisskissnapoli.it/webradio/kiss-kiss-soft/",
+      "country": "IT",
+      "favicon": "https://kisskissnapoli.it/wp-content/uploads/elementor/thumbs/kisskiss_soft-py8k5n1kmyquvj2avlt6g9u4jw0aqotxl1cp0wme5o.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-pfarrradio-kaltern-caldaro",
+      "name": "Pfarrradio Kaltern-Caldaro",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiocast.cloud/radio/8110/radio.mp3?1603457029",
+      "homepage": "https://www.pfarrei-kaltern.it/de/pfarrliche-medien/pfarrsender",
+      "country": "IT",
+      "tags": [
+        "christian",
+        "katholic",
+        "katholik",
+        "religion",
+        "religious"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-dance-anni-90",
+      "name": "RADIO DANCE anni 90",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiodance.streamingmedia.it/it.aac",
+      "homepage": "https://www.radio.dance/",
+      "country": "IT",
+      "tags": [
+        "90s",
+        "dance"
+      ],
+      "favicon": "https://www.radio.dance/logo_radiodance90s_512.png",
+      "bitrate": 320,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radiolina",
+      "name": "Radiolina",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.shoutcast.com/radiolina",
+      "homepage": "https://radiolina.it/",
+      "country": "IT",
+      "favicon": "https://radiolina.it/wp-content/uploads/2021/10/cropped-Radiolina150x150-192x192.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-rvs-radio-villa-sound",
+      "name": "RVS Radio Villa Sound",
+      "broadcaster": "independent",
+      "streamUrl": "https://eu4.fastcast4u.com/proxy/lmarengo?mp=/;",
+      "homepage": "http://www.villasound.net/",
+      "country": "IT",
+      "tags": [
+        "pop",
+        "villafalletto"
+      ],
+      "bitrate": 96,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-happy-station",
+      "name": "Happy Station ",
+      "broadcaster": "independent",
+      "streamUrl": "https://rtr99.fluidstream.eu/rtr99_happy_hq.aac",
+      "homepage": "https://happystation.radio/",
+      "country": "IT",
+      "tags": [
+        "happy music",
+        "happyhits"
+      ],
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-loredana-berte",
+      "name": "Loredana Berte",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.zeno.fm/34avuktawp8uv",
+      "homepage": "https://zeno.fm/radio/web-radio-network-le-sorelle-berte/",
+      "country": "IT",
+      "favicon": "https://zeno.fm/favicon.ico",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-studio-nord-rock-cafe",
+      "name": "Radio Studio Nord Rock Cafè",
+      "broadcaster": "independent",
+      "streamUrl": "https://nr6.newradio.it:19363/;",
+      "homepage": "https://www.rsn.it/",
+      "country": "IT",
+      "tags": [
+        "rock",
+        "tolmezzo"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-utopia-firenze",
+      "name": "Radio Utopia Firenze",
+      "broadcaster": "independent",
+      "streamUrl": "https://nr12.newradio.it:8624/stream?ext=.mp3",
+      "homepage": "https://www.radioutopia.biz/",
+      "country": "IT",
+      "tags": [
+        "pop"
+      ],
+      "favicon": "https://www.radioutopia.biz/radio-utopia.png",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-margherita-giovane",
+      "name": "Margherita Giovane",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.radiomargherita.com/stream/radiomargheritagiovane",
+      "homepage": "https://www.radiomargherita.com/",
+      "country": "IT",
+      "tags": [
+        "pop music"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-amica-biella",
+      "name": "Radio Amica, Biella",
+      "broadcaster": "independent",
+      "streamUrl": "https://s10.myradiostream.com/35674/listen.mp3",
+      "homepage": "https://www.radioamica.net/",
+      "country": "IT",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        45.5375,
+        8.0557
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-cittadella",
+      "name": "Radio Cittadella",
+      "broadcaster": "independent",
+      "streamUrl": "https://nr14.newradio.it:8960/stream?ext=.mp3",
+      "homepage": "https://www.radiocittadella.it/",
+      "country": "IT",
+      "tags": [
+        "hits"
+      ],
+      "favicon": "https://www.radiocittadella.it/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-linetti-deejay-linus-wfm",
+      "name": "Radio Linetti (Deejay Linus WFM)",
+      "broadcaster": "independent",
+      "streamUrl": "https://streamcdnr11-4c4b867c89244861ac216426883d1ad0.msvdn.net/webradio/deejaywfmlinus/live.m3u8",
+      "homepage": "https://www.deejay.it/",
+      "country": "IT",
+      "tags": [
+        "only the golden classics",
+        "radio"
+      ],
+      "favicon": "https://cdn.gelestatic.it/deejay/sites/2/2019/04/linetti-320x320.png",
+      "codec": "UNKNOWN",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-studio-nord",
+      "name": "Radio Studio Nord",
+      "broadcaster": "independent",
+      "streamUrl": "https://nr6.newradio.it:19104/;",
+      "homepage": "https://www.rsn.it/",
+      "country": "IT",
+      "tags": [
+        "tolmezzo",
+        "various"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-volere-e-volare",
+      "name": "Radio volere e volare",
+      "broadcaster": "independent",
+      "streamUrl": "https://bay1.streamfm.it:8010/aacp",
+      "homepage": "https://radiolive.online/radio-volere-e-volare/",
+      "country": "IT",
+      "bitrate": 64,
+      "codec": "AAC",
+      "geo": [
+        41.8773,
+        12.5052
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-rds-avola",
+      "name": "RDS Avola",
+      "broadcaster": "independent",
+      "streamUrl": "https://be.server89.com:10989/stream.mp3",
+      "homepage": "https://www.rdsavola.it/",
+      "country": "IT",
+      "favicon": "https://www.rdsavola.it/img/core-img/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-franco-califano",
+      "name": "Franco Califano",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-39.zeno.fm/tcfbbvcdvp8uv?zs=k4Ch0DfKQh2hoqKasxb-3g",
+      "homepage": "https://zeno.fm/radio/web-radio-network-franco-califano/",
+      "country": "IT",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-amore-italia",
+      "name": "Radio Amore Italia",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream10.xdevel.com/audio6s977886-2320/stream/icecast.audio",
+      "homepage": "https://www.grupporadioamore.it/",
+      "country": "IT",
+      "favicon": "https://www.grupporadioamore.it/images/stories/loghi/radio_amore_italia.jpg",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-capital-xmas",
+      "name": "RADIO Capital XMAS",
+      "broadcaster": "independent",
+      "streamUrl": "https://4c4b867c89244861ac216426883d1ad0.msvdn.net/webradio/capitalsoft/live.m3u8",
+      "homepage": "https://www.capital.it/web%20radio/05/",
+      "country": "IT",
+      "tags": [
+        "folk"
+      ],
+      "favicon": "https://www.capital.it/wp-content/themes/network-capital/favicon.ico",
+      "codec": "UNKNOWN",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-citta-aperta",
+      "name": "Radio Città Aperta",
+      "broadcaster": "independent",
+      "streamUrl": "https://be.server89.com/8020/stream",
+      "homepage": "https://www.radiocittaperta.it/",
+      "country": "IT",
+      "tags": [
+        "indie"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-easy-network",
+      "name": "Radio Easy Network",
+      "broadcaster": "independent",
+      "streamUrl": "https://sphera.fluidstream.eu/easy.aac",
+      "homepage": "https://www.easynetwork.fm/",
+      "country": "IT",
+      "favicon": "https://www.easynetwork.fm/wp-content/uploads/2016/07/logo-radio-easy-network-nerp.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-gelosa",
+      "name": "Radio Gelosa",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice02.fluidstream.net/gelosa.mp3?FLID=1&type=.mp3",
+      "homepage": "https://www.radiogelosa.it/ascolta-radio-gelosa/",
+      "country": "IT",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-ricordi",
+      "name": "Radio Ricordi ",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream1.xdevel.com/audio2s975889-476/stream/icecast.audio",
+      "homepage": "https://www.adn24.it/radio-ricordi/radio-ricordi-live-streaming/",
+      "country": "IT",
+      "favicon": "https://www.adn24.it/favicon.ico",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-sud-orientale-rso",
+      "name": "Radio Sud Orientale RSO",
+      "broadcaster": "independent",
+      "streamUrl": "https://nrf1.newradio.it/stream/9750",
+      "homepage": "https://rsoradio.it/",
+      "country": "IT",
+      "favicon": "https://www.rsoradio.it/images/sponsor/banner4.jpg",
+      "bitrate": 96,
+      "codec": "MP3",
+      "geo": [
+        37.0738,
+        15.2843
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-wow-latin",
+      "name": "Radio WoW Latin",
+      "broadcaster": "independent",
+      "streamUrl": "https://sphera.fluidstream.eu/rwow_latin.mp3",
+      "homepage": "https://radiowow.com/",
+      "country": "IT",
+      "tags": [
+        "latin"
+      ],
+      "favicon": "https://radiowow.com/wp-content/uploads/2024/09/cropped-radio-wow-180x180.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radiogamma5",
+      "name": "RADIOGAMMA5",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice05.fluidstream.net/fluid0510.mp3",
+      "homepage": "http://www.radiogammacinque.it/",
+      "country": "IT",
+      "favicon": "http://www.radiogammacinque.it/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        45.4046,
+        11.8389
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-rtr99-happy-station",
+      "name": "Rtr99 Happy Station",
+      "broadcaster": "independent",
+      "streamUrl": "https://rtr99.fluidstream.eu/rtr99_happy.aac",
+      "homepage": "http://www.happystation.radio/",
+      "country": "IT",
+      "bitrate": 64,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-aci",
+      "name": "ACI",
+      "broadcaster": "independent",
+      "streamUrl": "https://nr7.newradio.it:19353/stream",
+      "homepage": "https://www.luceverde.it/radio.html",
+      "country": "IT",
+      "favicon": "https://www.luceverde.it/favicons/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-alto-jonio-raj",
+      "name": "Radio Alto Jonio - RAJ",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream1.xdevel.com/audio0s975781-332/stream/icecast.audio",
+      "homepage": "https://www.facebook.com/radioaltojonio",
+      "country": "IT",
+      "favicon": "https://www.facebook.com/favicon.ico",
+      "codec": "MP3",
+      "geo": [
+        40.322,
+        17.5719
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-kiss-kiss-1",
+      "name": "Radio Kiss Kiss + 1",
+      "broadcaster": "independent",
+      "streamUrl": "https://kk.fluidstream.eu/KissKiss1.mp3",
+      "homepage": "http://www.kisskiss.it/",
+      "country": "IT",
+      "tags": [
+        "entertainment",
+        "local radio",
+        "pop"
+      ],
+      "favicon": "https://kisskiss.it/wp-content/uploads/2022/04/1.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        40.8635,
+        14.2189
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-leopolda",
+      "name": "Radio Leopolda",
+      "broadcaster": "independent",
+      "streamUrl": "https://onair7.xdevel.com/proxy/xautocloud_ohfs_1545?mp=/stream",
+      "homepage": "https://www.radioleopolda.it/",
+      "country": "IT",
+      "favicon": "https://www.radioleopolda.it/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-linea-young-generation",
+      "name": "Radio Linea Young Generation",
+      "broadcaster": "independent",
+      "streamUrl": "https://rblive.it:8140/radio.mp3",
+      "homepage": "https://www.radiolinea.it/diretta-young-generation/",
+      "country": "IT",
+      "tags": [
+        "new generation"
+      ],
+      "favicon": "https://www.radiolinea.it/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-max-partenope",
+      "name": "Radio Max Partenope",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.zeno.fm/zmygsdxpks8uv",
+      "homepage": "https://zeno.fm/radio/radio-max-partenope/",
+      "country": "IT",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-star-92e5",
+      "name": "Radio Star 92e5",
+      "broadcaster": "independent",
+      "streamUrl": "https://vramacciv2-danidi01.radioca.st/stream",
+      "homepage": "http://www.radiostar92e5.it/",
+      "country": "IT",
+      "tags": [
+        "2000s",
+        "70s",
+        "80s",
+        "90s"
+      ],
+      "favicon": "http://www.radiostar92e5.it/favicon.ico",
+      "bitrate": 96,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radioreload-it",
+      "name": "RadioReload.it",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream3.xdevel.com/audio0s975522-197/stream/icecast.audio",
+      "homepage": "https://www.radioreload.it/",
+      "country": "IT",
+      "tags": [
+        "contemporary",
+        "dance"
+      ],
+      "favicon": "https://mytuner.global.ssl.fastly.net/media/tvos_radios/72cjm2r4d33m.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-holy-family",
+      "name": "Holy Family ",
+      "broadcaster": "independent",
+      "streamUrl": "https://mercury.reliastream.com/proxy/fratel?mp=/stream",
+      "homepage": "https://aeron.ning.com/",
+      "country": "IT",
+      "bitrate": 24,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-nation-70s",
+      "name": "Nation 70s",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen-nation.sharp-stream.com/nationradio70s.mp3",
+      "homepage": "https://listen-nation.sharp-stream.com/nationradio70s.mp3",
+      "country": "IT",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-crossover-disco",
+      "name": "RADIO CROSSOVER DISCO",
+      "broadcaster": "independent",
+      "streamUrl": "https://sp4.server89.com/8002/stream",
+      "homepage": "https://radiocrossoverdisco.com/",
+      "country": "IT",
+      "favicon": "https://radiocrossoverdisco.com/wp-content/uploads/2024/02/logo-senza-sfondo.png?w=559",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-linea-drive",
+      "name": "Radio Linea Drive",
+      "broadcaster": "independent",
+      "streamUrl": "https://rblive.it:8100//radio.mp3",
+      "homepage": "https://www.radiolinea.it/diretta-drive/",
+      "country": "IT",
+      "tags": [
+        "drive"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-yes",
+      "name": "Radio YES",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream1.aswifi.it/radioyes/live/index.m3u8",
+      "homepage": "https://yesmagazine.it/radio-yes-dab/",
+      "country": "IT",
+      "tags": [
+        "music",
+        "news",
+        "sport",
+        "talk"
+      ],
+      "favicon": "https://i0.wp.com/yesmagazine.it/wp-content/uploads/2020/04/image3.jpeg",
+      "codec": "UNKNOWN",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-stazione-playlist",
+      "name": "Stazione Playlist",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.zeno.fm/5fnppy0ag0hvv",
+      "homepage": "https://stjoseph.ning.com/",
+      "country": "IT",
+      "tags": [
+        "catholic radio"
+      ],
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-gedi-radio-capital-soft",
+      "name": "GEDI - Radio Capital Soft",
+      "broadcaster": "independent",
+      "streamUrl": "https://streamcdnr14-4c4b867c89244861ac216426883d1ad0.msvdn.net/webradio/capitalsoft/playlist.m3u8",
+      "homepage": "https://www.capital.it/webradio/05/",
+      "country": "IT",
+      "tags": [
+        "pop"
+      ],
+      "favicon": "https://cdn.gelestatic.it/capital/sites/2/2019/06/webradio-radio-capital-soft-1200x627.jpg",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-hybrid-radio",
+      "name": "Hybrid Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://nr9.newradio.it/proxy/content?mp=/stream",
+      "homepage": "https://www.radiohybrid.net/",
+      "country": "IT",
+      "tags": [
+        "easy listening"
+      ],
+      "favicon": "https://www.radiohybrid.net/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-dj-goku24",
+      "name": "Radio DJ Goku24",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-152.zeno.fm/b2d9xxu8khruv",
+      "homepage": "https://djgoku24.it/",
+      "country": "IT",
+      "tags": [
+        "dance",
+        "hits",
+        "pop"
+      ],
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-polignano-web",
+      "name": "radio polignano web",
+      "broadcaster": "independent",
+      "streamUrl": "https://sp3.server89.com:7018/",
+      "homepage": "https://sp3.server89.com:7018/;",
+      "country": "IT",
+      "tags": [
+        "music"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-sole-luna",
+      "name": "RADIO SOLE LUNA",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast3.server89.com/radio/8040/radio.mp3",
+      "homepage": "https://radiosoleluna.wixsite.com/shaky-micio",
+      "country": "IT",
+      "tags": [
+        "music"
+      ],
+      "favicon": "https://www.wix.com/favicon.ico",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-art-of-music-web-radio",
+      "name": "ART OF MUSIC • Web Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://sr6.inmystream.it/proxy/artofmusic?mp=/stream",
+      "homepage": "https://artofmusic.fm/",
+      "country": "IT",
+      "favicon": "https://artofmusic.fm/resources/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-controradio",
+      "name": "Controradio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s4.yesstreaming.net:17199/stream",
+      "homepage": "https://www.controradio.it/",
+      "country": "IT",
+      "tags": [
+        "blues",
+        "jazz",
+        "news",
+        "rock",
+        "soul",
+        "world"
+      ],
+      "favicon": "https://www.controradio.it/wp-content/uploads/2021/09/cropped-favicon-32x32.png",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-ala",
+      "name": "Radio Ala",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast.radioala.it:8443/stream?type=.mp3",
+      "homepage": "https://www.radioala.it/",
+      "country": "IT",
+      "tags": [
+        "dance",
+        "jazz",
+        "pop"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        45.7572,
+        11.005
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-dancefloor-90-s",
+      "name": "Radio Dancefloor - 90's",
+      "broadcaster": "independent",
+      "streamUrl": "https://audio.radiodancefloor.it/live128k.mp3",
+      "homepage": "https://www.radiodancefloor.it/",
+      "country": "IT",
+      "favicon": "https://www.radiodancefloor.it/wp-content/uploads/2021/09/logo_2022_mobile.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-poderosa",
+      "name": "Radio Poderosa",
+      "broadcaster": "independent",
+      "streamUrl": "https://s5.radio.co/sf025b6002/listen",
+      "homepage": "https://radiopoderosa.org/",
+      "country": "IT",
+      "tags": [
+        "political",
+        "social"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-sicilia-express",
+      "name": "RADIO SICILIA EXPRESS",
+      "broadcaster": "independent",
+      "streamUrl": "https://ssl3.azotosolutions.com:1052/stream",
+      "homepage": "https://azotosolutions.com/player/radiosiciliaexpress/",
+      "country": "IT",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-vomero",
+      "name": "Radio Vomero ",
+      "broadcaster": "independent",
+      "streamUrl": "https://free.rcast.net/67426",
+      "homepage": "https://www.radiovomero.it/",
+      "country": "IT",
+      "tags": [
+        "pop"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-rin-italia-network",
+      "name": "RIN Italia Network",
+      "broadcaster": "independent",
+      "streamUrl": "https://nr15.newradio.it:9100/stream",
+      "homepage": "https://rinitalianetwork.com/",
+      "country": "IT",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-rtr-99-story",
+      "name": "RTR 99 Story",
+      "broadcaster": "independent",
+      "streamUrl": "https://rtr99.fluidstream.eu/rtr99_story.mp3?id=lJNQvCT7kq&FLID=1&aw_0_req.gdpr=true&listenerid=05cf4c0e10ce1fd7d4c8ca2a37c45d16&awparams=companionAds%3Atrue",
+      "homepage": "https://www.rtr99.it/story/",
+      "country": "IT",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-zak-radio-sicilia",
+      "name": "Zak Radio Sicilia",
+      "broadcaster": "independent",
+      "streamUrl": "https://zakradiosicilia.radioca.st/stream#.mp3",
+      "homepage": "https://www.zakradio.ne/",
+      "country": "IT",
+      "tags": [
+        "mixed music",
+        "mixed programming"
+      ],
+      "bitrate": 96,
+      "codec": "MP3",
+      "geo": [
+        38.0098,
+        12.5366
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-105-story",
+      "name": "105 Story",
+      "broadcaster": "independent",
+      "streamUrl": "https://icy.unitedradio.it/105Story.mp3?aw_0_req.userConsentV2=&listenerId=e01becbe77271731a6ab06043a29ef98",
+      "homepage": "https://www.105.net/sezioni/739/105-story",
+      "country": "IT",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-bru-zane-classical-radio",
+      "name": "Bru Zane Classical Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://uk2.streamingpulse.com/ssl/bzr?v=20200621",
+      "homepage": "https://bru-zane.com/classical-radio/",
+      "country": "IT",
+      "favicon": "https://bru-zane.com/wp-content/uploads/2019/09/logo-small.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-combo-radio",
+      "name": "Combo Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.radio.co/sed646842d/listen",
+      "homepage": "https://thisiscombo.com/",
+      "country": "IT",
+      "tags": [
+        "electronic"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-united-hip-hop",
+      "name": "United Hip Hop",
+      "broadcaster": "independent",
+      "streamUrl": "https://icy.unitedradio.it/um049.mp3",
+      "homepage": "https://unitedradio.it/",
+      "country": "IT",
+      "tags": [
+        "hip hop",
+        "hip-hop",
+        "rap",
+        "rap hiphop rnb",
+        "rnb"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-2000",
+      "name": "Radio 2000",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radio2000.it/",
+      "homepage": "https://www.radio2000.it/",
+      "country": "IT",
+      "tags": [
+        "oldies",
+        "schlager"
+      ],
+      "favicon": "https://www.radio2000.it/wp-content/uploads/2017/11/cropped-radio2000_logo-2-270x270.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.7972,
+        11.9399
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-macomer-centrale",
+      "name": "Radio Macomer Centrale",
+      "broadcaster": "independent",
+      "streamUrl": "https://usa1-vn.mixstream.net/:8014/listen.mp3",
+      "homepage": "https://www.radiomacomer.com/",
+      "country": "IT",
+      "bitrate": 96,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-v2-beat-italy",
+      "name": "V2 Beat Italy",
+      "broadcaster": "independent",
+      "streamUrl": "https://de1se01.v2beat.live/icecast.audio",
+      "homepage": "https://www.vibee.tv/",
+      "country": "IT",
+      "bitrate": 128,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-dj-osso-radio",
+      "name": "DJ Osso Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rcs.revma.com/x3ab37sgn7uvv",
+      "homepage": "https://www.djossoradio.it/",
+      "country": "IT",
+      "tags": [
+        "happy music"
+      ],
+      "codec": "MP3",
+      "geo": [
+        41.8336,
+        12.4995
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-ms-hit-radio",
+      "name": "MS Hit Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://mshit-radio.stream.laut.fm/mshit-radio?ref=radiode&t302=2020-10-27_18-44-16&uuid=df04811c-7724-4496-89b7-cd02544437ed",
+      "homepage": "https://mshit-radio.stream.laut.fm/",
+      "country": "IT",
+      "tags": [
+        "pop rock"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radiospeaker-it",
+      "name": "RADIOSPEAKER.IT",
+      "broadcaster": "independent",
+      "streamUrl": "https://nr5.newradio.it/proxy/webradfest?mp=/stream2",
+      "homepage": "https://radiospeaker.it/",
+      "country": "IT",
+      "favicon": "https://www.radiospeaker.it/wp-content/themes/radiospeaker/images/player-cover.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-lifegate",
+      "name": "lifegate",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream2.xdevel.com/audio0s975809-423/stream/icecast.audio",
+      "homepage": "https://www.lifegate.it/",
+      "country": "IT",
+      "tags": [
+        "lounge",
+        "new age"
+      ],
+      "codec": "MP3",
+      "geo": [
+        43.2652,
+        10.7227
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-m2o-originals-radio",
+      "name": "m2o originals radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/m2o-originals-radio",
+      "homepage": "https://m2ooriginals.wixsite.com/my-site",
+      "country": "IT",
+      "tags": [
+        "dance music",
+        "electronic dance music",
+        "hands up",
+        "italo dance",
+        "musica"
+      ],
+      "favicon": "https://static.wixstatic.com/media/b9d036_d21d18b1eff34d019064204ad012c786~mv2.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-90-s-4-you",
+      "name": "Radio 90's 4 You",
+      "broadcaster": "independent",
+      "streamUrl": "https://streamsrv2.nets-sr.com:8004/stream",
+      "homepage": "https://www.radiocity4you.it/",
+      "country": "IT",
+      "tags": [
+        "dance",
+        "pop",
+        "rock"
+      ],
+      "bitrate": 192,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-flyweb",
+      "name": "Radio Flyweb",
+      "broadcaster": "independent",
+      "streamUrl": "https://nrf1.newradio.it:9930/?ver=413378",
+      "homepage": "https://www.radioflyweb.it/",
+      "country": "IT",
+      "favicon": "https://www.radioflyweb.it/wp-content/uploads/2022/05/Logo_radioflyweb_95x70.png",
+      "bitrate": 96,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-planet-music",
+      "name": "Radio Planet Music",
+      "broadcaster": "independent",
+      "streamUrl": "https://ns3156088.ip-51-89-96.eu:2000/stream/RadioPlanetMusic",
+      "homepage": "https://www.radioplanetmusic.it/",
+      "country": "IT",
+      "tags": [
+        "top 40"
+      ],
+      "favicon": "https://www.radioplanetmusic.it/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-station-one",
+      "name": "Radio Station One",
+      "broadcaster": "independent",
+      "streamUrl": "https://sr10.inmystream.it/proxy/bwrso?mp=/stream",
+      "homepage": "https://www.stationone.it/",
+      "country": "IT",
+      "tags": [
+        "classic hits",
+        "hits"
+      ],
+      "favicon": "https://www.stationone.it/wp-content/uploads/2021/12/cropped-cropped-Logo-Station-One-Radio-300.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-rigiriamo-web-radio",
+      "name": "Rigiriamo Web Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://onair7.xdevel.com/proxy/xautocloud_zswr_1060?mp=/;stream/;",
+      "homepage": "https://rigiriamo.it/",
+      "country": "IT",
+      "tags": [
+        "80s",
+        "90s",
+        "afro disco",
+        "hits",
+        "italo disco",
+        "pop"
+      ],
+      "favicon": "https://rigiriamo.it/wp-content/uploads/2024/01/rigira-con-noi-2.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        45.007,
+        10.9801
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-mongrando-radio-italia",
+      "name": "Mongrando Radio Italia",
+      "broadcaster": "independent",
+      "streamUrl": "https://a7.asurahosting.com:7000/radio.mp3",
+      "homepage": "https://sites.google.com/view/radiomongrando/home-page",
+      "country": "IT",
+      "tags": [
+        "world music"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-party-radio",
+      "name": "Party Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream12.top-ix.org/partygroove2",
+      "homepage": "https://www.fastmediasnc.it/party_radio/",
+      "country": "IT",
+      "tags": [
+        "70s",
+        "80s",
+        "90s",
+        "classics",
+        "dance",
+        "disco"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-fusion-italia",
+      "name": "Radio Fusion Italia",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.shoutcastitalia.com/proxy/fusion?mp=/stream",
+      "homepage": "https://radiofusion.it/",
+      "country": "IT",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-omega-sound",
+      "name": "Radio Omega Sound",
+      "broadcaster": "independent",
+      "streamUrl": "https://nr9.newradio.it/proxy/radioome?mp=/stream",
+      "homepage": "https://www.radioomega.it/",
+      "country": "IT",
+      "tags": [
+        "anzio",
+        "world music"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-roma-mobilita",
+      "name": "Radio Roma mobilità",
+      "broadcaster": "independent",
+      "streamUrl": "https://nr9.newradio.it:19021/stream?ext=.mp3",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "IT",
+      "tags": [
+        "news"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-studio-delta-la-piu",
+      "name": "Radio Studio Delta - la piu",
+      "broadcaster": "independent",
+      "streamUrl": "https://rsd.streamingmedia.it/play.mp3",
+      "homepage": "https://www.radiostudiodelta.it/",
+      "country": "IT",
+      "favicon": "https://radiostudiodelta.it/wp-content/uploads/2014/08/mobile-logo-rsd.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-suby",
+      "name": "Radio Suby",
+      "broadcaster": "independent",
+      "streamUrl": "https://icy.unitedradio.it/Suby.mp3",
+      "homepage": "https://www.radiosubasio.it/player/#!/channel/2",
+      "country": "IT",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-amore-blu",
+      "name": "Radio Amore Blu",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream10.xdevel.com/audio4s977886-2318/stream/icecast.audio",
+      "homepage": "https://www.grupporadioamore.it/",
+      "country": "IT",
+      "favicon": "https://www.grupporadioamore.it/images/stories/loghi/radio_amore_blu.jpg",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-caos-italia",
+      "name": "Radio Caos Italia",
+      "broadcaster": "independent",
+      "streamUrl": "https://sr14.inmystream.it/stream/radiocaos",
+      "homepage": "https://radiocaositalia.it/",
+      "country": "IT",
+      "bitrate": 128,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-energy-is-on-flac",
+      "name": "Radio Energy Is On (Flac)",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radioenergy.to/stream",
+      "homepage": "https://radioenergy.to/",
+      "country": "IT",
+      "favicon": "https://radioenergy.to/wp-content/uploads/2018/03/LogoEnergy.png",
+      "bitrate": 1536,
+      "codec": "OGG",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-erre18",
+      "name": "Radio ERRE18",
+      "broadcaster": "independent",
+      "streamUrl": "https://player.erre18.com:8010/radioerre18.mp3",
+      "homepage": "https://erre18.com/",
+      "country": "IT",
+      "tags": [
+        "80s",
+        "blues",
+        "hard rock",
+        "jazz",
+        "metal",
+        "movie soundtracks"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-gattopardo",
+      "name": "RADIO GATTOPARDO",
+      "broadcaster": "independent",
+      "streamUrl": "https://sr11.inmystream.it/proxy/radiogattopardo?mp=/stream&1700931042510",
+      "homepage": "https://www.radiogattopardo.it/",
+      "country": "IT",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-soffio",
+      "name": "Radio Soffio",
+      "broadcaster": "independent",
+      "streamUrl": "https://sr2.inmystream.it/proxy/radiosoffio/stream",
+      "homepage": "https://www.radiosoffio.it/",
+      "country": "IT",
+      "tags": [
+        "classic italian pop",
+        "italian oldies",
+        "italian pop",
+        "musica italiana",
+        "pop",
+        "top 40"
+      ],
+      "favicon": "https://www.radiosoffio.it/wp-content/uploads/2021/09/logo-e1631203629175-150x150.png",
+      "bitrate": 128,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-teleradio1",
+      "name": "TeleRadio1 ",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/teleradio1",
+      "homepage": "https://teleradio1.com/",
+      "country": "IT",
+      "tags": [
+        "italian pop",
+        "italo disco",
+        "musica italiana"
+      ],
+      "favicon": "https://teleradio1.com/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        45.622,
+        10.8168
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-grs-gruppo-radio-sperone",
+      "name": "GRS - Gruppo Radio Sperone",
+      "broadcaster": "independent",
+      "streamUrl": "https://onair7.xdevel.com/proxy/xautocloud_luge_1982?mp=/;1/",
+      "homepage": "https://grupporadiosperone.it/",
+      "country": "IT",
+      "tags": [
+        "golden music",
+        "goldies",
+        "livestream",
+        "local news",
+        "new hits",
+        "sport"
+      ],
+      "favicon": "https://grupporadiosperone.it/wp-content/uploads/2022/07/LogoCompleto-Quadrato-BGBlack.jpg",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        40.9544,
+        14.6053
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-amore",
+      "name": "Radio Amore",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream10.xdevel.com/audio8s977886-2322/stream/icecast.audio",
+      "homepage": "https://www.grupporadioamore.it/",
+      "country": "IT",
+      "favicon": "https://www.grupporadioamore.it/images/stories/loghi/radio_amore.jpg",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-capital-30-songs",
+      "name": "radio Capital 30 songs",
+      "broadcaster": "independent",
+      "streamUrl": "https://4c4b867c89244861ac216426883d1ad0.msvdn.net/radiodeejay30songs/radiodeejay30songs/play1.m3u8",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "IT",
+      "tags": [
+        "pop"
+      ],
+      "codec": "UNKNOWN",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-gioiosa-marina",
+      "name": "Radio Gioiosa Marina",
+      "broadcaster": "independent",
+      "streamUrl": "https://sr7.inmystream.it/proxy/radiogioiosamarina?mp=/stream",
+      "homepage": "https://www.radiogioiosamarina.it/",
+      "country": "IT",
+      "tags": [
+        "adult contemporary",
+        "local news",
+        "marina di gioiosa ionica"
+      ],
+      "favicon": "https://www.radiogioiosamarina.it/wp-content/uploads/2024/06/favicon.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-gold-wonderland",
+      "name": "RADIO GOLD WONDERLAND",
+      "broadcaster": "independent",
+      "streamUrl": "https://ad1.xdevel.com/radiogoldwl",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "IT",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-latina",
+      "name": "RADIO LATINA",
+      "broadcaster": "independent",
+      "streamUrl": "https://media.velcom.it:8014/radiolatina",
+      "homepage": "https://www.radiolatina.it/",
+      "country": "IT",
+      "favicon": "https://www.radiolatina.it/wp-content/uploads/2023/05/Radio-Latina-logo-sito.png",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-laziale-88-100-fm",
+      "name": "Radio Laziale 88.100 FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream9.xdevel.com/audio3s975363-2397/stream/icecast.audio",
+      "homepage": "https://www.radiolaziale.com/",
+      "country": "IT",
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-olbia-web",
+      "name": "RADIO OLBIA WEB",
+      "broadcaster": "independent",
+      "streamUrl": "https://nrf1.newradio.it:10026/stream",
+      "homepage": "https://www.radioolbiaweb.it/",
+      "country": "IT",
+      "favicon": "https://static.wixstatic.com/media/d6d54a_fdd52cdf89174685a44168e8d1c7dc19~mv2.png/v1/fill/w_121,h_121,al_c,q_85,usm_0.66_1.00_0.01,enc_auto/default%202_edited.png",
+      "bitrate": 96,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-sole-vittoria",
+      "name": "Radio Sole Vittoria",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiosole-fellini.radioca.st/",
+      "homepage": "https://www.radiosole.eu/",
+      "country": "IT",
+      "tags": [
+        "music"
+      ],
+      "favicon": "https://www.radiosole.eu/images/favicon_radiosole.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-gedi-deejay-gasolina",
+      "name": "GEDI - Deejay Gasolina",
+      "broadcaster": "independent",
+      "streamUrl": "https://streamcdnr7-4c4b867c89244861ac216426883d1ad0.msvdn.net/webradio/deejaygasolina/playlist.m3u8",
+      "homepage": "https://www.deejay.it/webradio/08/",
+      "country": "IT",
+      "tags": [
+        "latin"
+      ],
+      "favicon": "https://cdn.gelestatic.it/deejay/sites/2/2016/03/webradio_deejay_gasolina.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-nettuno-bologna-uno",
+      "name": "NETTUNO BOLOGNA UNO",
+      "broadcaster": "independent",
+      "streamUrl": "https://audio6.nemostream.tv/proxy/nettunobologna1ice1/stream",
+      "homepage": "http://www.radiobolognauno.it/",
+      "country": "IT",
+      "favicon": "https://www.fm-world.it/wp-content/uploads/2020/09/WhatsApp-Image-2020-09-11-at-23.46.25.jpeg.webp",
+      "bitrate": 96,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-al-serv-della-divina-misericordia",
+      "name": "Radio al Serv della Divina Misericordia",
+      "broadcaster": "independent",
+      "streamUrl": "https://nr9.newradio.it/proxy/mpalmisa?mp=/stream?ext=.mp3",
+      "homepage": "https://www.apostolegc.net/ita/radio/",
+      "country": "IT",
+      "tags": [
+        "christian"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-amica-partinico",
+      "name": "Radio Amica Partinico",
+      "broadcaster": "independent",
+      "streamUrl": "https://nr12.newradio.it/stream/8676/stream",
+      "homepage": "https://www.radioamica.it/",
+      "country": "IT",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-diva-fm",
+      "name": "Radio Diva FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream10.xdevel.com/audio0s977410-1985/stream/icecast.audio?1727095495120",
+      "homepage": "http://www.radiodiva.it/",
+      "country": "IT",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-lombardia",
+      "name": "Radio Lombardia",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream6.xdevel.com/audio0s976574-1328/stream/icecast.audio",
+      "homepage": "https://www.radiolombardia.it/",
+      "country": "IT",
+      "favicon": "https://www.radiolombardia.it/wp-content/uploads/2024/05/LOGO_bianco-1-1024x1024.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-mille-baci",
+      "name": "Radio Mille Baci",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-154.zeno.fm/6qzpb1exszzuv",
+      "homepage": "https://radiomillebaci.com/",
+      "country": "IT",
+      "tags": [
+        "hits",
+        "love songs",
+        "pop"
+      ],
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-monte-carlo-fm",
+      "name": "Radio Monte Carlo FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://icy.unitedradio.it/RMC.aac",
+      "homepage": "https://www.radiomontecarlo.net/radio-onair/",
+      "country": "IT",
+      "tags": [
+        "pop",
+        "rock"
+      ],
+      "favicon": "https://img-api.cloud.mediaset.net/api/images/rd/v1/ita/aHR0cHM6Ly9yYWRpbzMub21ueXMuY29tL3dwLWNvbnRlbnQvdXBsb2Fkcy8yMDI1LzA2L2RlZmF1bHQtMS5qcGc/-/0/0?r=91587740ec678bd2765cf54837744f04",
+      "bitrate": 96,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-musica-tuttaunaltramusica",
+      "name": "Radio Musica TuttaUnAltraMusica",
+      "broadcaster": "independent",
+      "streamUrl": "https://nrf1.newradio.it:10434/stream",
+      "homepage": "https://radiomusicatv.it/",
+      "country": "IT",
+      "favicon": "https://cdn-profiles.tunein.com/s303872/images/logod.jpg?t=637806298200000000",
+      "bitrate": 96,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-play-emotions",
+      "name": "Radio Play Emotions",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.shoutcastitalia.com/proxy/playemotions?mp=/stream",
+      "homepage": "http://www.playemotions.it/#",
+      "country": "IT",
+      "favicon": "https://www.playemotions.it/wp-content/uploads/2022/12/pngegg.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-pret-a-porter",
+      "name": "Radio Pret a Porter",
+      "broadcaster": "independent",
+      "streamUrl": "https://onair7.xdevel.com/proxy/xautocloud_ammg_1275?mp=/;1/",
+      "homepage": "https://www.radiopretaporter.com/",
+      "country": "IT",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-sacra-famiglia",
+      "name": "RADIO SACRA FAMIGLIA",
+      "broadcaster": "independent",
+      "streamUrl": "https://nr6.newradio.it/proxy/aieconlu?mp=/stream",
+      "homepage": "https://www.radiosacrafamiglia.it/",
+      "country": "IT",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-sunbeat",
+      "name": "Radio Sunbeat",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rcs.revma.com/5tbxc6f39yuvv",
+      "homepage": "https://radiosunbeat.com/",
+      "country": "IT",
+      "tags": [
+        "chillout",
+        "edm",
+        "upbeat"
+      ],
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-valle-camonica",
+      "name": "Radio Valle Camonica",
+      "broadcaster": "independent",
+      "streamUrl": "https://onair20.xdevel.com/proxy/vallecamonica?mp=/;stream/;",
+      "homepage": "https://new.radiovallecamonica.it/",
+      "country": "IT",
+      "favicon": "https://new.radiovallecamonica.it/wp-content/uploads/2023/03/logo_new.png",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radioradio",
+      "name": "Radioradio",
+      "broadcaster": "independent",
+      "streamUrl": "https://sr6.inmystream.it/proxy/rrshout?mp=/stream",
+      "homepage": "https://www.radioradio.it/",
+      "country": "IT",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-rft-movida-club",
+      "name": "RFT Movida Club",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.smartradio.ch:8505/stream",
+      "homepage": "https://radioticino.com/rft-movida/",
+      "country": "IT",
+      "tags": [
+        "club",
+        "dance",
+        "house",
+        "old skool"
+      ],
+      "favicon": "https://radioticino.com/wp-content/uploads/2019/09/RFT-Movida-Club-300x300.png",
+      "bitrate": 48,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-soloanni80",
+      "name": "SoloAnni80",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/soloanni80",
+      "homepage": "https://soloanni80.blogspot.com/",
+      "country": "IT",
+      "tags": [
+        "80s dance"
+      ],
+      "favicon": "https://soloanni80.blogspot.com/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        39.2532,
+        9.1814
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-sorriso",
+      "name": "Sorriso",
+      "broadcaster": "independent",
+      "streamUrl": "https://klasse1.fluidstream.eu/sorriso?FLID=1&type=.aac",
+      "homepage": "https://www.sorrriso.it/",
+      "country": "IT",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-virgin-radio-rock-ballads",
+      "name": "Virgin Radio Rock Ballads",
+      "broadcaster": "independent",
+      "streamUrl": "https://icy.unitedradio.it/Virgin_06.mp3",
+      "homepage": "https://www.virginradio.it/web-radio/virgin-radio-rock-ballads/",
+      "country": "IT",
+      "tags": [
+        "rock",
+        "soft rock"
+      ],
+      "favicon": "https://img-api.cloud.mediaset.net/api/images/rd/v1/ita/aHR0cHM6Ly93d3cudmlyZ2lucmFkaW8uaXQvd3AtY29udGVudC91cGxvYWRzLzIwMjUvMTEvV2VicmFkaW8tVmlyZ2luLTIwMjAtUm9ja0JhbGxhZHMtMTU4ODA2MjM0NzE4NXBuZy12aXJnaW5fcmFkaW9fcm9ja19iYWxsYWRzLnBuZw/-/0/0?r=11acbeadd748211a27a11f42433abe6a",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-ac3x-radio",
+      "name": "AC3X Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ac3xradio.com/liveaac",
+      "homepage": "https://ac3xradio.com/",
+      "country": "IT",
+      "tags": [
+        "classical music"
+      ],
+      "favicon": "https://ac3xradio.com/logo.png",
+      "codec": "AAC",
+      "geo": [
+        42.2326,
+        12.4805
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-die-antenne",
+      "name": "Die Antenne",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radio2000.it/antenne",
+      "homepage": "https://www.dieantenne.it/",
+      "country": "IT",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-giglio-rosso",
+      "name": "RADIO GIGLIO ROSSO",
+      "broadcaster": "independent",
+      "streamUrl": "https://nr14.newradio.it:8823/stream?ext=.mp3",
+      "homepage": "https://www.radiogigliorosso.it/",
+      "country": "IT",
+      "favicon": "https://www.radiogigliorosso.it/wp-content/uploads/2023/01/logowhite2-768x902.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-like",
+      "name": "Radio Like",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice43.fluidstream.net/antenna2.mp3?FLID=1&type=.mp3",
+      "homepage": "https://www.radiolike.it/",
+      "country": "IT",
+      "favicon": "https://players.fluidstream.it/RadioAntenna2/images/logo320.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-monte-carlo-80",
+      "name": "Radio Monte Carlo 80",
+      "broadcaster": "independent",
+      "streamUrl": "https://icy.unitedradio.it/rmcweb008",
+      "homepage": "https://www.radiomontecarlo.net/web-radio/radio-monte-carlo-80/",
+      "country": "IT",
+      "tags": [
+        "80's",
+        "80s"
+      ],
+      "favicon": "https://img-api.cloud.mediaset.net/api/images/rd/v1/ita/aHR0cHM6Ly9yYWRpbzMub21ueXMuY29tL3dwLWNvbnRlbnQvdXBsb2Fkcy8yMDI1LzEwL1JNQ184MF9XZWJSYWRpby0xNjAxNTI3NzM2NzYzLTIuanBnLXJtY184MC0yLmpwZw/-/0/0?r=1b99011b2b5c550c59f7eefa09dd81b6",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-replay-news-italiano",
+      "name": "REPLAY NEWS - Italiano",
+      "broadcaster": "independent",
+      "streamUrl": "https://replaynewsit.ice.infomaniak.ch/replaynewsit-128.mp3",
+      "homepage": "https://www.replaynews.net/",
+      "country": "IT",
+      "tags": [
+        "news"
+      ],
+      "favicon": "https://www.publicsante.com/BIENVENU/LOGO%20REPLAY%20NEWS-IT.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-rv-1-superhit",
+      "name": "Rv 1 Superhit",
+      "broadcaster": "independent",
+      "streamUrl": "https://rv1-superhit.stream.laut.fm/rv1-superhit",
+      "homepage": "https://www.rv1.it/rv1-superhit.php",
+      "country": "IT",
+      "favicon": "https://www.rv1.it/images/Rv1-SuperHIT_317x315.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-studio-100-radio",
+      "name": "Studio 100 Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s16.myradiostream.com:5626/;",
+      "homepage": "http://www.radiostudio100.com/",
+      "country": "IT",
+      "tags": [
+        "hits"
+      ],
+      "bitrate": 96,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-bussola-24-radiobussola-radiobussola24",
+      "name": "Radio Bussola 24 (RadioBussola, RadioBussola24)",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiobussola24.radioca.st/stream",
+      "homepage": "https://www.radiobussola.it/",
+      "country": "IT",
+      "tags": [
+        "calcio",
+        "cronaca",
+        "local news",
+        "local radio",
+        "pop",
+        "radio locale"
+      ],
+      "favicon": "https://www.radiobussola.it/app/player/images/icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        40.6702,
+        14.7821
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-meano",
+      "name": "Radio Meano",
+      "broadcaster": "independent",
+      "streamUrl": "https://meteomeano.stream.laut.fm/meteomeano?.mp3",
+      "homepage": "https://laut.fm/meteomeano",
+      "country": "IT",
+      "tags": [
+        "classic hits",
+        "oldies"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.1056,
+        12.0605
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-monte-carlo-disco-funk",
+      "name": "Radio Monte Carlo Disco Funk",
+      "broadcaster": "independent",
+      "streamUrl": "https://icy.unitedradio.it/rmcweb025",
+      "homepage": "https://www.radiomontecarlo.net/web-radio/radio-monte-carlo-disco-funk/",
+      "country": "IT",
+      "tags": [
+        "70's",
+        "70s disco",
+        "disco funk",
+        "funk"
+      ],
+      "favicon": "https://img-api.cloud.mediaset.net/api/images/rd/v1/ita/aHR0cHM6Ly9yYWRpbzMub21ueXMuY29tL3dwLWNvbnRlbnQvdXBsb2Fkcy8yMDI1LzEwL1JNQ19ESVNDT0ZVTktfV2ViUmFkaW8tMTYwMTUyODAyNzQ1MC0yLmpwZy1yYWRpb19tb250ZV9jYXJsb19kaXNjb19mdW5rLTIuanBn/-/0/0?r=feb9fbd1bba1b43ee74ae2046068ed2f",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-divina-fm",
+      "name": "Divina FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://maurizi1.radioca.st/stream.mp3",
+      "homepage": "https://www.divinafm.it/",
+      "country": "IT",
+      "favicon": "https://www.divinafm.it//wp-content/uploads/logo.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-free-radio-conselve",
+      "name": "Free Radio Conselve",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice17.fluidstream.net/conselve.mp3?FLID=M",
+      "homepage": "https://freeradioconselve.it/",
+      "country": "IT",
+      "favicon": "https://players.fluidstream.it/Conselve/images/512.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-nostream",
+      "name": "NoStream",
+      "broadcaster": "independent",
+      "streamUrl": "https://nostream.mastodon.uno/hls/0/stream.m3u8",
+      "homepage": "https://nostream.mastodon.uno/#",
+      "country": "IT",
+      "codec": "UNKNOWN",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radio-rf101",
+      "name": "Radio RF101",
+      "broadcaster": "independent",
+      "streamUrl": "https://rf101.radioca.st/",
+      "homepage": "https://www.rf101.it/",
+      "country": "IT",
+      "tags": [
+        "top 40"
+      ],
+      "bitrate": 256,
+      "codec": "AAC+",
+      "geo": [
+        37.3768,
+        14.2328
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "it-hey-dj-radio",
+      "name": "HEY DJ RADIO",
+      "broadcaster": "independent",
+      "streamUrl": "https://nr3.newradio.it:18303/stream?ver=777128",
+      "homepage": "https://www.heydjradio.com/",
+      "country": "IT",
+      "favicon": "https://www.heydjradio.com/new/wp-content/uploads/2018/11/heyDJ_logo_index_small.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "it-radioattivainformazione",
+      "name": "RadioAttivaInformazione",
+      "broadcaster": "independent",
+      "streamUrl": "https://radioattiva.duckdns.org/hls/radioattivainformazione/live.m3u8",
+      "homepage": "https://radioattivainformazione.it/",
+      "country": "IT",
+      "bitrate": 52,
+      "codec": "AAC",
+      "geo": [
+        45.3476,
+        11.8683
+      ],
+      "status": "stream-only"
     }
   ]
 }

--- a/public/stations.json
+++ b/public/stations.json
@@ -59779,6 +59779,12355 @@
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
+    },
+    {
+      "id": "fr-eurodance-90-radio",
+      "name": "EuroDance 90 radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-eurodance90.fr/radio/8000/128.mp3?1627933323",
+      "homepage": "https://eurodance90.fr/",
+      "country": "FR",
+      "tags": [
+        "dancefloor",
+        "electronic dance music",
+        "eurodance",
+        "pop dance",
+        "pop music"
+      ],
+      "favicon": "https://eurodance90.fr/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-abc-lounge-radio",
+      "name": "ABC Lounge Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://eu1.fastcast4u.com/proxy/kpmxz?mp=/1",
+      "homepage": "https://www.abc-lounge.com/radio/lounge-jazz-folk/#home",
+      "country": "FR",
+      "tags": [
+        "ambient",
+        "chillout",
+        "easy listening",
+        "lounge",
+        "smooth jazz"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-",
+      "name": "法国国际广播电台",
+      "broadcaster": "independent",
+      "streamUrl": "https://rfienchinois64k.ice.infomaniak.ch/rfienchinois-64.mp3",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "FR",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-urban-hit-maroc",
+      "name": "Urban Hit Maroc",
+      "broadcaster": "independent",
+      "streamUrl": "https://urbanhitrai.ice.infomaniak.ch/urbanhitrai.mp3",
+      "homepage": "https://www.urbanhit.fr/",
+      "country": "FR",
+      "favicon": "https://bocir-prod-bucket.s3.eu-west-1.amazonaws.com/radios/urbanhit/images/favicon.vnd.microsoft.icon",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-jazzradio-fr-jazz-classique",
+      "name": "Jazzradio.fr Jazz & Classique",
+      "broadcaster": "independent",
+      "streamUrl": "https://jazz-wr17.ice.infomaniak.ch/jazz-wr17-128.mp3",
+      "homepage": "https://www.jazzradio.fr/",
+      "country": "FR",
+      "tags": [
+        "classic",
+        "jazz"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-abc-lounge-jazz",
+      "name": "ABC Lounge Jazz",
+      "broadcaster": "independent",
+      "streamUrl": "https://eu1.fastcast4u.com/proxy/kpmxz/stream",
+      "homepage": "https://www.abc-lounge.com/",
+      "country": "FR",
+      "favicon": "https://www.abc-lounge.com/radio/wp-content/uploads/2019/11/logo-ABC-Lounge100.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-algorythme-drum-bass",
+      "name": "Algorythme Drum & Bass",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio9.pro-fhi.net/flux-endvtlna/stream",
+      "homepage": "https://www.algorythmeradio.com/",
+      "country": "FR",
+      "tags": [
+        "drum n bass",
+        "drum&bass"
+      ],
+      "favicon": "https://www.algorythmeradio.com/assets/images/icon-algo.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-fm-80-funky-music",
+      "name": "FM 80 Funky Music",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/467555/stream/523739",
+      "homepage": "https://www.fm80.fr/en/",
+      "country": "FR",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-b4b-radio-disco-funk",
+      "name": "B4B Radio DISCO FUNK",
+      "broadcaster": "independent",
+      "streamUrl": "https://eu10.fastcast4u.com:8120/",
+      "homepage": "https://www.b4bradio.com/",
+      "country": "FR",
+      "tags": [
+        "dance classics",
+        "disco funk",
+        "funk"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-rfm-pop-rock",
+      "name": "RFM POP-ROCK",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rfm.fr/rfm-wr10.aac",
+      "homepage": "http://www.rfm.fr/programmes/les-webradios",
+      "country": "FR",
+      "tags": [
+        "chansons françaises",
+        "pop",
+        "pop rock",
+        "rock"
+      ],
+      "favicon": "http://cdn-rfm.lanmedia.fr/apple-touch-icon-120x120.png",
+      "bitrate": 128,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-rfi-kiswahili",
+      "name": "RFI Kiswahili",
+      "broadcaster": "independent",
+      "streamUrl": "https://rfiswahili96k.ice.infomaniak.ch/rfiswahili-96k.mp3",
+      "homepage": "http://www.kiswahili.rfi.fr/",
+      "country": "FR",
+      "tags": [
+        "news"
+      ],
+      "favicon": "https://www.rfi.fr/favicon-194x194.png",
+      "bitrate": 96,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-heavy-metal",
+      "name": "Radio Heavy Metal",
+      "broadcaster": "independent",
+      "streamUrl": "https://manager7.streamradio.fr:1435/stream",
+      "homepage": "https://radioheavymetal76.wixsite.com/monsite",
+      "country": "FR",
+      "tags": [
+        "heavy metal"
+      ],
+      "favicon": "https://static.wixstatic.com/media/bae3bf_0b6fc93bb1584f329723c0241a93c65c~mv2.png/v1/fill/w_111,h_111,al_c,usm_0.66_1.00_0.01,enc_auto/LOGO%20RHM%20SUR%20ROUGE.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-latina-reggaeton",
+      "name": "Latina reggaeton",
+      "broadcaster": "independent",
+      "streamUrl": "https://latinareggaeton.ice.infomaniak.ch/latinareggaeton.mp3",
+      "homepage": "https://www.latina.fr/",
+      "country": "FR",
+      "tags": [
+        "reggaeton"
+      ],
+      "favicon": "https://bocir-prod-bucket.s3.eu-west-1.amazonaws.com/radios/latina/images/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-choco",
+      "name": "Radio Choco",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/669715/stream/733765",
+      "homepage": "https://radiochoco.com/",
+      "country": "FR",
+      "tags": [
+        "eclectic programming"
+      ],
+      "favicon": "https://image.radioking.io/radios/669715/logo/e0191854-a603-41f5-9729-121a1f215f57.jpeg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-vibration",
+      "name": "Radio Vibration",
+      "broadcaster": "independent",
+      "streamUrl": "https://vibration.ice.infomaniak.ch/vibration-high.mp3",
+      "homepage": "http://www.vibration.fr/",
+      "country": "FR",
+      "tags": [
+        "actu",
+        "app-id=335003717 (apple-itunes-app)",
+        "clips",
+        "direct",
+        "info",
+        "live"
+      ],
+      "favicon": "https://bocir-prod-bucket.s3.amazonaws.com/radios/vibration/images/favicon.vnd.microsoft.icon",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-bfm-business",
+      "name": "BFM Business",
+      "broadcaster": "independent",
+      "streamUrl": "https://audio.bfmtv.com/bfmbusiness_128.mp3",
+      "homepage": "https://bfmbusiness.bfmtv.com/mediaplayer/live-audio/",
+      "country": "FR",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-reggae-fr",
+      "name": "Reggae.fr",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/50473/stream/87415",
+      "homepage": "http://www.reggae.fr/popup-radio.php",
+      "country": "FR",
+      "tags": [
+        "dub",
+        "reggae",
+        "roots"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-classique",
+      "name": "Radio Classique",
+      "broadcaster": "independent",
+      "streamUrl": "https://str0.creacast.com/classique1",
+      "homepage": "https://www.radioclassique.fr/",
+      "country": "FR",
+      "favicon": "http://favicons.teamtailor-cdn.com/icon?size=80..120..200&url=https%3a%2f%2fwww.radioclassique.fr%2f",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-rfi-monde",
+      "name": "📺 RFI Monde",
+      "broadcaster": "independent",
+      "streamUrl": "https://rfiafrique64k.ice.infomaniak.ch/rfimonde-64.mp3",
+      "homepage": "https://www.karibshebdo.info/radios-web/rfi-radio",
+      "country": "FR",
+      "tags": [
+        "info",
+        "information",
+        "rfi"
+      ],
+      "favicon": "https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEi076SvIq9FK1ila6iO0HpdpC6f6eMrCLPrNli3Y6WYe_7cVIM8GTSIKi5L2v3bmwD298Xc2jjmRlPX9nzJseyatmlnRhmrgL7QBGiUKBWhNDpmpSigoBKW-DQg-ytDeOF-iUaikzXDJef87-Or9eBq7fXL13kARxykDqVbhhIuT_e9niBlF0ZMztzw/s1600/Capture%20d%E2%80%99%C3%A9cran_2024-11-19_14-44-01.png",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-franceinfo",
+      "name": "franceinfo",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radiofrance.fr/franceinfo/franceinfo_hifi.m3u8?id=radiofrance",
+      "homepage": "https://www.radiofrance.fr/franceinfo",
+      "country": "FR",
+      "favicon": "https://www.radiofrance.fr/s3/cruiser-production/2022/06/52e277e9-95f8-44c4-8fda-6dfabc337b12/1200x680_franceinfo-logo-rs.jpg",
+      "codec": "UNKNOWN",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-fip-pop",
+      "name": "FIP Pop",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.radiofrance.fr/fippop-hifi.aac",
+      "homepage": "https://www.fip.fr/pop/webradio",
+      "country": "FR",
+      "tags": [
+        "aac",
+        "pop",
+        "public radio",
+        "radio france"
+      ],
+      "favicon": "https://www.fip.fr/dist/favicons/logo-120.png",
+      "bitrate": 192,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-latina-bachata",
+      "name": "Latina bachata",
+      "broadcaster": "independent",
+      "streamUrl": "https://latinabachata.ice.infomaniak.ch/latinabachata.mp3",
+      "homepage": "https://www.latina.fr/",
+      "country": "FR",
+      "tags": [
+        "bachata"
+      ],
+      "favicon": "https://bocir-prod-bucket.s3.eu-west-1.amazonaws.com/radios/latina/images/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-italopower",
+      "name": "Radio ItaloPower!",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.deevaradio.net:10443/italopower",
+      "homepage": "http://www.radioitalopower.com/",
+      "country": "FR",
+      "tags": [
+        "disco",
+        "electronica",
+        "italian"
+      ],
+      "favicon": "http://www.radioitalopower.com/assets/img/apple-touch-icon.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-love-radio-only-love-songs-70s80s90s-www-love-ra",
+      "name": "LOVE RADIO Only Love Songs 70s80s90s - www.love.radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://loveradio.streamingmedia.it/france",
+      "homepage": "https://love.radio/",
+      "country": "FR",
+      "tags": [
+        "love",
+        "love songs",
+        "lovesongs",
+        "romantic"
+      ],
+      "bitrate": 192,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-europe-2-radio-officiel",
+      "name": "Europe 2 Radio Officiel",
+      "broadcaster": "independent",
+      "streamUrl": "https://europe2.lmn.fm/europe2-57600/playlist.m3u8?aw_0_1st.playerid=lagardereappEurope2",
+      "homepage": "https://www.europe2.fr/webradios",
+      "country": "FR",
+      "tags": [
+        "pop rock"
+      ],
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        48.853,
+        2.3483
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-courtoisie",
+      "name": "Radio Courtoisie",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice.creacast.com/radio-courtoisie",
+      "homepage": "https://www.radiocourtoisie.fr/",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-mc-doualiya",
+      "name": "MC doualiya",
+      "broadcaster": "independent",
+      "streamUrl": "https://montecarlodoualiya128k.ice.infomaniak.ch/mc-doualiya.mp3",
+      "homepage": "https://www.mc-doualiya.com/",
+      "country": "FR",
+      "tags": [
+        "news"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-cinemix",
+      "name": "Cinemix",
+      "broadcaster": "independent",
+      "streamUrl": "https://kathy.torontocast.com:1825/stream",
+      "homepage": "https://www.cinemix.us/",
+      "country": "FR",
+      "tags": [
+        "film music",
+        "film scores",
+        "instrumental",
+        "soundtrack"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-le-bon-mix-hifi-flac-1411-kbps",
+      "name": "Le Bon Mix HiFi Flac 1411 Kbps",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream10.xdevel.com/audio17s976748-2218/stream/icecast.audio",
+      "homepage": "https://www.lebonmix.radio/hifi",
+      "country": "FR",
+      "tags": [
+        "eclectic",
+        "electro",
+        "jazz",
+        "pop",
+        "rock",
+        "world"
+      ],
+      "favicon": "https://static.wixstatic.com/media/8f2aad_93ae56d1764947358ca5524a248f789e~mv2.png",
+      "codec": "OGG",
+      "geo": [
+        43.6074,
+        1.4404
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-galaxie-new-wave",
+      "name": "Galaxie New Wave",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.radioking.com/play/galaxienewwave",
+      "homepage": "http://galaxie-radio1.radio-website.com/",
+      "country": "FR",
+      "favicon": "http://galaxie-radio1.radio-website.com/upload/578f3bce151616.43092430.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-fip-no-pub",
+      "name": "FIP (no pub)",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radiofrance.fr/fip/fip_hifi.m3u8",
+      "homepage": "https://www.radiofrance.fr/fip",
+      "country": "FR",
+      "tags": [
+        "eclectic",
+        "m3u8",
+        "public radio",
+        "radio france"
+      ],
+      "favicon": "https://www.radiofrance.fr/s3/cruiser-production/2023/03/3a1422a4-6f1f-4e17-874c-bad21e67f39b/300x300_sc_fip-avatar.jpg",
+      "codec": "UNKNOWN",
+      "geo": [
+        48.8525,
+        2.2783
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-rfm-la-radio-couleur",
+      "name": "RFM - La Radio Couleur",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rfm.fr/rfm-wr3.aac",
+      "homepage": "http://www.rfm.fr/",
+      "country": "FR",
+      "tags": [
+        "70 80 hits"
+      ],
+      "favicon": "http://cdn-rfm.lanmedia.fr/apple-touch-icon-120x120.png",
+      "bitrate": 128,
+      "codec": "AAC+",
+      "geo": [
+        48.8693,
+        2.3612
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-esperance-parole-de-dieu",
+      "name": "Radio Espérance Parole de Dieu",
+      "broadcaster": "independent",
+      "streamUrl": "https://esperance.streamakaci.com/parole-de-dieu.mp3",
+      "homepage": "http://radio-esperance.fr/",
+      "country": "FR",
+      "tags": [
+        "christian"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-france-bleu-provence",
+      "name": "France Bleu Provence",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.radiofrance.fr/fbprovence-midfi.mp3?ID=radiofrance",
+      "homepage": "https://www.francebleu.fr/provence",
+      "country": "FR",
+      "tags": [
+        "france",
+        "provence",
+        "radio"
+      ],
+      "favicon": "https://www.francebleu.fr/img/logo-france-bleu-seo.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-djam-radio-aac192lc",
+      "name": "Djam Radio - AAC192LC",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream9.xdevel.com/audio1s976748-1515/stream/icecast.audio",
+      "homepage": "https://www.djam.radio/",
+      "country": "FR",
+      "favicon": "https://static.wixstatic.com/media/8f2aad_b81fa83db54340c3af97af5cf2cd0d0e~mv2.png",
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-rtl-france",
+      "name": "RTL France",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.m6radio.quortex.io/webpHJPXnXrN7B6J7Q8mcqmxP/grouprtl/national/long/audio-64000/index.m3u8",
+      "homepage": "https://www.rtl.fr/direct",
+      "country": "FR",
+      "tags": [
+        "news",
+        "pop"
+      ],
+      "favicon": "https://www.radio.fr/images/broadcasts/da/51/10220/c300.png",
+      "bitrate": 64,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-latina-fiesta",
+      "name": "Latina fiesta",
+      "broadcaster": "independent",
+      "streamUrl": "https://latinafiesta.ice.infomaniak.ch/latinafiesta.mp3",
+      "homepage": "https://www.latina.fr/",
+      "country": "FR",
+      "tags": [
+        "latin music"
+      ],
+      "favicon": "https://ecouter.lesindesradios.net/logos/orange329.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-oui-fm-les-slows-du-rock",
+      "name": "OUI FM LES SLOWS DU ROCK",
+      "broadcaster": "independent",
+      "streamUrl": "https://ouifmlesslowsdurock.ice.infomaniak.ch/ouifmslowrock.mp3",
+      "homepage": "https://www.ouifm.fr/",
+      "country": "FR",
+      "tags": [
+        "slow rock"
+      ],
+      "favicon": "https://bocir-prod-bucket.s3.eu-west-1.amazonaws.com/radios/oui-fm/images/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-esperance-gregorien",
+      "name": "Radio Espérance Grégorien",
+      "broadcaster": "independent",
+      "streamUrl": "https://esperance.streamakaci.com/gregorien.mp3",
+      "homepage": "http://radio-esperance.fr/",
+      "country": "FR",
+      "tags": [
+        "christian"
+      ],
+      "favicon": "http://radio-esperance.fr/wp-content/themes/radio-esperance/fichiers/ico/apple-touch-icon-120x120.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-record-goa-psy",
+      "name": "Record Goa Psy",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiorecord.hostingradio.ru/goa96.aacp",
+      "homepage": "https://caribshebdo.wordpress.com/category/radios-web/",
+      "country": "FR",
+      "tags": [
+        "goa",
+        "psy",
+        "trance"
+      ],
+      "favicon": "https://s1.wp.com/i/favicon.ico",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-latcho-flamenco",
+      "name": "Latcho Flamenco",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/109486/stream/148513",
+      "homepage": "https://latchoflamenco.wifeosite.com/",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-djam-radio-flac-1411-kbps",
+      "name": "Djam Radio - Flac 1411 Kbps",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream10.xdevel.com/audio15s976748-2280/stream/icecast.audio",
+      "homepage": "https://www.djam.radio/",
+      "country": "FR",
+      "favicon": "https://static.wixstatic.com/media/8f2aad_f0ad87746b3f4cebb1e67e1a25e89b6e~mv2.png",
+      "codec": "OGG",
+      "geo": [
+        43.6053,
+        1.4444
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-allzik-disney",
+      "name": "Allzik Disney ",
+      "broadcaster": "independent",
+      "streamUrl": "https://allzic52.ice.infomaniak.ch/allzic52.mp3",
+      "homepage": "https://www.allzicradio.com/en/player/listen/3700/allzic-radio-disney",
+      "country": "FR",
+      "favicon": "https://www.allzicradio.com/media/radios/allzic-disney_600px-carre.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-metal-invasion-radio",
+      "name": "Metal Invasion Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.metal-invasion.fr/radio/8000/stream96",
+      "homepage": "https://metal-invasion.fr/",
+      "country": "FR",
+      "tags": [
+        "hard rock",
+        "heavy metal",
+        "metal"
+      ],
+      "bitrate": 96,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-france-musique-opera",
+      "name": "France Musique Opéra",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.radiofrance.fr/francemusiqueopera-hifi.aac",
+      "homepage": "https://www.francemusique.fr/opera",
+      "country": "FR",
+      "tags": [
+        "opera",
+        "public radio",
+        "radio france"
+      ],
+      "bitrate": 192,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-allzic-radio-orientale",
+      "name": "Allzic Radio Orientale",
+      "broadcaster": "independent",
+      "streamUrl": "https://allzic33.ice.infomaniak.ch/allzic33.aac",
+      "homepage": "https://global.superradio.cc/",
+      "country": "FR",
+      "tags": [
+        "music",
+        "orientale"
+      ],
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-skyrock-100-francais",
+      "name": "Skyrock 100% FRANÇAIS ",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.skyrock.net/s/francais_aac_64k?tvr_name=radiofr&tvr_section1=64aac",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "FR",
+      "tags": [
+        "rap"
+      ],
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-oui-fm-rock-80-s",
+      "name": "OUI FM ROCK 80's",
+      "broadcaster": "independent",
+      "streamUrl": "https://ouifmrock80s.ice.infomaniak.ch/ouifmeighties.mp3",
+      "homepage": "https://www.ouifm.fr/",
+      "country": "FR",
+      "tags": [
+        "80's",
+        "rock"
+      ],
+      "favicon": "https://bocir-prod-bucket.s3.amazonaws.com/radios/oui-fm/radiostream/6fo6l1uD2X/vignette.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-la-grosse-radio-reggae",
+      "name": "La Grosse Radio Reggae",
+      "broadcaster": "independent",
+      "streamUrl": "https://hd.lagrosseradio.info/lagrosseradio-reggae-192.mp3",
+      "homepage": "https://caribshebdo.wordpress.com/2020/09/02/radio-web-la-grosse-reggae/",
+      "country": "FR",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-oui-fm-blues-n-rock",
+      "name": "OUI FM BLUES'N'ROCK",
+      "broadcaster": "independent",
+      "streamUrl": "https://ouifmbluesnrock.ice.infomaniak.ch/ouifmbluesnrock-128.mp3",
+      "homepage": "https://www.ouifm.fr/",
+      "country": "FR",
+      "tags": [
+        "blues rock"
+      ],
+      "favicon": "https://bocir-prod-bucket.s3.eu-west-1.amazonaws.com/radios/oui-fm/images/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-francia-internacional",
+      "name": "RADIO FRANCIA INTERNACIONAL",
+      "broadcaster": "independent",
+      "streamUrl": "https://rfienespagnol64k.ice.infomaniak.ch/rfienespagnol-64.mp3",
+      "homepage": "https://www.rfi.fr/es/",
+      "country": "FR",
+      "tags": [
+        "radio francia internacional"
+      ],
+      "favicon": "https://www.rfi.fr/apple-touch-icon.png",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-rfm-100-francais",
+      "name": "RFM 100% Français",
+      "broadcaster": "independent",
+      "streamUrl": "https://wr.lmn.fm/rfm-wr11.aac",
+      "homepage": "http://www.rfm.fr/",
+      "country": "FR",
+      "favicon": "http://cdn-rfm.lanmedia.fr/favicon-32x32.png",
+      "bitrate": 128,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-littoral-fm-perpignan",
+      "name": "LITTORAL FM Perpignan",
+      "broadcaster": "independent",
+      "streamUrl": "https://littoralfmperpignan.ice.infomaniak.ch/littoralfmperpignan.mp3",
+      "homepage": "https://littoral.fm/",
+      "country": "FR",
+      "favicon": "https://bocir-prod-bucket.s3.eu-west-1.amazonaws.com/radios/littoral/images/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-oui-fm-alternatif",
+      "name": "OUI FM ALTERNATIF",
+      "broadcaster": "independent",
+      "streamUrl": "https://ouifm2.ice.infomaniak.ch/ouifm2.mp3",
+      "homepage": "https://www.ouifm.fr/",
+      "country": "FR",
+      "tags": [
+        "alternative rock"
+      ],
+      "favicon": "https://bocir-prod-bucket.s3.amazonaws.com/radios/oui-fm/radiostream/S2UWS5S3lJ/vignette.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-fip-metal",
+      "name": "FIP Metal",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.radiofrance.fr/fipmetal-hifi.aac?id=radiofrance",
+      "homepage": "https://www.radiofrance.fr/fip/radio-metal",
+      "country": "FR",
+      "tags": [
+        "hard rock",
+        "metal",
+        "thrash"
+      ],
+      "favicon": "https://www.radiofrance.fr/s3/cruiser-production/2022/07/160994f8-296b-4cd8-97a0-34c9111cdd9d/400x400_fip-metal-20222x_2.webp",
+      "bitrate": 192,
+      "codec": "AAC",
+      "geo": [
+        48.8526,
+        2.2783
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-badradio-24-7-og-phonk-memphis-houston-trap-tril",
+      "name": "badradio 24/7 OG Phonk, Memphis, Houston, Trap & Trill",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.radio.co/s2b2b68744/listen",
+      "homepage": "https://badradio.nz/",
+      "country": "FR",
+      "tags": [
+        "houston",
+        "phonk",
+        "trap",
+        "trap & trill"
+      ],
+      "favicon": "https://yt3.ggpht.com/ytc/AMLnZu8eXtkd-wn5s-Ww_RXId5AsUc0kqfM-1hikJJtzjw=s88-c-k-c0x00ffffff-no-rj",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-blackbox-classic-us",
+      "name": "BlackBox classic US",
+      "broadcaster": "independent",
+      "streamUrl": "https://blackbox-classic-us.ice.infomaniak.ch/blackbox-classic-us.mp3",
+      "homepage": "https://www.blackboxfm.fr/",
+      "country": "FR",
+      "favicon": "https://bocir-prod-bucket.s3.eu-west-1.amazonaws.com/radios/blackbox/images/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-pulsradio-dance",
+      "name": "Pulsradio Dance",
+      "broadcaster": "independent",
+      "streamUrl": "https://sc4.gergosnet.com/pulsHD.mp3",
+      "homepage": "https://www.pulsradio.com/",
+      "country": "FR",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        48.886,
+        2.3458
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-rock-folk-rock-n-folk",
+      "name": "Rock & Folk (rock n folk)",
+      "broadcaster": "independent",
+      "streamUrl": "https://rockfolk.ice.infomaniak.ch/rockfolk.mp3",
+      "homepage": "https://www.rocknfolk.com/",
+      "country": "FR",
+      "tags": [
+        "blues",
+        "classic rock",
+        "metal",
+        "punk",
+        "rock"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-esperance-enseignement",
+      "name": "Radio Espérance Enseignement",
+      "broadcaster": "independent",
+      "streamUrl": "https://esperance.streamakaci.com/enseignement.mp3",
+      "homepage": "http://radio-esperance.fr/",
+      "country": "FR",
+      "tags": [
+        "christian"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-esperance-louange",
+      "name": "Radio Espérance Louange",
+      "broadcaster": "independent",
+      "streamUrl": "https://esperance.streamakaci.com/louange.mp3",
+      "homepage": "http://radio-esperance.fr/",
+      "country": "FR",
+      "tags": [
+        "christian"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-oui-fm-rock-inde",
+      "name": "OUI FM ROCK INDÉ",
+      "broadcaster": "independent",
+      "streamUrl": "https://ouifm5.ice.infomaniak.ch/ouifm5.mp3",
+      "homepage": "https://www.ouifm.fr/",
+      "country": "FR",
+      "tags": [
+        "indie rock"
+      ],
+      "favicon": "https://bocir-prod-bucket.s3.eu-west-1.amazonaws.com/radios/oui-fm/images/favicon.ico",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-vaticana-francais",
+      "name": "Radio Vaticana Francais",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.vaticannews.va/stream-fr",
+      "homepage": "https://www.vaticannews.va/fr.html",
+      "country": "FR",
+      "favicon": "https://www.vaticannews.va/etc/designs/vatican-news/release/library/main/images/favicons/apple-icon-114x114.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-rfi-russia",
+      "name": "RFI Russia",
+      "broadcaster": "independent",
+      "streamUrl": "https://rfiukraine.ice.infomaniak.ch/rfiukraine-96.mp3",
+      "homepage": "https://www.rfi.fr/ru/",
+      "country": "FR",
+      "tags": [
+        "news",
+        "talk"
+      ],
+      "favicon": "https://www.rfi.fr/apple-touch-icon.png",
+      "bitrate": 96,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-jazz-radio-electro-swing",
+      "name": "Jazz Radio Electro Swing",
+      "broadcaster": "independent",
+      "streamUrl": "https://jazz-wr04.ice.infomaniak.ch/jazz-wr04-64.aac?i=67090",
+      "homepage": "https://www.jazzradio.fr/",
+      "country": "FR",
+      "tags": [
+        "electro swing",
+        "jazz"
+      ],
+      "favicon": "https://www.jazzradio.fr/media/radio/thumb/180x180_electro-swing.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-europe-1-musique-classique",
+      "name": "Europe 1 Musique Classique",
+      "broadcaster": "independent",
+      "streamUrl": "https://wr.lmn.fm/e1-wr3.aac?aw_0_1st.playerid=lgrdnwsRadioplayer",
+      "homepage": "https://www.europe1.fr/culture/nouveau-ecoutez-europe-musiqueclassique-4095055",
+      "country": "FR",
+      "tags": [
+        "classic"
+      ],
+      "favicon": "https://resize-europe1.lanmedia.fr/f/webp/r/622,311,forcex,center-middle/img/var/europe1/storage/images/europe1/culture/nouveau-ecoutez-europe-musiqueclassique-4095055/58235479-1-fre-FR/NOUVEAU-Ecoutez-Europe-musique-classique.png",
+      "bitrate": 128,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-urban-afro",
+      "name": "Urban afro",
+      "broadcaster": "independent",
+      "streamUrl": "https://urbanhitblack.ice.infomaniak.ch/urbanhitblack128.mp3",
+      "homepage": "https://www.urbanhit.fr/",
+      "country": "FR",
+      "favicon": "https://bocir-prod-bucket.s3.eu-west-1.amazonaws.com/radios/urbanhit/images/favicon.vnd.microsoft.icon",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-rmc-gold",
+      "name": "RMC GOLD",
+      "broadcaster": "independent",
+      "streamUrl": "https://hls-rmcgold.nextradiotv.com/ssai/192k/media.m3u8",
+      "homepage": "https://rmc.bfmtv.com/en-direct/rmc-gold/",
+      "country": "FR",
+      "tags": [
+        "oldies"
+      ],
+      "codec": "UNKNOWN",
+      "geo": [
+        48.8462,
+        2.3444
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-notre-dame-lower-bitrate",
+      "name": "Radio Notre Dame (lower bitrate)",
+      "broadcaster": "independent",
+      "streamUrl": "https://windu.radionotredame.net/RadioNotreDame-Fm.mp3",
+      "homepage": "https://radionotredame.net/",
+      "country": "FR",
+      "tags": [
+        "christian",
+        "culture",
+        "religious",
+        "talk"
+      ],
+      "favicon": "https://radionotredame.net/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-oui-fm-rock-70-s",
+      "name": "OUI FM ROCK 70's",
+      "broadcaster": "independent",
+      "streamUrl": "https://ouifmrock70s.ice.infomaniak.ch/ouifmseventies.mp3",
+      "homepage": "https://www.ouifm.fr/",
+      "country": "FR",
+      "tags": [
+        "70's",
+        "rock"
+      ],
+      "favicon": "https://bocir-prod-bucket.s3.eu-west-1.amazonaws.com/radios/oui-fm/images/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-africa-radio-rumba-webradio",
+      "name": "Africa Radio Rumba Webradio",
+      "broadcaster": "independent",
+      "streamUrl": "https://webradio1.ice.infomaniak.ch/webradio4-128.mp3",
+      "homepage": "https://www.africaradio.com/",
+      "country": "FR",
+      "tags": [
+        "african music"
+      ],
+      "favicon": "https://images.lesindesradios.fr/fit-in/300x2000/filters:format(webp)/radios/africaradio/radiostream/dnV47tflYH/vignette.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-ici-nord",
+      "name": "ICI NORD",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radiofrance.fr/fbnord/fbnord_midfi.m3u8",
+      "homepage": "https://www.francebleu.fr/nord",
+      "country": "FR",
+      "tags": [
+        "régionale"
+      ],
+      "favicon": "https://www.francebleu.fr/images/logo-ici.jpg",
+      "codec": "UNKNOWN",
+      "geo": [
+        50.638,
+        3.0693
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-oui-fm-rock-90-s",
+      "name": "OUI FM ROCK 90's",
+      "broadcaster": "independent",
+      "streamUrl": "https://ouifmrock90s.ice.infomaniak.ch/ouifmnineties.mp3",
+      "homepage": "https://www.ouifm.fr/",
+      "country": "FR",
+      "tags": [
+        "90's",
+        "rock"
+      ],
+      "favicon": "https://bocir-prod-bucket.s3.eu-west-1.amazonaws.com/radios/oui-fm/images/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-pulsradio-2000-64k-aac",
+      "name": "PulsRadio 2000 (64k AAC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://sc6.gergosnet.com:80/puls00AAC64.mp3",
+      "homepage": "https://www.pulsradio.com/2000/",
+      "country": "FR",
+      "tags": [
+        "dance",
+        "electronic",
+        "trance"
+      ],
+      "favicon": "https://www.pulsradio.com/apple-icon-120x120.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-fip-jazz-hi-fi",
+      "name": "FIP Jazz (Hi-Fi)",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radiofrance.fr/fipjazz/fipjazz_hifi.m3u8?id=radiofrance",
+      "homepage": "https://www.radiofrance.fr/fip/radio-jazz",
+      "country": "FR",
+      "tags": [
+        "jazz"
+      ],
+      "favicon": "https://www.radiofrance.fr/s3/cruiser-production/2019/06/840a4431-0db0-4a94-aa28-53f8de011ab6/300x300_fip-jazz-01.jpg",
+      "codec": "UNKNOWN",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-nostalgie-france",
+      "name": "Radio Nostalgie France",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.nrjaudio.fm/oug7girb92oc?origine=tingfm",
+      "homepage": "http://www.nostagie.fr/",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-urban-hit-rap-fr",
+      "name": "Urban Hit rap FR",
+      "broadcaster": "independent",
+      "streamUrl": "https://urbanhitrapfr.ice.infomaniak.ch/urbanhitrapfr-128.mp3",
+      "homepage": "https://www.urbanhit.fr/",
+      "country": "FR",
+      "favicon": "https://bocir-prod-bucket.s3.eu-west-1.amazonaws.com/radios/urbanhit/images/favicon.vnd.microsoft.icon",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-europe-2-classics",
+      "name": "Europe 2 Classics",
+      "broadcaster": "independent",
+      "streamUrl": "https://europe2.lmn.fm/vr-wr2.mp3?aw_0_1st.playerid=lagardereappVirgin",
+      "homepage": "https://www.europe2.fr/webradios",
+      "country": "FR",
+      "tags": [
+        "pop",
+        "pop rock",
+        "rock"
+      ],
+      "favicon": "https://www.europe2.fr/wp-content/themes/melty/europeradio/assets/images/radio/radio_2002.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.8575,
+        2.3483
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-metal",
+      "name": "Radio Metal",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio3.pro-fhi.net/live/Radio%20Metal",
+      "homepage": "http://www.radiometal.com/",
+      "country": "FR",
+      "tags": [
+        "metal"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-rire-et-chansons",
+      "name": "Rire et Chansons",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.nrjaudio.fm/ou8o8xgk7oiu?origine=fluxradios",
+      "homepage": "https://www.rireetchansons.fr/",
+      "country": "FR",
+      "favicon": "https://img.nrj.fr/OImjPWH1tkT1NaUMPlxsY49g9BI=/medias%2F2024%2F03%2Fvvscnx9i3yteabtkx8nlpdusmqj6uo8hshh9iphoit8_65fbfe026c3a5.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-vintage-80-90",
+      "name": "Vintage 80 90",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio8.pro-fhi.net/live/VINTAGE80-90",
+      "homepage": "https://www.facebook.com/radiovintage8090",
+      "country": "FR",
+      "favicon": "https://www.facebook.com/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-buddha-beach",
+      "name": "Buddha Beach",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio4.vip-radios.fm:18054/stream-128kmp3-BuddhaBeach",
+      "homepage": "https://www.vip-radios.fm/station/buddha-beach/",
+      "country": "FR",
+      "favicon": "https://www.vip-radios.fm/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-frequence-3-gold-flac",
+      "name": "Frequence 3 Gold FLAC",
+      "broadcaster": "independent",
+      "streamUrl": "https://frequence3.net-radio.fr/frequence3gold.flac",
+      "homepage": "https://www.frequence3.com/les-radios-frequence-3/gold/",
+      "country": "FR",
+      "tags": [
+        "80s",
+        "90s"
+      ],
+      "favicon": "https://api2.frequence3.net/static/img/stations/horizontal/frequence3gold.png",
+      "bitrate": 128,
+      "codec": "OGG",
+      "geo": [
+        48.8498,
+        2.3446
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-galaxietek",
+      "name": "GalaxieTek",
+      "broadcaster": "independent",
+      "streamUrl": "https://fr.radioking.com/play/galaxietek",
+      "homepage": "http://www.galaxieradio.fr/",
+      "country": "FR",
+      "tags": [
+        "electronic",
+        "techno"
+      ],
+      "favicon": "http://www.galaxieradio.fr/upload/578f3bce151616.43092430.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-oui-fm-rock-2000",
+      "name": "OUI FM ROCK 2000",
+      "broadcaster": "independent",
+      "streamUrl": "https://ouifmrock2000s.ice.infomaniak.ch/ouifmrock2000.mp3",
+      "homepage": "https://www.ouifm.fr/",
+      "country": "FR",
+      "tags": [
+        "2000",
+        "rock"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-esperance",
+      "name": "Radio Espérance",
+      "broadcaster": "independent",
+      "streamUrl": "https://esperance.streamakaci.com/esperance.mp3",
+      "homepage": "http://radio-esperance.fr/",
+      "country": "FR",
+      "tags": [
+        "christian"
+      ],
+      "favicon": "http://radio-esperance.fr/wp-content/themes/radio-esperance/fichiers/ico/apple-touch-icon-120x120.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-oui-fm-reggae",
+      "name": "OUI FM REGGAE",
+      "broadcaster": "independent",
+      "streamUrl": "https://ouifmganja.ice.infomaniak.ch/ouifmganja-128.mp3",
+      "homepage": "https://www.ouifm.fr/",
+      "country": "FR",
+      "tags": [
+        "reggae"
+      ],
+      "favicon": "https://bocir-prod-bucket.s3.amazonaws.com/radios/oui-fm/radiostream/ufIfkfDXSl/vignette.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-meme-dans-les-orties",
+      "name": "* Meme dans les orties *",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.sk8ter.org:8443/stream",
+      "homepage": "http://memeradio.org/",
+      "country": "FR",
+      "tags": [
+        "electronic"
+      ],
+      "favicon": "https://memeradio.org/favicon_meme.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        48.8685,
+        2.3838
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-oui-fm-classic-rock",
+      "name": "OUI FM CLASSIC ROCK",
+      "broadcaster": "independent",
+      "streamUrl": "https://ouifm3.ice.infomaniak.ch/ouifm3.mp3",
+      "homepage": "https://www.ouifm.fr/",
+      "country": "FR",
+      "tags": [
+        "classic rock"
+      ],
+      "favicon": "https://bocir-prod-bucket.s3.amazonaws.com/radios/oui-fm/radiostream/3qhtSltZ27/vignette.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-jazzradio-fr-funk",
+      "name": "JazzRadio.fr Funk",
+      "broadcaster": "independent",
+      "streamUrl": "https://jazz-wr06.ice.infomaniak.ch/jazz-wr06-128.mp3",
+      "homepage": "https://www.jazzradio.fr/",
+      "country": "FR",
+      "tags": [
+        "funk"
+      ],
+      "favicon": "https://www.jazzradio.fr/apple-touch-icon-120x120.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-couleurs-jazz",
+      "name": "Couleurs JAZZ",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.radioking.com/play/couleurs-jazz/216016",
+      "homepage": "https://couleursjazz.fr/",
+      "country": "FR",
+      "tags": [
+        "jazz"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-tsugi",
+      "name": "Tsugi",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.radioking.com/play/tsugi-radio",
+      "homepage": "https://www.tsugi.fr/tsugi-radio/",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-jazzradio-fr-blues",
+      "name": "JazzRadio.fr Blues",
+      "broadcaster": "independent",
+      "streamUrl": "https://jazzblues.ice.infomaniak.ch/jazzblues-high.mp3",
+      "homepage": "https://www.jazzradio.fr/",
+      "country": "FR",
+      "tags": [
+        "blues"
+      ],
+      "favicon": "https://www.jazzradio.fr/media/radio/thumb/100x100_blues.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-fip-metal-2",
+      "name": "Fip : Metal",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radiofrance.fr/fipmetal/fipmetal_hifi.m3u8",
+      "homepage": "https://www.radiofrance.fr/fip/radio-metal",
+      "country": "FR",
+      "tags": [
+        "metal"
+      ],
+      "favicon": "https://www.radiofrance.fr/dist/favicons/logo-120.png",
+      "codec": "UNKNOWN",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-galaxie-radio",
+      "name": "Galaxie Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.radioking.com/play/galaxieradio",
+      "homepage": "http://galaxie-radio1.radio-website.com/",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-bide-et-musique",
+      "name": "Bide et Musique",
+      "broadcaster": "independent",
+      "streamUrl": "https://relay2.bide-et-musique.com:9143/",
+      "homepage": "http://www.bide-et-musique.com/",
+      "country": "FR",
+      "tags": [
+        "oldies"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-mbs-gold",
+      "name": "MBS Gold",
+      "broadcaster": "independent",
+      "streamUrl": "https://mbs.ice.infomaniak.ch/mbs-128.mp3",
+      "homepage": "https://radiombs.fr/",
+      "country": "FR",
+      "tags": [
+        "eighties"
+      ],
+      "favicon": "https://bocir-prod-bucket.s3.amazonaws.com/radios/mbs/images/favicon.x-icon",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-le-bon-mix-radio-97-9",
+      "name": "Le Bon Mix Radio 97.9",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream10.xdevel.com/audio13s976748-2017/stream/icecast.audio",
+      "homepage": "https://www.lebonmix.radio/",
+      "country": "FR",
+      "tags": [
+        "disco",
+        "electro",
+        "funk",
+        "jazz",
+        "music",
+        "pop"
+      ],
+      "favicon": "https://admuzzum.xdevel.com/cloud/x/cid/35/im/png/XZXW/Q/XY/20dcef61bfe95be20b65258bba132163.png",
+      "bitrate": 320,
+      "codec": "AAC+",
+      "geo": [
+        43.613,
+        1.4392
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-france-bleu-alsace",
+      "name": "France Bleu Alsace",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.radiofrance.fr/fbalsace-midfi.mp3",
+      "homepage": "https://www.francebleu.fr/alsace",
+      "country": "FR",
+      "tags": [
+        "public radio"
+      ],
+      "favicon": "https://www.francebleu.fr/images/favicon-112.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.5775,
+        7.762
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-classic-fm-france",
+      "name": "Classic FM France",
+      "broadcaster": "independent",
+      "streamUrl": "https://classicfm.ice.infomaniak.ch/classic-fm.mp3",
+      "homepage": "https://www.classicfm.fr/",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-esperance-musique-sacree",
+      "name": "Radio Espérance Musique Sacrée",
+      "broadcaster": "independent",
+      "streamUrl": "https://esperance.streamakaci.com/musique.mp3",
+      "homepage": "http://radio-esperance.fr/",
+      "country": "FR",
+      "tags": [
+        "christian"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-rtl-2",
+      "name": "RTL 2",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.rtl.fr/rtl2-1-44-128?listen=webGJmqBU59boQ7rZDjrGO5e4",
+      "homepage": "https://www.rtl2.fr/",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.8199,
+        2.3456
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-star",
+      "name": "Radio STAR",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/9728/stream/20210",
+      "homepage": "http://radio-star.site-radio.com/",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-africa-radio-paris",
+      "name": "Africa Radio Paris",
+      "broadcaster": "independent",
+      "streamUrl": "https://african1paris.ice.infomaniak.ch/african1paris-128.mp3",
+      "homepage": "https://www.africaradio.com/",
+      "country": "FR",
+      "tags": [
+        "african music",
+        "news",
+        "talk"
+      ],
+      "favicon": "https://images.lesindesradios.fr/fit-in/300x2000/filters:format(webp)/filters:quality(100)/radios/africaradio/images/logo_RvDT2jBisJ.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-frequence-3-dance-flac-powered-by-ikoula-m2-club",
+      "name": "FREQUENCE 3 - DANCE FLAC [Powered by IKOULA] - M2 Club",
+      "broadcaster": "independent",
+      "streamUrl": "https://onair.net-radio.fr/frequence3dance.flac",
+      "homepage": "https://www.frequence3.com/",
+      "country": "FR",
+      "tags": [
+        "dance",
+        "house"
+      ],
+      "bitrate": 128,
+      "codec": "OGG",
+      "geo": [
+        47.592,
+        0.9157
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-fip-sacre-francais",
+      "name": "FIP Sacré Français !",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radiofrance.fr/fipsacrefrancais/fipsacrefrancais.m3u8?id=radiofrance",
+      "homepage": "https://www.radiofrance.fr/fip/radio-sacre-francais",
+      "country": "FR",
+      "tags": [
+        "fip",
+        "french",
+        "french chansons",
+        "french music",
+        "public radio",
+        "radio france"
+      ],
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/thumb/1/16/FIP_logo_2021.svg/2048px-FIP_logo_2021.svg.png",
+      "bitrate": 107,
+      "codec": "AAC",
+      "geo": [
+        48.8526,
+        2.2782
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-rfm-slow",
+      "name": "RFM Slow",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rfm.fr/rfm-wr13.aac",
+      "homepage": "https://stream.rfm.fr/rfm-wr13.aac",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-skyrock-plm",
+      "name": "Skyrock PLM",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.skyrock.net/s/plm_aac_128k?tvr_name=apistreamfm",
+      "homepage": "https://skyrock.fm/plm/",
+      "country": "FR",
+      "tags": [
+        "militaire"
+      ],
+      "bitrate": 128,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-oui-fm-rock-60-s",
+      "name": "OUI FM ROCK 60's",
+      "broadcaster": "independent",
+      "streamUrl": "https://ouifmrock60s.ice.infomaniak.ch/ouifmsixties.mp3",
+      "homepage": "https://www.ouifm.fr/",
+      "country": "FR",
+      "tags": [
+        "60's",
+        "rock"
+      ],
+      "favicon": "https://bocir-prod-bucket.s3.eu-west-1.amazonaws.com/radios/oui-fm/images/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-virage-radio-metal",
+      "name": "Virage Radio Metal",
+      "broadcaster": "independent",
+      "streamUrl": "https://virage-radio-metal.ice.infomaniak.ch/virage-radio-metal.aac?i=65804",
+      "homepage": "https://www.virageradio.com/",
+      "country": "FR",
+      "tags": [
+        "metal"
+      ],
+      "favicon": "https://www.virageradio.com/apple-touch-icon-120x120.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-jazz-radio-blues",
+      "name": "JAZZ RADIO Blues",
+      "broadcaster": "independent",
+      "streamUrl": "https://jazzblues.ice.infomaniak.ch/jazzblues-high.aac?i=77905",
+      "homepage": "https://www.jazzradio.fr/radio/webradio/3/blues",
+      "country": "FR",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "geo": [
+        45.7664,
+        4.856
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-jazz-radio-jazz-fusion",
+      "name": "Jazz Radio Jazz Fusion",
+      "broadcaster": "independent",
+      "streamUrl": "https://jazz-radio-fusion.ice.infomaniak.ch/jazz-radio-fusion.mp3",
+      "homepage": "https://www.jazzradio.fr/radio/webradio/43/afro-jazz",
+      "country": "FR",
+      "favicon": "https://www.allzicradio.com/media/radios/jazzradio-1400x1400_fusion.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-50-50",
+      "name": "Radio 50/50",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radio5050.com/",
+      "homepage": "https://www.radio5050.com/",
+      "country": "FR",
+      "favicon": "https://www.radio5050.com/assets/img/favicons/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-rva-radio",
+      "name": "RVA radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://rva.ice.infomaniak.ch/rva-high.mp3",
+      "homepage": "https://www.radiorva.com/",
+      "country": "FR",
+      "tags": [
+        "auvergne",
+        "hits",
+        "pop",
+        "vichy"
+      ],
+      "favicon": "https://www.radiorva.com/apple-touch-icon-120x120.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-kohina",
+      "name": "Kohina",
+      "broadcaster": "independent",
+      "streamUrl": "https://kohina.duckdns.org/icecast/stream.ogg",
+      "homepage": "http://www.kohina.com/",
+      "country": "FR",
+      "tags": [
+        "chiptunes",
+        "retro games"
+      ],
+      "codec": "OGG",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-galaxie-vintage",
+      "name": "Galaxie Vintage",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.radioking.com/play/galaxievintage",
+      "homepage": "http://galaxie-radio1.radio-website.com/",
+      "country": "FR",
+      "favicon": "http://galaxie-radio1.radio-website.com/upload/578f3bce151616.43092430.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-grenouille",
+      "name": "Radio grenouille",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.radiogrenouille.com:8443/live",
+      "homepage": "http://www.radiogrenouille.com/",
+      "country": "FR",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-nova-reggae",
+      "name": "Nova Reggae",
+      "broadcaster": "independent",
+      "streamUrl": "https://nova-reggae.ice.infomaniak.ch/nova-reggae-256.aac",
+      "homepage": "https://www.nova.fr/",
+      "country": "FR",
+      "bitrate": 256,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-alouette",
+      "name": "Alouette",
+      "broadcaster": "independent",
+      "streamUrl": "https://alouette.ice.infomaniak.ch/alouette-high.mp3",
+      "homepage": "http://www.alouette.fr/",
+      "country": "FR",
+      "favicon": "https://bocir-prod-bucket.s3.amazonaws.com/radios/alouette/images/favicon.x-icon",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-87-5-nantes",
+      "name": "..87,5!. Nantes",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/15130/stream/28217",
+      "homepage": "https://875naoned.wixsite.com/radio",
+      "country": "FR",
+      "tags": [
+        "alternative",
+        "alternative rock",
+        "classic rock",
+        "electro",
+        "electronic",
+        "electronica"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-lyl-radio",
+      "name": "LYL Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.lyl.live/live",
+      "homepage": "https://lyl.live/",
+      "country": "FR",
+      "tags": [
+        "independent",
+        "music",
+        "variety"
+      ],
+      "favicon": "https://lyl.live/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        45.7689,
+        4.8311
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-cinemusic-radio",
+      "name": "CINEMUSIC Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/422/stream/62785",
+      "homepage": "https://cinemusic.fr/",
+      "country": "FR",
+      "tags": [
+        "cinema",
+        "classical",
+        "jazz",
+        "movie",
+        "movie scores",
+        "music"
+      ],
+      "favicon": "https://cinemusicradio.com/upload/design/63b2a6080fdb31.87854813.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-galaxie-lounge",
+      "name": "Galaxie Lounge",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/45838/stream/82624",
+      "homepage": "http://galaxie-radio1.radio-website.com/",
+      "country": "FR",
+      "favicon": "http://galaxie-radio1.radio-website.com/upload/578f3bce151616.43092430.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-rjr-radio-jeunes-reims-mp3-128k",
+      "name": "RJR - Radio Jeunes Reims (MP3 128k)",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rjrradio.fr/rjr.mp3",
+      "homepage": "https://www.rjrradio.fr/",
+      "country": "FR",
+      "tags": [
+        "pop/rock"
+      ],
+      "favicon": "https://www.rjrradio.fr/sites/default/files/logo2016.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        49.2504,
+        4.0372
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-sun-classique",
+      "name": "SUN Classique",
+      "broadcaster": "independent",
+      "streamUrl": "https://diffusion.lafrap.fr/sun-classique.mp3",
+      "homepage": "https://www.lesonunique.com/",
+      "country": "FR",
+      "tags": [
+        "classical",
+        "classique",
+        "instrumental",
+        "opera",
+        "salon"
+      ],
+      "favicon": "https://www.lesonunique.com/datasun/images_flux/logos/SD/classique.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-europe-1-musique",
+      "name": "Europe 1 Musique",
+      "broadcaster": "independent",
+      "streamUrl": "https://wr.lmn.fm/e1-wr5.aac?aw_0_1st.playerid=lgrdnwsRadioplayer",
+      "homepage": "https://www.europe1.fr/culture/nouveau-ecoutez-europe-musique-4095053",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-meuh",
+      "name": "Radio Meuh",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiomeuh2.ice.infomaniak.ch/radiomeuh2-128.mp3",
+      "homepage": "https://www.radiomeuh.com/",
+      "country": "FR",
+      "favicon": "https://www.radiomeuh.com/android-icon-192x192.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-swigg",
+      "name": "Swigg",
+      "broadcaster": "independent",
+      "streamUrl": "https://start-adofm.ice.infomaniak.ch/start-adofm-high.mp3",
+      "homepage": "https://www.swigg.fr/",
+      "country": "FR",
+      "tags": [
+        "rap"
+      ],
+      "favicon": "https://ecouter.lesindesradios.net/logos/orange4.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radiogospel",
+      "name": "RadioGospel",
+      "broadcaster": "independent",
+      "streamUrl": "https://d3m456gauclwb5.cloudfront.net/radiogospel_high",
+      "homepage": "https://www.radiogospel.fr/",
+      "country": "FR",
+      "tags": [
+        "gospel"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-frequence-3-world-flac",
+      "name": "Fréquence 3 - World FLAC",
+      "broadcaster": "independent",
+      "streamUrl": "https://frequence3.net-radio.fr/frequence3world.flac",
+      "homepage": "https://www.frequence3.com/",
+      "country": "FR",
+      "tags": [
+        "world music"
+      ],
+      "bitrate": 128,
+      "codec": "OGG",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-hotel-costes",
+      "name": "Hotel Costes",
+      "broadcaster": "independent",
+      "streamUrl": "https://s3.radio.co/s39c195d74/listen",
+      "homepage": "https://www.hotelcostes.com/en",
+      "country": "FR",
+      "tags": [
+        "chansons françaises",
+        "downtempo",
+        "euro disco",
+        "italo disco",
+        "lounge"
+      ],
+      "bitrate": 192,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-pomme-d-api",
+      "name": "Radio Pomme D'api",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.radiopommedapi.com/radio.aac",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-kizrock-metal",
+      "name": "Kizrock Métal",
+      "broadcaster": "independent",
+      "streamUrl": "https://go.2stream.net/kizrock_metal",
+      "homepage": "https://kizrock.com/",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        49.107,
+        1.7578
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-nrj-hits",
+      "name": "Nrj Hits",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.nrjaudio.fm/ou7xugf3s5gi?origine=playernrj&aw_0_req.userConsentV2=&aw_0_1st.station=NRJ-Hits",
+      "homepage": "https://www.nrj.fr/webradios/mur-des-radios/nrj-hits",
+      "country": "FR",
+      "tags": [
+        "hits"
+      ],
+      "favicon": "https://img.nrj.fr/8loJFyDgG_Gm_fgnk1fhkYIewhI=/medias%2F2021%2F06%2Flogo-nrj_60db2627d4729.svg",
+      "bitrate": 128,
+      "codec": "AAC+",
+      "geo": [
+        47.9428,
+        2.9883
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-oui-fm-acoustic",
+      "name": "OUI FM ACOUSTIC",
+      "broadcaster": "independent",
+      "streamUrl": "https://ouifmacoustic.ice.infomaniak.ch/ouifmacoustic.mp3",
+      "homepage": "https://www.ouifm.fr/",
+      "country": "FR",
+      "tags": [
+        "acoustic",
+        "rock"
+      ],
+      "favicon": "https://bocir-prod-bucket.s3.amazonaws.com/radios/oui-fm/radiostream/NSzUtv6XGF/vignette.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-france-bleu-100-chanson-francaise",
+      "name": "France Bleu 100% chanson française ",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.radiofrance.fr/fbchansonfrancaise-midfi.mp3",
+      "homepage": "https://www.francebleu.fr/radio-chanson-francaise",
+      "country": "FR",
+      "tags": [
+        "french"
+      ],
+      "favicon": "https://www.francebleu.fr/favicons/apple-touch-icon-180x180.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-ici-maintenant",
+      "name": "Radio Ici & Maintenant",
+      "broadcaster": "independent",
+      "streamUrl": "https://s64.radiolize.com/radio/8090/radio.mp3",
+      "homepage": "https://didierdeplaige.com/",
+      "country": "FR",
+      "tags": [
+        "cultural",
+        "culture",
+        "talk & speech"
+      ],
+      "favicon": "https://fr.wikipedia.org/wiki/Ici_et_Maintenant_!#/media/Fichier:RIM.jpg",
+      "bitrate": 64,
+      "codec": "AAC",
+      "geo": [
+        48.8529,
+        2.347
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-crooner-radio",
+      "name": "Crooner Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://direct.croonerradio.fr/croonerradio-midfi.mp3",
+      "homepage": "https://www.croonerradio.fr/",
+      "country": "FR",
+      "tags": [
+        "crooner",
+        "crooners"
+      ],
+      "favicon": "https://www.croonerradio.fr/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-opensky-flac-868kb",
+      "name": "Opensky (flac)868kb",
+      "broadcaster": "independent",
+      "streamUrl": "https://audio.opensky.radio:8082/flac?_res_tag_=audio",
+      "homepage": "https://opensky.radio/",
+      "country": "FR",
+      "tags": [
+        "pop"
+      ],
+      "codec": "OGG",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-virage-radio-legendes-du-rock",
+      "name": "Virage Radio Légendes du Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://virage-radio-legende-du-rock.ice.infomaniak.ch/virage-radio-legende-du-rock.aac",
+      "homepage": "https://www.virageradio.com/radio/webradio/1/virage-radio",
+      "country": "FR",
+      "favicon": "https://www.virageradio.com/media/radio/thumb/150x150_61e543e1c1713-virage-legendes-plan-de-travail-1.webp",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-douce-france",
+      "name": "Douce France",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.chantefrance.com/Chante_France.aac",
+      "homepage": "https://doucefrance.radio/",
+      "country": "FR",
+      "favicon": "https://doucefrance.radio/favicon.ico",
+      "bitrate": 96,
+      "codec": "AAC+",
+      "geo": [
+        48.8522,
+        2.3502
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-superloustic",
+      "name": "Superloustic",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.superloustic.com/listen",
+      "homepage": "https://www.superloustic.com/",
+      "country": "FR",
+      "favicon": "https://i0.wp.com/www.superloustic.com/wp-content/uploads/logo500-2-.png?fit=180%2c180&#038;ssl=1",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-europe-2-hits",
+      "name": "Europe 2 Hits",
+      "broadcaster": "independent",
+      "streamUrl": "https://europe2.lmn.fm/vr-wr4.mp3?aw_0_1st.playerid=lagardereappVirgin",
+      "homepage": "https://www.europe2.fr/webradios",
+      "country": "FR",
+      "tags": [
+        "pop rock"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.8516,
+        2.3518
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-italienne-de-grenoble",
+      "name": "Radio Italienne de Grenoble",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/204517/stream/247270",
+      "homepage": "https://radioitaliennegrenoble.fr/",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-wave-radio-89-8-hossegor",
+      "name": "WAVE RADIO 89.8 Hossegor",
+      "broadcaster": "independent",
+      "streamUrl": "https://s34.myradiostream.com/12340/listen.mp3",
+      "homepage": "https://waveradio.fm/",
+      "country": "FR",
+      "tags": [
+        "alternative / indie",
+        "downtempo",
+        "electro",
+        "electronic",
+        "funk",
+        "fuzz"
+      ],
+      "favicon": "https://waveradio.fm/wp-content/themes/waveradio/img/favicons/apple-icon-120x120.png",
+      "bitrate": 160,
+      "codec": "MP3",
+      "geo": [
+        43.6639,
+        -1.3955
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-krimi",
+      "name": "Radio Krimi",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio13.pro-fhi.net/flux-nwsimjda2/stream",
+      "homepage": "http://www.radiokrimi.com/",
+      "country": "FR",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-frequence-3-urban-flac",
+      "name": "Fréquence 3 Urban FLAC",
+      "broadcaster": "independent",
+      "streamUrl": "https://frequence3.net-radio.fr/frequence3urban.flac",
+      "homepage": "https://www.frequence3.com/les-radios-frequence-3/urban/",
+      "country": "FR",
+      "tags": [
+        "hip-hop",
+        "r&b",
+        "rap",
+        "urban"
+      ],
+      "bitrate": 128,
+      "codec": "OGG",
+      "geo": [
+        48.8565,
+        2.3473
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-europe-2-happy-rock-hours",
+      "name": "Europe 2 Happy Rock Hours",
+      "broadcaster": "independent",
+      "streamUrl": "https://europe2.lmn.fm/vr-wr5.mp3?aw_0_1st.playerid=lagardereappVirgin",
+      "homepage": "https://www.europe2.fr/webradios",
+      "country": "FR",
+      "tags": [
+        "pop rock",
+        "rock"
+      ],
+      "favicon": "https://www.europe2.fr/wp-content/themes/melty/europeradio/assets/images/radio/radio_2005.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.8601,
+        2.3483
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-barbouillots",
+      "name": "Radio Barbouillots",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rcvfm.fr:8000/barbouillots-192k.mp3",
+      "homepage": "https://radiobarbouillots.com/",
+      "country": "FR",
+      "tags": [
+        "jeunesse"
+      ],
+      "favicon": "https://radiobarbouillots.com/__ovh/common/img/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-lyon-1ere",
+      "name": "Lyon 1ère",
+      "broadcaster": "independent",
+      "streamUrl": "https://lyon1ere.ice.infomaniak.ch/lyon1ere-high.mp3",
+      "homepage": "http://www.lyonpremiere.com/",
+      "country": "FR",
+      "favicon": "http://i2.cdn-image.com/__media__/pics/468/netsol-favicon-2020.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-m40-generation-do",
+      "name": "M40 Génération Do",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.m40radio.fr/listen/m40-generation-do/m40-generation-do-128.mp3",
+      "homepage": "https://m40radio.fr/",
+      "country": "FR",
+      "favicon": "https://cdn.m40radio.fr/wp-content/uploads/radio-m40-generation-do-370x370.webp",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-jazz-radio-lounge",
+      "name": "Jazz Radio Lounge",
+      "broadcaster": "independent",
+      "streamUrl": "https://jazzlounge.ice.infomaniak.ch/jazzlounge-high.aac?i=57064",
+      "homepage": "https://www.jazzradio.fr/",
+      "country": "FR",
+      "tags": [
+        "jazz lounge"
+      ],
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-africa-radio-naija-webradio",
+      "name": "Africa Radio Naija Webradio",
+      "broadcaster": "independent",
+      "streamUrl": "https://webradio1.ice.infomaniak.ch/webradio3-128.mp3",
+      "homepage": "https://www.africaradio.com/",
+      "country": "FR",
+      "tags": [
+        "african music"
+      ],
+      "favicon": "https://images.lesindesradios.fr/fit-in/300x2000/filters:format(webp)/radios/africaradio/radiostream/QP0HYlUIr3/vignette.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-girl-power",
+      "name": "Girl Power",
+      "broadcaster": "independent",
+      "streamUrl": "https://scoopgirls.ice.infomaniak.ch/radioscoop-girls-64.aac",
+      "homepage": "http://www.radioscoop.com/",
+      "country": "FR",
+      "tags": [
+        "female vocalists",
+        "female vocals",
+        "female voices",
+        "femininity",
+        "feminist",
+        "pop"
+      ],
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-starsystem-fm-max",
+      "name": "Starsystem FM (MAX)",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiosurle.net:8765/starsystemfm",
+      "homepage": "https://radiosurle.net/",
+      "country": "FR",
+      "tags": [
+        "humour",
+        "radio libre",
+        "trash talk"
+      ],
+      "bitrate": 96,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-le-grigri",
+      "name": "Le Grigri",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.radioking.com/play/legrigri/273715",
+      "homepage": "https://www.le-grigri.com/",
+      "country": "FR",
+      "tags": [
+        "african music",
+        "free jazz",
+        "hip-hop",
+        "jazz",
+        "world music"
+      ],
+      "favicon": "https://www.le-grigri.com/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-esperance-en-marie",
+      "name": "Radio Espérance En Marie",
+      "broadcaster": "independent",
+      "streamUrl": "https://esperance.streamakaci.com/aufil.mp3",
+      "homepage": "http://radio-esperance.fr/",
+      "country": "FR",
+      "tags": [
+        "christian"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-1-splash-jazz",
+      "name": "#1 Splash Jazz",
+      "broadcaster": "independent",
+      "streamUrl": "https://ais-sa2.cdnstream1.com/2346_128.mp3",
+      "homepage": "https://www.splashradio.eu/",
+      "country": "FR",
+      "tags": [
+        "big band",
+        "classic jazz",
+        "cool jazz",
+        "free jazz",
+        "jazz",
+        "jazz fusion"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-africa-radio-abidjan-webradio",
+      "name": "Africa Radio Abidjan Webradio",
+      "broadcaster": "independent",
+      "streamUrl": "https://africaradio.ice.infomaniak.ch/abidjan128.mp3",
+      "homepage": "https://www.africaradio.com/",
+      "country": "FR",
+      "tags": [
+        "african music"
+      ],
+      "favicon": "https://images.lesindesradios.fr/fit-in/300x2000/filters:format(webp)/radios/africaradio/radiostream/4D9oGPMZbK/vignette_CL9ZJm8Vsg.png",
+      "bitrate": 96,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-rinse-france",
+      "name": "Rinse France",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio10.pro-fhi.net/radio/9041/stream",
+      "homepage": "https://www.rinse.fm/channels/france/",
+      "country": "FR",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-roots-legacy-radio",
+      "name": "Roots Legacy Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://l.rootslegacy.fr/;",
+      "homepage": "https://www.rootslegacy.fr/",
+      "country": "FR",
+      "favicon": "https://www.rootslegacy.fr/images/logo.webp",
+      "bitrate": 224,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-yumi-co-radio",
+      "name": "Yumi Co. Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://yumicoradio.net/stream",
+      "homepage": "https://yumicoradio.net/",
+      "country": "FR",
+      "tags": [
+        "anime groove",
+        "city pop",
+        "future funk",
+        "nu disco",
+        "synthwave",
+        "vaporwave"
+      ],
+      "favicon": "https://i.imgur.com/cVC439t.png",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-allzic-radio-rock-fm",
+      "name": "Allzic Radio Rock FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://allzic17.ice.infomaniak.ch/allzic17.mp3",
+      "homepage": "https://www.allzicradio.com/fr/player/listen/1087/allzic-radio-rock-fm",
+      "country": "FR",
+      "tags": [
+        "pop rock"
+      ],
+      "favicon": "https://www.allzicradio.com/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-oui-fm-girls-rock",
+      "name": "OUI FM GIRLS ROCK",
+      "broadcaster": "independent",
+      "streamUrl": "https://ouifmgirlsrock.ice.infomaniak.ch/ouifmgirlsrock.mp3",
+      "homepage": "https://www.ouifm.fr/",
+      "country": "FR",
+      "tags": [
+        "female voices",
+        "rock"
+      ],
+      "favicon": "https://bocir-prod-bucket.s3.eu-west-1.amazonaws.com/radios/oui-fm/images/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-blues-cafe-radio",
+      "name": "Blues Café Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://manager4.streamradio.fr/bluescaferadio?x=1693763714913",
+      "homepage": "https://bluesactu.wixsite.com/bluescaferadio",
+      "country": "FR",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/8/73528.v11.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-oui-fm-rock-francais",
+      "name": "OUI FM ROCK FRANCAIS",
+      "broadcaster": "independent",
+      "streamUrl": "https://ouifmrockfrancais.ice.infomaniak.ch/ouifmrockfrancais.mp3",
+      "homepage": "https://www.ouifm.fr/",
+      "country": "FR",
+      "tags": [
+        "rock"
+      ],
+      "favicon": "https://bocir-prod-bucket.s3.amazonaws.com/radios/oui-fm/radiostream/3fkpVzB8Cc/vignette.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-yiddish-pour-tous",
+      "name": "Yiddish pour tous",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.radioking.com/play/radio-yiddish-pour-tous",
+      "homepage": "https://www.yiddishpourtous.com/",
+      "country": "FR",
+      "favicon": "https://static.wixstatic.com/media/b8f8f5_53a68559e3164f088e45f9f66f18954d%7Emv2.png/v1/fill/w_32%2Ch_32%2Clg_1%2Cusm_0.66_1.00_0.01/b8f8f5_53a68559e3164f088e45f9f66f18954d%7Emv2.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-algorythme-lounge-bossa",
+      "name": "Algorythme Lounge & Bossa",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio8.pro-fhi.net/flux-sinllzly/stream",
+      "homepage": "https://www.algorythmeradio.com/",
+      "country": "FR",
+      "tags": [
+        "bossa",
+        "lounge"
+      ],
+      "favicon": "https://www.algorythmeradio.com/assets/images/icon-algo.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-guadeloupe-france-television",
+      "name": "Guadeloupe France Télévision",
+      "broadcaster": "independent",
+      "streamUrl": "https://guadeloupe.ice.infomaniak.ch/guadeloupe-128.mp3",
+      "homepage": "https://caribshebdo.wordpress.com/2020/03/30/guadeloupe-1ere-radio-live/",
+      "country": "FR",
+      "tags": [
+        "info",
+        "kompa",
+        "tradition",
+        "zouk"
+      ],
+      "favicon": "https://s1.wp.com/i/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-soul-radio-classics",
+      "name": "SOUL RADIO Classics",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.soulradio.eu/eu",
+      "homepage": "https://soulradio.eu/",
+      "country": "FR",
+      "tags": [
+        "classic soul",
+        "soul"
+      ],
+      "bitrate": 192,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-made-in-80",
+      "name": "Made in 80",
+      "broadcaster": "independent",
+      "streamUrl": "https://madein80.leswebradios.fr/",
+      "homepage": "https://madein80.fr/",
+      "country": "FR",
+      "tags": [
+        "1980s hits",
+        "80's",
+        "80s",
+        "the best of 80's"
+      ],
+      "favicon": "https://madein80.fr/wp-content/uploads/2020/12/Logo-Made-in-80-V2-blanc-400-ssslog.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        43.7751,
+        2.6367
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-modular-station",
+      "name": "Modular-Station",
+      "broadcaster": "independent",
+      "streamUrl": "https://broadcast.modular-station.com/radio/8000/radio.aac",
+      "homepage": "https://modular-station.com/",
+      "country": "FR",
+      "tags": [
+        "ambient",
+        "electronic",
+        "experimental",
+        "modular synthesis",
+        "soundscape",
+        "techno"
+      ],
+      "favicon": "https://modular-station.com/app/themes/modular-station/dist/images/modular-station-192_3bcbc4e6.png",
+      "bitrate": 192,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-heavy1",
+      "name": "Heavy1",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/119653/stream/159127",
+      "homepage": "https://www.heavy1.radio/",
+      "country": "FR",
+      "tags": [
+        "hard rock",
+        "heavy metal",
+        "rock"
+      ],
+      "favicon": "https://static.mytuner.mobi/media/tvos_radios/sdapkvmjcrmh.jpg",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        48.8676,
+        2.3456
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-le-poste-parisien",
+      "name": "Le poste parisien ",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream10.xdevel.com/audio12s976748-1798/stream/icecast.audio",
+      "homepage": "https://www.posteparisien.fr/",
+      "country": "FR",
+      "tags": [
+        "9ties",
+        "eighties"
+      ],
+      "favicon": "https://static.wixstatic.com/media/8f2aad_f34c5a8400a54644a8d1c5845b03ce35~mv2.png/v1/fill/w_360,h_128,al_c,q_85,usm_0.66_1.00_0.01,enc_auto/8f2aad_f34c5a8400a54644a8d1c5845b03ce35~mv2.png",
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-jazz-saxo",
+      "name": "Jazz Saxo",
+      "broadcaster": "independent",
+      "streamUrl": "https://jzr-saxo.ice.infomaniak.ch/jzr-saxo.mp3",
+      "homepage": "https://www.jazzradio.fr/",
+      "country": "FR",
+      "favicon": "https://www.jazzradio.fr/media/radio/thumb/180x180_lounge.webp",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-oui-fm-woodstock",
+      "name": "OUI FM WOODSTOCK",
+      "broadcaster": "independent",
+      "streamUrl": "https://ouifmwoodstock.ice.infomaniak.ch/ouifmwoodstock.mp3",
+      "homepage": "https://www.ouifm.fr/",
+      "country": "FR",
+      "tags": [
+        "rock"
+      ],
+      "favicon": "https://bocir-prod-bucket.s3.amazonaws.com/radios/oui-fm/radiostream/xD29y7pjPX/vignette.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-tsfjazz",
+      "name": "TSFJazz",
+      "broadcaster": "independent",
+      "streamUrl": "https://tsfjazz.ice.infomaniak.ch/tsfjazz-high.mp3",
+      "homepage": "https://www.tsfjazz.com/",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.8011,
+        2.417
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-jazz-only-women",
+      "name": "Jazz Only Women",
+      "broadcaster": "independent",
+      "streamUrl": "https://jazz-wr16.ice.infomaniak.ch/jazz-wr16-128.mp3",
+      "homepage": "https://www.jazzradio.fr/",
+      "country": "FR",
+      "favicon": "https://www.jazzradio.fr/media/radio/thumb/180x180_only-women.webp",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-brony",
+      "name": "Radio Brony",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.radiobrony.fr/mp3",
+      "homepage": "https://radiobrony.fr/",
+      "country": "FR",
+      "tags": [
+        "brony",
+        "fan music",
+        "live show",
+        "mlp",
+        "my little pony: friendship is magic"
+      ],
+      "favicon": "https://radiobrony.fr/img/icons/bwavatar-details.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-brony-ogg",
+      "name": "Radio Brony (OGG)",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.radiobrony.fr/ogg",
+      "homepage": "https://radiobrony.fr/",
+      "country": "FR",
+      "tags": [
+        "brony",
+        "fan music",
+        "live show",
+        "mlp",
+        "my little pony",
+        "my little pony: friendship is magic"
+      ],
+      "favicon": "https://radiobrony.fr/img/icons/bwavatar-details.png",
+      "codec": "OGG",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-jazz-classic",
+      "name": "Jazz Classic",
+      "broadcaster": "independent",
+      "streamUrl": "https://jazz-wr01.ice.infomaniak.ch/jazz-wr01-128.mp3",
+      "homepage": "https://www.jazzradio.fr/",
+      "country": "FR",
+      "favicon": "https://www.jazzradio.fr/media/radio/thumb/180x180_classic-jazz.webp",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-le-grigri-radio-porte-bonheur",
+      "name": "Le Grigri, radio porte-bonheur",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/139090/stream/179170",
+      "homepage": "https://www.le-grigri.com/",
+      "country": "FR",
+      "tags": [
+        "grigri",
+        "legrigri"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-brume",
+      "name": "radio brume",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.radioking.com/play/brume-campus-lyon/546695",
+      "homepage": "https://www.radiobrume.fr/",
+      "country": "FR",
+      "tags": [
+        "rock"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        45.7831,
+        4.8758
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-positively-meditation",
+      "name": "📻 Positively Meditation",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.positivity.radio/pr/posimeditation/icecast.audio",
+      "homepage": "https://multimedias.karibshebdo.info/radios-web/positively-meditation",
+      "country": "FR",
+      "tags": [
+        "méditation"
+      ],
+      "favicon": "https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEgtmuQxXsk4FaNYHUD5IPcExKD0y4EU8OU1rSzpdaIrX-0CrYddUFVaGixVG6WJDz7A5EYjo_UbJ-DSt56f9J5Z0rK4O_JhDCrH2nkc6BViZLmpa9gwh3ZUzyHavUE2Buz_DVrLMbwBX_VKxqxrDLCgV11NeUZmxbI4MTZ0KSkjhoWAePu_j2xXVuhTRA/s1600/Capture%20d%E2%80%99%C3%A9cran_2024-12-19_16-17-59.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-africa-radio-coupe-decale-webradio",
+      "name": "Africa Radio Coupé Decalé Webradio",
+      "broadcaster": "independent",
+      "streamUrl": "https://webradio1.ice.infomaniak.ch/webradio1-128.mp3",
+      "homepage": "https://www.africaradio.com/",
+      "country": "FR",
+      "tags": [
+        "african music"
+      ],
+      "favicon": "https://images.lesindesradios.fr/fit-in/300x2000/filters:format(webp)/radios/africaradio/radiostream/CkIE3S769N/vignette.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-reggae-mix-station",
+      "name": "Reggae Mix Station",
+      "broadcaster": "independent",
+      "streamUrl": "https://france1.coollabel-productions.com/proxy/reggaemix340/stream",
+      "homepage": "http://www.reggaemixstation.com/",
+      "country": "FR",
+      "favicon": "http://www.reggaemixstation.com/templates/rsjuno/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-jazzradio-fr-jazz-cinema",
+      "name": "Jazzradio.fr Jazz & Cinema",
+      "broadcaster": "independent",
+      "streamUrl": "https://jzr-wr20.ice.infomaniak.ch/jzr-wr20.mp3",
+      "homepage": "https://www.jazzradio.fr/",
+      "country": "FR",
+      "tags": [
+        "cinema",
+        "jazz"
+      ],
+      "favicon": "https://www.jazzradio.fr/apple-touch-icon-120x120.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-hits-1",
+      "name": "Hits 1",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio12.pro-fhi.net/live/Hits%201%20radio",
+      "homepage": "https://www.hits1radio.com/",
+      "country": "FR",
+      "tags": [
+        "contemporary hits",
+        "dance",
+        "electro",
+        "electronic",
+        "hits",
+        "pop"
+      ],
+      "favicon": "https://www.hits1radio.com/wp-content/uploads/2019/03/cropped-1024-5-180x180.png",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-broussaille",
+      "name": "Radio Broussaille",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radiobroussaille.fr:8443/broussaille-hifi",
+      "homepage": "https://radiobroussaille.fr/",
+      "country": "FR",
+      "tags": [
+        "adfree",
+        "broussaille",
+        "creative",
+        "direct",
+        "foss",
+        "gascon"
+      ],
+      "favicon": "https://stream.radiobroussaille.fr:8443/favicon-32x32.png",
+      "bitrate": 320,
+      "codec": "AAC",
+      "geo": [
+        43.7316,
+        0.8782
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-larzac",
+      "name": "Radio Larzac",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radiolarzac.org/hls/master.m3u8",
+      "homepage": "https://radiolarzac.org/",
+      "country": "FR",
+      "tags": [
+        "eclectic"
+      ],
+      "favicon": "https://www.radiolarzac.org/wp-content/uploads/2019/01/Petit-logo-couleurs-sans-fond.png",
+      "bitrate": 320,
+      "codec": "UNKNOWN",
+      "geo": [
+        44.0984,
+        3.0809
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-rtl-100-france",
+      "name": "RTL 100% FRANCE",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.m6radio.quortex.io/webpHJPXnXrN7B6J7Q8mcqmxP/webradio/rtl100pc80/130/audio-64000/index.m3u8",
+      "homepage": "https://www.rtl.fr/radios",
+      "country": "FR",
+      "tags": [
+        "chansons françaises",
+        "music"
+      ],
+      "favicon": "https://images.rtl.fr/~c/300v300/rtl/www/1374199-100-webradio-2800x2800.jpg",
+      "bitrate": 64,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-frequence-3-dance",
+      "name": "Fréquence 3 Dance",
+      "broadcaster": "independent",
+      "streamUrl": "https://frequence3.net-radio.fr/frequence3dance.mp3",
+      "homepage": "https://www.frequence3.com/",
+      "country": "FR",
+      "tags": [
+        "dance",
+        "pop"
+      ],
+      "bitrate": 160,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-jazz-manouche",
+      "name": "Jazz Manouche",
+      "broadcaster": "independent",
+      "streamUrl": "https://jazz-wr02.ice.infomaniak.ch/jazz-wr02-128.mp3",
+      "homepage": "https://www.jazzradio.fr/radio/webradio/10/jazz-manouche",
+      "country": "FR",
+      "favicon": "https://www.jazzradio.fr/media/radio/thumb/180x180_jazz-manouche.webp",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        45.5341,
+        2.8125
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-doudou",
+      "name": "Radio Doudou",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/11565/stream/22961",
+      "homepage": "http://radiodoudou.com/",
+      "country": "FR",
+      "tags": [
+        "baby",
+        "childrens music"
+      ],
+      "favicon": "http://radiodoudou.com/upload/52f8cc26745829.05897109.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-rbs",
+      "name": "Radio RBS",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.radioking.com/play/radio-rbs-1",
+      "homepage": "https://www.radiorbs.com/",
+      "country": "FR",
+      "tags": [
+        "electro",
+        "funk",
+        "hiphop",
+        "house",
+        "world music"
+      ],
+      "favicon": "https://www.radiorbs.com/app/themes/rbs/build/images/favicon/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-alternative-radio-hd",
+      "name": "Alternative Radio HD",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.radioking.com/play/alternative-radio-1/224215",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "FR",
+      "tags": [
+        "international"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-les-inrocks-radio",
+      "name": "Les Inrocks Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://inrocksradio.ice.infomaniak.ch/inrocksradio-128.mp3",
+      "homepage": "https://www.lesinrocks.com/radios/les-inrocks-radio/",
+      "country": "FR",
+      "favicon": "https://www.lesinrocks.com/wp-content/thumbnails/uploads/2021/02/Inrockuptibles-10-t-400x496.gif",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-phare-fm-france",
+      "name": "PHARE FM FRANCE",
+      "broadcaster": "independent",
+      "streamUrl": "https://str0.creacast.com/pharefm",
+      "homepage": "https://pharefm.com/",
+      "country": "FR",
+      "favicon": "https://static.mytuner.mobi/media/tvos_radios/FbDDtBn6v5.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-blagues-courtes",
+      "name": "bLaGuEs cOuRtEs",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.blagues-courtes.fr/stream",
+      "homepage": "https://blagues-courtes.fr/",
+      "country": "FR",
+      "tags": [
+        "blagues",
+        "jokes"
+      ],
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-sun-soul-funk",
+      "name": "SUN Soul & Funk",
+      "broadcaster": "independent",
+      "streamUrl": "https://diffusion.lafrap.fr/sun-soul.funk.mp3",
+      "homepage": "https://www.lesonunique.com/",
+      "country": "FR",
+      "tags": [
+        "funk",
+        "hip hop",
+        "jazz fusion",
+        "soul"
+      ],
+      "favicon": "https://www.lesonunique.com/datasun/images_flux/logos/HD/soulandfunk.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-aioli-radio",
+      "name": "Aïoli Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.aioli-radio.org/main.ogg",
+      "homepage": "https://www.aioli-radio.org/",
+      "country": "FR",
+      "tags": [
+        "ambient",
+        "autres",
+        "chanson",
+        "classique",
+        "dancehall",
+        "dub"
+      ],
+      "favicon": "https://www.aioli-radio.org/icons/icon-144x144.png?v=1fcb4097b832c16b2996c0ec84a6fd0e",
+      "codec": "OGG",
+      "geo": [
+        43.9478,
+        4.8084
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-ici-100-chanson-francaise",
+      "name": "ICI 100% Chanson française",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.radiofrance.fr/fbchansonfrancaise-hifi.aac",
+      "homepage": "https://www.francebleu.fr/radio/radio-chanson-francaise",
+      "country": "FR",
+      "tags": [
+        "variété française 80's 90's & 2000's"
+      ],
+      "favicon": "https://www.francebleu.fr/favicons/apple-touch-icon-180x180.png",
+      "bitrate": 192,
+      "codec": "AAC",
+      "geo": [
+        48.8525,
+        2.2782
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-rjfm-club-80",
+      "name": "rjfm club 80",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/2725/stream/72647",
+      "homepage": "https://fr.radioking.com/radio/rjfm-club-80",
+      "country": "FR",
+      "tags": [
+        "1980s",
+        "80's",
+        "hd"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-francais-dans-le-monde",
+      "name": "Francais dans le monde",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/2079/stream/63043",
+      "homepage": "https://link.radioking.com/francaisdanslemonde",
+      "country": "FR",
+      "tags": [
+        "general"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-sun-hip-hop",
+      "name": "SUN Hip Hop",
+      "broadcaster": "independent",
+      "streamUrl": "https://diffusion.lafrap.fr/sun-hip-hop.mp3",
+      "homepage": "https://www.lesonunique.com/",
+      "country": "FR",
+      "tags": [
+        "groove",
+        "hip hop",
+        "jazz",
+        "r&b",
+        "rap"
+      ],
+      "favicon": "https://www.lesonunique.com/datasun/images_flux/logos/SD/hiphop.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-abc-dance",
+      "name": "ABC Dance",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.radioking.com/play/abc-dance/374263",
+      "homepage": "https://www.abcdanceradio.com/",
+      "country": "FR",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-fly-foot-selecta",
+      "name": "Fly Foot Selecta",
+      "broadcaster": "independent",
+      "streamUrl": "https://manager5.streamradio.fr:1185/stream",
+      "homepage": "https://www.radio-fly-foot-selecta.com/",
+      "country": "FR",
+      "tags": [
+        "black",
+        "dub",
+        "hiphop",
+        "jungle",
+        "ragga",
+        "reggae"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-nova-hiphop",
+      "name": "Nova HipHop",
+      "broadcaster": "independent",
+      "streamUrl": "https://nova-odn.ice.infomaniak.ch/nova-odn-256.aac",
+      "homepage": "https://www.nova.fr/radios/nova-hip-hop/",
+      "country": "FR",
+      "tags": [
+        "hip-hop and rap oldies"
+      ],
+      "favicon": "https://www.nova.fr/wp-content/uploads/sites/2/2022/11/Nova-Hip-Hop.png?resize=503%2C503&quality=75",
+      "bitrate": 256,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-jazz",
+      "name": "Jazz",
+      "broadcaster": "independent",
+      "streamUrl": "https://jazz-wr18.ice.infomaniak.ch/jazz-wr18-128.mp3",
+      "homepage": "https://www.jazzradio.fr/",
+      "country": "FR",
+      "favicon": "https://www.jazzradio.fr/media/radio/thumb/180x180_nouveautes-soul.webp",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-fpp-frequence-paris-plurielle-rfpp",
+      "name": "FPP Fréquence Paris Plurielle rfpp",
+      "broadcaster": "independent",
+      "streamUrl": "https://direct.rfpp.net/fpp.mp3",
+      "homepage": "https://rfpp.net/",
+      "country": "FR",
+      "tags": [
+        "political talk",
+        "politique",
+        "radio associative",
+        "radio libre",
+        "voix des sans voix"
+      ],
+      "favicon": "https://rfpp.net/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.853,
+        2.3479
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-clapas",
+      "name": "Radio Clapas",
+      "broadcaster": "independent",
+      "streamUrl": "https://stations.radioclapas.fr/radio/8130/radio.mp3",
+      "homepage": "https://www.radioclapas.fr/",
+      "country": "FR",
+      "favicon": "https://www.radioclapas.fr/wp-content/uploads/2015/10/favicon.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-jazz-piano",
+      "name": "Jazz Piano",
+      "broadcaster": "independent",
+      "streamUrl": "https://jzr-piano.ice.infomaniak.ch/jzr-piano.mp3",
+      "homepage": "https://www.jazzradio.fr/",
+      "country": "FR",
+      "favicon": "https://www.jazzradio.fr/media/radio/thumb/180x180_piano-jazz2.webp",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-urban-hit-a-l-ancienne",
+      "name": "Urban Hit à l'ancienne",
+      "broadcaster": "independent",
+      "streamUrl": "https://urbanhitalancienne.ice.infomaniak.ch/urbanhitalancienne.mp3",
+      "homepage": "https://www.urbanhit.fr/",
+      "country": "FR",
+      "favicon": "https://www.urbanhit.fr/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-isekoi-radio-non-stop-ambient",
+      "name": "ISEKOI Radio | Non-Stop Ambient",
+      "broadcaster": "independent",
+      "streamUrl": "https://public.isekoi-radio.com/listen/ambient/ambientradio.flac",
+      "homepage": "https://isekoi-radio.com/",
+      "country": "FR",
+      "tags": [
+        "ambient",
+        "meditation",
+        "relax",
+        "relaxation"
+      ],
+      "favicon": "https://i.postimg.cc/3rFkNkY4/LOGO-3-2-bg3.png",
+      "codec": "OGG",
+      "geo": [
+        50.633,
+        3.066
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-allzic-radio-zouk",
+      "name": "Allzic Radio Zouk",
+      "broadcaster": "independent",
+      "streamUrl": "https://allzic28.ice.infomaniak.ch/allzic28.mp3",
+      "homepage": "https://www.allzicradio.com/en/player/listen/1767/allzic-radio-zouk",
+      "country": "FR",
+      "tags": [
+        "music",
+        "zouk"
+      ],
+      "favicon": "https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-generations-dancehall",
+      "name": "🕺 Générations Dancehall",
+      "broadcaster": "independent",
+      "streamUrl": "https://generations-dancehall.ice.infomaniak.ch/generations-dancehall.aac",
+      "homepage": "https://www.karibshebdo.info/radios-web/g%C3%A9n%C3%A9rations-dancehall",
+      "country": "FR",
+      "tags": [
+        "dancehall"
+      ],
+      "favicon": "https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEjnhJmvti_BH6oOOGOTfiuUc26pCXXZbu2kSzAztx5Djgb1TqKDf64tgGm2EGlhR08B10iUj4Aa0YcM1960rrGNkQd9R_-nj5hJ4mOhz119h-ipkZtnyblHix9CHBS_vnoSa2QXCGHtWPDWg0M2oANax1FdG8cAey3Sw10FuQMWx8z8Sh9RH6Jw48py/s1600/Capture%20d%E2%80%99%C3%A9cran_2024-11-18_11-39-43.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-chante-france-70-s",
+      "name": "Chante France 70's",
+      "broadcaster": "independent",
+      "streamUrl": "https://chantefrance70s.ice.infomaniak.ch/chantefrance70s-128.mp3",
+      "homepage": "http://www.chantefrance.com/",
+      "country": "FR",
+      "tags": [
+        "chansons françaises",
+        "french chansons"
+      ],
+      "favicon": "https://m209.syncusercontent.com/mfs-60:c37f584aa5c7deb8c9c57eeb95104ba0=============================/p/Chante_France_70s.png?allowdd=0&datakey=nPZKWcukh3jvtGxH1MwrXHYJ3SBhifDYRyUBJ1fD+Yttofsl+mR7i+L1Cf9SNqIRQsa92m974+b6ltDsSj063imF9rT5QDVvXQuINdV63Npsr2X1Rn0r+wW4lTuZ/3CWmbCNOwyKcy3TcmPD+SbmnEzreg/C2ixTt4rACINutdGq4ke4n/Umd/z/oDgbI/mfDFqYCEpImYWXRUAAmXYiBPFQV1FQ8uzQTHmDUbnUAe28czGpswLbFGV6oqQ3vavsPvS6QZEPXrqgm6PgtxLuZG/BH31qST4ESPaXEETFE2p89kYS+V3fj7SQ7iYcY1s2XGwsKpDXSzaHkr/L1zzRNg&engine=ln-3.1.38&errurl=C1ZxI/xCDYvTxV4BPvWu7W0iiS/zZJpJoyjiNwOu3R4h/FFap7neKIORizWM82OsnayL9mmVtakaby4s30SPSpjLV5ceJmlX4CTUwjmyeMPXpJoZIDthJTEQKYSk+v7+6TYEznqOVi6xJFkGnc88JGWLi9DTf1D7A03U03IirrQXHPd9YJjiTeDewr+HoUpqAXMxoqqHgDmghJv3o9HTe6OYHqrwbUU3UXD8164mdSw/kdz189eAa6oie9kndmO65zz9+NTmXlY5r4ofnTGmQY/SF3L+rbIqGsPDnu7G1ZU4XojrH9j2QIoylqvHdF7C5wuckgedUMqcC5hETNGSMQ==&header1=Q29udGVudC1UeXBlOiBpbWFnZS9wbmc&header2=Q29udGVudC1EaXNwb3NpdGlvbjogaW5saW5lOyBmaWxlbmFtZT0iQ2hhbnRlX0ZyYW5jZV83MHMucG5nIjtmaWxlbmFtZSo9VVRGLTgnJ0NoYW50ZV9GcmFuY2VfNzBzLnBuZzs&ipaddress=1414030563&linkcachekey=72262aa90&linkoid=1991610004&mode=101&sharelink_id=17962746020004&timestamp=1708276526046&uagent=3b50c75381f12107280e9099b5b7674cf455a2e5&signature=12b2a47aa6dc67a944284a87b56a794977b5fb89&cachekey=60:c37f584aa5c7deb8c9c57eeb95104ba0=============================",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-monte-carlo-french",
+      "name": "Radio Monte Carlo French",
+      "broadcaster": "independent",
+      "streamUrl": "https://misato.ru-hoster.com:8079/stream",
+      "homepage": "https://www.montecarlo.uno/",
+      "country": "FR",
+      "favicon": "https://www.montecarlo.uno/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-france-inter-la-musique-d-inter-hifi",
+      "name": "France Inter La musique d'Inter Hifi",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.radiofrance.fr/franceinterlamusiqueinter-hifi.aac",
+      "homepage": "https://www.radiofrance.fr/franceinter/la-musique-inter",
+      "country": "FR",
+      "favicon": "https://www.radiofrance.fr/s3/cruiser-production-eu3/2024/06/2eb99120-ff28-414d-a805-c354c3967edf/300x300_sc_fi-webradio-c3b2.jpg",
+      "bitrate": 192,
+      "codec": "AAC",
+      "geo": [
+        48.8525,
+        2.2784
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-jazzradio-fr-groove",
+      "name": "JazzRadio.fr Groove",
+      "broadcaster": "independent",
+      "streamUrl": "https://jazz-wr08.ice.infomaniak.ch/jazz-wr08-128.mp3",
+      "homepage": "https://www.jazzradio.fr/",
+      "country": "FR",
+      "tags": [
+        "groove",
+        "soul"
+      ],
+      "favicon": "https://www.jazzradio.fr/media/radio/thumb/100x100_groove.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-liberte-fm",
+      "name": "Liberté FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.libertefm.fr/libertefm.192.mp3",
+      "homepage": "https://libertefm.fr/",
+      "country": "FR",
+      "tags": [
+        "hits",
+        "local news",
+        "local radio"
+      ],
+      "favicon": "https://libertefm.fr/upload/logos/touch-icon.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        45.2478,
+        0.3385
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-chante-france-80-s",
+      "name": "Chante France 80's",
+      "broadcaster": "independent",
+      "streamUrl": "https://chantefrance80s.ice.infomaniak.ch/chantefrance80s-128.mp3",
+      "homepage": "http://www.chantefrance.com/",
+      "country": "FR",
+      "tags": [
+        "chansons françaises",
+        "french chansons"
+      ],
+      "favicon": "https://m209.syncusercontent.com/mfs-60:62a5d44bbf259b3cd1bfc46b554dc870=============================/p/Chante_France_80s.PNG?allowdd=0&datakey=IiyCboqbabGVcgKaDzHK02vXW3Wky759JGLowzH0RO5kZXgBRhFkorPIHuNpTR9+35SR35ZpNbQ+kwtHURxsIulDqyud/UkpFEYEPU2UGLy4FjPkgwUl2C1PIScCRX0ZnWXDKcH6sbuJiRtmdarH0A3qt31L+jTBhgOETWvJ8i7zNIOy7FUFOnyiKGULsFiYVZ5Ta4FsdARFqu+JXxkZ1fSE4/W/E4ePYH58jkI7KHopwc5VG2wlbGy2zRmW+xW99ck7BeLtgglYJ1IGwflB1yYRLr3ZhnxqGAgiBRnZVFO6SB/N1HF3DduX2eg8RKl1oBkSoCFgzf3YnS9Tp83S3Q&engine=ln-3.1.38&errurl=hClSQ4MkSQjg1qv64K1t4MZGzA8/95NcIiROqX2SC/ATAZg9EuQgUaHPydUV/+gizUbVpzxtzONz1ZmDAbcLjzb6JI+kLZRjdmKO+ZDa2/ZLq3DGtvsXxJihIBsyGdnVlLT0/Yzm3hfa1ftoaMNbjzV2Jud3IZw5CxZ69QsIutUsC0Gv93kawZLvsFQ2QJFDUjzYHYCZC3Pm0hcy1N6EWSDH2snTlxy8erDa13+FluIyc4h6GS9V3Di2XS28g2K8BVRaqHzzhtwNnc7H2Q6s7L5YkN8KgPyq/PWt74IrfkeUXBUd4IHpqOhoz2kKVbnynrMRu+T2mg02oep3HFcT1g==&header1=Q29udGVudC1UeXBlOiBpbWFnZS9wbmc&header2=Q29udGVudC1EaXNwb3NpdGlvbjogaW5saW5lOyBmaWxlbmFtZT0iQ2hhbnRlX0ZyYW5jZV84MHMuUE5HIjtmaWxlbmFtZSo9VVRGLTgnJ0NoYW50ZV9GcmFuY2VfODBzLlBORzs&ipaddress=1414030563&linkcachekey=d0286fb30&linkoid=1991610004&mode=101&sharelink_id=17962735040004&timestamp=1708276131659&uagent=3b50c75381f12107280e9099b5b7674cf455a2e5&signature=05c24b5e57cc52ad8f43654652244e0a257732ff&cachekey=60:62a5d44bbf259b3cd1bfc46b554dc870=============================",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-oui-fm-bring-the-noise",
+      "name": "OUI FM BRING THE NOISE",
+      "broadcaster": "independent",
+      "streamUrl": "https://ouifmbringthenoise.ice.infomaniak.ch/ouifmbringthenoise.mp3",
+      "homepage": "https://www.ouifm.fr/",
+      "country": "FR",
+      "tags": [
+        "hard rock",
+        "rock"
+      ],
+      "favicon": "https://bocir-prod-bucket.s3.amazonaws.com/radios/oui-fm/radiostream/tBdigJT2rb/vignette.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-jazzradio-fr-gospel",
+      "name": "Jazzradio.fr Gospel",
+      "broadcaster": "independent",
+      "streamUrl": "https://jazz-wr07.ice.infomaniak.ch/jazz-wr07-64.aac",
+      "homepage": "https://www.jazzradio.fr/",
+      "country": "FR",
+      "favicon": "https://www.jazzradio.fr/apple-touch-icon-120x120.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-la-grosse-radio-metal",
+      "name": "La Grosse Radio Métal",
+      "broadcaster": "independent",
+      "streamUrl": "https://hd.lagrosseradio.info/lagrosseradio-metal-192.mp3",
+      "homepage": "https://caribshebdo.wordpress.com/2020/09/02/radio-web-la-grosse-reggae/",
+      "country": "FR",
+      "tags": [
+        "hard",
+        "metal",
+        "rock"
+      ],
+      "favicon": "https://s1.wp.com/i/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-sun-jazz",
+      "name": "SUN Jazz",
+      "broadcaster": "independent",
+      "streamUrl": "https://diffusion.lafrap.fr/sun-jazz.mp3",
+      "homepage": "https://www.lesonunique.com/",
+      "country": "FR",
+      "tags": [
+        "jazz"
+      ],
+      "favicon": "https://www.lesonunique.com/favicon.ico",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-allzic-radio-electro-chill",
+      "name": "Allzic Radio Electro Chill",
+      "broadcaster": "independent",
+      "streamUrl": "https://allzic57.ice.infomaniak.ch/allzic57.aac",
+      "homepage": "https://global.superradio.cc/",
+      "country": "FR",
+      "tags": [
+        "chill",
+        "electro",
+        "music"
+      ],
+      "favicon": "https://super-radio-global.devhub.top/logo/default.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-chante-france-60-s",
+      "name": "Chante France 60's",
+      "broadcaster": "independent",
+      "streamUrl": "https://chantefrance60s.ice.infomaniak.ch/chantefrance60s-128.mp3",
+      "homepage": "http://www.chantefrance.com/",
+      "country": "FR",
+      "tags": [
+        "french chansons"
+      ],
+      "favicon": "https://m209.syncusercontent.com/mfs-60:55d74e4ae967d2ce5319d319cd6cb6b4=============================/p/Chante_France_60s.png?allowdd=0&datakey=p4icmWAsP/iW76rIaDQC9Ysg5dCQp9i4iJbCdJ2w5vKh0mRJVmfh+5kkDcpRlS0ndGWjloOl6YLsYvCVKJCxbujo+EwVrnJwPdcMvC7vzD98e4iXFvh88hYDxmH2wyKZV8VPzlZXTfs7ThGK/xsieaiXjCeYAS6lvlTTE8db9sG0pXfKT2xHPrw3dD9aoHwoNxmo981FsKTP7AvZYBod21SlnGPpPHwMhm/Nhk649CooxAAG/8+MiRjLXA/VfiDltNldjZnXQgkDlGMgmJGzH0UzipVQSvuxF1PvTPstBJijeW6ilix/UzLdBjo/AImXBejg3v2yWYmHa8zxuK8mWg&engine=ln-3.1.38&errurl=eQ0fhQZycZt8LWx0aGP5KQvGt9ubloQoWjo/7GljAfAkIy+vm/to/as6JUhgrWy66YRhOGRFivSnewW+cRaF+NzD9oBx7E0FBJB1eGXJPsPnG4qQb6N4lvmu9gXz/xrx5gWr2Cwmerj+3+3okPeAclq7iwxW5OQI5hSZ7AXlsTaShUJ0aDqSHK0kwUL7bqUqN/5hGsyGO/OZpWM+6DiF//f3qlEQacDDrRHyDB5Tro1eMrymmNtEiZ1qk9iVg3L9pWbLUpLzWNCGxCZa58GfhpE18kC3ugmpVOjvSWWi0Q/Qub0pUtTfGdvTg2ymdWVOSgj2QNBtd4X0aAboE0ihWA==&header1=Q29udGVudC1UeXBlOiBpbWFnZS9wbmc&header2=Q29udGVudC1EaXNwb3NpdGlvbjogaW5saW5lOyBmaWxlbmFtZT0iQ2hhbnRlX0ZyYW5jZV82MHMucG5nIjtmaWxlbmFtZSo9VVRGLTgnJ0NoYW50ZV9GcmFuY2VfNjBzLnBuZzs&ipaddress=1414030563&linkcachekey=5de014cb0&linkoid=1991610004&mode=101&sharelink_id=17962599040004&timestamp=1708274054580&uagent=3b50c75381f12107280e9099b5b7674cf455a2e5&signature=92710090a3c3d30b2d50444687a77b3287fc2049&cachekey=60:55d74e4ae967d2ce5319d319cd6cb6b4=============================",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-generation-soul-disco-funk",
+      "name": "GENERATION SOUL DISCO FUNK",
+      "broadcaster": "independent",
+      "streamUrl": "https://gestream.fr/g-radio-sd.aac",
+      "homepage": "https://www.generationdiscofunk.com/",
+      "country": "FR",
+      "favicon": "https://www.generationdiscofunk.com/wp-content/uploads/2022/08/Logo_G_Radio_500px-370x370.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-vinyltimes",
+      "name": "VINYLTIMES",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/7551/stream/385141",
+      "homepage": "https://www.vinylestimes.fr/",
+      "country": "FR",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        48.9898,
+        2.0937
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-chansons-oubliees-ou-presque",
+      "name": "Chansons oubliees ou presque",
+      "broadcaster": "independent",
+      "streamUrl": "https://manager7.streamradio.fr:2580/stream?1701295921862",
+      "homepage": "https://lasourcedelian.wixsite.com/chansons-oubliees",
+      "country": "FR",
+      "tags": [
+        "chansons françaises",
+        "french chansons"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-666",
+      "name": "Radio 666",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream2.radio666.net/remote192.aac",
+      "homepage": "https://radio666.com/",
+      "country": "FR",
+      "favicon": "https://ferarock.org/sites/default/files/ferarock/styles/auto_1280/public/ged/666_haut_coul_jpg.jpg?itok=mSLbBGGd",
+      "bitrate": 192,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-sunset-jazz-radio",
+      "name": "SUNSET JAZZ RADIO",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio2.vip-radios.fm:18077/stream-mp3-SunsetJazz",
+      "homepage": "http://www.sunset-jazz-radio.com/",
+      "country": "FR",
+      "tags": [
+        "soft jazz – 100% vocal"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.8524,
+        2.347
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-africa-radio-mandingue-webradio",
+      "name": "Africa Radio Mandingue Webradio",
+      "broadcaster": "independent",
+      "streamUrl": "https://webradio1.ice.infomaniak.ch/webradio2-128.mp3",
+      "homepage": "https://www.africaradio.com/",
+      "country": "FR",
+      "tags": [
+        "african music"
+      ],
+      "favicon": "https://images.lesindesradios.fr/fit-in/300x2000/filters:format(webp)/radios/africaradio/radiostream/pmoKDezn85/vignette.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-equinoxe",
+      "name": "Radio Equinoxe",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.radioking.com/play/radio-equinoxe",
+      "homepage": "http://radioequinoxe.com/",
+      "country": "FR",
+      "tags": [
+        "electronic"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-lovely",
+      "name": "LOVELY",
+      "broadcaster": "independent",
+      "streamUrl": "https://lovely.ice.infomaniak.ch/lovely-128.mp3",
+      "homepage": "https://radiolovely.fr/",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-maxi-80",
+      "name": "Maxi 80",
+      "broadcaster": "independent",
+      "streamUrl": "https://audio1.maxi80.com/;?1722579303309",
+      "homepage": "https://www.maxi80.com/",
+      "country": "FR",
+      "favicon": "https://cdn-radiotime-logos.tunein.com/s108907d.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-soft-radio",
+      "name": "Soft Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream10.xdevel.com/audio14s976748-2279/stream/icecast.audio",
+      "homepage": "https://www.softradio.net/",
+      "country": "FR",
+      "tags": [
+        "calm",
+        "classical",
+        "eclectic",
+        "jazz",
+        "relaxing",
+        "soft"
+      ],
+      "favicon": "https://static.wixstatic.com/media/8f2aad_aa6143964e8d4a1f80be28d048517260~mv2.png",
+      "bitrate": 192,
+      "codec": "AAC+",
+      "geo": [
+        43.6075,
+        1.4403
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-frequence-plus",
+      "name": "Fréquence Plus",
+      "broadcaster": "independent",
+      "streamUrl": "https://freqplus.ice.infomaniak.ch/freqplus-high.aac",
+      "homepage": "http://www.frequenceplusfm.com/",
+      "country": "FR",
+      "favicon": "https://www.frequenceplus.fr/img/favicon-32x32.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-mona-fm-plus-de-fiesta",
+      "name": "Mona FM Plus De Fiesta",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.radioking.com/play/mona-fm-plus-de-fiesta",
+      "homepage": "http://www.monafm.fr/",
+      "country": "FR",
+      "favicon": "http://www.monafm.fr/upload/56780b7eab7e73.51115541.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-france-inter-la-musique-d-inter",
+      "name": "France Inter La musique d'Inter",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.radiofrance.fr/franceinterlamusiqueinter-midfi.mp3",
+      "homepage": "https://www.radiofrance.fr/franceinter/la-musique-inter",
+      "country": "FR",
+      "favicon": "https://www.radiofrance.fr/s3/cruiser-production-eu3/2024/06/2eb99120-ff28-414d-a805-c354c3967edf/300x300_sc_fi-webradio-c3b2.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-jazz-latin",
+      "name": "Jazz Latin",
+      "broadcaster": "independent",
+      "streamUrl": "https://jazz-wr09.ice.infomaniak.ch/jazz-wr09-128.mp3",
+      "homepage": "https://www.jazzradio.fr/",
+      "country": "FR",
+      "favicon": "https://www.jazzradio.fr/media/radio/thumb/180x180_latin-jazz.webp",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-blackbox-us",
+      "name": "BlackBox US",
+      "broadcaster": "independent",
+      "streamUrl": "https://blackbox-us.ice.infomaniak.ch/blackbox-us.mp3",
+      "homepage": "https://www.blackboxfm.fr/",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-oui-fm-summertime",
+      "name": "OUI FM SUMMERTIME",
+      "broadcaster": "independent",
+      "streamUrl": "https://ouifmsummertime.ice.infomaniak.ch/ouifmsummertime.mp3",
+      "homepage": "https://www.ouifm.fr/",
+      "country": "FR",
+      "tags": [
+        "rock"
+      ],
+      "favicon": "https://bocir-prod-bucket.s3.eu-west-1.amazonaws.com/radios/oui-fm/images/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-oxygene-radio",
+      "name": "Oxygène Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice.creacast.com/ofm_hq.mp3",
+      "homepage": "https://www.oxygeneradio.com/",
+      "country": "FR",
+      "favicon": "https://bocir-prod-bucket.s3.amazonaws.com/radios/oxygeneradio/images/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        48.0685,
+        -0.7686
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-maxi-france-radio",
+      "name": "Maxi France radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.maxifrance.radio/stream",
+      "homepage": "https://www.maxifrance.radio/",
+      "country": "FR",
+      "tags": [
+        "chansons françaises",
+        "pop",
+        "rock",
+        "variety hits"
+      ],
+      "favicon": "https://www.maxifrance.radio/wp-content/uploads/2023/03/cropped-logo-512.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        45.8043,
+        3.0762
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-toutes-les-couleurs-du-trad",
+      "name": "Toutes les couleurs du trad",
+      "broadcaster": "independent",
+      "streamUrl": "https://my2.radiolize.com/radio/8100/radio.mp3",
+      "homepage": "http://couleursdutrad.dx.am/",
+      "country": "FR",
+      "tags": [
+        "celtic",
+        "chansons françaises",
+        "european music",
+        "folk music",
+        "folklore",
+        "medieval"
+      ],
+      "bitrate": 96,
+      "codec": "AAC",
+      "geo": [
+        48.8581,
+        2.333
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-fip-cultes",
+      "name": "FIP Cultes",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radiofrance.fr/fipcultes/fipcultes.m3u8?id=radiofranceBose",
+      "homepage": "https://www.radiofrance.fr/fip/radio-cultes",
+      "country": "FR",
+      "bitrate": 105,
+      "codec": "AAC",
+      "geo": [
+        48.8556,
+        2.347
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-kiss-pop-rock",
+      "name": "KISS Pop Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiola.me/listen/kiss_pop_rock/radio.mp3",
+      "homepage": "http://kiss-pop-rock.net/",
+      "country": "FR",
+      "tags": [
+        "blues",
+        "pop",
+        "pop rock",
+        "rock",
+        "soul"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        48.6489,
+        -2.026
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-rire-et-chansons-sketches",
+      "name": "Rire et Chansons Sketches",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.nrjaudio.fm/ou8oqegk7oiu?aw_0_1st.station=Rire-Chansons-SKETCHES&origine=mytuner",
+      "homepage": "https://www.rireetchansons.fr/webradios/mur-des-radios/rire-et-chansons-sketches",
+      "country": "FR",
+      "tags": [
+        "comedy"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.8483,
+        2.3502
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-1000-hits-90s",
+      "name": "1000 Hits 90s",
+      "broadcaster": "independent",
+      "streamUrl": "https://c4.auracast.net:8050/;",
+      "homepage": "https://www.splashradio.eu/",
+      "country": "FR",
+      "tags": [
+        "90s",
+        "classic hits",
+        "oldies"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-espace-latino",
+      "name": "Espace Latino",
+      "broadcaster": "independent",
+      "streamUrl": "https://egwr-espace-latino.ice.infomaniak.ch/egwr-espace-latino.mp3",
+      "homepage": "https://www.radioespace.com/radio/webradio/14/radio-espace-latino",
+      "country": "FR",
+      "tags": [
+        "latino"
+      ],
+      "favicon": "https://www.radioespace.com/media/radio/thumb/180x180_64ecb84d55b4a-latino-sans-fond.webp",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-nova-soul",
+      "name": "Nova Soul",
+      "broadcaster": "independent",
+      "streamUrl": "https://nova-soul.ice.infomaniak.ch/nova-soul-256.aac",
+      "homepage": "https://www.nova.fr/radios/nova-soul/",
+      "country": "FR",
+      "tags": [
+        "soul"
+      ],
+      "bitrate": 256,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-lamellotron",
+      "name": "LaMellotron",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/477719/stream/534044",
+      "homepage": "https://www.lemellotron.com/",
+      "country": "FR",
+      "tags": [
+        "dj sets",
+        "various"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-b4b-disco-funk-hd",
+      "name": "B4B DISCO FUNK [HD]",
+      "broadcaster": "independent",
+      "streamUrl": "https://eu10.fastcast4u.com:8120/stream?icy=http",
+      "homepage": "https://www.b4bradio.com/radio-funk.html#radios",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-phare-fm-worship",
+      "name": "Phare FM Worship",
+      "broadcaster": "independent",
+      "streamUrl": "https://str0.creacast.com/pharefm_worship",
+      "homepage": "http://www.pharefm.com/",
+      "country": "FR",
+      "tags": [
+        "chrétien"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-pais",
+      "name": "Ràdio País",
+      "broadcaster": "independent",
+      "streamUrl": "https://stunnel2.cyber-streaming.com:9272/stream",
+      "homepage": "https://www.radiopais.fr/",
+      "country": "FR",
+      "tags": [
+        "bearn",
+        "folk",
+        "gascony",
+        "music",
+        "news",
+        "occitania"
+      ],
+      "favicon": "https://www.radiopais.fr/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-rfi-portugais",
+      "name": "RFI Portugais",
+      "broadcaster": "independent",
+      "streamUrl": "https://rfienportugais64k.ice.infomaniak.ch/rfienportugais-64.mp3",
+      "homepage": "https://www.rfi.fr/pt/",
+      "country": "FR",
+      "favicon": "https://www.rfi.fr/apple-touch-icon.png",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-crooner-radio-premium",
+      "name": "Crooner Radio Premium",
+      "broadcaster": "independent",
+      "streamUrl": "https://direct.croonerradio.fr/croonerradio-inprivate-midfi.mp3",
+      "homepage": "https://www.croonerradio.fr/stations-de-radio/crooner-radio-premium-webradio/",
+      "country": "FR",
+      "favicon": "https://www.croonerradio.fr/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-isekoi-radio-chill-zone",
+      "name": "ISEKOI Radio | Chill Zone",
+      "broadcaster": "independent",
+      "streamUrl": "https://public.isekoi-radio.com/listen/chill/radio.mp3",
+      "homepage": "https://isekoi-radio.com/",
+      "country": "FR",
+      "tags": [
+        "chill",
+        "chillout",
+        "electronic",
+        "house",
+        "intelligent drum and bass",
+        "intelligent drum&bass"
+      ],
+      "favicon": "https://i.postimg.cc/ncdMKNsn/LOGO-3-2-bg4.png",
+      "codec": "MP3",
+      "geo": [
+        50.633,
+        3.066
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-oui-fm-top-of-the-week",
+      "name": "OUI FM TOP OF THE WEEK",
+      "broadcaster": "independent",
+      "streamUrl": "https://ouifmtopoftheweek.ice.infomaniak.ch/ouifmtopweek.mp3",
+      "homepage": "https://www.ouifm.fr/",
+      "country": "FR",
+      "tags": [
+        "rock"
+      ],
+      "favicon": "https://bocir-prod-bucket.s3.eu-west-1.amazonaws.com/radios/oui-fm/images/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-blackbox-fr",
+      "name": "BlackBox FR",
+      "broadcaster": "independent",
+      "streamUrl": "https://blackbox-fr.ice.infomaniak.ch/blackbox-fr.mp3",
+      "homepage": "https://www.blackboxfm.fr/",
+      "country": "FR",
+      "favicon": "https://bocir-prod-bucket.s3.eu-west-1.amazonaws.com/radios/blackbox/images/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-brony-aac",
+      "name": "Radio Brony (AAC+)",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiobrony.live/aac",
+      "homepage": "https://radiobrony.fr/",
+      "country": "FR",
+      "tags": [
+        "brony",
+        "fan music",
+        "live show",
+        "mlp",
+        "my little pony",
+        "my little pony: friendship is magic"
+      ],
+      "favicon": "https://radiobrony.fr/img/icons/bwavatar-details.png",
+      "bitrate": 96,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-mylenefarmer",
+      "name": "MyleneFarmer",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.mylene.net/mp3/a_tout_jamais_npd_s_remix.mp3",
+      "homepage": "https://www.mylene.net/mp3/a_tout_jamais_npd_s_remix.mp3",
+      "country": "FR",
+      "tags": [
+        "pop"
+      ],
+      "favicon": "https://www.mylene.net/favicon.ico",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-oui-fm-garage",
+      "name": "OUI FM GARAGE",
+      "broadcaster": "independent",
+      "streamUrl": "https://ouifmgaragerock.ice.infomaniak.ch/ouifmgaragerock-128.mp3",
+      "homepage": "https://www.ouifm.fr/",
+      "country": "FR",
+      "tags": [
+        "garage",
+        "rock"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-le-bon-mix-dynamic-aac192lc",
+      "name": "Le Bon Mix Dynamic - AAC192LC",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream10.xdevel.com/audio15s976748-2112/stream/icecast.audio",
+      "homepage": "https://www.lebonmix.radio/",
+      "country": "FR",
+      "tags": [
+        "electro",
+        "house music",
+        "techno"
+      ],
+      "favicon": "https://static.wixstatic.com/media/8f2aad_dcbd6c98b6d541609e600ae3d73de849~mv2.png",
+      "bitrate": 192,
+      "codec": "AAC+",
+      "geo": [
+        43.6003,
+        1.4481
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-africa-radio-africa-club-webradio",
+      "name": "Africa Radio Africa Club Webradio",
+      "broadcaster": "independent",
+      "streamUrl": "https://webradio1.ice.infomaniak.ch/webradio5-128.mp3",
+      "homepage": "https://www.africaradio.com/",
+      "country": "FR",
+      "tags": [
+        "african music"
+      ],
+      "favicon": "https://bocir-prod-bucket.s3.eu-west-1.amazonaws.com/radios/africaradio/images/favicon.x-icon",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-oui-fm-girls-rock-aac-64k",
+      "name": "OUI FM GIRLS ROCK [AAC 64k]",
+      "broadcaster": "independent",
+      "streamUrl": "https://ouifmgirlsrock.ice.infomaniak.ch/ouifmgirlsrock.aac",
+      "homepage": "https://www.ouifm.fr/",
+      "country": "FR",
+      "tags": [
+        "female voices",
+        "rock"
+      ],
+      "favicon": "https://www.ouifm.fr/favicon.ico",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-aviva",
+      "name": "Radio Aviva",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio13.pro-fhi.net/listen-tpgmxyoe-stream.mp3",
+      "homepage": "https://www.radio-aviva.com/",
+      "country": "FR",
+      "tags": [
+        "00s",
+        "70s",
+        "80s",
+        "90s",
+        "dance",
+        "house"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        43.6181,
+        3.8785
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-europe-2-pays-de-la-loire",
+      "name": "Europe 2 Pays de la Loire",
+      "broadcaster": "independent",
+      "streamUrl": "https://europe2.lmn.fm/europe2-44000/playlist.m3u8",
+      "homepage": "https://www.europe2.fr/",
+      "country": "FR",
+      "tags": [
+        "pop",
+        "rock",
+        "top 40 pop"
+      ],
+      "favicon": "https://www.europe2.fr/wp-content/themes/melty/europeradio/assets/images/favicons/favicon128.png",
+      "bitrate": 127,
+      "codec": "AAC",
+      "geo": [
+        47.1902,
+        -1.4712
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-micheline",
+      "name": "Radio Micheline",
+      "broadcaster": "independent",
+      "streamUrl": "https://hosting.studioradiomedia.fr:2165/stream",
+      "homepage": "https://www.radiomicheline.com/",
+      "country": "FR",
+      "favicon": "https://www.radiomicheline.com/style/favicon.gif",
+      "bitrate": 256,
+      "codec": "MP3",
+      "geo": [
+        44.5619,
+        4.7461
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-nolife-radio",
+      "name": "NoLife-Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.nolife-radio.com/",
+      "homepage": "https://nolife-radio.com/",
+      "country": "FR",
+      "tags": [
+        "chiptune",
+        "video game music"
+      ],
+      "bitrate": 96,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-chante-france",
+      "name": "Chante France",
+      "broadcaster": "independent",
+      "streamUrl": "https://chantefrance.ice.infomaniak.ch/chantefrance-128.mp3",
+      "homepage": "http://www.chantefrance.com/",
+      "country": "FR",
+      "tags": [
+        "french chansons"
+      ],
+      "favicon": "https://m209.syncusercontent.com/mfs-60:cb6f4bc6ae404acfd00aa8544532d2ee=============================/p/Chante_France.png?allowdd=0&datakey=R5YpRVrhYNeD+1hOJOFXmKaneQKyptagGRsnPqFrMgk09zt/aoimFAWj1E4bzIjOU0g1o5MxlP746mGz5VH3wucpR5G6vC+Me0h0ZeYV7EIbiWelnDRsKOCxz2SmUhhfBttEkOZKO5UkFp/tRjvFV/vr9BzlZwzWen8c4n7G0K1otVJmrwPADQlhBtYAytiT/Jl4ZxmCEtDVv0JTRPofYBE20DvltkTD6lbo4R6kJWG2GsPW0Wy528a/cu0Vbjfu4kw2ondZeMahCBtPufqoymgCOpBIbD4jmaYN2YJqVBzLLbNJFyjkuGHbszVKrIOf4GFEFtc/+5ZwfK9ph5HhGw&engine=ln-3.1.38&errurl=RSx/vozVCnVLZv1bk0MyaWdETxt++NDMXx9XYlrZeFiSATv5OY89vUAfztxyJMSadtZ+3VKLgARqcHmRX/vO1WsIByONH7dqCTePiCMNrEDofZw2E5fG9FLHL0O3MdUBqsE9PQPFyiyLgxh4jt3M8h2/CyQ5k/kAUiil4fRBsSeY0tUY/lr40FfGlLbDdFSo5G7EXEcpUcRSpRiUGOVAqpbWuOlNvypwAPo5Fg6jpoZwyB9o/Oquhovzrne5RL+gKBq3rIzDh8TK+cdBy2lWpH/8SgTv1YcB+qoyjtsQMl8S+PGdKrpU/uvcwFY7fO6exyMiUlhjK3Y6nd+MsyJJDQ==&header1=Q29udGVudC1UeXBlOiBpbWFnZS9wbmc&header2=Q29udGVudC1EaXNwb3NpdGlvbjogaW5saW5lOyBmaWxlbmFtZT0iQ2hhbnRlX0ZyYW5jZS5wbmciO2ZpbGVuYW1lKj1VVEYtOCcnQ2hhbnRlX0ZyYW5jZS5wbmc7&ipaddress=1414030563&linkcachekey=7e09c8630&linkoid=1991610004&mode=101&sharelink_id=17962716890004&timestamp=1708275384958&uagent=3b50c75381f12107280e9099b5b7674cf455a2e5&signature=12c67b7cb607d73d96ee853fdb7988614ac1afcb&cachekey=60:cb6f4bc6ae404acfd00aa8544532d2ee=============================",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-chante-france-emotion",
+      "name": "Chante France Emotion",
+      "broadcaster": "independent",
+      "streamUrl": "https://chantefranceemotion.ice.infomaniak.ch/chantefranceemotion-128.mp3",
+      "homepage": "http://www.chantefrance.com/",
+      "country": "FR",
+      "tags": [
+        "french chansons"
+      ],
+      "favicon": "https://m209.syncusercontent.com/mfs-60:43ecf5b292ac1b6f285193c7c725f5dd=============================/p/Chante_France_Emotion.png?allowdd=0&datakey=i/PT4c2NxHrPaDTi+Yeso3NvhzVjXGY8e854v2JgVqcZcRzCJNt03VboxcYBmUmkQ5VZqXzxuWfBHpvJAOBJPhTkpDOl2PdazHOSQ8LGw8KqNIW+ei8epzQOcBoj0d9esLBXCgRtyMIheoK/tJ6I1aHmX1qMkJ0rhyamKh7RdTrgT4LWCQHlcPiSYpRyjmoFwjolU5GdfshKXsSzarrfgVp0po08SEV5x3qbY8QcTEWSIbEuQdAz0TUEmZ8VzFJTIjYjLXgRMEIvwRfDlMA948hMiyDHShUa1lKUFxjEfjo53q8WwX0tccXAh39Liy51s3DLgwhpRNuc0DfzCc6/HQ&engine=ln-3.1.38&errurl=b8sHYYFv+3CSKKM8U+y2mAAUUUvBJ9F7ajDZzVNEa+J2tFuqLNNhMMuhPyAwv3N1N7Ij2L63a/GXER7pk8+kJqLD98Ai2occw4p2kDEpZ4IF3Sy4gtyzvoZv6jafPMrhYeNZcvDNdMu2XlnPa/ci7vav/JfIHi99UKKGyY+lNfAj8bQ4RyHyLZwznF8vgYJ0zFjXX97q/wAA3CW0cfPmLUVHzyVsPX7AZS2qR7CaEO6oQKRMuKZfYwYvTfCGIWunFafV9q2GcqBzZP3VvTM9qiVazDfDqLc6pnJKfBroAgvW6Sg1xbyEt+z17yec5mEjnb3UqdKcqne4nffJfM8sjg==&header1=Q29udGVudC1UeXBlOiBpbWFnZS9wbmc&header2=Q29udGVudC1EaXNwb3NpdGlvbjogaW5saW5lOyBmaWxlbmFtZT0iQ2hhbnRlX0ZyYW5jZV9FbW90aW9uLnBuZyI7ZmlsZW5hbWUqPVVURi04JydDaGFudGVfRnJhbmNlX0Vtb3Rpb24ucG5nOw&ipaddress=1414030563&linkcachekey=6d4567cd0&linkoid=1991610004&mode=101&sharelink_id=17962625190004&timestamp=1708274362118&uagent=3b50c75381f12107280e9099b5b7674cf455a2e5&signature=7d74438887f3bb4ff771a5a1858c57ffca49c156&cachekey=60:43ecf5b292ac1b6f285193c7c725f5dd=============================",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-dio",
+      "name": "Radio Dio",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.aurafm.org/RadioDio",
+      "homepage": "https://radiodio.org/",
+      "country": "FR",
+      "tags": [
+        "89.5 fm",
+        "alternative",
+        "feminist",
+        "ferarock",
+        "local music",
+        "local news"
+      ],
+      "favicon": "https://radiodio.org/wp-content/themes/point/apple-touch-icon.png",
+      "bitrate": 160,
+      "codec": "MP3",
+      "geo": [
+        45.4267,
+        4.4092
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-orient",
+      "name": "Radio Orient",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rcs.revma.com/7hnrkawf4p8uv.mp3",
+      "homepage": "https://https//www.radioorient.com",
+      "country": "FR",
+      "tags": [
+        "arabic music",
+        "islam",
+        "news",
+        "paris",
+        "radio maghreb"
+      ],
+      "favicon": "https://cdn.instant.audio/images/logos/ecouterradioenligne-com/orient.png",
+      "codec": "MP3",
+      "geo": [
+        48.833,
+        2.2374
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-generations-r-b",
+      "name": "🕺 Générations R&B",
+      "broadcaster": "independent",
+      "streamUrl": "https://generationfm-slowjam.ice.infomaniak.ch/generationfm-slowjam-high.aac",
+      "homepage": "https://www.karibshebdo.info/radios-web/g%C3%A9n%C3%A9rations-rb",
+      "country": "FR",
+      "tags": [
+        "rnb"
+      ],
+      "favicon": "https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEg5HJuS6yWCZCykQR-TGHZWdD1_-17zir7HncDBK8NG2ZQI-fdZP8JiFabyZi8Qlw5qGkBK3rIQ0GX4D5bRVYLE1M2hgsgGwZGY-chOArST8GHIMaS-yj7f_-jOl9ytuB_WgH1v_bDZia8cmgF_1t6RBLbht4wZr_ZzixiYFhDAp71uB5kj_ggwDU56/s1600/Capture%20d%E2%80%99%C3%A9cran_2024-11-18_11-48-02.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-allzic-radio-jazz-lounge",
+      "name": "Allzic Radio Jazz Lounge",
+      "broadcaster": "independent",
+      "streamUrl": "https://allzic03.ice.infomaniak.ch/allzic03.mp3",
+      "homepage": "https://www.allzicradio.com/en/player/listen/1/allzic-radio-jazz-lounge",
+      "country": "FR",
+      "tags": [
+        "jazz",
+        "music"
+      ],
+      "favicon": "https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-maxi-france",
+      "name": "Maxi France",
+      "broadcaster": "independent",
+      "streamUrl": "https://sr3.publicssl.net/srv/8358/stream",
+      "homepage": "https://www.maxifrance.radio/",
+      "country": "FR",
+      "tags": [
+        "free radio",
+        "french music",
+        "maxi france"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        43.287,
+        5.3909
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-rfm-party-90",
+      "name": "RFM PARTY 90",
+      "broadcaster": "independent",
+      "streamUrl": "https://rfm.lmn.fm/rfm-wr5.aac",
+      "homepage": "http://www.rfm.fr/",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "AAC+",
+      "geo": [
+        46.016,
+        4.3945
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-rtl-100-hits",
+      "name": "RTL 100% Hits",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.m6radio.quortex.io/webpHJPXnXrN7B6J7Q8mcqmxP/webradio/rtl/201/audio-64000/index.m3u8",
+      "homepage": "https://www.rtl.fr/radios",
+      "country": "FR",
+      "tags": [
+        "classic hits",
+        "hits",
+        "music"
+      ],
+      "favicon": "https://images.rtl.fr/~c/300v300/rtl/www/1197826-webradio-1400x1400.jpg",
+      "bitrate": 64,
+      "codec": "AAC",
+      "geo": [
+        48.8796,
+        2.2754
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-maurice-radio-libre",
+      "name": "Maurice Radio Libre",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio13.pro-fhi.net/live/MauriceRadioLibre",
+      "homepage": "https://mauriceradiolibre.com/",
+      "country": "FR",
+      "favicon": "https://i0.wp.com/mauriceradiolibre.com/wp-content/uploads/2021/03/cropped-fav.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        48.8922,
+        2.3456
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-abc-relax",
+      "name": "ABC Relax",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.abcrelax.com/",
+      "homepage": "https://abcrelax.com/",
+      "country": "FR",
+      "favicon": "https://abcrelax.com/img/abc.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-generations-rnb-gold",
+      "name": "🕺 Générations RNB Gold",
+      "broadcaster": "independent",
+      "streamUrl": "https://generations-rnb-gold.ice.infomaniak.ch/generations-rnb-gold.aac",
+      "homepage": "https://www.karibshebdo.info/radios-web/g%C3%A9n%C3%A9rations-rnb-gold",
+      "country": "FR",
+      "tags": [
+        "rap hiphop rnb",
+        "rnb"
+      ],
+      "favicon": "https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEisO5t14VXrwoJGhJNwKv7yTJFODlagq6q5wcl_a49WiMtiYf1Wk2B648liuElB_H-G6MG1nvjCIeI7fuiC5Pa2_8Ps14AMHAOWAsi6Wine2B3PDGe7NWijzJanue0AboSEpe_SWmAjvIvLqokAyoa3LNwxIl2uPmkBqx2iJKP_jy0DEihoJ9rHBTQbBA/s1600/Capture%20d%E2%80%99%C3%A9cran_2024-11-14_19-24-08.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-fip-hip-hop",
+      "name": "FIP Hip-Hop",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radiofrance.fr/fiphiphop/fiphiphop.m3u8",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "FR",
+      "tags": [
+        "hiphop",
+        "music"
+      ],
+      "favicon": "https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png",
+      "bitrate": 107,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-chante-france-nouveautes",
+      "name": "Chante France Nouveautés",
+      "broadcaster": "independent",
+      "streamUrl": "https://chantefrancenouveautes.ice.infomaniak.ch/chantefrancenouveautes-128.mp3",
+      "homepage": "http://www.chantefrance.com/",
+      "country": "FR",
+      "tags": [
+        "french chansons"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-m40-eurodance",
+      "name": "M40 Eurodance",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.m40radio.fr/listen/m40-eurodance/m40-eurodance-128.mp3",
+      "homepage": "https://m40radio.fr/",
+      "country": "FR",
+      "tags": [
+        "dance"
+      ],
+      "favicon": "https://cdn.m40radio.fr/wp-content/uploads/radio-m40-eurodance-370x370.webp",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-zai-zai",
+      "name": "Radio Zaï Zaï",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/204667/stream/247420",
+      "homepage": "https://zaizai-radio.org/",
+      "country": "FR",
+      "tags": [
+        "alternative rock",
+        "chill",
+        "dub",
+        "electro",
+        "electronic",
+        "reggae"
+      ],
+      "favicon": "https://zaizai-radio.org/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        45.6526,
+        0.1538
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-dubsideradio",
+      "name": "dubsideradio",
+      "broadcaster": "independent",
+      "streamUrl": "https://puma.streemlion.com:5505/stream",
+      "homepage": "https://www.dubsideradio.com/",
+      "country": "FR",
+      "tags": [
+        "dub",
+        "reggae"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        48.454,
+        -2.0476
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-presence-toulouse",
+      "name": "Radio Présence Toulouse",
+      "broadcaster": "independent",
+      "streamUrl": "https://direct.radiopresence.com/presence",
+      "homepage": "http://www.radiopresence.com/",
+      "country": "FR",
+      "tags": [
+        "christian"
+      ],
+      "favicon": "http://www.radiopresence.com/plugins/theme_presence/img/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-allzic-radio-pop-queens",
+      "name": "Allzic Radio Pop Queens",
+      "broadcaster": "independent",
+      "streamUrl": "https://allzic54.ice.infomaniak.ch/allzic54.aac",
+      "homepage": "https://global.superradio.cc/",
+      "country": "FR",
+      "tags": [
+        "music",
+        "pop",
+        "queens"
+      ],
+      "favicon": "https://super-radio-global.devhub.top/logo/default.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-europe-2-new",
+      "name": "Europe 2 New",
+      "broadcaster": "independent",
+      "streamUrl": "https://europe2.lmn.fm/vr-wr1.mp3?aw_0_1st.playerid=lagardereappVirgin",
+      "homepage": "https://www.europe2.fr/webradios",
+      "country": "FR",
+      "tags": [
+        "pop rock"
+      ],
+      "favicon": "https://www.europe2.fr/wp-content/themes/melty/europeradio/assets/images/radio/radio_2001.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.8592,
+        2.349
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-france-musique-la-b-o",
+      "name": "France Musique la B.O.",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.radiofrance.fr/francemusiquelabo-hifi.aac",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "FR",
+      "tags": [
+        "classical"
+      ],
+      "bitrate": 192,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-campus-paris",
+      "name": "Radio Campus Paris",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.radiocampusparis.org/stream/",
+      "homepage": "https://www.radiocampusparis.org/",
+      "country": "FR",
+      "tags": [
+        "modern",
+        "radio by young people for young people"
+      ],
+      "bitrate": 128000,
+      "codec": "MP3",
+      "geo": [
+        48.8582,
+        2.2945
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-reccord-trance-hits",
+      "name": "📻 Reccord Trance Hits",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiorecord.hostingradio.ru/trancehits96.aacp",
+      "homepage": "https://radiosweb.karibshebdo.info/radios-web/reccord-trance-hits",
+      "country": "FR",
+      "tags": [
+        "trance"
+      ],
+      "favicon": "https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEjjTv4bYwmRWORccw4X-4Uv7nRsWg9-dWxvvTceRT7MqMaK6c8KS_n_iqet7hMwg3V6uspvj3iUG_3Nl19_rC49PF3btRucbk2fXVHglfO1U09ddwuD8POvSShyVXSn86HAQLK0r6J4x37bE32LK19egO7R3VAOcYz0A5JSQE7f-4HO8dMwX5zSvH8b/s1600/Capture%20d%E2%80%99%C3%A9cran_2024-12-08_08-45-54.png",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-europa-radio-jazz-hd",
+      "name": "Europa Radio Jazz HD",
+      "broadcaster": "independent",
+      "streamUrl": "https://streams.radiomast.io/818607ce-8815-42fb-8dfc-344234a0ff83",
+      "homepage": "https://www.europaradiojazz.org/",
+      "country": "FR",
+      "tags": [
+        "jazz"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-europe-2-mix-rock-electro-pop",
+      "name": "Europe 2 Mix / Rock, Electro, Pop",
+      "broadcaster": "independent",
+      "streamUrl": "https://europe2.lmn.fm/vr-wr6.mp3?aw_0_1st.playerid=lagardereappVirgin",
+      "homepage": "https://www.europe2.fr/webradios",
+      "country": "FR",
+      "tags": [
+        "electro",
+        "pop",
+        "rock"
+      ],
+      "favicon": "https://www.europe2.fr/wp-content/themes/melty/europeradio/assets/images/radio/radio_wr6_v2.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-europe-2-nouvelle-scene",
+      "name": "Europe 2 Nouvelle Scène",
+      "broadcaster": "independent",
+      "streamUrl": "https://europe2.lmn.fm/vr-wr8.mp3?aw_0_1st.playerid=lagardereappVirgin",
+      "homepage": "https://www.europe2.fr/webradios",
+      "country": "FR",
+      "tags": [
+        "french pop",
+        "pop",
+        "pop rock"
+      ],
+      "favicon": "https://www.europe2.fr/wp-content/themes/melty/europeradio/assets/images/radio/radio_2008.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.8581,
+        2.349
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-hotmix-lounge",
+      "name": "hotmix Lounge",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.hotmixradio.com/hotmix-lounge-en-mp3?",
+      "homepage": "https://www.radio.fr/s/hotmixlounge",
+      "country": "FR",
+      "tags": [
+        "lounge music"
+      ],
+      "favicon": "https://www.radio.fr/300/hotmixlounge.jpeg?version=cf0ac3e994b5c65899372a763b4b9cdf",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.9109,
+        2.1973
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-flouka",
+      "name": "Radio Flouka",
+      "broadcaster": "independent",
+      "streamUrl": "https://flouka.out.airtime.pro/flouka_a",
+      "homepage": "https://www.radioflouka.com/",
+      "country": "FR",
+      "tags": [
+        "arab",
+        "internet radio",
+        "underground"
+      ],
+      "favicon": "https://www.radioflouka.com/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-rstlss",
+      "name": "RSTLSS",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radiosolution.fr/rstlss.mp3",
+      "homepage": "https://rstlss.com/",
+      "country": "FR",
+      "tags": [
+        "classic rock",
+        "heavy metal",
+        "metal",
+        "pop rock",
+        "rock"
+      ],
+      "favicon": "https://rstlss.com/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-virgin-radio-metal",
+      "name": "Virgin Radio Metal",
+      "broadcaster": "independent",
+      "streamUrl": "https://virginmetal.ice.infomaniak.ch/virgin-radio-metal.mp3",
+      "homepage": "https://www.virginradio.fr/",
+      "country": "FR",
+      "tags": [
+        "metal"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        45.7443,
+        4.8807
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-africa-radio-selecta-webradio",
+      "name": "Africa Radio Selecta Webradio",
+      "broadcaster": "independent",
+      "streamUrl": "https://webradio6.ice.infomaniak.ch/webradio6-128.mp3",
+      "homepage": "https://www.africaradio.com/",
+      "country": "FR",
+      "tags": [
+        "african music"
+      ],
+      "favicon": "https://www.africaradio.com/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-gege",
+      "name": "Radio Gege",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.mistercouzin.net/listen",
+      "homepage": "https://www.mistercouzin.net/",
+      "country": "FR",
+      "codec": "OGG",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-rcv-99-fm",
+      "name": "RCV 99 fm",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/3086/stream/9476",
+      "homepage": "https://rcv-lille.radio-website.com/",
+      "country": "FR",
+      "tags": [
+        "electro",
+        "jazz",
+        "punk",
+        "reggae",
+        "rock"
+      ],
+      "favicon": "https://rcv-lille.radio-website.com/upload/5db063f7699121.01150875.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.6341,
+        3.0486
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-rjr-radio-jeunes-reims-aac-128k",
+      "name": "RJR - Radio Jeunes Reims (AAC 128k)",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rjrradio.fr/rjr.aac",
+      "homepage": "https://www.rjrradio.fr/",
+      "country": "FR",
+      "tags": [
+        "pop/rock"
+      ],
+      "favicon": "https://www.rjrradio.fr/sites/default/files/logo2016.png",
+      "bitrate": 192,
+      "codec": "AAC",
+      "geo": [
+        49.2504,
+        4.0372
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-sun-rock",
+      "name": "SUN Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://diffusion.lafrap.fr/sun-rock.mp3",
+      "homepage": "https://www.lesonunique.com/",
+      "country": "FR",
+      "tags": [
+        "alternative rock",
+        "classic rock",
+        "pop rock",
+        "rock"
+      ],
+      "favicon": "https://www.lesonunique.com/datasun/images_flux/logos/SD/rock.png",
+      "bitrate": 160,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-playlist-music-radio",
+      "name": "Playlist Music Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio13.pro-fhi.net/listen/pdpyrses/stream.mp3",
+      "homepage": "https://www.playlist-webradio.net/",
+      "country": "FR",
+      "favicon": "https://www.playlist-webradio.net/wp-content/uploads/logo-web-1.jpg",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-alouette-le-club",
+      "name": "Alouette Le Club",
+      "broadcaster": "independent",
+      "streamUrl": "https://alouetteleclub.ice.infomaniak.ch/alouetteleclub-128.mp3",
+      "homepage": "https://www.alouette.fr/",
+      "country": "FR",
+      "favicon": "https://bocir-prod-bucket.s3.eu-west-1.amazonaws.com/radios/alouette/radiostream/CACNRjDCGu/vignette_NM9owAwwwM.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-frequence-3-gold",
+      "name": "Fréquence 3 Gold",
+      "broadcaster": "independent",
+      "streamUrl": "https://frequence3.net-radio.fr/frequence3gold.mp3",
+      "homepage": "https://www.frequence3.com/",
+      "country": "FR",
+      "tags": [
+        "pop"
+      ],
+      "bitrate": 160,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-allzic-radio-annees-70",
+      "name": "Allzic Radio Années 70",
+      "broadcaster": "independent",
+      "streamUrl": "https://allzic50.ice.infomaniak.ch/allzic50.aac",
+      "homepage": "https://global.superradio.cc/",
+      "country": "FR",
+      "tags": [
+        "70s",
+        "music"
+      ],
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-irulegiko-irratia",
+      "name": "Irulegiko Irratia",
+      "broadcaster": "independent",
+      "streamUrl": "https://hosting.studioradiomedia.fr:1365/stream",
+      "homepage": "https://www.irulegikoirratia.eus/",
+      "country": "FR",
+      "tags": [
+        "abisuak",
+        "basque music",
+        "local information",
+        "local music",
+        "local news"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        43.1638,
+        -1.2369
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-rci-guadeloupe",
+      "name": "RCI Guadeloupe",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rcs.revma.com/v4hf7bwspwzuv",
+      "homepage": "https://rci.fm/guadeloupe",
+      "country": "FR",
+      "favicon": "https://rci.fm/sites/default/files/webradio/radioguadeloupe.png",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-slowly-radio",
+      "name": "Slowly Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.slowlyradio.com/",
+      "homepage": "https://slowlyradio.com/",
+      "country": "FR",
+      "favicon": "https://slowlyradio.com/wp-content/uploads/2023/06/slowlyradio-iconlogo_v-2_4.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-africa-radio-manu-dibango-webradio",
+      "name": "Africa Radio Manu Dibango Webradio",
+      "broadcaster": "independent",
+      "streamUrl": "https://webradio7.ice.infomaniak.ch/webradio7-128.mp3",
+      "homepage": "https://www.africaradio.com/",
+      "country": "FR",
+      "tags": [
+        "african music"
+      ],
+      "favicon": "https://images.lesindesradios.fr/fit-in/300x2000/filters:format(webp)/radios/africaradio/radiostream/yXjSg233Sq/vignette_Tf3DO2vq08.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-allzic-radio-love",
+      "name": "Allzic Radio Love",
+      "broadcaster": "independent",
+      "streamUrl": "https://allzic34.ice.infomaniak.ch/allzic34.aac",
+      "homepage": "https://global.superradio.cc/",
+      "country": "FR",
+      "tags": [
+        "love",
+        "music"
+      ],
+      "favicon": "https://super-radio-global.devhub.top/logo/default.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-efr12-radio",
+      "name": "EFR12 Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/151768/stream/192217",
+      "homepage": "https://www.efr12.com/radio/",
+      "country": "FR",
+      "tags": [
+        "eurovision",
+        "eurovision song contest",
+        "pop"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-egregore-radio",
+      "name": "Egregore Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.egrego.re/radio/8000/radio.mp3",
+      "homepage": "https://www.egrego.re/",
+      "country": "FR",
+      "tags": [
+        "music",
+        "variety"
+      ],
+      "favicon": "https://www.egrego.re/RESOURCES/IMAGES/EGREGORELOGO.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-latina-work",
+      "name": "Latina @work",
+      "broadcaster": "independent",
+      "streamUrl": "https://latinawork.ice.infomaniak.ch/latinawork.mp3",
+      "homepage": "https://www.latina.fr/",
+      "country": "FR",
+      "tags": [
+        "latin music"
+      ],
+      "favicon": "https://bocir-prod-bucket.s3.eu-west-1.amazonaws.com/radios/latina/images/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-neo",
+      "name": "Radio Néo",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice.creacast.com/radio-neo-paris",
+      "homepage": "http://www.radioneo.org/",
+      "country": "FR",
+      "tags": [
+        "chanson française",
+        "electro",
+        "rock"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-sanef-107-7-est",
+      "name": "Sanef 107.7 - Est\r\n",
+      "broadcaster": "independent",
+      "streamUrl": "https://sanef.ice.infomaniak.ch/sanef1077-est.mp3",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "FR",
+      "tags": [
+        "talk & speech"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-crooner-radio-movies",
+      "name": "Crooner Radio - Movies",
+      "broadcaster": "independent",
+      "streamUrl": "https://croonerradio_movies.ice.infomaniak.ch/croonerradio-movies-midfi.mp3",
+      "homepage": "https://superradio.cc/",
+      "country": "FR",
+      "tags": [
+        "crooner",
+        "movie music",
+        "music"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-france-culture-sans-pub",
+      "name": "France Culture (sans pub)",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radiofrance.fr/franceculture/franceculture.m3u8?id=radiofranceBose",
+      "homepage": "http://www.franceculture.fr/",
+      "country": "FR",
+      "tags": [
+        "culture",
+        "drama",
+        "features",
+        "generalist",
+        "science"
+      ],
+      "bitrate": 107,
+      "codec": "AAC",
+      "geo": [
+        48.8538,
+        2.3446
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-hotmix-dance",
+      "name": "Hotmix Dance",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.hotmixradio.com/hotmix-dance-en-mp3",
+      "homepage": "https://web.hotmixradio.com/",
+      "country": "FR",
+      "tags": [
+        "dance",
+        "electro",
+        "electronic"
+      ],
+      "favicon": "https://web.hotmixradio.com/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-lyon-demain",
+      "name": "Lyon Demain",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/93388/stream/131857",
+      "homepage": "https://www.lyondemain.fr/",
+      "country": "FR",
+      "tags": [
+        "france",
+        "local news",
+        "lyon"
+      ],
+      "favicon": "https://i1.wp.com/www.lyondemain.fr/wp-content/uploads/2018/09/cropped-logo-1-1.png?fit=300%2C100",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        45.7623,
+        4.8573
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-campus-bordeaux",
+      "name": "Radio campus bordeaux",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.radio-campus.org:8002/campus-bordeaux",
+      "homepage": "https://www.radiocampusbordeaux.fr/",
+      "country": "FR",
+      "tags": [
+        "blues",
+        "classique",
+        "folk",
+        "hip-hop",
+        "jazz",
+        "reggae"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        44.795,
+        -0.6164
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-uylenspiegel",
+      "name": "Radio Uylenspiegel",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/474857/stream/531260",
+      "homepage": "http://www.uylenspiegel.eu/",
+      "country": "FR",
+      "tags": [
+        "folk"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        50.7997,
+        2.4877
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radyoga",
+      "name": "Radyoga",
+      "broadcaster": "independent",
+      "streamUrl": "https://play.radioking.io/radyoga/72311",
+      "homepage": "https://www.radyoga.fr/",
+      "country": "FR",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-rire-et-chansons-canulars",
+      "name": "Rire et Chansons Canulars",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.nrjaudio.fm/ouwgjmsk6j4d?aw_0_1st.station=Rire-Chansons-CANULARS&origine=mytuner",
+      "homepage": "https://www.rireetchansons.fr/webradios/mur-des-radios/rire-et-chansons-canulars",
+      "country": "FR",
+      "tags": [
+        "comedy"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.8482,
+        2.3506
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-virage-radio-legende-du-rock",
+      "name": "Virage radio Légende du rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://virage-radio-legende-du-rock.ice.infomaniak.ch/virage-radio-legende-du-rock.mp3",
+      "homepage": "https://www.virageradio.com/radio/webradio/12/virage-radio-legendes-du-rock",
+      "country": "FR",
+      "favicon": "https://www.virageradio.com/apple-touch-icon-120x120.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        45.7657,
+        4.834
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-100-radio-80",
+      "name": "100% Radio 80",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.brol.tech/jamendolounge?https://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendoloungehttps://streaming.brol.tech/jamendolounge",
+      "homepage": "https://www.youtube.com/watch?v=Fkk9DI-8el4",
+      "country": "FR",
+      "tags": [
+        "to people of russia ... there is a war in ukraine right now ... the forces of the russian federation are attacking civilian infrastructure in kharkiv ... kyiv ... chernihiv ... sumy ... irpin and dozens of other cities ... people are dying both civilians and military servicemen including russian conscripts who were thrown into the fighting ... in order to deprive its own people of access to information the government of the russian federation has forbidden calling a war a war ... shut down independent media and is passing a number of dictatorial laws ... these laws are meant to silence all those who are against war ... you can be jailed for multiple years for simply calling for peace ... do not be silent ... silence is a sign that you accept the russian governments policy ... you can choose not to be silent"
+      ],
+      "favicon": "https://zws.im/󠁵󠁢󠁱󠁡󠁱󠁩󠁴",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-music-radio",
+      "name": "Music Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.musicradio.ai/listen/musicradio.ai/radio.mp3",
+      "homepage": "https://musicradio.ai/",
+      "country": "FR",
+      "tags": [
+        "chillout",
+        "chillout+lounge",
+        "club house",
+        "cool jazz",
+        "disco funk",
+        "easy listening"
+      ],
+      "favicon": "https://musicradio.ai/wp-content/uploads/2025/03/logo_musicradio.jpg",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-marseillette",
+      "name": "Radio Marseillette",
+      "broadcaster": "independent",
+      "streamUrl": "https://rcast.pro-fhi.net:9006/stream",
+      "homepage": "http://www.marseillettefm.com/",
+      "country": "FR",
+      "favicon": "http://www.marseillettefm.com/upload/design/5fb2b8c9ef7578.99339700.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-reccord-techno",
+      "name": "📻 Reccord Techno",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiorecord.hostingradio.ru/techno96.aacp",
+      "homepage": "https://radiosweb.karibshebdo.info/radios-web/reccord-techno",
+      "country": "FR",
+      "tags": [
+        "techno"
+      ],
+      "favicon": "https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEiI5_Myi5uOecneUImHJK8q-e0Io_-5O-gV_OnFXXNqLUgmNsSFvXsopp4uVR78Xiwo2vaQNk8EU8Z7LO-rKfES0PaKMs-JIxUTtGa2U1DzGnJHFYl_xE46dh5XEekozg0QLbzZHKRWbLMNqh7-gIBUSWsZE-GayFYEv5tIApyEkBPf4rAUntjFT2n9/s1600/Capture%20d%E2%80%99%C3%A9cran_2024-12-08_09-03-57.png",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-algorythme-radio",
+      "name": "Algorythme Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio3.pro-fhi.net/flux-ejzloxke/stream",
+      "homepage": "https://www.algorythmeradio.com/",
+      "country": "FR",
+      "tags": [
+        "house",
+        "old school"
+      ],
+      "favicon": "https://www.algorythmeradio.com/assets/images/icon-algo.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-isekoi-radio",
+      "name": "ISEKOI Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://public.isekoi-radio.com/listen/isekoi/radio.flac",
+      "homepage": "https://isekoi-radio.com/",
+      "country": "FR",
+      "tags": [
+        "dance",
+        "dnb",
+        "drum & bass",
+        "eclectic",
+        "electronic",
+        "hip-hop"
+      ],
+      "favicon": "https://i.postimg.cc/BQZXKJnh/LOGO-3-2-bg1.png",
+      "codec": "OGG",
+      "geo": [
+        50.633,
+        3.066
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-campus-clermont-ferrand",
+      "name": "Radio Campus Clermont-Ferrand",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.radio-campus.org:8002/clermont-ferrand",
+      "homepage": "https://www.campus-clermont.net/",
+      "country": "FR",
+      "tags": [
+        "culture",
+        "electronic",
+        "french music",
+        "humour",
+        "jazz",
+        "politics"
+      ],
+      "bitrate": 256,
+      "codec": "MP3",
+      "geo": [
+        45.7751,
+        3.0785
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-kreiz-breizh",
+      "name": "Radio Kreiz Breizh",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radios.bzh/listen/rkb/radio.mp3",
+      "homepage": "https://www.rkb.bzh/",
+      "country": "FR",
+      "tags": [
+        "breton"
+      ],
+      "bitrate": 256,
+      "codec": "MP3",
+      "geo": [
+        48.3236,
+        -3.3508
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-slow-radio",
+      "name": "Slow Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://play.radioking.io/slow-radio/601307",
+      "homepage": "https://www.slow-village.fr/en",
+      "country": "FR",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-galaxie-fm-95-30",
+      "name": " Galaxie FM 95.30 ",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/15684/stream/29075",
+      "homepage": "https://www.galaxieradio.fr/",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        50.7035,
+        3.2137
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr--2",
+      "name": ".. مختصر التفسير ",
+      "broadcaster": "independent",
+      "streamUrl": "https://qurango.net/radio/mukhtasartafsir",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "FR",
+      "tags": [
+        "classical"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-generation-jul",
+      "name": "Génération JUL",
+      "broadcaster": "independent",
+      "streamUrl": "https://generations-jul.ice.infomaniak.ch/generations-jul.mp3",
+      "homepage": "https://generations.fr/",
+      "country": "FR",
+      "tags": [
+        "rap"
+      ],
+      "favicon": "https://generations.fr/apple-touch-icon-120x120.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-generation-mix",
+      "name": "Génération Mix",
+      "broadcaster": "independent",
+      "streamUrl": "https://ecmanager2.pro-fhi.net/generationmix",
+      "homepage": "https://www.generation-mix.fr/",
+      "country": "FR",
+      "tags": [
+        "pop music"
+      ],
+      "bitrate": 64,
+      "codec": "AAC",
+      "geo": [
+        50.4617,
+        2.9892
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-nrj-clermont",
+      "name": "NRJ Clermont",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.nrjaudio.fm/oumrck8fnozc",
+      "homepage": "https://www.nrj.fr/",
+      "country": "FR",
+      "favicon": "https://www.nrj.fr/uploads/assets/nrj/favicon.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "geo": [
+        45.8012,
+        3.1201
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-collection",
+      "name": "Radio collection",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/251653/stream/296545",
+      "homepage": "https://www.radiocollection.fr/",
+      "country": "FR",
+      "tags": [
+        "pop rock"
+      ],
+      "favicon": "https://www.radiocollection.fr/upload/favicon.ico",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-lapurdi-irratia",
+      "name": "Radio Lapurdi Irratia",
+      "broadcaster": "independent",
+      "streamUrl": "https://direct.lapurdi.net/radio-lapurdi",
+      "homepage": "https://www.lapurdi.net/",
+      "country": "FR",
+      "tags": [
+        "kristau irratia - radio chretienne"
+      ],
+      "favicon": "https://www.lapurdi.net/squelettes/img/logo_web_small.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        43.483,
+        -1.483
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-wit-fm",
+      "name": "Wit FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://start-witfm.ice.infomaniak.ch/start-witfm-high.mp3",
+      "homepage": "http://www.witfm.fr/",
+      "country": "FR",
+      "favicon": "https://bocir-prod-bucket.s3.amazonaws.com/radios/witfm/images/favicon.vnd.microsoft.icon",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-france-inter-la-musique-inter",
+      "name": "France inter - La musique Inter",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radiofrance.fr/franceinterlamusiqueinter/franceinterlamusiqueinter_hifi.m3u8?id=radiofrance",
+      "homepage": "https://www.radiofrance.fr/franceinter/la-musique-inter",
+      "country": "FR",
+      "favicon": "https://www.radiofrance.fr/dist/favicons/logo-120.png",
+      "codec": "UNKNOWN",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-la-grosse-radio-rock",
+      "name": "La Grosse Radio Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://hd.lagrosseradio.info/lagrosseradio-rock-192.mp3",
+      "homepage": "https://caribshebdo.wordpress.com/2020/09/02/radio-web-la-grosse-reggae/",
+      "country": "FR",
+      "tags": [
+        "blues",
+        "disco",
+        "jazz",
+        "rock"
+      ],
+      "favicon": "https://s1.wp.com/i/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-8-ardennes",
+      "name": "Radio 8 Ardennes",
+      "broadcaster": "independent",
+      "streamUrl": "https://sc.creacast.com/radio8.mp3",
+      "homepage": "https://radio8fm.com/",
+      "country": "FR",
+      "favicon": "https://radio8fm.com/img/logo120.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-allzicradio-jazz-lounge",
+      "name": "AllzicRadio Jazz Lounge",
+      "broadcaster": "independent",
+      "streamUrl": "https://allzic03.ice.infomaniak.ch/allzic03.aac",
+      "homepage": "https://www.allzicradio.com/",
+      "country": "FR",
+      "favicon": "https://www.allzicradio.com/media/radios/thumb/160x160_allzic-jazz_600px-carre.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-m-radio-sur-la-route",
+      "name": "M Radio - Sur la route",
+      "broadcaster": "independent",
+      "streamUrl": "https://voix-du-sud.ice.infomaniak.ch/voix-du-sud.mp3",
+      "homepage": "https://mradio.fr/radio/webradio/18/m-radio-sur-la-route",
+      "country": "FR",
+      "tags": [
+        "chanson",
+        "chanson française",
+        "chansons",
+        "chansons françaises",
+        "french chansons"
+      ],
+      "favicon": "https://mradio.fr/media/radio/thumb/180x180_62569c3c02364-sur-la-route.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-presence-lot",
+      "name": "Radio Presence Lot",
+      "broadcaster": "independent",
+      "streamUrl": "https://direct.radiopresence.com/radio-presence-lot",
+      "homepage": "https://www.radiopresence.com/",
+      "country": "FR",
+      "tags": [
+        "christian"
+      ],
+      "favicon": "http://direct.radiopresence.com/presence.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        44.433,
+        1.433
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-rjr-radio-jeunes-reims-opus-128k",
+      "name": "RJR - Radio Jeunes Reims (Opus 128k)",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rjrradio.fr/rjr.ogg",
+      "homepage": "https://www.rjrradio.fr/",
+      "country": "FR",
+      "tags": [
+        "pop/rock"
+      ],
+      "favicon": "https://www.rjrradio.fr/sites/default/files/logo2016.png",
+      "codec": "OGG",
+      "geo": [
+        49.2504,
+        4.0372
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-100-pop-new-wave",
+      "name": "100% POP - NEW WAVE",
+      "broadcaster": "independent",
+      "streamUrl": "https://nationalanthems.info/fr-52.mp3?https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3https://nationalanthems.info/fr-52.mp3",
+      "homepage": "https://rb.gy/jbj7y1",
+      "country": "FR",
+      "tags": [
+        "to people of russia ... there is a war in ukraine right now ... the forces of the russian federation are attacking civilian infrastructure in kharkiv ... kyiv ... chernihiv ... sumy ... irpin and dozens of other cities ... people are dying both civilians and military servicemen including russian conscripts who were thrown into the fighting ... in order to deprive its own people of access to information the government of the russian federation has forbidden calling a war a war ... shut down independent media and is passing a number of dictatorial laws ... these laws are meant to silence all those who are against war ... you can be jailed for multiple years for simply calling for peace ... do not be silent ... silence is a sign that you accept the russian governments policy ... you can choose not to be silent"
+      ],
+      "favicon": "https://www.youtube.com/s/desktop/dd166493/img/logos/favicon_144x144.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-jazz-lounge",
+      "name": "Jazz Lounge",
+      "broadcaster": "independent",
+      "streamUrl": "https://jazzlounge.ice.infomaniak.ch/jazzlounge-high.mp3",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-lfm-radio",
+      "name": "LFM Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.radioking.com/play/passionauto974/63343",
+      "homepage": "http://lfm.re/",
+      "country": "FR",
+      "tags": [
+        "outre-mer"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-sun-nantes",
+      "name": "SUN Nantes",
+      "broadcaster": "independent",
+      "streamUrl": "https://diffusion.lafrap.fr/sunhd.mp3",
+      "homepage": "https://lesonunique.com/",
+      "country": "FR",
+      "favicon": "https://lesonunique.com/images/pwa/icon-512x512.png",
+      "bitrate": 160,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-allzic-radio-kitch",
+      "name": "Allzic Radio Kitch",
+      "broadcaster": "independent",
+      "streamUrl": "https://allzic59.ice.infomaniak.ch/allzic59.aac",
+      "homepage": "https://global.superradio.cc/",
+      "country": "FR",
+      "tags": [
+        "kitch",
+        "music"
+      ],
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-couleursjazz",
+      "name": "CouleursJAZZ",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/127546/stream/167344",
+      "homepage": "https://couleursjazz.fr/",
+      "country": "FR",
+      "favicon": "https://couleursjazz.fr/wp-content/uploads/2020/04/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-generations-90",
+      "name": "Générations 90",
+      "broadcaster": "independent",
+      "streamUrl": "https://generations-90.ice.infomaniak.ch/generations-90.aac",
+      "homepage": "https://generations.fr/radio/webradio/23/generations-90-s",
+      "country": "FR",
+      "tags": [
+        "90's",
+        "france",
+        "hiphop",
+        "rap"
+      ],
+      "favicon": "https://generations.fr/media/radio/generations-90s-logo-smartphone.webp",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "geo": [
+        46.9922,
+        2.1094
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-fuze",
+      "name": "Radio Fuze",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-ssl.radios-arra.fr:8443/fuze",
+      "homepage": "https://radiofuze.fr/",
+      "country": "FR",
+      "tags": [
+        "france",
+        "radio associative",
+        "radio locale"
+      ],
+      "favicon": "https://radiofuze.fr/wp-content/uploads/2020/06/cropped-Frame-17-1-192x192.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        44.0115,
+        4.4181
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-allzic-radio-zouk-2",
+      "name": "🕺 Allzic Radio Zouk",
+      "broadcaster": "independent",
+      "streamUrl": "https://allzic28.ice.infomaniak.ch/allzic28.aac",
+      "homepage": "https://www.karibshebdo.info/radios-web/allzic-radio-zouk",
+      "country": "FR",
+      "tags": [
+        "zouk"
+      ],
+      "favicon": "https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEjAeMRiwfT_G0MkzgGmbeKtGXCiK19-Xybb5ra4fGd9a4bpI_kx_RhuoZ3j9Xuwg6MTSgfrlMF6BB6YQTgLKAoKkEnuMqmmnNbqbcM-ilOKnjNiOD3khYfzD6krS-AfKoC2mKjRym2xaFMzq_e_RbCXPPqu9phHygrLJhkAH4DLMOBTu5tPBbg99Tiw/s320/Capture%20d%E2%80%99%C3%A9cran_2024-11-21_19-52-06.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-la-belle-aventure",
+      "name": "Radio La Belle Aventure",
+      "broadcaster": "independent",
+      "streamUrl": "https://flux.radiolabelleaventure.com/listen/radio_la_belle_aventure/radio.mp3",
+      "homepage": "https://www.radiolabelleaventure.com/",
+      "country": "FR",
+      "tags": [
+        "chanson française",
+        "eclectic",
+        "oldies",
+        "pop",
+        "radio libre",
+        "rock"
+      ],
+      "favicon": "https://www.radiolabelleaventure.com/wp-content/uploads/2025/05/cropped-logo-transparent-192x192.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        48.1074,
+        -1.7064
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-reccord-reggae",
+      "name": "📻 Reccord Reggae",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiorecord.hostingradio.ru/reggae96.aacp",
+      "homepage": "https://radiosweb.karibshebdo.info/radios-web/reccord-reggae",
+      "country": "FR",
+      "tags": [
+        "dub reggae",
+        "ragga",
+        "reggae"
+      ],
+      "favicon": "https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEiwmIz_Xot-rVbingUduX4x6zZ7Fhni986FZenMwEP9bDu0RfUai1I9W85y2u3ki-SBF4XPMybR8QibwM2m1Y1fwn-CmvxDDpcRNe_bSeA865IVBbbeV02naE2voMhdKC8h6c-LsxI4_hyucURzfLhcQXO0RbbGADS7s7f8LVJkjdpTsPnslYA72S1S/s1600/Capture%20d%E2%80%99%C3%A9cran_2024-12-08_10-07-00.png",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-alouette-indie",
+      "name": "ALOUETTE INDIE",
+      "broadcaster": "independent",
+      "streamUrl": "https://alouetteindie.ice.infomaniak.ch/alouetteindie-128.mp3",
+      "homepage": "https://www.alouette.fr/",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-big-bang-radio",
+      "name": "BIG BANG RADIO",
+      "broadcaster": "independent",
+      "streamUrl": "https://streams.radiomast.io/2b410ada-8653-40aa-a654-3e8954cf4a4d",
+      "homepage": "https://bigbangradio.live/",
+      "country": "FR",
+      "favicon": "https://bigbangradio.live/wp-content/uploads/2022/06/LOGO0080-big-bang.png",
+      "bitrate": 1500,
+      "codec": "OGG",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-hotmix-meal",
+      "name": "Hotmix meal",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.hotmixradio.com/hotmix-metal-en-mp3",
+      "homepage": "https://web.hotmixradio.com/",
+      "country": "FR",
+      "tags": [
+        "heavy metal",
+        "metal",
+        "nu metal"
+      ],
+      "favicon": "https://web.hotmixradio.com/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-m-radio-2000",
+      "name": "m radio 2000 ",
+      "broadcaster": "independent",
+      "streamUrl": "https://mfmwr-020.ice.infomaniak.ch/mfmwr-020.mp3",
+      "homepage": "https://mradio.fr/radio/webradio/13/annees-2000",
+      "country": "FR",
+      "favicon": "https://mradio.fr/apple-touch-icon-120x120.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-allzic-radio-golds-francais",
+      "name": "Allzic Radio Golds Français",
+      "broadcaster": "independent",
+      "streamUrl": "https://allzic30.ice.infomaniak.ch/allzic30.aac",
+      "homepage": "https://global.superradio.cc/",
+      "country": "FR",
+      "tags": [
+        "music"
+      ],
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-allzic-radio-hommage-johnny",
+      "name": "Allzic Radio Hommage Johnny",
+      "broadcaster": "independent",
+      "streamUrl": "https://allzic56.ice.infomaniak.ch/allzic56.aac",
+      "homepage": "https://global.superradio.cc/",
+      "country": "FR",
+      "tags": [
+        "music"
+      ],
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-allzic-radio-noel",
+      "name": "Allzic Radio Noël",
+      "broadcaster": "independent",
+      "streamUrl": "https://allzic42.ice.infomaniak.ch/allzic42.aac",
+      "homepage": "https://global.superradio.cc/",
+      "country": "FR",
+      "tags": [
+        "music",
+        "noël"
+      ],
+      "favicon": "https://super-radio-global.devhub.top/logo/default.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-plein-air-jura-la-radio-hit-regionale",
+      "name": "Radio Plein Air Jura - La Radio Hit Régionale",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-1.pleinair.net:8443/dr_jura.mp3",
+      "homepage": "https://pleinair.net/",
+      "country": "FR",
+      "tags": [
+        "pop music"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        46.686,
+        5.5467
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-allzic-radio-lounge",
+      "name": "Allzic Radio Lounge",
+      "broadcaster": "independent",
+      "streamUrl": "https://allzic21.ice.infomaniak.ch/allzic21.mp3",
+      "homepage": "https://www.allzicradio.com/en/player/listen/1655/allzic-radio-lounge",
+      "country": "FR",
+      "tags": [
+        "lounge",
+        "music"
+      ],
+      "favicon": "https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-alouette-nouveaux-talents",
+      "name": "Alouette nouveaux talents",
+      "broadcaster": "independent",
+      "streamUrl": "https://alouettenouveauxtalents.ice.infomaniak.ch/alouettenouveauxtalents-128.mp3",
+      "homepage": "https://www.alouette.fr/",
+      "country": "FR",
+      "favicon": "https://bocir-prod-bucket.s3.amazonaws.com/radios/alouette/images/favicon.x-icon",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-happyness-radio-amiens",
+      "name": "Happyness Radio Amiens",
+      "broadcaster": "independent",
+      "streamUrl": "https://azuracast-broadcast.happynessamiens.fr/listen/happyness_dab/player",
+      "homepage": "https://happynessamiens.fr/",
+      "country": "FR",
+      "tags": [
+        "2000s",
+        "chansons françaises",
+        "electro",
+        "gold",
+        "hits",
+        "pop music"
+      ],
+      "favicon": "https://happynessamiens.fr/wp-content/uploads/2024/04/favicon.jpg",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        49.8871,
+        2.303
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-open-sky",
+      "name": "Open Sky",
+      "broadcaster": "independent",
+      "streamUrl": "https://audio.opensky.radio:8082/stream",
+      "homepage": "https://opensky.radio/",
+      "country": "FR",
+      "favicon": "https://opensky.radio/images/small-logo.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-nissa-pantai",
+      "name": "Ràdio Nissa Pantai",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/79270/stream/117373",
+      "homepage": "http://www.nissapantai.com/",
+      "country": "FR",
+      "tags": [
+        "music",
+        "occitan"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-wave-radio",
+      "name": "Wave Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s34.myradiostream.com/:12340/listen.mp3",
+      "homepage": "https://waveradio.fm/",
+      "country": "FR",
+      "tags": [
+        "beach",
+        "surf",
+        "surfside beach"
+      ],
+      "favicon": "https://waveradio.fm/wp-content/themes/waveradio/img/favicons/apple-icon-120x120.png",
+      "bitrate": 160,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-canal-b-94mhz",
+      "name": "Canal B - 94Mhz",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.levillage.org/canalb",
+      "homepage": "http://www.canalb.fr/",
+      "country": "FR",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-frequence-tropicale",
+      "name": "Frequence tropicale",
+      "broadcaster": "independent",
+      "streamUrl": "https://ecmanager2.pro-fhi.net:1640/stream",
+      "homepage": "https://frequence-tropicale.fr/",
+      "country": "FR",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-jazz-radio-afro",
+      "name": "Jazz Radio Afro",
+      "broadcaster": "independent",
+      "streamUrl": "https://jazz-radio-afro.ice.infomaniak.ch/jazz-radio-afro.mp3",
+      "homepage": "https://www.jazzradio.fr/radio/webradio/43/afro-jazz",
+      "country": "FR",
+      "favicon": "https://www.jazzradio.fr/apple-touch-icon-120x120.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-nostalgie",
+      "name": "Nostalgie",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.nrjaudio.fm/ouwgwqsk6j4d",
+      "homepage": "https://www.nostalgie.fr/",
+      "country": "FR",
+      "favicon": "https://img.nrj.fr/L3zosrZkW7lmgFtxF9yG8USZq6c=/medias%2F2022%2F02%2F62150f1f4ce26_62150f240ef6d.svg",
+      "bitrate": 128,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-saint-ferreol",
+      "name": "Radio Saint Ferréol",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.aurafm.org/RadioSaintFerreol",
+      "homepage": "https://www.radiosaintfe.com/",
+      "country": "FR",
+      "codec": "MP3",
+      "geo": [
+        44.7286,
+        5.0227
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-scoop-lyon",
+      "name": "Radio SCOOP - Lyon",
+      "broadcaster": "independent",
+      "streamUrl": "https://radioscooplyon.ice.infomaniak.ch/radioscoop-lyon-64.aac",
+      "homepage": "https://www.radioscoop.com/",
+      "country": "FR",
+      "favicon": "https://www.radioscoop.com/favicon.ico",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-sofa",
+      "name": "Radio Sofa",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/292531/stream/338878",
+      "homepage": "https://www.radio-sofa.com/",
+      "country": "FR",
+      "tags": [
+        "acoustic",
+        "jazz",
+        "lounge",
+        "lounge music",
+        "lounge radio",
+        "musique éclectique"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.8632,
+        2.4382
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-rmf-radio",
+      "name": "RMF Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.radioking.com/play/rmf-radio/376729",
+      "homepage": "https://www.rmf-radio.com/",
+      "country": "FR",
+      "favicon": "https://static.wixstatic.com/media/773fc3_1242bcad92c741eeb1aca7bfd293f577~mv2.jpg/v1/fill/w_180%2Ch_180%2Clg_1%2Cusm_0.66_1.00_0.01/773fc3_1242bcad92c741eeb1aca7bfd293f577~mv2.jpg",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-ultra-max",
+      "name": "Ultra Max",
+      "broadcaster": "independent",
+      "streamUrl": "https://ssl-1.radiohost.pl:9111/stream",
+      "homepage": "https://ultra-max.fun/",
+      "country": "FR",
+      "tags": [
+        "electronic"
+      ],
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-urban-hit-rai",
+      "name": "Urban hit raï",
+      "broadcaster": "independent",
+      "streamUrl": "https://urbanhitus.ice.infomaniak.ch/urbanhitus-128.mp3",
+      "homepage": "https://urbanhitus.ice.infomaniak.ch/urbanhitus-128.mp3",
+      "country": "FR",
+      "tags": [
+        "rai"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-8beats",
+      "name": "8Beats",
+      "broadcaster": "independent",
+      "streamUrl": "https://n10.radiojar.com/2fa4wbch308uv",
+      "homepage": "https://8beats.co/",
+      "country": "FR",
+      "favicon": "https://8beats.co/favicon.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-allzic-radio-jazz",
+      "name": "Allzic Radio Jazz",
+      "broadcaster": "independent",
+      "streamUrl": "https://allzic40.ice.infomaniak.ch/allzic40.aac",
+      "homepage": "https://global.superradio.cc/",
+      "country": "FR",
+      "tags": [
+        "jazz",
+        "music"
+      ],
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-pistache-la-radio",
+      "name": "Pistache La Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://rpstrm.pistache.org:9443/pistache.mp3",
+      "homepage": "https://www.pistache.org/",
+      "country": "FR",
+      "tags": [
+        "adult contemporary",
+        "pop",
+        "soft rock"
+      ],
+      "favicon": "https://www.pistache.org/favicon.ico",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        48.0809,
+        0.0439
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-boa",
+      "name": "Radio BOA",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radios.bzh/hls/boa/aac_hifi.m3u8",
+      "homepage": "https://radio-boa.bzh/",
+      "country": "FR",
+      "tags": [
+        "breizh",
+        "bretagne",
+        "generalist",
+        "local music",
+        "local radio",
+        "music"
+      ],
+      "favicon": "https://radio-boa.bzh/_ipx/f_webp&s_250x329/logo_white_vertical.svg",
+      "codec": "UNKNOWN",
+      "geo": [
+        47.8693,
+        -3.5503
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-mdm",
+      "name": "Radio MDM",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radio-mdm.fr:8443/stream.mp3",
+      "homepage": "https://www.radio-mdm.fr/",
+      "country": "FR",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-scoop-pop-rock",
+      "name": "Radio SCOOP - Pop & Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://scooprock.ice.infomaniak.ch/radioscoop-rock-64.aac",
+      "homepage": "https://www.radio-en-ligne.fr/radio-scoop-pop",
+      "country": "FR",
+      "favicon": "https://static.mytuner.mobi/media/tvos_radios/qCy5jNEamp.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-alouette-maine-et-loire",
+      "name": "ALOUETTE MAINE ET LOIRE",
+      "broadcaster": "independent",
+      "streamUrl": "https://alouette-angers.ice.infomaniak.ch/alouette-angers-128.mp3",
+      "homepage": "http://www.alouette.fr/",
+      "country": "FR",
+      "favicon": "http://www.alouette.fr/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        47.4742,
+        -0.5385
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-crooner-radio-frenchy",
+      "name": "Crooner Radio Frenchy",
+      "broadcaster": "independent",
+      "streamUrl": "https://direct.croonerradio.fr/croonerradio-frenchy-midfi.mp3",
+      "homepage": "https://www.croonerradio.fr/",
+      "country": "FR",
+      "favicon": "https://www.croonerradio.fr/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-europe-2-centre",
+      "name": "Europe 2 Centre",
+      "broadcaster": "independent",
+      "streamUrl": "https://europe2.lmn.fm/europe2-37000/playlist.m3u8",
+      "homepage": "https://www.facebook.com/Europe2Centre/",
+      "country": "FR",
+      "favicon": "https://www.facebook.com/favicon.ico",
+      "bitrate": 127,
+      "codec": "AAC",
+      "geo": [
+        47.3843,
+        0.7024
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-nouvo-nova",
+      "name": "Nouvo Nova",
+      "broadcaster": "independent",
+      "streamUrl": "https://nova-nouvo.ice.infomaniak.ch/nova-nouvo-256.aac",
+      "homepage": "https://www.nova.fr/",
+      "country": "FR",
+      "favicon": "https://www.nova.fr/favicon.ico",
+      "bitrate": 255,
+      "codec": "AAC",
+      "geo": [
+        47.6121,
+        2.373
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-grand-brive",
+      "name": "Radio Grand Brive",
+      "broadcaster": "independent",
+      "streamUrl": "https://hosting.studioradiomedia.fr:1420/stream.mp3",
+      "homepage": "https://www.radiograndbrive.fr/",
+      "country": "FR",
+      "tags": [
+        "local news",
+        "musical discovery",
+        "radio associative"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        45.1585,
+        1.5329
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-mega",
+      "name": "Radio Méga",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.ferarock.org:8020/radio-mega",
+      "homepage": "https://www.radio-mega.com/",
+      "country": "FR",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-rencontre-dunkerque",
+      "name": "Radio Rencontre Dunkerque",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/153745/stream/194338",
+      "homepage": "http://radio-rencontre.fr/",
+      "country": "FR",
+      "tags": [
+        "accordéon",
+        "musique de vieux"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-reccord-chill-house",
+      "name": "📻 Radio Reccord Chill House",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiorecord.hostingradio.ru/organic96.aacp",
+      "homepage": "https://multimedias.karibshebdo.info/radios-web/record-chill-house",
+      "country": "FR",
+      "tags": [
+        "chill house",
+        "house"
+      ],
+      "favicon": "https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEiaywxXeHlWtxJ-YR4cdblac_NbEi3yK_drJqEg109pJe2Halhyphenhyphenp7sm_Uoa19TkNkkWh3vUOpKBR8hxUp0c8LSAM2GJNetn1eMWRaQ3ZeGG-PIRmTNPbT9y-_jY_Nd138VO6Jc5TU7BlFlAkvBl3B6ypWP9jXyJg5Z4xIEbgQGzivsuLizFAQDSOzMx/s1600/Capture%20d%E2%80%99%C3%A9cran_2024-11-20_10-10-10.png",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-reccord-garage-uk",
+      "name": "📻 Reccord Garage UK",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiorecord.hostingradio.ru/ukgarage96.aacp",
+      "homepage": "https://radiosweb.karibshebdo.info/radios-web/reccord-garage-uk",
+      "country": "FR",
+      "tags": [
+        "uk garage"
+      ],
+      "favicon": "https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEj_3RdF5cVH6q2LM_ODf6MgxlD4oSISDe8zLTTyN7wQ65ftFxfjOC4FvoW3wEHDeoZPI46pnJcUp0jESGo-NPwN8hwwipe5XXXsvNUsv5qonbUtcnAubEmtqkfNtHohWY6VdQPJUUBDp4XYUCwvlIaxu5ASAFKM49y3XSwlCRUjvYXboeK587WhM6hL/s1600/Capture%20d%E2%80%99%C3%A9cran_2024-12-08_09-36-30.png",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-frequence-3-world",
+      "name": "Fréquence 3 World",
+      "broadcaster": "independent",
+      "streamUrl": "https://frequence3.net-radio.fr/frequence3world.mp3",
+      "homepage": "https://www.frequence3.com/",
+      "country": "FR",
+      "tags": [
+        "pop",
+        "world"
+      ],
+      "bitrate": 160,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-le-grand-studio-rtl",
+      "name": "Le Grand Studio RTL",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.m6radio.quortex.io/webpHJPXnXrN7B6J7Q8mcqmxP/webradio/legrandstudiortl/130/audio-64000/index.m3u8",
+      "homepage": "https://www.rtl.fr/radios",
+      "country": "FR",
+      "tags": [
+        "chansons françaises",
+        "live music",
+        "music"
+      ],
+      "bitrate": 64,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-playloud",
+      "name": "Playloud",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream2.playloud.fr/stream",
+      "homepage": "https://www.playloud.fr/",
+      "country": "FR",
+      "tags": [
+        "electro"
+      ],
+      "favicon": "https://www.playloud.fr/wp-content/uploads/2019/09/cropped-logopld-1-192x192.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-allzic-radio-road-66",
+      "name": "Allzic Radio Road 66",
+      "broadcaster": "independent",
+      "streamUrl": "https://allzic37.ice.infomaniak.ch/allzic37.aac",
+      "homepage": "https://global.superradio.cc/",
+      "country": "FR",
+      "tags": [
+        "music"
+      ],
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-c-lab",
+      "name": "C-Lab",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.c-lab.fr/stream/",
+      "homepage": "https://www.c-lab.fr/",
+      "country": "FR",
+      "tags": [
+        "eclectic"
+      ],
+      "favicon": "https://www.c-lab.fr/apple-icon-57x57.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        48.1184,
+        -1.7127
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-hotmix",
+      "name": "hotmix",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.hotmixradio.fr/hotmix-blues-en-mp3",
+      "homepage": "https://web.hotmixradio.com/en",
+      "country": "FR",
+      "tags": [
+        "blues"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-infraordinary-five-radio-stations",
+      "name": "Infraordinary Five Radio Stations",
+      "broadcaster": "independent",
+      "streamUrl": "https://infraordinary.fiveradiostations.com:8443/stream",
+      "homepage": "https://www.fiveradiostations.com/infraordinaryfm",
+      "country": "FR",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-les-enfants-du-rhone",
+      "name": "Les enfants du Rhône",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/300/stream/1430",
+      "homepage": "https://ledr.fr/",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        45.7755,
+        4.8249
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-bro-gwened",
+      "name": "Radio Bro Gwened",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radios.bzh/listen/rbg/radio.mp3",
+      "homepage": "https://rbg.bzh/",
+      "country": "FR",
+      "favicon": "https://rbg.bzh//app/themes/rbg-radio/assets/images/logo_RBG.png",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-de-noel",
+      "name": "Radio de Noël ",
+      "broadcaster": "independent",
+      "streamUrl": "https://live1.jupinfo.fr:8443/radiodenoel",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "FR",
+      "tags": [
+        "misc"
+      ],
+      "bitrate": 140,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radios-libres-en-perigord-rlp102-3-mp3-192",
+      "name": "Radios Libres en Perigord - RLP102.3 - MP3 192",
+      "broadcaster": "independent",
+      "streamUrl": "https://direct.radioslibresenperigord.com/rlp.192.mp3",
+      "homepage": "http://www.radioslibresenperigord.com/",
+      "country": "FR",
+      "tags": [
+        "local"
+      ],
+      "favicon": "https://www.radioslibresenperigord.com/wp-content/uploads/2023/09/LOGO-Transparent-RLP-2021.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        45.175,
+        0.692
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-generations-g-funk",
+      "name": "🕺Générations G-Funk",
+      "broadcaster": "independent",
+      "streamUrl": "https://generationsgfunk.ice.infomaniak.ch/generations-g-funk.aac",
+      "homepage": "https://www.karibshebdo.info/radios-web/g%C3%A9n%C3%A9rations-g-funk",
+      "country": "FR",
+      "tags": [
+        "funk"
+      ],
+      "favicon": "https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEjwPKCWHMqaCU1Ec6MPYdlqPT71jCL6sTfO8gf_3ZTYr3HYFrfZcZtO_gq6UdWfAu5QHY3X5Q2gUvrtPOLbHWmf2HlsB9oC6jCxIH3FtCL9iS0-kz_iZE-FgMWmZ8JYYrPOzYOxEb0VsDz16Im3SCKtrCIrlDBlzT5H3FLfInkzkyI2d4_1HARLbURg/s239/Capture%20d%E2%80%99%C3%A9cran_2024-11-18_11-54-00.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-frequence-3-urban",
+      "name": "Fréquence 3 Urban",
+      "broadcaster": "independent",
+      "streamUrl": "https://frequence3.net-radio.fr/frequence3urban-128.mp3",
+      "homepage": "https://www.frequence3.com/",
+      "country": "FR",
+      "tags": [
+        "pop",
+        "urban"
+      ],
+      "bitrate": 160,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-kto-radio",
+      "name": "KTO Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://liveradiokto.akamaized.net/hls/live/20000054/ktoradio/master.m3u8",
+      "homepage": "https://www.ktoradio.com/",
+      "country": "FR",
+      "favicon": "https://www.ktoradio.com/_next/image?url=https%3A%2F%2Fns3200830.ip-141-94-133.eu%2Fradioscreen%2Fdata%2Fprod%2Fe7696813-ef6f-4d8a-b522-ddf327bdd87a%2Fdab-gen%2Fimage.jpg%3Fts%3D1768733601157&w=256&q=75",
+      "bitrate": 466,
+      "codec": "UNKNOWN",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-presence-figeac",
+      "name": "Radio Presence Figeac",
+      "broadcaster": "independent",
+      "streamUrl": "https://direct.radiopresence.com/radio-presence-figeac",
+      "homepage": "https://www.radiopresence.com/",
+      "country": "FR",
+      "tags": [
+        "christian"
+      ],
+      "favicon": "http://direct.radiopresence.com/presence.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        44.599,
+        2.033
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-rca-nantes",
+      "name": "RCA Nantes",
+      "broadcaster": "independent",
+      "streamUrl": "https://rcanantes.ice.infomaniak.ch/rcanantes-192.mp3",
+      "homepage": "https://www.rcalaradio.com/",
+      "country": "FR",
+      "favicon": "https://bocir-prod-bucket.s3.eu-west-1.amazonaws.com/radios/rca/images/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-generations-afrobeat",
+      "name": "🕺 Générations Afrobeat",
+      "broadcaster": "independent",
+      "streamUrl": "https://generations-wr001.ice.infomaniak.ch/generations-wr001.aac",
+      "homepage": "https://www.karibshebdo.info/radios-web/g%C3%A9n%C3%A9rations-afrobeat",
+      "country": "FR",
+      "favicon": "https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEiZy0wOk5FYtm_-xPGU6ybRw0xs5yDONOacu2katB3tZiXrYQdy37NQdoRza9lxQzl-dJ6rBvETfPgDK5ubuw_Wcp4pmIzWsX8YJ0FrU4CQPhgWPibEb7-vXVhrylaH-QPO7qN16aOe5k49nIR98GobZRyZBHk4aRZdXX8mqJ4j5ULmK1uME5eX3TYd/s1600/Capture%20d%E2%80%99%C3%A9cran_2024-11-18_11-28-48.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-campus-grenoble",
+      "name": "Radio Campus Grenoble",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.campusgrenoble.org/rcg112",
+      "homepage": "https://campusgrenoble.org/",
+      "country": "FR",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-mbs",
+      "name": "Radio MBS",
+      "broadcaster": "independent",
+      "streamUrl": "https://mbs.ice.infomaniak.ch/mbs-64.aac",
+      "homepage": "https://www.radiombs.fr/",
+      "country": "FR",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "geo": [
+        48.9652,
+        2.2297
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-titine",
+      "name": "Radio Titine",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/435545/stream/489533",
+      "homepage": "http://radiotitine.com/",
+      "country": "FR",
+      "tags": [
+        "love",
+        "pop",
+        "smooth jazz",
+        "west coast"
+      ],
+      "favicon": "https://static.wixstatic.com/media/578136_24e4883683c748a2a776595e66118a35%7emv2.png/v1/fit/w_2500,h_1330,al_c/578136_24e4883683c748a2a776595e66118a35%7emv2.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-millenium-fm-electro-dj-webradio",
+      "name": "Millenium FM Electro DJ Webradio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio7.pro-fhi.net:19141/milleniumfm.mp3",
+      "homepage": "https://milleniumfm.fr/",
+      "country": "FR",
+      "tags": [
+        "dance",
+        "dance music",
+        "dubstep",
+        "electro",
+        "electronic",
+        "electronic dance music"
+      ],
+      "favicon": "https://milleniumfm.fr/wp-content/uploads/2022/01/Logo-Millenium-FM_2021_grand.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        45.7573,
+        4.8353
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-phare-fm-louange",
+      "name": "Phare FM Louange ",
+      "broadcaster": "independent",
+      "streamUrl": "https://str0.creacast.com/pharefm_louange",
+      "homepage": "http://www.pharefm.com/",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-gatine",
+      "name": "Radio Gâtine",
+      "broadcaster": "independent",
+      "streamUrl": "https://hosting.radiomedia.fr:1615/stream",
+      "homepage": "https://radiogatine.fr/",
+      "country": "FR",
+      "favicon": "https://radiogatine.fr/upload/design/5d0a55c722f2a8.17678226.png",
+      "bitrate": 170,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-univers",
+      "name": "Radio Univers",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream4.vestaradio.com/RadioUnivers",
+      "homepage": "https://www.radio-univers.com/",
+      "country": "FR",
+      "tags": [
+        "jazz",
+        "poetry",
+        "progressive rock",
+        "world music"
+      ],
+      "favicon": "https://www.radio-univers.com/wp-includes/images/w-logo-blue-white-bg.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        48.4508,
+        -1.6608
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-eklectywaves-the-sharing-radio",
+      "name": "EklectyWaves - The Sharing Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://play.radioking.io/eklectywaves-the-sharing-radio",
+      "homepage": "https://www.eklectywaves.com/",
+      "country": "FR",
+      "tags": [
+        "blues",
+        "classic rock",
+        "metal",
+        "pop rock",
+        "progressive",
+        "rock"
+      ],
+      "favicon": "https://www.radioplug.co.uk/img/channel/19-03-2025-22-43-21-c.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-frequence-7",
+      "name": "Fréquence 7",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.aurafm.org/Frequence7",
+      "homepage": "https://www.frequence7.net/",
+      "country": "FR",
+      "favicon": "https://www.frequence7.net/images/logo.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-groove-cabane",
+      "name": "Groove Cabane",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/314264/stream/361499",
+      "homepage": "https://www.groovecabane.com/",
+      "country": "FR",
+      "tags": [
+        "disco",
+        "electro house",
+        "funk",
+        "groove"
+      ],
+      "favicon": "https://www.groovecabane.com/upload/5fc908afba9a83.98129202.ico",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-m-radio-au-travail",
+      "name": "M Radio - Au travail",
+      "broadcaster": "independent",
+      "streamUrl": "https://mradio-au-travail.ice.infomaniak.ch/mradio-au-travail.mp3",
+      "homepage": "https://mradio.fr/radio/webradio",
+      "country": "FR",
+      "tags": [
+        "at work",
+        "working"
+      ],
+      "favicon": "https://mradio.fr/media/option/logo.webp",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        45.7595,
+        4.8287
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-m-radio-nouveautes",
+      "name": "M Radio - Nouveautés",
+      "broadcaster": "independent",
+      "streamUrl": "https://mfmwr-005.ice.infomaniak.ch/mfmwr-005.mp3",
+      "homepage": "https://mradio.fr/",
+      "country": "FR",
+      "favicon": "https://mradio.fr/media/radio/thumb/160x160_61f1616475e1c-nouveautes.webp",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.8527,
+        2.3488
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-m40-deep-dance",
+      "name": "M40 Deep dance",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.m40radio.fr/listen/m40-deep-dance/m40-deep-dance-128.mp3",
+      "homepage": "https://m40radio.fr/",
+      "country": "FR",
+      "tags": [
+        "deep"
+      ],
+      "favicon": "https://cdn.m40radio.fr/wp-content/uploads/radio-m40-deep-dance-370x370.webp",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-mydoom-666",
+      "name": "Mydoom-666",
+      "broadcaster": "independent",
+      "streamUrl": "https://mydoom666.radio.fm/md666-128k",
+      "homepage": "https://mydoom666.radio.fm/",
+      "country": "FR",
+      "favicon": "https://cdn.instant.audio/images/logos/ecouterradioenligne-com/mydoom-666.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-rockenfolie",
+      "name": "Rockenfolie",
+      "broadcaster": "independent",
+      "streamUrl": "https://player.rockenfolie.com/",
+      "homepage": "https://rockenfolie.com/",
+      "country": "FR",
+      "tags": [
+        "rock"
+      ],
+      "favicon": "https://rockenfolie.fr/wp-content/uploads/2021/01/LOGO_ROCKENFOLIE_65.png",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-generations-reggae",
+      "name": "🕺Générations Reggae",
+      "broadcaster": "independent",
+      "streamUrl": "https://generations-caraibes.ice.infomaniak.ch/generations-caraibes-high.aac",
+      "homepage": "https://www.karibshebdo.info/radios-web/g%C3%A9n%C3%A9rations-reggae",
+      "country": "FR",
+      "tags": [
+        "reggae"
+      ],
+      "favicon": "https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEiTBk8X74XIwW8i4X_NDA9IBt-HBCTczbmzpMQdTdCKxOSNo8rw0dD4gTvvkbRQpBsCGHrS7QWvwWMvwLMN18__X8QLaLGl093m1lJ81DsW_KHtiIF1CnZp8bmf8qb5Q48YwB_2JGAf1WlicRQmY3Y2uuLBRlL4FwowcOTrh6s5avSQ93yN1S7ZeBeU/s1600/Capture%20d%E2%80%99%C3%A9cran_2024-11-18_12-42-25.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-air-connect",
+      "name": "Air Connect",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.airconnectradio.com/ac192.mp3",
+      "homepage": "https://airconnectradio.com/",
+      "country": "FR",
+      "tags": [
+        "edm",
+        "house",
+        "pop",
+        "urban"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        47.3213,
+        5.0415
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-beemboomradio",
+      "name": "beemboomradio",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/299368/stream/356549",
+      "homepage": "https://beemboomradio.com/",
+      "country": "FR",
+      "tags": [
+        "chic",
+        "eclectic",
+        "electronic"
+      ],
+      "favicon": "https://d1taocs3kfk7z6.cloudfront.net/track/cover/35e0182a-2536-4cb0-9f3a-2be4f244da02",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        48.9432,
+        2.2613
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-rbr-103-4-106-8fm",
+      "name": "RBR 103.4/106.8FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.vestaradio.com/RBR?nocache=72616#",
+      "homepage": "https://rbrfm.com/",
+      "country": "FR",
+      "favicon": "https://rbrfm.com/sites/default/files/logo_site_1.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-zone-mix",
+      "name": "Zone Mix",
+      "broadcaster": "independent",
+      "streamUrl": "https://zone-mix.stream.laut.fm/zone-mix?t302=2018-02-12_08-42-17&uuid=960992d8-7019-468f-8628-5cec46e9fa42",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "FR",
+      "tags": [
+        "electronic"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-nova-danse",
+      "name": "Nova Danse",
+      "broadcaster": "independent",
+      "streamUrl": "https://nova-dance.ice.infomaniak.ch/nova-dance-128.mp3",
+      "homepage": "https://www.nova.fr/",
+      "country": "FR",
+      "favicon": "https://www.nova.fr/wp-content/thumbnails/uploads/sites/2/2020/09/Cards-Nova-Danse-t-400x496.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-black-corvette",
+      "name": "Black Corvette",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio2.vip-radios.fm:18084/stream-mp3-BlackCorvette",
+      "homepage": "http://www.black-corvette.com/",
+      "country": "FR",
+      "tags": [
+        "groove jazz",
+        "neo soul… 100%vocal",
+        "r&b soul"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-cool-radio",
+      "name": "Cool Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/530131/stream/588580",
+      "homepage": "https://www.lamusiquequifaitdubien.com/cool-radio",
+      "country": "FR",
+      "tags": [
+        "lounge music",
+        "musique du monde",
+        "smooth jazz"
+      ],
+      "favicon": "https://static.wixstatic.com/media/a276e6_268d8bb5969c4360808f3688aa0f7ce4~mv2.png/v1/fill/w_454,h_454,al_c,q_85,usm_0.66_1.00_0.01,enc_auto/LOGO%20COOL%20RADIO%20MAI%202023.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-d4b",
+      "name": "D4B",
+      "broadcaster": "independent",
+      "streamUrl": "https://d4b.ice.infomaniak.ch/d4b-96.mp3",
+      "homepage": "https://www.radiod4b.asso.fr/",
+      "country": "FR",
+      "favicon": "https://www.radiod4b.asso.fr/wp-content/uploads/2023/06/logo.png",
+      "bitrate": 96,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-generation-soul",
+      "name": "génération Soul",
+      "broadcaster": "independent",
+      "streamUrl": "https://gene-wr07.ice.infomaniak.ch/gene-wr07.mp3",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "FR",
+      "tags": [
+        "classical"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-generations-france",
+      "name": "GENERATIONS France",
+      "broadcaster": "independent",
+      "streamUrl": "https://generationfm.ice.infomaniak.ch/generationfm-high.aac?i=70138",
+      "homepage": "https://generations.fr/",
+      "country": "FR",
+      "favicon": "https://generations.fr/media/option/logo.webp",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-hello-provence",
+      "name": "Hello Provence",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice.creacast.com/hello-provence-mp3",
+      "homepage": "https://www.helloprovence.fr/",
+      "country": "FR",
+      "tags": [
+        "local radio"
+      ],
+      "favicon": "https://www.helloprovence.fr/img/news/61561d9050c77.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        43.3076,
+        5.3888
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-info-rc",
+      "name": "Info RC",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.aurafm.org/InfoRC",
+      "homepage": "https://www.inforc.fr/",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        44.6217,
+        4.389
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-m40-electro-swing",
+      "name": "M40 Electro Swing",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.m40radio.fr/listen/m40-electro-swing/m40-electro-swing-128.mp3",
+      "homepage": "https://m40radio.fr/",
+      "country": "FR",
+      "tags": [
+        "electro"
+      ],
+      "favicon": "https://cdn.m40radio.fr/wp-content/uploads/radio-m40-electro-swing-370x370.webp",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-arpitania",
+      "name": "Radio Arpitania",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/28783/stream/64720",
+      "homepage": "http://www.oarp.eu/",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-fil-de-l-eau",
+      "name": "Radio Fil de l'eau",
+      "broadcaster": "independent",
+      "streamUrl": "https://hosting.studioradiomedia.fr:2495/stream",
+      "homepage": "https://radiofildeleau.fr/",
+      "country": "FR",
+      "tags": [
+        "eclectic",
+        "gers",
+        "information",
+        "occitan"
+      ],
+      "favicon": "http://radiofildeleau.fr/wp-content/uploads/logo-rfe-2016.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-vinci-autoroutes-ouest-centre",
+      "name": "Radio VINCI Autoroutes Ouest Centre",
+      "broadcaster": "independent",
+      "streamUrl": "https://sc.creacast.com/rva-cofiroute-1",
+      "homepage": "https://radio.vinci-autoroutes.com/",
+      "country": "FR",
+      "favicon": "https://radio.vinci-autoroutes.com/images/flux/ouest-centre-1400.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-rts-programme-frequence-plus",
+      "name": "RTS programme Fréquence Plus",
+      "broadcaster": "independent",
+      "streamUrl": "https://frequenceplus71.ice.infomaniak.ch/frequenceplus71-128.mp3",
+      "homepage": "http://www.frequenceplusfm.com/",
+      "country": "FR",
+      "favicon": "https://www.frequenceplus.fr/img/favicon-32x32.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-virgin-radio-rock-party",
+      "name": "Virgin Radio Rock Party ",
+      "broadcaster": "independent",
+      "streamUrl": "https://virginradio.ice.infomaniak.ch/virgin-radio.mp3",
+      "homepage": "https://virginradio.fr/radio/webradio",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        45.7592,
+        4.8319
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-allzic-french-mix",
+      "name": "Allzic French Mix",
+      "broadcaster": "independent",
+      "streamUrl": "https://allzic65frenchmix.ice.infomaniak.ch/allzic65.aac",
+      "homepage": "https://www.allzicradio.com/player/listen/4307/allzic-french-mix",
+      "country": "FR",
+      "tags": [
+        "contemporary",
+        "music",
+        "remixes"
+      ],
+      "favicon": "https://www.allzicradio.com/media/radios/thumb/195x195_65d4a0817a09d-french-mix.jpg",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-christmas-hits-1",
+      "name": "Christmas hits 1",
+      "broadcaster": "independent",
+      "streamUrl": "https://hits1christmas-audiomediaradio.radioca.st/christmas",
+      "homepage": "https://www.hits1radio.com/",
+      "country": "FR",
+      "favicon": "https://www.hits1radio.com/wp-content/uploads/2019/03/dummy-e1554135926529.jpg",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-cuberadio-fr",
+      "name": "Cuberadio.fr",
+      "broadcaster": "independent",
+      "streamUrl": "https://api.cuberadio.fr/play",
+      "homepage": "https://cuberadio.fr/",
+      "country": "FR",
+      "tags": [
+        "amateur radio"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-le-bouquet-granvillais",
+      "name": "Le bouquet Granvillais",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.radioking.com/play/lebouquetgranvillais",
+      "homepage": "https://radio.lebouquetgranvillais.fr/",
+      "country": "FR",
+      "tags": [
+        "actualites",
+        "local information",
+        "local music",
+        "pop music"
+      ],
+      "favicon": "https://radio.lebouquetgranvillais.fr/upload/51bf0534b8eaa1.96289316.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.8382,
+        -1.5977
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-nrj-new-hits-friday",
+      "name": "Nrj New Hits Friday",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.nrjaudio.fm/ou8vstgk7oiu?origine=playernrj&aw_0_req.userConsentV2=&aw_0_1st.station=NRJ-New-Hits-Friday",
+      "homepage": "https://www.nrj.fr/webradios/mur-des-radios/nrj",
+      "country": "FR",
+      "tags": [
+        "hits"
+      ],
+      "favicon": "https://www.nrj.fr/uploads/assets/nrj/favicon.ico",
+      "bitrate": 128,
+      "codec": "AAC+",
+      "geo": [
+        47.7068,
+        1.9336
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-plum-fm",
+      "name": "Plum fm",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radios.bzh/listen/plumfm/radio.mp3",
+      "homepage": "https://www.plumfm.net/",
+      "country": "FR",
+      "favicon": "https://static.wixstatic.com/media/695ef4_9d20d326e8d243788c285f11121c9994~mv2.png/v1/crop/x_0,y_2,w_2101,h_737/fill/w_326,h_114,al_c,q_85,usm_0.66_1.00_0.01,enc_auto/LOGO%20ok%20PLUMFM.png",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-occitania",
+      "name": "Radio Occitania",
+      "broadcaster": "independent",
+      "streamUrl": "https://sd-151888.dedibox.fr/proxy/occitania/occitania",
+      "homepage": "https://radio-occitania.com/",
+      "country": "FR",
+      "favicon": "https://i0.wp.com/radio-occitania.com/wp-content/uploads/2020/10/logo-ROC-2lignes.jpg?w=373&ssl=1",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-pitchoun",
+      "name": "Radio Pitchoun",
+      "broadcaster": "independent",
+      "streamUrl": "https://webradio.tvradio-pitchoun.fr:8443/radiopitchoun.aac",
+      "homepage": "http://tvradio-pitchoun.fr/",
+      "country": "FR",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-scoop-powerdance",
+      "name": "Radio Scoop Powerdance",
+      "broadcaster": "independent",
+      "streamUrl": "https://scooppowerdance.ice.infomaniak.ch/radioscoop-powerdance-64.aac",
+      "homepage": "https://www.radioscoop.com/",
+      "country": "FR",
+      "tags": [
+        "dance"
+      ],
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-allzic-radio-top-10",
+      "name": "Allzic Radio TOP 10",
+      "broadcaster": "independent",
+      "streamUrl": "https://allzic22.ice.infomaniak.ch/allzic22.aac",
+      "homepage": "https://global.superradio.cc/",
+      "country": "FR",
+      "tags": [
+        "music",
+        "top 10"
+      ],
+      "favicon": "https://super-radio-global.devhub.top/logo/default.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-eipm",
+      "name": "EIPM",
+      "broadcaster": "independent",
+      "streamUrl": "https://stunnel1.cyber-streaming.com:9046/stream?type=http&nocache=30",
+      "homepage": "https://radio-eipm.fr/",
+      "country": "FR",
+      "tags": [
+        "misc"
+      ],
+      "favicon": "https://radio-eipm.fr/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-france-bleu-armorique",
+      "name": "France Bleu Armorique",
+      "broadcaster": "independent",
+      "streamUrl": "https://direct.francebleu.fr/live/fbarmorique-midfi.mp3",
+      "homepage": "https://www.francebleu.fr/armorique",
+      "country": "FR",
+      "tags": [
+        "music",
+        "regional"
+      ],
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/thumb/e/e1/France_Bleu_2021.svg/800px-France_Bleu_2021.svg.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-graffiti-urban-radio",
+      "name": "Graffiti Urban Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://diffusion.lafrap.fr/graffiti",
+      "homepage": "https://www.graffitiradio.fr/",
+      "country": "FR",
+      "tags": [
+        "alternative",
+        "community radio",
+        "independent",
+        "independent radio"
+      ],
+      "bitrate": 56,
+      "codec": "AAC+",
+      "geo": [
+        46.6646,
+        -1.4577
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-kolectiv",
+      "name": "Kolectiv'",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/480/stream/1844",
+      "homepage": "http://www.kolectiv.fr/",
+      "country": "FR",
+      "tags": [
+        "radio associative"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.7642,
+        0.629
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-le-bon-mix",
+      "name": "LE BON MIX",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream10.xdevel.com/audio11s976748-2015/stream/icecast.audio",
+      "homepage": "https://www.lebonmix.radio/",
+      "country": "FR",
+      "favicon": "https://admuzzum.xdevel.com/cloud/x/cid/35/im/png/XZXW/Q/XY/20dcef61bfe95be20b65258bba132163.png",
+      "bitrate": 192,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-pulsradio-trance",
+      "name": "PulsRadio Trance",
+      "broadcaster": "independent",
+      "streamUrl": "https://sc4.gergosnet.com/pulstranceHD.mp3",
+      "homepage": "https://www.pulsradio.com/trance",
+      "country": "FR",
+      "tags": [
+        "trance",
+        "vocal trance"
+      ],
+      "favicon": "https://static2.mytuner.mobi/media/tvos_radios/269/pulsradio-trance.f0336c60.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-karata",
+      "name": "Radio Karata",
+      "broadcaster": "independent",
+      "streamUrl": "https://dynstreamgradioflux.fr:8060/stream",
+      "homepage": "https://www.radiokarata.com/",
+      "country": "FR",
+      "favicon": "https://www.radiokarata.com/favicon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-pfm",
+      "name": "Radio PFM",
+      "broadcaster": "independent",
+      "streamUrl": "https://diff.radiopfm.com/flux.mp3",
+      "homepage": "https://www.radiopfm.com/article/pfm-en-ligne",
+      "country": "FR",
+      "tags": [
+        "generalist"
+      ],
+      "favicon": "https://www.radiopfm.com/static/img/favicon.d95773dc7037.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radios-libres-en-perigord-rlp102-3-aac-64",
+      "name": "Radios Libres en Perigord - RLP102.3 - AAC+ 64",
+      "broadcaster": "independent",
+      "streamUrl": "https://direct.radioslibresenperigord.com/rlp.64.aac",
+      "homepage": "http://www.radioslibresenperigord.com/",
+      "country": "FR",
+      "tags": [
+        "local"
+      ],
+      "favicon": "https://www.radioslibresenperigord.com/wp-content/uploads/2023/09/LOGO-Transparent-RLP-2021.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "geo": [
+        45.175,
+        0.692
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-retro-souvenirs-radio",
+      "name": "Retro Souvenirs Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/108/stream/890",
+      "homepage": "https://www.retrosouvenirs.com/",
+      "country": "FR",
+      "tags": [
+        "70s",
+        "80s",
+        "oldies"
+      ],
+      "favicon": "https://static.wixstatic.com/media/82b05f_8193c647efa94b70a93346c2a9e39f19%7emv2.jpg/v1/fill/w_32%2ch_32%2clg_1%2cusm_0.66_1.00_0.01/82b05f_8193c647efa94b70a93346c2a9e39f19%7emv2.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-generations-rap-u-s",
+      "name": "🕺Générations Rap U.S",
+      "broadcaster": "independent",
+      "streamUrl": "https://generationfm-underground.ice.infomaniak.ch/generationfm-underground-high.aac",
+      "homepage": "https://www.karibshebdo.info/radios-web/g%C3%A9n%C3%A9rations-rap-u-s",
+      "country": "FR",
+      "tags": [
+        "rap us"
+      ],
+      "favicon": "https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEhDDint7_sPO4IWJn2Hunk69PuUwNl8hG_loo5oRMDVrePNuuzqneX2yRe1iE2KHLJUx3nkrLkco7sTbbjwP_m0GCmYisEB7jsI0trOiGlBJUFS_kE9U52Gipjhm4r70XmHnBzf8i13FH5MhW3DxykjyyGBhu5yj7T3RN_puqjtWp0hIn5Uq1sUKpXi/s1600/Capture%20d%E2%80%99%C3%A9cran_2024-11-18_12-32-28.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-allzic-radio-live-gold",
+      "name": "Allzic Radio Live GOLD",
+      "broadcaster": "independent",
+      "streamUrl": "https://allzic45.ice.infomaniak.ch/allzic45.aac",
+      "homepage": "https://global.superradio.cc/",
+      "country": "FR",
+      "tags": [
+        "music"
+      ],
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-antxeta-irratia",
+      "name": "Antxeta irratia",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.antxetamedia.eus:8443/antxeta1",
+      "homepage": "https://antxetamedia.eus/",
+      "country": "FR",
+      "tags": [
+        "local news",
+        "news"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        43.3968,
+        -1.6303
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-collector-radio",
+      "name": "Collector Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ouifm6.ice.infomaniak.ch/collector-rnt.mp3?ua=InfomaniakPlayer",
+      "homepage": "https://www.collectorradio.fr/",
+      "country": "FR",
+      "favicon": "https://images.lesindesradios.fr/filters:quality(100)/radios/collector-radio/images/logo.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-euradio",
+      "name": "EURadio",
+      "broadcaster": "independent",
+      "streamUrl": "https://euradio.fr/stream/",
+      "homepage": "https://euradio.fr/",
+      "country": "FR",
+      "favicon": "https://euradio.fr/apple-touch-icon.png",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-fm43",
+      "name": "FM43",
+      "broadcaster": "independent",
+      "streamUrl": "https://fm43.ice.infomaniak.ch/fm43-64.aac",
+      "homepage": "https://www.radiofm43.org/",
+      "country": "FR",
+      "favicon": "https://static.wixstatic.com/media/a5ad8a_939ac18665c14249bff6512b85ba3fb2%7emv2.png/v1/fill/w_180%2ch_180%2clg_1%2cusm_0.66_1.00_0.01/a5ad8a_939ac18665c14249bff6512b85ba3fb2%7emv2.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-frequence-luz",
+      "name": "Frequence Luz",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-ssl.radios-arra.fr:8443/frequenceluz",
+      "homepage": "https://www.frequenceluz.com/",
+      "country": "FR",
+      "tags": [
+        "alternative",
+        "funk",
+        "local music",
+        "local news",
+        "pop",
+        "rnb"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        42.8709,
+        -0.0032
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-pinata",
+      "name": "Pinata",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/96031/stream/134656",
+      "homepage": "https://www.pinataradio.com/",
+      "country": "FR",
+      "tags": [
+        "electronica",
+        "hiphop",
+        "jazz"
+      ],
+      "favicon": "https://i1.sndcdn.com/avatars-WNhpWtZWyficOMFg-CT1Hyw-t200x200.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        43.6567,
+        3.8672
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-pulsradio-90",
+      "name": "PulsRadio - 90",
+      "broadcaster": "independent",
+      "streamUrl": "https://sc4.gergosnet.com/puls90HD.mp3",
+      "homepage": "https://www.pulsradio.com/90/",
+      "country": "FR",
+      "tags": [
+        "90s"
+      ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/1/8671.v9.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-broussaille-lo-fi-aac-128",
+      "name": "Radio Broussaille (Lo-Fi AAC 128)",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radiobroussaille.fr:8443/broussaille-lofi",
+      "homepage": "https://radiobroussaille.fr/",
+      "country": "FR",
+      "tags": [
+        "adfree",
+        "broussaille",
+        "creative",
+        "direct",
+        "foss",
+        "gascon"
+      ],
+      "favicon": "https://stream.radiobroussaille.fr:8443/favicon-32x32.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        43.7316,
+        0.8782
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-deja-vu",
+      "name": "Radio Déjà Vu",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/22274/stream/63592",
+      "homepage": "https://radio-dejavu.com/",
+      "country": "FR",
+      "tags": [
+        "rock"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-tempete",
+      "name": "Radio Tempête",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/372772/stream/422929",
+      "homepage": "https://radiotempete.com/",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-virage-radio-chambery",
+      "name": "VIRAGE RADIO CHAMBERY",
+      "broadcaster": "independent",
+      "streamUrl": "https://virageradio.ice.infomaniak.ch/virageradio-chambery.aac?i=47784",
+      "homepage": "https://www.virageradio.com/",
+      "country": "FR",
+      "favicon": "https://www.virageradio.com/media/option/logo-virage.webp",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-ecoutez-mon-petit-france-inter",
+      "name": "Écoutez Mon petit France Inter",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radiofrance.fr/monpetitfranceinter/monpetitfranceinter_hifi.m3u8",
+      "homepage": "https://www.radiofrance.fr/podcasts/enfants",
+      "country": "FR",
+      "tags": [
+        "kids",
+        "musiques des enfants"
+      ],
+      "favicon": "https://www.radiofrance.fr/pikapi/images/cbfde3c3-8213-45a6-ac89-b6a3b521025c/200x200",
+      "codec": "UNKNOWN",
+      "geo": [
+        48.8589,
+        2.2852
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-forum-maine-et-loire",
+      "name": "Forum Maine et Loire",
+      "broadcaster": "independent",
+      "streamUrl": "https://start-forum.ice.infomaniak.ch/start-forum-high.mp3",
+      "homepage": "https://www.forum.fr/",
+      "country": "FR",
+      "favicon": "https://bocir-prod-bucket.s3.eu-west-1.amazonaws.com/radios/forum/images/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-max-radio-grenoble",
+      "name": "Max Radio Grenoble",
+      "broadcaster": "independent",
+      "streamUrl": "https://maxfm.ice.infomaniak.ch/maxfm-945.mp3",
+      "homepage": "https://max.radio/",
+      "country": "FR",
+      "tags": [
+        "dance",
+        "dance music",
+        "electro",
+        "electronic",
+        "electronic dance music",
+        "pop"
+      ],
+      "favicon": "https://max.radio/player/img/logo.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        45.1862,
+        5.7316
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-nrj-pop",
+      "name": "NRJ POP",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.nrjaudio.fm/oumrai8fnozc?origine=fluxurlradio&aw_0_1st.station=NRJ-Best-Hits-Ever",
+      "homepage": "https://www.nrj.com/",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.7436,
+        2.6367
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-bartas",
+      "name": "Radio Bartas",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-ssl.radios-arra.fr:8443/radiobartas",
+      "homepage": "https://www.radiobartas.net/",
+      "country": "FR",
+      "tags": [
+        "local",
+        "music",
+        "talk"
+      ],
+      "favicon": "https://www.radiobartas.net/wp-content/uploads/2019/08/logo-RADIO-BARTAS-final.jpg",
+      "bitrate": 224,
+      "codec": "MP3",
+      "geo": [
+        48.8763,
+        1.0547
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-kerne",
+      "name": "Radio Kerne",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radios.bzh/listen/kerne/radio.mp3",
+      "homepage": "https://www.radiokerne.bzh/fr/",
+      "country": "FR",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-rvr",
+      "name": "RVR",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.aurafm.org:7443/rvr-tarareplata",
+      "homepage": "http://www.rvrradio.fr/",
+      "country": "FR",
+      "tags": [
+        "talk & speech"
+      ],
+      "bitrate": 160,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-reccord-groove-tribal",
+      "name": "📻 Reccord Groove/Tribal",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiorecord.hostingradio.ru/groovetribal96.aacp",
+      "homepage": "https://radiosweb.karibshebdo.info/radios-web/reccord-groovetribal",
+      "country": "FR",
+      "tags": [
+        "groove",
+        "tribal"
+      ],
+      "favicon": "https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEicK_fRt2NiH5qCq-6CRWb4vZ2x3fDQOZgW49y2X6pr62c04UDZstgaBYWrhOljUQHGJOrofLCvUw3YZ913xV7yB0F3CijWFQj-vHDwiKO5tWO-q3vPBxEM9iJVe9uTAAmAOFkiai2ihdIfhry7SpjavxU1N9YguCr2SyghRFoLQp-HU1-TCxuJdIZg/s1600/Capture%20d%E2%80%99%C3%A9cran_2024-12-08_09-45-42.png",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-marsanaryas",
+      "name": " MARSANARYAS",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.marsanaryas.com/radio/live/",
+      "homepage": "https://www.marsanaryas.com/",
+      "country": "FR",
+      "tags": [
+        "independent",
+        "talk"
+      ],
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-4u-70s-flower",
+      "name": "4U 70s Flower",
+      "broadcaster": "independent",
+      "streamUrl": "https://str4uice.streamakaci.com/4u70s.mp3",
+      "homepage": "https://www.4urock.com/",
+      "country": "FR",
+      "tags": [
+        "rock classic"
+      ],
+      "codec": "MP3",
+      "geo": [
+        48.5515,
+        7.7783
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-gu-radio",
+      "name": "Gu Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/371/stream/1583",
+      "homepage": "http://g-u.tv/",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-jade-fm",
+      "name": "Jade FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://diffusion.lafrap.fr/radiochrono.mp3",
+      "homepage": "https://jadefm.fr/",
+      "country": "FR",
+      "favicon": "https://jadefm.fr/upload/6034f72fbd05f4.03480480.ico",
+      "bitrate": 80,
+      "codec": "MP3",
+      "geo": [
+        47.1153,
+        -2.1055
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-m40-latino",
+      "name": "M40 Latino",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.m40radio.fr/listen/m40-latino/m40-latino-128.mp3",
+      "homepage": "https://m40radio.fr/",
+      "country": "FR",
+      "tags": [
+        "latino"
+      ],
+      "favicon": "https://cdn.m40radio.fr/wp-content/uploads/radio-m40-latino-370x370.webp",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-m40-rnb",
+      "name": "M40 Rnb",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.m40radio.fr/listen/m40-rnb/m40-rnb-128.mp3",
+      "homepage": "https://m40radio.fr/",
+      "country": "FR",
+      "tags": [
+        "rnb"
+      ],
+      "favicon": "https://cdn.m40radio.fr/wp-content/uploads/radio-m40-rnb-370x370.webp",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-playlist-radio",
+      "name": "Playlist Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://playlist.ice.infomaniak.ch/playlist-192.mp3",
+      "homepage": "https://playlistradio.fr/",
+      "country": "FR",
+      "favicon": "https://playlistradio.fr/images/logo.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-delta",
+      "name": "Radio Delta",
+      "broadcaster": "independent",
+      "streamUrl": "https://s4.radio.co/s2fcf9497b/listen",
+      "homepage": "https://deltaradio.fr/",
+      "country": "FR",
+      "favicon": "https://deltaradio.fr/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-primitive",
+      "name": "RADIO PRIMITIVE",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.radioprimitive.fr:8443/live.mp3",
+      "homepage": "http://radioprimitive.fr/",
+      "country": "FR",
+      "favicon": "https://www.radioprimitive.fr/images/permanent/logo-square",
+      "bitrate": 160,
+      "codec": "MP3",
+      "geo": [
+        49.2615,
+        4.0322
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-rtl-la-collection-georges-lang",
+      "name": "RTL La Collection Georges Lang",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.m6radio.quortex.io/webpHJPXnXrN7B6J7Q8mcqmxP/webradio/rtl-georges-lang/130/audio-64000/index.m3u8",
+      "homepage": "https://www.rtl.fr/radios",
+      "country": "FR",
+      "tags": [
+        "classic rock",
+        "country",
+        "rock",
+        "rock n roll"
+      ],
+      "bitrate": 64,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-4u-classic-rock",
+      "name": "4U Classic Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://str4uice.streamakaci.com/4uclassicrock.mp3",
+      "homepage": "https://www.4urock.com/",
+      "country": "FR",
+      "tags": [
+        "classic rock",
+        "hits"
+      ],
+      "favicon": "https://www.4urock.com/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-cpc-scene-radio",
+      "name": "CPC Scene Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://a1.asurahosting.com/listen/cpc_scene_radio/radio.mp3",
+      "homepage": "https://radio.cpcscene.net/",
+      "country": "FR",
+      "tags": [
+        "chiptune",
+        "chiptunes"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-france-bleu-haute-normandie",
+      "name": "France Bleu Haute Normandie",
+      "broadcaster": "independent",
+      "streamUrl": "https://direct.francebleu.fr/live/fbhautenormandie-midfi.mp3",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "FR",
+      "tags": [
+        "news"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-frequence-hit",
+      "name": "Fréquence Hit",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.frequencehit.com/frequencehit.mp3",
+      "homepage": "https://www.frequencehit.com/",
+      "country": "FR",
+      "tags": [
+        "classic hits",
+        "hits",
+        "music non stop",
+        "non-stop music",
+        "rock",
+        "top 40 hits"
+      ],
+      "favicon": "https://www.frequencehit.com/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        48.2086,
+        -1.6494
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-kizrock-rock",
+      "name": "Kizrock Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://go.2stream.net/kizrock",
+      "homepage": "https://kizrock.com/",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        47.4697,
+        3.1641
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-la-grosse-tambouille",
+      "name": "La Grosse Tambouille",
+      "broadcaster": "independent",
+      "streamUrl": "https://flux.lagrossetambouille.fr/main",
+      "homepage": "https://lagrossetambouille.fr/",
+      "country": "FR",
+      "tags": [
+        "grosse tambouille",
+        "indépendante",
+        "libre",
+        "musique",
+        "sanspub",
+        "éclectique"
+      ],
+      "favicon": "https://lagrossetambouille.fr/logo.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-m-radio-live",
+      "name": "M Radio Live",
+      "broadcaster": "independent",
+      "streamUrl": "https://mfmwr-008.ice.infomaniak.ch/mfmwr-008.mp3",
+      "homepage": "https://mradio.fr/radio/webradio/21/m-radio-live",
+      "country": "FR",
+      "tags": [
+        "pop"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-m40-makina",
+      "name": "M40 Makina",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.m40radio.fr/listen/m40-makina/m40-makina-128.mp3",
+      "homepage": "https://m40radio.fr/",
+      "country": "FR",
+      "tags": [
+        "techno"
+      ],
+      "favicon": "https://cdn.m40radio.fr/wp-content/uploads/radio-m40-makina-370x370.webp",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-neptune-fm",
+      "name": "Neptune FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://diffusion.lafrap.fr/neptune.mp3",
+      "homepage": "https://neptunefm.com/",
+      "country": "FR",
+      "tags": [
+        "actualités"
+      ],
+      "favicon": "https://neptunefm.com/upload/538ef0b6cab2e5.71343553.ico",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-party-dance-francehttps-www-vip-radios-fm-statio",
+      "name": "Party Dance Francehttps://www.vip-radios.fm/station/party-dance-radio/",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio4.vip-radios.fm:18042/stream-128kmp3-PartyDance",
+      "homepage": "https://www.vip-radios.fm/station/party-dance-radio/",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-pulsradio-2000",
+      "name": "PulsRadio 2000",
+      "broadcaster": "independent",
+      "streamUrl": "https://sc6.gergosnet.com/puls00HD.mp3",
+      "homepage": "https://www.pulsradio.com/2000/",
+      "country": "FR",
+      "tags": [
+        "00s"
+      ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/4/8674.v8.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-ac-s",
+      "name": "Radio AC'S",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/33824/stream/199675",
+      "homepage": "https://radioacs.radio-website.com/",
+      "country": "FR",
+      "tags": [
+        "french chansons",
+        "french rap",
+        "pop",
+        "rap",
+        "rock",
+        "world music"
+      ],
+      "favicon": "https://radioacs.radio-website.com/upload/design/63ca6b9be24252.73424119.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        48.9407,
+        2.1929
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-rennes",
+      "name": "Radio Rennes",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream4.vestaradio.com/RADIORENNES",
+      "homepage": "https://www.radiorennes.fr/",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.1151,
+        -1.6775
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-allzic-radio-live-fr",
+      "name": "Allzic Radio Live FR",
+      "broadcaster": "independent",
+      "streamUrl": "https://allzic44.ice.infomaniak.ch/allzic44.aac",
+      "homepage": "https://global.superradio.cc/",
+      "country": "FR",
+      "tags": [
+        "music"
+      ],
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-hag-fm",
+      "name": "Hag' FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://hagfm.streamakaci.com/hagfm.mp3",
+      "homepage": "https://www.hagfm.com/",
+      "country": "FR",
+      "tags": [
+        "alternative",
+        "pop",
+        "rock"
+      ],
+      "favicon": "https://www.hagfm.com/wp-content/uploads/2023/06/Logo-sans-fond-110x69.png",
+      "bitrate": 256,
+      "codec": "MP3",
+      "geo": [
+        49.6645,
+        -1.8324
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-ici-armorique",
+      "name": "ici Armorique",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.radiofrance.fr/fbarmorique-midfi.mp3",
+      "homepage": "https://www.francebleu.fr/radio/armorique",
+      "country": "FR",
+      "favicon": "https://www.francebleu.fr/favicon56.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-m40-le-klub",
+      "name": "M40 le klub'",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.m40radio.fr/listen/le-klub-by-m40/le-klub-by-m40-128.mp3",
+      "homepage": "https://m40radio.fr/",
+      "country": "FR",
+      "tags": [
+        "club"
+      ],
+      "favicon": "https://cdn.m40radio.fr/wp-content/uploads/favicon-100x100.webp",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-m40-maxi-dance",
+      "name": "M40 Maxi Dance",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.m40radio.fr/listen/m40-maxi-dance/m40-maxi-dance-128.mp3",
+      "homepage": "https://m40radio.fr/",
+      "country": "FR",
+      "tags": [
+        "dance"
+      ],
+      "favicon": "https://cdn.m40radio.fr/wp-content/uploads/radio-m40-maxi-dance-370x370.webp",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-dynamo",
+      "name": "Radio Dynamo",
+      "broadcaster": "independent",
+      "streamUrl": "https://dynamo.ice.infomaniak.ch/dynamo.aac",
+      "homepage": "https://radiodynamo.org/",
+      "country": "FR",
+      "favicon": "https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Flookaside.fbsbx.com%2Flookaside%2Fcrawler%2Fmedia%2F%3Fmedia_id%3D239189915631042&f=1&nofb=1&ipt=4eb369aa11463f4c4d2b6adfdad6d8b2f9a7dc22b4d5b714a31f44e1e787a9b9&ipo=images",
+      "bitrate": 96,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-troutrou",
+      "name": "Radio Troutrou",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/353374/stream/413698",
+      "homepage": "https://radiotroutrou.com/",
+      "country": "FR",
+      "tags": [
+        "various"
+      ],
+      "favicon": "https://radiotroutrou.com/apple-touch-icon.png?",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        49.3663,
+        0.0865
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-rig-90-7-fm",
+      "name": "Rig 90.7 fm",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.aquifm.fr/listenrig.mp3",
+      "homepage": "https://www.rigfm.fr/",
+      "country": "FR",
+      "tags": [
+        "es"
+      ],
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-zeno-fm-hypnotissimo",
+      "name": "ZENO FM - HYPNOtissimo",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.zeno.fm/m7rg3ynt9k0uv",
+      "homepage": "https://www.youtube.com/playlist?list=PL46FdNad6dC2qDK3S7kAf-abxQcRsFcqO",
+      "country": "FR",
+      "favicon": "https://zeno.fm/_ipx/f_webp&q_85&fit_cover&s_288x288/https://images.zeno.fm/YYNPJHO5wNHx7Hm8tQ6bIj3vkg4FQW64oMBvitFZ_As/rs:fill:288:288/g:ce:0:0/aHR0cHM6Ly9wcm94eS56ZW5vLmZtL2NvbnRlbnQvc3RhdGlvbnMvYWd4emZucGxibTh0YzNSaGRITnlNZ3NTQ2tGMWRHaERiR2xsYm5RWWdJQ1F3ZjNkdmdrTUN4SU9VM1JoZEdsdmJsQnliMlpwYkdVWWdJRFFxYm5WNXdvTW9nRUVlbVZ1YncvaW1hZ2UvP3U9MTY2MTU3MjE2MDAwMA.webp",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-generations-funk",
+      "name": "🕺 Générations Funk",
+      "broadcaster": "independent",
+      "streamUrl": "https://gene-wr05.ice.infomaniak.ch/gene-wr05.aac",
+      "homepage": "https://www.karibshebdo.info/radios-web/g%C3%A9n%C3%A9rations-funk",
+      "country": "FR",
+      "tags": [
+        "funk"
+      ],
+      "favicon": "https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEg5HJuS6yWCZCykQR-TGHZWdD1_-17zir7HncDBK8NG2ZQI-fdZP8JiFabyZi8Qlw5qGkBK3rIQ0GX4D5bRVYLE1M2hgsgGwZGY-chOArST8GHIMaS-yj7f_-jOl9ytuB_WgH1v_bDZia8cmgF_1t6RBLbht4wZr_ZzixiYFhDAp71uB5kj_ggwDU56/s1600/Capture%20d%E2%80%99%C3%A9cran_2024-11-18_11-48-02.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-europe-2-maine-et-loire",
+      "name": "Europe 2 Maine et loire",
+      "broadcaster": "independent",
+      "streamUrl": "https://europe2.lmn.fm/europe2-49000/playlist.m3u8",
+      "homepage": "https://www.facebook.com/Europe2PaysdelaLoire/",
+      "country": "FR",
+      "bitrate": 127,
+      "codec": "AAC",
+      "geo": [
+        47.4459,
+        -0.5466
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-melody-vintage-radio",
+      "name": "Melody Vintage Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rcs.revma.com/5a05fstup42vv",
+      "homepage": "https://www.melody.tv/radio/melody/",
+      "country": "FR",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/9/67559.v9.png",
+      "codec": "MP3",
+      "geo": [
+        48.7721,
+        2.3844
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-prune",
+      "name": "Prune",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.prun.net/stream/",
+      "homepage": "https://www.prun.net/",
+      "country": "FR",
+      "favicon": "https://www.prun.net/favicon.ico",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-campus-orleans",
+      "name": "Radio Campus Orléans",
+      "broadcaster": "independent",
+      "streamUrl": "https://streams.labomedia.org:8443/stream_rco",
+      "homepage": "https://orleans.radiocampus.org/",
+      "country": "FR",
+      "favicon": "https://www.magcentre.fr/wp-content/uploads/2015/03/radio-campus-orleans.jpg",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-fg-98-2",
+      "name": "Radio FG 98.2",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rcs.revma.com/wknqhm4yuchvv",
+      "homepage": "https://www.radiofg.com/",
+      "country": "FR",
+      "favicon": "https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse1.mm.bing.net%2Fth%2Fid%2FOIP.xYs-7QDFZLe3JLyEmOuMHAHaGb%3Fpid%3DApi&f=1&ipt=a4b9fe03598a6c8d9f40fc0dcc26deccfa541340435253746eb3def913cf03d0&ipo=images",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-pulsar",
+      "name": "Radio Pulsar",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiopulsar.ice.infomaniak.ch/radiopulsar-192.mp3",
+      "homepage": "https://www.radio-pulsar.org/",
+      "country": "FR",
+      "favicon": "https://www.radio-pulsar.org/wp-content/uploads/2018/10/cropped-PULSAR_Logo-officiel-192x192.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        46.5687,
+        0.3865
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-saint-louis",
+      "name": "Radio Saint Louis",
+      "broadcaster": "independent",
+      "streamUrl": "https://stunnel2.cyber-streaming.com:9142/;stream.mp3",
+      "homepage": "https://webradio.radiosaintlouis.com/",
+      "country": "FR",
+      "favicon": "https://webradio.radiosaintlouis.com/assets/images/logo_rsl_globe_slogan.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radiocanut",
+      "name": "RadioCanut",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.aurafm.org/radiocanut",
+      "homepage": "https://radiocanut.org/",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        45.7688,
+        4.8299
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-tst-radio",
+      "name": "TST Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/113992/stream/153202",
+      "homepage": "https://www.tst-radio.com/",
+      "country": "FR",
+      "tags": [
+        "alternative",
+        "pop",
+        "rock"
+      ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/8/74428.v2.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        49.4403,
+        1.094
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-generations-soul",
+      "name": "🕺Générations Soul",
+      "broadcaster": "independent",
+      "streamUrl": "https://gene-wr07.ice.infomaniak.ch/gene-wr07.aac",
+      "homepage": "https://www.karibshebdo.info/radios-web/g%C3%A9n%C3%A9rations-soul",
+      "country": "FR",
+      "tags": [
+        "soul"
+      ],
+      "favicon": "https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEjKuoeFfqhbcNxeo-YM3ea420CIU4V9z16HIoDo25FqM0Cc6u8eF7Yrm1Aa4FEs0Kex8-1-YggLWwCyuLxPGk28-9dSEpVCDCR_FkGxO8S4-qd9sF9SHuVYjhInufPYGHc5Xi19v39GOZHmrYBQ-e0z8KWVOYDbLfPKHn5_v80g1f3Wmm6NNqPteKcX/s1600/Capture%20d%E2%80%99%C3%A9cran_2024-11-18_12-47-27.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-cob-fm-saint-brieuc",
+      "name": "COB' FM Saint-Brieuc",
+      "broadcaster": "independent",
+      "streamUrl": "https://myradiostream.com/embed/assets/mp3/test.mp3",
+      "homepage": "https://www.cobfm.com/",
+      "country": "FR",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-gure-irratia",
+      "name": "Gure irratia",
+      "broadcaster": "independent",
+      "streamUrl": "https://hosting.studioradiomedia.fr:1345/stream",
+      "homepage": "https://www.gureirratia.eus/",
+      "country": "FR",
+      "favicon": "https://www.inakinoblia.com/wp-content/uploads/2019/11/gure-irratia.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-le-village-pop",
+      "name": "Le village pop",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/200437/stream/243028",
+      "homepage": "http://levillagepop.com/",
+      "country": "FR",
+      "tags": [
+        "folk",
+        "indie",
+        "pop rock",
+        "rock"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-m40-poprock",
+      "name": "M40 PopRock",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.m40radio.fr/listen/m40-pop-rock/m40-pop-rock-128.mp3",
+      "homepage": "https://m40radio.fr/",
+      "country": "FR",
+      "tags": [
+        "pop rock"
+      ],
+      "favicon": "https://cdn.m40radio.fr/wp-content/uploads/radio-m40-pop-rock-370x370.webp",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-mon-tout-petit-france-inter",
+      "name": "Mon tout petit France Inter ",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radiofrance.fr/montoutpetitfranceinter/montoutpetitfranceinter_hifi.m3u8?id=radiofrance",
+      "homepage": "https://www.radiofrance.fr/podcasts/enfants",
+      "country": "FR",
+      "tags": [
+        "3 ans",
+        "enfants",
+        "kids",
+        "musiques des enfants"
+      ],
+      "favicon": "https://www.radiofrance.fr/pikapi/images/cbfde3c3-8213-45a6-ac89-b6a3b521025c/200x200",
+      "codec": "UNKNOWN",
+      "geo": [
+        48.8748,
+        2.3456
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-nrj-tiktok",
+      "name": "NRJ TIKTOK",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.nrjaudio.fm/ougfbmrb92oc?origine=playernrj&aw_0_req.userConsentV2=&aw_0_1st.station=NRJ-TIKTOK",
+      "homepage": "https://www.nrj.fr/webradios/mur-des-radios/nrj-tiktok",
+      "country": "FR",
+      "tags": [
+        "nrj",
+        "tiktok"
+      ],
+      "favicon": "https://img.nrj.fr/iGYpE-czKe0IPznKQ-vMWxbwXxQ=/80x80/https%3A%2F%2Fplayers.nrjaudio.fm%2Flive-metadata%2Fplayer%2Fimg%2Fplayer-files%2Fnrj%2Flogos%2F640x640%2FNRJ-WR--TIKTOK.jpg",
+      "bitrate": 128,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-public-health-radio-arabic",
+      "name": "Public Health Radio Arabic",
+      "broadcaster": "independent",
+      "streamUrl": "https://publichealthradioar.ice.infomaniak.ch/publichealthradioar-128.mp3",
+      "homepage": "https://www.publichealthradio.net/",
+      "country": "FR",
+      "tags": [
+        "health",
+        "health programming",
+        "information"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.8337,
+        2.2581
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-replay-news-story-francais",
+      "name": "REPLAY NEWS - Story (Français)",
+      "broadcaster": "independent",
+      "streamUrl": "https://replaynewsstory.ice.infomaniak.ch/replaynewsstory-128.mp3",
+      "homepage": "https://www.replaynews.net/",
+      "country": "FR",
+      "tags": [
+        "news",
+        "storytelling"
+      ],
+      "favicon": "https://www.publicsante.com/BIENVENU/LOGO%20REPLAY%20NEWS%20STORY.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-alencon-fm",
+      "name": "Alençon FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/290959/stream/337222",
+      "homepage": "https://www.alenconfm.fr/index.php",
+      "country": "FR",
+      "favicon": "https://www.alenconfm.fr/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-allzic-radio",
+      "name": "Allzic radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://allzic53.ice.infomaniak.ch/allzic53.mp3",
+      "homepage": "https://www.allzicradio.com/fr/player/listen/3693/allzic-radio-chill-out",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-dhectar",
+      "name": "DHECTAR",
+      "broadcaster": "independent",
+      "streamUrl": "https://manager.dhectar.fr:1065/stream",
+      "homepage": "https://www.dhectar.fr/index.php",
+      "country": "FR",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-e-kwality-radio",
+      "name": "E-KWALITY RADIO",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.radioking.com/play/e-kwality-radio/478513",
+      "homepage": "https://e-kwalityradio.com/",
+      "country": "FR",
+      "favicon": "https://e-kwalityradio.com/wp-content/uploads/2023/11/LogoTransp_FondFonce_650x200.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-europa-radio-jazz-sd",
+      "name": "Europa Radio Jazz SD",
+      "broadcaster": "independent",
+      "streamUrl": "https://streams.radiomast.io/e947f0b4-cf71-4ed7-934d-2f4661acb0a3",
+      "homepage": "https://europaradiojazz.org/",
+      "country": "FR",
+      "tags": [
+        "jazz"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-f-hits",
+      "name": "F. HITS",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.fhits.fr:8000/fhits_96.aac",
+      "homepage": "https://www.fhits.fr/",
+      "country": "FR",
+      "favicon": "https://www.fhits.fr/inc/img/FHITS_LOGO.png",
+      "bitrate": 96,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-iaradio-new-wave",
+      "name": "IAradio New Wave",
+      "broadcaster": "independent",
+      "streamUrl": "https://iaradionewwave.ice.infomaniak.ch/iaradionewwave-128.mp3",
+      "homepage": "https://iaradio.eu/",
+      "country": "FR",
+      "tags": [
+        "new wave"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.8534,
+        2.3487
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-le-son-parisien",
+      "name": "Le Son Parisien",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.lesonparisien.com/hi.mp3",
+      "homepage": "https://www.lesonparisien.com/en/",
+      "country": "FR",
+      "favicon": "https://www.lesonparisien.com/images/lsp/logos/le_son_parisien_logo_120x120.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-m40-80s",
+      "name": "M40 80s",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.m40radio.fr/listen/m40-80s/m40-80s-128.mp3",
+      "homepage": "https://m40radio.fr/",
+      "country": "FR",
+      "tags": [
+        "80's"
+      ],
+      "favicon": "https://cdn.m40radio.fr/wp-content/uploads/radio-m40-80s-370x370.webp",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-nova-vintage",
+      "name": "Nova Vintage",
+      "broadcaster": "independent",
+      "streamUrl": "https://nova-vnt.ice.infomaniak.ch/nova-vnt-128.mp3",
+      "homepage": "https://www.nova.fr/radios/nova-classics/",
+      "country": "FR",
+      "favicon": "https://www.nova.fr/wp-content/thumbnails/uploads/sites/2/2021/02/cropped-favicon-t-180x180.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-open-sky-192kbps-mp3-oise",
+      "name": "Open Sky (192kbps mp3, \"OISE\")",
+      "broadcaster": "independent",
+      "streamUrl": "https://audio.opensky.radio:8082/oise",
+      "homepage": "https://opensky.radio/",
+      "country": "FR",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-beton-tours-93-6",
+      "name": "Radio Béton - Tours 93.6",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radiobeton.com:8001/stream.mp3",
+      "homepage": "https://www.radiobeton.com/",
+      "country": "FR",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        47.4144,
+        0.6857
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-lengadoc",
+      "name": "Ràdio Lengadòc",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-ssl.radios-arra.fr:8443/lengadocnarbonne",
+      "homepage": "https://www.lengadoc.eu/",
+      "country": "FR",
+      "favicon": "https://www.lengadoc.eu/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-rdwa",
+      "name": "RDWA",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.aurafm.org/R-Dwa",
+      "homepage": "https://www.rdwa.fr/",
+      "country": "FR",
+      "tags": [
+        "eclectic"
+      ],
+      "favicon": "https://www.aurafm.org/wp-content/uploads/rdwa.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-skylegend",
+      "name": "SKYLEGEND",
+      "broadcaster": "independent",
+      "streamUrl": "https://webradiostream.eu:8200/stream",
+      "homepage": "https://www.skylegend2024.fr/",
+      "country": "FR",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-timbre-fm",
+      "name": "Timbre FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radios.bzh/listen/timbrefm/radio.mp3",
+      "homepage": "https://timbrefm.fr/fr",
+      "country": "FR",
+      "favicon": "https://api.radios.bzh/assets/ff89d84e-f51e-4427-aa00-a5f58a195ee8",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-generations-rap-u-s-gold",
+      "name": "🕺Générations RAP U.S Gold",
+      "broadcaster": "independent",
+      "streamUrl": "https://gene-wr08.ice.infomaniak.ch/gene-wr08.aac",
+      "homepage": "https://www.karibshebdo.info/radios-web/g%C3%A9n%C3%A9rations-rap-u-s-gold",
+      "country": "FR",
+      "tags": [
+        "rap us"
+      ],
+      "favicon": "https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEjIigPaU9oa23mO6Wm0WejrEozwAahxyAgLd2rm2mVCHHYmSUarkXJuygYvhLxjINVfp9ixKvpjAr9RYnnK7KOBaWX9Jbcq6KEo54VbXJ7LekPZyURmnnUg8UlbC17V9OMgDZzNdxSTT7hx1oDDC8BzZwbNxuHJ_cBJ6K9HLd-DrHN2hb8CH9DXgZnt/s1600/Capture%20d%E2%80%99%C3%A9cran_2024-11-18_12-26-34.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-mohammed-ayyub",
+      "name": ".mohammed ayyub",
+      "broadcaster": "independent",
+      "streamUrl": "https://qurango.net/radio/mohammed_ayyub",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "FR",
+      "tags": [
+        "classical"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-c9-radio",
+      "name": "C9 Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.c9.fr/c9radio-192.mp3",
+      "homepage": "https://www.c9.fr/",
+      "country": "FR",
+      "tags": [
+        "dance",
+        "pop",
+        "rock",
+        "talk",
+        "top 40"
+      ],
+      "favicon": "https://www.c9.fr/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        48.851,
+        2.3497
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-elise-radio",
+      "name": "Elise radio ",
+      "broadcaster": "independent",
+      "streamUrl": "https://elise.wanastream.com:25000/;stream.nsv",
+      "homepage": "https://www.eliseradio.com/",
+      "country": "FR",
+      "tags": [
+        "90's",
+        "années 80",
+        "electro",
+        "emission",
+        "jazz",
+        "pop music"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.2478,
+        6.6412
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-france-musique-ocora",
+      "name": "France Musique Ocora",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.radiofrance.fr/francemusiqueocoramonde-midfi.mp3",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-la-grande-evasion",
+      "name": "La grande évasion",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.lagrandeevasion.fr/evasion",
+      "homepage": "https://lagrandeevasion.fr/",
+      "country": "FR",
+      "tags": [
+        "movie",
+        "music"
+      ],
+      "favicon": "https://www.lagrandeevasion.fr/wp-content/themes/gnu/library/fav/favicon-32x32.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-m40",
+      "name": "M40",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.m40radio.fr/listen/m40/m40-128.mp3",
+      "homepage": "https://m40radio.fr/",
+      "country": "FR",
+      "favicon": "https://cdn.m40radio.fr/wp-content/uploads/radio-m40-370x370.webp",
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        46.7436,
+        2.4609
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-platine-45-radio",
+      "name": "Platine 45 Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ecmanager.pro-fhi.net:1710/;",
+      "homepage": "https://www.platine45radio.fr/",
+      "country": "FR",
+      "tags": [
+        "2000s",
+        "80s",
+        "90s",
+        "pop",
+        "rock",
+        "the best of 80's"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        44.1248,
+        4.0891
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-public-sante-generation-seniors",
+      "name": "Public Santé Génération Seniors",
+      "broadcaster": "independent",
+      "streamUrl": "https://publicsantegenerationsenior.ice.infomaniak.ch/publicsantegenerationsenior-192.mp3",
+      "homepage": "https://www.publicsante.com/PLAYER/PLAYERFOFF.php?r=1",
+      "country": "FR",
+      "tags": [
+        "health",
+        "wellness"
+      ],
+      "favicon": "https://www.publicsante.com/LOGO_SENIORS.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-boom-boom",
+      "name": "Radio Boom Boom",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioboomboom.com/listen/rbb/radio.mp3",
+      "homepage": "https://www.radioboomboom.com/",
+      "country": "FR",
+      "tags": [
+        "classical",
+        "dub",
+        "jazz",
+        "pop",
+        "reggae",
+        "rock"
+      ],
+      "favicon": "https://i.ibb.co/9sVFjX6/boomboom400.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        48.8482,
+        2.3504
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-couleur-chartreuse",
+      "name": "Radio Couleur Chartreuse",
+      "broadcaster": "independent",
+      "streamUrl": "https://vps.cbad.fr:8443/rcc",
+      "homepage": "https://www.radiocc.fr/",
+      "country": "FR",
+      "favicon": "https://i0.wp.com/www.radiocc.fr/wp-content/uploads/2024/05/cropped-Logo_RCC_Vert_3_Frequences.png?resize=270%2C270&ssl=1",
+      "codec": "MP3",
+      "geo": [
+        45.3422,
+        5.809
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-grand-lieu",
+      "name": "Radio Grand Lieu",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/377152/stream/427591",
+      "homepage": "https://radiograndlieu.fr/",
+      "country": "FR",
+      "tags": [
+        "eclectic",
+        "regional radio"
+      ],
+      "favicon": "https://radiograndlieu.fr/wp-content/uploads/2021/05/cropped-cropped-radio-grand-lieu_logo_t1-81.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        47.1235,
+        -1.6329
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-vallee-bergerac",
+      "name": "Radio Vallée Bergerac",
+      "broadcaster": "independent",
+      "streamUrl": "https://hosting.studioradiomedia.fr:1755/stream",
+      "homepage": "https://rvb-radio.fr/",
+      "country": "FR",
+      "favicon": "https://rvb-radio.fr/images/br.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-valois-multien",
+      "name": "Radio Valois Multien",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.radio-valois-multien.fr/live.mp3",
+      "homepage": "https://www.radio-valois-multien.fr/",
+      "country": "FR",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-roots-legacy",
+      "name": "Roots Legacy",
+      "broadcaster": "independent",
+      "streamUrl": "https://l.rootslegacy.fr/mp3test",
+      "homepage": "https://rootslegacy.fr/index.html",
+      "country": "FR",
+      "favicon": "https://rootslegacy.fr/favicon.ico",
+      "bitrate": 224,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-saravadio",
+      "name": "Saravadio",
+      "broadcaster": "independent",
+      "streamUrl": "https://manager8.streamradio.fr:3355/stream",
+      "homepage": "https://saravadio.fr/",
+      "country": "FR",
+      "tags": [
+        "alternative / indie"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        50.3662,
+        2.3497
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-veronica-60-s-70-s",
+      "name": "Veronica 60's & 70's",
+      "broadcaster": "independent",
+      "streamUrl": "https://eu1.fastcast4u.com/proxy/veronica?mp=/1",
+      "homepage": "http://veronica.atspace.eu/",
+      "country": "FR",
+      "tags": [
+        "pop rock"
+      ],
+      "favicon": "http://veronica.atspace.eu/images/Slide%20Show/veronica_slide.jpg",
+      "bitrate": 96,
+      "codec": "MP3",
+      "geo": [
+        43.5294,
+        6.7456
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-xiberoko-botza",
+      "name": "Xiberoko Botza",
+      "broadcaster": "independent",
+      "streamUrl": "https://hosting.studioradiomedia.fr:2975/stream",
+      "homepage": "https://xiberokobotza.org/",
+      "country": "FR",
+      "favicon": "https://xiberokobotza.org/images/korporatiboa/xiberobotza_logoa_web-txiki.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        43.2199,
+        -0.8888
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-reccord-latina",
+      "name": "📻 Reccord Latina",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiorecord.hostingradio.ru/latina96.aacp",
+      "homepage": "https://radiosweb.karibshebdo.info/radios-web/reccord-latina",
+      "country": "FR",
+      "tags": [
+        "latino"
+      ],
+      "favicon": "https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEjdJb2y7bqVOTkYUc29lfrzoMrCtu1_-74ZYJlTfpBl648rSQKwsvQz8oK4d1p3UvF334b7ATeVmsnHJpbfPjkVEGveU9SlfPCpROnF8Xk8sn5RH_mxoE5W0DoJnF3QueF7GO_cBzaRHmV3Ffo0_-cYISj7WM_J1_Eu9o5T2H8WlbyjupVtRUq8HiTH/s1600/Capture%20d%E2%80%99%C3%A9cran_2024-12-08_09-23-05.png",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-alouette-indre-et-loire",
+      "name": "ALOUETTE INDRE ET LOIRE",
+      "broadcaster": "independent",
+      "streamUrl": "https://alouette-tours.ice.infomaniak.ch/alouette-tours-128.mp3",
+      "homepage": "https://www.alouette.fr/",
+      "country": "FR",
+      "favicon": "https://www.alouette.fr/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        47.3972,
+        0.7024
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-l-eko",
+      "name": "L'Eko",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.ekodesgarrigues.com/eko-des-garrigues-256k.ogg",
+      "homepage": "http://ekodesgarrigues.com/",
+      "country": "FR",
+      "favicon": "https://www.ekodesgarrigues.com/images/logoeko.jpg",
+      "bitrate": 320,
+      "codec": "OGG",
+      "geo": [
+        43.5942,
+        3.8788
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-la-radio-de-jet",
+      "name": "la radio de Jet",
+      "broadcaster": "independent",
+      "streamUrl": "https://diffusion.lafrap.fr/jetfm.mp3",
+      "homepage": "https://www.jetfm.fr/",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-lars-n",
+      "name": "LARS'N",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.larsn.fr:8443/main",
+      "homepage": "https://radio.larsn.fr/",
+      "country": "FR",
+      "tags": [
+        "documentaries",
+        "local music",
+        "local radio",
+        "musique",
+        "radio associative"
+      ],
+      "codec": "OGG",
+      "geo": [
+        45.2922,
+        3.3835
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-open-sky-128kbps-mp3-hd",
+      "name": "Open Sky (128kbps mp3, \"HD\")",
+      "broadcaster": "independent",
+      "streamUrl": "https://audio.opensky.radio:8082/stream128",
+      "homepage": "https://opensky.radio/",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-puls-radio-trance",
+      "name": "Puls Radio - Trance",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecastlb.pulsradio.com/pulstranceHD.mp3",
+      "homepage": "https://www.pulsradio.com/trance",
+      "country": "FR",
+      "tags": [
+        "electronic",
+        "trance"
+      ],
+      "favicon": "https://www.radio.pl/300/pulsradiotrance.png?version=5f8e49ae10ab7623baa67f8f41b5507c535057d6",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-activ",
+      "name": "radio Activ'",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radios.bzh/hls/radioactiv/live.m3u8",
+      "homepage": "https://www.radio-activ.com/",
+      "country": "FR",
+      "tags": [
+        "all of edm and all of music"
+      ],
+      "favicon": "https://www.radio-activ.com/wp-content/uploads/2025/03/cropped-LOGO-RADIO-ACTIV.png",
+      "bitrate": 52,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-dance-annees-90",
+      "name": "RADIO DANCE années 90",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiodance.streamingmedia.it/fr.aac",
+      "homepage": "https://www.radio.dance/fr",
+      "country": "FR",
+      "tags": [
+        "90s dance",
+        "dance"
+      ],
+      "favicon": "https://www.radio.dance/logo_radiodance90s_512.png",
+      "bitrate": 320,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-fusion",
+      "name": "RADIO FUSION",
+      "broadcaster": "independent",
+      "streamUrl": "https://stunnel2.cyber-streaming.com:9276/stream?type=http&nocache=27045",
+      "homepage": "https://www.radiofusion.fr/",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-rwl",
+      "name": "Radio RWL",
+      "broadcaster": "independent",
+      "streamUrl": "https://ecmanager3.pro-fhi.net:1835/stream",
+      "homepage": "https://radiorwl.fr/",
+      "country": "FR",
+      "tags": [
+        "pop"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        50.9492,
+        1.8649
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-show",
+      "name": "Radio Show",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/22937/stream/63601",
+      "homepage": "http://www.radioshow.fr/",
+      "country": "FR",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-ringard-willycat",
+      "name": "Ringard Willycat",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/441272/stream/495536",
+      "homepage": "https://fr.play.radioking.com/radio/ringard-willycat",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-shadowfr69-radio",
+      "name": "shadowfr69 Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.shadowfr69.eu/mp3",
+      "homepage": "https://shadowfr69.eu/",
+      "country": "FR",
+      "tags": [
+        "japanese anime soundtracks game jpop vgm ost"
+      ],
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-vip-radios-hit-club-dance",
+      "name": "Vip Radios - Hit Club Dance",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio4.vip-radios.fm:18051/stream-128kmp3-HitClubDance",
+      "homepage": "https://radio.vip-radios.fm/",
+      "country": "FR",
+      "tags": [
+        "dance",
+        "electronic",
+        "trance"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-yellow-radio",
+      "name": "Yellow Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://yellowradio.ice.infomaniak.ch/yellowradio.mp3",
+      "homepage": "https://yellow.radio/",
+      "country": "FR",
+      "tags": [
+        "dance",
+        "deep",
+        "electro",
+        "pop"
+      ],
+      "favicon": "https://yellow.radio/Logo_Yellow_Radio_180x180.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        43.7064,
+        7.2613
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-adhan-92100",
+      "name": "Adhan-92100",
+      "broadcaster": "independent",
+      "streamUrl": "https://azuracast-canada.myautodj.com/listen/adhane_92100/radio.mp3",
+      "homepage": "https://tunein.com/radio/Adhan-999-s350855/?lang=fr",
+      "country": "FR",
+      "tags": [
+        "coran",
+        "islam",
+        "islamic religion",
+        "prayer",
+        "prayers",
+        "religion"
+      ],
+      "favicon": "https://cdn-profiles.tunein.com/s350855/images/logod.png?t=639027000500000000",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.8339,
+        2.2457
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-bls-guyane",
+      "name": "BLS GUYANE",
+      "broadcaster": "independent",
+      "streamUrl": "https://servidor15.brlogic.com:7292/live",
+      "homepage": "https://blsguyane.webradiosite.com/",
+      "country": "FR",
+      "favicon": "https://blsguyane.webradiosite.com/",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.8927,
+        1.0107
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-distorsion",
+      "name": "Distorsion",
+      "broadcaster": "independent",
+      "streamUrl": "https://hosting.studioradiomedia.fr:2955/stream",
+      "homepage": "https://www.assodistorsion.fr/la-radio-en-streaming-en-direct/",
+      "country": "FR",
+      "favicon": "https://www.assodistorsion.fr/wp-content/uploads/2022/10/cropped-Banniere-1024x267.png",
+      "bitrate": 140,
+      "codec": "MP3",
+      "geo": [
+        43.6454,
+        0.5866
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-iaradio-metal",
+      "name": "IAradio Metal",
+      "broadcaster": "independent",
+      "streamUrl": "https://iaradiometal.ice.infomaniak.ch/iaradiometal-128.mp3",
+      "homepage": "https://iaradio.eu/",
+      "country": "FR",
+      "tags": [
+        "metal"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.8533,
+        2.3488
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-iaradio-world-music",
+      "name": "IAradio World music",
+      "broadcaster": "independent",
+      "streamUrl": "https://iaradioworldmusic.ice.infomaniak.ch/iaradioworldmusic-128.mp3",
+      "homepage": "https://iaradio.eu/",
+      "country": "FR",
+      "tags": [
+        "world music"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.8533,
+        2.3487
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-m40-by-oskana",
+      "name": "M40 by Oskana",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.m40radio.fr/listen/m40-by-oskana/m40-by-oskana-128.mp3",
+      "homepage": "https://m40radio.fr/",
+      "country": "FR",
+      "tags": [
+        "dance"
+      ],
+      "favicon": "https://cdn.m40radio.fr/wp-content/uploads/favicon-100x100.webp",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-m40-fiesta",
+      "name": "M40 Fiesta",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.m40radio.fr/listen/m40-fiesta/m40-fiesta-128.mp3",
+      "homepage": "https://m40radio.fr/",
+      "country": "FR",
+      "tags": [
+        "fiesta"
+      ],
+      "favicon": "https://cdn.m40radio.fr/wp-content/uploads/radio-m40-fiesta-370x370.webp",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-maritima-radio",
+      "name": "Maritima Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://maritima936.ice.infomaniak.ch/maritima936-128.mp3",
+      "homepage": "https://maritima.fr/radio",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        43.278,
+        5.4492
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-mixfeever",
+      "name": "MixFeever",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.mixfeever.com/feevermix",
+      "homepage": "https://www.mixfeever.com/",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-nrj-beauvais",
+      "name": "NRJ Beauvais",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.nrjaudio.fm/ouamuxw2dqao",
+      "homepage": "https://www.nrj.fr/",
+      "country": "FR",
+      "favicon": "https://www.nrj.fr/uploads/assets/nrj/favicon.png",
+      "bitrate": 128,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-ods-radio-rock",
+      "name": "ODS Radio Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://ods-rock.ice.infomaniak.ch/ods-rock.mp3",
+      "homepage": "https://www.odsradio.com/radio/webradio/23/ods-radio-rock",
+      "country": "FR",
+      "tags": [
+        "alternative rock",
+        "indie rock",
+        "pop rock",
+        "rock",
+        "soft rock"
+      ],
+      "favicon": "https://www.odsradio.com/media/radio/thumb/360x360_691f2bc5851bf-plan-de-travail-1.webp",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        45.8985,
+        6.1261
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-public-health-radio-italiano",
+      "name": "Public Health Radio Italiano",
+      "broadcaster": "independent",
+      "streamUrl": "https://publichealthradioit.ice.infomaniak.ch/publichealthradioit-128.mp3",
+      "homepage": "https://www.publicsante.com/",
+      "country": "FR",
+      "tags": [
+        "health"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.8533,
+        2.3488
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-scoop-clermont",
+      "name": "Radio SCOOP - Clermont",
+      "broadcaster": "independent",
+      "streamUrl": "https://radioscoopclermont-ferrand.ice.infomaniak.ch/radioscoop-clermont-64.aac",
+      "homepage": "https://www.radioscoop.com/",
+      "country": "FR",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-val-d-or-rvo",
+      "name": "Radio Val d'Or - RVO",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream3.vestaradio.com/RADIOVALDOR?nocache=34033",
+      "homepage": "https://www.radiovaldor.com/",
+      "country": "FR",
+      "favicon": "https://www.radiovaldor.com/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        46.8242,
+        -0.1401
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-rcb",
+      "name": "RCB",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio12.pro-fhi.net/radio/9013/stream.mp3",
+      "homepage": "https://www.radiorcb.net/",
+      "country": "FR",
+      "favicon": "https://assets.zyrosite.com/cdn-cgi/image/format=auto,w=450,fit=crop,q=95/AwvLXg02pQhzqaMQ/cropped-logo-rcb-transparent-web-redimensionna-c-e-A3QEZ6BJlKFnx09B.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        48.4785,
+        7.2159
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-rdwa-luc",
+      "name": "RDWA Luc",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.aurafm.org/R-Dwa-LUC",
+      "homepage": "https://www.rdwa.fr/",
+      "country": "FR",
+      "tags": [
+        "dub",
+        "eclectic",
+        "electronic",
+        "funk",
+        "jazz",
+        "reggae"
+      ],
+      "favicon": "https://www.aurafm.org/wp-content/uploads/rdwa.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        44.7535,
+        5.3694
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-supernana",
+      "name": "Supernana",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiosurle.net:8765/showsupernana",
+      "homepage": "https://www.show-supernana.com/",
+      "country": "FR",
+      "tags": [
+        "talk show"
+      ],
+      "bitrate": 96,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-terre-marine-fm",
+      "name": "Terre Marine FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio3.pro-fhi.net:19045/stream",
+      "homepage": "https://www.terremarinefm.com/",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-toulouse-fm",
+      "name": "Toulouse FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://n32a-eu.rcs.revma.com/1x41712gy7uvv",
+      "homepage": "https://toulousefm.fr/",
+      "country": "FR",
+      "tags": [
+        "2000's",
+        "2000s",
+        "2010",
+        "2010's",
+        "2010s",
+        "2020"
+      ],
+      "favicon": "https://medias.preprod.bocir.fr/t:app(web)/t:r(unknown)/fit-in/300x2000/filters:format(webp)/filters:quality(100)/radios/toulousefm/images/logo_kQmQJ1D8OB.png",
+      "codec": "MP3",
+      "geo": [
+        43.5714,
+        1.425
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-100-radio-carcassonne",
+      "name": "100% Radio Carcassonne",
+      "broadcaster": "independent",
+      "streamUrl": "https://100radio-carcassonne.ice.infomaniak.ch/100radio-carcassonne-128.mp3",
+      "homepage": "https://www.centpourcent.com/",
+      "country": "FR",
+      "tags": [
+        "hot adult contemporary",
+        "pop"
+      ],
+      "favicon": "https://images.lesindesradios.fr/fit-in/300x2000/filters:format(webp)/filters:quality(100)/radios/centpourcent/images/logo_HuGMY5WoOm.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        43.5097,
+        2.37
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-agora-cote-d-azur",
+      "name": "AGORA CÔTE D’AZUR",
+      "broadcaster": "independent",
+      "streamUrl": "https://agoracotedazur.ice.infomaniak.ch/agoracotedazur.mp3",
+      "homepage": "https://www.agoracotedazur.fr/",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-h2o-lac-d-annecy",
+      "name": "H2O Lac d'Annecy",
+      "broadcaster": "independent",
+      "streamUrl": "https://h2oradio.net-radio.fr/h2oradio-256.mp3",
+      "homepage": "http://www.h2oradio.fr/index.php",
+      "country": "FR",
+      "favicon": "http://www.h2oradio.fr/assets/img/basic/b2_lac.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-helia",
+      "name": "Helia",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.heliaradios.fr/listen/helia/radio.mp3",
+      "homepage": "https://heliaradios.fr/players/helia",
+      "country": "FR",
+      "favicon": "https://heliaradios.fr/wp-content/uploads/2022/10/helia-radios-2024-clr.png",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-hit53",
+      "name": "Hit53",
+      "broadcaster": "independent",
+      "streamUrl": "https://azura.hit53.fr/hit128.mp3",
+      "homepage": "https://hit53.fr/",
+      "country": "FR",
+      "tags": [
+        "contemporary hits",
+        "dance",
+        "electro",
+        "pop"
+      ],
+      "favicon": "https://hit53.fr/favicon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.0697,
+        -0.7721
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-hits-1-cognac",
+      "name": "Hits 1 Cognac",
+      "broadcaster": "independent",
+      "streamUrl": "https://hits1cognac-audiomediaradio.radioca.st/hits1cognac",
+      "homepage": "https://www.hits1radio.com/",
+      "country": "FR",
+      "tags": [
+        "dance",
+        "dj",
+        "dj sets",
+        "edm",
+        "electronic",
+        "hits"
+      ],
+      "favicon": "https://www.hits1radio.com/wp-content/uploads/2019/03/dummy-e1554135926529.jpg",
+      "bitrate": 256,
+      "codec": "MP3",
+      "geo": [
+        45.7079,
+        -0.3234
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-horizon-la-radio-libre-100-9fm",
+      "name": "Horizon la radio libre 100.9fm",
+      "broadcaster": "independent",
+      "streamUrl": "https://horizonlaradiolibre.ice.infomaniak.ch/horizonlaradiolibre-128.mp3",
+      "homepage": "https://www.horizon-fm.fr/",
+      "country": "FR",
+      "tags": [
+        "local news",
+        "pop music"
+      ],
+      "favicon": "https://horizon-fm.fr/wp-content/uploads/2015/03/logoanimeRouge.gif",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        49.53,
+        0.9331
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-ma",
+      "name": "ma",
+      "broadcaster": "independent",
+      "streamUrl": "https://rfimandingue64k.ice.infomaniak.ch/rfimandingue-64k.mp3",
+      "homepage": "https://rfimandingue64k.ice.infomaniak.ch/rfimandingue-64k.mp3",
+      "country": "FR",
+      "tags": [
+        "info"
+      ],
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-odc-live",
+      "name": "ODC Live",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.zest.radio/radio/8000/radio.mp3",
+      "homepage": "https://zest.radio/",
+      "country": "FR",
+      "tags": [
+        "electronic"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-fuori-campo",
+      "name": "Radio Fuori Campo",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/397948/stream/449947",
+      "homepage": "https://www.radiofuoricampo.com/",
+      "country": "FR",
+      "tags": [
+        "culture",
+        "italian",
+        "multicultural"
+      ],
+      "favicon": "https://www.radiofuoricampo.com/upload/60a6b1ff356589.85028903.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        45.7628,
+        4.8807
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-lenga-d-oc",
+      "name": "Radio lenga d'Oc",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-ssl.radios-arra.fr:8443/rlo",
+      "homepage": "http://radiolengadoc.com/",
+      "country": "FR",
+      "favicon": "https://radiolengadoc.com/wp-content/themes/radiolengadoc/template-parts/header/logo-rlo/LOGO-RLO_CARNAVAL.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-scoop-bourg",
+      "name": "Radio SCOOP - Bourg",
+      "broadcaster": "independent",
+      "streamUrl": "https://radioscoopbourg-en-bresse.ice.infomaniak.ch/radioscoop-bourg-64.aac",
+      "homepage": "https://www.radioscoop.com/",
+      "country": "FR",
+      "favicon": "https://www.radioscoop.com/favicon.ico",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-scoop-stetienne",
+      "name": "Radio SCOOP - StEtienne",
+      "broadcaster": "independent",
+      "streamUrl": "https://radioscoopsaintetienne.ice.infomaniak.ch/radioscoop-stetienne-64.aac",
+      "homepage": "https://www.radioscoop.com/",
+      "country": "FR",
+      "favicon": "https://www.radioscoop.com/favicon.ico",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-top-side",
+      "name": "Radio Top Side",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/33560/stream/275656",
+      "homepage": "https://www.radiotopside.com/",
+      "country": "FR",
+      "tags": [
+        "local",
+        "local news",
+        "local radio",
+        "pop",
+        "pop music",
+        "pop rock"
+      ],
+      "favicon": "https://www.radiotopside.com/upload/design/6446351012a075.09916797.jpeg",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        43.7753,
+        7.5031
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-rlocale-radio",
+      "name": "Rlocale Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://rlocale.org/listen/rlocale//rlocale-128k.aac",
+      "homepage": "https://rlocale.fr/",
+      "country": "FR",
+      "favicon": "https://rlocale.fr/wp-content/uploads/2023/11/cropped-logo-rlocale-245x245-1-180x180.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-soulbox",
+      "name": "Soulbox",
+      "broadcaster": "independent",
+      "streamUrl": "https://eu1.fastcast4u.com/proxy/soulbox?mp=/1",
+      "homepage": "http://soulbox.legtux.org/",
+      "country": "FR",
+      "bitrate": 96,
+      "codec": "MP3",
+      "geo": [
+        44.2893,
+        3.5156
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-clapas-jazz",
+      "name": "Clapas Jazz",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radioclapas.fr/listen/clapas_jazz/radio.mp3",
+      "homepage": "https://www.radioclapas.fr/#",
+      "country": "FR",
+      "favicon": "https://www.radioclapas.fr/player/jazz.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        43.6121,
+        3.8845
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-cote-sud-fm",
+      "name": "COTE SUD FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://sd-151888.dedibox.fr/proxy/cotesud/csfm",
+      "homepage": "https://www.cotesudfm.fr/",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-divergence-fm",
+      "name": "Divergence FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.divergence-fm.org:8001/divergence.mp3",
+      "homepage": "https://divergence-fm.org/",
+      "country": "FR",
+      "favicon": "https://upload.wikimedia.org/wikipedia/fr/6/6d/Logo_Divergence-FM.jpg",
+      "bitrate": 256,
+      "codec": "MP3",
+      "geo": [
+        43.6127,
+        3.8788
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-frequence-sille",
+      "name": "Fréquence Sillé",
+      "broadcaster": "independent",
+      "streamUrl": "https://stric6.streamakaci.com/frequencesille.mp3",
+      "homepage": "https://frequence-sille.org/",
+      "country": "FR",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-globule-radio",
+      "name": "Globule Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://905.ice.infomaniak.ch/905-128.mp3",
+      "homepage": "https://globule.chamonix.radio/",
+      "country": "FR",
+      "favicon": "https://globule.chamonix.radio/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        45.9263,
+        6.8716
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-hotmixradio-frenchy",
+      "name": "Hotmixradio frenchy ",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.hotmixradio.com/hotmix-frenchy-fr-mp3?",
+      "homepage": "https://hotmixradio.com/en",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-iaradio-classique",
+      "name": "IAradio Classique",
+      "broadcaster": "independent",
+      "streamUrl": "https://iaradioclassique.ice.infomaniak.ch/iaradioclassique-128.mp3",
+      "homepage": "https://iaradio.eu/",
+      "country": "FR",
+      "tags": [
+        "classic"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.8534,
+        2.3488
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-iaradio-dance-house",
+      "name": "IAradio Dance House",
+      "broadcaster": "independent",
+      "streamUrl": "https://iaradiodance.ice.infomaniak.ch/iaradiodance-128.mp3",
+      "homepage": "https://iaradio.eu/",
+      "country": "FR",
+      "tags": [
+        "dance",
+        "house"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.8534,
+        2.3488
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-iaradio-disco-funk",
+      "name": "IAradio Disco Funk",
+      "broadcaster": "independent",
+      "streamUrl": "https://iaradiodisco.ice.infomaniak.ch/iaradiodisco-128.mp3",
+      "homepage": "https://iaradio.eu/",
+      "country": "FR",
+      "tags": [
+        "disco funk"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.8534,
+        2.3487
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-ici-picardie",
+      "name": "ICI Picardie",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radiofrance.fr/fbpicardie/fbpicardie_lofi.m3u8",
+      "homepage": "https://www.francebleu.fr/radio/picardie",
+      "country": "FR",
+      "favicon": "https://france3-regions.francetvinfo.fr/image/thQ-APUfopLbhRQ-a29GfT_Hmb8/1398x819/regions/2024/11/04/capture-6728a8716f4ef458287475.jpg",
+      "codec": "UNKNOWN",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-mix-machine-radio",
+      "name": "Mix Machine Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://a6.asurahosting.com:7520/radio.mp3",
+      "homepage": "https://www.mixmachine.fr/",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-ola-radio",
+      "name": "Ola Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ola-radio.radiocult.fm/stream",
+      "homepage": "https://www.olaradio.fr/",
+      "country": "FR",
+      "favicon": "https://www.olaradio.fr/favicon.ico",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-oz-fm",
+      "name": "OZ FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://ozfm.streamb.live/SB00174?ver=460097",
+      "homepage": "https://ozfm.com/",
+      "country": "FR",
+      "favicon": "https://ozfm.com/wp-content/uploads/2023/07/OZFM.retro_.png",
+      "bitrate": 96,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-public-sante-sexo",
+      "name": "Public Santé Sexo",
+      "broadcaster": "independent",
+      "streamUrl": "https://publicsantesexo.ice.infomaniak.ch/publicsantesexo-192.mp3",
+      "homepage": "https://www.publicsante.com/",
+      "country": "FR",
+      "tags": [
+        "santé",
+        "sexo"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        48.8534,
+        2.3488
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-contact",
+      "name": "Radio Contact",
+      "broadcaster": "independent",
+      "streamUrl": "https://n22a-eu.rcs.revma.com/6gygqc1gy7uvv",
+      "homepage": "https://radiocontact.fr/",
+      "country": "FR",
+      "tags": [
+        "chanson française",
+        "chansons françaises",
+        "france",
+        "francophone",
+        "french",
+        "french chansons"
+      ],
+      "favicon": "https://medias.lesindesradios.fr/t:app(web)/t:r(unknown)/fit-in/300x2000/filters:format(webp)/filters:quality(100)/radios/contactfm/images/logo_dBRvfZGGAL.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-fatx",
+      "name": "Radio FATX",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.fatx.fr/radio_fatx",
+      "homepage": "https://www.fatx.fr/",
+      "country": "FR",
+      "tags": [
+        "80s",
+        "90s"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-fg-underground",
+      "name": "Radio FG Underground",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiofg.impek.com/ufg.mp3",
+      "homepage": "https://www.radiofg.com/",
+      "country": "FR",
+      "tags": [
+        "electronic dance music",
+        "underground"
+      ],
+      "favicon": "https://www.lawebradio.com/news/wp-content/uploads/2017/10/ima2-fgradio-undrgrnd-102017.jpg",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-gandharva-gana",
+      "name": "Radio Gandharva Gana",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/45994/stream/82780",
+      "homepage": "https://www.rggweb.fr/",
+      "country": "FR",
+      "favicon": "https://image.jimcdn.com/app/cms/image/transf/dimension=785x10000:format=jpg/path/s9008a6e38990bd8e/image/id0a55168bf28da62/version/1681464442/image.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-gresivaudan",
+      "name": "Radio Grésivaudan",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.aurafm.org/Radio-Gresivaudan",
+      "homepage": "https://www.radio-gresivaudan.org/",
+      "country": "FR",
+      "tags": [
+        "local news",
+        "local radio"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        45.51,
+        5.7774
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-media-antilles-le-son-des-iles",
+      "name": "Radio Media Antilles - Le Son Des Iles",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio3.pro-fhi.net/listen/pzjdzjjq/stream.mp3",
+      "homepage": "https://www.radiomediaantilles.com/",
+      "country": "FR",
+      "tags": [
+        "bucaramanga",
+        "tropical music",
+        "zouk"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-new-s-fm",
+      "name": "Radio New's FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.aurafm.org/RadioNewsFM",
+      "homepage": "https://www.radio-newsfm.com/",
+      "country": "FR",
+      "favicon": "https://www.radio-newsfm.com/wp-content/uploads/2020/09/Logo-Newsfm-1.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-nunc",
+      "name": "Radio Nunc",
+      "broadcaster": "independent",
+      "streamUrl": "https://diffusion.radionunc.org:8443/stream",
+      "homepage": "https://radionunc.org/",
+      "country": "FR",
+      "tags": [
+        "field recording"
+      ],
+      "bitrate": 96,
+      "codec": "MP3",
+      "geo": [
+        43.2929,
+        5.3891
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-zig-zag-pays-de-romans",
+      "name": "Radio Zig Zag - Pays de Romans",
+      "broadcaster": "independent",
+      "streamUrl": "https://zig.syndicastream.fr:8443/stream",
+      "homepage": "https://www.radiozigzag.com/",
+      "country": "FR",
+      "tags": [
+        "local",
+        "local radio",
+        "pop",
+        "pop music",
+        "pop rock"
+      ],
+      "favicon": "https://www.radiozigzag.com/upload/players/5e8c9be47883d0.52483364.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        45.0467,
+        5.0522
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radiovino",
+      "name": "RadioVino",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/40700/stream/77213",
+      "homepage": "https://www.radiovino.fr/",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-rci-martinique",
+      "name": "RCI Martinique",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rcs.revma.com/t0abpqyspwzuv",
+      "homepage": "https://rci.fm/martinique",
+      "country": "FR",
+      "tags": [
+        "caribbean",
+        "caribbean music",
+        "konpa",
+        "local news",
+        "zouk"
+      ],
+      "favicon": "https://rci.fm/sites/default/files/webradio/radiomartinique.png",
+      "codec": "MP3",
+      "geo": [
+        14.6219,
+        -61.04
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-replay-news-eco-francais",
+      "name": "REPLAY NEWS - Eco (Français)",
+      "broadcaster": "independent",
+      "streamUrl": "https://replaynewseco.ice.infomaniak.ch/replaynewseco-128.mp3",
+      "homepage": "https://www.replaynews.net/",
+      "country": "FR",
+      "tags": [
+        "economic news",
+        "economics",
+        "news"
+      ],
+      "favicon": "https://www.publicsante.com/BIENVENU/LOGO%20REPLAY%20NEWS%20ECO.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-rtvfm",
+      "name": "RTVFM",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.vestaradio.com/RTVFM",
+      "homepage": "https://www.rtvfm.net/",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-sun-radio-bar",
+      "name": "Sun Radio Bar",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio2.vip-radios.fm:18065/stream-128kmp3-BarSoulside",
+      "homepage": "https://www.vip-radios.fm/",
+      "country": "FR",
+      "tags": [
+        "deep",
+        "groove",
+        "nu disco"
+      ],
+      "favicon": "https://www.vip-radios.fm/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        45.5341,
+        3.1641
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-the-lounge-hour",
+      "name": "The Lounge Hour",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen2.streamaudio.co/stream/8056",
+      "homepage": "https://theloungehour.netlify.app/",
+      "country": "FR",
+      "tags": [
+        "calm",
+        "chillout",
+        "instrumental music",
+        "jazz",
+        "lounge",
+        "smooth jazz"
+      ],
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-villages-fm",
+      "name": "Villages FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream3.vestaradio.com/VILLAGESFM",
+      "homepage": "https://www.villagesfm.com/",
+      "country": "FR",
+      "favicon": "https://www.villagesfm.com/wp-content/uploads/2023/12/logo-villagesFM-980x576.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-klm-fm",
+      "name": "📻 KLM FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://us3new.listen2myradio.com:2199/listen.php?port=8117",
+      "homepage": "https://radiosweb.karibshebdo.info/radios-web/klm-fm",
+      "country": "FR",
+      "tags": [
+        "kompa",
+        "konpa"
+      ],
+      "favicon": "https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEjTw3lsCbI8ZcwYsEss5GhURlItGfxXLAeI0kDc5D_dOyc_yS8XrLoPJaUy8wlvdJem90NpWW65skgJCwlSCtBWaGH3Mw7CIm3F1PlaKvimGM2skZIUutxYWplI8wG-emyVONIMby2rc8IfAc017YEs3RWwwFdXpUFqONUABApu3JL36HW3lgJ5ubhL/s1600/Capture%20d%E2%80%99%C3%A9cran_2024-12-12_11-09-39.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-generations-west-indies",
+      "name": "🕺Générations West Indies",
+      "broadcaster": "independent",
+      "streamUrl": "https://generationswestindies.ice.infomaniak.ch/generations-westindies.aac",
+      "homepage": "https://www.karibshebdo.info/radios-web/g%C3%A9n%C3%A9rations-west-indies",
+      "country": "FR",
+      "favicon": "https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEhiFozjJWY-tZRSm8l1R7JyIRiXTBa1ErIgz5b9B8xti42-yyi_jh9f23snj8vitHJ2pjz0ELbL54TGzgWvXMHpy6ILH1mri0yUZUWtsul-QIlPyocgNWFy7y10qRxg3BSwLO8uQNXBr150GiSDyYPyGoLdiZFP4WZ8tdr5IzgEOxxjGtFM_yvzT633/s1600/Capture%20d%E2%80%99%C3%A9cran_2024-11-18_12-56-44.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-4u-hard-fm",
+      "name": "4U Hard FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.4uradios.com/4uhardfm.mp3",
+      "homepage": "https://www.4uradios.com/hard-fm/",
+      "country": "FR",
+      "tags": [
+        "hard rock heavy metal"
+      ],
+      "favicon": "https://www.4uradios.com/images/4uhardfm.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-crazy-radio",
+      "name": "Crazy Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio10.pro-fhi.net/flux-bphdrtog/stream?1722411025208",
+      "homepage": "https://www.crazyradio.fr/",
+      "country": "FR",
+      "favicon": "https://www.crazyradio.fr/wp-content/uploads/2020/10/Suivez-Sportissimeaux-01-300x122.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-f-hits-classics",
+      "name": "F. HITS Classics",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.fhits.fr:8014/fhits_classics_96.aac",
+      "homepage": "https://www.fhits.fr/",
+      "country": "FR",
+      "bitrate": 96,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-franceinfo-aac-lofi",
+      "name": "franceinfo aac lofi",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.radiofrance.fr/franceinfo-lofi.aac",
+      "homepage": "https://icecast.radiofrance.fr/franceinfo-lofi.aac",
+      "country": "FR",
+      "tags": [
+        "news"
+      ],
+      "bitrate": 32,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-iaradio-jazz",
+      "name": "IAradio Jazz",
+      "broadcaster": "independent",
+      "streamUrl": "https://iaradiojazz.ice.infomaniak.ch/iaradiojazz-128.mp3",
+      "homepage": "https://iaradio.eu/",
+      "country": "FR",
+      "tags": [
+        "jazz"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.8533,
+        2.3487
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-iaradio-slow-crooner",
+      "name": "IAradio Slow & Crooner",
+      "broadcaster": "independent",
+      "streamUrl": "https://iaradioslowcrooner.ice.infomaniak.ch/iaradioslowcrooner-128.mp3",
+      "homepage": "https://iaradio.eu/",
+      "country": "FR",
+      "tags": [
+        "crooner",
+        "slow"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.8534,
+        2.3488
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-identite-radio",
+      "name": "Identité radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/26860/stream/59584",
+      "homepage": "https://identiteradio.com/",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-in2-mix-fr",
+      "name": "In2 Mix FR",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/384/stream/1613",
+      "homepage": "https://in2mixxradio.com/",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-la-radio-des-artistes-oublies",
+      "name": "La Radio Des Artistes Oubliés",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-179.zeno.fm/hg9eg9q5quzuv?zt=eyJhbGciOiJIUzI1NiJ9.eyJzdHJlYW0iOiJoZzllZzlxNXF1enV2IiwiaG9zdCI6InN0cmVhbS0xNzkuemVuby5mbSIsInRtIjpmYWxzZSwicnR0bCI6NSwianRpIjoiNk1IbmR3V29Td0dRVzhGUUkwME1iQSIsImlhdCI6MTc2ODQ1ODU0MywiZXhwIjoxNzY4NDU4NjAzfQ.SZ9a15333MeMXeGDqwTCEKtPvQpV57TgK4Wl3j6PyH4",
+      "homepage": "https://onlineradiobox.com/fr/desartistesoublies",
+      "country": "FR",
+      "tags": [
+        "alternative",
+        "pop"
+      ],
+      "codec": "MP3",
+      "geo": [
+        43.9152,
+        5.9236
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-latitude",
+      "name": "Latitude",
+      "broadcaster": "independent",
+      "streamUrl": "https://latitude.ice.infomaniak.ch/troyes.aac",
+      "homepage": "https://latitude.fm/",
+      "country": "FR",
+      "tags": [
+        "dance",
+        "pop dance",
+        "pop music",
+        "top40"
+      ],
+      "favicon": "https://www.latitude.fm/wp-content/uploads/2020/09/favicon.jpg",
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-live-nation-radio",
+      "name": "Live Nation Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://livenationradio.ice.infomaniak.ch/livenationradio-midfi.mp3",
+      "homepage": "https://www.livenation.fr/radio",
+      "country": "FR",
+      "tags": [
+        "pop"
+      ],
+      "favicon": "https://networksites.livenationinternational.com/networksites/qlnlvvtn/ln-radio-stacked-4.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-m40-rai",
+      "name": "M40 Raî",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.m40radio.fr/listen/m40-rai/m40-rai-128.mp3",
+      "homepage": "https://m40radio.fr/",
+      "country": "FR",
+      "tags": [
+        "rai"
+      ],
+      "favicon": "https://cdn.m40radio.fr/wp-content/uploads/radio-m40-rai-370x370.webp",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-nrj-bruno-mars",
+      "name": "NRJ BRUNO MARS",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.nrjaudio.fm/ouycwb36zcw2?origine=playernrj&aw_0_req.userConsentV2=&aw_0_1st.station=",
+      "homepage": "https://www.nrj.fr/webradios/mur-des-radios",
+      "country": "FR",
+      "tags": [
+        "bruno mars"
+      ],
+      "favicon": "https://static.mytuner.mobi/media/tvos_radios/399/nrj-bruno-mars.eb7a1976.jpg",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-power-maxx",
+      "name": "POWER MAXX",
+      "broadcaster": "independent",
+      "streamUrl": "https://sr3.publicssl.net/srv/7016/stream",
+      "homepage": "https://onlineradiobox.com/fr/powermaxx/?lang=en&p=5",
+      "country": "FR",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/4/76854.v16.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-proxi-radio",
+      "name": "Proxi Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://hosting.studioradiomedia.fr:2390/stream",
+      "homepage": "https://www.proxiradio.eu/",
+      "country": "FR",
+      "tags": [
+        "hits",
+        "pop"
+      ],
+      "favicon": "https://www.proxiradio.eu/favicon.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-public-health-radio-espanol",
+      "name": "Public Health Radio Espanol",
+      "broadcaster": "independent",
+      "streamUrl": "https://publichealthradioes.ice.infomaniak.ch/publichealthradioes-128.mp3",
+      "homepage": "https://www.publicsante.com/",
+      "country": "FR",
+      "tags": [
+        "health"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.8533,
+        2.3488
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-public-sante-detente",
+      "name": "Public Sante Detente",
+      "broadcaster": "independent",
+      "streamUrl": "https://publicsantedetente.ice.infomaniak.ch/publicsantedetente-192.mp3",
+      "homepage": "https://www.publicsante.com/",
+      "country": "FR",
+      "tags": [
+        "santé"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        48.8533,
+        2.3488
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-public-sante-loisirs-sports",
+      "name": "Public Santé Loisirs & Sports",
+      "broadcaster": "independent",
+      "streamUrl": "https://publicsanteloisirssports.ice.infomaniak.ch/publicsanteloisirssports-192.mp3",
+      "homepage": "https://www.publicsante.com/",
+      "country": "FR",
+      "tags": [
+        "loisirs",
+        "santé",
+        "sport"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        48.8533,
+        2.3486
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-public-sante-nutri-conso",
+      "name": "Public Santé Nutri Conso",
+      "broadcaster": "independent",
+      "streamUrl": "https://publicsantenutri-conso.ice.infomaniak.ch/publicsantenutri-conso-192.mp3",
+      "homepage": "https://www.publicsante.com/",
+      "country": "FR",
+      "tags": [
+        "conso",
+        "nutri",
+        "santé"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        48.8533,
+        2.3487
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-capsule",
+      "name": "Radio Capsule",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiocapsule.com/radio/radio320.mp3",
+      "homepage": "https://radiocapsule.com/",
+      "country": "FR",
+      "tags": [
+        "electronica"
+      ],
+      "favicon": "https://radiocapsule.com/images/logo_capsule_transparent_320.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-club-105-7fm",
+      "name": "RADIO CLUB 105.7FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://stunnel1.cyber-streaming.com:9128/listen.mp3",
+      "homepage": "https://radioclub.fr/wp-admin/",
+      "country": "FR",
+      "favicon": "https://radioclub.fr/wp-content/uploads/2024/08/cropped-269965503_533759981882903_4768925474557172552_n-270x270.jpg",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-disney-paris",
+      "name": "Radio Disney Paris",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-176.zeno.fm/ks5wfxkubv8uv?zt=eyJhbGciOiJIUzI1NiJ9.eyJzdHJlYW0iOiJrczV3ZnhrdWJ2OHV2IiwiaG9zdCI6InN0cmVhbS0xNzYuemVuby5mbSIsInJ0dGwiOjUsImp0aSI6IkVJTkxJclhkVEMtSEZHSzZFWS1iQVEiLCJpYXQiOjE3NzI3MDE4NDQsImV4cCI6MTc3MjcwMTkwNH0.QREohi8XJgDrhW8gOyF6uCpTTT6L-MOCMR6KO44intw",
+      "homepage": "https://zeno.fm/radio/radio-disney-paris",
+      "country": "FR",
+      "favicon": "https://res.cloudinary.com/dfuxhgkej/image/upload/v1772702338/aHR0cHM6Ly9wcm94eS56ZW5vLmZtL2NvbnRlbnQvc3RhdGlvbnMvYWd4emZucGxibTh0YzNSaGRITnlNZ3NTQ2tGMWRHaERiR2xsYm5RWWdJQ3drb1BwekFvTUN4SU9VM1JoZEdsdmJsQnliMlpwYkdVWWdJQ3dzdmpVdEFnTW9nRUVlbVZ1YncvaW1hZ2UvP3U9MTY2MTM1MDE3NjAwM_xzvuqi.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-dunes",
+      "name": "Radio Dunes",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rcast.net/62863",
+      "homepage": "https://radiodunes.com/",
+      "country": "FR",
+      "favicon": "https://radiodunes.com/wp-content/uploads/2021/05/cropped-logo-dunes.jpg",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-echo-des-choucas-rec",
+      "name": "Radio Echo des Choucas (REC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://hosting.radiomedia.fr:2005/stream",
+      "homepage": "https://radiorec.fr/",
+      "country": "FR",
+      "tags": [
+        "french chansons",
+        "french music",
+        "jazz"
+      ],
+      "favicon": "https://radiorec.fr/wp-content/uploads/2025/03/cropped-logo-REC-2024-1-32x32.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        46.5701,
+        0.6489
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-galaxie-31",
+      "name": "Radio Galaxie 31",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-ssl.radios-arra.fr:8443/radiogalaxie",
+      "homepage": "https://radiogalaxie31.com/",
+      "country": "FR",
+      "favicon": "https://radiogalaxie31.com/wp-content/uploads/Site/Commun/RGalaxie.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-gresivaudan-chambery",
+      "name": "Radio Gresivaudan Chambery",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.aurafm.org/Radio-Gresivaudan-Chambery",
+      "homepage": "https://www.radio-gresivaudan.org/",
+      "country": "FR",
+      "favicon": "https://www.radio-gresivaudan.org/wp-content/uploads/2024/02/cropped-New_Logo-Photoroom.png-Photoroom-768x284.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-scarpe-sensee",
+      "name": "Radio Scarpe Sensée",
+      "broadcaster": "independent",
+      "streamUrl": "https://radioscarpe.ice.infomaniak.ch/radioscarpe-128.mp3",
+      "homepage": "https://radioscarpesensee.com/",
+      "country": "FR",
+      "favicon": "https://radioscarpesensee.com/index/wp-content/uploads/cropped-logo-scarpe-200x200.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-scoop-roanne",
+      "name": "Radio SCOOP - Roanne",
+      "broadcaster": "independent",
+      "streamUrl": "https://radioscooproanne.ice.infomaniak.ch/radioscoop-roanne-64.aac",
+      "homepage": "https://www.radioscoop.com/",
+      "country": "FR",
+      "favicon": "https://www.radioscoop.com/dyn/img.php?id=506831.jpg&w=512&h=512",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-tou-caen",
+      "name": "RADIO TOU'CAEN",
+      "broadcaster": "independent",
+      "streamUrl": "https://str0.creacast.com/direct-toucaen",
+      "homepage": "https://radio-toucaen.fr/",
+      "country": "FR",
+      "tags": [
+        "caen"
+      ],
+      "favicon": "https://radio-toucaen.fr/wp-content/themes/radiotoucaen/img/logo-player-toucaen.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        49.2038,
+        -0.3798
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-sing-sing",
+      "name": "Sing Sing",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.sing-sing-bis.org:8443/singsingaac128",
+      "homepage": "https://www.sing-sing-bis.org/index.php",
+      "country": "FR",
+      "favicon": "https://www.sing-sing-bis.org/navi/images/haut.gif",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-tikka-radio",
+      "name": "TIKKA Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://libretimetikka-8b513026764d.herokuapp.com/stream",
+      "homepage": "https://www.tikka.live/",
+      "country": "FR",
+      "tags": [
+        "music"
+      ],
+      "favicon": "https://www.tikka.live/tikkalogowhite.ico",
+      "codec": "OGG",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-tsumugi",
+      "name": "Tsumugi",
+      "broadcaster": "independent",
+      "streamUrl": "https://azuracast.mahoro-net.org/listen/tsumugi/radio.mp3",
+      "homepage": "https://azuracast.mahoro-net.org/public/tsumugi",
+      "country": "FR",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-vertige-radio",
+      "name": "Vertige Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.vestaradio.com/VertigeRadio",
+      "homepage": "https://vertigeradio.com/",
+      "country": "FR",
+      "favicon": "https://uploads.monsiteradio.com/logo/23-23-logovertigeradioone.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-agnes-b-radio-europe",
+      "name": "Agnes B Radio Europe",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/131488/stream/171370",
+      "homepage": "https://www.agnesb.com/en-eu/radio.html",
+      "country": "FR",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-bien-etre-animal",
+      "name": "Bien Etre Animal",
+      "broadcaster": "independent",
+      "streamUrl": "https://bienetreanimal.ice.infomaniak.ch/bienetreanimal-128.mp3",
+      "homepage": "http://www.radiobienetreanimal.com/",
+      "country": "FR",
+      "tags": [
+        "animal",
+        "bien etre",
+        "santé"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.8534,
+        2.3488
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-blt-radio",
+      "name": "BLT Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://play.radioking.io/blt-radio",
+      "homepage": "https://blt-radio.com/",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-clapas-chanson",
+      "name": "Clapas Chanson",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radioclapas.fr/listen/clapas_chanson/radio.mp3",
+      "homepage": "https://www.radioclapas.fr/#",
+      "country": "FR",
+      "tags": [
+        "chansons françaises"
+      ],
+      "favicon": "https://www.radioclapas.fr/player/chanson.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        43.613,
+        3.8822
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-dy10",
+      "name": "DY10",
+      "broadcaster": "independent",
+      "streamUrl": "https://flux.radiody10.com/airtime_128",
+      "homepage": "https://radiody10.com/",
+      "country": "FR",
+      "favicon": "https://res.cloudinary.com/bshano/image/upload/f_auto/v1623968490/webradio/stations/radio-dy10.jpg",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-ed92",
+      "name": "ED92",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/497074/stream/554176",
+      "homepage": "https://www.ed92.org/",
+      "country": "FR",
+      "favicon": "https://image.radioking.io/radios/497074/logo/8a111dde-c44f-4c3b-a142-517a57f6fbf8.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.8658,
+        2.7902
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-happyness-amiens",
+      "name": "Happyness Amiens",
+      "broadcaster": "independent",
+      "streamUrl": "https://azuracast-scrs-2.foxoud.synology.me/listen/happyness_amiens/player",
+      "homepage": "https://happynessradio.fr/",
+      "country": "FR",
+      "tags": [
+        "2000s",
+        "chanson française",
+        "disco",
+        "electro",
+        "gold",
+        "hits"
+      ],
+      "favicon": "https://happynessamiens.fr/wp-content/uploads/2025/01/Happyness-Amiens@3x-50.jpg",
+      "codec": "MP3",
+      "geo": [
+        49.894,
+        2.2956
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-iaradio-guinguette",
+      "name": "IAradio Guinguette",
+      "broadcaster": "independent",
+      "streamUrl": "https://iaradioguinguette.ice.infomaniak.ch/iaradioguinguette-128.mp3",
+      "homepage": "https://iaradio.eu/",
+      "country": "FR",
+      "tags": [
+        "accordéon",
+        "guinguette"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.8533,
+        2.3488
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-iaradio-opera",
+      "name": "IAradio Opéra",
+      "broadcaster": "independent",
+      "streamUrl": "https://iaradioopera.ice.infomaniak.ch/iaradioopera-128.mp3",
+      "homepage": "https://iaradio.eu/",
+      "country": "FR",
+      "tags": [
+        "opéra"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.8533,
+        2.3488
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-la-grande-ourse",
+      "name": "La Grande Ourse ✨",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast.lagrandeourse.radio.fm/listen/radio/live.mp3",
+      "homepage": "https://lagrandeourse.radio.fm/",
+      "country": "FR",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-la-radio-sous-la-cerise",
+      "name": "La radio sous la cerise ",
+      "broadcaster": "independent",
+      "streamUrl": "https://laradio.souslacerise.fr/radio.m3u8",
+      "homepage": "https://laradio.souslacerise.fr/radio/",
+      "country": "FR",
+      "tags": [
+        "kids",
+        "musiques des enfants"
+      ],
+      "bitrate": 46,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-mathis-fm",
+      "name": "MATHIS FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://mathisfm57.stream.laut.fm/mathisfm57?t302=2026-03-08_16-21-19&uuid=52d1fa64-f5a7-4c02-a729-8c44d7098970",
+      "homepage": "https://laut.fm/mathisfm57",
+      "country": "FR",
+      "tags": [
+        "pop rock hip hop"
+      ],
+      "favicon": "https://assets.laut.fm/98c165c3cf1ebe429ada106a3ba14932?t=_640x640",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        49.1836,
+        6.4968
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-open-sky-96kbps-mp3-low",
+      "name": "Open Sky (96kbps mp3, \"low\")",
+      "broadcaster": "independent",
+      "streamUrl": "https://audio.opensky.radio:8082/stream96",
+      "homepage": "https://opensky.radio/",
+      "country": "FR",
+      "bitrate": 96,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-public-health-radio-deutch",
+      "name": "Public Health Radio Deutch",
+      "broadcaster": "independent",
+      "streamUrl": "https://publichealthradiode.ice.infomaniak.ch/publichealthradiode-128.mp3",
+      "homepage": "https://www.publichealth.net/",
+      "country": "FR",
+      "tags": [
+        "health",
+        "health programming",
+        "information"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.8341,
+        2.2569
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-public-health-radio-russian",
+      "name": "Public Health Radio Russian",
+      "broadcaster": "independent",
+      "streamUrl": "https://publichealthradioru.ice.infomaniak.ch/publichealthradioru-128.mp3",
+      "homepage": "https://www.publichealthradio.net/",
+      "country": "FR",
+      "tags": [
+        "health",
+        "info"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.8545,
+        2.3486
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-agape",
+      "name": "Radio Agape",
+      "broadcaster": "independent",
+      "streamUrl": "https://agape.jireh.ovh/;?type=http&nocache=68",
+      "homepage": "https://agape1.fr/",
+      "country": "FR",
+      "favicon": "https://agape1.fr/wp-content/uploads/2019/11/cropped-Sanstitre-34.png",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-jeans",
+      "name": "Radio Jeans",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.mandragola.com/radiojeans",
+      "homepage": "https://www.radiojeans.net/",
+      "country": "FR",
+      "favicon": "https://www.radiojeans.net/images/logo_radiojeans.gif",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-rempart",
+      "name": "Radio Rempart",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.pro-fhi.net:19112/;stream1",
+      "homepage": "https://radiorempart.fr/",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-sud-besancon",
+      "name": "Radio Sud Besançon",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiosudbesancon.ice.infomaniak.ch/radiosudbesancon-128.mp3",
+      "homepage": "https://radiosud.net/",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-redzing-radio",
+      "name": "Redzing Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://onair.redzingradio.com/redzing-256",
+      "homepage": "https://redzingradio.com/",
+      "country": "FR",
+      "tags": [
+        "dance",
+        "electro",
+        "pop",
+        "top40"
+      ],
+      "favicon": "https://redzingradio.com/wp-content/uploads/2020/06/cropped-logo_cerclebleu_RedzingRadio_2022.png",
+      "bitrate": 256,
+      "codec": "MP3",
+      "geo": [
+        43.6984,
+        7.2808
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-sensuelle-radio",
+      "name": "sensuelle radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio10.pro-fhi.net/live/SENSUELLERADIO",
+      "homepage": "https://www.sensuelleradio.com/",
+      "country": "FR",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        -21.003,
+        55.2846
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-soov-radio",
+      "name": "Soov Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://play.radioking.io/soovradio",
+      "homepage": "https://soovradio.page.radio/",
+      "country": "FR",
+      "favicon": "https://ibb.co/Txw6DG8n",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-stellarfm",
+      "name": "StellarFM",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.stellarfm.fr/listen/stellarfm/radio.mp3",
+      "homepage": "https://stellarfm.fr/",
+      "country": "FR",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-x-move",
+      "name": "X-Move",
+      "broadcaster": "independent",
+      "streamUrl": "https://s26.myradiostream.com:11428/stream.mp3",
+      "homepage": "https://www.xmove.fr/",
+      "country": "FR",
+      "favicon": "https://www.xmove.fr/wp-content/uploads/2023/09/LOGO-770x513.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-gwoka-radio",
+      "name": "🕺 Gwoka Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ecmanager2.pro-fhi.net:1650/;",
+      "homepage": "https://www.karibshebdo.info/radios-web/gwoka-radio",
+      "country": "FR",
+      "favicon": "https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEgc3tUvjP7AVS0LRQbqIVESMlT3_nHdOWLRN1KjF78k4FOHy6OavrGUAzPgqU3VjCsscsejqNIbCeZfUW9FIPrwqGMMUJS2ttBm8zcr0tSpzvFZHT7xXSvybD6gA58ed8ejsDBWkKJkfFbu_bBAN76qukujOFI3TcUPmcCZpFAN1SSdnNbskIVfkS3i/s320/Capture%20d%E2%80%99%C3%A9cran_2024-11-21_10-59-47.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-duuu",
+      "name": "*Duuu",
+      "broadcaster": "independent",
+      "streamUrl": "https://duuu.out.airtime.pro/duuu_a",
+      "homepage": "https://duuuradio.fr/",
+      "country": "FR",
+      "tags": [
+        "arts",
+        "lectures",
+        "live concerts",
+        "poetry",
+        "sound art"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-bcc-blues-rock-radio",
+      "name": "BCC Blues Rock Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio12.pro-fhi.net/radio/9132/stream.mp3",
+      "homepage": "https://www.bigcactuscountry.fr/player/#BCC-Blues-Rock-Radio",
+      "country": "FR",
+      "favicon": "https://www.bccrock.fr/media/yootheme/cache/ba/Logo_BCC_blues_ROCK-baa97e44.webp?src=images/logo/Logo_BCC_blues_ROCK.png&thumbnail=400,400,&type=webp,100&hash=69c0ddd3",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-camp-radio",
+      "name": "CAMP Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.camp/campradio.ogg",
+      "homepage": "https://listen.camp/",
+      "country": "FR",
+      "tags": [
+        "ambient",
+        "avantgarde",
+        "classical music",
+        "cosmic",
+        "dream pop",
+        "drone"
+      ],
+      "favicon": "https://favicon.im/listen.camp",
+      "codec": "OGG",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-clapas-rock",
+      "name": "Clapas Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radioclapas.fr/listen/clapas_rock/radio.mp3",
+      "homepage": "https://www.radioclapas.fr/",
+      "country": "FR",
+      "tags": [
+        "rock"
+      ],
+      "favicon": "https://www.radioclapas.fr/player/rock.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        43.6125,
+        3.8908
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-dunkerque-street-radio",
+      "name": "Dunkerque Street Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://azuracast.conceptradio.fr/hls/dunkerque_street_radio/live.m3u8",
+      "homepage": "https://dunkerquestreetradio.fr/",
+      "country": "FR",
+      "favicon": "https://image.noelshack.com/fichiers/2026/16/6/1776466582-3f50cb77-2c14-4e71-8c62-fbe061fba9dc.jpg",
+      "bitrate": 211,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-france-bleu-azur",
+      "name": "France Bleu Azur",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radiofrance.fr/fbazur/fbazur.m3u8?id=radiofrance",
+      "homepage": "https://www.francebleu.fr/radio/azur",
+      "country": "FR",
+      "favicon": "https://www.francebleu.fr/client/immutable/assets/logo-ici-small.DwiLDMIK.svg",
+      "bitrate": 107,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-friendly-radio",
+      "name": "Friendly Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/6014/stream/14771",
+      "homepage": "https://www.friendlyradio.fr/",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-g-one-radio",
+      "name": "G One Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.garden/api/ara/content/listen/pahlMAe0/channel.mp3?1726401108732",
+      "homepage": "https://www.goneradio.com/",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-groove-nation",
+      "name": "Groove Nation",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/70135/stream/107968",
+      "homepage": "https://groovenation.radio/",
+      "country": "FR",
+      "favicon": "https://uk.radio.net/300/groovenationradio.png?version=272d1ee194194d1596a58f38cbb9ccad",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-happyness-oise",
+      "name": "Happyness Oise",
+      "broadcaster": "independent",
+      "streamUrl": "https://azuracast-scrs-2.foxoud.synology.me/listen/happyness_oise/player",
+      "homepage": "https://happynessradio.fr/",
+      "country": "FR",
+      "tags": [
+        "2000s",
+        "chanson française",
+        "disco",
+        "electro",
+        "gold",
+        "hits"
+      ],
+      "favicon": "https://happynessoise.fr/wp-content/uploads/2025/01/Happyness-Oise@3x-50.jpg",
+      "codec": "MP3",
+      "geo": [
+        49.3572,
+        2.2463
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-hotmix-80",
+      "name": "Hotmix 80",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.hotmixradio.com/hotmix-80-en-mp3?provider=radiobrowser",
+      "homepage": "https://web.hotmixradio.com/fr",
+      "country": "FR",
+      "tags": [
+        "80s"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.8526,
+        2.345
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-hotmix-lofi",
+      "name": "hotmix LoFi",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.hotmixradio.com/hotmix-lofi-en-mp3",
+      "homepage": "https://hotmixradio.com/",
+      "country": "FR",
+      "tags": [
+        "hip-hop",
+        "lofi"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-hotmix-rnb",
+      "name": "Hotmix RnB",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.hotmixradio.fr/hotmix-rnb-en-pre",
+      "homepage": "http://https//streaming.hotmixradio.fr",
+      "country": "FR",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-i2-radio",
+      "name": "i2 Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/635275/stream/698023",
+      "homepage": "https://www.radioking.com/",
+      "country": "FR",
+      "favicon": "https://drive.google.com/file/d/1EMB3qjCKgDO2dd26B58GKmzIsF6EfByM/view?usp=sharing",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-iaradio-lounge",
+      "name": "IAradio Lounge",
+      "broadcaster": "independent",
+      "streamUrl": "https://iaradiolounge.ice.infomaniak.ch/iaradiolounge-128.mp3",
+      "homepage": "https://iaradio.eu/",
+      "country": "FR",
+      "tags": [
+        "lounge"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.8532,
+        2.3487
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-iaradio-pop-rock",
+      "name": "IAradio Pop Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://iaradiopoprock.ice.infomaniak.ch/iaradiopoprock-128.mp3",
+      "homepage": "https://iaradio.eu/",
+      "country": "FR",
+      "tags": [
+        "pop rock"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.8533,
+        2.3488
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-iaradio-reggae",
+      "name": "IAradio Reggae",
+      "broadcaster": "independent",
+      "streamUrl": "https://iaradioreggae.ice.infomaniak.ch/iaradioreggae-128.mp3",
+      "homepage": "https://iaradio.eu/",
+      "country": "FR",
+      "tags": [
+        "reggae"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.8533,
+        2.3487
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-lradio",
+      "name": "Lradio",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/267025/stream/312298",
+      "homepage": "https://www.lradio.fr/index",
+      "country": "FR",
+      "favicon": "https://www.lradio.fr/img/upload/65993118959aa.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-m2s-radio",
+      "name": "M2S Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.m2sradio.fr/radio.aac",
+      "homepage": "https://mordus2savoie.fr/",
+      "country": "FR",
+      "tags": [
+        "club",
+        "latino",
+        "pop",
+        "rap",
+        "variety"
+      ],
+      "favicon": "https://listen.m2sradio.fr/assets/logo-01.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-meteo-terrasse-fab",
+      "name": "Météo Terrasse Fab",
+      "broadcaster": "independent",
+      "streamUrl": "https://fqboy.com/labo/weather/rss/audio/meteo.mp3",
+      "homepage": "https://fqboy.com/",
+      "country": "FR",
+      "tags": [
+        "local weather"
+      ],
+      "codec": "MP3",
+      "geo": [
+        48.8664,
+        2.4306
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-milo-radio",
+      "name": "Milo Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/779491/stream/847056",
+      "homepage": "https://www.miloradio.com/",
+      "country": "FR",
+      "tags": [
+        "timeless"
+      ],
+      "favicon": "https://www.miloradio.com/img/milo.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-mix-maxi-radio",
+      "name": "Mix Maxi Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ecmanager.pro-fhi.net:1455/stream",
+      "homepage": "https://www.mixmaxiradio.fr/",
+      "country": "FR",
+      "favicon": "https://www.mixmaxiradio.fr/favicon.ico",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-musique-d-inter",
+      "name": "Musique d'Inter",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radiofrance.fr/franceinterlamusiqueinter/franceinterlamusiqueinter.m3u8?id=radiofranceBose",
+      "homepage": "https://www.radiofrance.fr/franceinter/la-musique-inter",
+      "country": "FR",
+      "favicon": "https://cmsphoto.ww-cdn.com/superstatic/36765/art/grande/81114591-58479823.jpg?v=1718955523",
+      "bitrate": 107,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-nova-nouva",
+      "name": "Nova Nouva",
+      "broadcaster": "independent",
+      "streamUrl": "https://nova-nouvo.ice.infomaniak.ch/nova-nouvo-128.mp3",
+      "homepage": "https://www.nova.fr/radios/nouvo-nova/",
+      "country": "FR",
+      "favicon": "https://www.nova.fr/wp-content/thumbnails/uploads/sites/2/2024/04/NOVA-NOUVO-400x496-1-t-1006x1006.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-nrj-disney-hits-live",
+      "name": "NRJ DISNEY HITS live",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.nrjaudio.fm/oudbxj2h9r57",
+      "homepage": "https://www.nrj.fr/webradios/mur-des-radios/nrj-disney-hits",
+      "country": "FR",
+      "tags": [
+        "disney",
+        "nrj",
+        "radio disney"
+      ],
+      "favicon": "https://res.cloudinary.com/dfuxhgkej/image/upload/v1773587606/nrj-la-playlist-disney-du-genie.e889f0e6_okvkyw.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-nrj-linkin-park",
+      "name": "NRJ LINKIN PARK",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.nrjaudio.fm/ouvfbfoarp52",
+      "homepage": "https://www.nrj.fr/webradios/mur-des-radios/nrj-linkin-park",
+      "country": "FR",
+      "tags": [
+        "english",
+        "france",
+        "linkin park",
+        "linkinpark",
+        "metal",
+        "nrj"
+      ],
+      "favicon": "https://www.radio.net/300/nrjlinkinpark.jpeg?version=9ec7666b0204107fd6befaf6e99299f6a38aaff9",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-abf",
+      "name": "Radio ABF",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radioabf.com/abf-low.aac",
+      "homepage": "https://radioabf.com/",
+      "country": "FR",
+      "favicon": "https://radioabf.com/logo-abf.png",
+      "bitrate": 32,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-atlantis-107fm",
+      "name": "Radio Atlantis 107FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio8.pro-fhi.net/radio/9005/atlantis320",
+      "homepage": "https://radioatlantis.fr/",
+      "country": "FR",
+      "favicon": "https://i0.wp.com/radioatlantis.fr/wp-content/uploads/elementor/thumbs/LogoAtlantisBlack-pfblhncaz7c4p0k8iv0x6p2lgpz65o1tplvp2kpgnu.png?w=1170&ssl=1",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-brassens",
+      "name": "Radio Brassens",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.zestream.eu/listen/radiobrassens/radio.mp3",
+      "homepage": "https://www.radiobrassens.com/",
+      "country": "FR",
+      "tags": [
+        "chanson française"
+      ],
+      "favicon": "https://www.radiobrassens.com/wp-content/uploads/2024/02/cropped-logo-radio-brassens-1-1.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        47.9428,
+        2.1094
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-cagnac",
+      "name": "Radio Cagnac",
+      "broadcaster": "independent",
+      "streamUrl": "https://go.2stream.net/cagnac_sd.mp3",
+      "homepage": "https://www.radiocagnac.fr/",
+      "country": "FR",
+      "favicon": "https://www.radiocagnac.fr/img/slidertop.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-contact-vosges",
+      "name": "Radio Contact Vosges",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.ssl-stream.com/listen/radio_contact/radio.mp3",
+      "homepage": "https://rcvradio.fr/",
+      "country": "FR",
+      "favicon": "https://www.facebook.com/profile.php?id=61584378462518",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-de-la-save",
+      "name": "Radio de la Save",
+      "broadcaster": "independent",
+      "streamUrl": "https://sd-151888.dedibox.fr/proxy/radiodelasave/rdls",
+      "homepage": "https://www.radiodelasave.com/",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-of-magic",
+      "name": "Radio of Magic",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/418372/stream/471466",
+      "homepage": "https://www.radio-of-magic.com/fr/",
+      "country": "FR",
+      "tags": [
+        "disney",
+        "disneyland paris",
+        "kids",
+        "radio disney"
+      ],
+      "favicon": "https://www.radio-of-magic.com/wp-content/uploads/2021/05/favicon-512x512-1.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-presence-pyrenees",
+      "name": "Radio Presence Pyrenees",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.radiopresence.com/radio-presence-pyrenees",
+      "homepage": "https://www.radiopresence.com/",
+      "country": "FR",
+      "favicon": "http://direct.radiopresence.com/presence.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-sisko-fm",
+      "name": "Radio sisko fm",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.zeno.fm/nesckintyb8uv",
+      "homepage": "https://www.radiosiskofm.fr/",
+      "country": "FR",
+      "tags": [
+        "news"
+      ],
+      "favicon": "https://primary.jwwb.nl/public/o/l/o/temp-ibtrsekethdwduzkuoxo/reel-video-instagram-voyage-moderne-minimaliste-blanc-et-jaune-publication_20240929_182455_0000-high-high-t1jvz2.png?enable-io=true&enable=upscale&height=140&quality=70",
+      "codec": "MP3",
+      "geo": [
+        43.1861,
+        5.5907
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio230",
+      "name": "Radio230",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radio230.com/",
+      "homepage": "https://radio230.com/",
+      "country": "FR",
+      "favicon": "https://radio230.com/favicon.ico",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radionysos",
+      "name": "Radionysos",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/254980/stream/299539",
+      "homepage": "https://www.radionysos.com/",
+      "country": "FR",
+      "tags": [
+        "alternative",
+        "electronic",
+        "folk",
+        "rock",
+        "soul",
+        "various"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-replay-news-sport-francais",
+      "name": "REPLAY NEWS - Sport (Français)",
+      "broadcaster": "independent",
+      "streamUrl": "https://replaynewssport.ice.infomaniak.ch/replaynewssport-128.mp3",
+      "homepage": "https://www.replaynews.net/",
+      "country": "FR",
+      "tags": [
+        "sports"
+      ],
+      "favicon": "https://www.publicsante.com/BIENVENU/LOGO%20REPLAY%20NEWS%20SPORT.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-rvb-radio-vallee-bergerac",
+      "name": "RVB - Radio Vallée Bergerac",
+      "broadcaster": "independent",
+      "streamUrl": "https://hosting.studioradiomedia.fr:1750/stream",
+      "homepage": "https://rvb-radio.fr/",
+      "country": "FR",
+      "favicon": "https://rvb-radio.fr/upload/design/68b6fce80cf423.82381308.jpeg",
+      "codec": "MP3",
+      "geo": [
+        44.8547,
+        0.4885
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-station-b",
+      "name": "Station B",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.lastationb.fr/stationb",
+      "homepage": "https://www.lastationb.fr/",
+      "country": "FR",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-sunshine-radio",
+      "name": "Sunshine Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://sunshine.ice.infomaniak.ch/sunshine-mp3.mp3",
+      "homepage": "https://sunshineradio.fr/",
+      "country": "FR",
+      "tags": [
+        "80s",
+        "90s"
+      ],
+      "favicon": "https://sunshineradio.fr/wp-content/uploads/2024/08/favicon.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-tempo-62",
+      "name": "TEMPO 62",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.radioking.com/play/tempo-62",
+      "homepage": "https://tempo62.com/",
+      "country": "FR",
+      "favicon": "https://tempo62.com/upload/photos/6571e750aad770.98045674_carre.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-vertige-radio-gold",
+      "name": "Vertige Radio Gold",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.vestaradio.com/VertigeRadioGold",
+      "homepage": "https://vertigeradio.fr/",
+      "country": "FR",
+      "tags": [
+        "goldies",
+        "hits",
+        "oldies",
+        "radio france"
+      ],
+      "favicon": "https://vertigeradio.fr/uploads/streams/stream_1_1769945055_7d9e28fd.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-mlpfm",
+      "name": "/mlpfm/",
+      "broadcaster": "independent",
+      "streamUrl": "https://dash.mlp.radio:8020/radio.mp3",
+      "homepage": "https://mlp.radio/",
+      "country": "FR",
+      "favicon": "https://mlp.radio/static/uploads/browser_icon/180.1732808201.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-5sens-radio",
+      "name": "5Sens Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.5sens.fr/radio/stream.php",
+      "homepage": "https://radio.5sens.fr/",
+      "country": "FR",
+      "tags": [
+        "games",
+        "talk radio"
+      ],
+      "favicon": "https://radio.5sens.fr/photos/podcasts/favicon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-air-connect-radio",
+      "name": "Air Connect Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.airconnectradio.com/ac64.aac",
+      "homepage": "https://airconnectradio.com/",
+      "country": "FR",
+      "favicon": "https://airconnectradio.com/wp-content/uploads/2025/01/ac-grand.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-akro-radio",
+      "name": "Akro Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.akroradio.com:10012/AkroRadio",
+      "homepage": "https://www.akroradio.com/",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-akroradio-www-akroradio-com",
+      "name": "AkroRadio - www.akroradio.com",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.akroradio.com/listen/akroradio/AkroRadio",
+      "homepage": "https://www.akroradio.com/",
+      "country": "FR",
+      "tags": [
+        "80's",
+        "90's",
+        "dance",
+        "hits",
+        "techno",
+        "top40"
+      ],
+      "favicon": "https://akroradio.com/wp-content/uploads/2023/09/cropped-icone.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-aubymix",
+      "name": "AubyMix",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.aubymix.fr:8443/mp3?1771423833872",
+      "homepage": "https://aubymix.fr/",
+      "country": "FR",
+      "favicon": "https://aubymix.fr/wp-content/uploads/2025/03/logo_aubymix_avec_texte_transparent.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-bcc-classic-rock-radio",
+      "name": "BCC Classic Rock Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio12.pro-fhi.net/radio/9134/stream.mp3",
+      "homepage": "https://www.bigcactuscountry.fr/player/#BCC-Classic-Rock-Radio",
+      "country": "FR",
+      "favicon": "https://www.bccrock.fr/media/yootheme/cache/e0/Logo_BCC_ROCK_-e037e6ac.webp?src=images/logo/Logo_BCC_ROCK_.png&thumbnail=400,400,&type=webp,100&hash=c6ecc033",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-breniges-fm",
+      "name": "Bréniges FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.rcs.revma.com/uzz0fgg64zcwv",
+      "homepage": "https://www.breniges-fm.com/",
+      "country": "FR",
+      "tags": [
+        "hits",
+        "local news"
+      ],
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-comtoise-radio",
+      "name": "Comtoise Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.tiennot.net/comtoise.aac",
+      "homepage": "https://www.comtoiseradio.fr/",
+      "country": "FR",
+      "favicon": "https://www.comtoiseradio.fr/images/logo.png",
+      "bitrate": 192,
+      "codec": "AAC",
+      "geo": [
+        47.8173,
+        6.3805
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-crooner-radio-192-48",
+      "name": "Crooner Radio 192/48",
+      "broadcaster": "independent",
+      "streamUrl": "https://croonerradio.ice.infomaniak.ch/croonerradio-hifi.mp3",
+      "homepage": "https://www.croonerradio.fr/",
+      "country": "FR",
+      "favicon": "https://www.croonerradio.fr",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        46.0732,
+        2.1094
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-crooner-radio-julio-iglesias",
+      "name": "Crooner Radio Julio Iglesias",
+      "broadcaster": "independent",
+      "streamUrl": "https://croonerradio_julioiglesias.ice.infomaniak.ch/croonerradio-julioiglesias-midfi.mp3",
+      "homepage": "https://www.croonerradio.fr/player/#crooner_j_iglesias",
+      "country": "FR",
+      "favicon": "https://www.croonerradio.fr/wp-content/uploads/2019/04/crooner-julio-iglesias-bio-190424.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-dlrp",
+      "name": "DLRP",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream4.vestaradio.com/DLRP",
+      "homepage": "https://dlrp.fr/",
+      "country": "FR",
+      "tags": [
+        "disney",
+        "disneyland paris",
+        "radio disney"
+      ],
+      "favicon": "https://dlrp.fr/wp-content/uploads/2023/08/dlrp-jaune.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-dzfishradio",
+      "name": "DZFISHRADIO",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.dzfishradio.com/listen/dzfishradio/radio.mp3",
+      "homepage": "https://www.dzfishradio.com/",
+      "country": "FR",
+      "favicon": "https://www.dzfishradio.com/IMG/logo/dzfishradio_sticker.png?1693428086",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-f-hits-aquitaine",
+      "name": "F. HITS AQUITAINE",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.f-group.fr/listen/fhitsaquitaine/fhits_aquitaine_96.aac",
+      "homepage": "https://fhits-aquitaine.fr/",
+      "country": "FR",
+      "tags": [
+        "musique",
+        "pop"
+      ],
+      "favicon": "https://i.postimg.cc/QCrDdq8S/PP-FB-INSTA-FHITS-AQUITAINE.png",
+      "bitrate": 96,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-france-antilles-radio",
+      "name": "France Antilles Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://2stream.net/fa_radio.mp3",
+      "homepage": "https://www.martinique.franceantilles.fr/",
+      "country": "FR",
+      "favicon": "https://assets.franceantilles.fr/common/images/logo_FAR-Color.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-g-tracks-radio",
+      "name": "G-tracks Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.citrus3.com:8010/stream",
+      "homepage": "https://gtracksradio.com/#",
+      "country": "FR",
+      "favicon": "https://gtracksradio.com/wp-content/uploads/2023/04/cropped-GTRLogo.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-generation-soul-disco-funk-radio",
+      "name": "GENERATION SOUL DISCO FUNK RADIO",
+      "broadcaster": "independent",
+      "streamUrl": "https://gestream.fr/g-radio-hd.mp3",
+      "homepage": "https://www.generationdiscofunk.com/",
+      "country": "FR",
+      "tags": [
+        "acid jazz",
+        "disco",
+        "funk",
+        "groove",
+        "neo soul",
+        "new jack swing"
+      ],
+      "favicon": "https://generationdiscofunk.com/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        48.8532,
+        2.348
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-good-morning-poker",
+      "name": "Good Morning Poker",
+      "broadcaster": "independent",
+      "streamUrl": "https://streamer.radio.co/s43556a89a/listen",
+      "homepage": "https://www.goodmorningpoker.com/",
+      "country": "FR",
+      "tags": [
+        "poker"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-iaradio",
+      "name": "IAradio",
+      "broadcaster": "independent",
+      "streamUrl": "https://iaradio.ice.infomaniak.ch/iaradio-128.mp3",
+      "homepage": "https://iaradio.eu/",
+      "country": "FR",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.8545,
+        2.347
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-iaradio-rap",
+      "name": "IAradio Rap",
+      "broadcaster": "independent",
+      "streamUrl": "https://iaradiorap.ice.infomaniak.ch/iaradiorap-128.mp3",
+      "homepage": "https://iaradio.eu/",
+      "country": "FR",
+      "tags": [
+        "rap"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.8533,
+        2.3488
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-jack-rocks-live",
+      "name": "Jack Rocks LIVE",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio12.pro-fhi.net/radio/9174/stream?fbclid=IwAR3SdOLxThn4vewpYN2LWNu1a_R8iZAmAU4hT7_VTD5wRNTiuKzQ3h5liE8",
+      "homepage": "https://www.jackrockslive.net/",
+      "country": "FR",
+      "favicon": "https://static.wixstatic.com/media/f8b2f4_df1d1ffd77474f71ab448ac5c9c5f866~mv2.jpg/v1/fill/w_260,h_260,al_c,q_80,usm_0.66_1.00_0.01,enc_avif,quality_auto/Logo_derni%C3%A8re_version_rec_c.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        49.2727,
+        2.5186
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-knaradio",
+      "name": "KNAradio",
+      "broadcaster": "independent",
+      "streamUrl": "https://webradiostream.eu/radio/8070/stream",
+      "homepage": "https://knaradio.fr/",
+      "country": "FR",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-line-out-radio",
+      "name": "Line Out Radio ����",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/416299/stream/469240",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "FR",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-magic-radio-proxima",
+      "name": "Magic Radio - Proxima",
+      "broadcaster": "independent",
+      "streamUrl": "https://mp3.magic-radio.net/prox192",
+      "homepage": "https://magic-radio.net/",
+      "country": "FR",
+      "favicon": "https://magic-radio.net/fichier_000_1.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-nia-pacifique",
+      "name": "NIA Pacifique",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.nia.nc/radio/8000/pacific-hq-stream.aac?1772351904",
+      "homepage": "https://nia.nc/",
+      "country": "FR",
+      "favicon": "https://nia.nc/static/icons/favicon.ico",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-projet-xy",
+      "name": "PROJET XY",
+      "broadcaster": "independent",
+      "streamUrl": "https://flux.saaslys.com:8000/radio.mp3",
+      "homepage": "https://flux.saaslys.com/public/projectxy",
+      "country": "FR",
+      "favicon": "https://cdn-images.dzcdn.net/images/artist/bec649ded67ae4a1741650e148d9af6b/500x500-000000-80-0-0.jpg",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-public-health-radio-polish",
+      "name": "Public Health Radio Polish",
+      "broadcaster": "independent",
+      "streamUrl": "https://publichealthradiopl.ice.infomaniak.ch/publichealthradiopl-128.mp3",
+      "homepage": "https://www/",
+      "country": "FR",
+      "tags": [
+        "health",
+        "health programming",
+        "information"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.834,
+        2.2574
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-public-health-radio-portugues",
+      "name": "Public Health Radio Portugues",
+      "broadcaster": "independent",
+      "streamUrl": "https://publichealthradiopt.ice.infomaniak.ch/publichealthradiopt-128.mp3",
+      "homepage": "https://www.publicsante.com/",
+      "country": "FR",
+      "tags": [
+        "health"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.8534,
+        2.3488
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-cap-a-cap",
+      "name": "Ràdio Cap a cap",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/361189/stream/410758",
+      "homepage": "https://www.radiocapacap.fr/",
+      "country": "FR",
+      "tags": [
+        "traditional"
+      ],
+      "codec": "MP3",
+      "geo": [
+        43.6965,
+        -1.0642
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-stonewall",
+      "name": "radio Stonewall",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.radioking.com/play/radio-stonewall",
+      "homepage": "https://radiostonewall.com/",
+      "country": "FR",
+      "favicon": "https://radiostonewall.com/wp-content/uploads/2024/11/cropped-462553932_532380849605032_4391091688937223115_n.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-temps-rodez",
+      "name": "Radio Temps Rodez",
+      "broadcaster": "independent",
+      "streamUrl": "https://sd-151888.dedibox.fr/proxy/radiotemps/rtr",
+      "homepage": "https://radiotemps.com/",
+      "country": "FR",
+      "favicon": "https://radiotemps.com/wp-content/uploads/2020/12/LOGO.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radio-shoppe-com",
+      "name": "radio-shoppe.com",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radio-shoppe.ydns.eu/",
+      "homepage": "http://radio-shoppe.ydns.eu/#page-top",
+      "country": "FR",
+      "favicon": "http://radio-shoppe.ydns.eu/radio-shoppe/img/base_logo_cet.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-radiosmp",
+      "name": "RadioSMP",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.lf-corp.fr/smpnational",
+      "homepage": "https://radiosmp.fr/",
+      "country": "FR",
+      "tags": [
+        "rap"
+      ],
+      "bitrate": 128,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-rayvox",
+      "name": "Rayvox",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.rayvox.org:8443/flux",
+      "homepage": "https://www.rayvox.org/",
+      "country": "FR",
+      "tags": [
+        "alternative / indie",
+        "arts",
+        "culture",
+        "music"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        43.8399,
+        4.3592
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-reggae-arte-radio",
+      "name": "Reggae Arte radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/269104/stream/314461",
+      "homepage": "https://reggaearte.wixsite.com/accueil/en",
+      "country": "FR",
+      "tags": [
+        "reggae"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        45.7783,
+        4.8505
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-satellite-fm-paris",
+      "name": "Satellite FM Paris",
+      "broadcaster": "independent",
+      "streamUrl": "https://manager11.streamradio.fr:2935/stream",
+      "homepage": "https://www.satellitefmparis.fr/",
+      "country": "FR",
+      "favicon": "https://assets.zyrosite.com/AR0lXpjaNMcx2PBw/satellite-fm-paris-logo-2026_800-i6cWKluIZLl2TQtC.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        48.8161,
+        2.2853
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-sun-junior",
+      "name": "SUN Junior",
+      "broadcaster": "independent",
+      "streamUrl": "https://diffusion.lafrap.fr/sun-junior.mp3",
+      "homepage": "https://lesonunique.com/",
+      "country": "FR",
+      "favicon": "https://lesonunique.com/images/pwa/icon-512x512.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "fr-unfazed-onair",
+      "name": "Unfazed OnAir",
+      "broadcaster": "independent",
+      "streamUrl": "https://srv.webradiomanager.fr:1045/stream",
+      "homepage": "https://www.unfazedonair.fr/",
+      "country": "FR",
+      "favicon": "https://static.wixstatic.com/media/cc8d99_6770b0d30090457aa528788c142a1c36~mv2.png/v1/fill/w_1200,h_900,fp_0.50_0.50,q_95,enc_avif,quality_auto/cc8d99_6770b0d30090457aa528788c142a1c36~mv2.png",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Full Radio Browser sweep of IT stations — imports **426 stream-only stubs** (no cap, per sponsor override).

### Scan stats
- Total RB stations in analysis file: 1612
- Playable (ok + ok-hls): ~452 (based on pre-state analysis)
- Already curated by uuid: 7

### What was imported: 426 stations
All sorted by votes descending.

**Top 3 by votes:**
| Name | Votes | Stream URL |
|---|---|---|
| Radio Armisa | 16,508 | https://onair.armisa.it/listen/armisa/radio.mp3 |
| 70 80 Hits HQ | 12,622 | https://nr8.newradio.it:19574/stream |
| CLASSIC HITS RADIO Italia | 5,818 | https://classichitsradio.streamingmedia.it/play |

### Skipped
- 7 skipped: uuid already in YAML (curated stations)
- 6 skipped: name conflict with existing YAML entry
- 3 skipped: stream URL conflict with existing YAML entry
- 10 skipped: intra-set name deduplication (lower-voted duplicate)

### Verification
- `npm run catalog` ✓ (4635 stations published)
- `npm run check-catalog` ✓ (0 errors)
- `npm run check-duplicates` ✓ (0 collisions)
- `npm test -- --run` ✓ (294 tests passed)

### Branch note
Stacked on `curate/fr-2026-05-04`. Next country: ES (`curate/es-2026-05-04`).