### PR TITLE
curate: import US tier 1 (votes ≥100, ~646)

### DIFF
--- a/data/stations.yaml
+++ b/data/stations.yaml
@@ -36241,3 +36241,9260 @@
   stationuuid: 1659d626-b7db-48e0-82d7-d0d645bf43ae
   changeuuid: ee6f62b6-cc71-4f97-86ec-6e62e23cdb96
   reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-classic-vinyl-hd
+  broadcaster: independent
+  name: Classic Vinyl HD
+  streamUrl: https://icecast.walmradio.com:8443/classic
+  bitrate: 320
+  codec: MP3
+  favicon: "https://icecast.walmradio.com:8443/classic.jpg"
+  homepage: "https://walmradio.com/classic"
+  country: US
+  status: stream-only
+  stationuuid: d1a54d2e-623e-4970-ab11-35f7b56c5ec3
+  changeuuid: 16db532a-778d-4c7c-a79a-38858f24f933
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-christmas-vinyl-hd
+  broadcaster: independent
+  name: Christmas Vinyl HD
+  streamUrl: https://icecast.walmradio.com:8443/christmas
+  bitrate: 320
+  codec: MP3
+  favicon: "https://icecast.walmradio.com:8443/christmas.png"
+  homepage: "https://walmradio.com/christmas"
+  country: US
+  status: stream-only
+  stationuuid: 6eff3484-4ab4-4d36-bf27-9172c5aac15c
+  changeuuid: e9b63fe9-41fb-4f1f-9905-e4821d073da6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-walm-old-time-radio
+  broadcaster: independent
+  name: WALM - Old Time Radio
+  streamUrl: https://icecast.walmradio.com:8443/otr
+  bitrate: 64
+  codec: MP3
+  favicon: "https://icecast.walmradio.com:8443/otr.jpg"
+  homepage: "https://walmradio.com/otr"
+  country: US
+  status: stream-only
+  stationuuid: 313046e3-b203-4b9d-bc3e-393da7d97126
+  changeuuid: d661b7a4-aa8b-43b3-b36d-da7372c82e62
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-classic-hits-radio-70-80-discofunk-modernsoul-bo
+  broadcaster: independent
+  name: CLASSIC HITS RADIO 70 80 DiscoFunk ModernSoul Boogie
+  streamUrl: https://radiopanther.radiolebowski.com/play
+  codec: AAC
+  homepage: "http://classichits.radio/"
+  country: US
+  status: stream-only
+  stationuuid: c93f9c76-2ad4-464d-bff4-7f46e95f2601
+  changeuuid: 497f1f05-61d6-4379-a93a-a86a135dd924
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-poptron-128k-mp3
+  broadcaster: independent
+  name: SomaFM PopTron (128k MP3)
+  streamUrl: https://ice2.somafm.com/poptron-128-mp3
+  bitrate: 128
+  codec: MP3
+  favicon: "https://somafm.com/img3/poptron-400.png"
+  homepage: "https://somafm.com/poptron/"
+  country: US
+  status: stream-only
+  stationuuid: 960e0117-0601-11e8-ae97-52543be04c81
+  changeuuid: 93172430-c60c-4935-8c9c-cc961973a3ff
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-left-coast-70s-320k-mp3
+  broadcaster: independent
+  name: SomaFM Left Coast 70s (320k MP3)
+  streamUrl: https://ice5.somafm.com/seventies-320-mp3
+  bitrate: 320
+  codec: MP3
+  favicon: "https://somafm.com/img3/seventies400.jpg"
+  homepage: "https://somafm.com/seventies/"
+  country: US
+  status: stream-only
+  stationuuid: 961e37ee-0601-11e8-ae97-52543be04c81
+  changeuuid: fe835baf-4708-4b63-9a38-42a0a49a2d4e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-funky-radio-only-funk-music-60-s-70-s
+  broadcaster: independent
+  name: "FUNKY RADIO - Only Funk Music (60's 70's)"
+  streamUrl: https://funkyradio.streamingmedia.it/play.mp3
+  bitrate: 320
+  codec: MP3
+  homepage: "https://funky.radio/"
+  country: US
+  status: stream-only
+  stationuuid: c77c45c4-cf37-414c-ae34-868f7d9cd944
+  changeuuid: ced52b08-5118-4b23-9a49-b81b983ba050
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-miami-beach-radio
+  broadcaster: independent
+  name: Miami Beach Radio
+  streamUrl: https://streaming.radiostreamlive.com/miamibeachradio_devices
+  bitrate: 128
+  codec: MP3
+  favicon: "https://cdn-elements.radiostreamlive.com/v1/images/favicon.ico"
+  homepage: "https://www.miamibeachradio.com/"
+  country: US
+  status: stream-only
+  stationuuid: cd477c35-d625-11e8-a54a-52543be04c81
+  changeuuid: 574b5f58-ae2e-47d1-9bd1-df529806e14a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-marti
+  broadcaster: independent
+  name: Radio Marti
+  streamUrl: https://ocb01.akacast.akamaistream.net/7/365/437903/v1/ibb.akacast.akamaistream.net/ocb01
+  codec: MP3
+  favicon: "https://www.radiotelevisionmarti.com/content/responsive/ocb/img/webapp/ico-128x128.png"
+  homepage: "https://www.radiotelevisionmarti.com/"
+  country: US
+  status: stream-only
+  stationuuid: 203cb219-42c9-11e9-aa55-52543be04c81
+  changeuuid: f8a16cf5-44af-4669-8bb4-49b5e9d73a6b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-lush-128k-mp3
+  broadcaster: independent
+  name: SomaFM Lush (128k MP3)
+  streamUrl: https://ice2.somafm.com/lush-128-mp3
+  bitrate: 128
+  codec: MP3
+  favicon: "https://somafm.com/img3/lush-400.jpg"
+  homepage: "https://somafm.com/lush/"
+  country: US
+  status: stream-only
+  stationuuid: 961173b5-0601-11e8-ae97-52543be04c81
+  changeuuid: 0381a553-c39d-4e28-8254-43ff6b789ccd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-z-92-miami-92-3-fm-wcmq-fm-spanish-broadcasting-
+  broadcaster: independent
+  name: "Z 92 (Miami) - 92.3 FM - WCMQ-FM - Spanish Broadcasting System - Miami, Florida"
+  streamUrl: https://liveaudio.lamusica.com/MIA_WCMQ_icy
+  bitrate: 320
+  codec: AAC
+  favicon: "https://cdn-profiles.tunein.com/s27943/images/logod.png"
+  homepage: "https://www.lamusica.com/stations/wcmq"
+  country: US
+  status: stream-only
+  stationuuid: 03eccedf-bf40-4413-8d52-817c298331e2
+  changeuuid: e88f4ee7-6d65-430f-9d93-4c6289363f73
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-70s-80s-disco-funk-modernsoul-boogie
+  broadcaster: independent
+  name: 70s 80s Disco Funk ModernSoul Boogie
+  streamUrl: https://discofunk.streamingmedia.it/usa
+  bitrate: 192
+  codec: MP3
+  homepage: "https://funky.radio/discofunk_modernsoul_boogie"
+  country: US
+  status: stream-only
+  stationuuid: bafbd6cc-65e0-4af7-907b-dd1c425e8917
+  changeuuid: 803b2902-3237-4ac7-bfff-9b37714e8648
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-metal-detector-128k-aac
+  broadcaster: independent
+  name: SomaFM Metal Detector (128k AAC)
+  streamUrl: https://ice4.somafm.com/metal-128-aac
+  bitrate: 128
+  codec: AAC
+  favicon: "https://somafm.com/img3/metal-400.png"
+  homepage: "https://somafm.com/metal/"
+  country: US
+  status: stream-only
+  stationuuid: 960de41d-0601-11e8-ae97-52543be04c81
+  changeuuid: 790a8df4-2568-4f68-989a-3ecc7779b8fb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-metal-rock-radio
+  broadcaster: independent
+  name: metal rock radio
+  streamUrl: https://kathy.torontocast.com:2800/;
+  bitrate: 128
+  codec: MP3
+  homepage: "http://www.metalrock.fm/"
+  country: US
+  status: stream-only
+  stationuuid: ceb6b3af-3bfb-4135-bace-9fa6fac9e8ac
+  changeuuid: 9c951e5f-56d9-46e5-88d8-631f433f2ab9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-voa-learning-english
+  broadcaster: independent
+  name: VOA Learning English
+  streamUrl: https://voa-ingest.akamaized.net/hls/live/2035234/160_342L/playlist.m3u8
+  bitrate: 140
+  codec: AAC
+  favicon: "http://www.voanews.com/content/responsive/voa/img/webapp/ico-128x128.png"
+  homepage: "http://www.voanews.com/t/60.html"
+  country: US
+  status: stream-only
+  stationuuid: fd200b5d-0137-4a87-8afc-3275da795c2a
+  changeuuid: 6e2f7e64-8f8e-4bb0-a35e-982db06b637b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-smoothjazz-com-128k-mp3
+  broadcaster: independent
+  name: SmoothJazz.com 128k mp3
+  streamUrl: https://smoothjazz.cdnstream1.com/2585_128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: "https://www.smoothjazz.com/sites/default/files/theme/sj-circle-logo.png"
+  homepage: "https://www.smoothjazz.com/"
+  country: US
+  status: stream-only
+  stationuuid: 0eb3dbcf-05f7-480e-83f4-7718102a4820
+  changeuuid: e7919ec5-9103-4a95-bd34-13caabe3d996
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-fluid-128k-mp3
+  broadcaster: independent
+  name: SomaFM Fluid (128k MP3)
+  streamUrl: https://ice4.somafm.com/fluid-128-mp3
+  bitrate: 128
+  codec: MP3
+  favicon: "https://somafm.com/img3/fluid-400.jpg"
+  homepage: "https://somafm.com/fluid/"
+  country: US
+  status: stream-only
+  stationuuid: 9614e0a1-0601-11e8-ae97-52543be04c81
+  changeuuid: eac84768-f59a-4a1d-8221-05d4b51de01b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-country-live-new-york
+  broadcaster: independent
+  name: Radio Country Live New York
+  streamUrl: https://streaming.radiostreamlive.com/radiocountrylive_devices
+  bitrate: 128
+  codec: MP3
+  favicon: "https://cdn-elements.radiostreamlive.com/v1/images/favicon.ico"
+  homepage: "http://www.radiocountrylive.com/"
+  country: US
+  status: stream-only
+  stationuuid: 962b764a-0601-11e8-ae97-52543be04c81
+  changeuuid: 695a3446-b619-422a-817d-f1be3f1d512b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-megarock-radio-320k
+  broadcaster: independent
+  name: Megarock Radio 320k
+  streamUrl: https://stream3.megarockradio.net:80/
+  bitrate: 320
+  codec: MP3
+  favicon: "https://megarockradio.net/favicon.ico"
+  homepage: "https://megarockradio.net/"
+  country: US
+  status: stream-only
+  stationuuid: e5b81ad3-bb7d-41a5-a3d3-0f715434778e
+  changeuuid: 4bf53477-b033-49e1-81ee-d5ea76cd3447
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-heavyweight-reggae-256k-mp3
+  broadcaster: independent
+  name: SomaFM Heavyweight Reggae (256k MP3)
+  streamUrl: https://ice6.somafm.com/reggae-256-mp3
+  bitrate: 320
+  codec: MP3
+  favicon: "https://somafm.com/img3/reggae400.jpg"
+  homepage: "https://somafm.com/reggae/"
+  country: US
+  status: stream-only
+  stationuuid: 701106b9-59e3-11ea-be63-52543be04c81
+  changeuuid: ec9a3590-4278-4d20-96e3-1664e55302f5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-msnbc
+  broadcaster: independent
+  name: MSNBC
+  streamUrl: https://tunein.cdnstream1.com/3511_96.mp3
+  bitrate: 96
+  codec: MP3
+  favicon: "https://nodeassets.nbcnews.com/cdnassets/projects/ramen/favicon/msnbc/all-other-sizes-PNG.ico/favicon-96x96.png"
+  homepage: "https://www.msnbc.com/"
+  country: US
+  status: stream-only
+  stationuuid: 0b2c57db-885d-46d8-bbee-0651449759f1
+  changeuuid: de063d90-1a42-4bca-9bbe-1d188b57163f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-love-live-new-york
+  broadcaster: independent
+  name: Radio Love Live New York
+  streamUrl: https://streaming.radiostreamlive.com/radiolovelive_devices
+  bitrate: 128
+  codec: MP3
+  favicon: "https://cdn-elements.radiostreamlive.com/v1/images/favicon.ico"
+  homepage: "http://www.radiolovelive.com/"
+  country: US
+  status: stream-only
+  stationuuid: 961cc45e-0601-11e8-ae97-52543be04c81
+  changeuuid: eca7fa6b-f74e-4b35-a545-cdea8240c5ae
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-bluegrass-country
+  broadcaster: independent
+  name: Bluegrass Country
+  streamUrl: https://ice24.securenetsystems.net/WAMU
+  bitrate: 64
+  codec: AAC+
+  favicon: "https://bluegrasscountry.org/favicon.ico"
+  homepage: "https://bluegrasscountry.org/"
+  country: US
+  status: stream-only
+  stationuuid: 655def6d-734f-4ef7-972a-6abc56763162
+  changeuuid: d736a75f-0c66-4b10-b62a-2e80bd2aca88
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-classical-kdfc
+  broadcaster: independent
+  name: Classical KDFC
+  streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/KDFCFMAAC.aac
+  bitrate: 128
+  codec: AAC+
+  favicon: "https://radiostationusa.fm/assets/image/radio/180/KDFCFM.png"
+  homepage: "https://www.kdfc.com/"
+  country: US
+  status: stream-only
+  stationuuid: b06d68db-53b6-4692-9120-e6699d95dc9c
+  changeuuid: 67bdd788-bbe5-4a38-a581-7f91797a6718
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-kpfa
+  broadcaster: independent
+  name: KPFA
+  streamUrl: https://streams.kpfa.org:8443/kpfa
+  bitrate: 185
+  codec: MP3
+  favicon: "https://kpfa.org/favicon.ico"
+  homepage: "https://kpfa.org/"
+  country: US
+  status: stream-only
+  stationuuid: 662f715d-0b0c-4986-84e2-0cfb465caaf2
+  changeuuid: 47a99d16-e99b-41ad-bfa4-2925186fd67a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-comedy-104-radiostorm
+  broadcaster: independent
+  name: Comedy 104 - Radiostorm
+  streamUrl: https://ais-sa5.cdnstream1.com/b42761_64mp3
+  bitrate: 96
+  codec: MP3
+  favicon: "https://radiostorm.com/wp-content/uploads/2018/01/cropped-imgpsh_fullsize2-180x180.png"
+  homepage: "https://radiostorm.com/"
+  country: US
+  status: stream-only
+  stationuuid: c2958dcc-75ad-4ece-8781-6a465f4fb09f
+  changeuuid: 6e7518f5-02ba-4799-9540-e8e4baeb3ac5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-trap-radio-trap-radio
+  broadcaster: independent
+  name: TRAP RADIO TRAP.radio
+  streamUrl: https://trapradio.streamingmedia.it/play
+  bitrate: 128
+  codec: AAC+
+  homepage: "http://trap.radio/"
+  country: US
+  status: stream-only
+  stationuuid: 63c56fba-2e27-4983-a78e-5798aba8d73a
+  changeuuid: 38e1d207-20df-4d60-9bd1-78657bc24223
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-station
+  broadcaster: independent
+  name: 美国之音
+  streamUrl: https://voa-ingest.akamaized.net/hls/live/2035206/151_124L/playlist.m3u8
+  bitrate: 140
+  codec: AAC
+  favicon: null
+  homepage: "https://voa-ingest.akamaized.net/"
+  country: US
+  status: stream-only
+  stationuuid: b05b65e3-0936-4e7b-9f07-364cba23d7b2
+  changeuuid: 1d3a2222-7acd-47e5-8844-2e949b712d7b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-secret-agent-32k-aac
+  broadcaster: independent
+  name: SomaFM Secret Agent (32k AAC)
+  streamUrl: https://ice6.somafm.com/secretagent-32-aac
+  bitrate: 32
+  codec: AAC
+  favicon: "https://somafm.com/img3/secretagent-400.jpg"
+  homepage: "https://somafm.com/secretagent/"
+  country: US
+  status: stream-only
+  stationuuid: 960d68cf-0601-11e8-ae97-52543be04c81
+  changeuuid: 9a75949d-8887-4a02-a87f-5a4ea96e0174
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-classic-rock-109
+  broadcaster: independent
+  name: Classic Rock 109
+  streamUrl: https://jenny.torontocast.com:2000/stream/ClassicRock109
+  bitrate: 128
+  codec: MP3
+  homepage: "http://www.classicrock109.com/site/index.html"
+  country: US
+  status: stream-only
+  stationuuid: 073c45b3-3f5a-451b-a93b-867fc250b6c2
+  changeuuid: 7971c666-7d05-4077-972d-6875d7b1129d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-deep-space-one-32k-aac
+  broadcaster: independent
+  name: SomaFM Deep Space One (32k AAC)
+  streamUrl: https://ice2.somafm.com/deepspaceone-32-aac
+  bitrate: 32
+  codec: AAC
+  favicon: "http://somafm.com/img3/deepspaceone-400.jpg"
+  homepage: "https://somafm.com/deepspaceone/"
+  country: US
+  status: stream-only
+  stationuuid: 6f73bc13-3c4b-11e8-b74d-52543be04c81
+  changeuuid: 2c617cb5-fd6a-47e1-9497-abacf46d1f2e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-left-coast-70s-128k-mp3
+  broadcaster: independent
+  name: SomaFM Left Coast 70s (128k MP3)
+  streamUrl: https://ice2.somafm.com/seventies-128-mp3
+  bitrate: 128
+  codec: MP3
+  favicon: "https://somafm.com/img3/seventies400.jpg"
+  homepage: "https://somafm.com/seventiesr/"
+  country: US
+  status: stream-only
+  stationuuid: 961210eb-0601-11e8-ae97-52543be04c81
+  changeuuid: ca069b28-9d59-4d7c-910e-c2f2774a1a53
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-funky-radio-only-funk-music-60-s-70-s-439fafd7
+  broadcaster: independent
+  name: "FUNKY RADIO - Only Funk Music (60's & 70's)"
+  streamUrl: https://funkyradio.streamingmedia.it/audio.aac
+  bitrate: 128
+  codec: AAC+
+  homepage: "https://funky.radio/"
+  country: US
+  status: stream-only
+  stationuuid: 439fafd7-b35b-4a6c-b22f-d9e4fbd9dfd4
+  changeuuid: 808ee462-7882-4e9f-b7c8-7c1cb1f037b4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-boot-liquor-320k-mp3
+  broadcaster: independent
+  name: SomaFM Boot Liquor (320k MP3)
+  streamUrl: https://ice4.somafm.com/bootliquor-320-mp3
+  bitrate: 320
+  codec: MP3
+  favicon: "https://somafm.com/img3/bootliquor-400.jpg"
+  homepage: "https://somafm.com/bootliquor/"
+  country: US
+  status: stream-only
+  stationuuid: ffe33802-6417-11e9-a622-52543be04c81
+  changeuuid: a171b663-ebfc-4485-97ee-fe65be8f4191
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-christian-life-radio
+  broadcaster: independent
+  name: Christian Life Radio
+  streamUrl: https://ice64.securenetsystems.net/CLR1MP3
+  bitrate: 128
+  codec: MP3
+  homepage: "https://www.communitynetradio.org/christianliferadio"
+  country: US
+  status: stream-only
+  stationuuid: 964184b3-0601-11e8-ae97-52543be04c81
+  changeuuid: 2181e80a-0f21-4a1f-8273-ce6d29c2d854
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-sonic-universe-128k-mp3
+  broadcaster: independent
+  name: SomaFM Sonic Universe (128k MP3)
+  streamUrl: https://ice5.somafm.com/sonicuniverse-128-mp3
+  bitrate: 128
+  codec: MP3
+  favicon: "https://somafm.com/img3/sonicuniverse-400.jpg"
+  homepage: "https://somafm.com/sonicuniverse/"
+  country: US
+  status: stream-only
+  stationuuid: 961249b2-0601-11e8-ae97-52543be04c81
+  changeuuid: 75ab7463-b05f-4c5e-9e2e-11a4dbd67c1b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-paradise-rock-mix-flac
+  broadcaster: independent
+  name: Radio Paradise Rock Mix FLAC
+  streamUrl: https://stream.radioparadise.com/rock-flac
+  bitrate: 1441
+  codec: OGG
+  favicon: "https://radioparadise.com/apple-touch-icon.png"
+  homepage: "https://radioparadise.com/"
+  country: US
+  status: stream-only
+  stationuuid: 786d2939-00eb-479d-b3f0-f0f7673ea7e0
+  changeuuid: d41d7f6d-6bf2-4822-aed4-077860fc2ee5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-funky-corner-radio-usa
+  broadcaster: independent
+  name: _Funky Corner Radio (USA)
+  streamUrl: https://ais-sa2.cdnstream1.com/2447_192.mp3
+  bitrate: 192
+  codec: MP3
+  homepage: "https://www.funkycorner.it/"
+  country: US
+  status: stream-only
+  stationuuid: 43718921-41a0-48f5-9645-c467d19a5095
+  changeuuid: fcbf1131-f83d-426f-8f0e-64f43a8aa5b9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-america-s-country
+  broadcaster: independent
+  name: "America's Country"
+  streamUrl: https://ais-sa2.cdnstream1.com/1976_128.mp3
+  bitrate: 128
+  codec: AAC
+  favicon: "https://marinifamily.files.wordpress.com/2015/08/favicon.png"
+  homepage: "https://americascountry.us/"
+  country: US
+  status: stream-only
+  stationuuid: 3b92f8c7-deac-4a81-8a9c-3b0f995d73e4
+  changeuuid: 56e1d8b8-57e2-460b-a3ce-b338bb596a98
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-100-hip-hop-and-rnb-fm
+  broadcaster: independent
+  name: .100 Hip hop and RNB FM
+  streamUrl: https://ice64.securenetsystems.net/LFTM
+  bitrate: 32
+  codec: AAC+
+  homepage: "https://ice64.securenetsystems.net/LFTM"
+  country: US
+  status: stream-only
+  stationuuid: 7eb9e8ed-47f6-4cae-889a-774f6462db5f
+  changeuuid: e8ccf569-75f1-4ed4-9d97-a0b3e0580278
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-beat-blender-128k-mp3
+  broadcaster: independent
+  name: SomaFM Beat Blender (128k MP3)
+  streamUrl: https://ice6.somafm.com/beatblender-128-mp3
+  bitrate: 128
+  codec: MP3
+  favicon: "https://somafm.com/img3/beatblender-400.jpg"
+  homepage: "https://somafm.com/beatblender/"
+  country: US
+  status: stream-only
+  stationuuid: 960eb232-0601-11e8-ae97-52543be04c81
+  changeuuid: 18d5390d-c189-4e3c-9d97-a005dd5c65bd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-suburbs-of-goa-128k-aac
+  broadcaster: independent
+  name: SomaFM Suburbs of Goa (128k AAC)
+  streamUrl: https://ice4.somafm.com/suburbsofgoa-128-aac
+  bitrate: 128
+  codec: AAC
+  favicon: "https://somafm.com/img3/suburbsofgoa-400.png"
+  homepage: "https://somafm.com/suburbsofgoa/"
+  country: US
+  status: stream-only
+  stationuuid: 9614f116-0601-11e8-ae97-52543be04c81
+  changeuuid: 372f8f87-9c81-4655-89c7-89c925fbec74
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-christian-power-praise-dot-net
+  broadcaster: independent
+  name: Christian Power Praise Dot Net
+  streamUrl: https://listen.christianrock.net/stream/13/
+  bitrate: 120
+  codec: AAC
+  favicon: "https://www.christianpowerpraise.net/apple-touch-icon.png"
+  homepage: "https://www.christianpowerpraise.net/"
+  country: US
+  status: stream-only
+  stationuuid: 96147f07-0601-11e8-ae97-52543be04c81
+  changeuuid: 2bd14d6b-f740-4530-9bf8-8cb0d12299e7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-1460-espn-deportes
+  broadcaster: independent
+  name: 1460 ESPN Deportes
+  streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/KENOAMAAC.aac
+  bitrate: 32
+  codec: AAC+
+  homepage: "https://www.lvsportsnetwork.com/"
+  country: US
+  status: stream-only
+  stationuuid: ebc56104-6898-4609-aa8c-7cfe7a66cb3f
+  changeuuid: 74a8e59c-ff40-4104-be0a-7d3856c27a17
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-groove-salad-128k-aac
+  broadcaster: independent
+  name: SomaFM Groove Salad (128k AAC)
+  streamUrl: https://ice5.somafm.com/groovesalad-128-aac
+  bitrate: 128
+  codec: AAC
+  favicon: "https://somafm.com/img3/groovesalad-400.jpg"
+  homepage: "https://somafm.com/groovesalad/"
+  country: US
+  status: stream-only
+  stationuuid: 962aa032-0601-11e8-ae97-52543be04c81
+  changeuuid: f6ea2a70-b98b-4fbb-92a6-2144639fcd14
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-bloomberg-99-1-105-7-hd2
+  broadcaster: independent
+  name: Bloomberg 99.1/105.7 HD2
+  streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/WBBRDCAAC.aac
+  bitrate: 32
+  codec: AAC+
+  favicon: "https://www.bloombergradio.com/content/plugins/bloomberg-favicon/dist/img/amber-120x120.png"
+  homepage: "https://www.bloombergradio.com/"
+  country: US
+  status: stream-only
+  stationuuid: 2992ab47-a3d5-4ab2-9881-bf7657fa1c03
+  changeuuid: daae6821-03d3-4bd4-a04f-3fb1dfdfdad3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-red-state-talk-radio
+  broadcaster: independent
+  name: Red State Talk Radio
+  streamUrl: https://s2.radio.co/s572ad25f7/listen
+  bitrate: 128
+  codec: MP3
+  favicon: "https://redstatetalkradio.com/wp-content/uploads/2021/03/cropped-rstr588x588-180x180.png"
+  homepage: "http://redstatetalkradio.com/"
+  country: US
+  status: stream-only
+  stationuuid: ffa1a827-ba13-4837-89d3-a9c54f74b6ca
+  changeuuid: 87181b60-8964-4c5d-9d81-ba32da4dcce1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-the-independent-fm
+  broadcaster: independent
+  name: The Independent FM
+  streamUrl: https://listen.radioking.com/radio/293701/stream/340084
+  bitrate: 320
+  codec: MP3
+  homepage: "https://www.radioking.com/radio/the-independent-fm-1"
+  country: US
+  status: stream-only
+  stationuuid: a722ad53-b10d-4087-85d8-5fabe061f758
+  changeuuid: a0385778-44a8-4bad-b880-900aa724a14e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-smooth-r-b-105-7
+  broadcaster: independent
+  name: "Smooth R&B 105.7"
+  streamUrl: https://ais-sa1.streamon.fm/7281_64k.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: "https://krnb.com/favicon.ico"
+  homepage: "https://krnb.com/"
+  country: US
+  status: stream-only
+  stationuuid: ab963dea-5579-4378-9975-751f7a7a3eaf
+  changeuuid: 2818b382-ab29-40ba-8fc1-97a2ff74409b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-chilltrax
+  broadcaster: independent
+  name: chilltrax
+  streamUrl: https://streamssl.chilltrax.com/
+  bitrate: 128
+  codec: MP3
+  country: US
+  status: stream-only
+  stationuuid: 9e1377e3-623c-4b8f-a162-4da9c1fcdbf1
+  changeuuid: 923d2b65-a94c-4551-b40d-b7b242851e8e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-seven-inch-soul-128k-mp3
+  broadcaster: independent
+  name: SomaFM Seven Inch Soul (128k MP3)
+  streamUrl: https://ice5.somafm.com/7soul-128-mp3
+  bitrate: 160
+  codec: MP3
+  favicon: "https://somafm.com/img3/7soul-400.jpg"
+  homepage: "https://somafm.com/7soul/"
+  country: US
+  status: stream-only
+  stationuuid: 9612102b-0601-11e8-ae97-52543be04c81
+  changeuuid: d17cd841-e31b-4e50-a058-0efdfb1e8566
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-folk-forward-128k-mp3
+  broadcaster: independent
+  name: SomaFM Folk Forward (128k MP3)
+  streamUrl: https://ice1.somafm.com/folkfwd-128-mp3
+  bitrate: 128
+  codec: MP3
+  favicon: "https://somafm.com/img3/folkfwd-400.jpg"
+  homepage: "https://somafm.com/folkfwd/"
+  country: US
+  status: stream-only
+  stationuuid: 960e14a9-0601-11e8-ae97-52543be04c81
+  changeuuid: a1d5f576-79eb-4acc-be22-abeb8c8eee1d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-folk-forward-128k-aac
+  broadcaster: independent
+  name: SomaFM Folk Forward (128k AAC)
+  streamUrl: https://ice5.somafm.com/folkfwd-128-aac
+  bitrate: 128
+  codec: AAC
+  favicon: "https://somafm.com/img3/folkfwd-400.jpg"
+  homepage: "https://somafm.com/folkfwd/"
+  country: US
+  status: stream-only
+  stationuuid: d420bcf1-bb4c-11e9-acb2-52543be04c81
+  changeuuid: 2f81305d-cda9-443c-90db-f0ee6200993b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-abiding-radio-instrumental
+  broadcaster: independent
+  name: Abiding Radio - Instrumental
+  streamUrl: https://streams.abidingradio.com:7800/1
+  bitrate: 128
+  codec: MP3
+  favicon: "https://www.abidingradio.org/wp-content/uploads/2022/05/cropped-new_icon.png"
+  homepage: "https://www.abidingradio.com/"
+  country: US
+  status: stream-only
+  stationuuid: dee09ddb-8e41-11e8-aa66-52543be04c81
+  changeuuid: 84c4ccea-1794-4aed-8b63-8e91409db7b7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-paradise-main-mix-flac
+  broadcaster: independent
+  name: Radio Paradise Main Mix FLAC
+  streamUrl: https://stream.radioparadise.com/flac
+  bitrate: 1441
+  codec: OGG
+  favicon: "https://radioparadise.com/apple-touch-icon.png"
+  homepage: "https://radioparadise.com/"
+  country: US
+  status: stream-only
+  stationuuid: 9fe19f6a-6e9c-4c58-bdf1-4d8431934d09
+  changeuuid: 6ce0b02c-0077-4a18-8133-0b74a36b1eee
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-dnb-edm
+  broadcaster: independent
+  name: "DnB&EDM"
+  streamUrl: https://edmdnb.com:448/radio/8000/radio.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: "https://edmdnb.com/"
+  country: US
+  status: stream-only
+  stationuuid: e2f8a671-835a-4223-ad0f-33ac7aa9ed05
+  changeuuid: a354f0fc-330e-4fc9-a6fd-06c0d47b2ca2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-def-con-radio-128k-aac
+  broadcaster: independent
+  name: SomaFM DEF CON Radio (128k AAC)
+  streamUrl: https://ice6.somafm.com/defcon-128-aac
+  bitrate: 128
+  codec: AAC
+  favicon: "https://somafm.com/img3/defcon400.png"
+  homepage: "https://somafm.com/defcon/"
+  country: US
+  status: stream-only
+  stationuuid: 5b59ea80-6ce9-11e8-b15b-52543be04c81
+  changeuuid: db5b50ce-6131-4d70-885e-5741c917cc9c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-cnn-international-audio
+  broadcaster: independent
+  name: CNN International Audio
+  streamUrl: https://tunein.cdnstream1.com/3519_96.aac
+  bitrate: 98
+  codec: AAC
+  favicon: "https://raw.githubusercontent.com/AusIPTV/IPTVLogos/master/CNN_International_Logo.png"
+  homepage: "https://www.cnn.com/"
+  country: US
+  status: stream-only
+  stationuuid: 7094b698-b1ac-4f08-a6cd-ac35f906765d
+  changeuuid: aa896ec1-6254-4924-a3e0-f696a6374d2a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-fox-news
+  broadcaster: independent
+  name: Fox News
+  streamUrl: https://247preview.foxnews.com/hls/live/2020027/fncv3preview/primary.m3u8
+  bitrate: 311
+  codec: UNKNOWN
+  homepage: "https://superradio.cc/"
+  country: US
+  status: stream-only
+  stationuuid: 3da2910e-3a5d-4d57-90bb-7fe6f00b29f8
+  changeuuid: dc632b57-50ab-46f9-8b81-4769ebc1c549
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-tu-94-9
+  broadcaster: independent
+  name: Tu 94.9
+  streamUrl: https://stream.revma.ihrhls.com/zc577
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/5b3e27cde11698161e4ae966?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)"
+  homepage: "https://tu949fm.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 5613bc2e-254f-4ead-ad5a-419d9fd0d89d
+  changeuuid: 6ce20a03-c7f0-4d76-ba82-a0be858d927e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-underground-80s-256k-mp3
+  broadcaster: independent
+  name: SomaFM Underground 80s (256k MP3)
+  streamUrl: https://ice6.somafm.com/u80s-256-mp3
+  bitrate: 256
+  codec: MP3
+  favicon: "https://somafm.com/img3/u80s-400.png"
+  homepage: "https://somafm.com/u80s/"
+  country: US
+  status: stream-only
+  stationuuid: ed1fb9a0-6416-11e9-a622-52543be04c81
+  changeuuid: 38e2f568-cecd-44db-b387-95bc42fdb529
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-new-york-live
+  broadcaster: independent
+  name: Radio New York Live
+  streamUrl: https://streaming.radiostreamlive.com/radionylive_devices
+  bitrate: 128
+  codec: MP3
+  favicon: "https://cdn-elements.radiostreamlive.com/v1/images/favicon.ico"
+  homepage: "http://www.radionylive.com/"
+  country: US
+  status: stream-only
+  stationuuid: 961f7778-0601-11e8-ae97-52543be04c81
+  changeuuid: 3fc5d283-cf10-47d5-b6b2-d182c0141dad
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-paradise-world-etc-mix-320k-aac
+  broadcaster: independent
+  name: Radio Paradise World/Etc Mix 320k AAC
+  streamUrl: https://stream.radioparadise.com/world-etc-320
+  bitrate: 320
+  codec: AAC
+  favicon: "https://radioparadise.com/apple-touch-icon.png"
+  homepage: "https://radioparadise.com/"
+  country: US
+  status: stream-only
+  stationuuid: 21a282be-44f4-4b8e-aae9-b4c2041af4a5
+  changeuuid: 3638d4a8-f099-40af-b979-9331a2b39f08
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-christian-rock-dot-net
+  broadcaster: independent
+  name: Christian Rock Dot Net
+  streamUrl: https://listen.christianrock.net/stream/11/
+  bitrate: 120
+  codec: AAC
+  favicon: "https://www.christianrock.net/apple-touch-icon.png"
+  homepage: "https://www.christianrock.net/"
+  country: US
+  status: stream-only
+  stationuuid: 960cfee5-0601-11e8-ae97-52543be04c81
+  changeuuid: 20965f1c-2132-4f67-8b81-a3483439d10e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-mega-96-3-los-angeles-96-3-fm-kxol-fm-spanish-br
+  broadcaster: independent
+  name: "Mega 96.3 (Los Angeles) - 96.3 FM - KXOL-FM - Spanish Broadcasting System - Los Angeles, California"
+  streamUrl: https://liveaudio.lamusica.com/LA_KXOL_icy
+  bitrate: 128
+  codec: AAC
+  homepage: "https://www.lamusica.com/stations/kxol"
+  country: US
+  status: stream-only
+  stationuuid: 0534207e-dea1-4239-a4be-d38017df2e61
+  changeuuid: 11066155-457f-4b38-aad8-012b06e38ee8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-groove-salad-classic-128k-mp3
+  broadcaster: independent
+  name: SomaFM Groove Salad Classic (128k MP3)
+  streamUrl: https://ice2.somafm.com/gsclassic-128-mp3
+  bitrate: 160
+  codec: MP3
+  favicon: "https://somafm.com/img3/gsclassic400.jpg"
+  homepage: "https://somafm.com/groovesalad/"
+  country: US
+  status: stream-only
+  stationuuid: e6fa9a8a-02a8-11e9-a1be-52543be04c81
+  changeuuid: 7d886792-6269-4d4d-9e59-5da7f419c57d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-groove-salad-hls-flac
+  broadcaster: independent
+  name: SomaFM Groove Salad (HLS FLAC)
+  streamUrl: https://hls.somafm.com/hls/groovesalad/FLAC/program.m3u8
+  codec: MP4
+  favicon: "https://somafm.com/img3/groovesalad-400.jpg"
+  homepage: "https://somafm.com/groovesalad/"
+  country: US
+  status: stream-only
+  stationuuid: 000f6a5e-fdbb-489c-90c5-89fd4c9e1113
+  changeuuid: d695b735-d02e-4ff2-b2aa-10d9497be3da
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-disco-studio-54
+  broadcaster: independent
+  name: Disco Studio 54
+  streamUrl: https://maiban00.radioca.st/stream
+  bitrate: 320
+  codec: MP3
+  favicon: "https://discostudio54.com/favicon.ico"
+  homepage: "https://discostudio54.com/"
+  country: US
+  status: stream-only
+  stationuuid: 7895ba8d-a1c9-4bb5-9b61-9e2893338c78
+  changeuuid: 1a98add3-e069-462d-a120-ffec5b00cfd0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-red-state-talk-radio-encore
+  broadcaster: independent
+  name: Red State Talk Radio Encore
+  streamUrl: https://s2.radio.co/sf03a6a4b2/listen
+  bitrate: 128
+  codec: MP3
+  homepage: "http://redstatetalkradio.com/"
+  country: US
+  status: stream-only
+  stationuuid: 7914c61d-09a7-46d0-8c53-d250e7cd43e5
+  changeuuid: 2099054c-bd08-4788-a9bb-18a16c41b13c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-cbs-news
+  broadcaster: independent
+  name: CBS News
+  streamUrl: https://cbsn-us.cbsnstream.cbsnews.com/out/v1/55a8648e8f134e82a470f83d562deeca/master.m3u8
+  bitrate: 273
+  codec: AAC
+  homepage: "https://superradio.cc/"
+  country: US
+  status: stream-only
+  stationuuid: 744d4afd-05c2-4c84-b8e9-a64f66bf08fc
+  changeuuid: 36689931-c1c3-4149-b9db-aedc3a07c563
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-rock-on
+  broadcaster: independent
+  name: Radio Rock On
+  streamUrl: https://streaming.radiostreamlive.com/radiorockon_devices
+  bitrate: 128
+  codec: MP3
+  favicon: "https://cdn-elements.radiostreamlive.com/v1/images/favicon.ico"
+  homepage: "http://www.radiorockon.com/"
+  country: US
+  status: stream-only
+  stationuuid: 962b77a9-0601-11e8-ae97-52543be04c81
+  changeuuid: 6fe9664c-18b0-4baa-996f-37566ae296ab
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-soma-fm-groove-salad-320k-aac-hls
+  broadcaster: independent
+  name: Soma FM Groove Salad 320K AAC HLS
+  streamUrl: https://hls.somafm.com/hls/groovesalad/320k/program.m3u8
+  bitrate: 320000
+  codec: MP4
+  favicon: "https://somafm.com/img3/groovesalad-400.png"
+  homepage: "https://www.somafm.com/"
+  country: US
+  status: stream-only
+  stationuuid: 608bc971-3ec5-4c05-8143-de96c3bdb030
+  changeuuid: e29f280a-644f-4030-b1fa-893fc46d1d92
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-wskq-mega-97-9
+  broadcaster: independent
+  name: WSKQ Mega 97.9
+  streamUrl: https://liveaudio.lamusica.com/NY_WSKQ_icy?listenerid=94d1ac3bf877b65e4e17cd7e9bfec132&awparams=companionAds%3Atrue&aw_0_1st.version=1.1.12%3Ahtml5&aw_0_1st.playerid=lamusica.web.mobile&aw_0_1st.skey=1690194521&sw_bp=1
+  bitrate: 128
+  codec: AAC
+  homepage: "https://www.lamusica.com/stations/wskq"
+  country: US
+  status: stream-only
+  stationuuid: 8bbc30b2-3b03-4c45-beed-35b98f18a367
+  changeuuid: 1b19b3bd-f82d-49b9-a4d4-96677feddb9c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-chill-lounge-florida-usa-128k-mp3
+  broadcaster: independent
+  name: Chill Lounge Florida (USA) 128k mp3
+  streamUrl: https://vip2.fastcast4u.com/proxy/chillfla?mp=/1
+  bitrate: 128
+  codec: MP3
+  homepage: "https://vip2.fastcast4u.com/proxy/chillfla?mp=/1"
+  country: US
+  status: stream-only
+  stationuuid: 8bd983bb-80a0-48cf-a1d4-4bc7484719d7
+  changeuuid: 5e34c9bc-05dc-46c6-b6c2-ae882d0adc8c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-begoodradio-com-80s-metal
+  broadcaster: independent
+  name: Begoodradio.com 80s metal
+  streamUrl: https://bigrradio.cdnstream1.com/5212_128
+  bitrate: 128
+  codec: MP3
+  favicon: "http://begoodradio.com/images/logo.png"
+  homepage: "http://begoodradio.com/"
+  country: US
+  status: stream-only
+  stationuuid: 9189bb75-e1f7-475c-b837-564a172cb178
+  changeuuid: c5f57425-defa-4695-83b5-1907c8cfdc3d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-24-7-comedy
+  broadcaster: independent
+  name: 24/7 Comedy
+  streamUrl: https://stream.revma.ihrhls.com/zc4902
+  codec: AAC
+  favicon: "https://www.iheart.com/favicon.ico"
+  homepage: "https://www.iheart.com/live/247-comedy-4902/"
+  country: US
+  status: stream-only
+  stationuuid: a2c3cec0-1dfd-4feb-b96a-e6ee2979fc5c
+  changeuuid: ffbc26ff-ea71-450c-9d8d-59e8fa37da8b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-dub-step-beyond-128k-mp3
+  broadcaster: independent
+  name: SomaFM Dub Step Beyond (128k MP3)
+  streamUrl: https://ice2.somafm.com/dubstep-128-mp3
+  bitrate: 128
+  codec: MP3
+  favicon: "https://somafm.com/img3/dubstep-400.jpg"
+  homepage: "https://somafm.com/dubstep/"
+  country: US
+  status: stream-only
+  stationuuid: 960eb3a4-0601-11e8-ae97-52543be04c81
+  changeuuid: abf2c50c-863c-45d0-a339-bc214bfa72a3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-frisky-radio
+  broadcaster: independent
+  name: Frisky Radio
+  streamUrl: https://stream.frisky.friskyradio.com/mp3_low
+  bitrate: 96
+  codec: MP3
+  favicon: "https://s3.amazonaws.com/media.friskyradio.com/favicon.png"
+  homepage: "https://www.friskyradio.com/"
+  country: US
+  status: stream-only
+  stationuuid: 9c2115ee-1bfe-4ca6-981e-2104d7636aee
+  changeuuid: a2214f63-8154-420d-84dc-d3c6f06ade45
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-werave-music-radio-01-dark-and-underground
+  broadcaster: independent
+  name: WeRave Music Radio 01 - Dark and Underground
+  streamUrl: https://stream.zeno.fm/pjktyby8dn5tv
+  codec: MP3
+  favicon: "https://werave.com.br/wp-content/uploads/cropped-weravemusic-180x180.png"
+  homepage: "https://werave.com.br/en"
+  country: US
+  status: stream-only
+  stationuuid: 1f73fdc3-e4df-48db-bcec-83a9460f1c93
+  changeuuid: 61d61beb-3c6b-44d2-a5ec-170e4d3239a4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-fox-sports-1260
+  broadcaster: independent
+  name: Fox Sports 1260
+  streamUrl: https://stream.revma.ihrhls.com/zc905
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/5d262bd52a4b03e3a623f6a5?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)"
+  homepage: "https://foxsports1260.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 6cdde1c1-fce3-4421-aeea-20cf0d4d000b
+  changeuuid: 4ecfd66c-4534-4876-8114-e0210f778e04
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-paradise-mellow-mix-64k-aac
+  broadcaster: independent
+  name: Radio Paradise Mellow Mix 64k AAC
+  streamUrl: https://stream.radioparadise.com/mellow-64
+  bitrate: 64
+  codec: AAC
+  favicon: "https://radioparadise.com/apple-touch-icon.png"
+  homepage: "https://radioparadise.com/"
+  country: US
+  status: stream-only
+  stationuuid: 6d264e68-5179-4e0f-ad2e-fca103afba28
+  changeuuid: 240105ac-3abc-4434-83de-98e0e76c398d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-104-9-max-country
+  broadcaster: independent
+  name: 104.9 Max Country
+  streamUrl: https://ais-sa1.streamon.fm/7246_48k.aac
+  bitrate: 48
+  codec: AAC+
+  favicon: "https://media.ruralradio.co/nrr/uploads/sites/12/2021/02/cropped-ktmx-2-180x180.png"
+  homepage: "https://1049maxcountry.com/"
+  country: US
+  status: stream-only
+  stationuuid: d8e81685-d2e6-4794-adb5-7278f6b25695
+  changeuuid: 5142a945-71a9-4c17-913f-bf5e3ba5db8e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-soul-radio-classics
+  broadcaster: independent
+  name: SOUL RADIO Classics
+  streamUrl: https://listen.soulradio.us/us
+  bitrate: 192
+  codec: AAC+
+  homepage: "https://soulradio.us/"
+  country: US
+  status: stream-only
+  stationuuid: 951ebca8-80cf-4047-a2b4-3a5d403ed3ae
+  changeuuid: 2b467630-1a31-4b84-b9cf-fdd60da4c451
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-your-classical-chamber-music
+  broadcaster: independent
+  name: Your Classical Chamber Music
+  streamUrl: https://chambermusic.stream.publicradio.org/chambermusic.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: "https://www.yourclassical.org/"
+  country: US
+  status: stream-only
+  stationuuid: 820d9afb-91c1-4c8d-bd93-e858741059b9
+  changeuuid: a3f56d84-00c7-418e-b0ad-2997f401f559
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-the-blaze-radio
+  broadcaster: independent
+  name: The Blaze radio
+  streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/BLZE_1.mp3
+  bitrate: 64
+  codec: MP3
+  homepage: "http://theblaze.com/"
+  country: US
+  status: stream-only
+  stationuuid: 32811bda-1a78-40b5-a572-d3e17c055da3
+  changeuuid: 279ff1d9-6100-4bda-b3cd-942610e61051
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-bloomberg-radio-boston
+  broadcaster: independent
+  name: Bloomberg Radio Boston
+  streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/WRCAAMAAC.aac
+  bitrate: 112
+  codec: AAC+
+  favicon: "https://www.bloombergradio.com/content/plugins/bloomberg-favicon/dist/img/amber-120x120.png"
+  homepage: "https://www.bloombergradio.com/"
+  country: US
+  status: stream-only
+  stationuuid: da3527f7-b71e-49e0-a9d5-57102350ffc5
+  changeuuid: 18552abc-43f6-4ce0-8404-cd29973e7374
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-chicago-house
+  broadcaster: independent
+  name: CHICAGO HOUSE
+  streamUrl: https://stream.radio.co/sae989fe39/listen
+  bitrate: 192
+  codec: MP3
+  country: US
+  status: stream-only
+  stationuuid: 95912a6e-9de0-4b3b-b120-c9988d70d4a8
+  changeuuid: f645a200-45a4-40a3-bb56-eebc8c51965f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-conyers-old-time-radio
+  broadcaster: independent
+  name: Conyers Old Time Radio
+  streamUrl: https://s8.yesstreaming.net:17011/stream
+  bitrate: 64
+  codec: MP3
+  homepage: "http://www.conyersradio.net/"
+  country: US
+  status: stream-only
+  stationuuid: 38055669-97a7-11e9-a605-52543be04c81
+  changeuuid: eeb4c014-3665-4d69-b816-7627c08bddd1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-illinois-street-lounge-128k-mp3
+  broadcaster: independent
+  name: SomaFM Illinois Street Lounge (128k MP3)
+  streamUrl: https://ice4.somafm.com/illstreet-128-mp3
+  bitrate: 128
+  codec: MP3
+  favicon: "https://somafm.com/img3/illstreet-400.jpg"
+  homepage: "https://somafm.com/illstreet/"
+  country: US
+  status: stream-only
+  stationuuid: 960d67e8-0601-11e8-ae97-52543be04c81
+  changeuuid: a04edabc-8d0f-44c7-b79b-7d2cc7c5239c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-vaporwaves-128k-aac
+  broadcaster: independent
+  name: SomaFM Vaporwaves (128k AAC)
+  streamUrl: https://ice6.somafm.com/vaporwaves-128-aac
+  bitrate: 128
+  codec: AAC
+  favicon: "https://somafm.com/img3/vaporwaves400.png"
+  homepage: "https://somafm.com/vaporwaves/"
+  country: US
+  status: stream-only
+  stationuuid: 7ce0842a-0414-4d3e-8c16-e39030c4bfb8
+  changeuuid: f33789e1-c1cf-4169-a4a9-6286206d608c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-boot-liquor-128k-aac
+  broadcaster: independent
+  name: SomaFM Boot Liquor (128k AAC)
+  streamUrl: https://ice1.somafm.com/bootliquor-128-aac
+  bitrate: 128
+  codec: AAC
+  favicon: "https://somafm.com/img3/bootliquor-400.jpg"
+  homepage: "https://somafm.com/bootliquor/"
+  country: US
+  status: stream-only
+  stationuuid: a4ce32b4-3c4c-11e8-b74d-52543be04c81
+  changeuuid: 76503d72-24bb-4d0e-9649-c7a4e6dfdf68
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-104-5-latino-hits
+  broadcaster: independent
+  name: 104.5 Latino Hits
+  streamUrl: https://stream.revma.ihrhls.com/zc4051
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/5956ab6d089c9f13b01e4cc4?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)"
+  homepage: "https://1045latinohits.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 6fe3eb2c-f2f2-45b0-98ea-d875d302a5c4
+  changeuuid: bd2f38e8-66c5-47e0-8b3c-682cd9287301
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-american-tamil-radio
+  broadcaster: independent
+  name: American Tamil Radio
+  streamUrl: https://cp11.serverse.com/proxy/hgsmgluv?mp=/stream
+  bitrate: 128
+  codec: MP3
+  homepage: "https://americantamilradio.com/"
+  country: US
+  status: stream-only
+  stationuuid: 5d743713-b997-4b1a-888a-17f052af1a13
+  changeuuid: 4a63f76b-3479-478a-990b-6a4f74146387
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-cliqhop-idm-128k-mp3
+  broadcaster: independent
+  name: SomaFM CliqHop IDM (128k MP3)
+  streamUrl: https://ice2.somafm.com/cliqhop-128-mp3
+  bitrate: 128
+  codec: MP3
+  favicon: "https://somafm.com/img3/cliqhop-400.jpg"
+  homepage: "https://somafm.com/cliqhop/"
+  country: US
+  status: stream-only
+  stationuuid: 960eb467-0601-11e8-ae97-52543be04c81
+  changeuuid: 02b879ef-9787-4262-a779-89a7e2984db9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-la-mega-105-7
+  broadcaster: independent
+  name: La Mega 105.7
+  streamUrl: https://ice41.securenetsystems.net/WEMG
+  bitrate: 32
+  codec: AAC+
+  homepage: "https://www.lamega1057.com/"
+  country: US
+  status: stream-only
+  stationuuid: 0ec03b18-cb48-44c2-ab5c-b3fe74cb7272
+  changeuuid: a49cb4fc-5aae-405d-9525-7912973b7f04
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-mission-control-128k-mp3
+  broadcaster: independent
+  name: SomaFM Mission Control (128k MP3)
+  streamUrl: https://ice4.somafm.com/missioncontrol-128-mp3
+  bitrate: 128
+  codec: MP3
+  favicon: "https://somafm.com/img3/missioncontrol-400.jpg"
+  homepage: "https://somafm.com/missioncontrol/"
+  country: US
+  status: stream-only
+  stationuuid: 9614eb15-0601-11e8-ae97-52543be04c81
+  changeuuid: 979b0188-eb39-4b7d-aa93-dd775f8bfbf0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-wosu-89-7-npr-news
+  broadcaster: independent
+  name: WOSU 89.7 NPR News
+  streamUrl: https://wosu.streamguys1.com/NPR_128
+  bitrate: 128
+  codec: AAC+
+  favicon: "https://wosu.org/apple-touch-icon.png"
+  homepage: "https://wosu.org/"
+  country: US
+  status: stream-only
+  stationuuid: 70e8dcc9-5f8e-4225-8d8e-e7487a3791f5
+  changeuuid: 3fae2d4e-4506-4b36-8f35-e42739d2d2d4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-christmas-lounge-256k
+  broadcaster: independent
+  name: SomaFM Christmas Lounge 256k
+  streamUrl: https://ice2.somafm.com/christmas-256-mp3
+  bitrate: 256
+  codec: MP3
+  favicon: "https://somafm.com/img3/christmas-400.jpg"
+  homepage: "https://somafm.com/christmas/"
+  country: US
+  status: stream-only
+  stationuuid: c0c02d01-f94e-11e8-a97a-52543be04c81
+  changeuuid: 83acca6b-c601-4013-9899-c796b9a4f867
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-paradise-world-etc-mix-flac
+  broadcaster: independent
+  name: Radio Paradise World/Etc Mix FLAC
+  streamUrl: https://stream.radioparadise.com/world-etc-flac
+  bitrate: 1441
+  codec: OGG
+  favicon: "https://radioparadise.com/apple-touch-icon.png"
+  homepage: "https://radioparadise.com/"
+  country: US
+  status: stream-only
+  stationuuid: 6263a7a9-804a-4ce3-9056-cfc98f2fa90f
+  changeuuid: da4575bf-3d4b-4100-8b25-ab42eed6af02
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-2000-s-country-music-radio
+  broadcaster: independent
+  name: "2000's Country Music Radio"
+  streamUrl: https://2.mystreaming.net/uber/cmr00scountry/icecast.audio
+  codec: MP3
+  favicon: "https://static2.mytuner.mobi/media/tvos_radios/904/country-music-radio-00s-country.5f83bb9f.png"
+  homepage: "https://mytuner-radio.com/radio/country-music-radio-00s-country-487904/"
+  country: US
+  status: stream-only
+  stationuuid: 81262f7e-fb9d-4ad1-bcee-d4a64f2fa662
+  changeuuid: 80e44811-d894-483a-bb7f-316f5989cf44
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-free-texas
+  broadcaster: independent
+  name: Radio Free Texas
+  streamUrl: https://server10.reliastream.com/proxy/damiller?mp=/stream
+  bitrate: 128
+  codec: MP3
+  homepage: "https://radiofreetexas.com/"
+  country: US
+  status: stream-only
+  stationuuid: a746c820-ddaa-4760-b53c-db268386b34e
+  changeuuid: 46c941da-79e6-4118-bbf1-e007065be585
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-erotica-lounge
+  broadcaster: independent
+  name: EROTICA LOUNGE
+  streamUrl: https://stream.zeno.fm/89asra0sfa0uv
+  codec: MP3
+  homepage: "https://tunein.com/radio/EROTICA-LOUNGE-s260655/"
+  country: US
+  status: stream-only
+  stationuuid: 74eac2e4-dd81-48d3-b47f-87f2f2a8b45a
+  changeuuid: a716bb9b-5da6-4a76-a0f3-ebbd59126d48
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-sonic-universe-128k-aac
+  broadcaster: independent
+  name: SomaFM Sonic Universe (128k AAC)
+  streamUrl: https://ice2.somafm.com/sonicuniverse-128-aac
+  bitrate: 128
+  codec: AAC
+  favicon: "https://somafm.com/img3/sonicuniverse-400.jpg"
+  homepage: "https://somafm.com/sonicuniverse/"
+  country: US
+  status: stream-only
+  stationuuid: 6d69c0fb-3cc2-11e8-b74d-52543be04c81
+  changeuuid: 6f75ed00-329e-4118-b0c0-487037f80fc2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-non-stop-oldies
+  broadcaster: independent
+  name: Non-Stop Oldies
+  streamUrl: https://ais-sa2.cdnstream1.com/2383_128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: "https://static.wixstatic.com/media/00a61a_a29da417d9ce44d18dc83e35a30c2f43.png/v1/crop/x_24,y_30,w_555,h_544/fill/w_136,h_133,al_c,q_85,usm_0.66_1.00_0.01,enc_auto/00a61a_a29da417d9ce44d18dc83e35a30c2f43.png"
+  homepage: "http://www.nonstopoldies.com/"
+  country: US
+  status: stream-only
+  stationuuid: 0653bfab-cb60-44e9-9511-d89b993c48f9
+  changeuuid: e874778c-f070-4387-90c9-e28cfbcd7cfd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-whisperings-solo-piano-radio
+  broadcaster: independent
+  name: Whisperings Solo Piano Radio
+  streamUrl: https://pianosolo.streamguys1.com/live
+  bitrate: 96
+  codec: MP3
+  homepage: "http://www.solopianoradio.com/"
+  country: US
+  status: stream-only
+  stationuuid: fc2e6c39-7139-4f7a-a0c6-a859244332be
+  changeuuid: 4f263651-964f-4c6a-8be1-bb379ca3a69d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-soma-fm-groove-salad-320k-aac-hls-surround
+  broadcaster: independent
+  name: Soma FM Groove Salad 320K AAC HLS Surround
+  streamUrl: https://hls.somafm.com/hls//gs-surround/program.m3u8
+  bitrate: 326
+  codec: AAC
+  favicon: "https://www.somafm.com/apple-touch-icon.png"
+  homepage: "https://www.somafm.com/"
+  country: US
+  status: stream-only
+  stationuuid: 38f80a1f-cb96-4ad2-9d6b-a3e66b671882
+  changeuuid: 89e1acd6-a66a-4259-a7a3-cfa286b67949
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-classic-hits-radio
+  broadcaster: independent
+  name: CLASSIC HITS RADIO
+  streamUrl: https://classichitsradio.streamingmedia.it/usa
+  codec: AAC
+  homepage: "https://classichits.radio/"
+  country: US
+  status: stream-only
+  stationuuid: 1a2c46d8-8bbc-4d1f-8d5a-185cae41c4d4
+  changeuuid: 48e37a16-6381-481b-96d4-65b5e28108ec
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-cbs-sports-radio-105-3
+  broadcaster: independent
+  name: CBS Sports Radio 105.3
+  streamUrl: https://crystalout.surfernetwork.com:8001/KINB-FM_MP3
+  bitrate: 64
+  codec: MP3
+  favicon: "https://www.cbssportsradio1053.com/favicon.ico"
+  homepage: "https://www.cbssportsradio1053.com/"
+  country: US
+  status: stream-only
+  stationuuid: 1a03b739-4c4d-45cf-a65a-617240d6f25d
+  changeuuid: 05a813db-1bbf-442f-ae20-b243423a68da
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-italo-disco
+  broadcaster: independent
+  name: Radio Italo Disco
+  streamUrl: https://broadcast.miami/proxy/italodisco?mp=/stream/;
+  bitrate: 320
+  codec: MP3
+  homepage: "https://www.radio-italodisco.com/"
+  country: US
+  status: stream-only
+  stationuuid: 253e7440-69be-469c-bbee-cbf32f2a2a5c
+  changeuuid: dbbfb6ae-5baa-4af7-8039-f66ebab9ef91
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-sfliny-dance-music
+  broadcaster: independent
+  name: Sfliny Dance Music
+  streamUrl: https://ec4.yesstreaming.net:3780/
+  bitrate: 320
+  codec: MP3
+  homepage: "https://www.sfliny.com/"
+  country: US
+  status: stream-only
+  stationuuid: 123031eb-70cf-41b4-9cdc-f8a44fd7070a
+  changeuuid: 6432c012-b84d-4135-9a18-d7ad8e9e8ba8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-smooth-jazz
+  broadcaster: independent
+  name: Smooth Jazz
+  streamUrl: https://smoothjazz.cdnstream1.com/2585_320.mp3
+  bitrate: 320
+  codec: MP3
+  country: US
+  status: stream-only
+  stationuuid: 9f5c94ab-74b7-465b-97f2-09d7fbbcc873
+  changeuuid: 677fd19d-e33f-4911-afdf-01e7133f72c4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-kusc-91-5-los-angeles-ca-96kbps-aac
+  broadcaster: independent
+  name: "KUSC 91.5 Los Angeles, CA (96kbps AAC)"
+  streamUrl: https://16603.live.streamtheworld.com/KUSCAAC96_SC
+  bitrate: 96
+  codec: AAC+
+  favicon: "https://upload.wikimedia.org/wikipedia/commons/e/e2/KUSC_Logo.jpg"
+  homepage: "http://www.kusc.org/"
+  country: US
+  status: stream-only
+  stationuuid: c624a501-939a-11e9-a605-52543be04c81
+  changeuuid: 9174af86-aa49-4ee2-9702-d88367b94978
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-free-fm-new-york
+  broadcaster: independent
+  name: Free FM New York
+  streamUrl: https://rocafmadrid.radioca.st/
+  bitrate: 320
+  codec: MP3
+  favicon: "https://3.bp.blogspot.com/-BTWauI1ML7o/XZOklz5WuRI/AAAAAAAAAeA/R8qBxhme8UEELRogqYOhtWG4p0BVhiwVgCK4BGAYYCw/s752/free%2Bancho.jpg"
+  homepage: "http://freefmradio.net/"
+  country: US
+  status: stream-only
+  stationuuid: c7e5b008-2c9f-4a10-b431-41b7d0b06af2
+  changeuuid: 88feb324-1b04-4d65-9645-b529c7835eb5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-beat-blender-128k-aac
+  broadcaster: independent
+  name: SomaFM Beat Blender (128k AAC)
+  streamUrl: https://ice6.somafm.com/beatblender-128-aac
+  bitrate: 128
+  codec: AAC
+  favicon: "https://somafm.com/img3/beatblender-400.jpg"
+  homepage: "https://somafm.com/beatblender/"
+  country: US
+  status: stream-only
+  stationuuid: 39a19b72-7c6d-11e9-aa30-52543be04c81
+  changeuuid: 87d04d23-cb63-43db-8948-4b6f46378f4e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-106-1-kiss-fm-seattle
+  broadcaster: independent
+  name: 106.1 KISS FM Seattle
+  streamUrl: https://stream.revma.ihrhls.com/zc4257
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/5f3e24545eacd47f0c407f1b?ops=gravity(%22center%22),contain(32,32),quality(65)"
+  homepage: "https://kissfmseattle.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: dbeea354-e9ed-43dc-b7e6-e83c1955e5a7
+  changeuuid: 9651fc0e-f19d-42bc-9d2a-aa9ed7e5df56
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-vision-cristiana-internacional
+  broadcaster: independent
+  name: Radio Visión Cristiana Internacional
+  streamUrl: https://livestreamcdn.net:2000/stream/RadioVisionCristianaRadio/
+  bitrate: 128
+  codec: MP3
+  favicon: "https://static.wixstatic.com/media/6ddfc3_fba02465eaf5460d8452b49c8a599888%7emv2.png/v1/fill/w_180%2ch_180%2clg_1%2cusm_0.66_1.00_0.01/6ddfc3_fba02465eaf5460d8452b49c8a599888%7emv2.png"
+  homepage: "https://www.radiovision.net/"
+  country: US
+  status: stream-only
+  stationuuid: ee79421b-497f-430f-9f94-5d8dd0f944fa
+  changeuuid: cbf5355d-0494-4b61-a598-7d9c3c8ce855
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-90-5-wesa
+  broadcaster: independent
+  name: 90.5 WESA
+  streamUrl: https://ais-sa3.cdnstream1.com/2556_128.mp3
+  bitrate: 56
+  codec: MP3
+  favicon: "https://wesa.fm/apple-touch-icon.png"
+  homepage: "https://wesa.fm/"
+  country: US
+  status: stream-only
+  stationuuid: c0ee8a22-381c-4282-9cb6-078d9fcda47a
+  changeuuid: 56a49151-f7d1-4d9f-af4c-4cd7cba101f5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-kpbs
+  broadcaster: independent
+  name: KPBS
+  streamUrl: https://kpbs.streamguys1.com/kpbs-mp3
+  bitrate: 128
+  codec: MP3
+  favicon: "https://www.kpbs.org/apple-touch-icon.png"
+  homepage: "https://www.kpbs.org/"
+  country: US
+  status: stream-only
+  stationuuid: afebc420-e448-4299-ad01-52f630f0e14f
+  changeuuid: 5451cc38-85f3-424f-bbe7-692a0b1d226f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-the-disco-planet
+  broadcaster: independent
+  name: The Disco Planet
+  streamUrl: https://broadcast.miami/proxy/thediscoplanet?mp=/stream/;
+  bitrate: 320
+  codec: MP3
+  homepage: "https://www.thediscoplanet.com/"
+  country: US
+  status: stream-only
+  stationuuid: f6c4a84f-024b-4cbe-835f-4d59cd6b1348
+  changeuuid: adc78175-0cb5-433d-97fc-d257fd81ff56
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-free-fm-80s-san-francisco
+  broadcaster: independent
+  name: Free FM 80s San Francisco
+  streamUrl: https://freefm80.radioca.st/
+  bitrate: 320
+  codec: MP3
+  favicon: "https://lh5.googleusercontent.com/h_uHjSxZZ4iir8iw8zBcv84t38DX33BPd0x1cG0RKw1wbWAwGwImnUhtfFepUDc_T_SLbuAdiLOSaageDeGoOnKyAEQxzPY9cH2neNhvxjIFAvnbzjs3E_zrw0xasWgj=w1280"
+  homepage: "http://www.freefmworld.com/"
+  country: US
+  status: stream-only
+  stationuuid: 7b49c831-83e8-407a-a655-0ff50b2869f6
+  changeuuid: 5ce0d785-bac8-46fd-9587-1d1f29de7f47
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-outlaw-country-radio
+  broadcaster: independent
+  name: Outlaw Country Radio
+  streamUrl: https://usa17.fastcast4u.com/proxy/kievradio?mp=/1
+  bitrate: 320
+  codec: MP3
+  favicon: "https://fastcast4u.com/player/kievradio/_user/cover/k/kievradio/ch0_permanent.png"
+  homepage: "https://www.outlaw.fm/"
+  country: US
+  status: stream-only
+  stationuuid: 0af543e7-f8a6-4f0e-afde-bd5fe4420520
+  changeuuid: c0bb2412-9083-4d59-8183-3c5d85fd49a0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-cbn-classic-christian-radio
+  broadcaster: independent
+  name: CBN Classic Christian Radio
+  streamUrl: https://streams.cbnradio.com/Classic-Christian-128K?app=cbnplayer
+  bitrate: 128
+  codec: MP3
+  favicon: "https://www1.cbn.com//sites/all/themes/cbn_default/images/favicons/mstile-144x144.png"
+  homepage: "https://www1.cbn.com/radio/classicchristian"
+  country: US
+  status: stream-only
+  stationuuid: 415fb78a-a24b-11e9-a787-52543be04c81
+  changeuuid: c6f99e10-5c12-42a3-91d9-7ea94ce7d471
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-hot-93-5-old-school
+  broadcaster: independent
+  name: HOT 93.5 Old School
+  streamUrl: https://stream.revma.ihrhls.com/zc6841
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/1f67e399b15c874f81d7a053b849ae5e?ops=gravity(%22center%22),contain(32,32),quality(65)"
+  homepage: "https://hotelpaso.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 77d0a14d-96d7-44ec-92f2-0a2db9260b8d
+  changeuuid: 37de9395-5e8e-4c1e-9bdd-283c84b6f310
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-christian-hard-rock-dot-net
+  broadcaster: independent
+  name: Christian Hard Rock Dot Net
+  streamUrl: https://listen.christianrock.net/stream/15/
+  bitrate: 128
+  codec: AAC
+  favicon: "https://www.christianhardrock.net/apple-touch-icon.png"
+  homepage: "https://www.christianhardrock.net/"
+  country: US
+  status: stream-only
+  stationuuid: 962caa2a-0601-11e8-ae97-52543be04c81
+  changeuuid: 41894ecb-281b-4348-9557-429d125491e6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-motown
+  broadcaster: independent
+  name: Radio Motown
+  streamUrl: https://broadcast.miami/proxy/motown?mp=/stream/;
+  bitrate: 320
+  codec: MP3
+  homepage: "https://www.radio-motown.com/"
+  country: US
+  status: stream-only
+  stationuuid: fc1d4165-28ef-465e-96e9-77f0b24b5361
+  changeuuid: b3008561-acb0-42e8-8f96-1a0fb677de83
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-all-classical-portland
+  broadcaster: independent
+  name: All Classical Portland
+  streamUrl: https://allclassical.streamguys1.com/ac96k
+  bitrate: 96
+  codec: AAC
+  favicon: "https://www.allclassical.org/wp-content/themes/acp-theme/img/acp_logo_600x600.jpg"
+  homepage: "https://www.allclassical.org/"
+  country: US
+  status: stream-only
+  stationuuid: 0f49923b-f244-43f7-b451-6be86a1621d5
+  changeuuid: 5205e667-f42b-4fb9-ad5d-d1b12a1456fd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-folk-music-notebook
+  broadcaster: independent
+  name: Folk Music Notebook
+  streamUrl: https://s3.radio.co/s0b5d4adb5/listen
+  bitrate: 256
+  codec: MP3
+  favicon: "https://img1.wsimg.com/isteam/ip/33ac2230-3451-4ad7-8894-0d3a839af97f/favicon/ed9ab985-710c-4588-afef-f6388e1a738a.png/:/rs=w:64,h:64,m"
+  homepage: "https://folkmusicnotebook.com/"
+  country: US
+  status: stream-only
+  stationuuid: 442fad00-5089-4616-a981-5ab4d8ee4539
+  changeuuid: ca962809-0d6d-45e8-9385-d5527387173a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-hd-radio-the-blues
+  broadcaster: independent
+  name: HD Radio - The Blues
+  streamUrl: https://haradioblues-rfritschka.radioca.st/
+  bitrate: 128
+  codec: MP3
+  homepage: "http://www.hd-radio.net/"
+  country: US
+  status: stream-only
+  stationuuid: 7fad4733-280c-4ed7-b92a-5558fee04f42
+  changeuuid: 09051a5d-d509-49e3-9358-e09d738234e9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-news-talk-560-klvi
+  broadcaster: independent
+  name: News Talk 560 KLVI
+  streamUrl: https://stream.revma.ihrhls.com/zc2197
+  codec: AAC
+  homepage: "https://klvi.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 9f7f0c70-d7e6-4d8f-a56b-ad2bf0f2f4c0
+  changeuuid: 3f659ef1-3417-4376-ae45-abba456f92d0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-wqxr-105-9-fm
+  broadcaster: independent
+  name: WQXR 105.9 FM
+  streamUrl: https://stream.wqxr.org/wqxr-web?nyprBrowserId=32c67956bf1d5600
+  bitrate: 128
+  codec: MP3
+  favicon: "https://media.wnyc.org/i/500/500/c/80/1/wqxr_1_1.png"
+  homepage: "https://www.wqxr.org/"
+  country: US
+  status: stream-only
+  stationuuid: 30928802-8f3b-4083-94ee-7cb3c6c41790
+  changeuuid: c7ab5656-7924-4abf-948b-4a113cdee413
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-wbgo-jazz-88-3-fm
+  broadcaster: independent
+  name: WBGO Jazz 88.3 FM
+  streamUrl: https://ais-sa8.cdnstream1.com/3629_128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: "https://npr.brightspotcdn.com/dims4/default/76ee71f/2147483647/strip/true/crop/200x100+0+0/resize/400x200!/format/webp/quality/90/?url=http%3A%2F%2Fnpr-brightspot.s3.amazonaws.com%2Fa7%2F2f%2Fbfa4b00449099118e45fefe81fe8%2Fwbgo-logo-200x100.png"
+  homepage: "https://www.wbgo.org/"
+  country: US
+  status: stream-only
+  stationuuid: 3487079b-91b1-4fb8-b315-c4150e705b7a
+  changeuuid: 09ff454f-c5ff-4efc-ab6c-2c2ce38e9613
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-100-3-kiss-fm
+  broadcaster: independent
+  name: 100.3 KISS FM
+  streamUrl: https://stream.revma.ihrhls.com/zc1629
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/603e5a2a4bb413272bf15fca?ops=gravity(%22center%22),contain(32,32),quality(65)"
+  homepage: "https://1003kissfm.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 9a05abfa-5013-4a9b-aa21-befce068cbcf
+  changeuuid: 723e5a9f-91f5-4de0-968b-6c7d6f36b032
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-poptron-128k-aac
+  broadcaster: independent
+  name: SomaFM PopTron (128k AAC)
+  streamUrl: https://ice5.somafm.com/poptron-128-aac
+  bitrate: 128
+  codec: AAC
+  favicon: "https://somafm.com/img3/poptron-400.png"
+  homepage: "https://somafm.com/poptron/"
+  country: US
+  status: stream-only
+  stationuuid: 9634ce58-0601-11e8-ae97-52543be04c81
+  changeuuid: 0d84674b-c908-4127-bb18-f5ecba004a91
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-thistleradio-128k-aac
+  broadcaster: independent
+  name: SomaFM ThistleRadio (128k AAC)
+  streamUrl: https://ice6.somafm.com/thistle-128-aac
+  bitrate: 128
+  codec: AAC
+  favicon: "https://somafm.com/img3/thistle-400.jpg"
+  homepage: "https://somafm.com/thistle/"
+  country: US
+  status: stream-only
+  stationuuid: 9612745b-0601-11e8-ae97-52543be04c81
+  changeuuid: c7b6c341-2a15-484b-afa3-21e309c8e2d3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-classical-kusc-mp3-256
+  broadcaster: independent
+  name: Classical KUSC MP3 256
+  streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/KUSCMP256.mp3
+  bitrate: 256
+  codec: MP3
+  favicon: "https://www.kusc.org/icons/kusc/apple-touch-icon-120x120.png"
+  homepage: "https://www.kusc.org/"
+  country: US
+  status: stream-only
+  stationuuid: 19e862e9-6e08-432a-b680-12556221d72b
+  changeuuid: 6ef73f86-3dfa-491a-81ea-c1500140942e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-cliqhop-idm-256k-mp3
+  broadcaster: independent
+  name: SomaFM CliqHop IDM (256k MP3)
+  streamUrl: https://ice6.somafm.com/cliqhop-256-mp3
+  bitrate: 256
+  codec: MP3
+  favicon: "https://somafm.com/img3/cliqhop-400.jpg"
+  homepage: "https://somafm.com/cliqhop/"
+  country: US
+  status: stream-only
+  stationuuid: 3cbbd896-6419-11e9-a622-52543be04c81
+  changeuuid: 4c09ff29-46f2-4057-a24a-8e8af6ea81d8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-smooth-jazz-florida
+  broadcaster: independent
+  name: Smooth Jazz Florida
+  streamUrl: https://streaming.live365.com/a57422
+  bitrate: 128
+  codec: MP3
+  favicon: "https://img1.wsimg.com/isteam/ip/93edd3ac-b031-446a-99c8-fe88e7f00e40/smooth%20jazz%20logo%2012-20-2013%201400X1400%20(20-0002.png"
+  homepage: "https://smoothjazzflorida.com/"
+  country: US
+  status: stream-only
+  stationuuid: 615fe9a1-b87f-463e-bfdf-dd8ceb040bc4
+  changeuuid: 61e4ab23-6bc4-46b9-b467-e28a64bd6785
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-smooth-jazz-global-radio
+  broadcaster: independent
+  name: Smooth Jazz Global Radio
+  streamUrl: https://smoothjazz.cdnstream1.com/2585_256.mp3
+  bitrate: 256
+  codec: MP3
+  country: US
+  status: stream-only
+  stationuuid: ad3c109f-d8cc-46d1-bc45-67c72ec586d3
+  changeuuid: 2657d6b4-ff52-48f1-a872-a192f5ae4ff0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-gotradio-soft-rock-cafe
+  broadcaster: independent
+  name: GotRadio - Soft Rock Café
+  streamUrl: https://pureplay.cdnstream1.com/6010_64.aac/playlist.m3u8
+  bitrate: 64
+  codec: AAC+
+  favicon: "https://cdn.onlineradiobox.com/img/l/6/10096.v3.png"
+  homepage: "https://gotradio.com/music/"
+  country: US
+  status: stream-only
+  stationuuid: 318e5292-4dbf-4045-9d90-a86f2cfe9ff1
+  changeuuid: 259e287e-da4e-4d69-bcbd-fc879c3689d8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-dub-step-beyond-256k-mp3
+  broadcaster: independent
+  name: SomaFM Dub Step Beyond (256k MP3)
+  streamUrl: https://ice6.somafm.com/dubstep-256-mp3
+  bitrate: 256
+  codec: MP3
+  favicon: "https://somafm.com/img3/dubstep-400.jpg"
+  homepage: "https://somafm.com/dubstep/"
+  country: US
+  status: stream-only
+  stationuuid: f4dee6f0-22a3-11ea-aa0c-52543be04c81
+  changeuuid: 684492c6-5a68-431b-a69b-cf0a32445f20
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-abiding-radio-bluegrass-hymns
+  broadcaster: independent
+  name: Abiding Radio - Bluegrass Hymns
+  streamUrl: https://streams.abidingradio.com:7840/1
+  bitrate: 128
+  codec: MP3
+  favicon: "https://www.abidingradio.org/wp-content/uploads/2022/05/cropped-new_icon.png"
+  homepage: "https://www.abidingradio.com/"
+  country: US
+  status: stream-only
+  stationuuid: 961d3490-0601-11e8-ae97-52543be04c81
+  changeuuid: 240ea42b-a0f7-4083-8756-1ba5b4dcf2b9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-country-gospel-radio
+  broadcaster: independent
+  name: Country Gospel Radio
+  streamUrl: https://usa18.fastcast4u.com/proxy/loudcrymedia1?mp=/1
+  bitrate: 128
+  codec: MP3
+  favicon: "https://mytuner.global.ssl.fastly.net/media/tvos_radios/xfme9rznysxa.jpg"
+  homepage: "https://fastcast4u.com/player/loudcrymedia1-tqqumpgu/"
+  country: US
+  status: stream-only
+  stationuuid: e60f3c40-7402-4cfc-a729-a1605cda5440
+  changeuuid: 82dfa297-7791-465a-a763-f8e36126fdd4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-vaporwaves-128k-mp3
+  broadcaster: independent
+  name: SomaFM Vaporwaves (128k MP3)
+  streamUrl: https://ice5.somafm.com/vaporwaves-128-mp3
+  bitrate: 128
+  codec: MP3
+  favicon: "https://somafm.com/img3/vaporwaves400.png"
+  homepage: "https://somafm.com/vaporwaves/"
+  country: US
+  status: stream-only
+  stationuuid: 0e60a2b4-99de-4507-9931-a23449bcae1d
+  changeuuid: bf872732-e7e2-480d-94e1-a4616307af2e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-your-classical-favorites
+  broadcaster: independent
+  name: Your Classical - Favorites
+  streamUrl: https://favorites.stream.publicradio.org/favorites.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: "https://www.yourclassical.org/apple-touch-icon.png"
+  homepage: "https://www.yourclassical.org/"
+  country: US
+  status: stream-only
+  stationuuid: 96478eb8-0601-11e8-ae97-52543be04c81
+  changeuuid: 7930fb8a-e143-42f5-b793-210a317c3ab8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-ambient-fm
+  broadcaster: independent
+  name: ambient.fm
+  streamUrl: https://ambient.fm/live/
+  bitrate: 128
+  codec: MP3
+  homepage: "https://ambient.fm/"
+  country: US
+  status: stream-only
+  stationuuid: 44b7f191-9478-46b0-a3b5-5a0ea2b2d64e
+  changeuuid: a3932dc3-ca5d-44ca-a87a-a557acbf2a61
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-hip-hop-workout-radio
+  broadcaster: independent
+  name: " Hip Hop Workout Radio"
+  streamUrl: https://stream.revma.ihrhls.com/zc7785
+  codec: AAC
+  favicon: "https://zeno.fm/_ipx/q_100&fit_cover&s_160x160/https://images.zeno.fm/wwYkKshlr8K1X3i0JLV-I51b8dt3bzZXTKlYyMf6F-o/rs:fill:256:256/g:ce:0:0/aHR0cHM6Ly9wcm94eS56ZW5vLmZtL2NvbnRlbnQvc3RhdGlvbnMvYWd4emZucGxibTh0YzNSaGRITnlNZ3NTQ2tGMWRHaERiR2xsYm5RWWdJQ1E5SWJRdHdzTUN4SU9VM1JoZEdsdmJsQnliMlpwYkdVWWdJRFFvNFM2aWdvTW9nRUVlbVZ1YncvaW1hZ2UvP3U9MTY2MTM3NDkxOTAwMA.webp"
+  homepage: "https://stream.revma/"
+  country: US
+  status: stream-only
+  stationuuid: bbd2fa5a-0b6c-4833-81b4-ca69acb8f264
+  changeuuid: 03d946a7-25dc-488b-b5d3-974dd2dccca4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-kora-98-3-the-texas-country-original
+  broadcaster: independent
+  name: KORA 98.3 The Texas Country Original
+  streamUrl: https://ais-sa1.streamon.fm/7410_48k.aac/playlist.m3u8?aw_0_1st.playerid=esPlayer&aw_0_1st.skey=1562173335
+  bitrate: 48
+  codec: AAC
+  favicon: "https://dehayf5mhw1h7.cloudfront.net/wp-content/uploads/sites/218/2014/10/31194420/KORA-CLASSIC-HD2-Transparent.png"
+  homepage: "https://www.983korafm.com/"
+  country: US
+  status: stream-only
+  stationuuid: 4405c47b-9db5-11e9-a787-52543be04c81
+  changeuuid: a37d4dfd-5c77-40dc-b4b9-959499a9c120
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-never-ending-radio-show
+  broadcaster: independent
+  name: Never Ending Radio Show
+  streamUrl: https://streaming.live365.com/a81246
+  bitrate: 128
+  codec: MP3
+  homepage: "https://neverendingradioshow.com/"
+  country: US
+  status: stream-only
+  stationuuid: fdeb9d6a-1dd0-4b6a-97ff-f5a7d76d5420
+  changeuuid: d0fa14bc-d780-451e-950e-42b4ff0f5aca
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-classic-rock-florida
+  broadcaster: independent
+  name: Classic Rock Florida
+  streamUrl: https://streaming.live365.com/a06375
+  bitrate: 192
+  codec: MP3
+  homepage: "https://classicrockflorida.com/"
+  country: US
+  status: stream-only
+  stationuuid: 0da886fb-afb7-497f-a5c7-d0a7dddfccad
+  changeuuid: 7d550e40-32e1-4a65-b9d6-b2d15561232f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-kirn-670-am
+  broadcaster: independent
+  name: KIRN 670 AM
+  streamUrl: https://stream.zeno.fm/0bybax2r3heuv
+  codec: AAC
+  homepage: "https://www.670amkirn.com/"
+  country: US
+  status: stream-only
+  stationuuid: 377a2642-1612-41a0-8d17-afcd90462aef
+  changeuuid: 26501a00-95cf-46a1-87be-420c60143436
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-underground-80s-32k-aac
+  broadcaster: independent
+  name: SomaFM Underground 80s (32k AAC)
+  streamUrl: https://ice2.somafm.com/u80s-32-aac
+  bitrate: 32
+  codec: AAC
+  favicon: "https://somafm.com/img3/u80s-400.png"
+  homepage: "https://somafm.com/u80s/"
+  country: US
+  status: stream-only
+  stationuuid: f6281131-2932-11e8-91bf-52543be04c81
+  changeuuid: e1ffb4ea-f852-48f2-832d-9399d557a05f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-90-s-country-music-radio
+  broadcaster: independent
+  name: "90's Country Music Radio"
+  streamUrl: https://2.mystreaming.net/uber/cmr90scountry/icecast.audio
+  codec: MP3
+  favicon: "https://static2.mytuner.mobi/media/tvos_radios/905/country-music-radio-90s-country.5f83bb9f.png"
+  homepage: "https://mytuner-radio.com/radio/country-music-radio-90s-country-487905/"
+  country: US
+  status: stream-only
+  stationuuid: a64d61e0-48b9-4bfc-a57c-0117f58b9ea4
+  changeuuid: d6251ff9-db89-42a8-a2c1-06cb66bad57b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-deep-space-one-64k-aac
+  broadcaster: independent
+  name: SomaFM Deep Space One (64k AAC)
+  streamUrl: https://ice2.somafm.com/deepspaceone-64-aac
+  bitrate: 64
+  codec: AAC
+  favicon: "http://somafm.com/img3/deepspaceone-400.jpg"
+  homepage: "https://somafm.com/deepspaceone/"
+  country: US
+  status: stream-only
+  stationuuid: 964867ec-0601-11e8-ae97-52543be04c81
+  changeuuid: 41e085ed-3801-49b8-8b07-3c1d0a872cf8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-wls-94-7-fm-chicago-il
+  broadcaster: independent
+  name: "WLS 94.7-FM Chicago, IL"
+  streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/WLSFM.mp3
+  bitrate: 80
+  codec: MP3
+  homepage: "http://www.947wls.com/"
+  country: US
+  status: stream-only
+  stationuuid: 3e5220ca-65d0-4410-b274-7ab30f0ac8e7
+  changeuuid: 175daacb-d358-40ee-b0ca-f8de0dbc2c38
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-classical-king-fm-evergreen-channel
+  broadcaster: independent
+  name: Classical King FM - Evergreen Channel
+  streamUrl: https://classicalking.streamguys1.com/evergreen-aac-128k
+  bitrate: 128
+  codec: AAC+
+  favicon: "https://dehayf5mhw1h7.cloudfront.net/wp-content/uploads/sites/1108/2019/05/15152826/cropped-favico-192x192.png"
+  homepage: "https://www.king.org/"
+  country: US
+  status: stream-only
+  stationuuid: a2bdf19f-b5b8-4ab6-b12b-591d415897d6
+  changeuuid: 4f394aa5-7ba7-4f41-ba65-da0a1a54eb3c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-love-radio-only-love-songs-70s80s90s
+  broadcaster: independent
+  name: LOVE RADIO Only Love Songs 70s80s90s
+  streamUrl: https://loveradio.streamingmedia.it/usa
+  bitrate: 192
+  codec: AAC+
+  homepage: "https://love.radio/"
+  country: US
+  status: stream-only
+  stationuuid: f5c44481-8caa-4559-af0d-e650f61650b3
+  changeuuid: 5f024597-8476-4ce5-9dbb-9deb5216aabc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-lush-128k-aac
+  broadcaster: independent
+  name: SomaFM Lush (128k AAC)
+  streamUrl: https://ice5.somafm.com/lush-128-aac
+  bitrate: 128
+  codec: AAC
+  favicon: "https://somafm.com/img3/lush-400.jpg"
+  homepage: "https://somafm.com/lush/"
+  country: US
+  status: stream-only
+  stationuuid: 7f925432-152f-11ea-a87e-52543be04c81
+  changeuuid: 836d698c-2a9f-44e9-9414-be55224df936
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-classic-hits-109
+  broadcaster: independent
+  name: Classic Hits 109
+  streamUrl: https://broadcast.classichits109.com/70s-90s
+  bitrate: 128
+  codec: MP3
+  favicon: "https://cdn-profiles.tunein.com/s297004/images/logog.png"
+  homepage: "https://www.classichits109.com/"
+  country: US
+  status: stream-only
+  stationuuid: 34135e58-c4b4-4aaa-89b3-c42254ba7307
+  changeuuid: bff8d740-cf63-4b58-812c-b4b0ba82a644
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-vpr-vermont-public-radio-relay-bbc
+  broadcaster: independent
+  name: VPR(Vermont Public Radio) relay BBC
+  streamUrl: https://vprbbc.streamguys1.com/vprbbc24.mp3
+  bitrate: 24
+  codec: MP3
+  homepage: "https://www.vpr.org/"
+  country: US
+  status: stream-only
+  stationuuid: 2d18054f-40ee-4682-907a-408e840dc4ff
+  changeuuid: bc2c1096-ed43-4379-9947-21c41b170bdf
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-digitalis-128k-mp3
+  broadcaster: independent
+  name: SomaFM Digitalis (128k MP3)
+  streamUrl: https://ice5.somafm.com/digitalis-128-mp3
+  bitrate: 128
+  codec: MP3
+  favicon: "https://somafm.com/img3/digitalis-400.jpg"
+  homepage: "https://somafm.com/digitalis/"
+  country: US
+  status: stream-only
+  stationuuid: 9614a721-0601-11e8-ae97-52543be04c81
+  changeuuid: 4c3447c6-63f2-44aa-9b83-b7c269210507
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-smooth-jazz-jjz
+  broadcaster: independent
+  name: Smooth Jazz JJZ
+  streamUrl: https://stream.revma.ihrhls.com/zc7390
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/5a848c6b2b914714d7008912?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)"
+  homepage: "https://wjjz.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 5057cd0e-fc3a-428f-84d1-189aaa61aad5
+  changeuuid: bdf5e292-5bdc-4770-abf8-a7b0243ceec4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-rainwave-chiptune
+  broadcaster: independent
+  name: RainWave Chiptune
+  streamUrl: https://relay.rainwave.cc/chiptune.ogg
+  codec: OGG
+  country: US
+  status: stream-only
+  stationuuid: aed36f60-4a68-4c79-866c-da5f9c405d5d
+  changeuuid: 9af9ef3c-5a8f-468b-9dc9-1a288ba9d93f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-wtop-103-5-fm
+  broadcaster: independent
+  name: WTOP 103.5 FM
+  streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/WTOPFM.mp3
+  bitrate: 96
+  codec: MP3
+  favicon: "https://wtop.com/wp-content/themes/wtop-new/assets/img/favicons/apple-touch-icon-120x120.png"
+  homepage: "https://wtop.com/"
+  country: US
+  status: stream-only
+  stationuuid: 2748845d-79fa-414e-a78f-a8fc2093ae20
+  changeuuid: 15b5cc13-00b5-4d9d-9cb7-22863f5e23a6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-wioe-oldies-101-1-south-whitley-indiana
+  broadcaster: independent
+  name: "WIOE Oldies 101.1 South Whitley, Indiana"
+  streamUrl: https://audio-edge-w4d68.yul.o.radiomast.io/c9bc1a59
+  bitrate: 128
+  codec: MP3
+  homepage: "https://wioe.com/site/"
+  country: US
+  status: stream-only
+  stationuuid: 0c1ca951-393a-47f7-a056-c08278326f65
+  changeuuid: 53995ae5-7e02-4df1-ad6b-63b3c936fd51
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-art-acoustic-blues
+  broadcaster: independent
+  name: Radio Art Acoustic Blues
+  streamUrl: https://live.radioart.com/fAcoustic_blues.mp3
+  bitrate: 96
+  codec: MP3
+  favicon: "https://radioart.com/templates/yootheme/vendor/yootheme/theme-joomla/assets/images/favicon.png"
+  homepage: "https://radioart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 676c4b02-c87c-4332-86f8-161370736772
+  changeuuid: e4cc322d-ea2e-4eb2-a2eb-628ab5767884
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-bloomberg-960
+  broadcaster: independent
+  name: Bloomberg 960
+  streamUrl: https://stream.revma.ihrhls.com/zc301
+  codec: AAC
+  favicon: "https://www.bloombergradio.com/content/plugins/bloomberg-favicon/dist/img/amber-120x120.png"
+  homepage: "https://www.bloombergradio.com/"
+  country: US
+  status: stream-only
+  stationuuid: 691ffd8c-d8b0-42a0-a7ca-3d486e5e4ccd
+  changeuuid: d324d1e1-3e1c-4aa3-8665-17dff3afa43f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-the-disco-paradise
+  broadcaster: independent
+  name: The Disco Paradise
+  streamUrl: https://broadcast.miami/proxy/thediscoparadise?mp=/stream/;
+  bitrate: 320
+  codec: MP3
+  homepage: "https://www.thediscoparadise.com/"
+  country: US
+  status: stream-only
+  stationuuid: 01b3760e-106d-4fdb-9196-6f746e82cd5b
+  changeuuid: fc77d16c-2c60-4721-8c85-12a1697d44cc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-bible-broadcasting-network-english
+  broadcaster: independent
+  name: Bible Broadcasting Network English
+  streamUrl: https://streams.radiomast.io/844b0a81-f4b9-485e-adaa-aab8d3ea9f7f
+  bitrate: 64
+  codec: AAC
+  homepage: "https://bbn1.bbnradio.org/english/bbn-live-stream-url/"
+  country: US
+  status: stream-only
+  stationuuid: 5db78b36-c4bc-4ca4-8c03-351a311c8f18
+  changeuuid: 03c9233b-174d-46a8-b502-2b25d1ce70e4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-95-7-that-station
+  broadcaster: independent
+  name: 95.7 That Station
+  streamUrl: https://ais-sa8.cdnstream1.com/2749_64.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: "https://cdn.onlineradiobox.com/img/l/0/114200.v4.png"
+  homepage: "https://thatstation.net/"
+  country: US
+  status: stream-only
+  stationuuid: 3904e33b-d230-43da-8114-e1ea97485ace
+  changeuuid: 18d01e8a-174e-4f00-91dc-a693934854b5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-a-strangely-isolated-place-9128
+  broadcaster: independent
+  name: A Strangely Isolated Place / 9128
+  streamUrl: https://streams.radio.co/s0aa1e6f4a/listen
+  bitrate: 320
+  codec: MP3
+  favicon: "https://9128.live/favicon.ico"
+  homepage: "https://9128.live/"
+  country: US
+  status: stream-only
+  stationuuid: 9f2e560d-6c79-11ea-b1cf-52543be04c81
+  changeuuid: 0434e77f-90ed-4cdd-834a-8da975227b58
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-whisperings-solo-piano-radio-aac-48
+  broadcaster: independent
+  name: "Whisperings: Solo Piano Radio (AAC 48)"
+  streamUrl: https://pianosolo.streamguys1.com/pianosolo48.aac
+  bitrate: 48
+  codec: AAC+
+  homepage: "https://www.solopianoradio.com/"
+  country: US
+  status: stream-only
+  stationuuid: f92c89e2-5fbd-41f4-a890-631e63f19163
+  changeuuid: 923d6fe5-a683-43a2-b197-baceebda4cd1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-art-vocal-lounge
+  broadcaster: independent
+  name: Radio Art Vocal Lounge
+  streamUrl: https://live.radioart.com/fVocal_lounge.mp3
+  bitrate: 96
+  codec: MP3
+  favicon: "https://radioart.com/favicon.ico"
+  homepage: "https://radioart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 89f33981-9670-4e75-8248-9ea133c558cc
+  changeuuid: aa8df429-f3ef-4fdd-816e-501f1c444684
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-la-mega-1290
+  broadcaster: independent
+  name: La Mega 1290
+  streamUrl: https://crystalout.surfernetwork.com:8001/WCHK-AM_MP3
+  codec: MP3
+  homepage: "https://www.lamegatl.com/"
+  country: US
+  status: stream-only
+  stationuuid: 54988bcf-c3d3-4fa9-9158-b2e0fad17414
+  changeuuid: a3b91c79-1f1d-4ea6-be77-5ab64bfd2f24
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-the-trip-128k-aac
+  broadcaster: independent
+  name: SomaFM The Trip (128k AAC)
+  streamUrl: https://ice2.somafm.com/thetrip-128-aac
+  bitrate: 128
+  codec: AAC
+  favicon: "https://somafm.com/img3/thetrip-400.jpg"
+  homepage: "https://somafm.com/thetrip/"
+  country: US
+  status: stream-only
+  stationuuid: 828dd71a-f952-11e8-a97a-52543be04c81
+  changeuuid: 5047bd0e-4bbc-4da0-ab9f-0030c346fe0b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-groove-salad-64k-aac
+  broadcaster: independent
+  name: SomaFM Groove Salad (64k AAC)
+  streamUrl: https://ice2.somafm.com/groovesalad-64-aac
+  bitrate: 64
+  codec: AAC
+  favicon: "https://somafm.com/img3/groovesalad-400.jpg"
+  homepage: "https://somafm.com/groovesalad/"
+  country: US
+  status: stream-only
+  stationuuid: 84bcd49b-3f3e-11e8-b74d-52543be04c81
+  changeuuid: 82bd75e0-c036-4ac3-a7cf-699f4efcbd2c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-folk-alley-irish
+  broadcaster: independent
+  name: Folk Alley Irish
+  streamUrl: https://freshgrass.streamguys1.com/irish-128mp3
+  bitrate: 128
+  codec: MP3
+  favicon: "https://www.folkalley.com/favicon.ico"
+  homepage: "https://www.folkalley.com/music/playlist/today/irish"
+  country: US
+  status: stream-only
+  stationuuid: 80f853f5-61f3-46e7-95fe-2d57da3fd1f3
+  changeuuid: 7a397dbd-2d4c-427c-8a04-da46ed6a25bb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-covers-128k-mp3
+  broadcaster: independent
+  name: SomaFM Covers (128k MP3)
+  streamUrl: https://ice5.somafm.com/covers-128-mp3
+  bitrate: 128
+  codec: MP3
+  favicon: "https://somafm.com/img3/covers-400.jpg"
+  homepage: "https://somafm.com/covers/"
+  country: US
+  status: stream-only
+  stationuuid: 960d9165-0601-11e8-ae97-52543be04c81
+  changeuuid: f30207f8-01a8-4d73-892e-cc687f15a159
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-1-oldies
+  broadcaster: independent
+  name: __1 oldies
+  streamUrl: https://80sexitos.stream.laut.fm/80sexitos
+  bitrate: 128
+  codec: MP3
+  homepage: "https://musica80.radioclub.es/"
+  country: US
+  status: stream-only
+  stationuuid: 02bc9a87-6db4-42c0-ace1-388c269e49d5
+  changeuuid: dfda78d7-7b6e-47c6-9c4b-4b8010953d52
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-sf-10-33-128k-mp3
+  broadcaster: independent
+  name: SomaFM SF 10-33 (128k MP3)
+  streamUrl: https://ice2.somafm.com/sf1033-128-mp3
+  bitrate: 128
+  codec: MP3
+  favicon: "https://somafm.com/img3/sf1033-400.jpg"
+  homepage: "https://somafm.com/sf1033/"
+  country: US
+  status: stream-only
+  stationuuid: 9614ed70-0601-11e8-ae97-52543be04c81
+  changeuuid: 0d6a0449-f24b-4d80-94b3-ced419d5eead
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-crnet-hard-rock-128
+  broadcaster: independent
+  name: CRnet Hard Rock (128)
+  streamUrl: https://shoutcast.christianrock.net/stream/3/
+  bitrate: 128
+  codec: MP3
+  favicon: "https://www.christianhardrock.net/apple-touch-icon.png"
+  homepage: "https://www.christianhardrock.net/"
+  country: US
+  status: stream-only
+  stationuuid: f957a66c-9ed9-4d96-8878-0f6ca24504ec
+  changeuuid: ca395d75-d071-4b2e-b7d8-3c0def2134ce
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-iheartpodcast-am-1470
+  broadcaster: independent
+  name: iHeartPodcast AM 1470
+  streamUrl: https://stream.revma.ihrhls.com/zc3348
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/61a9a007eb66236c043ab853?ops=gravity(%22center%22),contain(32,32),quality(65)"
+  homepage: "https://podcastam1470.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: d6351baa-dcc9-45d3-a251-825c6dbf2c11
+  changeuuid: f8c1b231-6557-4c42-90f5-cf79d0f0c897
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-magic-80s-florida-128-kbit-s
+  broadcaster: independent
+  name: Magic 80s Florida (128 kbit/s)
+  streamUrl: https://streaming.live365.com/a79417
+  bitrate: 128
+  codec: MP3
+  favicon: null
+  homepage: "https://magicoldiesflorida.com/"
+  country: US
+  status: stream-only
+  stationuuid: 491fbb30-9a91-44e3-a7d6-0d4d821090b1
+  changeuuid: 951ef5e1-6298-4a10-863c-d593fcb9c3c1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-secret-agent-64k-aac
+  broadcaster: independent
+  name: SomaFM Secret Agent (64k AAC)
+  streamUrl: https://ice2.somafm.com/secretagent-64-aac
+  bitrate: 64
+  codec: AAC
+  favicon: "https://somafm.com/img3/secretagent-400.jpg"
+  homepage: "https://somafm.com/secretagent/"
+  country: US
+  status: stream-only
+  stationuuid: d9b43ea7-3c4d-11e8-b74d-52543be04c81
+  changeuuid: d5e9eab9-b5f4-4c6b-9aa4-57c6dddd4cb5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-bbn-spanish
+  broadcaster: independent
+  name: BBN Spanish
+  streamUrl: https://streams.radiomast.io/475ebed1-595e-4717-b888-64fe8fc6b09f
+  bitrate: 56
+  codec: AAC
+  homepage: "https://bbn1.bbnradio.org/spanish/escuche-bbn/"
+  country: US
+  status: stream-only
+  stationuuid: 302fcad4-9206-4157-af00-3fcbbc770757
+  changeuuid: a6e749f8-111b-4d3b-8ff0-2f2b736a7592
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-classic-american-top-40
+  broadcaster: independent
+  name: Classic American Top 40
+  streamUrl: https://stream.revma.ihrhls.com/zc6545
+  codec: AAC
+  favicon: "https://www.iheart.com/favicon.ico"
+  homepage: "https://www.iheart.com/live/classic-american-top-40-6545/"
+  country: US
+  status: stream-only
+  stationuuid: 87d3bd83-0546-438d-9758-7b80a6bd17e9
+  changeuuid: ed417087-11d7-4dde-96c9-c17f0b949173
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-wxpn-88-5-philadelphia-pa
+  broadcaster: independent
+  name: "WXPN 88.5 Philadelphia, PA"
+  streamUrl: https://wxpnhi.xpn.org/xpnhi
+  bitrate: 128
+  codec: MP3
+  favicon: "http://www.xpn.org/favicon.ico"
+  homepage: "http://www.xpn.org/"
+  country: US
+  status: stream-only
+  stationuuid: 960dd7a5-0601-11e8-ae97-52543be04c81
+  changeuuid: 7b665697-429e-42f8-818b-edebe2213129
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-kexp-90-3-seattle-wa-aac-160k
+  broadcaster: independent
+  name: "KEXP 90.3 Seattle, WA (AAC 160K)"
+  streamUrl: https://kexp.streamguys1.com/kexp160.aac
+  bitrate: 162
+  codec: AAC
+  favicon: "http://www.kexp.org/static/assets/img/favicon-32x32.png"
+  homepage: "https://www.kexp.org/"
+  country: US
+  status: stream-only
+  stationuuid: 445cbb3a-1c4e-49aa-a268-f5b6acfa8f2e
+  changeuuid: 71bacbd1-62aa-463d-954f-800e7831bddf
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-cbn-cross-country-christmas
+  broadcaster: independent
+  name: CBN Cross Country Christmas
+  streamUrl: https://streams.cbnradio.com/christmas-128K?%20Title1=CBN%20Cross%20Country%20Christmas
+  bitrate: 128
+  codec: MP3
+  favicon: "http://www1.cbn.com//sites/all/themes/cbn_default/images/favicons/mstile-144x144.png"
+  homepage: "http://www1.cbn.com/radio/crosscountrychristmas"
+  country: US
+  status: stream-only
+  stationuuid: f7678323-fd4c-11e8-a1be-52543be04c81
+  changeuuid: 48987baa-619e-45f9-921e-5039e3e54f75
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-hamrah
+  broadcaster: independent
+  name: Radio Hamrah رادیو همراه
+  streamUrl: https://stream.zenolive.com/gxdq0awu30duv.aac
+  codec: MP3
+  favicon: "http://www.radiohamrah.com/favicon.ico"
+  homepage: "http://www.radiohamrah.com/"
+  country: US
+  status: stream-only
+  stationuuid: 70fdae0c-8528-11e9-aa30-52543be04c81
+  changeuuid: df7226e1-1d8a-423c-889c-1949a565768b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-101-9-kiss-fm
+  broadcaster: independent
+  name: 101.9 KISS FM
+  streamUrl: https://stream.revma.ihrhls.com/zc4864
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/64550dbc69b3a602416192b8?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)"
+  homepage: "https://1019kissfm.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: cacf6613-10e5-483f-ba98-17c15bb823b9
+  changeuuid: 0a834350-2771-438e-a985-fdc6c3ae257d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-smooth-lounge-global-radio
+  broadcaster: independent
+  name: Smooth Lounge Global Radio
+  streamUrl: https://smoothjazz.cdnstream1.com/2586_256.mp3
+  bitrate: 256
+  codec: MP3
+  country: US
+  status: stream-only
+  stationuuid: 6d59604a-7f2f-4f5f-8a00-bc5264372fe2
+  changeuuid: 1f9de6b6-30be-486d-a8db-ed614e962569
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-oldies-93-5
+  broadcaster: independent
+  name: Oldies 93.5
+  streamUrl: https://stream.revma.ihrhls.com/zc5110
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/5ed665ad7531da667f4c89af?ops=gravity(%22center%22),contain(32,32),quality(65)"
+  homepage: "https://oldies935.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: d42866cc-a1c0-45ad-96c6-9639b366b51d
+  changeuuid: 187ddbfb-8f26-48dc-a4b6-09b5ef9a8e42
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-abiding-radio-sacred
+  broadcaster: independent
+  name: Abiding Radio - Sacred
+  streamUrl: https://streams.abidingradio.com:7820/1
+  bitrate: 128
+  codec: MP3
+  favicon: "https://www.abidingradio.org/wp-content/uploads/2022/05/cropped-new_icon.png"
+  homepage: "https://www.abidingradio.com/"
+  country: US
+  status: stream-only
+  stationuuid: 961d33bc-0601-11e8-ae97-52543be04c81
+  changeuuid: bc8eb7b1-f42f-482f-87c8-3829008c1672
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-the-river-of-calm
+  broadcaster: independent
+  name: The River Of Calm
+  streamUrl: https://listen.radioking.com/radio/49831/stream/86743
+  bitrate: 128
+  codec: MP3
+  favicon: "https://play-lh.googleusercontent.com/HT2ucrf6Yvsfvt1yHz0TxD7JlMcj7-RhF4k6mkDISMesN0_rWv26av2NdURuakftH2U"
+  homepage: "https://www.theriverofcalm.com/"
+  country: US
+  status: stream-only
+  stationuuid: cfc90da8-50fe-4465-880d-137f73d52f4d
+  changeuuid: 562b351f-61d8-4586-ad52-f856c9990855
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-dark-asylum
+  broadcaster: independent
+  name: Dark Asylum
+  streamUrl: https://darkclubradio.stream.laut.fm/darkclubradio?t302=2017-10-06_10-10-19&uuid=04ef8081-69df-483f-b486-2b7cfc49a09d
+  bitrate: 128
+  codec: MP3
+  country: US
+  status: stream-only
+  stationuuid: c07d41ed-3746-4ff5-a6b8-cb0581c3b117
+  changeuuid: 81824bf2-1905-4109-b26f-6184f6e66908
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-mpr-classical-piano
+  broadcaster: independent
+  name: MPR Classical Piano
+  streamUrl: https://holiday.stream.publicradio.org/peacefulpiano.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: "https://www.mpr.org/"
+  country: US
+  status: stream-only
+  stationuuid: 2c6fcb10-d03b-4af3-9081-b284bf6594e0
+  changeuuid: 4d508abd-c25b-4690-9dc5-fc3eae459616
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-art-vocal-jazz
+  broadcaster: independent
+  name: Radio Art Vocal Jazz
+  streamUrl: https://live.radioart.com/fVocal_jazz.mp3
+  bitrate: 96
+  codec: MP3
+  favicon: "https://www.radioart.com/templates/yootheme/vendor/yootheme/theme-joomla/assets/images/favicon.png"
+  homepage: "https://www.radioart.com/"
+  country: US
+  status: stream-only
+  stationuuid: a3f74af8-5662-4f65-97d6-c9972a3efcfb
+  changeuuid: 9ab782f2-f19b-4dae-9996-41ec0efc5c08
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-mast-chinese
+  broadcaster: independent
+  name: Radio Mast Chinese
+  streamUrl: https://streams.radiomast.io/ce298b32-8776-4192-9900-092f44b63e7f
+  bitrate: 56
+  codec: AAC
+  homepage: "https://bbn1.bbnradio.org/"
+  country: US
+  status: stream-only
+  stationuuid: 30b021a8-04fa-466e-846a-1c4a69048e9d
+  changeuuid: 0157038e-cdd6-458d-a1d8-6ea498df625a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-christian-hits
+  broadcaster: independent
+  name: Christian Hits
+  streamUrl: https://shoutcast.christianrock.net/stream/5/
+  bitrate: 128
+  codec: MP3
+  favicon: "https://www.christianhits.net/apple-touch-icon.png"
+  homepage: "https://www.christianhits.net/"
+  country: US
+  status: stream-only
+  stationuuid: 1759b890-4403-4125-b232-c2b8aa6b6392
+  changeuuid: ead05f7b-9e25-45a6-b87b-e65dbceadefc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-4u-classic-rock
+  broadcaster: independent
+  name: 4u Classic Rock
+  streamUrl: https://str4uice.streamakaci.com/4uclassicrock.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: "https://cdn.onlineradiobox.com/img/l/4/15394.v1.png"
+  homepage: "http://www.4urock.com/"
+  country: US
+  status: stream-only
+  stationuuid: 71066c31-3c0f-47bf-ac4e-2ec0e417fba5
+  changeuuid: ef0b59b3-c9fb-4d84-8e86-6efecbc21175
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-99-9-gator-country
+  broadcaster: independent
+  name: 99.9 Gator Country
+  streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/WGNEAAC.aac
+  bitrate: 64
+  codec: AAC+
+  homepage: "https://www.999gatorcountry.com/"
+  country: US
+  status: stream-only
+  stationuuid: 22cb8a0b-ac40-479d-a823-fabc83961618
+  changeuuid: 8419ac57-e031-4892-9efe-10938416155c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-kdfc-classical-california-ultimate-playlist
+  broadcaster: independent
+  name: KDFC Classical California Ultimate Playlist
+  streamUrl: https://19273.live.streamtheworld.com/CC1_S01AAC_96_SC
+  bitrate: 96
+  codec: AAC+
+  homepage: "https://classicalcalifornia.org/kdfc/streams/classicalcaliforniaultimateplaylist"
+  country: US
+  status: stream-only
+  stationuuid: 672e9a6b-d60a-4345-818c-e11ca7ba0f2a
+  changeuuid: 8f3bb20c-1177-45b3-9829-3db9333ab278
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-poptron-32k-aac
+  broadcaster: independent
+  name: SomaFM PopTron (32k AAC)
+  streamUrl: https://ice2.somafm.com/poptron-32-aac
+  bitrate: 32
+  codec: AAC
+  favicon: "https://somafm.com/img3/poptron-400.png"
+  homepage: "https://somafm.com/poptron/"
+  country: US
+  status: stream-only
+  stationuuid: 6c548f13-7427-11ea-b1cf-52543be04c81
+  changeuuid: d43bbfe0-6ffd-434e-93f2-1a66327eb7d3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-salsoul
+  broadcaster: independent
+  name: Radio Salsoul
+  streamUrl: https://broadcast.miami/proxy/salsoul?mp=/stream/;
+  bitrate: 320
+  codec: MP3
+  homepage: "https://www.radiosalsoul.com/"
+  country: US
+  status: stream-only
+  stationuuid: 37ae40d9-3ed6-45e7-8036-e46c11be6c27
+  changeuuid: 8adb814b-7f23-4b5e-8920-874d746475ca
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-rbn-republic-broadcastin-network
+  broadcaster: independent
+  name: RBN - Republic Broadcastin Network
+  streamUrl: https://cast2.my-control-panel.com/proxy/rbn/stream;
+  bitrate: 32
+  codec: MP3
+  favicon: "https://uk.radio.net/images/broadcasts/17/89/17630/c300.png"
+  homepage: "https://republicbroadcasting.org/"
+  country: US
+  status: stream-only
+  stationuuid: 7b5b6832-98c3-4d3f-ba4f-87cf46e2d6e2
+  changeuuid: c789b2ba-95cf-48d8-b70a-6d1b22914535
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-metal-detector-32k-aac
+  broadcaster: independent
+  name: SomaFM Metal Detector (32k AAC)
+  streamUrl: https://ice4.somafm.com/metal-32-aac
+  bitrate: 40
+  codec: AAC
+  favicon: "https://somafm.com/img3/metal-400.png"
+  homepage: "https://somafm.com/metal/"
+  country: US
+  status: stream-only
+  stationuuid: 42b89f69-bff0-48ba-ae66-a554e84414d7
+  changeuuid: 40149d93-9eab-4ee0-b542-e1b0155db14c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-bloomberg-tv
+  broadcaster: independent
+  name: Bloomberg TV
+  streamUrl: https://liveprodeuwest.akamaized.net/eu1/Channel-EUTVqvs-AWS-ireland-1/Source-EUTVqvs-1000-1_live.m3u8
+  codec: UNKNOWN
+  favicon: "https://assets.bwbx.io/s3/multimedia/public/app/images/favicons/apple-touch-icon_120x120-34d187e11c.png"
+  homepage: "https://www.bloomberg.com/live/europe"
+  country: US
+  status: stream-only
+  stationuuid: 1bf2f1ee-507d-11e8-a4d1-52543be04c81
+  changeuuid: ac8a59b1-1d3e-4270-ba3b-0fdb00f64dc4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-heavyweight-reggae-32k-aac
+  broadcaster: independent
+  name: SomaFM Heavyweight Reggae (32k AAC)
+  streamUrl: https://ice6.somafm.com/reggae-32-aac
+  bitrate: 32
+  codec: AAC
+  favicon: "https://somafm.com/img3/reggae400.jpg"
+  homepage: "https://somafm.com/reggae/"
+  country: US
+  status: stream-only
+  stationuuid: eb1746ec-92bb-4d42-b87e-72b82f2e68b0
+  changeuuid: 53091d7a-50a9-467b-a9c3-593fa7d821a7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-kiye-88-7-fm-kamiah-id
+  broadcaster: independent
+  name: "KIYE 88.7 FM Kamiah, ID"
+  streamUrl: https://ais-sa1.streamon.fm/7012_24k.aac
+  bitrate: 96
+  codec: AAC
+  favicon: "https://i2.wp.com/kiye.org/wp-content/uploads/2016/10/cropped-kiye-logo-small-1.png?fit=512%2C512&ssl=1"
+  homepage: "https://kiye.org/"
+  country: US
+  status: stream-only
+  stationuuid: 366dd4d1-9e76-11e8-a767-52543be04c81
+  changeuuid: dee46d71-303e-4241-8c92-61f5808e06d5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-happy-rave-radio-90s-happy-hardcore
+  broadcaster: independent
+  name: "Happy Rave Radio [90s Happy Hardcore]"
+  streamUrl: https://happyrave-rex.radioca.st/stream
+  bitrate: 320
+  codec: MP3
+  favicon: "https://www.happyraveradio.com/wp-content/uploads/2021/03/happyraveradio_logo-e1615388979808.jpg"
+  homepage: "https://www.happyraveradio.com/"
+  country: US
+  status: stream-only
+  stationuuid: 95474386-aaca-4d90-9d5c-3913ea75bce1
+  changeuuid: 56391d4d-c6ac-4ea3-8614-0afb22e2bec1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-nbc-news-radio-https
+  broadcaster: independent
+  name: NBC News Radio (https)
+  streamUrl: https://stream.revma.ihrhls.com/zc6043
+  codec: AAC
+  favicon: "https://iscale.iheart.com/catalog/live/6043"
+  homepage: "https://www.iheart.com/live/nbc-news-radio-6043/"
+  country: US
+  status: stream-only
+  stationuuid: 7e3a9846-2dc4-4e4c-b085-1305b40dbeec
+  changeuuid: bd92cd56-43e2-4221-a2ee-c5d0731ecb9f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-cape-christian-radio
+  broadcaster: independent
+  name: Cape Christian Radio
+  streamUrl: https://ice64.securenetsystems.net/CCR1MP3
+  bitrate: 128
+  codec: MP3
+  homepage: "https://www.communitynetradio.org/christianliferadio"
+  country: US
+  status: stream-only
+  stationuuid: 96418c03-0601-11e8-ae97-52543be04c81
+  changeuuid: f651d62e-5330-4d35-8b6d-bf768f4172a8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-drone-zone-64k-aac
+  broadcaster: independent
+  name: SomaFM Drone Zone (64k AAC)
+  streamUrl: https://ice6.somafm.com/dronezone-64-aac
+  bitrate: 64
+  codec: AAC
+  favicon: "https://somafm.com/img3/dronezone-400.jpg"
+  homepage: "https://somafm.com/dronezone/"
+  country: US
+  status: stream-only
+  stationuuid: 964ee88c-0601-11e8-ae97-52543be04c81
+  changeuuid: 973716f9-14b3-4cca-8958-22d41d6fec07
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-107-5-kiss-fm
+  broadcaster: independent
+  name: 107.5 KISS FM
+  streamUrl: https://stream.revma.ihrhls.com/zc2740
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/5c251d5a6395ee2ae15bf8f8?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)"
+  homepage: "https://1075kissfm.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: c3d8d912-fe80-4620-88b8-ea4abd7122c6
+  changeuuid: fab28fe8-1f18-405b-8716-b7e3ef16da1b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-96-7-kiss-fm
+  broadcaster: independent
+  name: 96.7 KISS FM
+  streamUrl: https://stream.revma.ihrhls.com/zc2173
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/new_assets/5935ef64fca9ad9f777a7778?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)"
+  homepage: "https://967kissfm.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: a754c593-04f6-4261-98cf-fb5221e8de66
+  changeuuid: de2a8a64-dfcf-40f5-97d1-dbd38dacc6e4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-smooth-jazz-cd-101-9
+  broadcaster: independent
+  name: Smooth Jazz CD 101.9
+  streamUrl: https://streaming.live365.com/a43749
+  bitrate: 128
+  codec: MP3
+  homepage: "https://smoothjazzcd1019.com/"
+  country: US
+  status: stream-only
+  stationuuid: 8dd2bb00-74af-44ac-b92b-70c88bcdf1b7
+  changeuuid: 43df20dd-65e6-45f6-89be-c87ec904411a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-paradise-world-etc-mix-64k-aac
+  broadcaster: independent
+  name: Radio Paradise World/Etc Mix 64k AAC
+  streamUrl: https://stream.radioparadise.com/world-etc-64
+  bitrate: 64
+  codec: AAC
+  favicon: "https://radioparadise.com/apple-touch-icon.png"
+  homepage: "https://radioparadise.com/"
+  country: US
+  status: stream-only
+  stationuuid: 22f72eb5-cc37-4525-9f9d-15204c8165ef
+  changeuuid: 4cb20abc-7d49-4e3d-bcfb-e8c9147bc1fd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-lush-64k-aac
+  broadcaster: independent
+  name: SomaFM Lush (64k AAC)
+  streamUrl: https://ice4.somafm.com/lush-64-aac
+  bitrate: 64
+  codec: AAC
+  favicon: "https://somafm.com/img3/lush-400.jpg"
+  homepage: "https://somafm.com/lush/"
+  country: US
+  status: stream-only
+  stationuuid: a172a67e-4199-11e8-b74d-52543be04c81
+  changeuuid: 668c78e9-b752-4b90-a243-ef063725f281
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-power-of-worship-radio
+  broadcaster: independent
+  name: Power of Worship Radio
+  streamUrl: https://fwd.autopo.st/powerofworshipradio
+  codec: AAC
+  favicon: "https://mmo.aiircdn.com/177/61e36614722ca.png"
+  homepage: "https://www.powerofworship.net/"
+  country: US
+  status: stream-only
+  stationuuid: 54867e97-1294-47bc-82c1-7d2e8fe26b51
+  changeuuid: c7fe2905-95aa-4b23-8b27-60e961675613
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-wfmt-classical-aac-256
+  broadcaster: independent
+  name: WFMT Classical AAC 256
+  streamUrl: https://wfmt.streamguys1.com/main-source
+  bitrate: 258
+  codec: AAC
+  favicon: "https://static.mytuner.mobi/media/tvos_radios/XBEtTEnnMS.jpg"
+  homepage: "https://www.wfmt.com/"
+  country: US
+  status: stream-only
+  stationuuid: 3d84e338-1226-401e-8184-401b91f81b10
+  changeuuid: f27d2a9c-31f7-404b-b8dd-ed308869e0fc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-symphony
+  broadcaster: independent
+  name: Radio Symphony
+  streamUrl: https://streaming.radiostreamlive.com/radiosymphony_devices
+  bitrate: 128
+  codec: MP3
+  favicon: "https://cdn-elements.radiostreamlive.com/v1/images/favicon.ico"
+  homepage: "http://www.radiosymphony.com/"
+  country: US
+  status: stream-only
+  stationuuid: 962b76f6-0601-11e8-ae97-52543be04c81
+  changeuuid: e44d651c-6681-41e0-8870-c1448a76d075
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-ah-fm
+  broadcaster: independent
+  name: AH.FM
+  streamUrl: https://air.unmixed.ru/ah192
+  bitrate: 192
+  codec: MP3
+  homepage: "https://ah.fm/"
+  country: US
+  status: stream-only
+  stationuuid: 07163890-096f-424e-bec2-f17b4e378221
+  changeuuid: 78fb702f-be0c-4214-80f2-a50c6398a5fc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-paradise-rock-mix-64k-aac
+  broadcaster: independent
+  name: Radio Paradise Rock Mix 64k AAC
+  streamUrl: https://stream.radioparadise.com/rock-64
+  bitrate: 64
+  codec: AAC
+  favicon: "https://radioparadise.com/apple-touch-icon.png"
+  homepage: "https://radioparadise.com/"
+  country: US
+  status: stream-only
+  stationuuid: 9e54d6fc-16a6-4308-9c15-c60aeb1e2de8
+  changeuuid: 83704273-7382-42d5-9a6b-383090e10bb5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-nettalk-america
+  broadcaster: independent
+  name: NetTalk America
+  streamUrl: https://stream.zeno.fm/st9bhqvgvceuv
+  codec: MP3
+  favicon: "https://img1.wsimg.com/isteam/ip/6e7215c5-5ca4-45c2-b61c-24421c4a5003/74cfc8bf-f67f-4e7d-ad46-0ac09ca2d362.gif.png/:/cr=t:0%25,l:0%25,w:100%25,h:100%25/rs=w:1536"
+  homepage: "https://nettalkamerica.com/"
+  country: US
+  status: stream-only
+  stationuuid: 9b8167c1-2f58-4ac1-8ce4-721ea2677232
+  changeuuid: 00be1e8e-3e50-4bfa-be70-09e4c1bcfdfc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-indie-pop-rocks-64k-aac
+  broadcaster: independent
+  name: "SomaFM Indie Pop Rocks! (64k AAC)"
+  streamUrl: https://ice6.somafm.com/indiepop-64-aac
+  bitrate: 64
+  codec: AAC
+  favicon: "https://somafm.com/img3/indiepop-400.jpg"
+  homepage: "https://somafm.com/indiepop/"
+  country: US
+  status: stream-only
+  stationuuid: 216291a6-e304-4da4-a837-6cfee6ec70ad
+  changeuuid: eaaf0251-2f32-4b1b-a87e-5045a5797ad6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-christian-classic-rock-dot-net
+  broadcaster: independent
+  name: Christian Classic Rock Dot Net
+  streamUrl: https://listen.christianrock.net/stream/14/
+  bitrate: 112
+  codec: AAC
+  favicon: "https://www.christianclassicrock.net/apple-touch-icon.png"
+  homepage: "https://www.christianclassicrock.net/"
+  country: US
+  status: stream-only
+  stationuuid: 9617c64c-0601-11e8-ae97-52543be04c81
+  changeuuid: a700fe84-00fd-44ed-ae33-c26ad7bc489b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-america-1
+  broadcaster: independent
+  name: Radio America 1
+  streamUrl: https://s6.yesstreaming.net:18003/ra1
+  bitrate: 64
+  codec: MP3
+  favicon: "https://www.radioamerica.com/wp-content/uploads/2024/11/cropped-favicon-180x180.png"
+  homepage: "https://www.radioamerica.com/"
+  country: US
+  status: stream-only
+  stationuuid: 582b52b0-6935-442d-8106-592bbb08937a
+  changeuuid: 80d7d0ce-a7ed-4752-a72f-7c199fd6390d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-sunny-99-9-el-paso
+  broadcaster: independent
+  name: Sunny 99.9 El Paso
+  streamUrl: https://stream.revma.ihrhls.com/zc3188
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/5e595c77f75fa2234df660f1?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)"
+  homepage: "https://sunny999fm.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: abcf53cb-dc5d-448c-b5a0-e9e778838531
+  changeuuid: 6c95a4a2-ffbd-4f5f-9635-d8831d406c6b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-el-nuevo-zol-106-7-fm
+  broadcaster: independent
+  name: El Nuevo Zol 106.7 FM
+  streamUrl: https://liveaudio.lamusica.com/MIA_WXDJ_icy
+  bitrate: 320
+  codec: AAC
+  favicon: "https://radiostationusa.fm/assets/image/radio/180/WXDJ.png"
+  homepage: "https://www.lamusica.com/stations/wxdj"
+  country: US
+  status: stream-only
+  stationuuid: fee23ba3-3b49-4906-ae40-ab57c0502d0a
+  changeuuid: 7e0f22c2-ccba-47f1-949e-054383a36c28
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-indie-x-fm
+  broadcaster: independent
+  name: Indie X FM
+  streamUrl: https://kathy.torontocast.com:2695/stream
+  bitrate: 320
+  codec: MP3
+  favicon: "https://img1.wsimg.com/isteam/ip/6b751bf2-5843-4590-8843-d4025327a155/favicon/b60d118d-2ffa-4828-9955-afea07eb614f.png/:/rs=w:180,h:180,m"
+  homepage: "https://indiexfm.com/"
+  country: US
+  status: stream-only
+  stationuuid: 2d0403e9-2d8f-4a6a-8a55-0720bb80bfb8
+  changeuuid: 64661405-3783-4330-9a04-10ff0e279d09
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-bloomberg-tv-new
+  broadcaster: independent
+  name: Bloomberg TV new
+  streamUrl: https://www.bloomberg.com/media-manifest/streams/phoenix-us.m3u8
+  bitrate: 1500
+  codec: AAC
+  favicon: "https://www.bloomberg.com/favicon.ico"
+  homepage: "https://www.bloomberg.com/live"
+  country: US
+  status: stream-only
+  stationuuid: e03033f5-0259-451c-909a-70cd8fee8494
+  changeuuid: 67e49b83-7b7d-41a5-8e01-5d5c20728a65
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-wfed-federal-news-network
+  broadcaster: independent
+  name: WFED Federal News Network
+  streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/WFEDAM.mp3
+  bitrate: 96
+  codec: MP3
+  favicon: "https://federalnewsnetwork.com/wp-content/uploads/2017/12/cropped-icon-512x512-1.png"
+  homepage: "https://federalnewsnetwork.com/"
+  country: US
+  status: stream-only
+  stationuuid: c4346a0a-6beb-11ea-b1cf-52543be04c81
+  changeuuid: fbd8978a-3dc9-4a61-b8be-714fb58d242b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-classical-kusc
+  broadcaster: independent
+  name: Classical KUSC
+  streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/KUSCAAC64.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: "https://www.kusc.org/icons/kusc/apple-touch-icon-120x120.png"
+  homepage: "https://www.kusc.org/"
+  country: US
+  status: stream-only
+  stationuuid: 21290f3a-26db-4bc6-a5e2-6266893ebb11
+  changeuuid: b194b46c-2a90-40a7-8d38-041ffbfe1abd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-space-station-soma-64k-aac
+  broadcaster: independent
+  name: SomaFM Space Station Soma (64k AAC)
+  streamUrl: https://ice4.somafm.com/spacestation-64-aac
+  bitrate: 64
+  codec: AAC
+  favicon: "https://somafm.com/img3/spacestation-400.png"
+  homepage: "https://somafm.com/spacestation/"
+  country: US
+  status: stream-only
+  stationuuid: 3d0b3549-3c4c-11e8-b74d-52543be04c81
+  changeuuid: b9f8361e-cf86-4060-be80-b5f0892871b9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-94-7-kumu-128kbps
+  broadcaster: independent
+  name: 94.7 KUMU (128kbps)
+  streamUrl: https://pacificmedia.cdnstream1.com/2783_128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: "https://kumu.com/wp-content/uploads/sites/14/KUMU-Web-Logo-180x115-1.png"
+  homepage: "https://kumu.com/"
+  country: US
+  status: stream-only
+  stationuuid: faea95b2-cd79-4e9d-9048-016c05039226
+  changeuuid: 176855b2-5e72-49fd-a48d-c7729cc0b93e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-smoothjazz-com-64k-aac
+  broadcaster: independent
+  name: " SmoothJazz.com 64k aac+"
+  streamUrl: https://smoothjazz.cdnstream1.com/2585_64.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: "https://www.smoothjazz.com/sites/default/files/theme/sj-circle-logo.png"
+  homepage: "https://www.smoothjazz.com/"
+  country: US
+  status: stream-only
+  stationuuid: 393224fb-a0a8-4685-ab4e-a5ced5c80d93
+  changeuuid: 327f5f53-3df0-4048-bfa0-4001c2403d31
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-90-5-wicn-public-radio-jazz-for-new-england
+  broadcaster: independent
+  name: 90.5 WICN Public Radio - Jazz+ for New England
+  streamUrl: https://wicn-ice.streamguys1.com/live-mp3
+  bitrate: 256
+  codec: MP3
+  favicon: "https://www.wicn.org/wp-content/uploads/2019/06/cropped-android-chrome-512x512-192x192.png"
+  homepage: "https://www.wicn.org/"
+  country: US
+  status: stream-only
+  stationuuid: cacd1a66-67b8-11ea-be63-52543be04c81
+  changeuuid: d025ad8f-ef0e-48ee-a568-1f593b11aeac
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-jazz-wyoming
+  broadcaster: independent
+  name: Jazz Wyoming
+  streamUrl: https://wyoming-public-ice.streamguys1.com/JZZ128MP3
+  bitrate: 128
+  codec: MP3
+  favicon: "https://www.wyomingpublicmedia.org/apple-touch-icon.png"
+  homepage: "https://www.wyomingpublicmedia.org/show/jazz-wyoming"
+  country: US
+  status: stream-only
+  stationuuid: 49131fdd-98aa-4602-b584-1a8acbd05825
+  changeuuid: 0efcd974-3deb-40c9-b74a-8a215b0f459a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-progulus-online-progressive-rock-radio
+  broadcaster: independent
+  name: Progulus - Online Progressive Rock Radio
+  streamUrl: https://centova.radioservers.biz/proxy/klemmer/stream
+  bitrate: 192
+  codec: MP3
+  favicon: "https://progulus.com/favicon.ico"
+  homepage: "https://progulus.com/rprweb/#page-playing"
+  country: US
+  status: stream-only
+  stationuuid: 154457e2-f136-447b-96fa-d061f2536acf
+  changeuuid: 76b259a2-563a-4c89-ae55-bb014087e2bf
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-wwoz-new-orleans-public-radio
+  broadcaster: independent
+  name: WWOZ - New Orleans Public Radio
+  streamUrl: https://www.wwoz.org/listen/hi
+  bitrate: 128
+  codec: MP3
+  favicon: "https://www.wwoz.org//sites/default/files/favicons-bw/apple-touch-icon-57x57.png"
+  homepage: "https://www.wwoz.org/"
+  country: US
+  status: stream-only
+  stationuuid: 9ceb61e8-5101-11e9-a4d7-52543be04c81
+  changeuuid: bce04b5a-b08b-4b51-9a08-650be96e048c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-electricfm-america-s-reals-dance
+  broadcaster: independent
+  name: "ELECTRICFM - America's Reals Dance! "
+  streamUrl: https://live.electricfm.com/electricfm
+  bitrate: 64
+  codec: AAC+
+  favicon: "https://www.electricfm.com/apple-icon-120x120.png"
+  homepage: "https://www.electricfm.com/"
+  country: US
+  status: stream-only
+  stationuuid: 62aad7a6-e09c-4ebd-9840-f96892000abe
+  changeuuid: 9498b8ea-2153-4f98-a0fc-9a8978753463
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-c-span
+  broadcaster: independent
+  name: C-SPAN
+  streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/CSPANRADIO.mp3
+  bitrate: 40
+  codec: MP3
+  favicon: "https://static.c-spanvideo.org/apple-touch-icon-iphone-retina-display.png"
+  homepage: "https://www.c-span.org/"
+  country: US
+  status: stream-only
+  stationuuid: 771964e5-3e72-11e8-b74d-52543be04c81
+  changeuuid: b3a5172a-78d5-4ae3-a2b5-0706aabd79df
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-heady
+  broadcaster: independent
+  name: HEADY
+  streamUrl: https://c22.radioboss.fm:18364/stream
+  bitrate: 320
+  codec: AAC
+  favicon: "https://cdn.prod.website-files.com/63222115e90f0d1c63a9e53a/63222115e90f0de32da9e58c_fav-20.png"
+  homepage: "https://www.heady.fm/"
+  country: US
+  status: stream-only
+  stationuuid: 70133397-5845-4524-bcda-701da75f46fa
+  changeuuid: 1c1145c6-5f44-4d49-b76f-8d2e40078cf8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-new-wave-bestnet-radio
+  broadcaster: independent
+  name: New Wave - BestNet Radio
+  streamUrl: https://bigrradio.cdnstream1.com/5162_128
+  bitrate: 128
+  codec: MP3
+  homepage: "https://bestnetradio.com/"
+  country: US
+  status: stream-only
+  stationuuid: 4a86f1be-475a-43d4-ba5f-92d326edbea5
+  changeuuid: 0430d575-a8ac-487d-a7f6-3873fccd0492
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-kost-103-5
+  broadcaster: independent
+  name: KOST 103.5
+  streamUrl: https://stream.revma.ihrhls.com/zc193
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/4f8b2d8763a2d58e545fa71e11b46bb2?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)"
+  homepage: "https://kost1035.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 51306363-5c47-47b2-adb6-4e25bda8b787
+  changeuuid: c6bf33a0-773b-423f-8250-1342bf7eecb6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-ukulele-island
+  broadcaster: independent
+  name: Ukulele Island
+  streamUrl: https://tunein-ondemand.cdnstream1.com/multi_bump_sonic_pre_pre.mp3?aw_0_1st.playerid=LogitechSqueeze&aw_0_1st.skey=1768433575&aw_0_1st.abtest=&partnerId=LogitechSqueeze&aw_0_1st.stationId=s205522&aw_0_1st.premium=false&source=TuneIn&aw_0_req.gdpr=true&aw_0_1st.platform=tunein&aw_0_1st.ads_partner_alias=ce.LogitechSqueezebox&aw_0_azn.planguage=en&aw_0_1st.is_ondemand=false&aw_0_1st.topicId=na&aw_0_1st.affiliateIds=a40075%2ca40276&aw_0_1st.bandId=16
+  codec: MP3
+  homepage: "http://ukulele-island.com/"
+  country: US
+  status: stream-only
+  stationuuid: 36b2caa4-41e0-11e9-aa55-52543be04c81
+  changeuuid: 9dc1ff7a-c35c-4c0c-a392-34f713948a94
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-rusrek
+  broadcaster: independent
+  name: "Канал \"Русский ХИТ\" Radio Rusrek Радио Русская Реклама"
+  streamUrl: https://securestreams6.autopo.st:2130/onlyrussian
+  bitrate: 128
+  codec: MP3
+  favicon: "https://radio.rusrek.com/images/phocaopengraph/logo-2019-06.jpg"
+  homepage: "https://radio.rusrek.com/"
+  country: US
+  status: stream-only
+  stationuuid: c81ff020-d472-4c9b-83ce-5d58ab01e2c1
+  changeuuid: f6d845d4-9940-4ca7-ba27-25ee25b171cd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-drone-zone-32k-aac
+  broadcaster: independent
+  name: SomaFM Drone Zone (32k AAC)
+  streamUrl: https://ice6.somafm.com/dronezone-32-aac
+  bitrate: 32
+  codec: AAC
+  favicon: "https://somafm.com/img3/dronezone-400.jpg"
+  homepage: "https://somafm.com/dronezone/"
+  country: US
+  status: stream-only
+  stationuuid: e4fafef6-9924-11e9-a605-52543be04c81
+  changeuuid: 12a292ca-dbbb-44a8-9794-2a55c7e3feb2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-92-5-and-93-3-the-bull
+  broadcaster: independent
+  name: 92.5 and 93.3 The Bull
+  streamUrl: https://stream.revma.ihrhls.com/zc6168
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/593d4f30e7970b302d32a0f4?ops=gravity(%22center%22),contain(32,32),quality(65)"
+  homepage: "https://thebullcountry.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 14f8076d-409d-4cb5-8de4-90eee6297510
+  changeuuid: 5ea64cb9-1c9a-469a-9d1a-61956389ae9a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-vocaloid-radio-320kbps
+  broadcaster: independent
+  name: Vocaloid Radio (320kbps)
+  streamUrl: https://vocaloid.radioca.st/stream
+  bitrate: 320
+  codec: MP3
+  favicon: "https://vocaloidradio.com/favicon.ico"
+  homepage: "https://vocaloidradio.com/"
+  country: US
+  status: stream-only
+  stationuuid: 8fbe9ffe-2ab4-4faa-85cc-251cc68d0f4f
+  changeuuid: bb76cfc6-afdf-44d3-8af9-42a5b765a7fe
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-cruisin-oldies-94-7-fm-1110-am
+  broadcaster: independent
+  name: "Cruisin' Oldies 94.7 FM & 1110 AM"
+  streamUrl: https://ice8.securenetsystems.net/KGFL
+  bitrate: 64
+  codec: AAC+
+  homepage: "https://www.kgflam.com/"
+  country: US
+  status: stream-only
+  stationuuid: e32f0699-86cd-476b-82f3-13b27152292c
+  changeuuid: 5f7d27d2-f2ca-44b5-8630-940edb96776f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-the-disco-palace
+  broadcaster: independent
+  name: The Disco Palace
+  streamUrl: https://broadcast.miami/proxy/thediscopalace?mp=/stream/;
+  bitrate: 320
+  codec: MP3
+  homepage: "https://www.thediscopalace.com/"
+  country: US
+  status: stream-only
+  stationuuid: d43f5fc2-0ca7-4e2b-a5d0-66b44604e47f
+  changeuuid: a01ae76c-6d63-4c55-9b2e-3bf0351a09b6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-groovy-radio-60-s-and-70-s-oldies
+  broadcaster: independent
+  name: "Groovy Radio - 60's and 70's Oldies"
+  streamUrl: https://r1.comcities.com/proxy/emogddug/stream
+  bitrate: 160
+  codec: MP3
+  favicon: "https://kvkvi.com/wp-content/uploads/2024/02/luxa.org-bordered-Groovy-White-600x600-jpg.jpg"
+  homepage: "https://groovyradio.us/"
+  country: US
+  status: stream-only
+  stationuuid: 69363afd-b084-41e6-a0d4-79bebb629204
+  changeuuid: 900aee8c-7742-404f-9757-632b5c0b7346
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-k-star-country-99-7-fm
+  broadcaster: independent
+  name: K-Star Country 99.7 FM
+  streamUrl: https://ice41.securenetsystems.net/KVST
+  bitrate: 64
+  codec: AAC+
+  favicon: "https://www.kstarcountry.com/website/wp-content/uploads/2017/01/listenlive.png"
+  homepage: "https://www.kstarcountry.com/"
+  country: US
+  status: stream-only
+  stationuuid: 3a0a3af4-c83d-4977-96c7-6a54b2d50f9d
+  changeuuid: f06837e9-cc0c-4f0f-a8fe-97c7f87a1281
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-ritmo-95
+  broadcaster: independent
+  name: RITMO 95
+  streamUrl: https://liveaudio.lamusica.com/MIA_WRMA_icy?
+  bitrate: 319
+  codec: AAC
+  favicon: "https://firebasestorage.googleapis.com/v0/b/radiogalaxy-580f4.appspot.com/o/images%2FIMG_20240913_142656254.jpg?alt=media&token=443199c8-7964-4267-a4c9-bcf994223858"
+  homepage: "https://mytuner-radio.com/es/emisora/ritmo-957-441541/"
+  country: US
+  status: stream-only
+  stationuuid: 3b83627a-a834-44ea-8d3b-60e307d73678
+  changeuuid: 2c282e8b-f6d2-4bd5-abd1-e897c767fc9c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-revolution-93-5
+  broadcaster: independent
+  name: Revolution 93.5
+  streamUrl: https://centova87.shoutcastservices.com/proxy/revolution935/stream
+  bitrate: 128
+  codec: MP3
+  homepage: "https://www.google.com/url?sa=t&source=web&cd=&cad=rja&uact=8&ved=2ahUKEwj1yd_XzJKDAxUrk4kEHehEDzIQFnoECA0QAQ&url=https%3A%2F%2Fwww.revolution935.com%2F&usg=AOvVaw3AuU1XL-Nq5ZSMh9C5HbYu&opi=89978449"
+  country: US
+  status: stream-only
+  stationuuid: 12a8828d-8350-4b10-bc04-22770a41188d
+  changeuuid: 9edccbff-5c6a-478c-9aef-00f7a52e00fb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-mytime-movie-network
+  broadcaster: independent
+  name: MyTime Movie Network
+  streamUrl: https://appletree-mytime-samsungbrazil.amagi.tv/playlist.m3u8
+  bitrate: 1020
+  codec: AAC
+  favicon: "https://mytimemovienetwork.com/favicon.ico"
+  homepage: "https://mytimemovienetwork.com/"
+  country: US
+  status: stream-only
+  stationuuid: 24f0f202-eb15-464f-8c60-a6c0e36f9dd6
+  changeuuid: 62cccf90-68f3-48b9-8d81-5081121dbd85
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-kiro-fm
+  broadcaster: independent
+  name: KIRO -FM
+  streamUrl: https://bonneville.cdnstream1.com/2643_48.aac
+  bitrate: 47
+  codec: AAC+
+  favicon: "https://cdn.bonneville.cloud/i/KIRO-FM/square_600x600.webp"
+  homepage: "https://mynorthwest.com/"
+  country: US
+  status: stream-only
+  stationuuid: 87b4bf08-ae69-4c4d-a272-093b9930d5be
+  changeuuid: d41f0b73-870b-43e3-a789-225987195714
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-the-great-american-songbook-aac
+  broadcaster: independent
+  name: "The Great American Songbook [aac]"
+  streamUrl: https://remote.selfip.net:8030/1
+  bitrate: 64
+  codec: AAC+
+  homepage: "https://greatamericansongbook.info/index.html"
+  country: US
+  status: stream-only
+  stationuuid: b819d32c-651d-4d54-92f3-0d920e54aee3
+  changeuuid: 6e990836-558d-4e20-bc34-e0c8825a66de
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-werave-music-radio-02-study-and-chillout
+  broadcaster: independent
+  name: WeRave Music Radio 02 - Study and Chillout
+  streamUrl: https://stream.zeno.fm/cpnv07rjvp0vv
+  codec: MP3
+  favicon: "https://werave.com.br/wp-content/uploads/2020/09/vinyl.png"
+  homepage: "https://werave.com.br/en"
+  country: US
+  status: stream-only
+  stationuuid: 3a60b563-a65d-4cec-a9bf-e74ac94042a1
+  changeuuid: 569ddf1c-2714-429b-94bb-fc76451d5783
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-90s-country
+  broadcaster: independent
+  name: 90s Country
+  streamUrl: https://stream.revma.ihrhls.com/zc6870
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/new_assets/fd6065ae-5f96-46fe-b70d-c3b2d791cb36"
+  homepage: "https://www.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 8144c605-f9c3-4089-a11a-567a9d168d24
+  changeuuid: 2674243c-bf6d-48e8-93c8-5a0d7a822ddc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-vintage-obscura-radio
+  broadcaster: independent
+  name: Vintage Obscura Radio
+  streamUrl: https://radio.vintageobscura.net/stream
+  bitrate: 64
+  codec: MP3
+  favicon: "https://vintageobscura.net/./img/ms-icon-144x144.png"
+  homepage: "https://vintageobscura.net/"
+  country: US
+  status: stream-only
+  stationuuid: cbf99152-7860-11ea-b1cf-52543be04c81
+  changeuuid: 70f85fca-9030-4bfa-802a-afcc864fc3c3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-fox-sports-98-9fm-1340am
+  broadcaster: independent
+  name: FOX Sports 98.9FM / 1340AM
+  streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/KRLVAMAAC.aac
+  bitrate: 32
+  codec: AAC+
+  homepage: "https://www.lvsportsnetwork.com/"
+  country: US
+  status: stream-only
+  stationuuid: cb235fac-021d-4f8a-b9ae-2754d0b512f5
+  changeuuid: 06d24185-3d30-4a80-ab56-470cb64c53b4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-left-coast-70s-128k-aac
+  broadcaster: independent
+  name: SomaFM Left Coast 70s (128k AAC)
+  streamUrl: https://ice6.somafm.com/seventies-128-aac
+  bitrate: 128
+  codec: AAC
+  favicon: "https://somafm.com/img3/seventies400.jpg"
+  homepage: "https://somafm.com/seventies/"
+  country: US
+  status: stream-only
+  stationuuid: 716d575c-b469-4958-b7db-9fb0afbac973
+  changeuuid: 8b28bee9-46fd-45da-ad02-707d3aee3f5f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-wfla-970-am-tampa-bay-fl
+  broadcaster: independent
+  name: "WFLA 970 AM Tampa Bay, FL"
+  streamUrl: https://stream.revma.ihrhls.com/zc2823
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/60675fb63e8b1ff06401afd2?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)"
+  homepage: "https://wflanews.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: d6c87ff7-c14e-460a-84b7-1ca6c77c7a36
+  changeuuid: 079ed1be-797f-41e3-947a-f2675e6fc1fe
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-105-9-fm-wmal
+  broadcaster: independent
+  name: 105.9 FM WMAL
+  streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/WMALFMAAC.aac
+  bitrate: 48
+  codec: AAC+
+  homepage: "https://www.wmal.com/"
+  country: US
+  status: stream-only
+  stationuuid: 8b78046f-2a55-4a50-a210-e6706669ff0b
+  changeuuid: 008a2028-6c24-4467-a190-33a72691af2d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us--c16337ec
+  broadcaster: independent
+  name: 自由亚洲
+  streamUrl: https://stream-160.zeno.fm/ub3pfplpqbktv?zt=eyJhbGciOiJIUzI1NiJ9.eyJzdHJlYW0iOiJ1YjNwZnBscHFia3R2IiwiaG9zdCI6InN0cmVhbS0xNjAuemVuby5mbSIsInRtIjpmYWxzZSwicnR0bCI6NSwianRpIjoiWEYybFJHNTNUYS1hLWp1VWdiY3pBZyIsImlhdCI6MTc2ODQ0MjYxMSwiZXhwIjoxNzY4NDQyNjcxfQ.06_HWbLfxMfXVTmCHzGzYQ6e74o-ifU8nWoLPrgZwDE
+  codec: MP3
+  homepage: "http://www.xsbnrtv.cn/"
+  country: US
+  status: stream-only
+  stationuuid: c16337ec-14be-423d-a9fe-3ec7ed9aa373
+  changeuuid: 39517ca3-1ac6-4a45-9354-34538c87bd11
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-n5md-128k-aac
+  broadcaster: independent
+  name: SomaFM n5MD (128k AAC)
+  streamUrl: https://ice6.somafm.com/n5md-128-aac
+  bitrate: 128
+  codec: AAC
+  favicon: "https://somafm.com/img3/n5md-400.png"
+  homepage: "https://somafm.com/n5md/"
+  country: US
+  status: stream-only
+  stationuuid: cd280bad-abd6-47ab-8847-735b4f6dc937
+  changeuuid: 8a519673-c61f-4d25-8e73-e69fcafecf4c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-italy-live
+  broadcaster: independent
+  name: Radio Italy Live
+  streamUrl: https://streaming.radiostreamlive.com/radioitalylive_devices
+  bitrate: 128
+  codec: MP3
+  favicon: "https://cdn-elements.radiostreamlive.com/v1/images/favicon.ico"
+  homepage: "http://www.radioitalylive.com/"
+  country: US
+  status: stream-only
+  stationuuid: 9628df4f-0601-11e8-ae97-52543be04c81
+  changeuuid: 98c23db9-ff7a-4bd5-a2df-147e7b4c2d48
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-sunset-chillout-lounge
+  broadcaster: independent
+  name: Sunset Chillout Lounge
+  streamUrl: https://listen.radioking.com/radio/571682/stream/631712
+  bitrate: 192
+  codec: MP3
+  favicon: "https://sunsetchilloutlounge.com/wp-content/uploads/2023/04/sunrise_sunset_captions_puns_quotes_instagram-7-300x225.jpg"
+  homepage: "https://sunsetchilloutlounge.com/"
+  country: US
+  status: stream-only
+  stationuuid: cb136507-425b-4934-8991-d7fc8873c849
+  changeuuid: 8a3382dd-4093-4d37-8135-0ee85e55a1d5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-hpr4-bluegrass-gospel
+  broadcaster: independent
+  name: HPR4 Bluegrass Gospel
+  streamUrl: https://us2.maindigitalstream.com/ssl/7739
+  bitrate: 128
+  codec: MP3
+  favicon: "http://www.hpr.org/icon-normal.png"
+  homepage: "https://hpr.org/"
+  country: US
+  status: stream-only
+  stationuuid: 90ae9607-5033-4ce3-9540-f995b73ff19a
+  changeuuid: 5211fc3e-f944-4e6a-aaea-1551ac897306
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-mast-japanese
+  broadcaster: independent
+  name: Radio Mast Japanese
+  streamUrl: https://streams.radiomast.io/a622d414-52a6-4426-b3b8-ed2a4dbb704b
+  bitrate: 64
+  codec: AAC
+  favicon: "https://bbn1.bbnradio.org/favicon.ico"
+  homepage: "https://bbn1.bbnradio.org/japanese/"
+  country: US
+  status: stream-only
+  stationuuid: 6e741528-a244-4c73-bb70-c382c79c1b25
+  changeuuid: 636fa6f6-f93a-4288-ba4e-fcdf291b1607
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-smooth-groove-radio-the-vibe
+  broadcaster: independent
+  name: Smooth Groove Radio - The Vibe
+  streamUrl: https://usa17.fastcast4u.com/proxy/smoothgr?mp=/1
+  bitrate: 320
+  codec: MP3
+  favicon: "http://thevibesmoothgrooveradio.weebly.com/uploads/9/7/3/1/97313354/published/jazz.jpeg?1494363671"
+  homepage: "http://thevibesmoothgrooveradio.weebly.com/#"
+  country: US
+  status: stream-only
+  stationuuid: 314294c9-f198-487c-99a9-e28a0d49e82c
+  changeuuid: a8305c49-7bea-4eb4-9387-0ae187ef347b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-abiding-radio-kids
+  broadcaster: independent
+  name: Abiding Radio - Kids
+  streamUrl: https://streams.abidingradio.com:7810/1
+  bitrate: 128
+  codec: MP3
+  favicon: "https://www.abidingradio.org/wp-content/uploads/2022/05/cropped-new_icon.png"
+  homepage: "https://www.abidingradio.com/"
+  country: US
+  status: stream-only
+  stationuuid: 961909c2-0601-11e8-ae97-52543be04c81
+  changeuuid: ee3abb58-2d79-4e01-b503-2ae1a0b1679a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-animenfo-radio
+  broadcaster: independent
+  name: AnimeNfo Radio
+  streamUrl: https://stream.zenolive.com/xwa8ckz7mzzuv
+  codec: MP3
+  favicon: "https://listenonlineradio.com/wp-content/uploads/cropped-icon-180x180.png"
+  homepage: "https://www.listenonlineradio.com/japan/animenfo-radio"
+  country: US
+  status: stream-only
+  stationuuid: 565733aa-99ea-4e66-b57a-3b806d3cdfc9
+  changeuuid: 23892f67-3763-4c75-8218-d5c748b2c639
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-cbs-sports-radio-on-am-1500
+  broadcaster: independent
+  name: CBS Sports Radio on AM 1500
+  streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/KHKAAMAAC.aac
+  bitrate: 64
+  codec: AAC+
+  homepage: "https://nbcsportsradiohawaii.com/"
+  country: US
+  status: stream-only
+  stationuuid: d6eb9b29-fec4-4b1b-b49e-e3a3e56044f6
+  changeuuid: 6749a998-6437-421f-adf7-8f6ca1e351e7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-groovewave-jazz
+  broadcaster: independent
+  name: GrooveWave Jazz
+  streamUrl: https://stm1.srvif.com:7530/
+  bitrate: 128
+  codec: MP3
+  favicon: "https://www.groovewave.com/favicon.ico"
+  homepage: "https://www.groovewave.com/jazz/jazz.htm"
+  country: US
+  status: stream-only
+  stationuuid: 54fa22a2-3289-4c3a-8a68-7dd1a1664f43
+  changeuuid: 13909f65-6027-4e2c-9c06-9a458915e647
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-exclusively-lana-del-rey
+  broadcaster: independent
+  name: Exclusively Lana Del Rey
+  streamUrl: https://nl4.mystreaming.net/er/lanadelrey/icecast.audio
+  codec: MP3
+  favicon: "https://liveonlineradio.net/wp-content/uploads/2022/05/Exclusively-Lana-Del-Rey-220x108.webp"
+  homepage: "https://play.exclusive.radio/"
+  country: US
+  status: stream-only
+  stationuuid: 85817f91-210b-4ab8-b03c-b9b333b39874
+  changeuuid: fcbe5289-6eda-4bbd-907f-c01ce36ede73
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-paradise-main-mix-flac-meta
+  broadcaster: independent
+  name: Radio Paradise Main Mix FLAC+Meta
+  streamUrl: https://stream.radioparadise.com/flacm
+  bitrate: 1442
+  codec: OGG
+  favicon: "https://radioparadise.com/apple-touch-icon.png"
+  homepage: "https://radioparadise.com/home"
+  country: US
+  status: stream-only
+  stationuuid: a766bfe4-e0e1-48b1-846d-270d7973e500
+  changeuuid: 6d5a0efb-a181-4e5a-991b-54680a00d359
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-country-90s-radio
+  broadcaster: independent
+  name: Country 90s Radio
+  streamUrl: https://stream.revma.ihrhls.com/zc6870/hls.m3u8
+  bitrate: 24
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/new_assets/fd6065ae-5f96-46fe-b70d-c3b2d791cb36"
+  homepage: "https://www.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 60aa8a84-a8cc-409f-85b1-ab9b8d11b78d
+  changeuuid: 14b150cd-b4d5-4b70-a6cc-2c4515b21991
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-wbz-news-radio-1030
+  broadcaster: independent
+  name: WBZ News Radio 1030
+  streamUrl: https://stream.revma.ihrhls.com/zc7729
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/622f5be7b4c3b4cfaf1dc63d?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)"
+  homepage: "https://wbznewsradio.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 44805572-0849-4214-827d-530c24c7598c
+  changeuuid: db759ee1-6c60-4f71-b573-99c614ae62ab
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-drumbases-pace
+  broadcaster: independent
+  name: drumbases.pace
+  streamUrl: https://radio.drumbase.space/listen/drumbase.space/radio.mp3
+  codec: MP3
+  homepage: "https://drumbase.space/"
+  country: US
+  status: stream-only
+  stationuuid: ce38da1c-df6f-4330-bb1e-1c8836a30de0
+  changeuuid: 16bb4cf8-cec8-4744-98c6-2c1348eda51d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-old-time-radio-usa
+  broadcaster: independent
+  name: Old Time Radio  USA
+  streamUrl: https://ais-sa3.cdnstream1.com/2607_128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: "https://static.wixstatic.com/media/7d32c5_2a0e314736a54369a945724dd2c84980%7emv2.png/v1/fill/w_180%2ch_180%2clg_1%2cusm_0.66_1.00_0.01/7d32c5_2a0e314736a54369a945724dd2c84980%7emv2.png"
+  homepage: "https://www.wotrradionetwork.com/"
+  country: US
+  status: stream-only
+  stationuuid: 01b6708a-2496-42e2-a40e-1fbfe9e4f8c9
+  changeuuid: c1b3f886-9984-4c4a-8ef7-6ac48020cef7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-yourclassical-relax
+  broadcaster: independent
+  name: YourClassical relax
+  streamUrl: https://relax.stream.publicradio.org/relax.aac
+  bitrate: 47
+  codec: AAC+
+  favicon: "https://www.yourclassical.org/apple-touch-icon.png"
+  homepage: "https://www.yourclassical.org/playlist/relax-stream"
+  country: US
+  status: stream-only
+  stationuuid: 4387d303-e936-4aff-bbf1-823eb6f3f6ad
+  changeuuid: 5546d3ef-1f20-44ff-8dce-85f7903f019b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-power-99
+  broadcaster: independent
+  name: Power 99
+  streamUrl: https://stream.revma.ihrhls.com/zc2009
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/593f129c04f04dd9141a0b46?ops=gravity(%22center%22),contain(32,32),quality(65)"
+  homepage: "https://power99.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 18137760-7250-4c75-a4dc-54508d37f2cc
+  changeuuid: 1d12c308-afec-4fd4-9bed-b3ad35756407
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-95-7-big-fm
+  broadcaster: independent
+  name: 95.7 BIG FM
+  streamUrl: https://stream.revma.ihrhls.com/zc2689
+  codec: AAC
+  homepage: "https://957bigfm.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: b662e02e-9b1a-41e7-bfd5-54ff1393c351
+  changeuuid: a6674bc3-3494-4e15-8d64-626b7e52e467
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-joy-fm
+  broadcaster: independent
+  name: Joy FM
+  streamUrl: https://positivealtradio.streamguys1.com/wxrimp3
+  bitrate: 64
+  codec: AAC+
+  homepage: "https://joyfm.org/"
+  country: US
+  status: stream-only
+  stationuuid: 1dea8fe8-2e76-11ea-aa0c-52543be04c81
+  changeuuid: 941c0b1f-6db3-4855-aa8e-8006280ab1fc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-930-am-wky-espn-deportes
+  broadcaster: independent
+  name: 930 AM WKY ESPN Deportes
+  streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/WKYAMAAC.aac
+  bitrate: 48
+  codec: AAC+
+  homepage: "https://www.wkydeportes.com/"
+  country: US
+  status: stream-only
+  stationuuid: 88ab6716-5c52-4595-854e-538b92dad5c2
+  changeuuid: 8c53ab27-0950-479f-bbf6-dbe65b0c5425
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-yourclassical-guitar
+  broadcaster: independent
+  name: YourClassical Guitar
+  streamUrl: https://favorites.stream.publicradio.org/guitar.aac
+  bitrate: 47
+  codec: AAC+
+  favicon: "https://www.yourclassical.org/apple-touch-icon.png"
+  homepage: "https://www.yourclassical.org/playlist/guitar-stream"
+  country: US
+  status: stream-only
+  stationuuid: 86b5e3dd-60b1-4b7d-a031-e6d867b0995f
+  changeuuid: b2985717-b063-4625-875e-cf874bbf7247
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-christian-talk-fm
+  broadcaster: independent
+  name: Christian Talk FM
+  streamUrl: https://n07.radiojar.com/cm4by4kt2ceuv?rj-ttl=5&rj-tok=AAABel9L5qIAT_t_lI31ovcv0A
+  codec: MP3
+  homepage: "https://www.christiantalkfm.com/"
+  country: US
+  status: stream-only
+  stationuuid: 70c4e5a8-1ab5-47f9-afa1-bc6edf586c47
+  changeuuid: ad0a6252-62d2-4669-aebf-d761d173647f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-taylor-swift
+  broadcaster: independent
+  name: Taylor Swift
+  streamUrl: https://nl4.mystreaming.net/er/taylorswift/icecast.audio
+  codec: MP3
+  favicon: "https://e1.pngegg.com/pngimages/630/656/png-clipart-taylor-swift-taylor-swift-1-thumbnail.png"
+  homepage: "https://www.exclusive.radio/"
+  country: US
+  status: stream-only
+  stationuuid: 4ac71b97-daa9-47dd-893e-4addf52c3f96
+  changeuuid: a7827f0d-74d5-44cf-a6b5-57767c5be4c5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-lofi-afrobeats-radio
+  broadcaster: independent
+  name: LoFi Afrobeats Radio
+  streamUrl: https://stream.zeno.fm/34vsiqt1kaktv
+  codec: MP3
+  favicon: "https://zeno.fm/_next/image/?url=https%3A%2F%2Fimages.zeno.fm%2FzZe3OLAP0usX0Z0Q53XrrFuLKaNHO50zZ0gS3s8578k%2Frs%3Afit%3A240%3A240%2Fg%3Ace%3A0%3A0%2FaHR0cHM6Ly9zdHJlYW0tdG9vbHMuemVub21lZGlhLmNvbS9jb250ZW50L3N0YXRpb25zLzc1MTZmNTdlLTQ3ZTctNDQ1My1hYzFkLWRkNDliZGE5OWExZS9pbWFnZS8_dXBkYXRlZD0xNjk4NzExMzA2MDAw.webp&w=1920&q=100"
+  homepage: "https://zeno.fm/radio/lofi-afrobeats/"
+  country: US
+  status: stream-only
+  stationuuid: b77daf98-4cc2-47d1-88df-ac2129dff42e
+  changeuuid: 97268133-ca35-47f2-9096-455431dc108e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-exclusively-mike-oldfield
+  broadcaster: independent
+  name: Exclusively Mike Oldfield
+  streamUrl: https://nl4.mystreaming.net/er/mikeoldfield/icecast.audio
+  codec: MP3
+  favicon: "https://you.radio/cdn-cgi/image/width=400,quality=75/https://manager.uber.radio/static/uploads/station/e10b5af0-38e5-4592-9343-aa75bdc05fb7.jpg"
+  homepage: "https://play.you.radio/station/18/1518"
+  country: US
+  status: stream-only
+  stationuuid: 8915c68e-8438-4001-9dad-8e676bd21322
+  changeuuid: c821aa41-d632-41d6-a6f6-8642a584479f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-99-1-the-ranch
+  broadcaster: independent
+  name: 99.1 The Ranch
+  streamUrl: https://ice9.securenetsystems.net/KWSV
+  bitrate: 32
+  codec: AAC+
+  favicon: "https://www.991theranch.com/images/favicon/apple-touch-icon.png"
+  homepage: "https://www.991theranch.com/"
+  country: US
+  status: stream-only
+  stationuuid: 15c4572a-70e9-475b-b73b-452aff0deeff
+  changeuuid: 2295390e-5362-4fa6-b51b-d7ebc9cea1fc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-107-5-wgci
+  broadcaster: independent
+  name: 107.5 WGCI
+  streamUrl: https://stream.revma.ihrhls.com/zc841
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/5a03593628adca546d27a748?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)"
+  homepage: "https://wgci.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 19d879ef-2bb5-4281-989d-46e578e7ae40
+  changeuuid: b0373184-868e-40d7-b813-1f0090da0618
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-exa-fm-pop-music-in-spanish-and-english
+  broadcaster: independent
+  name: "  EXA FM: POP MUSIC in Spanish and English"
+  streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XHPSFMAAC.aac
+  bitrate: 48
+  codec: AAC+
+  favicon: "https://exafm.com/u/plantillas/p/exa-fm/imgs/favicons//apple-touch-icon.png?v2"
+  homepage: "https://exafm.com/plaza/veracruz/"
+  country: US
+  status: stream-only
+  stationuuid: 203eef04-b6e0-4dac-b483-c7290e12d0d8
+  changeuuid: f13f8d00-299f-4b0d-951b-bb16ca80f209
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-wkdm
+  broadcaster: independent
+  name: WKDM 纽约华语广播国语台
+  streamUrl: https://video1.getstreamhosting.com:8292/stream?.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: "http://gbm.123tv.cn/file/2023/08-1690893620.jpg"
+  homepage: "https://nysino.com/am1380/"
+  country: US
+  status: stream-only
+  stationuuid: 809a0f17-d636-497e-a38b-3b3031ce2d40
+  changeuuid: 91fcf3e5-5fe8-43dd-bdf2-5d2a4dce81e5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-wrte-90-7-fm
+  broadcaster: independent
+  name: WRTE 90.7 FM
+  streamUrl: https://wdcb-ice.streamguys1.com/wdcb128
+  bitrate: 128
+  codec: MP3
+  homepage: "https://wdcb.org/"
+  country: US
+  status: stream-only
+  stationuuid: b0f9fafa-e387-4c8e-abe9-67678005e353
+  changeuuid: 3400bcf0-44e4-4605-9eb5-6ea8f9e50dc2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-heart-soul-92-1-1140
+  broadcaster: independent
+  name: "Heart & Soul 92.1 & 1140"
+  streamUrl: https://crystalout.surfernetwork.com:8001/KRMP_MP3
+  codec: MP3
+  homepage: "https://www.okcheartandsoul.com/"
+  country: US
+  status: stream-only
+  stationuuid: ec14c868-1c79-437b-90ef-d6c9e3751ee8
+  changeuuid: c91d6659-5991-4f04-94f0-57474601b903
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-texas-rebel-radio
+  broadcaster: independent
+  name: Texas Rebel Radio
+  streamUrl: https://ice41.securenetsystems.net/KNAF?playSessionID=6CC4A665-B891-1B7E-1922BD6BD5D4109F
+  bitrate: 32
+  codec: AAC+
+  homepage: "https://texasrebelradio.com/"
+  country: US
+  status: stream-only
+  stationuuid: 7c67f9b4-7a55-48f5-bf55-1f0c51760ef0
+  changeuuid: 8467bd1d-3cfc-4780-98e2-fdc549253c4b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-wkyu-88-9-wku-public-radio-bowling-green-ky
+  broadcaster: independent
+  name: "WKYU 88.9 \"WKU Public Radio\" Bowling Green, KY"
+  streamUrl: https://dal-wku-stream-1.neighborhoodca.com/stream
+  bitrate: 128
+  codec: MP3
+  homepage: "http://wkyufm.org/"
+  country: US
+  status: stream-only
+  stationuuid: 96260fdb-0601-11e8-ae97-52543be04c81
+  changeuuid: 01e710c0-e4bc-43f1-95d1-db55f78b77ac
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-klou-103-3-stl-s-best-variety-of-the-70s-80s-90s
+  broadcaster: independent
+  name: "KLOU 103.3 - STL's Best Variety of the 70s, 80s & 90s"
+  streamUrl: https://stream.revma.ihrhls.com/zc3463
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/6639ff25b916cb55e5b14c02a1078758?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)"
+  homepage: "https://klou.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 72ea609c-bdcc-4c73-b1c7-8949f35e2a04
+  changeuuid: 6fc3c833-f7dd-4d18-81dd-aa84b5165c1f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-your-classical-radio
+  broadcaster: independent
+  name: Your Classical - Radio
+  streamUrl: https://ycradio.stream.publicradio.org/ycradio.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: "https://www.yourclassical.org/apple-touch-icon.png"
+  homepage: "https://www.yourclassical.org/"
+  country: US
+  status: stream-only
+  stationuuid: 9caa88bd-ef4a-4933-9ef3-6841c65a94c2
+  changeuuid: 322a382b-afc2-4b5f-b9ee-b39af13c4107
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-christian-industrial-radio
+  broadcaster: independent
+  name: Christian Industrial Radio
+  streamUrl: https://christianindustrial.net/listen/radio/radio.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: "https://christianindustrial.net/"
+  country: US
+  status: stream-only
+  stationuuid: 6120ddf7-ed9a-43e5-a747-fccd3bd16564
+  changeuuid: 524020e4-092e-458f-bcfc-d80cff357f0b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-light-favorites-easy-108
+  broadcaster: independent
+  name: Light Favorites Easy 108
+  streamUrl: https://ais-sa2.cdnstream1.com/1299_128
+  bitrate: 128
+  codec: MP3
+  homepage: "http://easy108.net/"
+  country: US
+  status: stream-only
+  stationuuid: 9b07254b-c557-49cd-ad4a-6e414a9877cc
+  changeuuid: ea4c190f-3cd5-4950-ab50-06d2beba8d1d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-sunny-99-1
+  broadcaster: independent
+  name: SUNNY 99.1
+  streamUrl: https://stream.revma.ihrhls.com/zc2273
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/5c6c7ebe564112eb3f91819d?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)"
+  homepage: "https://sunny99.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 4669679b-2422-4129-a963-f6e6fd31b03d
+  changeuuid: f56e8b15-e3dd-4241-b1d8-7f4604866236
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-cbs-sports-1430-am
+  broadcaster: independent
+  name: CBS Sports 1430 AM
+  streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/WXNTAMAAC.aac
+  bitrate: 80
+  codec: AAC+
+  homepage: "https://www.cbssportsradio1430.com/"
+  country: US
+  status: stream-only
+  stationuuid: 4cca5032-15b2-4d23-b390-545e09c89bb0
+  changeuuid: 918e744f-adda-4528-91ae-d700c84f79f4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-ancient-faith-radio
+  broadcaster: independent
+  name: Ancient Faith Radio
+  streamUrl: https://ancientfaith.streamguys1.com/music
+  bitrate: 96
+  codec: AAC+
+  homepage: "http://www.ancientfaith.com/"
+  country: US
+  status: stream-only
+  stationuuid: 1b0cb1d8-9e80-11e8-a767-52543be04c81
+  changeuuid: 6263f406-f156-4697-90e5-61b76595415b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-deep-space-one-128k-mp3
+  broadcaster: independent
+  name: SomaFM Deep Space One (128k MP3)
+  streamUrl: https://ice6.somafm.com/deepspaceone-128-mp3
+  bitrate: 128
+  codec: MP3
+  favicon: "http://somafm.com/img3/deepspaceone-400.jpg"
+  homepage: "https://somafm.com/deepspaceone/"
+  country: US
+  status: stream-only
+  stationuuid: a807ecc5-8410-4704-bac4-aed64ba76742
+  changeuuid: 3d1d77bc-7f0e-4209-b22f-67a402b70800
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-fox-sports-1360
+  broadcaster: independent
+  name: Fox Sports 1360
+  streamUrl: https://stream.revma.ihrhls.com/zc4688
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/c54a5ffebe8db4757ebbe6dd81f187fd?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)"
+  homepage: "https://foxsports1360.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: d66b6453-1398-4230-b706-fc084b6976e8
+  changeuuid: ef2eb3bc-b894-4b46-9bdb-4731b73182bc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-94-5-the-buzz
+  broadcaster: independent
+  name: 94.5 The Buzz
+  streamUrl: https://stream.revma.ihrhls.com/zc2281
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/604a7bfd7e474524b9ae1a16?ops=gravity(%22center%22),contain(300,300)&quality=80"
+  homepage: "https://thebuzz.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: f51112f4-42c8-4a16-879e-af090f2fe56c
+  changeuuid: 9d1ce2bb-d369-4640-93c2-7c107074cdb9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-hot-95-9
+  broadcaster: independent
+  name: Hot 95.9
+  streamUrl: https://ice.zradio.org/h/high.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: "https://zradio.org/listen/"
+  country: US
+  status: stream-only
+  stationuuid: 964893e7-0601-11e8-ae97-52543be04c81
+  changeuuid: 26389f8b-3ef4-4710-98e3-399ed72fb3fd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-smooth-jazz-101-1
+  broadcaster: independent
+  name: Smooth Jazz 101.1
+  streamUrl: https://crystalout.surfernetwork.com:8001/WJZA-AM_MP3
+  codec: MP3
+  homepage: "https://www.smoothjazzatl.com/"
+  country: US
+  status: stream-only
+  stationuuid: 46d2e1f5-b7ec-464e-9913-cb848488abdc
+  changeuuid: f5189dcc-3ea2-4c25-af6e-ac3e0a655982
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-paradise-main-mix-64k-aac
+  broadcaster: independent
+  name: Radio Paradise Main Mix 64k AAC
+  streamUrl: https://stream.radioparadise.com/aac-64
+  bitrate: 64
+  codec: AAC
+  favicon: "https://radioparadise.com/apple-touch-icon.png"
+  homepage: "https://radioparadise.com/"
+  country: US
+  status: stream-only
+  stationuuid: 82b3d31f-0b79-445b-ad19-36395e8ed052
+  changeuuid: 50ffc534-2a65-4483-ac38-d91658a9d0d6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-big-b-radio-asian-pop
+  broadcaster: independent
+  name: Big B Radio - Asian pop
+  streamUrl: https://antares.dribbcast.com/proxy/apop?mp=/s?
+  bitrate: 128
+  codec: MP3
+  homepage: "https://bigbradio.net/"
+  country: US
+  status: stream-only
+  stationuuid: 5a7b01dc-23b1-4d9d-9a04-9476682e3b4f
+  changeuuid: a9f024fa-13d2-4749-8a1b-6d055203c45c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-yar-plus
+  broadcaster: independent
+  name: Radio Yar Plus
+  streamUrl: https://stream-171.zeno.fm/2jwyo983y49vv?zt=eyJhbGciOiJIUzI1NiJ9.eyJzdHJlYW0iOiIyand5bzk4M3k0OXZ2IiwiaG9zdCI6InN0cmVhbS0xNzEuemVuby5mbSIsInJ0dGwiOjUsImp0aSI6ImxuWlJyYXZfUS1TamI0MXJEUGFZSWciLCJpYXQiOjE3MzgxMDczNzUsImV4cCI6MTczODEwNzQzNX0.s37s0rmtffdTaKEhQMIwFMUl6mxQZ6C-O54FMSjDm-8&an-uid=975551466766821786&triton-uid=cookie%3Aaa378a8e-a987-4993-9848-db8cf7da7bd4&adtonosListenerId=01JJQMBBZVVS1YHWMJMFDSY4Q4&aw_0_req_lsid=609a2ec3b6fcae06b387373c64032f16
+  codec: MP3
+  favicon: "https://zeno.fm/_ipx/q_85&fit_cover&s_288x288/https://images.zeno.fm/7XCVsr_ZE1q3fpPcrCpQD1prYmMrjHoCWo2u7sHhGYU/rs:fill:288:288/g:ce:0:0/aHR0cHM6Ly9wcm94eS56ZW5vLmZtL2NvbnRlbnQvc3RhdGlvbnMvZDYxZWM4ZjMtZTI1NC00ODBmLWE1NzAtNTZhNjYxYjY0ZTllL2ltYWdlLz91PTE3MzgxNTc4NTMwMDA.webp"
+  homepage: "https://radioyar.com/"
+  country: US
+  status: stream-only
+  stationuuid: a639fa64-2956-4a43-90a4-a3e9b0e5150f
+  changeuuid: cdd81ccd-0c58-49d2-8cc5-94157065b65d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-t-k-disco
+  broadcaster: independent
+  name: Radio T.K. Disco
+  streamUrl: https://broadcast.miami/proxy/tkdisco?mp=/stream/;
+  bitrate: 320
+  codec: MP3
+  homepage: "https://www.radiotkdisco.com/"
+  country: US
+  status: stream-only
+  stationuuid: 305ccb54-3ea9-4c09-a9ce-768dade0794d
+  changeuuid: 84aeaecc-4dbe-432f-aa38-0a1a1edbf390
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-106-9-the-eagle
+  broadcaster: independent
+  name: 106.9 The Eagle
+  streamUrl: https://ice9.securenetsystems.net/KEGK
+  bitrate: 32
+  codec: AAC+
+  homepage: "https://1069eagle.com/"
+  country: US
+  status: stream-only
+  stationuuid: 809976d5-2a3f-4c6a-9318-f80649e90fe8
+  changeuuid: 2ee05965-7c1e-45d3-a698-a958b1ca6baa
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-classical-piano
+  broadcaster: independent
+  name: classical piano
+  streamUrl: https://cms.stream.publicradio.org/cms.aac
+  bitrate: 47
+  codec: AAC+
+  country: US
+  status: stream-only
+  stationuuid: f5c737a4-5e54-4638-8e31-83b87df3acbe
+  changeuuid: 8867789f-3dc9-47c0-ba64-f88fc762f986
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radiogpt
+  broadcaster: independent
+  name: RadioGPT
+  streamUrl: https://ais-sa1.streamon.fm/7838_128k.aac/playlist.m3u8
+  bitrate: 128
+  codec: AAC
+  favicon: "https://listen.streamon.fm/favicon.ico"
+  homepage: "https://listen.streamon.fm/radiogpt"
+  country: US
+  status: stream-only
+  stationuuid: a492f2c4-884d-4625-a244-a3687d9c6e43
+  changeuuid: 9cf27d34-a12f-4567-aaf0-430b34add002
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-the-trip-64k-aac
+  broadcaster: independent
+  name: SomaFM The Trip (64k AAC)
+  streamUrl: https://ice2.somafm.com/thetrip-64-aac
+  bitrate: 64
+  codec: AAC
+  favicon: "https://somafm.com/img3/thetrip-400.jpg"
+  homepage: "https://somafm.com/thetrip/"
+  country: US
+  status: stream-only
+  stationuuid: b51e3b5c-3eee-11e8-b74d-52543be04c81
+  changeuuid: f94c5169-9f34-49f8-8428-d387caa57c46
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-yoto-sleep-radio
+  broadcaster: independent
+  name: Yoto Sleep Radio
+  streamUrl: https://s3.radio.co/s74390585c/listen
+  bitrate: 96
+  codec: AAC
+  favicon: "https://www.datocms-assets.com/48136/1666621552-sleep_sounds_icon.png"
+  homepage: "https://us.yotoplay.com/sleep"
+  country: US
+  status: stream-only
+  stationuuid: 1241bcf6-bb71-4d4a-940a-5fcc1dc98e35
+  changeuuid: 57dda87a-43ba-468f-bf07-1f67c6e903eb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-94-7-alternative-anchorage
+  broadcaster: independent
+  name: 94.7 Alternative Anchorage
+  streamUrl: https://ice10.securenetsystems.net/KZND
+  bitrate: 32
+  codec: AAC+
+  favicon: "https://radiostationusa.fm/assets/image/radio/180/KZND-FM.jpeg"
+  homepage: "https://alternativeanchorage.com/"
+  country: US
+  status: stream-only
+  stationuuid: 7cfee864-040c-4afc-a556-993d273d6d24
+  changeuuid: 5f23b598-6772-4f25-b9e0-4510f550282e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-gospel-highway-11
+  broadcaster: independent
+  name: Gospel Highway 11
+  streamUrl: https://ice23.securenetsystems.net/WNAP
+  bitrate: 48
+  codec: AAC+
+  homepage: "https://www.mygospelhighway11.com/"
+  country: US
+  status: stream-only
+  stationuuid: 7f59bb69-d524-4b03-a291-118490256253
+  changeuuid: ac90fbc7-0164-488b-ab48-3d2ccc400d21
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-kvto-am1400-fm93-7
+  broadcaster: independent
+  name: KVTO AM1400 FM93.7 旧金山湾区中文电台
+  streamUrl: https://us2.maindigitalstream.com/ssl/KVTO
+  bitrate: 64
+  codec: MP3
+  favicon: "https://kvto.net/assets/img/basic/AM1400logo.png"
+  homepage: "https://kvto.net/"
+  country: US
+  status: stream-only
+  stationuuid: 1442c526-4b68-423e-a14d-76f7fe16f7d7
+  changeuuid: bfc1eadd-10d8-4ad9-a389-8bff17339bed
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-sangeet-radio-fm-95-1-am-1460-houston-tx-us
+  broadcaster: independent
+  name: "Sangeet Radio FM 95.1 AM 1460 Houston, TX, US"
+  streamUrl: https://ice8.securenetsystems.net/SGTRADIO
+  bitrate: 32
+  codec: AAC+
+  favicon: "https://i0.wp.com/sangeetradio.com/wp-content/uploads/2020/05/cropped-512x512-1.png?fit=180%2c180&#038;ssl=1"
+  homepage: "https://sangeetradio.com/"
+  country: US
+  status: stream-only
+  stationuuid: b01369dd-2147-425e-a7a5-bf52f096f3fa
+  changeuuid: d13dce44-fe35-4d7d-a32d-03d59cda85e5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-alt-98-7
+  broadcaster: independent
+  name: ALT 98.7
+  streamUrl: https://stream.revma.ihrhls.com/zc201
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets/images/08e927dc-5949-41d6-972b-b5581a0850f3.png"
+  homepage: "https://alt987fm.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 6e96bc6f-597e-4745-a97a-0755c6ed34f2
+  changeuuid: f24e5760-84bd-4424-8c62-41e055412b74
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-news-talk-99-5-wrno
+  broadcaster: independent
+  name: News Talk 99.5 WRNO
+  streamUrl: https://stream.revma.ihrhls.com/zc1033
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/66e48d2c709d7268702bcb1c?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)"
+  homepage: "https://wrno.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: cc16773b-5953-439f-872e-5c2f485a28b8
+  changeuuid: f7559cbf-11d1-4d72-a0f6-86b294eb38f8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-70s-80s-hits
+  broadcaster: independent
+  name: 70s 80s Hits
+  streamUrl: https://azuracast.streams.gr/listen/oldieswebradio/hits70s80sradio.mp3?
+  bitrate: 128
+  codec: MP3
+  favicon: "https://cdn-web.tunein.com/assets/img/apple-touch-icon-180.png"
+  homepage: "https://hits70s80s.weebly.com/"
+  country: US
+  status: stream-only
+  stationuuid: cbd8974a-b3ef-4272-9f6d-370a48c0d1c8
+  changeuuid: 40b94b1b-8700-4208-84e8-be94f338d8f2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-vip-radio-dance
+  broadcaster: independent
+  name: VIP Radio Dance
+  streamUrl: https://usa11.fastcast4u.com/proxy/vipdance?mp=/;
+  bitrate: 128
+  codec: MP3
+  favicon: "https://vipdance.com/assets/images/android-chrome-192x192-128x128-1.png"
+  homepage: "https://vipdance.com/"
+  country: US
+  status: stream-only
+  stationuuid: 4c7a959d-a096-4a4b-806f-fdea6d779d58
+  changeuuid: 14ff33a1-ab8a-4e97-86d8-2325ea1f2ab1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-100-hip-hop-and-rnb-fm-official
+  broadcaster: independent
+  name: 100 Hip Hop and RNB FM (Official)
+  streamUrl: https://streaming.shoutcast.com/100-hip-hop-and-rnb-fm
+  bitrate: 128
+  codec: MP3
+  favicon: "https://static.mytuner.mobi/media/tvos_radios/887/rnb-and-hip-hop-radio.51c457d0.png"
+  homepage: "https://uk.radio.net/s/100hiphopandrnb"
+  country: US
+  status: stream-only
+  stationuuid: dba1b7bc-6b92-409c-a543-8b42eec25636
+  changeuuid: fdbc7f07-f064-4125-9f6f-5e14cbb7a1fc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-93-7-el-patron-pura-musica-perrona
+  broadcaster: independent
+  name: 93.7 El Patron (Pura Música Perróna)
+  streamUrl: https://stream.revma.ihrhls.com/zc53/hls.m3u8
+  bitrate: 24
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/6421b1c32608d1fa904eecae"
+  homepage: "https://elpatronphoenix.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 877ac421-62dc-4a8b-8fe8-edfcf05448ff
+  changeuuid: 5a3e9da5-0f72-418a-a772-2252f96bfee1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-mast-russian
+  broadcaster: independent
+  name: Radio Mast Russian
+  streamUrl: https://streams.radiomast.io/1f7e18dd-42dc-4869-9785-a9800456b9e3
+  bitrate: 64
+  codec: AAC
+  homepage: "https://bbn1.bbnradio.org/russian/"
+  country: US
+  status: stream-only
+  stationuuid: 1af1d5cb-0f45-4569-8360-3034f565c4aa
+  changeuuid: a32548f8-3a8d-4a5f-a734-32e890769618
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-softrockradio-net
+  broadcaster: independent
+  name: SoftRockRadio.net
+  streamUrl: https://gold.streamguys1.com/softrock.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: "https://softrockradio.net/"
+  country: US
+  status: stream-only
+  stationuuid: 4c004dcb-2f42-49b3-a642-6e8390d6aac5
+  changeuuid: 528381de-9c5d-4984-984d-bc2cc219d0d2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-department-store-christmas
+  broadcaster: independent
+  name: SomaFM Department Store Christmas
+  streamUrl: https://ice4.somafm.com/deptstore-128-aac
+  bitrate: 128
+  codec: AAC
+  favicon: "https://somafm.com/img3/deptstore400.jpg"
+  homepage: "https://somafm.com/deptstore/"
+  country: US
+  status: stream-only
+  stationuuid: 545c4495-a370-4ed9-8735-03e56b854ae2
+  changeuuid: 7adc17fb-2432-49f0-9197-562ec49c7bc0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-100-7-the-bay
+  broadcaster: independent
+  name: 100.7 The Bay
+  streamUrl: https://ais-sa1.streamon.fm/7225_48k.aac
+  bitrate: 48
+  codec: AAC+
+  favicon: "https://www.thebayonline.com/apple-touch-icon.png"
+  homepage: "https://www.thebayonline.com/"
+  country: US
+  status: stream-only
+  stationuuid: b36a6bda-bece-4d93-844c-268f5297cea3
+  changeuuid: fd8e8b2a-63b2-46e6-a6e0-f67e6d4aaac0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-folk-forward-64k-aac
+  broadcaster: independent
+  name: SomaFM Folk Forward (64k AAC)
+  streamUrl: https://ice2.somafm.com/folkfwd-64-aac
+  bitrate: 64
+  codec: AAC
+  favicon: "https://somafm.com/img3/folkfwd-400.jpg"
+  homepage: "https://somafm.com/folkfwd/"
+  country: US
+  status: stream-only
+  stationuuid: 3387f4be-bb4d-11e9-acb2-52543be04c81
+  changeuuid: 36822912-9d0b-43cb-9931-40755339790c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-good-news-tv
+  broadcaster: independent
+  name: Good News TV
+  streamUrl: https://stream.eleden.com/livegntv/ngrp:livegntv_all/chunklist_w1882925524_b484144.m3u8
+  codec: UNKNOWN
+  homepage: "https://www.mygoodnewstv.com/live"
+  country: US
+  status: stream-only
+  stationuuid: 9cda1f49-72c8-4966-8c94-01de29fb1b71
+  changeuuid: 522603b5-54a8-4d36-b606-ec76faad0d94
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-gotradio-og-s-hip-hop-and-rnb
+  broadcaster: independent
+  name: "GotRadio - OG's Hip Hop and RnB"
+  streamUrl: https://pureplay.cdnstream1.com/6045_128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: "https://cdn.onlineradiobox.com/img/l/5/10155.v2.png"
+  homepage: "https://pureplay.cdnstream1.com/6045_128.mp3"
+  country: US
+  status: stream-only
+  stationuuid: 9b71a2f6-1c91-4242-baa1-fa750ef366e4
+  changeuuid: c0be50ee-b618-4098-a9c6-f052297a7967
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-uctv-university-of-california
+  broadcaster: independent
+  name: UCTV - University of California
+  streamUrl: https://59e8e1c60a2b2.streamlock.net/509/509.stream/playlist.m3u8
+  bitrate: 1080
+  codec: AAC
+  country: US
+  status: stream-only
+  stationuuid: 7c3f84bc-adc7-47be-8401-0505cd06443c
+  changeuuid: 451e1944-0b0c-44b2-8a25-1847d14d0e9f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-talk-radio-1190
+  broadcaster: independent
+  name: Talk Radio 1190
+  streamUrl: https://stream.revma.ihrhls.com/zc4276
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/9b2473c277a06bf9ee69139dab0f80d6?ops=gravity(%22center%22),contain(32,32),quality(65)"
+  homepage: "https://1190talkradio.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 73338aba-acc7-4901-9dbb-3e73780982b1
+  changeuuid: cedf8b9c-b5f9-4548-84b6-e8cc01f0b60b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-wrko-am-680
+  broadcaster: independent
+  name: WRKO-AM 680
+  streamUrl: https://stream.revma.ihrhls.com/zc7750
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/623b3302f27ef877e7867576?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)"
+  homepage: "https://wrko.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: c6cfe25d-6f18-4b61-90a4-c74b941f440b
+  changeuuid: 33686261-7cce-4941-845c-3695039b32ea
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-exclusive-jj-cale
+  broadcaster: independent
+  name: Exclusive JJ Cale
+  streamUrl: https://2.mystreaming.net/er/jjcale/icecast.audio
+  codec: MP3
+  favicon: "https://you.radio/cdn-cgi/image/width=400,quality=75/https://manager.uber.radio/static/uploads/station/38e9316d-592d-4836-a90d-1488afd7bfe1.jpg"
+  homepage: "https://play.you.radio/station/362"
+  country: US
+  status: stream-only
+  stationuuid: 0f2c8475-8be8-4219-b312-5f8815f2d71c
+  changeuuid: f5f2644a-42d5-4a96-b75a-2980838202b7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-grace-fm
+  broadcaster: independent
+  name: GRACE Fm
+  streamUrl: https://ice23.securenetsystems.net/KXGRFM
+  bitrate: 32
+  codec: AAC+
+  favicon: "https://cloud-1de12d.b-cdn.net/media/iw=192&ih=any/3042768b3e79292c36a9508094eafafc.ico"
+  homepage: "https://www.gracefm.com/"
+  country: US
+  status: stream-only
+  stationuuid: b71a7d67-69c0-47f6-94fc-8dc3f0f7bc75
+  changeuuid: c12d1ab4-e4ed-476a-a97e-c24c1b2fb0ca
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-magic-107-7
+  broadcaster: independent
+  name: Magic 107.7
+  streamUrl: https://stream.revma.ihrhls.com/zc597
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/5f203df69dad71e167e50793?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)"
+  homepage: "https://magic107.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: e3f8d228-1bb6-42b9-8771-18daad167de6
+  changeuuid: 9fcd4ae7-7240-401d-98c8-aeb7b150e637
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-3abn-music-channel
+  broadcaster: independent
+  name: 3ABN Music Channel
+  streamUrl: https://war.streamguys1.com:7185/MC01
+  bitrate: 128
+  codec: MP3
+  favicon: "https://3abn.org/icons/3abn-apple-icon-180x180.png"
+  homepage: "https://3abn.org/3abn-music-channel.html"
+  country: US
+  status: stream-only
+  stationuuid: 58de3cc9-5036-11ea-b877-52543be04c81
+  changeuuid: 2fb52444-88d8-46ee-bed8-dff51120430c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-la-talk-radio
+  broadcaster: independent
+  name: LA Talk Radio
+  streamUrl: https://securestreams2.autopo.st:1185/;stream/1
+  bitrate: 112
+  codec: MP3
+  homepage: "https://www.latalkradio.com/"
+  country: US
+  status: stream-only
+  stationuuid: 0303f1d3-cc55-450e-8272-b9229d1d810a
+  changeuuid: b14c0231-bcfe-4a70-ae3a-d46cadfd4785
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somali-super-sport
+  broadcaster: independent
+  name: Somali Super Sport
+  streamUrl: https://stream.zeno.fm/7ytz1pedps8uv
+  codec: MP3
+  homepage: "https://somalisupersport.com/"
+  country: US
+  status: stream-only
+  stationuuid: dd6b78ba-4090-44da-ad9b-5cf6ed2d2d4b
+  changeuuid: 202df450-a22f-4f9d-bc79-bb1eaaf80aa6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-american-family-radio-talk
+  broadcaster: independent
+  name: "American Family Radio: Talk"
+  streamUrl: https://mediaserver3.afa.net:8443/talk.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: "https://afr.net/media/nxrpxumw/afr-logo-800x500.png"
+  homepage: "https://afr.net/"
+  country: US
+  status: stream-only
+  stationuuid: 7881e52f-9f8e-4fc3-ae1a-c6c3cb97d61d
+  changeuuid: a74f007f-5436-495c-94a3-f8726b35794a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-104-1-the-edge
+  broadcaster: independent
+  name: 104.1 The Edge
+  streamUrl: https://stream.revma.ihrhls.com/zc1397
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/5c2fd80baebb07ba9ae0033f?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)"
+  homepage: "https://1041theedge.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 06df8d64-facd-4e13-bfea-35e45a7bb779
+  changeuuid: cf3f9cea-9da7-45b8-9062-0f8b6a4b0996
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-fox-sports-radio-1400
+  broadcaster: independent
+  name: Fox Sports Radio 1400
+  streamUrl: https://stream.revma.ihrhls.com/zc2089
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/5ef24439f789c41536f7fe2b?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)"
+  homepage: "https://foxsportsradio1400.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: e7a2b928-e366-4ec2-8198-7f9235b87b48
+  changeuuid: 21ce5a70-93f2-4b07-b611-c30d7f80b5bd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-jesus-worship-club-radio
+  broadcaster: independent
+  name: Jesus Worship Club Radio
+  streamUrl: https://stream.radio.co/s08b6706bd/low
+  bitrate: 64
+  codec: AAC
+  favicon: "http://www.jesusworshipclub.com/uploads/9/6/3/0/96302130/editor/paypal.png?1592327061"
+  homepage: "http://www.jesusworshipclub.com/"
+  country: US
+  status: stream-only
+  stationuuid: b97c4813-0333-47c0-a969-08b0766aa556
+  changeuuid: a8e6c2a8-938c-4d55-b6d3-b5787b9268d5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-oldies-103-3-fm-1170-am
+  broadcaster: independent
+  name: Oldies 103.3 FM/1170 AM
+  streamUrl: https://ice24.securenetsystems.net/WFDLAM?&playSessionID=797937C8-FCF5-342C-87990F68DDABEC5D
+  bitrate: 64
+  codec: AAC+
+  favicon: "https://dehayf5mhw1h7.cloudfront.net/wp-content/uploads/sites/1442/2020/06/05150844/cropped-radioplus-logo-180x180.png"
+  homepage: "https://www.am1170radio.com/"
+  country: US
+  status: stream-only
+  stationuuid: ac80151d-c9f5-4fc2-9d68-1a0c69041d62
+  changeuuid: b2cfa88b-c49b-4b8a-a2cb-fb985f035fd0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-casablanca
+  broadcaster: independent
+  name: Radio Casablanca
+  streamUrl: https://broadcast.miami/proxy/casablanca?mp=/stream/;
+  bitrate: 320
+  codec: MP3
+  homepage: "https://www.radio-casablanca.com/"
+  country: US
+  status: stream-only
+  stationuuid: 53bf5f3e-b441-4f3b-a054-819ccbe31210
+  changeuuid: 94e5a59a-257e-41ca-8e89-a6686ad08730
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-bay-smooth-jazz
+  broadcaster: independent
+  name: Bay Smooth Jazz
+  streamUrl: https://radio2.vip-radios.fm:18039/stream-192kmp3-BaySmoothJazz
+  bitrate: 192
+  codec: MP3
+  country: US
+  status: stream-only
+  stationuuid: a5709713-a492-43ea-b139-b8771295452a
+  changeuuid: 070abf95-780d-4dc1-9bb4-b92e849d26ff
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-mega-97-1-1-para-latino-hits
+  broadcaster: independent
+  name: "Mega 97.1 (#1 Para Latino Hits )"
+  streamUrl: https://stream.revma.ihrhls.com/zc69/hls.m3u8
+  bitrate: 24
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/6330fb8345c37fdb34215c51"
+  homepage: "https://megatucson.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 8beff280-cd13-459f-b18f-cf4a7b3fafad
+  changeuuid: 02c3fbab-6ba4-43b6-92a8-0aee536e6e34
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-mia-92-1
+  broadcaster: independent
+  name: Mia 92.1
+  streamUrl: https://stream.revma.ihrhls.com/zc3633
+  codec: AAC
+  homepage: "https://mia921.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: dce022d3-5ee5-4d21-8531-1380362e198b
+  changeuuid: 04482803-e8ec-45b2-82ee-c32153886a58
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-z100-whtz-fm-100-3-new-york
+  broadcaster: independent
+  name: Z100 - WHTZ-FM 100.3 New York
+  streamUrl: https://stream.revma.ihrhls.com/zc2509
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/5e7b5d50bee47a8a2b396059?ops=gravity(%22center%22),contain(360,360)&quality=80"
+  homepage: "https://z100.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 56df9f1a-ed8b-4393-890a-2c0e6a0133a1
+  changeuuid: 41389064-7f3e-4977-a612-60f574bc8aae
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-kalx-90-7fm-berkeley
+  broadcaster: independent
+  name: KALX 90.7FM Berkeley
+  streamUrl: https://stream.kalx.berkeley.edu:8443/kalx-320.aac
+  bitrate: 320
+  codec: AAC+
+  favicon: "https://www.kalx.berkeley.edu/favicon.ico"
+  homepage: "https://www.kalx.berkeley.edu/"
+  country: US
+  status: stream-only
+  stationuuid: a256200d-2ec4-11e9-8f31-52543be04c81
+  changeuuid: ef80cb65-3420-42e8-a37e-20b6fb342b76
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-wild-94-3
+  broadcaster: independent
+  name: Wild 94.3
+  streamUrl: https://ice8.securenetsystems.net/KWDD
+  bitrate: 32
+  codec: AAC
+  homepage: "https://wild943.com/"
+  country: US
+  status: stream-only
+  stationuuid: 8e9a9c75-333d-4b17-989b-557b4f13f190
+  changeuuid: fe02f4c4-15e0-4648-983e-c17bd76b0b56
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-100-7-wzlx
+  broadcaster: independent
+  name: 100.7 WZLX
+  streamUrl: https://stream.revma.ihrhls.com/zc7730
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/new_assets/5e4febcf88989f180366cffc?ops=gravity(%22center%22),contain(32,32),quality(65)"
+  homepage: "https://wzlx.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 013fc655-1804-4a3a-a3c9-5abc2c8826b7
+  changeuuid: 0f35100f-beb9-4d28-98f4-718e6b8c9141
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-indie-pop-rocks-32k-aac
+  broadcaster: independent
+  name: "SomaFM Indie Pop Rocks! (32k AAC)"
+  streamUrl: https://ice5.somafm.com/indiepop-32-aac
+  bitrate: 32
+  codec: AAC
+  favicon: "https://somafm.com/img3/indiepop-400.jpg"
+  homepage: "https://somafm.com/indiepop/"
+  country: US
+  status: stream-only
+  stationuuid: 40d531b3-7149-48f5-869b-e96cbda62fa2
+  changeuuid: 9c04b1f2-da51-4d0d-b395-682c4fe54eaa
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-salsa-warriors
+  broadcaster: independent
+  name: Salsa Warriors
+  streamUrl: https://usa7.fastcast4u.com/proxy/salsawarrior?mp=/1
+  bitrate: 128
+  codec: MP3
+  homepage: "https://www.salsawarriors.com/"
+  country: US
+  status: stream-only
+  stationuuid: 3149e465-cad4-4f3f-a2d9-f03da1790eef
+  changeuuid: e6beb54c-f2ca-4428-af55-59fec9e95426
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-highfi-dream
+  broadcaster: independent
+  name: HighFi Dream
+  streamUrl: https://cdn06-us-east.radio.cloud/80ba63862a97bd69c593cc7a2ccaab1c_hq
+  bitrate: 1200
+  codec: OGG
+  favicon: "https://img1.wsimg.com/isteam/ip/56a4969b-e591-4c57-b68b-f6a75cf900d2/blob-c3b0c70.png"
+  homepage: "https://highfidream.com/"
+  country: US
+  status: stream-only
+  stationuuid: 77113a1f-0c93-46ea-9005-2546d33963fe
+  changeuuid: e177f3b9-a85f-424b-a09f-cffabf2d25db
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-groove-salad-16k-aac
+  broadcaster: independent
+  name: SomaFM Groove Salad (16k AAC)
+  streamUrl: https://ice1.somafm.com/groovesalad-16-aac
+  bitrate: 16
+  codec: AAC
+  favicon: "https://somafm.com/img3/groovesalad-400.jpg"
+  homepage: "https://somafm.com/groovesalad/"
+  country: US
+  status: stream-only
+  stationuuid: 05c3cfd3-2ad7-402d-9dfb-ff6209d9e1db
+  changeuuid: 0ff66d79-82cb-4577-a04c-a559a5501c3b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-dopephonk
+  broadcaster: independent
+  name: DOPEPHONK
+  streamUrl: https://listen.atomic.radio/dopephonk/middlequality
+  bitrate: 320
+  codec: MP3
+  favicon: "https://dopephonk.com/icons/android-chrome-192x192.png"
+  homepage: "https://dopephonk.com/"
+  country: US
+  status: stream-only
+  stationuuid: dcdf1511-4c4e-4b29-83d3-b79dbaf38d8a
+  changeuuid: 0c877578-9fb6-4e40-bd62-f038961005fb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-synthwave-radio
+  broadcaster: independent
+  name: Synthwave Radio
+  streamUrl: https://stream.synthwaveradio.eu/listen/synthwaveradio.eu/radio.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: "https://www.synthwaveradio.eu/"
+  country: US
+  status: stream-only
+  stationuuid: 1e73bd72-0693-442a-b6f6-4983bd4d2cd7
+  changeuuid: dbac6baf-ad43-4d7d-8930-f4be2168d161
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-96-1-kiss-fm
+  broadcaster: independent
+  name: 96.1 KISS FM
+  streamUrl: https://stream.revma.ihrhls.com/zc1333
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/609980bbc5876abd3347a3b9?ops=gravity(%22center%22),contain(32,32),quality(65)"
+  homepage: "https://961kissonline.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: edf46093-7150-4e7a-81ee-27662665ae56
+  changeuuid: d1dde4f6-8c51-4731-b2f7-6427f10518d6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-columbia
+  broadcaster: independent
+  name: Radio Columbia
+  streamUrl: https://broadcast.miami/proxy/columbia?mp=/stream/;
+  bitrate: 320
+  codec: MP3
+  homepage: "https://www.radio-columbia.com/"
+  country: US
+  status: stream-only
+  stationuuid: 7655e3e7-398c-4f4b-8354-acb681e3add8
+  changeuuid: 48e017bf-5d92-40df-9b07-0a8a64e1fa70
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-classic-hits-104-5-wjjk
+  broadcaster: independent
+  name: Classic Hits 104.5 WJJK
+  streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/WJJKFMAAC.aac
+  bitrate: 48
+  codec: AAC+
+  favicon: "https://www.1045wjjk.com/favicon.ico"
+  homepage: "https://www.1045wjjk.com/"
+  country: US
+  status: stream-only
+  stationuuid: 4e76db8c-6ba1-4bf1-9135-40303f8a32bd
+  changeuuid: 1de5ba4d-e402-4e49-acc0-ad188862b9c9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-conyers-old-time-radio-2nd-stream
+  broadcaster: independent
+  name: Conyers Old Time Radio 2nd Stream
+  streamUrl: https://s6.yesstreaming.net:17082/stream
+  bitrate: 64
+  codec: MP3
+  homepage: "https://conyersradio.net/"
+  country: US
+  status: stream-only
+  stationuuid: 405a606d-5bb8-45c1-bfc1-4c2ad879e53d
+  changeuuid: a9f84a5b-63c8-4838-814c-2c68add6cc50
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-kfm-radio
+  broadcaster: independent
+  name: KFM Radio
+  streamUrl: https://stream.zeno.fm/1adz268xt98uv
+  codec: AAC
+  homepage: "http://kfm-radio.org/"
+  country: US
+  status: stream-only
+  stationuuid: 601c5c6e-fdc8-4feb-84e4-05c2f153c7c5
+  changeuuid: 698a1497-ae2a-4301-ad14-9493a8892ef7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-classical-jazz-radio
+  broadcaster: independent
+  name: Classical Jazz Radio
+  streamUrl: https://ec1.yesstreaming.net:2905/stream
+  bitrate: 256
+  codec: MP3
+  homepage: "https://jazzradionetwork.com/classical-jazz-radio/"
+  country: US
+  status: stream-only
+  stationuuid: 668758f4-7ad5-4820-801c-f2ba58761f19
+  changeuuid: bad7e1f3-036e-4f60-83c8-9744b8b416ea
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-classical-king-fm
+  broadcaster: independent
+  name: Classical KING FM
+  streamUrl: https://classicalking.streamguys1.com/king-fm-aac-128k
+  bitrate: 128
+  codec: AAC
+  favicon: "https://dehayf5mhw1h7.cloudfront.net/wp-content/uploads/sites/1108/2022/10/22131738/ClassicalKING_Streaming_Main_125x125rnd.png"
+  homepage: "https://www.king.org/"
+  country: US
+  status: stream-only
+  stationuuid: a3a37dbb-823d-49da-88f9-9d22e308c0c1
+  changeuuid: fa7951e7-79ab-4152-b33d-594b40287f56
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-groove-salad-classic-64k-aac
+  broadcaster: independent
+  name: SomaFM Groove Salad Classic (64k AAC)
+  streamUrl: https://ice2.somafm.com/gsclassic-64-aac
+  bitrate: 64
+  codec: AAC
+  favicon: "https://somafm.com/img3/gsclassic400.jpg"
+  homepage: "https://somafm.com/groovesalad/"
+  country: US
+  status: stream-only
+  stationuuid: 47620077-20c1-11ea-a955-52543be04c81
+  changeuuid: 20890161-bf2e-49ae-bc3d-d16441d47a9e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-smooth-jazz-tampa-bay-hd
+  broadcaster: independent
+  name: Smooth Jazz - Tampa Bay HD
+  streamUrl: https://vip2.fastcast4u.com/proxy/sjtbhd?mp=/1
+  bitrate: 128
+  codec: MP3
+  favicon: "https://radio.zone/wp-content/uploads/2024/02/cropped-favicon-1-180x180.png"
+  homepage: "https://smoothjazztampabay.com/"
+  country: US
+  status: stream-only
+  stationuuid: ea8f5325-c95a-463f-aea5-f5da22c4a8fa
+  changeuuid: 86e10f45-d98e-426b-863c-bd40228d44f3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-fox-sports-radio-1380
+  broadcaster: independent
+  name: FOX Sports Radio 1380
+  streamUrl: https://stream.revma.ihrhls.com/zc5169
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/e22e222b4a92e441adc4fdfd68b621db?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)"
+  homepage: "https://khey1380.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: f415a351-e827-4e59-8231-d71550e8b7a6
+  changeuuid: 1d79a2f5-215e-4540-a927-8c24bf0d8d65
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-50-s-science-fiction-kotr
+  broadcaster: independent
+  name: "50's Science Fiction KOTR"
+  streamUrl: https://stream.kf7k.com/listen/scifi/radio.mp3
+  bitrate: 64
+  codec: MP3
+  favicon: "https://stream.kf7k.com/api/station/scifi/art/e89f8ef8f1b445020733f7a0"
+  homepage: "https://stream.kf7k.com/public/scifi"
+  country: US
+  status: stream-only
+  stationuuid: 3c2da98e-b7b7-4192-8ca4-3a625a301629
+  changeuuid: cc769969-c5e3-4915-80da-49224968000a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-big-105-9-south-florida-s-classic-rock
+  broadcaster: independent
+  name: "BIG 105.9 – South Florida's Classic Rock!"
+  streamUrl: https://stream.revma.ihrhls.com/zc557
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/63d7c12a09346a332020b492?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)"
+  homepage: "https://big1059.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 1e7dd438-eee2-41d1-bbd8-8b30fe32a657
+  changeuuid: 63e82be0-e36a-4bb8-9fce-8ddf06fb8ad2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-moody-radio-wmbi-90-1-fm
+  broadcaster: independent
+  name: Moody Radio WMBI 90.1 FM
+  streamUrl: https://14123.live.streamtheworld.com/WMBIFM.mp3
+  bitrate: 96
+  codec: MP3
+  favicon: "https://impact.moodybible.org/contentassets/a6a563d3318a44e783d8810875b5ad06/moody-radio-chicago_230px.png"
+  homepage: "https://www.moodyradio.org/stations/chicago/"
+  country: US
+  status: stream-only
+  stationuuid: d2dcbe53-1e31-4db0-afec-ad4abd36a4f6
+  changeuuid: f1b4671e-cb32-4c7e-b2cc-d3d5994a74a2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-sda-radio
+  broadcaster: independent
+  name: SDA Radio
+  streamUrl: https://usa18.fastcast4u.com/proxy/loudcrymedia6?mp=/1
+  bitrate: 128
+  codec: MP3
+  favicon: "https://loudcrymedia.com/wp-content/uploads/2018/06/cropped-logo-web-icon22-180x180.png"
+  homepage: "https://www.loudcrymedia.com/sda-radio/"
+  country: US
+  status: stream-only
+  stationuuid: 2866dd80-dfeb-442d-8f27-a6c98de13709
+  changeuuid: 1883460f-df33-4f17-b5c4-4b6af3421407
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-news-talk-630-wpro
+  broadcaster: independent
+  name: News Talk 630 WPRO
+  streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/WPROAMAAC.aac
+  bitrate: 48
+  codec: AAC+
+  homepage: "https://www.630wpro.com/"
+  country: US
+  status: stream-only
+  stationuuid: 4fe6f4cd-ef9a-48c9-9e39-989b0084eb67
+  changeuuid: 9c6b27d0-6750-46cc-99c0-10dcb1358ad6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-thistleradio-32k-aac
+  broadcaster: independent
+  name: SomaFM ThistleRadio (32k AAC)
+  streamUrl: https://ice6.somafm.com/thistle-32-aac
+  bitrate: 32
+  codec: AAC
+  favicon: "https://somafm.com/img3/thistle-400.jpg"
+  homepage: "https://somafm.com/thistle/"
+  country: US
+  status: stream-only
+  stationuuid: a57bf766-3c6b-11e8-b74d-52543be04c81
+  changeuuid: 471d3279-7e32-4e81-ac71-a9b5c20f5fdf
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-espn-radio-101-7-the-team
+  broadcaster: independent
+  name: ESPN Radio 101.7 The TEAM
+  streamUrl: https://ice8.securenetsystems.net/KQTM
+  bitrate: 32
+  codec: AAC+
+  homepage: "https://www.1017theteam.com/"
+  country: US
+  status: stream-only
+  stationuuid: 33ad7aee-4b7e-4f81-9367-caeb5bbc99fc
+  changeuuid: 5c77173c-b22b-42ec-ad51-86cb871c57e6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-hot-tejano-austin-online-www-hottejano-com-hotte
+  broadcaster: independent
+  name: "Hot Tejano (Austin) - Online - www.hottejano.com - hottejano.com LLC - Austin, Texas"
+  streamUrl: https://ithaca.cdnstream.com/1113_96
+  bitrate: 128
+  codec: MP3
+  favicon: "https://hottejano.com/wp-content/uploads/2020/11/hottejano250x250-140x140.png"
+  homepage: "https://hottejano.com/"
+  country: US
+  status: stream-only
+  stationuuid: 54e9be2f-8705-4841-a672-7effedcaf4d4
+  changeuuid: 77dc6791-6f27-48a5-b154-9ec297ef3410
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-1460-am-deportes-vegas
+  broadcaster: independent
+  name: 1460 AM Deportes Vegas
+  streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/KENOAM.mp3
+  bitrate: 24
+  codec: MP3
+  favicon: "https://dehayf5mhw1h7.cloudfront.net/wp-content/uploads/sites/2227/2020/10/12160146/keno-logo.png"
+  homepage: "https://www.deportesvegas.com/"
+  country: US
+  status: stream-only
+  stationuuid: 1ff7a5ae-714b-42be-8f63-7a0ac968f0db
+  changeuuid: fd8c4677-c4b6-4df1-8c5b-dffc426be8d1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-live-128k-mp3
+  broadcaster: independent
+  name: SomaFM Live (128k MP3)
+  streamUrl: https://ice5.somafm.com/live-128-mp3
+  bitrate: 128
+  codec: MP3
+  favicon: "https://somafm.com/img3/live-400.jpg"
+  homepage: "https://somafm.com/live/"
+  country: US
+  status: stream-only
+  stationuuid: d16bd3cc-36de-11e9-9b4e-52543be04c81
+  changeuuid: 7b64ea2e-d199-42c8-abe1-ab120cd17c29
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-instrumental-hop-radio
+  broadcaster: independent
+  name: Instrumental Hop Radio
+  streamUrl: https://cheetah.streemlion.com:2670/stream
+  bitrate: 128
+  codec: MP3
+  homepage: "https://www.instrumentalhopradio.com/"
+  country: US
+  status: stream-only
+  stationuuid: fd1064e3-af9c-4cd4-9fca-ffa3cfce5433
+  changeuuid: 83a295e3-840b-42b1-9236-95a418e1f5f9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-koke-99-3-98-5-fm-austin-tx
+  broadcaster: independent
+  name: "KOKE 99.3 & 98.5 FM - Austin, TX"
+  streamUrl: https://arn.leanstream.co/KOKEFM
+  bitrate: 64
+  codec: AAC+
+  homepage: "https://kokefm.com/"
+  country: US
+  status: stream-only
+  stationuuid: 21e82b22-9da7-11e9-a787-52543be04c81
+  changeuuid: 4b8f55b0-2067-4032-a21c-8756bb5f751c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-96-9-bob-fm
+  broadcaster: independent
+  name: 96.9 BOB FM
+  streamUrl: https://ais-sa1.streamon.fm/7215_48k.aac
+  bitrate: 96
+  codec: AAC
+  homepage: "https://www.bobfm969.com/"
+  country: US
+  status: stream-only
+  stationuuid: aff3eec4-26bc-44cb-976d-687573c3a93d
+  changeuuid: d2f4d7b6-570a-4201-bd7b-9d5236e51f5c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-no-agenda-show-stream-pls
+  broadcaster: independent
+  name: No Agenda Show Stream (pls)
+  streamUrl: https://listen.noagendastream.com/noagenda
+  codec: MP3
+  homepage: "http://www.noagendashow.com/"
+  country: US
+  status: stream-only
+  stationuuid: 070e2ca5-7b88-11e9-aa30-52543be04c81
+  changeuuid: ef4247f4-8793-4f26-b009-d6b582ca3545
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-96-9-hits-fm
+  broadcaster: independent
+  name: 96.9 Hits FM
+  streamUrl: https://ice9.securenetsystems.net/KLTAHD2
+  bitrate: 32
+  codec: AAC+
+  homepage: "https://www.969hitsfm.com/"
+  country: US
+  status: stream-only
+  stationuuid: 706e055a-e624-4634-934f-c956630c349e
+  changeuuid: 20f6dc20-5c96-47a1-91c9-2d7e73c43a6a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-102-3-the-beat
+  broadcaster: independent
+  name: 102.3 The Beat
+  streamUrl: https://stream.revma.ihrhls.com/zc2169
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/593da8dee7970b302d32a0f8?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)"
+  homepage: "https://thebeatatx.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: dac6ad1e-cddf-4998-978c-8334804217d3
+  changeuuid: 92bbff68-524a-4bff-b6f1-3ff7bde47d2d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us--1bd81fe9
+  broadcaster: independent
+  name: 白猿道广播电台
+  streamUrl: https://stream.zeno.fm/5uyxq85zm7zuv
+  codec: MP3
+  favicon: "https://baiyuandao.com/favicon.ico"
+  homepage: "https://baiyuandao.com/"
+  country: US
+  status: stream-only
+  stationuuid: 1bd81fe9-1529-46cf-99fb-624168c4a6ac
+  changeuuid: ed38ccdb-e25d-4efc-9eb0-00b6cecf67d3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-94-9-news-now
+  broadcaster: independent
+  name: 94.9 News Now
+  streamUrl: https://crystalout.surfernetwork.com:8001/WJJF-FM_MP3
+  codec: MP3
+  favicon: "https://dehayf5mhw1h7.cloudfront.net/wp-content/uploads/sites/1623/2021/05/25072657/cropped-logo-180x180.png"
+  homepage: "https://949newsnow.com/"
+  country: US
+  status: stream-only
+  stationuuid: 0d879293-073b-406c-9a1f-63969f977854
+  changeuuid: 8ed78fc8-f88a-4f88-a8db-6af3b73a72b2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-wjmj
+  broadcaster: independent
+  name: WJMJ
+  streamUrl: https://www.ophanim.net:8444/s/7760/
+  bitrate: 64
+  codec: MP3
+  favicon: "https://ortv.org/images/Logos/WJMJ_logo_R.png"
+  homepage: "https://ortv.org/WJMJ/wjmj.htm"
+  country: US
+  status: stream-only
+  stationuuid: 166112d7-607e-4c55-88fe-61667afb2e8c
+  changeuuid: b708a449-7e15-4f43-9fdb-97e49ad56148
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-kogo-am-600
+  broadcaster: independent
+  name: KOGO AM 600
+  streamUrl: https://ample.revma.ihrhls.com/zc257
+  codec: AAC
+  homepage: "https://www.iheart.com/live/am-600-257/"
+  country: US
+  status: stream-only
+  stationuuid: 8b3f6b80-dc27-41cb-88e9-51df312852f0
+  changeuuid: 28136cdf-81e0-47ad-81d0-3d1000dc1838
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-iq
+  broadcaster: independent
+  name: Radio IQ
+  streamUrl: https://wvtf.streamguys1.com/wvtf-edge/radioiq-aac-64/icecast.audio
+  bitrate: 56
+  codec: AAC+
+  favicon: "https://www.wvtf.org/apple-touch-icon.png"
+  homepage: "https://www.wvtf.org/"
+  country: US
+  status: stream-only
+  stationuuid: d7ed5bda-0746-11ea-a87e-52543be04c81
+  changeuuid: 631d2684-a5f5-4be2-9d73-4e4e86eaed64
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-91-7-kxt-the-republic-of-music
+  broadcaster: independent
+  name: "91.7 KXT The Republic of Music "
+  streamUrl: https://kera.streamguys1.com/kxtlive128
+  bitrate: 128
+  codec: MP3
+  favicon: "https://kxt.org/wp-content/themes/kxt-joints/favicon.png"
+  homepage: "https://kxt.org/"
+  country: US
+  status: stream-only
+  stationuuid: 56a468c9-3eca-4079-a758-b4051e1afb2b
+  changeuuid: b90eb871-51f2-4e34-a713-eb0dca2c21ed
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-rusrek-bbe2c59a
+  broadcaster: independent
+  name: "Канал \"Музыка без слов\" Radio Rusrek Радио Русская Реклама"
+  streamUrl: https://securestreams6.autopo.st:2130/instrumental
+  bitrate: 128
+  codec: MP3
+  favicon: "https://radio.rusrek.com/templates/rusrek/favicon.ico"
+  homepage: "https://radio.rusrek.com/"
+  country: US
+  status: stream-only
+  stationuuid: bbe2c59a-a45a-4227-844f-69d8e1f0123f
+  changeuuid: 1b172860-3bce-4a35-b9cd-58fcdf7ec245
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-93-3-wbzd-classic-hits
+  broadcaster: independent
+  name: 93.3 WBZD Classic Hits
+  streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/WBZDFMAAC.aac
+  bitrate: 32
+  codec: AAC+
+  favicon: "https://express-images.franklymedia.com/8949/sites/4/2022/11/22153124/wbzdfavicon64.png"
+  homepage: "https://www.wbzd.com/"
+  country: US
+  status: stream-only
+  stationuuid: b293d728-f748-4919-833f-41a541102a2a
+  changeuuid: 519ca427-7c84-4d89-ab40-44b54bc5922a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-afrobeats-rising-radio
+  broadcaster: independent
+  name: Afrobeats Rising Radio
+  streamUrl: https://stream.zeno.fm/fmf6pyudu3kvv
+  codec: MP3
+  favicon: "https://zeno.fm/_next/image/?url=https%3A%2F%2Fimages.zeno.fm%2FWUCzymdyj6ONlEodR_rKPcNI6PEDrfvP794nkeqYIew%2Frs%3Afit%3A240%3A240%2Fg%3Ace%3A0%3A0%2FaHR0cHM6Ly9zdHJlYW0tdG9vbHMuemVub21lZGlhLmNvbS9jb250ZW50L3N0YXRpb25zL2RjYmE5MDRlLWZlYzQtNDZjNy1iNDZhLTMwMDEyNmNjYjRmMS9pbWFnZS8_dXBkYXRlZD0xNzA3Njc2MTg3MDAw.webp&w=1920&q=100"
+  homepage: "https://zeno.fm/radio/afrobeats-rising-radio/"
+  country: US
+  status: stream-only
+  stationuuid: 56721bca-2a6f-4139-af8c-5afbdb302aeb
+  changeuuid: 93f66c45-a50a-4670-a4ac-5104a5efe86e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-cruisin-country-93-5
+  broadcaster: independent
+  name: Cruisin Country 93.5
+  streamUrl: https://stream.radio.co/s4867e9e93/listen
+  bitrate: 128
+  codec: MP3
+  homepage: "https://cruisinmaine.com/"
+  country: US
+  status: stream-only
+  stationuuid: cc69296f-8e12-417e-b25a-e223d77fb5ed
+  changeuuid: c38fb808-2d1f-4a24-8030-642294829f3a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-american-road-radio
+  broadcaster: independent
+  name: American Road Radio
+  streamUrl: https://c5.radioboss.fm:18224/stream
+  bitrate: 128
+  codec: MP3
+  favicon: "https://cdn.onlineradiobox.com/img/l/9/9549.v2.png"
+  homepage: "https://www.americanroadradio.com/"
+  country: US
+  status: stream-only
+  stationuuid: 7b5dfc08-7074-45de-bc41-bb83bbb43b2a
+  changeuuid: c96bf31d-750f-40c3-9bbf-bf62b08b654a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-wguc-cincinnati-classical-music-radio
+  broadcaster: independent
+  name: WGUC Cincinnati Classical Music Radio
+  streamUrl: https://stream.cinradio.org/wguc
+  bitrate: 320
+  codec: MP3
+  favicon: "https://wguc.org/wp-content/themes/wguc/favicon.ico"
+  homepage: "https://www.wguc.org/"
+  country: US
+  status: stream-only
+  stationuuid: 0f130230-7f5b-4aac-80a5-aac4003855b5
+  changeuuid: 07078e66-1f59-487a-b3d7-69bc44bc401a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-legends-radio
+  broadcaster: independent
+  name: Legends Radio
+  streamUrl: https://ice3.securenetsystems.net/WLML
+  bitrate: 48
+  codec: AAC+
+  favicon: "https://legendsradio.com/favicon.ico"
+  homepage: "https://legendsradio.com/"
+  country: US
+  status: stream-only
+  stationuuid: e6c5a42c-a8b7-41db-bb72-879d52ba5011
+  changeuuid: 17b6f131-80ed-45f7-b200-c33cc20fd388
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-102-9-now
+  broadcaster: independent
+  name: 102.9 NOW
+  streamUrl: https://stream.revma.ihrhls.com/zc2237
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/648373b015630e856cd84951?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)"
+  homepage: "https://1029now.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: c182ef57-161c-4f80-8fc9-2b2b290a8b01
+  changeuuid: c29d4449-4c79-40af-8694-2d725b605ac4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-spirit-catholic-radio
+  broadcaster: independent
+  name: Spirit Catholic Radio
+  streamUrl: https://ice7.securenetsystems.net/KVSS
+  bitrate: 32
+  codec: AAC+
+  favicon: "https://spiritcatholicradio.com/wp-content/themes/spirit-catholic-radio/favicon.png"
+  homepage: "https://spiritcatholicradio.com/"
+  country: US
+  status: stream-only
+  stationuuid: 7d2b1ae3-9e15-460c-aa00-1b22ca6eff37
+  changeuuid: f8ba16b1-4f27-486a-902c-5e65c9b1c9e8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-cajun-country-radio
+  broadcaster: independent
+  name: Cajun Country Radio
+  streamUrl: https://streaming.live365.com/a18002
+  bitrate: 128
+  codec: MP3
+  homepage: "https://www.cajuncountryradio.com/"
+  country: US
+  status: stream-only
+  stationuuid: 3cf575cf-21dd-4510-8a11-35516754ad50
+  changeuuid: 86424d5f-11af-4bf8-8037-fde1030e712f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-la-raza-102-3-107-1
+  broadcaster: independent
+  name: La Raza 102.3/107.1
+  streamUrl: https://crystalout.surfernetwork.com:8001/WLKQ-FM_MP3
+  codec: MP3
+  homepage: "https://www.laraza1023.com/"
+  country: US
+  status: stream-only
+  stationuuid: e45e3019-ebdb-4c6e-af07-e8079d04e91b
+  changeuuid: 4e32e706-320d-4739-950a-f730d3fd31c5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-1200-woai-talk-radio
+  broadcaster: independent
+  name: 1200 WOAI Talk Radio
+  streamUrl: https://stream.revma.ihrhls.com/zc2361/hls.m3u8
+  bitrate: 24
+  codec: AAC
+  favicon: "https://www.iheart.com/favicon.ico"
+  homepage: "https://www.iheart.com/live/1200-woai-2361/"
+  country: US
+  status: stream-only
+  stationuuid: dcf182c8-2c72-412d-9fab-e19f8dca379f
+  changeuuid: d2cb097f-316c-49e5-9902-b607aafd82f1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-93-7-the-ticket
+  broadcaster: independent
+  name: 93.7 The Ticket
+  streamUrl: https://ice8.securenetsystems.net/KNTK
+  bitrate: 32
+  codec: AAC+
+  homepage: "https://theticketfm.com/"
+  country: US
+  status: stream-only
+  stationuuid: 75466057-593d-4e15-9074-1835de5a2488
+  changeuuid: 0d7554b8-312f-4a0e-8e71-69ca9a29f987
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-bagel-radio
+  broadcaster: independent
+  name: BAGeL RADIO
+  streamUrl: https://ais-sa3.cdnstream1.com/2606_128.aac
+  bitrate: 128
+  codec: AAC
+  favicon: "https://images.squarespace-cdn.com/content/v1/616462d943ce4468804f598c/6ed86b2b-86ba-4ba3-995c-c150b6e15832/bagel_logo_sutro_8_flat.jpg"
+  homepage: "https://www.bagelradio.com/"
+  country: US
+  status: stream-only
+  stationuuid: f02d07b4-f1fe-4836-b202-242c4104a929
+  changeuuid: ec769658-f82e-4a65-87cf-11c253307811
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-nepa-s-espn-radio
+  broadcaster: independent
+  name: "NEPA's ESPN Radio"
+  streamUrl: https://ais-sa1.streamon.fm/7284_48k.aac
+  bitrate: 48
+  codec: AAC+
+  favicon: "https://dehayf5mhw1h7.cloudfront.net/wp-content/uploads/sites/2358/2025/01/04195002/wejl-logo-good-1-150x150.png"
+  homepage: "https://www.nepasespnradio.com/"
+  country: US
+  status: stream-only
+  stationuuid: a9cd3971-6787-40bf-a6fd-56c7b4b19fb9
+  changeuuid: 73e61bad-283f-4066-880e-7f7b346eea97
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-mirchi-bay-area
+  broadcaster: independent
+  name: Radio Mirchi Bay Area
+  streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/SFO_HIN_PSTAAC.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: "https://static-media.streema.com/media/cache/6c/23/6c23aa893f7a781a098f50d1a56a39a4.png"
+  homepage: "https://mirchi.in/radio/SFO_HIN_PST"
+  country: US
+  status: stream-only
+  stationuuid: 79e04d78-8c37-4083-9c70-caa009f84217
+  changeuuid: 2c3c16e7-5821-4bf1-b8f7-012b7c374589
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-metal-detector-128k-mp3
+  broadcaster: independent
+  name: SomaFM Metal Detector (128k MP3)
+  streamUrl: https://ice5.somafm.com/metal-128-mp3
+  bitrate: 128
+  codec: MP3
+  favicon: "https://somafm.com/img3/metal-400.png"
+  homepage: "https://somafm.com/metal/"
+  country: US
+  status: stream-only
+  stationuuid: 9a5811ad-f4b5-11e8-a471-52543be04c81
+  changeuuid: 7e1fe331-c370-4e46-965c-444a38067efb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-wgbh-89-7
+  broadcaster: independent
+  name: WGBH 89.7
+  streamUrl: https://streams.audio.wgbh.org/wgbh
+  bitrate: 96
+  codec: MP3
+  favicon: "https://wgbh.org/apple-touch-icon.png"
+  homepage: "https://wgbh.org/"
+  country: US
+  status: stream-only
+  stationuuid: d4aa449b-880b-4d45-adde-ca09739a0153
+  changeuuid: b37ddd22-e80f-4dd0-bb67-19e93b8b9ddc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-24-7-dance
+  broadcaster: independent
+  name: 24/7 - Dance
+  streamUrl: https://ip39.ip-178-33-37.eu/radio/8010/radio.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: "https://cdn.onlineradiobox.com/img/l/9/84659.v2.png"
+  country: US
+  status: stream-only
+  stationuuid: bc7a3b52-0672-43c1-b067-574b32a8d135
+  changeuuid: 31dbd473-41a1-449b-8d4e-8f56a5fa6519
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-the-peach
+  broadcaster: independent
+  name: The Peach
+  streamUrl: https://ice3.securenetsystems.net/PEACH
+  bitrate: 64
+  codec: AAC+
+  homepage: "https://tunein.com/radio/The-Peach-s309559/"
+  country: US
+  status: stream-only
+  stationuuid: e662127d-bb4f-40ce-8667-4fbd159efac5
+  changeuuid: cbc725f1-b8ef-4bbb-a8ed-a036d4f16951
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-wabc-770-am-newyork-ny
+  broadcaster: independent
+  name: "WABC 770 AM - NewYork, NY"
+  streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/WABCAM.mp3
+  bitrate: 96
+  codec: MP3
+  favicon: "https://dehayf5mhw1h7.cloudfront.net/wp-content/uploads/sites/1494/2022/01/21131743/77-WABC-Gold_narrow_4.png"
+  homepage: "https://wabcradio.com/"
+  country: US
+  status: stream-only
+  stationuuid: 4776668e-b2dc-45ab-bf4a-c72d892baaf4
+  changeuuid: 5d8938ce-8254-465c-aa7c-92e86d7c8c0f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-yourclassical-guitar-stream
+  broadcaster: independent
+  name: YourClassical Guitar Stream
+  streamUrl: https://guitar.stream.publicradio.org/guitar.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: "https://img.apmcdn.org/149a09c7f10962db985fc19a2eb503156a7dfc1f/uncropped/a6e58f-20221003-guitar-stream-tile-3000.png"
+  homepage: "https://www.yourclassical.org/playlist/guitar-stream"
+  country: US
+  status: stream-only
+  stationuuid: f81ad802-dc88-4571-bc76-8467e6777e6b
+  changeuuid: 5f497342-26f1-45cd-a3b5-71a3b1a87829
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-flashback-alternatives
+  broadcaster: independent
+  name: "Flashback Alternatives "
+  streamUrl: https://puma.streemlion.com/fa64
+  bitrate: 64
+  codec: AAC+
+  homepage: "https://www.flashbackalternatives.com/"
+  country: US
+  status: stream-only
+  stationuuid: e6a74045-963f-49b7-b920-cd8f8e30dd20
+  changeuuid: 5fa5de7d-a198-40c2-93f5-7febe2b20c50
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-iheart-radio-smells-like-the-90s
+  broadcaster: independent
+  name: iHeart Radio Smells Like the 90s
+  streamUrl: https://stream.revma.ihrhls.com/zc6437
+  codec: AAC
+  favicon: "http://www.iheart.com/favicon.ico"
+  homepage: "http://www.iheart.com/live/smells-like-the-90s-6437"
+  country: US
+  status: stream-only
+  stationuuid: 2fcb9026-b241-47b5-8e21-cb13bba8c320
+  changeuuid: ce2cb33a-2f03-4044-9426-2adcf5647389
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-kcmo-talk-radio
+  broadcaster: independent
+  name: KCMO Talk Radio
+  streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/KCMOAMAAC.aac
+  bitrate: 48
+  codec: AAC+
+  favicon: "https://www.kcmotalkradio.com/favicon.ico"
+  homepage: "https://www.kcmotalkradio.com/"
+  country: US
+  status: stream-only
+  stationuuid: cf274c97-88ec-4c66-b8f0-5b3ee1e46fd4
+  changeuuid: 20e3dbf8-6d10-4648-9bda-6696448a1881
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-gotradio-the-50-s
+  broadcaster: independent
+  name: "GotRadio - the 50's"
+  streamUrl: https://pureplay.cdnstream1.com/6005_128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: "https://gotradio.com/wp-content/uploads/2023/04/Gotradio.png"
+  homepage: "https://gotradio.com/radiochannel/the-50s/"
+  country: US
+  status: stream-only
+  stationuuid: 0ef7cf66-67a0-419c-b48b-0b4d91018365
+  changeuuid: d361fa4d-3602-4791-bf63-4bebb7a54a34
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-wisconsin-public-radio-npr-news-music-network
+  broadcaster: independent
+  name: "Wisconsin Public Radio: NPR News & Music Network"
+  streamUrl: https://wpr-ice.streamguys1.com/wpr-music-mp3-96
+  bitrate: 128
+  codec: MP3
+  favicon: "https://www.wpr.org/favicon.ico"
+  homepage: "https://www.wpr.org/"
+  country: US
+  status: stream-only
+  stationuuid: 4acbe395-a27a-4dab-ad87-a5f6666e38c6
+  changeuuid: f1df67f4-4676-432f-bdf8-e8b6f792b48d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-abiding-radio-seasonal
+  broadcaster: independent
+  name: Abiding Radio - Seasonal
+  streamUrl: https://streams.abidingradio.com:7830/1
+  bitrate: 128
+  codec: MP3
+  favicon: "https://www.abidingradio.org/wp-content/uploads/2022/05/cropped-new_icon.png"
+  homepage: "https://www.abidingradio.com/"
+  country: US
+  status: stream-only
+  stationuuid: 7fb5f565-def4-11e9-a8ba-52543be04c81
+  changeuuid: fe971461-2815-4add-aeb2-079f00cc3d3b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-oldies-wttf
+  broadcaster: independent
+  name: Oldies WTTF
+  streamUrl: https://ice64.securenetsystems.net/WTTF
+  bitrate: 32
+  codec: AAC+
+  homepage: "https://www.wttf.com/"
+  country: US
+  status: stream-only
+  stationuuid: 01ccc0e1-8dbe-4dcc-9c50-4219aa05ed1a
+  changeuuid: d2284eb9-510b-48b8-ba16-2e75e9c1853a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-twin-cities-news-talk
+  broadcaster: independent
+  name: Twin Cities News Talk
+  streamUrl: https://stream.revma.ihrhls.com/zc1213
+  codec: AAC
+  favicon: "https://radiostationusa.fm/assets/image/radio/180/KTLK.png"
+  homepage: "https://twincitiesnewstalk.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 09601bc4-1577-437c-8d1b-f9db317505c3
+  changeuuid: eaa5f89f-afcf-4c95-bc8e-eff5d6fe1bfa
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-95-7-the-party
+  broadcaster: independent
+  name: 95.7 The Party
+  streamUrl: https://stream.revma.ihrhls.com/zc2795/hls.m3u8
+  bitrate: 24
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/60f0775933b6574da5ac3308?ops=gravity(%22center%22),contain(32,32),quality(65)"
+  homepage: "https://957theparty.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: c3d808f7-74be-4a2a-bdc9-b87718ebe113
+  changeuuid: 73c5d4c2-f24c-45e7-b567-c4600d6c4e94
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-jan-usa
+  broadcaster: independent
+  name: Radio Jan USA
+  streamUrl: https://s4.voscast.com:8865/stream
+  bitrate: 128
+  codec: MP3
+  homepage: "http://radiojan.com/"
+  country: US
+  status: stream-only
+  stationuuid: 33be7333-5cf5-4128-8986-6e84edc8553a
+  changeuuid: 8a13af2b-4d13-44ee-b06f-39c5a698e9a7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-paradise-world-etc-flac-meta
+  broadcaster: independent
+  name: Radio Paradise World/etc FLAC+meta
+  streamUrl: https://stream.radioparadise.com/world-etc-flacm
+  bitrate: 1442
+  codec: OGG
+  favicon: "https://radioparadise.com/apple-touch-icon.png"
+  homepage: "http://radioparadise.com/"
+  country: US
+  status: stream-only
+  stationuuid: e64aad7f-fbf2-4b07-882a-a029820e2427
+  changeuuid: f9d01309-b10d-42eb-af24-95b3afb9874d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-smooth-jazz-wnua-chicago
+  broadcaster: independent
+  name: Smooth Jazz WNUA Chicago
+  streamUrl: https://vip2.fastcast4u.com/proxy/wnua?mp=/1
+  bitrate: 128
+  codec: MP3
+  favicon: "https://img1.wsimg.com/isteam/ip/static/pwa-app/logo-default.png/:/rs=w:180,h:180,m"
+  homepage: "https://smoothjazzwnua.com/"
+  country: US
+  status: stream-only
+  stationuuid: a8e1cfab-79ef-43f1-aeb7-1c98ca4f2eb8
+  changeuuid: d5fbdad9-2c72-4aba-a450-9c6e4975993c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-disney-country-fm-99-1
+  broadcaster: independent
+  name: Radio Disney Country FM 99.1
+  streamUrl: https://listen.radioking.com/radio/453221/stream/508076
+  bitrate: 128
+  codec: MP3
+  favicon: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSiSNzAYoI5Femhuri7WV9SNYheO4GO_Ovr_MUzgWIWYg&s/favicon.ico"
+  homepage: "https://www.radiodisney.com/"
+  country: US
+  status: stream-only
+  stationuuid: c6eed7cb-e3c9-4b3a-a627-f7df928a19e0
+  changeuuid: 6980b2d4-3319-44b1-89f2-b71d614ded38
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-new-york-yt
+  broadcaster: independent
+  name: Radio New York - YT
+  streamUrl: https://hoth.alonhosting.com:1425/stream
+  bitrate: 192
+  codec: MP3
+  homepage: "https://hoth.alonhosting.com:1425/stream"
+  country: US
+  status: stream-only
+  stationuuid: e7639a04-0f02-4e65-aec7-e6b15bd8cd4b
+  changeuuid: 7cb45208-b1be-4d87-ab90-d486b45b052b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-afrobeats-jazz
+  broadcaster: independent
+  name: Afrobeats jazz
+  streamUrl: https://stream.zeno.fm/iaf1anrme20vv
+  codec: MP3
+  favicon: "https://zenoimages.s3.us-west-001.backblazeb2.com/agxzfnplbm8tc3RhdHNyMgsSCkF1dGhDbGllbnQYgICIpfi21gsMCxIOU3RhdGlvblByb2ZpbGUYgICIpYGfuQoMogEEemVubw/images/logo?updated=1715828780462"
+  homepage: "https://zeno.fm/radio/afrobeats-jazz/"
+  country: US
+  status: stream-only
+  stationuuid: 07d0d874-609e-43df-942c-7043bb4f336b
+  changeuuid: aae8407e-3490-4bb3-a125-d95eae7c5aa7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-cbs-sports-radio-lynchburg
+  broadcaster: independent
+  name: CBS SPORTS Radio Lynchburg
+  streamUrl: https://ice66.securenetsystems.net/WVGM
+  bitrate: 32
+  codec: AAC+
+  homepage: "https://virginiatalkradionetwork.com/cbssportslynchburg-2/"
+  country: US
+  status: stream-only
+  stationuuid: 807bf3bd-4fb8-4f35-b702-6f96c8250baa
+  changeuuid: a56f8cc8-c9dc-479e-94b6-78b343317169
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-chris-tdl-radio-asmr
+  broadcaster: independent
+  name: Chris TDL Radio - ASMR
+  streamUrl: https://stream.zeno.fm/mwpb4ea6qs8uv
+  codec: MP3
+  favicon: "https://cdn.onlineradiobox.com/img/l/7/102307.v1.png"
+  homepage: "https://onlineradiobox.com/ca/christdlasmr/"
+  country: US
+  status: stream-only
+  stationuuid: f5048c0f-7021-4d67-95dc-ab3108d7b0d7
+  changeuuid: e2a5327e-93cf-46f7-b13e-8355c9ee1ef3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-95-1-hot-oldschool
+  broadcaster: independent
+  name: 95.1 HOT OLDSCHOOL
+  streamUrl: https://stream.revma.ihrhls.com/zc1393
+  codec: AAC
+  homepage: "https://hotabq.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 300a28a1-6ec2-4015-b65f-e8fc285499e3
+  changeuuid: f336f43b-6eee-4664-b1d5-afbaf0aa1508
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-mpr-classical-24-7
+  broadcaster: independent
+  name: MPR Classical 24/7
+  streamUrl: https://cms.stream.publicradio.org/cms.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: "https://www.yourclassical.org/apple-touch-icon.png"
+  homepage: "https://www.yourclassical.org/playlist/classical-mpr"
+  country: US
+  status: stream-only
+  stationuuid: 5cbe6727-6f0d-4aa5-ae59-22b0d19b34c9
+  changeuuid: 6e26878f-d82e-45c2-a303-967e4b79f280
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-dub-step-beyond-128k-aac
+  broadcaster: independent
+  name: SomaFM Dub Step Beyond (128k AAC)
+  streamUrl: https://ice6.somafm.com/dubstep-128-aac
+  bitrate: 128
+  codec: AAC
+  favicon: "https://somafm.com/img3/dubstep-400.jpg"
+  homepage: "https://somafm.com/dubstep/"
+  country: US
+  status: stream-only
+  stationuuid: cc91af7c-42ee-11e9-aa55-52543be04c81
+  changeuuid: 4ce574b8-4b24-4176-8d57-5ccccb5e5a64
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-soul-cafe-radio
+  broadcaster: independent
+  name: Soul Cafe Radio
+  streamUrl: https://usa10.fastcast4u.com:8960/
+  bitrate: 320
+  codec: MP3
+  favicon: "https://static.wixstatic.com/media/1d954e_c3026edf00f74d55bcd9b238ce7f24cf~mv2.jpg/v1/fill/w_455,h_413,al_c,q_80,usm_0.66_1.00_0.01,enc_auto/Soul%20Cafe%20Logo%20with%20Site.jpg"
+  homepage: "https://www.soulcaferadio.com/"
+  country: US
+  status: stream-only
+  stationuuid: 9e65f8df-6abd-4f35-b79d-3e5d602a75b1
+  changeuuid: 08754ba9-5d6c-4759-a378-0b0630395246
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-rca
+  broadcaster: independent
+  name: Radio RCA
+  streamUrl: https://broadcast.miami/proxy/rca?mp=/stream/;
+  bitrate: 320
+  codec: MP3
+  homepage: "https://www.radio-rca.com/"
+  country: US
+  status: stream-only
+  stationuuid: 5a3fc741-bffd-4cb1-93a9-b23f2152eb19
+  changeuuid: 51fe9904-b3d6-471e-9145-278a3c183946
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-wktu-ktu-103-5-the-beat-of-new-york-lake-success
+  broadcaster: independent
+  name: "WKTU \"KTU 103.5 The Beat of New York\" - Lake Success, NY"
+  streamUrl: https://ample.revma.ihrhls.com/zc1473/47_1rikugy8mw9th02/playlist.m3u8
+  codec: UNKNOWN
+  favicon: "https://i.iheart.com/v3/re/assets.brands/5e7b5ddfbee47a8a2b39605d?ops=gravity(%22center%22),contain(300,300)&quality=80"
+  homepage: "https://ktu.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: ae414367-526c-43f4-b5e1-979978cd307a
+  changeuuid: ccfa1b90-b0dd-4cd1-b69b-549ae2c4a0fb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-lofi-girl
+  broadcaster: independent
+  name: lofi girl
+  streamUrl: https://play.streamafrica.net/lofiradio
+  codec: MP3
+  homepage: "https://play.streamafrica.net/lofiradio"
+  country: US
+  status: stream-only
+  stationuuid: 56b0652e-f920-423e-aee2-5b72dda4da66
+  changeuuid: 27fca90a-e510-4874-9c12-e86280576219
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-wtam-1100-cleveland-ohio
+  broadcaster: independent
+  name: "WTAM 1100 - Cleveland, Ohio"
+  streamUrl: https://stream.revma.ihrhls.com/zc1749
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/5be5a5068788fad5368c18e9?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)"
+  homepage: "https://wtam.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: bd5229cc-0649-436b-a271-a194c84dafe7
+  changeuuid: c1089e94-d73d-4c89-83ad-af601844e551
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-edm-sessions
+  broadcaster: independent
+  name: EDM Sessions
+  streamUrl: https://s2.radio.co/s30844a0f4/low
+  bitrate: 64
+  codec: MP3
+  favicon: "https://edmsessions.com/sites/default/files/website-logo.png"
+  homepage: "https://edmsessions.com/"
+  country: US
+  status: stream-only
+  stationuuid: 29d8e402-3c54-4734-a37b-991fb94a8906
+  changeuuid: 0aeba62f-e731-43f8-a5a7-745025fd0552
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-free-fm-chill-new-york
+  broadcaster: independent
+  name: Free FM Chill New York
+  streamUrl: https://freefmchill.radioca.st/
+  bitrate: 320
+  codec: MP3
+  favicon: "https://lh3.googleusercontent.com/lqUvzW7kJu0P5C9RGWHvuTLMa9rLl8KcMkhTUHbN9MadQ1zWCYkK716Hojtl1z2VMmZy59zEbUcPw6tnTGZWk2gJBTGGlKGbJ2DUhDuZ2t8eoj5JirGQyUE_s1O6mZJgLg=w1280"
+  homepage: "http://www.freefmworld.com/"
+  country: US
+  status: stream-only
+  stationuuid: 9af2a6ee-f17e-471d-8c35-8d2d2b2f5b21
+  changeuuid: 2801a986-7667-41fd-bef6-423f7755cfe5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-doomed-256k-mp3
+  broadcaster: independent
+  name: SomaFM Doomed (256k MP3)
+  streamUrl: https://ice2.somafm.com/doomed-256-mp3
+  bitrate: 256
+  codec: MP3
+  favicon: "https://somafm.com/img3/doomed-400.png"
+  homepage: "https://somafm.com/doomed/"
+  country: US
+  status: stream-only
+  stationuuid: d35f26d3-71b3-4115-8fed-8352e8f6f32e
+  changeuuid: f186d470-816e-4b5f-bd1d-bc6fd5b8b062
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-my-country-99-3
+  broadcaster: independent
+  name: My Country 99.3
+  streamUrl: https://ice10.securenetsystems.net/WCON
+  bitrate: 32
+  codec: AAC+
+  homepage: "https://www.mycountry993.com/"
+  country: US
+  status: stream-only
+  stationuuid: ba98f62b-bb68-437b-903b-ace308694648
+  changeuuid: 52577e21-588b-4098-a4a6-f29db473ed7e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-atlantic
+  broadcaster: independent
+  name: Radio Atlantic
+  streamUrl: https://broadcast.miami/proxy/atlantic?mp=/stream/;
+  bitrate: 320
+  codec: MP3
+  homepage: "https://www.radio-atlantic.com/"
+  country: US
+  status: stream-only
+  stationuuid: 229a9e84-20c2-4d8a-9a8d-1018da56aa9c
+  changeuuid: 96f3eb9c-51f1-4cce-a66e-a3071be826df
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-viva-fm-orlando-99-5-orange-county-103-7-osceola
+  broadcaster: independent
+  name: Viva FM Orlando 99.5 Orange County/103.7 Osceola County
+  streamUrl: https://stream.broadcastserver.net:2020/stream/wvvo?_=23526
+  bitrate: 128
+  codec: MP3
+  favicon: "https://mmo.aiircdn.com/297/6544fa9112c3f.png"
+  homepage: "https://vivafmorlando.com/player"
+  country: US
+  status: stream-only
+  stationuuid: 3030c8d2-64e8-4bb0-b710-dca382d28da7
+  changeuuid: 711ddd62-0d21-412a-aa79-00bbb03ccddf
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-101-the-fox
+  broadcaster: independent
+  name: 101 The Fox
+  streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/KCFXFMAAC.aac
+  bitrate: 48
+  codec: AAC+
+  homepage: "https://www.101thefox.net/"
+  country: US
+  status: stream-only
+  stationuuid: 0e6c51a8-a35b-485f-83a1-4682dc045634
+  changeuuid: a7e1261a-122b-4cd2-b539-f4d159a08e76
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-classical-california-kdfc
+  broadcaster: independent
+  name: Classical California KDFC
+  streamUrl: https://14093.live.streamtheworld.com/KDFCFM_SC
+  bitrate: 128
+  codec: MP3
+  favicon: "https://www.kdfc.com/icons/kdfc/apple-touch-icon-120x120.png"
+  homepage: "https://www.kdfc.com/"
+  country: US
+  status: stream-only
+  stationuuid: b7c9b8f6-88bf-4cb3-b0ed-0db45e08d5e6
+  changeuuid: 0922eac0-b58b-49c1-a2b7-a48feb6a8482
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-dclm-radio-hausa
+  broadcaster: independent
+  name: DCLM Radio - Hausa
+  streamUrl: https://airtime.dclm.org/radio/8070/hausa
+  bitrate: 64
+  codec: MP3
+  homepage: "https://radio.dclm.org/hausa"
+  country: US
+  status: stream-only
+  stationuuid: be93cc58-ba04-4eee-b456-5d5103fc54d8
+  changeuuid: f094a8bd-5e89-4bc1-ab57-51a3f4e7348d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-west-end
+  broadcaster: independent
+  name: Radio West End
+  streamUrl: https://broadcast.miami/proxy/westend?mp=/stream/;
+  bitrate: 320
+  codec: MP3
+  homepage: "https://www.radiowestend.com/"
+  country: US
+  status: stream-only
+  stationuuid: 554bd5ec-2a71-4fe0-b74c-3deafaf22c64
+  changeuuid: e3d72691-f287-4130-a2a5-63bfad366b60
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-sfliny-christmas
+  broadcaster: independent
+  name: Sfliny Christmas
+  streamUrl: https://ec4.yesstreaming.net:3790/
+  bitrate: 320
+  codec: MP3
+  homepage: "http://www.sfliny.com/"
+  country: US
+  status: stream-only
+  stationuuid: c0a15a90-ea72-49d5-b36a-814214e69f38
+  changeuuid: 561795fd-5683-4077-95b6-fcb1cc92ac47
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-wlw-700-am-cincinnati-oh
+  broadcaster: independent
+  name: "WLW - 700 AM - Cincinnati, OH"
+  streamUrl: https://stream.revma.ihrhls.com/zc1713/hls.m3u8
+  bitrate: 22
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/new_assets/2f71b3f2-773d-48a3-892f-a6f72850d704?ops=fit(75%2C75)"
+  homepage: "https://www.iheart.com/live/700wlw-1713"
+  country: US
+  status: stream-only
+  stationuuid: c5df245d-ea2c-4d35-8ca9-bd29dca56853
+  changeuuid: e9bb4eb9-e939-4128-81e8-3012fce33b75
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-northwest-public-broadcasting-news
+  broadcaster: independent
+  name: Northwest Public Broadcasting - News
+  streamUrl: https://nwpb.streamguys1.com/nwprnews-aac-128-icy
+  bitrate: 130
+  codec: AAC
+  homepage: "https://nwpb.org/"
+  country: US
+  status: stream-only
+  stationuuid: 1321847e-3aad-4f59-aec4-44793c7b1835
+  changeuuid: 44e7590a-180e-496a-bca8-fa3bd3b5e263
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-101-9-the-twister
+  broadcaster: independent
+  name: 101.9 The Twister
+  streamUrl: https://stream.revma.ihrhls.com/zc1913
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/d3b3ea51ca0abb6b6417b68aaa730c6a?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)"
+  homepage: "https://thetwister.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: e35c3d73-0d68-4d2c-90fc-c91466602f2e
+  changeuuid: 8516a254-9348-493d-b1c0-91816dffc98f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-wgbh-wcrb-bach-channel
+  broadcaster: independent
+  name: WGBH-WCRB Bach Channel
+  streamUrl: https://audio.wgbh.org/Bach-8108
+  bitrate: 128
+  codec: MP3
+  favicon: "https://www.classicalwcrb.org/apple-touch-icon.png"
+  homepage: "https://www.classicalwcrb.org/ways-to-listen"
+  country: US
+  status: stream-only
+  stationuuid: 33090635-ce86-4a64-b7f2-412530dde927
+  changeuuid: 28ce4a45-b877-493a-975d-f8243d465b44
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-1oldies
+  broadcaster: independent
+  name: __1oldies
+  streamUrl: https://stream.laut.fm/80sexitos
+  bitrate: 128
+  codec: MP3
+  homepage: "https://laut.fm/80sexitos"
+  country: US
+  status: stream-only
+  stationuuid: f2617687-c34c-4b32-8529-611e1739d67a
+  changeuuid: 1963c57e-a1b8-4cb5-b181-b3e075d35248
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-98-9-magic-fm
+  broadcaster: independent
+  name: 98.9 Magic FM
+  streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/KKMGFMAAC.aac
+  bitrate: 48
+  codec: AAC+
+  favicon: "https://radiostationusa.fm/assets/image/radio/180/98.9 Magic FM.png"
+  homepage: "https://www.989magicfm.com/"
+  country: US
+  status: stream-only
+  stationuuid: a682fbfa-1c0d-41d4-a7f1-f35035c68054
+  changeuuid: 8f998c1e-2941-4419-9340-c9237b78dca4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-classical-catholic-radio
+  broadcaster: independent
+  name: Classical Catholic Radio
+  streamUrl: https://streaming.live365.com/a64105
+  bitrate: 128
+  codec: MP3
+  favicon: "https://classicalliberalarts.com/wp-content/uploads/classical-catholic-radio.png"
+  homepage: "https://classicalliberalarts.com/category/classical-catholic-radio/"
+  country: US
+  status: stream-only
+  stationuuid: 1de75d39-b273-43e4-8e0d-5b9780403661
+  changeuuid: 44f63488-4650-4b43-8a69-29be65bac472
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-gaslight-square-folk-united-states-folk-320kbps
+  broadcaster: independent
+  name: "Gaslight Square Folk  [United States Folk 320Kbps]"
+  streamUrl: https://stream-12.zeno.fm/bgu8g47ycg0uv
+  codec: MP3
+  homepage: "https://superradio.cc/"
+  country: US
+  status: stream-only
+  stationuuid: 53857bae-8ef9-471e-bda9-158618edfbb4
+  changeuuid: ab5a78c5-c265-4916-aec0-8bec1a8d96fa
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-country-107-3-wrwd
+  broadcaster: independent
+  name: Country 107.3 WRWD
+  streamUrl: https://stream.revma.ihrhls.com/zc1497
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/5e66aa553cce92f1f6a70865?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)"
+  homepage: "https://wrwdcountry.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 58cf5800-dc60-4edc-a388-d8e7b4ed4f8f
+  changeuuid: 64eba37d-9f68-4da0-aef6-eb6e96be43a1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-80s-90s-mix-bestnet-radio
+  broadcaster: independent
+  name: "80s & 90s Mix - BestNet Radio"
+  streamUrl: https://bigrradio.cdnstream1.com/5143_128
+  bitrate: 128
+  codec: MP3
+  homepage: "https://bestnetradio.com/#"
+  country: US
+  status: stream-only
+  stationuuid: a6828c89-1cda-490d-9e4f-248dc4e4929f
+  changeuuid: fbc44ad1-1bac-4485-821f-13375cdfa3e5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-hot-107-1
+  broadcaster: independent
+  name: HOT 107.1
+  streamUrl: https://stream1.flinn.com:8443/1071FM.aac
+  bitrate: 48
+  codec: AAC+
+  homepage: "https://www.hot1071.com/"
+  country: US
+  status: stream-only
+  stationuuid: 1f52f655-7b5b-462a-89e9-8de28f7ad029
+  changeuuid: 5736bb95-3083-4b2f-bf86-56ef6cc5a797
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-iheartradio-christmas-jazz
+  broadcaster: independent
+  name: iHeartRadio Christmas Jazz
+  streamUrl: https://stream.revma.ihrhls.com/zc7251/hls.m3u8
+  bitrate: 24
+  codec: AAC
+  favicon: "https://www.iheart.com/static/assets/favicon.ico"
+  homepage: "https://www.iheart.com/live/christmas-jazz-7251/"
+  country: US
+  status: stream-only
+  stationuuid: 2b9edb0c-2e72-4b5e-94c9-a7bc220962b6
+  changeuuid: fb2f08a1-6de5-4263-bb61-0b88ba1e1741
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-christmas-lounge-64k
+  broadcaster: independent
+  name: SomaFM Christmas Lounge 64k
+  streamUrl: https://ice5.somafm.com/christmas-64-aac
+  bitrate: 64
+  codec: AAC
+  favicon: "https://somafm.com/img3/christmas-400.jpg"
+  homepage: "https://somafm.com/christmas/"
+  country: US
+  status: stream-only
+  stationuuid: b0623467-f157-11e8-a471-52543be04c81
+  changeuuid: 49aea8af-35de-4656-8a8a-ecb51fa8c2f5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-sanctuary-radio-dark-electro-channel
+  broadcaster: independent
+  name: Sanctuary Radio (Dark Electro Channel)
+  streamUrl: https://patmos.cdnstream.com/proxy/sanctua1?mp=/stream
+  bitrate: 192
+  codec: MP3
+  homepage: "https://www.sanctuaryradio.com/"
+  country: US
+  status: stream-only
+  stationuuid: 4d863a83-aac6-4c7b-8e84-054630fd8033
+  changeuuid: 83e20673-37a9-41e6-83d8-b8421d0c1e37
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-gotradio-the-60s
+  broadcaster: independent
+  name: GotRadio - The 60s
+  streamUrl: https://pureplay.cdnstream1.com/6032_128.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: "https://gotradio.com/radiochannel/the-60s/"
+  country: US
+  status: stream-only
+  stationuuid: c73f143e-3306-4eb7-8d9d-5d59aec4c82b
+  changeuuid: f0950af2-76c1-48cd-a426-352f0168b0fb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-octave-radio
+  broadcaster: independent
+  name: Octave Radio
+  streamUrl: https://octaverecords.out.airtime.pro/octaverecords_a?_ga=2.139116787.1781832620.1687634712-199058362.1687634712
+  bitrate: 192
+  codec: MP3
+  favicon: "https://www.psaudio.com/cdn/shop/files/download__6_-removebg-preview.png?crop=center&height=32&v=1667600396&width=32"
+  homepage: "https://www.psaudio.com/blogs/pauls-posts/octave-radio"
+  country: US
+  status: stream-only
+  stationuuid: e846233f-de4b-49bb-8b93-c1c51d0a45b3
+  changeuuid: e14a2d79-009f-4df3-9f75-5cb742100372
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-thistleradio-128k-mp3
+  broadcaster: independent
+  name: SomaFM ThistleRadio (128k MP3)
+  streamUrl: https://ice5.somafm.com/thistle-128-mp3
+  bitrate: 128
+  codec: MP3
+  favicon: "https://somafm.com/img3/thistle-400.jpg"
+  homepage: "https://somafm.com/thistle/"
+  country: US
+  status: stream-only
+  stationuuid: 86d4122b-8c50-4515-8824-4f91bb7fc8de
+  changeuuid: 85aa9b6f-b83d-46d1-a0a3-b8b8aaf5dcdd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-talk-radio-102-3
+  broadcaster: independent
+  name: Talk Radio 102.3
+  streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/WGOWFMAAC.aac
+  bitrate: 48
+  codec: AAC+
+  favicon: "https://express-images.franklymedia.com/6616/sites/80/2023/07/20030055/wgow-fm-logo-1.png"
+  homepage: "https://www.wgow.com/"
+  country: US
+  status: stream-only
+  stationuuid: 20ad3c01-8909-4ee5-b298-3c0fc556243c
+  changeuuid: 23adeebb-6dea-477e-95e7-931ff4eebc36
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-the-beat-dance-hits
+  broadcaster: independent
+  name: The Beat - Dance Hits
+  streamUrl: https://us2.maindigitalstream.com/ssl/7743
+  bitrate: 128
+  codec: MP3
+  country: US
+  status: stream-only
+  stationuuid: 94f5f6aa-884f-406e-b6a1-e20cc3391a60
+  changeuuid: e825d608-e4bf-47bd-ac77-4c84b14dc529
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-wcpt-820-heartland-signal-progresive-talk-willow
+  broadcaster: independent
+  name: "WCPT 820 Heartland Signal Progresive Talk, Willow Springs IL"
+  streamUrl: https://26183.live.streamtheworld.com/WCPTAM.mp3
+  bitrate: 64
+  codec: MP3
+  favicon: "https://heartlandsignal.com/wp-content/themes/landslide/img/logo.png"
+  homepage: "https://heartlandsignal.com/"
+  country: US
+  status: stream-only
+  stationuuid: a4905602-833a-4cd8-9500-abc6440bf27b
+  changeuuid: 02117656-5018-4373-af4c-4a6083840538
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-cc-nuestra-musica-en-espanol
+  broadcaster: independent
+  name: "CC - Nuestra Música [En Español]"
+  streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/CC6_S01AAC_96.aac
+  bitrate: 96
+  codec: AAC+
+  favicon: "https://classicalcalifornia.org/apple-touch-icon.png"
+  homepage: "https://classicalcalifornia.org/"
+  country: US
+  status: stream-only
+  stationuuid: ec1ff05b-e4a6-479c-b5b7-eb19c5c62abb
+  changeuuid: ba680181-c11d-4591-98cc-5f625e4aee8c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-fox-sports-1450
+  broadcaster: independent
+  name: Fox Sports 1450
+  streamUrl: https://stream.revma.ihrhls.com/zc3286
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/5972568b82f0d41e6902d14d?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)"
+  homepage: "https://foxsports1450.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 923d070e-4665-4dda-b43e-d44ec5d9995f
+  changeuuid: fc63c718-c132-4b15-925d-9891f0ff66c6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-gator-107-9
+  broadcaster: independent
+  name: Gator 107.9
+  streamUrl: https://stream.revma.ihrhls.com/zc6855
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/9274387d8a2c3ba7dc3f66e976e8ebe8?ops=gravity(%22center%22),contain(32,32),quality(65)"
+  homepage: "https://gator1079.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 7c996149-abb4-44be-bb70-654e6c20d587
+  changeuuid: 785d644b-7053-4f1a-9d53-70d577b8d694
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-indie-disco
+  broadcaster: independent
+  name: Radio Indie Disco
+  streamUrl: https://broadcast.miami/proxy/indiedisco?mp=/stream/;
+  bitrate: 320
+  codec: MP3
+  homepage: "https://www.radio-indiedisco.com/"
+  country: US
+  status: stream-only
+  stationuuid: 4c6e20cd-c37a-4646-964b-11c866d9d772
+  changeuuid: 0b5c4937-b145-4ad7-b43b-4adfe66bb3a8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-wsrb-106-3-fm-chicago-s-r-b-lansing-il
+  broadcaster: independent
+  name: "WSRB 106.3 FM Chicago's R&B - Lansing, IL"
+  streamUrl: https://ais-sa8.cdnstream1.com/phvh2qaosfo/c2ebyqqdqjx
+  bitrate: 64
+  codec: AAC
+  favicon: "https://dehayf5mhw1h7.cloudfront.net/wp-content/uploads/sites/1370/2020/03/19092432/wsrb-logo.png"
+  homepage: "https://www.1063chicago.com/"
+  country: US
+  status: stream-only
+  stationuuid: 29ff8d79-48f9-46de-a8d4-3629808937f6
+  changeuuid: 778696a8-0c7d-4930-87d3-c64e5a43791d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-96-1-now
+  broadcaster: independent
+  name: 96.1 NOW
+  streamUrl: https://stream.revma.ihrhls.com/zc2357
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/5956a84d119bce55968b6240?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)"
+  homepage: "https://961now.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: ef7dc083-ea59-471f-a732-f926af05cc30
+  changeuuid: f2076b30-ef74-4e87-9652-8a609ae051ae
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-halloween-radio
+  broadcaster: independent
+  name: Halloween Radio
+  streamUrl: https://stream.revma.ihrhls.com/zc7001/hls.m3u8?streamid=7001
+  bitrate: 24
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/new_assets/12fbe317-623c-4596-8fb6-b9d01f39c72d"
+  homepage: "https://www.iheart.com/live/halloween-radio-7001/"
+  country: US
+  status: stream-only
+  stationuuid: 635f30d4-5a02-4ebf-a820-ed0fdce4d939
+  changeuuid: f15e8dda-8ded-4a75-9ee4-794c1c6d42f7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-107-9-the-bull
+  broadcaster: independent
+  name: 107.9 The Bull
+  streamUrl: https://ais-sa1.streamon.fm/7283_48k.aac
+  bitrate: 48
+  codec: AAC+
+  favicon: "https://media.ruralradio.co/nrr/uploads/sites/4/2021/02/cropped-ktic-1-180x180.png"
+  homepage: "https://kticradio.com/"
+  country: US
+  status: stream-only
+  stationuuid: b0b470cc-05b6-4b2b-b028-3f687af54de9
+  changeuuid: 2ed9e7bf-d939-4e25-85c9-d450957c58dc
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-ahfm
+  broadcaster: independent
+  name: AHFM
+  streamUrl: https://us.ah.fm/live
+  bitrate: 192
+  codec: MP3
+  homepage: "http://ah.fm/player/"
+  country: US
+  status: stream-only
+  stationuuid: dfa84622-0d6b-49d0-afaf-b751fdb5e555
+  changeuuid: ad1896b2-8949-4261-b4a1-f5df0b26fc80
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-downtown-radio-97-7
+  broadcaster: independent
+  name: Downtown Radio 97.7
+  streamUrl: https://stream.revma.ihrhls.com/zc5235
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/5efe61e920a313a2d124adf1?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)"
+  homepage: "https://downtown977.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: abda39c5-e3c0-4143-87d2-3365e56d33a5
+  changeuuid: 477c4623-1251-4a1b-ade8-a9bd990ebe89
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-q107-5
+  broadcaster: independent
+  name: Q107.5
+  streamUrl: https://stream1.flinn.com:8443/1075FM.aac
+  bitrate: 56
+  codec: AAC+
+  favicon: "https://www.q1075.com/favicon.ico"
+  homepage: "https://www.q1075.com/"
+  country: US
+  status: stream-only
+  stationuuid: 116a6b2d-d26b-4779-961f-73f201611e59
+  changeuuid: 9d969397-122a-4235-816c-cb1c4ed98e75
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-z106-7
+  broadcaster: independent
+  name: Z106.7
+  streamUrl: https://stream.revma.ihrhls.com/zc1245
+  codec: AAC
+  homepage: "https://z106.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: d07e0953-3d05-411e-acae-cf9a521b2ee0
+  changeuuid: ecf0f08f-3dfa-4bf3-a1ca-5d436f4aaaf7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-yacht-rock-radio
+  broadcaster: independent
+  name: Yacht Rock Radio
+  streamUrl: https://stream.revma.ihrhls.com/zc8681/hls.m3u8
+  bitrate: 24
+  codec: AAC
+  favicon: "https://www.iheart.com/favicon.ico"
+  homepage: "https://www.iheart.com/live/yacht-rock-radio-8681/"
+  country: US
+  status: stream-only
+  stationuuid: 03e55104-032c-4b85-8743-5e4c818e72ec
+  changeuuid: b2ec5a1a-43b3-4244-a409-2fbca9a14976
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-crnet-classic-rock-128
+  broadcaster: independent
+  name: CRnet Classic Rock (128)
+  streamUrl: https://shoutcast.christianrock.net/stream/9/
+  bitrate: 128
+  codec: MP3
+  favicon: "https://www.christianclassicrock.net/apple-touch-icon.png"
+  homepage: "https://www.christianclassicrock.net/"
+  country: US
+  status: stream-only
+  stationuuid: c7bba75d-0284-4deb-84fa-ad60318076f9
+  changeuuid: 7c34476d-51c0-4311-aae6-321f2126e25d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-aftermath-fm
+  broadcaster: independent
+  name: AFTERMATH.FM
+  streamUrl: https://s4.citrus3.com:8232/stream.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: "https://aftermath.fm/"
+  country: US
+  status: stream-only
+  stationuuid: 004410a2-5bd5-4402-9dbb-80955daad24e
+  changeuuid: 92ce6fd7-0f44-4887-8717-e41fcb2f9d1e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-z92-7-wdzz
+  broadcaster: independent
+  name: Z92.7 WDZZ
+  streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/WDZZFMAAC.aac
+  bitrate: 48
+  codec: AAC+
+  favicon: "https://www.wdzz.com/favicon.ico"
+  homepage: "https://www.wdzz.com/"
+  country: US
+  status: stream-only
+  stationuuid: 9c72de6e-b371-4081-a905-2619cccdca9e
+  changeuuid: e1a35a0f-f63d-4c6a-b1e6-b6c479489673
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-100-1-the-beat
+  broadcaster: independent
+  name: 100.1 The Beat
+  streamUrl: https://stream.revma.ihrhls.com/zc2069
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/5e5ea8306a4afbbaec08fb07?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)"
+  homepage: "https://thebeatcolumbia.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: bab670a6-5382-40e8-b05e-5f79e792b13e
+  changeuuid: 21aab7e8-33c0-4107-8969-47b17304638f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-maxima-95-3
+  broadcaster: independent
+  name: Maxima 95.3
+  streamUrl: https://ice66.securenetsystems.net/WKDB
+  bitrate: 64
+  codec: AAC+
+  favicon: "https://www.max953.com/favicon.ico"
+  homepage: "https://www.max953.com/"
+  country: US
+  status: stream-only
+  stationuuid: e4f002e4-7b64-4a36-a67a-dee2e343b3dc
+  changeuuid: a5350b98-f99c-419c-bb26-ca80ad47d760
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-the-joy-fm-worship
+  broadcaster: independent
+  name: The JOY FM (Worship)
+  streamUrl: https://rtn.cdnstream1.com/2581_96.aac?rand=95348
+  bitrate: 96
+  codec: AAC+
+  favicon: "https://florida.thejoyfm.com/sites/joyfl/images/logos/joyfm_icon128.png"
+  homepage: "https://florida.thejoyfm.com/"
+  country: US
+  status: stream-only
+  stationuuid: df5d4afc-5e24-4499-8d09-7a36e39a6962
+  changeuuid: 906af9b8-42ca-4b09-bf49-5e837c1ea0fe
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-100-3-the-bus
+  broadcaster: independent
+  name: 100.3 The Bus
+  streamUrl: https://stream.revma.ihrhls.com/zc2744
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/641b6a567790465c985e31c1?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)"
+  homepage: "https://thebusfm.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 7a5aebf3-a427-4773-8d17-6bb6f842653c
+  changeuuid: 84d1d68c-a7a9-4ffa-ae2d-4c073ee54669
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-93-5-the-mix
+  broadcaster: independent
+  name: 93.5 The Mix
+  streamUrl: https://ice7.securenetsystems.net/THEMIX
+  bitrate: 64
+  codec: AAC+
+  favicon: "https://www.935themix.com/favicon.ico"
+  homepage: "https://www.935themix.com/"
+  country: US
+  status: stream-only
+  stationuuid: 29e15a2d-cb1a-46d2-a709-ac6ea5cf3811
+  changeuuid: b9526a26-3bb6-4179-8bc5-f32ffbe22699
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-k97-1
+  broadcaster: independent
+  name: K97.1
+  streamUrl: https://stream.revma.ihrhls.com/zc2141
+  codec: AAC
+  homepage: "https://k97fm.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 178a9399-a2af-4c89-a5aa-81a399ed4a13
+  changeuuid: aa97121a-8da6-4d22-9d8f-fc9b54961bcd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-mystery-theater-usa
+  broadcaster: independent
+  name: Radio Mystery Theater USA
+  streamUrl: https://ais-sa3.cdnstream1.com/2800_128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: "https://static.wixstatic.com/media/7d32c5_12b386b9d6c147f28d7952c9d466bc06~mv2.png/v1/fill/w_1132,h_789,al_c,q_90,usm_0.66_1.00_0.01,enc_auto/317590051_5176753955758743_1784250402823184359_n.png"
+  homepage: "https://www.wotrradionetwork.com/"
+  country: US
+  status: stream-only
+  stationuuid: 4ad61111-7dca-4fec-945c-98ad1ef66cd3
+  changeuuid: dc353eeb-0048-4f16-99f7-0d051de4836f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-suburbs-of-goa-64k-aac
+  broadcaster: independent
+  name: SomaFM Suburbs of Goa (64k AAC)
+  streamUrl: https://ice5.somafm.com/suburbsofgoa-64-aac
+  bitrate: 64
+  codec: AAC
+  favicon: "https://somafm.com/img3/suburbsofgoa-400.png"
+  homepage: "https://somafm.com/suburbsofgoa/"
+  country: US
+  status: stream-only
+  stationuuid: 10706d9f-a1ce-4e51-90d7-abcac7e2a907
+  changeuuid: 57f87aae-856e-408e-94c8-fa0379cf23d2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-talk-radio-1080
+  broadcaster: independent
+  name: Talk Radio 1080
+  streamUrl: https://stream.revma.ihrhls.com/zc4908
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/641b4511de66c5274866b3e4?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)"
+  homepage: "https://talkradio1080.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 3b78910d-374a-4a56-a29b-198adc520fdf
+  changeuuid: 6c65fe58-9d1e-48fc-9678-fde3ba8c4c56
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-your-classical-holiday
+  broadcaster: independent
+  name: Your Classical - Holiday
+  streamUrl: https://holiday.stream.publicradio.org/holiday_yc.mp3?cb=8282040137
+  bitrate: 128
+  codec: MP3
+  favicon: "https://www.yourclassical.org/apple-touch-icon.png"
+  homepage: "https://www.yourclassical.org/"
+  country: US
+  status: stream-only
+  stationuuid: 96471b51-0601-11e8-ae97-52543be04c81
+  changeuuid: c16c29bf-3c3b-42b9-a167-c458c35e2a32
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-new-sounds-radio
+  broadcaster: independent
+  name: New Sounds Radio
+  streamUrl: https://q2stream.wqxr.org/q2-web
+  bitrate: 128
+  codec: MP3
+  favicon: "https://media.wnyc.org/i/600/600/l/80/1/ns_showcard-newsounds-radio-1.jpg"
+  homepage: "https://www.newsounds.org/"
+  country: US
+  status: stream-only
+  stationuuid: d71dd8f6-a3d7-11e8-abb8-52543be04c81
+  changeuuid: 396fd970-30b8-4cd6-ad37-fa3e74388c07
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-warner-bros
+  broadcaster: independent
+  name: Radio Warner Bros.
+  streamUrl: https://broadcast.miami/proxy/warnerbros?mp=/stream/;
+  bitrate: 320
+  codec: MP3
+  homepage: "https://www.radio-warnerbros.com/"
+  country: US
+  status: stream-only
+  stationuuid: 381fbf5e-1320-42b9-bcdd-a4395940c74b
+  changeuuid: 23877b5c-1fba-496b-89a6-b6e241048265
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-thistleradio-64k-aac
+  broadcaster: independent
+  name: SomaFM ThistleRadio (64k AAC)
+  streamUrl: https://ice5.somafm.com/thistle-64-aac
+  bitrate: 64
+  codec: AAC
+  favicon: "https://somafm.com/img3/thistle-400.jpg"
+  homepage: "https://somafm.com/thistle/"
+  country: US
+  status: stream-only
+  stationuuid: 2571dcf3-3c4e-11e8-b74d-52543be04c81
+  changeuuid: 81edee06-ffda-4ca7-98a4-f763378463bd
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-92-1-the-beat
+  broadcaster: independent
+  name: 92.1 The Beat
+  streamUrl: https://stream.revma.ihrhls.com/zc2449
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/5bdbaf635c185972cb54e597?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)"
+  homepage: "https://thebeatva.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 43d41d63-6f06-4d0f-86c2-6b58156f7fcf
+  changeuuid: df320dde-ce35-4484-a156-cf546f0bb704
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-hawk-country-106-9
+  broadcaster: independent
+  name: Hawk Country 106.9
+  streamUrl: https://ice24.securenetsystems.net/KIHK
+  bitrate: 32
+  codec: AAC+
+  favicon: "https://www.siouxcountyradio.com/favicon.ico"
+  homepage: "https://www.siouxcountyradio.com/"
+  country: US
+  status: stream-only
+  stationuuid: 5877d0b6-48cf-41aa-bdc9-e43c324d5b1c
+  changeuuid: 6c866fec-7937-4a0d-91b9-4e08bfe19e22
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-iheart-indie-radio
+  broadcaster: independent
+  name: iHeart Indie Radio
+  streamUrl: https://stream.revma.ihrhls.com/zc7189/hls.m3u8
+  bitrate: 24
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/new_assets/6ad7b9ac-b9e6-460d-8336-811ce8f84efa"
+  homepage: "https://www.iheart.com/live/indie-radio-7189/"
+  country: US
+  status: stream-only
+  stationuuid: 8d687510-cb24-435c-afdc-7ef659db9eaa
+  changeuuid: 55242a64-44de-42b5-800c-46929498b3d4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-kexp-90-3-fm-seattle
+  broadcaster: independent
+  name: KEXP 90.3 FM Seattle
+  streamUrl: https://kexp-mp3-128.streamguys1.com/kexp128.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: "https://www.kexp.org/static/assets/img/logo-black.svg"
+  homepage: "https://www.kexp.org/"
+  country: US
+  status: stream-only
+  stationuuid: e9fddd49-3ee2-4597-8574-1b7dbd00aac0
+  changeuuid: 1edbc8fd-7ba9-4cbc-b575-d02ad9a03ceb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-jose
+  broadcaster: independent
+  name: Radio Jose
+  streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/KLYYFMAAC.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: "https://elboton.com/wp-content/uploads/sites/6/2024/04/fav_96x96.png"
+  homepage: "https://www.joseradio.com/"
+  country: US
+  status: stream-only
+  stationuuid: 954dd743-e561-4b28-a1d2-5478b21a6323
+  changeuuid: c7df160c-2935-446e-b181-64a421d95fed
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-103-5-kiss-fm-wksc-fm-chicago
+  broadcaster: independent
+  name: 103.5 KISS FM - WKSC-FM Chicago
+  streamUrl: https://stream.revma.ihrhls.com/zc849
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/6040110a9538edc2d6937e84?ops=gravity(%22center%22),contain(360,360)&quality=80"
+  homepage: "https://1035kissfm.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: e3be401b-96d2-42b2-bbcd-a5d9591941b7
+  changeuuid: ab657c3b-03bf-4e13-b7fa-b309ce4ff8d5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-christiancountrygospel-net
+  broadcaster: independent
+  name: ChristianCountryGospel.Net
+  streamUrl: https://listen.christianrock.net/stream/18/
+  bitrate: 120
+  codec: AAC
+  homepage: "https://www.christiancountrygospel.net/"
+  country: US
+  status: stream-only
+  stationuuid: 976fa379-6bc4-4777-bf66-092e5a9f18d4
+  changeuuid: 83311072-3cd5-4f64-9f67-00f02d88d408
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-ih-country-radio
+  broadcaster: independent
+  name: iH Country Radio
+  streamUrl: https://stream.revma.ihrhls.com/zc4418
+  codec: AAC
+  favicon: "https://www.iheart.com/static/assets/favicon.ico"
+  homepage: "https://www.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 6a3566d7-4803-427f-9f16-237d35d9b97a
+  changeuuid: 6252043d-47ff-4228-8107-aa2fd65e195b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-onlyhit-k-pop
+  broadcaster: independent
+  name: OnlyHit K-Pop
+  streamUrl: https://kpop.onlyhit.us/play
+  bitrate: 128
+  codec: MP3
+  favicon: "https://kpop.onlyhit.us/logo.png"
+  homepage: "https://onlyhit.us/"
+  country: US
+  status: stream-only
+  stationuuid: 2e53ff8e-1d21-4e04-b0e9-f68257c4e7e9
+  changeuuid: f79c2c89-2fa1-4368-b709-c29414893ed5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-q105-1-rocks
+  broadcaster: independent
+  name: Q105.1 Rocks
+  streamUrl: https://ice3.securenetsystems.net/KQWB
+  bitrate: 32
+  codec: AAC+
+  homepage: "https://www.q1051rocks.com/"
+  country: US
+  status: stream-only
+  stationuuid: ba39e62a-fc3c-4df9-9e89-ea81843520e7
+  changeuuid: d138531e-8a15-407f-83df-b534985ebdd1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-100hitz-alternative-hitz
+  broadcaster: independent
+  name: 100Hitz - Alternative Hitz
+  streamUrl: https://pureplay.cdnstream1.com/6034_64.aac/playlist.m3u8
+  bitrate: 64
+  codec: AAC+
+  favicon: "https://cdn.onlineradiobox.com/img/l/1/10181.v5.png"
+  homepage: "https://100hitz.com/"
+  country: US
+  status: stream-only
+  stationuuid: bc522fb9-a9ce-4418-8ace-e766898bdae7
+  changeuuid: 2ddf8419-b38c-481b-b941-18ee91c13d62
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-105-3-kznn
+  broadcaster: independent
+  name: 105.3 KZNN
+  streamUrl: https://ice5.securenetsystems.net/KZNNFM
+  bitrate: 32
+  codec: AAC+
+  favicon: "https://resultsradioonline.com/images/favicon/apple-touch-icon.png"
+  homepage: "https://resultsradioonline.com/"
+  country: US
+  status: stream-only
+  stationuuid: 8c14c903-cc1a-4609-b209-506c51e7a9ab
+  changeuuid: 5e153838-6bb3-4e25-a1fb-43779790da01
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-the-patriot-am-1150
+  broadcaster: independent
+  name: The Patriot AM 1150
+  streamUrl: https://stream.revma.ihrhls.com/zc197
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/e0eca5d8d587c993be4872beadd83963?ops=gravity(%22center%22),contain(32,32),quality(65)"
+  homepage: "https://patriotla.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 8511b0ed-8585-44b4-86f4-df9e7222a81c
+  changeuuid: 35a921be-359d-4a53-9ea2-bac933fed330
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-wksu-classical
+  broadcaster: independent
+  name: WKSU Classical
+  streamUrl: https://stream.wksu.org/wksu3.mp3.128
+  bitrate: 128
+  codec: MP3
+  homepage: "http://wksu.org/#stream/0"
+  country: US
+  status: stream-only
+  stationuuid: 40db9f1f-8c68-11e8-aa66-52543be04c81
+  changeuuid: e8c91609-d908-4e4d-86ad-b9e12d263206
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-98-5-el-patron
+  broadcaster: independent
+  name: 98.5 El Patron
+  streamUrl: https://stream.revma.ihrhls.com/zc6969
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/64c483fd15cf1a701f2a697822f910f8?ops=gravity(%22center%22),contain(32,32),quality(65)"
+  homepage: "https://985elpatron.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: c122ae65-162d-4ef5-9279-03591a7bef3f
+  changeuuid: 0ab05d45-ff87-4f95-bf90-06e060af4ecf
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-metallica
+  broadcaster: independent
+  name: Metallica Радио
+  streamUrl: https://stream.pcradio.ru/Metallica-hi
+  codec: AAC
+  favicon: null
+  homepage: "https://pcradio.ru/"
+  country: US
+  status: stream-only
+  stationuuid: 7808e4fc-aaf1-4ea9-aa33-0a26a11be121
+  changeuuid: 0008defe-b9e2-4930-a07a-6b6365dadf0a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-bible-radio-network-english-channel
+  broadcaster: independent
+  name: Bible Radio Network - English Channel
+  streamUrl: https://shout2.brnstream.com/proxy/brnradio1?mp=/stream
+  bitrate: 128
+  codec: MP3
+  homepage: "https://brnradio.com/"
+  country: US
+  status: stream-only
+  stationuuid: 6f1b3f85-d55a-4b1a-ba13-0066ca216604
+  changeuuid: 00011706-6da1-4687-9da0-0237dde5346a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-kmhd-adaptive-aac
+  broadcaster: independent
+  name: KMHD Adaptive AAC
+  streamUrl: https://ais-sa3.cdnstream1.com/2442_128.aac/playlist.m3u8
+  bitrate: 256
+  codec: AAC
+  favicon: "https://kmhd.org/favicon.ico"
+  homepage: "https://kmhd.org/"
+  country: US
+  status: stream-only
+  stationuuid: 336527c2-5ead-4306-9748-6e8d51a1073c
+  changeuuid: e48bae96-6171-497e-9299-34d8e2763264
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-kvkvi-classic-hits
+  broadcaster: independent
+  name: KVKVI - Classic Hits
+  streamUrl: https://dc1.serverse.com/proxy/gjlrjfhp/stream
+  bitrate: 160
+  codec: MP3
+  favicon: "https://www.kvkvi.com/wp-content/uploads/fbrfg/apple-touch-icon.png"
+  homepage: "https://www.kvkvi.com/"
+  country: US
+  status: stream-only
+  stationuuid: 20869b7c-521b-452e-a4fe-5b50618f79ab
+  changeuuid: 485e326c-c8e8-424d-aff2-85955e2f8114
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-senshiphop
+  broadcaster: independent
+  name: senshiphop
+  streamUrl: https://sensihiphop.radioca.st/stream
+  bitrate: 192
+  codec: MP3
+  favicon: "https://m.media-amazon.com/images/I/51QYpQ9cA3L._UX250_FMwebp_QL85_.jpg"
+  homepage: "https://sensimedia.net/radio/stations/hiphop"
+  country: US
+  status: stream-only
+  stationuuid: c6e6f4b9-dfb7-423c-b416-12d2c34b81a2
+  changeuuid: a77e510f-408a-41cd-a81a-76fff17ee2df
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-99-5-the-word
+  broadcaster: independent
+  name: 99.5 The Word
+  streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/KGUFMAAC.aac
+  bitrate: 48
+  codec: AAC+
+  favicon: "https://cdn.saleminteractivemedia.com/shared/images/favicons/cross-32x32.ico"
+  homepage: "https://995theword.com/"
+  country: US
+  status: stream-only
+  stationuuid: 6fe03d49-de46-4a8c-8a29-c1e1fa6b7fa4
+  changeuuid: 583831f7-058c-432e-bbaa-c144cccf250b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-kissin-99-3
+  broadcaster: independent
+  name: "Kissin' 99.3"
+  streamUrl: https://ice66.securenetsystems.net/WKCNFM
+  bitrate: 32
+  codec: AAC+
+  homepage: "https://www.kissin993.com/"
+  country: US
+  status: stream-only
+  stationuuid: 76c67291-faf8-45b6-90f5-06d43ead6ba1
+  changeuuid: f3892b5b-0ead-4909-b372-0809321e8270
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-94-1-the-beat
+  broadcaster: independent
+  name: 94.1 The Beat
+  streamUrl: https://stream.revma.ihrhls.com/zc805
+  codec: AAC
+  favicon: "https://radiostationusa.fm/assets/image/radio/180/WQBT.png"
+  homepage: "https://941thebeat.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: a727285a-6c47-4537-a83b-1d0e04e6832e
+  changeuuid: bce7970f-9edf-4b2d-9a59-adff0514c560
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-audiobook-radio-audio-book-radio
+  broadcaster: independent
+  name: AudioBook Radio Audio Book Radio
+  streamUrl: https://audiobookradio.out.airtime.pro/audiobookradio_a
+  bitrate: 64
+  codec: MP3
+  homepage: "https://audiobookradio.net/listen/"
+  country: US
+  status: stream-only
+  stationuuid: 4d500348-dfbd-449e-8fbe-59d4fcd2ce90
+  changeuuid: 454ffc06-7306-41fe-88a2-5ff7c4d17f72
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-new-wave-radio
+  broadcaster: independent
+  name: New Wave Radio
+  streamUrl: https://digitalaudiobroadcasting.net:1085/stream
+  bitrate: 128
+  codec: MP3
+  homepage: "https://newwave.radio/"
+  country: US
+  status: stream-only
+  stationuuid: 419b75a9-c397-4ef4-80d4-c5b2001a2270
+  changeuuid: de4aab20-d3a8-4d46-9b86-f2301485ec6e
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-woodstock-100-1-wdst
+  broadcaster: independent
+  name: Radio Woodstock 100.1 WDST
+  streamUrl: https://stream.revma.ihrhls.com/zc7332
+  codec: AAC
+  homepage: "https://www.radiowoodstock.com/"
+  country: US
+  status: stream-only
+  stationuuid: d31f9a67-2781-472c-8788-11a1823fce23
+  changeuuid: 810a4fbc-4239-4849-91ba-ff3f8c4a2eea
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-san-diego-s-jazz
+  broadcaster: independent
+  name: "San Diego's Jazz"
+  streamUrl: https://ksds-ice.streamguys1.com/ksds.mp3
+  bitrate: 128
+  codec: MP3
+  country: US
+  status: stream-only
+  stationuuid: 6904d16b-b04a-4afd-bf02-cdef0bf521e8
+  changeuuid: f1161c4a-6d02-44a5-8b48-de7f6493788f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-70-s-hits-dj-jan-the-man
+  broadcaster: independent
+  name: "70's Hits DJ Jan The Man"
+  streamUrl: https://quincy.torontocast.com:2500/stream
+  bitrate: 128
+  codec: MP3
+  homepage: "http://www.djjandaman.com/"
+  country: US
+  status: stream-only
+  stationuuid: 7a1f3e47-782c-4f3a-8e3f-d717dd6b71fa
+  changeuuid: 1cf17394-04ea-485f-be56-8074e429a537
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-99-7-the-fox-charlotte-s-classic-rock-wrfx
+  broadcaster: independent
+  name: "99.7 The Fox - Charlotte's Classic Rock WRFX"
+  streamUrl: https://stream.revma.ihrhls.com/zc1613/hls.m3u8
+  bitrate: 24
+  codec: AAC
+  homepage: "https://www.wrfx.com/"
+  country: US
+  status: stream-only
+  stationuuid: 95c9e42e-8f5e-4bf6-a729-cfeff5ac9814
+  changeuuid: 26004076-6fe3-40bc-9bb3-d72a68dd75cf
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-praise-106-5
+  broadcaster: independent
+  name: Praise 106.5
+  streamUrl: https://crista-kwpz.streamguys1.com/kwpzmp3
+  bitrate: 64
+  codec: MP3
+  homepage: "https://www.praise1065.com/"
+  country: US
+  status: stream-only
+  stationuuid: bcf5aedf-1369-4424-b0de-429e56206cee
+  changeuuid: 447e3999-c23b-4b49-b218-a9326bb0a7ad
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-progradio
+  broadcaster: independent
+  name: ProgRadio
+  streamUrl: https://s4.radio.co/s1e0b382a0/listen
+  bitrate: 320
+  codec: AAC
+  favicon: "https://static.wixstatic.com/media/392d7d_6d4b9892efd641c18eebe0492a5e30a3~mv2.png"
+  homepage: "https://www.progradio.com/"
+  country: US
+  status: stream-only
+  stationuuid: 689fe07b-efa8-4b6f-8994-eba7d2ea7c46
+  changeuuid: be528faf-fbcb-4bab-b697-6140a6433a3c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-suburbs-of-goa-32k-aac
+  broadcaster: independent
+  name: SomaFM Suburbs of Goa (32k AAC)
+  streamUrl: https://ice4.somafm.com/suburbsofgoa-32-aac
+  bitrate: 32
+  codec: AAC
+  favicon: "https://somafm.com/img3/suburbsofgoa-400.png"
+  homepage: "https://somafm.com/suburbsofgoa/"
+  country: US
+  status: stream-only
+  stationuuid: b697b5a0-511f-46f6-80cf-8948cc7a6ceb
+  changeuuid: a7f4ef65-8578-4a49-ac55-3cd7858bb797
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-nu-metal-radio
+  broadcaster: independent
+  name: Nu Metal Radio
+  streamUrl: https://stream.revma.ihrhls.com/zc9483/hls.m3u8
+  bitrate: 24
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.streams/645295e48320086d02de7ca3"
+  homepage: "https://www.iheart.com/live/nu-metal-radio-9483/"
+  country: US
+  status: stream-only
+  stationuuid: ef38194d-10d6-403f-acf7-b5e268037fae
+  changeuuid: 4e2719f9-cada-4a61-9244-a4e7e1d89151
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-680-the-fan
+  broadcaster: independent
+  name: 680 The Fan
+  streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/WCNNAMAAC.aac
+  bitrate: 64
+  codec: AAC+
+  homepage: "https://www.680thefan.com/"
+  country: US
+  status: stream-only
+  stationuuid: c362c13e-0dca-489f-8a7f-aef4ec68c52f
+  changeuuid: 030e7698-5776-4c91-be6f-1a0cd5ce7f82
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-wcrb
+  broadcaster: independent
+  name: WCRB
+  streamUrl: https://wgbh-live.streamguys1.com/classical-hi
+  bitrate: 192
+  codec: MP3
+  homepage: "https://www.classicalwcrb.org/"
+  country: US
+  status: stream-only
+  stationuuid: b536a4b6-1b26-44af-bac3-0deb55f997bb
+  changeuuid: 705ffb5b-8144-433d-9597-e8a69df7aee8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-etoile-tv
+  broadcaster: independent
+  name: Etoile TV
+  streamUrl: https://estrellanews-roku.amagi.tv/playlist.m3u8
+  bitrate: 1478
+  codec: AAC,H.264
+  favicon: "https://static-ottera.com/prod/est/s3fs-public/favicon-32x32.png?7eu3pvdazdntt8kuqtdkxrkutgyf2mwl"
+  homepage: "http://www.estrellatv.com/"
+  country: US
+  status: stream-only
+  stationuuid: 43db9e9e-5730-42dc-9c94-8b1622c7d353
+  changeuuid: 7ca3d04b-4d76-47bb-9a49-e93c3c898abe
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-knbr-1050
+  broadcaster: independent
+  name: KNBR 1050
+  streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/KTCTAMAAC.aac
+  bitrate: 48
+  codec: AAC+
+  homepage: "https://www.knbr.com/"
+  country: US
+  status: stream-only
+  stationuuid: 12cb3ee1-7f46-4253-a884-bb97c8e738d7
+  changeuuid: ab28af70-b600-4b43-b648-791713c11212
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-kzsc-88-1-santa-cruz-ca
+  broadcaster: independent
+  name: "KZSC 88.1 Santa Cruz, CA"
+  streamUrl: https://kzscfms1-geckohost.radioca.st/kzschigh?type=.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: "https://www.kzsc.org/"
+  country: US
+  status: stream-only
+  stationuuid: 961e5e30-0601-11e8-ae97-52543be04c81
+  changeuuid: 619db724-7f69-4ea1-9e12-49e16b0f67a4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-classic-christian-rock-radio
+  broadcaster: independent
+  name: Classic Christian Rock Radio
+  streamUrl: https://s20.reliastream.com/stream/8004
+  bitrate: 128
+  codec: AAC
+  favicon: "https://www.classicchristianrock.net/images/Classic%20Christian%20Rock%20Radio%20text.jpg"
+  homepage: "https://www.classicchristianrock.net/"
+  country: US
+  status: stream-only
+  stationuuid: b9f34cdc-7ae7-4d37-8e64-d0c648bc1b90
+  changeuuid: 0adb3ebb-dd89-4d58-ab55-47948de2e04b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-classic-rock-legends-radio
+  broadcaster: independent
+  name: Classic Rock Legends Radio
+  streamUrl: https://puma.streemlion.com:3130/stream
+  bitrate: 320
+  codec: MP3
+  favicon: "https://classic-rock-legends-radio.yolasite.com/ws/media-library/76cb251b1188401199fda1e21afdce36/628d47596f5f4259b47d3db7aeaf45b3.png"
+  homepage: "https://classic-rock-legends-radio.yolasite.com/"
+  country: US
+  status: stream-only
+  stationuuid: 7ed29a17-550c-4fdd-8cef-2aa0de9a6d4a
+  changeuuid: 73d6335d-b64f-4e3a-95f5-2643faf3079f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-105-3-wdas-fm
+  broadcaster: independent
+  name: 105.3 WDAS FM
+  streamUrl: https://stream.revma.ihrhls.com/zc1993
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/new_assets/5e6058606c31dcbb42808f70?ops=gravity(%22center%22),contain(32,32),quality(65)"
+  homepage: "https://wdasfm.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: b5e6fdcf-05eb-49ac-9592-64b2a41be135
+  changeuuid: 99f58883-2e4b-4ebe-ae8d-795220722068
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-97-5-wcos
+  broadcaster: independent
+  name: 97.5 WCOS
+  streamUrl: https://stream.revma.ihrhls.com/zc2073
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/5e5ffdb3923e9a943a0dbed0?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)"
+  homepage: "https://975wcos.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: f2089601-d4d3-42b2-87bf-351aef3e21be
+  changeuuid: 3e61086a-09b1-4d2a-84e5-0dd3f91ca511
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-espn-1100am-100-9fm
+  broadcaster: independent
+  name: ESPN 1100AM / 100.9FM
+  streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/KWWNAMAAC.aac
+  bitrate: 32
+  codec: AAC+
+  homepage: "https://www.lvsportsnetwork.com/"
+  country: US
+  status: stream-only
+  stationuuid: 5fed3bde-573c-489d-8ff6-b08f16cc9c81
+  changeuuid: 1e0e4c27-6928-42b2-9b5b-82072522e542
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-klove
+  broadcaster: independent
+  name: Klove
+  streamUrl: https://maestro.emfcdn.com/stream_for/k-love/iheart/aac
+  bitrate: 64
+  codec: AAC+
+  favicon: "https://cdn-profiles.tunein.com/s22561/images/bannerx.jpg?t=637102372250000000"
+  homepage: "https://www.klove.com/"
+  country: US
+  status: stream-only
+  stationuuid: 5020fbf7-712b-41a9-9560-8be3fcb56935
+  changeuuid: 49cb7667-c46c-465c-ad11-cd621bbbe7fb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-wbor-91-1-fm
+  broadcaster: independent
+  name: WBOR 91.1 FM
+  streamUrl: https://listen.wbor.org/
+  bitrate: 192
+  codec: MP3
+  favicon: "https://wbor.org/assets/images/favicon.png?v=7be406e9"
+  homepage: "https://wbor.org/"
+  country: US
+  status: stream-only
+  stationuuid: 41a96a58-8d1d-468d-a12b-a6a2ab016284
+  changeuuid: 756910e9-1c28-47b6-bb63-8ca806befdba
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-102-5-kzok
+  broadcaster: independent
+  name: 102.5 KZOK
+  streamUrl: https://stream.revma.ihrhls.com/zc7787
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/5e3b423a10b101a0ff3406d6?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)"
+  homepage: "https://kzok.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 2f16b82c-00d9-4d6f-8f86-8a98e44d90e2
+  changeuuid: 900e25c8-4b46-465b-8621-86ddc596d91c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-93-9-wlit-fm-lite-fm
+  broadcaster: independent
+  name: 93.9 WLIT-FM LITE FM
+  streamUrl: https://stream.revma.ihrhls.com/zc853
+  codec: AAC
+  homepage: "https://939litefm.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: e03dd1dd-49b6-4afd-8579-f18bcb9eeab6
+  changeuuid: ded8b391-78a5-462f-a082-c5c19ecfd412
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-fm106-1
+  broadcaster: independent
+  name: FM106.1
+  streamUrl: https://stream.revma.ihrhls.com/zc2677
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/15c66fedb2bddab6309531a5dcf75949?ops=gravity(%22center%22),contain(32,32),quality(65)"
+  homepage: "https://fm106.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 16a00067-0ac1-490d-81da-afedca205f73
+  changeuuid: c48a3bcc-f40f-4b0f-8325-abb1fdaea77d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-i-hate-free-speech-radio
+  broadcaster: independent
+  name: I Hate Free Speech Radio
+  streamUrl: https://s22.myradiostream.com/15152/listen.mp3
+  bitrate: 128
+  codec: MP3
+  homepage: "http://ihatefreespeech.com/"
+  country: US
+  status: stream-only
+  stationuuid: 7428f0e4-2c80-4c2a-8659-307a3730e270
+  changeuuid: 57e84ff5-442b-4eee-a538-699f10242603
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-kbrh-am-1260
+  broadcaster: independent
+  name: KBRH AM 1260
+  streamUrl: https://wbrh.streamguys1.com/kbrh-mp3
+  bitrate: 128
+  codec: MP3
+  favicon: "https://wbrh.org/wp-content/uploads/2023/03/favicon2-100x100.gif"
+  homepage: "https://www.wbrh.org/"
+  country: US
+  status: stream-only
+  stationuuid: 1f86fce6-7892-4dbb-9539-635044f64761
+  changeuuid: ab1de57c-26ae-4752-969d-4151d9f1f2e7
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-kmfa
+  broadcaster: independent
+  name: KMFA
+  streamUrl: https://kmfa.streamguys1.com/KMFA-mp3
+  bitrate: 128
+  codec: MP3
+  homepage: "https://www.kmfa.org/"
+  country: US
+  status: stream-only
+  stationuuid: e151a924-6896-11ea-9d09-52543be04c81
+  changeuuid: de56e335-b3ed-4fe8-9fe7-154fbe66930b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-relevant-radio
+  broadcaster: independent
+  name: Relevant Radio
+  streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/RR_MAIN.mp3
+  bitrate: 128
+  codec: MP3
+  favicon: "https://t3.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=http://relevantradio.com&size=64"
+  homepage: "https://relevantradio.com/"
+  country: US
+  status: stream-only
+  stationuuid: 5445e13b-7e1f-46f6-825b-210874a85810
+  changeuuid: 51bd7b56-129f-4e23-918e-42ba4857c0b1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-93-1-amor-bachata-y-mas
+  broadcaster: independent
+  name: 93.1 AMOR (Bachata y Más )
+  streamUrl: https://liveaudio.lamusica.com/NY_WPAT_icy
+  bitrate: 127
+  codec: AAC
+  favicon: "https://www.lamusica.com/lamusica-white.svg"
+  homepage: "https://www.lamusica.com/stations/wpat"
+  country: US
+  status: stream-only
+  stationuuid: 71725f8f-d34e-451d-af84-7894e542cfb0
+  changeuuid: b03c4111-8198-4925-8899-2de2b354ffe5
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-b101
+  broadcaster: independent
+  name: B101
+  streamUrl: https://stream.revma.ihrhls.com/zc3217
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/5e5eb7de6acdd8e31fb6117f?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)"
+  homepage: "https://b101.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 484bb443-20c0-46ef-aed0-35cca5d4f23b
+  changeuuid: a6c1722d-946b-42a1-99bd-910a8cf40700
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-big-dog-103-5
+  broadcaster: independent
+  name: Big Dog 103.5
+  streamUrl: https://ice66.securenetsystems.net/WUUF
+  bitrate: 32
+  codec: AAC+
+  homepage: "https://www.bigdog1035.com/"
+  country: US
+  status: stream-only
+  stationuuid: bb3b6506-da6f-4714-9e70-4b23c755787f
+  changeuuid: c3cd4ed3-9da9-4853-aae1-b856a0d4b19a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-power-101-1-fm
+  broadcaster: independent
+  name: Power 101.1 FM
+  streamUrl: https://ice3.securenetsystems.net/WHJA2
+  bitrate: 32
+  codec: AAC+
+  homepage: "https://powerstation101.com/"
+  country: US
+  status: stream-only
+  stationuuid: 3ff76daa-4a27-4cc6-a065-3f182138c576
+  changeuuid: beafe55d-5fcf-4105-9cc9-19a29a16e609
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-real-talk-910
+  broadcaster: independent
+  name: Real Talk 910
+  streamUrl: https://stream.revma.ihrhls.com/zc297
+  codec: AAC
+  favicon: "https://www.iheart.com/static/assets/favicon.ico"
+  homepage: "https://realtalk910.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 97e6b809-e768-4a09-88b7-5c4646516abb
+  changeuuid: 17b13fac-b56e-4e2a-9032-d676f73163c2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-the-joy-fm-88-1fm-jacksonville
+  broadcaster: independent
+  name: The JOY FM 88.1FM Jacksonville
+  streamUrl: https://rtn.cdnstream1.com/2579_96.aac?rand=10817
+  bitrate: 96
+  codec: AAC+
+  favicon: "https://florida.thejoyfm.com/sites/joyfl/images/logos/joyfm_icon128.png"
+  homepage: "https://florida.thejoyfm.com/"
+  country: US
+  status: stream-only
+  stationuuid: edc9e891-a60f-41cd-a622-7a8e5fc6e491
+  changeuuid: f93cfe8d-504f-4f22-87e3-f3e0dbd9b849
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-1043-myfm
+  broadcaster: independent
+  name: 1043 MYfm
+  streamUrl: https://stream.revma.ihrhls.com/zc173
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/646249b860898f1d0cc3967d?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)"
+  homepage: "https://1043myfm.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: d613e5d5-2533-4079-bfe5-4ba2ff4a03da
+  changeuuid: 144b6695-6d71-4ff8-a5be-ea37b59dde56
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-buckeye-country-94-3
+  broadcaster: independent
+  name: Buckeye Country 94.3
+  streamUrl: https://stream.revma.ihrhls.com/zc3973
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/3e4367cb5fe014ebc7654bead10d28a7?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)"
+  homepage: "https://buckeyecountry943.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: fb67bead-1136-4bdd-94a2-2e1038920c7c
+  changeuuid: 379b41e4-df9e-4f32-b2d7-ccbd328965d1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-exa-fm-las-vegas-94-5-fm-kxli-radio-activo-broad
+  broadcaster: independent
+  name: "Exa FM Las Vegas - 94.5 FM - KXLI - Radio Activo Broadcasting, LLC - Las Vegas, Nevada"
+  streamUrl: https://ice9.securenetsystems.net/KXLI
+  bitrate: 32
+  codec: AAC+
+  favicon: "https://exafm.com/favicon.ico"
+  homepage: "https://exafm.com/lasvegas/"
+  country: US
+  status: stream-only
+  stationuuid: cef931e0-849d-4f55-a150-67fb82e44b31
+  changeuuid: db84e517-6ca2-4326-8355-0eab54e17ef9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-hpr1-traditional-classic-country
+  broadcaster: independent
+  name: "HPR1: Traditional Classic Country"
+  streamUrl: https://us2.maindigitalstream.com/ssl/7713
+  bitrate: 128
+  codec: MP3
+  favicon: "http://www.hpr.org/icon-normal.png"
+  homepage: "https://hpr.org/"
+  country: US
+  status: stream-only
+  stationuuid: f4896119-5e73-42be-8c07-bc1e7e79e815
+  changeuuid: 0f6f200e-308b-4ecc-93de-a1d699704e20
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-metal-devastation-radio
+  broadcaster: independent
+  name: Metal Devastation Radio
+  streamUrl: https://c13.radioboss.fm:18099/stream
+  bitrate: 320
+  codec: MP3
+  favicon: "https://metaldevastationradio.com/data/media/0/0/favicon_120.png?v=2"
+  homepage: "https://metaldevastationradio.com/"
+  country: US
+  status: stream-only
+  stationuuid: 102fd070-4146-4dd7-afca-88c8c6484b9b
+  changeuuid: f227b60b-f296-4275-90e9-2b87afbea094
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-slack-radio
+  broadcaster: independent
+  name: Slack Radio
+  streamUrl: https://s4.radio.co/s62c60f538/listen
+  bitrate: 320
+  codec: AAC
+  homepage: "http://www.slackradio.org/"
+  country: US
+  status: stream-only
+  stationuuid: 21d9fe6c-5426-405f-a755-fb703cfd6aac
+  changeuuid: 21a8d959-6bb1-43fd-bed9-da02e30096a1
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-sports-talk-1050-wtka
+  broadcaster: independent
+  name: Sports Talk 1050 WTKA
+  streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/WTKAAMAAC.aac
+  bitrate: 48
+  codec: AAC+
+  favicon: "https://express-images.franklymedia.com/6616/sites/283/2023/09/11060800/wtka-mastheadlogo.png"
+  homepage: "https://www.wtka.com/"
+  country: US
+  status: stream-only
+  stationuuid: f73aa403-b021-491f-b5c8-c8aaa8992138
+  changeuuid: 24c2011f-1174-4c81-abd8-4010c31a9d1c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-wfms-95-5
+  broadcaster: independent
+  name: WFMS 95.5
+  streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/WFMSFM_SC
+  bitrate: 80
+  codec: MP3
+  favicon: "https://www.wfms.com/favicon.ico"
+  homepage: "https://www.wfms.com/"
+  country: US
+  status: stream-only
+  stationuuid: b36b8ebb-1908-433e-acee-64cd30b23869
+  changeuuid: febc0d50-90f5-4f86-b488-e8bb92e4fa85
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-101-5-kgb
+  broadcaster: independent
+  name: 101.5 KGB
+  streamUrl: https://stream.revma.ihrhls.com/zc237
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/289e7a9c2382e8410a86b780804a6945?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)"
+  homepage: "https://101kgb.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 000b0c60-2505-4bef-bda7-35dad7381318
+  changeuuid: 1cac0da2-5f81-4306-91f1-64745695c0a9
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-kiss-98-3
+  broadcaster: independent
+  name: Kiss 98.3
+  streamUrl: https://ice64.securenetsystems.net/WKEMLP
+  bitrate: 32
+  codec: AAC+
+  homepage: "https://www.wkemkiss983.org/"
+  country: US
+  status: stream-only
+  stationuuid: f0996e0e-aa08-4352-9b3f-87c9e98cefb1
+  changeuuid: 27d00105-3d13-4472-bb38-d1a97a4cfef2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-magic-93-1
+  broadcaster: independent
+  name: Magic 93.1
+  streamUrl: https://ice66.securenetsystems.net/WBBK
+  bitrate: 64
+  codec: AAC
+  homepage: "https://mymagic93.com/"
+  country: US
+  status: stream-only
+  stationuuid: ae2986cc-b1e0-48ad-8942-e55c8f3467c5
+  changeuuid: b51f32fd-4903-45fb-8257-d05438eeb974
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-181-fm-good-time-oldies
+  broadcaster: independent
+  name: 181.fm good time oldies
+  streamUrl: https://listen.181fm.com/181-goodtime_128k.mp3
+  bitrate: 128
+  codec: MP3
+  country: US
+  status: stream-only
+  stationuuid: 80a0af27-afc4-4af3-b909-6be888941021
+  changeuuid: cd7d9eb6-ff9e-4207-9e71-6b3f5655f296
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-lounge-motion-fm
+  broadcaster: independent
+  name: Lounge Motion FM
+  streamUrl: https://vm.motionfm.com/motionthree_aacp
+  bitrate: 64
+  codec: AAC+
+  homepage: "http://www.motionfm.com/"
+  country: US
+  status: stream-only
+  stationuuid: c6832a91-9bec-4c7c-a9d3-6567a3ec1acc
+  changeuuid: af0b5434-29cd-4b0b-a083-69c02f33cd72
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-n5md-32k-aac
+  broadcaster: independent
+  name: SomaFM n5MD (32k AAC)
+  streamUrl: https://ice2.somafm.com/n5md-32-aac
+  bitrate: 32
+  codec: AAC
+  favicon: "https://somafm.com/img3/n5md-400.png"
+  homepage: "https://somafm.com/n5md/"
+  country: US
+  status: stream-only
+  stationuuid: 5c8936d3-4142-4874-aa67-6815e4d3755c
+  changeuuid: be6bbd7d-5e68-4b3d-9948-c581b9616de0
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-alt-101-5-the-desert-s-alternative
+  broadcaster: independent
+  name: "Alt 101.5 - The Desert's Alternative"
+  streamUrl: https://ice9.securenetsystems.net/ALT1015
+  bitrate: 64
+  codec: AAC+
+  homepage: "https://alt1015fm.com/"
+  country: US
+  status: stream-only
+  stationuuid: 47aec2ba-eda5-430d-b1ae-33ccfc80a190
+  changeuuid: 464d3199-8848-4a1b-beb9-66a7a11fee04
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-america-s-otr-gunsmoke
+  broadcaster: independent
+  name: "America's OTR - Gunsmoke"
+  streamUrl: https://streaming.live365.com/a68303
+  bitrate: 128
+  codec: MP3
+  favicon: "https://media.live365.com/download/2b93fa33-3af5-4aff-9cd5-78c288c71f69.png"
+  homepage: "https://americasotr.com/"
+  country: US
+  status: stream-only
+  stationuuid: 84a576b4-8312-43e9-aae9-9f9ce81753a1
+  changeuuid: 2fec8203-9c21-4bf7-950f-343151678ba2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-jazz24
+  broadcaster: independent
+  name: Jazz24
+  streamUrl: https://knkx-live-a.edge.audiocdn.com/6285_256k
+  bitrate: 256
+  codec: AAC
+  favicon: "https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse1.mm.bing.net%2Fth%2Fid%2FOIP.ugUKdyft-8Fo--PIPAXzGgAAAA%3Fpid%3DApi&f=1&ipt=f09f5c58d86f560fb392db2af56b9af0d7f4c9f2ae3401b90488c35484eba2cb&ipo=images"
+  homepage: "https://www.jazz24.org/"
+  country: US
+  status: stream-only
+  stationuuid: 1d730b8a-49e2-403d-870c-07b1e27be7fd
+  changeuuid: 2d04adbf-e434-4a25-a24f-738e0d84d25b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-sl100
+  broadcaster: independent
+  name: SL100
+  streamUrl: https://stream.revma.ihrhls.com/zc5112
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/5b733d7ac86aa1d1bdff5100?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)"
+  homepage: "https://sl100.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 62e68ea5-d4dd-43da-90e6-9138ad26c26e
+  changeuuid: c09b918e-b825-4e25-862d-e62e4628c507
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-hawaii-reggae-network
+  broadcaster: independent
+  name: Hawaii Reggae Network
+  streamUrl: https://ice8.securenetsystems.net/HRNO
+  bitrate: 64
+  codec: AAC+
+  homepage: "https://hawaiireggaenetwork.com/"
+  country: US
+  status: stream-only
+  stationuuid: 8db50028-caf7-4a39-a70b-2b71500560f6
+  changeuuid: 51b34116-320b-4e35-bc52-62375f14f838
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-hot-103-jamz
+  broadcaster: independent
+  name: Hot 103 Jamz
+  streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/KPRSFMAAC.aac
+  bitrate: 64
+  codec: AAC+
+  favicon: "https://dehayf5mhw1h7.cloudfront.net/wp-content/uploads/sites/962/2018/03/14144206/cropped-jamz-logo-180x180.png"
+  homepage: "https://www.kprs.com/"
+  country: US
+  status: stream-only
+  stationuuid: b7a35256-ce81-46fb-96aa-2717bf5f0110
+  changeuuid: d6447913-a6ce-46e7-982c-8d5467d924e3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-kmlb
+  broadcaster: independent
+  name: KMLB
+  streamUrl: https://ice66.securenetsystems.net/KMLB
+  bitrate: 96
+  codec: AAC+
+  homepage: "https://kmlb.com/"
+  country: US
+  status: stream-only
+  stationuuid: c13b596f-2e67-4f02-9594-6fc22e4cad7b
+  changeuuid: c2abfc36-a005-4138-aef8-1146fde13018
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-star-102-1
+  broadcaster: independent
+  name: Star 102.1
+  streamUrl: https://stream.revma.ihrhls.com/zc2815
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/5fe97892e9b7f0baf76383eb?ops=gravity(%22center%22),contain(32,32),quality(65)"
+  homepage: "https://star1021.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: f7cdb266-4a85-47d3-95ed-b8ec387b1305
+  changeuuid: 39192eca-b0d0-421d-be59-5c5fa053c640
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-ultimate-oldies-radio-musical-history-of-the-50-
+  broadcaster: independent
+  name: "Ultimate Oldies Radio! Musical History of the 50's, 60's, 70's & More!"
+  streamUrl: https://puma.streemlion.com:1785/stream
+  bitrate: 128
+  codec: AAC+
+  favicon: "https://www.ultimateoldiesradio.com/uploads/2/5/3/5/25355864/editor/oldies700-500x500.png?1630372797"
+  homepage: "https://www.ultimateoldiesradio.com/"
+  country: US
+  status: stream-only
+  stationuuid: ccc9f19c-59ab-4808-b29d-285e470ef626
+  changeuuid: c0310de5-db81-45d7-a536-5430867545f3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-92-3-wcol
+  broadcaster: independent
+  name: 92.3 WCOL
+  streamUrl: https://stream.revma.ihrhls.com/zc1757
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.eeo/59382154af0fd78f0d5d6a57?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)"
+  homepage: "https://wcol.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 98787f90-56e1-447f-9d93-637c8bbbcd56
+  changeuuid: 4c2b1a2b-f250-40bd-ab85-ce6b0a6d63da
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-adoration-from-family-life
+  broadcaster: independent
+  name: Adoration from Family Life
+  streamUrl: https://streaming.live365.com/a59117_2
+  bitrate: 128
+  codec: AAC+
+  homepage: "https://www.familylife.org/"
+  country: US
+  status: stream-only
+  stationuuid: e9a7c72e-77db-4ae2-881b-2cee6e79c498
+  changeuuid: 17d6da46-2d0c-46a2-a970-c63d8f5f1640
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-classic-metal-radio
+  broadcaster: independent
+  name: Classic Metal Radio
+  streamUrl: https://quincy.torontocast.com:2100/
+  bitrate: 128
+  codec: MP3
+  homepage: "http://classicmetalradio.net/"
+  country: US
+  status: stream-only
+  stationuuid: 3b3c2ad5-88d5-4dd2-b028-c09d243e3c4c
+  changeuuid: 366743e7-2939-40e5-8ceb-13e4ab598a00
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-crb-classical-99-5-aac-256
+  broadcaster: independent
+  name: CRB Classical 99.5 AAC 256
+  streamUrl: https://wgbh-live.streamguys1.com/wcrb-itunes-256k
+  bitrate: 255
+  codec: AAC
+  favicon: "https://www.classicalwcrb.org/apple-touch-icon.png"
+  homepage: "https://www.classicalwcrb.org/"
+  country: US
+  status: stream-only
+  stationuuid: d7a41686-831e-4e8d-8a3e-778db4ba985e
+  changeuuid: 58ce36ec-0b36-4ca7-a6ef-4082ad686e0f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-espn-99-5-northwest-arkansas
+  broadcaster: independent
+  name: ESPN 99.5 Northwest Arkansas
+  streamUrl: https://ice5.securenetsystems.net/KAKSFM
+  bitrate: 32
+  codec: AAC+
+  favicon: "https://img.sedoparking.com/templates/logos/sedo_logo.png"
+  homepage: "https://www.espn995.com/"
+  country: US
+  status: stream-only
+  stationuuid: 553f6b74-77f8-4e31-a702-73e11beb4463
+  changeuuid: 8e38792b-7e80-4fdf-8ef3-fa6b3e140781
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-beach-105-5
+  broadcaster: independent
+  name: Beach 105.5
+  streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/WBHUFMAAC.aac
+  bitrate: 32
+  codec: AAC+
+  homepage: "https://www.beach1055.com/"
+  country: US
+  status: stream-only
+  stationuuid: 23adf5de-1859-4165-9fe3-6fbd6754ba1f
+  changeuuid: 0d050d0a-69ac-4bb5-8cf1-e46769a52a7c
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-exclusively-kylie-minogue
+  broadcaster: independent
+  name: Exclusively Kylie Minogue
+  streamUrl: https://streaming.exclusive.radio/er-app/kylie/icecast.audio
+  codec: MP3
+  favicon: "https://play.exclusive.radio/static/assets/img/apple-icon-120x120.png"
+  homepage: "https://play.exclusive.radio/"
+  country: US
+  status: stream-only
+  stationuuid: 778f2c5c-c1f7-43b3-b942-3609222fe56c
+  changeuuid: ef4406c9-f419-4644-aa5f-5a75f93ff8d2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-folk-alley-freshgrass
+  broadcaster: independent
+  name: Folk Alley FreshGrass
+  streamUrl: https://freshgrass.streamguys1.com/ss1-128mp3
+  bitrate: 128
+  codec: MP3
+  homepage: "https://www.folkalley.com/music/playlist/today/freshgrass"
+  country: US
+  status: stream-only
+  stationuuid: 9f96edb3-1c4b-4373-b56a-be368cb1e368
+  changeuuid: d3c365d4-fa47-4c0a-b5fc-78d3dea1f349
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-jammin-oldies-radio-jammin-105
+  broadcaster: independent
+  name: Jammin Oldies Radio - Jammin 105
+  streamUrl: https://tlawler2.radioca.st/;
+  bitrate: 128
+  codec: AAC+
+  homepage: "http://jamminoldiesradio.com/"
+  country: US
+  status: stream-only
+  stationuuid: a2ec65f1-8962-438a-b6d5-2294ba0e78c9
+  changeuuid: 5bc9cda0-fbe8-40ae-9131-ff6d9d3671da
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-pure-country-89-3
+  broadcaster: independent
+  name: Pure Country 89.3
+  streamUrl: https://ice23.securenetsystems.net/QXFM
+  bitrate: 64
+  codec: AAC+
+  homepage: "https://qxfm.com/"
+  country: US
+  status: stream-only
+  stationuuid: 774fa26e-bfde-4158-81d2-8abc472ec3e0
+  changeuuid: 2fc3a8d6-e860-4b35-9c0b-e987b37b10ef
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-wqxr-q2-stream-new-york-public-radio-newark-nj
+  broadcaster: independent
+  name: "WQXR \"Q2 Stream\" New York Public Radio - Newark, NJ"
+  streamUrl: https://q2stream.wqxr.org/q2.aac
+  bitrate: 47
+  codec: AAC+
+  homepage: "http://www.wqxr.org/series/q2/"
+  country: US
+  status: stream-only
+  stationuuid: 96201d80-0601-11e8-ae97-52543be04c81
+  changeuuid: 252d836d-7821-437d-b52c-7bcb17b0f6d3
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-96-5-jack-fm
+  broadcaster: independent
+  name: 96.5 JACK-FM
+  streamUrl: https://stream.revma.ihrhls.com/zc7788
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/609c1d56e9956f81bdb9f27f?ops=gravity(%22center%22),contain(32,32),quality(65)"
+  homepage: "https://jackseattle.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 604e43c4-9257-412a-a2f2-b1cf92186172
+  changeuuid: 71e3d667-447c-4116-95d2-0fe0a7b1ba15
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-am-950-the-progressive-voice-of-minnesota
+  broadcaster: independent
+  name: AM 950 The Progressive Voice of Minnesota
+  streamUrl: https://ice25.securenetsystems.net/KTNF
+  bitrate: 32
+  codec: AAC+
+  homepage: "https://www.am950radio.com/"
+  country: US
+  status: stream-only
+  stationuuid: d5961721-55f8-4d38-b5a7-a14d29caa87d
+  changeuuid: 49374526-9b32-4d74-9d56-cdbdfd70de15
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-crnet-hard-rock-32
+  broadcaster: independent
+  name: CRnet Hard Rock (32)
+  streamUrl: https://shoutcast.christianrock.net/stream/4/
+  bitrate: 32
+  codec: MP3
+  favicon: "https://www.christianhardrock.net/apple-touch-icon.png"
+  homepage: "https://www.christianhardrock.net/"
+  country: US
+  status: stream-only
+  stationuuid: 3a9a9083-7d62-43ac-8ca0-1e74e3ba81b2
+  changeuuid: ee1ec5a8-cec2-4f82-8584-c7f56dead7a2
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-fox-sports-pueblo
+  broadcaster: independent
+  name: Fox Sports Pueblo
+  streamUrl: https://stream.revma.ihrhls.com/zc4015
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/5bdb13e742f2b3f9adfcf0fd?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)"
+  homepage: "https://foxsportspueblo.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: e09921da-715b-4cca-bdb1-4ca4cf56afb7
+  changeuuid: 6b24308d-bf03-41e8-be41-40155285bd3b
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-litt-live-grunge
+  broadcaster: independent
+  name: LITT Live - Grunge
+  streamUrl: https://das-sa39.cdnstream1.com/5570_128
+  bitrate: 128
+  codec: MP3
+  favicon: "https://dashradio-files.s3.amazonaws.com/development/icon_logos/164/logos/0e64637e-7b29-477e-883b-ae7408d275ee.png"
+  homepage: "https://littlive.com/grunge"
+  country: US
+  status: stream-only
+  stationuuid: 9b65470b-c31d-4a3a-b57b-eea8c62c58c9
+  changeuuid: d45ca921-e04d-460e-83e2-d04fb29799ac
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-more-fm-98-9
+  broadcaster: independent
+  name: More FM 98.9
+  streamUrl: https://radio.cadenanoticias.com/proxy/morefm989?mp=/morefm989
+  bitrate: 192
+  codec: AAC+
+  homepage: "https://morefmonline.com/"
+  country: US
+  status: stream-only
+  stationuuid: 752d1ea4-2d5d-4ddf-a50a-1e60ed6b8ce7
+  changeuuid: c46ac47f-54fb-474f-9263-7b1bd5e0eb14
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-phcc-gospel-radio
+  broadcaster: independent
+  name: PHCC Gospel Radio
+  streamUrl: https://c25.radioboss.fm:8130/4rm8tzo7qirtv
+  bitrate: 192
+  codec: MP3
+  homepage: "https://c25.radioboss.fm/u/130"
+  country: US
+  status: stream-only
+  stationuuid: a74405ea-97dc-417c-a261-9adaf86f1def
+  changeuuid: c21edaa9-a5ca-4f53-9e90-56a67f8a3046
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-wcbm-680
+  broadcaster: independent
+  name: WCBM 680
+  streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/WCBMAM.mp3
+  bitrate: 32
+  codec: MP3
+  homepage: "https://www.wcbm.com/"
+  country: US
+  status: stream-only
+  stationuuid: 17e479ee-53de-4e35-9baa-672bb011ae36
+  changeuuid: bee668e5-8d9f-4857-b30f-ae442bf59e64
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-wets-89-5-johnson-city-tn
+  broadcaster: independent
+  name: "WETS 89.5 Johnson City, TN"
+  streamUrl: https://wets-fm.streamguys1.com/live-1
+  bitrate: 90
+  codec: MP3
+  homepage: "http://www.etsu.edu/wets/"
+  country: US
+  status: stream-only
+  stationuuid: 961df649-0601-11e8-ae97-52543be04c81
+  changeuuid: 5af2340a-c3c8-4091-9343-20302aa404fb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-cat-country-98-7-wyct
+  broadcaster: independent
+  name: Cat Country 98.7 (WYCT)
+  streamUrl: https://adxc-live.streamguys1.com/catcountry987
+  bitrate: 96
+  codec: MP3
+  favicon: "https://cdn-profiles.tunein.com/s41848/images/logod.png?t=637191341190000000"
+  homepage: "https://catcountry987.com/"
+  country: US
+  status: stream-only
+  stationuuid: f114b1ad-13fc-4075-a0db-49d8b6bf5d4e
+  changeuuid: 3868092b-6d52-482b-8fd2-2079cb0775ea
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-concord
+  broadcaster: independent
+  name: Radio Concord
+  streamUrl: https://broadcast.miami/proxy/concord?mp=/stream/;
+  bitrate: 320
+  codec: MP3
+  homepage: "https://www.radio-concord.com/"
+  country: US
+  status: stream-only
+  stationuuid: 3693dbaa-d701-4c66-a714-1a4dd610bfc9
+  changeuuid: bdc5c9e8-d467-4fa2-af0c-fc701aa778a6
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-106-5-the-end
+  broadcaster: independent
+  name: 106.5 The END
+  streamUrl: https://stream.revma.ihrhls.com/zc1597
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/628c71139061c04f16dc01c9?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)"
+  homepage: "https://1065.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 0a40a0bf-761d-40cf-873e-71398ca05f55
+  changeuuid: 09205d74-5b62-46cd-8ff2-ef3d38279835
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-95-5-the-bull
+  broadcaster: independent
+  name: 95.5 The Bull
+  streamUrl: https://stream.revma.ihrhls.com/zc1345
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/81ab990f60deaac4a511ff33ad8c6087?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)"
+  homepage: "https://955thebull.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 9274d251-de24-4c2d-a4bb-47776ca44e77
+  changeuuid: 6a67a3b9-7166-417e-b912-fdb16bb775ab
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-98-5-wyld
+  broadcaster: independent
+  name: 98.5 WYLD
+  streamUrl: https://stream.revma.ihrhls.com/zc1053
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/5aea268408c82e0c34ad95f4?ops=gravity(%22center%22),contain(32,32),quality(65)"
+  homepage: "https://wyldfm.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 3cddec1d-c69a-4ef9-82e1-539f34d5bfe5
+  changeuuid: ef4bcb34-ac66-4d15-8ff6-a814fb4ced61
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-99-7-the-fox
+  broadcaster: independent
+  name: 99.7 The Fox
+  streamUrl: https://stream.revma.ihrhls.com/zc1613
+  codec: AAC
+  homepage: "https://997thefox.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 9aabd593-dc44-444f-bd00-e2cbed60760b
+  changeuuid: 979fa29f-ddce-4c34-8211-be5592928810
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-dc101-dc-s-alternative-rock-radio-station
+  broadcaster: independent
+  name: "DC101 / DC's Alternative Rock Radio Station"
+  streamUrl: https://stream.revma.ihrhls.com/zc2525
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/5e5d35f7ca55c01f9bfdc41f?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)"
+  homepage: "https://dc101.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 911a8bbe-af9e-4016-91ac-3e590403d5ab
+  changeuuid: 40fa330c-7db8-4162-a2dc-938bdc32b319
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-espn-710-los-angeles
+  broadcaster: independent
+  name: ESPN 710 Los Angeles
+  streamUrl: https://live.amperwave.net/direct/goodkarma-kspnamaac-ibc
+  bitrate: 64
+  codec: AAC+
+  homepage: "https://www.espn.com/radio/play/_/s/la"
+  country: US
+  status: stream-only
+  stationuuid: 36074435-1ae4-4eea-a597-c67a19035534
+  changeuuid: ca9a17b1-2113-4fc1-be41-820a747c0b8a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-hd-radio-rock-roll
+  broadcaster: independent
+  name: "HD Radio - Rock & Roll"
+  streamUrl: https://hdrockandroll-rfritschka.radioca.st/;
+  bitrate: 128
+  codec: MP3
+  homepage: "https://www.hd-radio.net/"
+  country: US
+  status: stream-only
+  stationuuid: e1e780ae-8b5c-471f-b4ff-98848f7892c9
+  changeuuid: da735155-226d-4e9c-9c40-bc8a04330185
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-news-talk-550-wdun
+  broadcaster: independent
+  name: News/Talk 550 WDUN
+  streamUrl: https://ice42.securenetsystems.net/WDUN
+  bitrate: 64
+  codec: AAC+
+  favicon: "https://radiostationusa.fm/assets/image/radio/180/WDUN.jpg"
+  homepage: "https://www.wdun.com/"
+  country: US
+  status: stream-only
+  stationuuid: dd31eb10-5e32-4fdb-bc60-3573714d068a
+  changeuuid: ce7c8f6d-64d7-4acb-922a-8310ec84897d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-bmg
+  broadcaster: independent
+  name: Radio BMG
+  streamUrl: https://broadcast.miami/proxy/bmg?mp=/stream/;
+  bitrate: 320
+  codec: MP3
+  homepage: "https://www.radio-bmg.com/"
+  country: US
+  status: stream-only
+  stationuuid: 18af8169-cec7-43ae-b10f-631e7caa0b92
+  changeuuid: 57aa981b-284e-46e0-857f-911312925af8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-xmas-in-frisco-64k-aac
+  broadcaster: independent
+  name: SomaFM Xmas in Frisco (64k AAC)
+  streamUrl: https://ice5.somafm.com/xmasinfrisko-64-aac
+  bitrate: 64
+  codec: AAC
+  favicon: "https://somafm.com/img3/xmasinfrisko-400.jpg"
+  homepage: "https://somafm.com/xmasinfrisko/"
+  country: US
+  status: stream-only
+  stationuuid: da163975-de68-11e8-a9cc-52543be04c81
+  changeuuid: 2f5440fd-0931-434c-99b8-1836383d6083
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-98-9-kiss-fm
+  broadcaster: independent
+  name: 98.9 KISS-FM
+  streamUrl: https://stream.revma.ihrhls.com/zc3387
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/5e1e38c8a5c5b9a85dbf29f6?ops=gravity(%22center%22),contain(32,32),quality(65)"
+  homepage: "https://kisslouisville.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 46e7c646-4581-4af8-9ed5-6810ab42852c
+  changeuuid: a9b5f8d8-98ae-45ee-9f4c-c9455da40145
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-kfan-fm-sports
+  broadcaster: independent
+  name: KFAN FM Sports
+  streamUrl: https://stream.revma.ihrhls.com/zc1209
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/7abeb696904580c44cd523e678ac767c?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)"
+  homepage: "https://kfan.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 67cfc9c9-77f3-4f50-9099-c9a82f8f4675
+  changeuuid: 989b85d8-1113-4b6a-a756-cbe8618a0112
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-digitalis-128k-aac
+  broadcaster: independent
+  name: SomaFM Digitalis (128k AAC)
+  streamUrl: https://ice6.somafm.com/digitalis-128-aac
+  bitrate: 128
+  codec: AAC
+  favicon: "https://somafm.com/img3/digitalis-400.jpg"
+  homepage: "https://somafm.com/digitalis/"
+  country: US
+  status: stream-only
+  stationuuid: bf0efe51-43bf-4f56-8f1a-c2a00fdb09da
+  changeuuid: 9bddf82a-7955-4096-985c-80a13bcb500f
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-air1
+  broadcaster: independent
+  name: AIR1
+  streamUrl: https://maestro.emfcdn.com/stream_for/air1/airable/aac
+  bitrate: 64
+  codec: AAC+
+  favicon: "https://cdn.corpemf.com/www/waf/air1/logo.png"
+  homepage: "https://www.air1.com/"
+  country: US
+  status: stream-only
+  stationuuid: 36ae4390-a4c1-4572-be11-72fe618fc0a5
+  changeuuid: 40c6eb6c-c941-4536-afaf-56644975bb28
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-ancient-faith-ministries-english-language-music
+  broadcaster: independent
+  name: Ancient Faith Ministries English language Music
+  streamUrl: https://ancientfaith.streamguys1.com/ancientfaith3
+  bitrate: 96
+  codec: AAC+
+  homepage: "https://www.ancientfaith.com/radio"
+  country: US
+  status: stream-only
+  stationuuid: 4966cc8f-372d-40e7-91a0-e01f7f7d279c
+  changeuuid: d4d51699-9f77-487b-8670-7f4bd061b1e4
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-crb-boston-early-music
+  broadcaster: independent
+  name: CRB - Boston Early Music
+  streamUrl: https://wgbh-live.streamguys1.com/BostonEarlyMusic-8112-aac
+  bitrate: 128
+  codec: AAC+
+  favicon: "https://www.classicalwcrb.org/apple-touch-icon.png"
+  homepage: "https://www.classicalwcrb.org/"
+  country: US
+  status: stream-only
+  stationuuid: 0604e118-822d-437d-aeee-b3aa37ad18f9
+  changeuuid: c49e7905-1376-49f2-8dd4-0301da55ec4d
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-freedom-93-7
+  broadcaster: independent
+  name: Freedom 93.7
+  streamUrl: https://stream.revma.ihrhls.com/zc381
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/5e6a4dec4b5295736a8f19f6?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)"
+  homepage: "https://freedom937.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: be5341c6-c1a7-4228-ae33-c84064910a80
+  changeuuid: 7e93f1fb-a767-40ea-be27-6142fc2bc619
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-polydor
+  broadcaster: independent
+  name: Radio Polydor
+  streamUrl: https://broadcast.miami/proxy/polydor?mp=/stream/;
+  bitrate: 320
+  codec: MP3
+  homepage: "https://www.radio-polydor.com/"
+  country: US
+  status: stream-only
+  stationuuid: 4c1c0792-b1cf-4558-82e1-72d5fb317e1a
+  changeuuid: ed289d98-33a8-4a5d-a741-baba14b57408
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-97-9-wjlb
+  broadcaster: independent
+  name: 97.9 WJLB
+  streamUrl: https://stream.revma.ihrhls.com/zc1141
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/59ceb6e9636154b7b7a9cf6c?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)"
+  homepage: "https://wjlbdetroit.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 4c242534-f83d-4f56-991d-aa9cb113c90a
+  changeuuid: 4143512d-4982-4f44-b674-b4d884c3eb1a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-news-radio-810-wgy
+  broadcaster: independent
+  name: News Radio 810 WGY
+  streamUrl: https://stream.revma.ihrhls.com/zc1413/hls.m3u8
+  bitrate: 24
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/5a43a4734d834fc016ebadf1?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)"
+  homepage: "https://wgy.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 45e3d77e-8411-4085-952e-b4cbf56ff738
+  changeuuid: 0e4815e9-45e4-460b-a5fe-a76879699874
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-p-funk-radio
+  broadcaster: independent
+  name: P-Funk Radio
+  streamUrl: https://ice66.securenetsystems.net/PFR
+  bitrate: 64
+  codec: AAC+
+  homepage: "https://www.pfunkradio.com/"
+  country: US
+  status: stream-only
+  stationuuid: f043ab90-9a40-4223-ace6-7acc9971b09c
+  changeuuid: a83915d0-48a8-438b-957f-4caf5bcabc6a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-real-98-3
+  broadcaster: independent
+  name: Real 98.3
+  streamUrl: https://stream.revma.ihrhls.com/zc6944
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/a1b14584587afc32d324600db6bc4d9f?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)"
+  homepage: "https://real983.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 3d2a3432-4344-498b-a760-e084d8886a47
+  changeuuid: fb53f953-0cf4-4cf9-944c-9cb197bf2843
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-beach-95-1
+  broadcaster: independent
+  name: Beach 95.1
+  streamUrl: https://ice3.securenetsystems.net/WBPC
+  bitrate: 64
+  codec: AAC+
+  favicon: "https://beach951.com/images/favicon/apple-touch-icon.png"
+  homepage: "https://beach951.com/"
+  country: US
+  status: stream-only
+  stationuuid: 2c9ab94a-b7be-4aa7-9150-9d5aebf4b846
+  changeuuid: dce7b1ee-76cf-45ff-8884-dee964bab32a
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-sonic-universe-32k-aac
+  broadcaster: independent
+  name: SomaFM Sonic Universe (32k AAC)
+  streamUrl: https://ice2.somafm.com/sonicuniverse-32-aac
+  bitrate: 32
+  codec: AAC
+  favicon: "https://somafm.com/img3/sonicuniverse-400.jpg"
+  homepage: "https://somafm.com/sonicuniverse/"
+  country: US
+  status: stream-only
+  stationuuid: 580d5a37-50aa-468e-826e-bdce55bd84dd
+  changeuuid: 0a9d9217-8c84-4572-b588-47f96b7a1994
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-100-7-wmms-cleveland-ohio
+  broadcaster: independent
+  name: "100.7 WMMS - Cleveland, Ohio"
+  streamUrl: https://stream.revma.ihrhls.com/zc1741
+  codec: AAC
+  favicon: "https://i.iheart.com/v3/re/assets.brands/59ba8c6becb804a54e71c0ca?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)"
+  homepage: "https://wmms.iheart.com/"
+  country: US
+  status: stream-only
+  stationuuid: 1668d514-0b53-4008-b724-c9504c2bfe76
+  changeuuid: d59ac061-5258-4d15-9110-0d14bd0e37ca
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-abn-antioch-otr
+  broadcaster: independent
+  name: ABN Antioch OTR
+  streamUrl: https://s6.yesstreaming.net:18000/listen
+  bitrate: 32
+  codec: MP3
+  favicon: "https://radio.macinmind.com/mobile/abn-radio256-2x.png"
+  homepage: "https://radio.macinmind.com/mobile/index.php#listen"
+  country: US
+  status: stream-only
+  stationuuid: 6d873e98-f950-4c7d-bc4f-6a65aacb892e
+  changeuuid: 90b0b927-f2c5-4391-a612-35e14dfc8559
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-desi-world-radio-usa
+  broadcaster: independent
+  name: desi world radio (USA)
+  streamUrl: https://stream.zeno.fm/4mbfcn4mf24tv
+  codec: MP3
+  homepage: "http://desiworldradio.com/"
+  country: US
+  status: stream-only
+  stationuuid: 78da01c7-0a2a-11ea-a87e-52543be04c81
+  changeuuid: ba124708-4eaf-44dc-9064-2e8a496b5af8
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-knbt-radio-new-braunfels
+  broadcaster: independent
+  name: KNBT Radio New Braunfels
+  streamUrl: https://ice5.securenetsystems.net/KNBT?playSessionID=7FECF4B8-DA9A-8B7C-5437CC2940B447FA
+  bitrate: 32
+  codec: AAC+
+  homepage: "https://www.radionb.com/knbt"
+  country: US
+  status: stream-only
+  stationuuid: e50b50ba-8ddb-4322-a471-5d4449376c55
+  changeuuid: d9fb79ac-64a4-4902-ba40-ca283de43cbb
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-polskie-radio-1030-chicago-wnvr
+  broadcaster: independent
+  name: Polskie Radio 1030 Chicago WNVR
+  streamUrl: https://s1.reliastream.com/proxy/polskieradio?mp=/stream
+  bitrate: 128
+  codec: MP3
+  favicon: "https://polskieradio.com/wp-content/uploads/2019/11/polskie-radio-logo.png"
+  homepage: "https://polskieradio.com/"
+  country: US
+  status: stream-only
+  stationuuid: ffbba95c-a223-4083-af98-96a44a209076
+  changeuuid: 8e420faf-9f31-427a-aad5-6a17c7c5cf64
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-radio-is-a-foreign-country
+  broadcaster: independent
+  name: Radio is a Foreign Country
+  streamUrl: https://s5.radio.co/s20251311a/listen
+  bitrate: 192
+  codec: MP3
+  homepage: "https://www.radioisaforeigncountry.org/"
+  country: US
+  status: stream-only
+  stationuuid: 0fab2a15-1e79-4e79-8b5a-dc3fde073093
+  changeuuid: 6a0fc833-9412-471b-9ccf-c9e8675108ec
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-somafm-digitalis-256k-mp3
+  broadcaster: independent
+  name: SomaFM Digitalis (256k MP3)
+  streamUrl: https://ice2.somafm.com/digitalis-256-mp3
+  bitrate: 256
+  codec: MP3
+  favicon: "https://somafm.com/img3/digitalis-400.jpg"
+  homepage: "https://somafm.com/digitalis/"
+  country: US
+  status: stream-only
+  stationuuid: facc531b-7afc-4065-a69f-16b874b30b85
+  changeuuid: b84b086d-b570-4dff-9478-3d1287064271
+  reviewedAt: "2026-05-04"
+
+# Auto-imported from Radio Browser (2026-05-04)
+- id: us-wuky-npr-rocks
+  broadcaster: independent
+  name: "WUKY - NPR Rocks "
+  streamUrl: https://wuky.streamguys1.com/wuky
+  bitrate: 98
+  codec: AAC
+  favicon: "https://www.wuky.org/favicon.ico"
+  homepage: "https://www.wuky.org/"
+  country: US
+  status: stream-only
+  stationuuid: e771586c-72b0-4c95-8799-18d886b32cca
+  changeuuid: 8eec9ec2-578c-4286-a6fd-9dace430bcb0
+  reviewedAt: "2026-05-04"

--- a/public/stations.json
+++ b/public/stations.json
@@ -47008,6 +47008,10576 @@
         16.3876
       ],
       "status": "stream-only"
+    },
+    {
+      "id": "us-classic-vinyl-hd",
+      "name": "Classic Vinyl HD",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.walmradio.com:8443/classic",
+      "homepage": "https://walmradio.com/classic",
+      "country": "US",
+      "tags": [
+        "1930",
+        "1940",
+        "1950",
+        "1960",
+        "beautiful music",
+        "big band"
+      ],
+      "favicon": "https://icecast.walmradio.com:8443/classic.jpg",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        40.7517,
+        -73.9754
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-christmas-vinyl-hd",
+      "name": "Christmas Vinyl HD",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.walmradio.com:8443/christmas",
+      "homepage": "https://walmradio.com/christmas",
+      "country": "US",
+      "tags": [
+        "christian",
+        "christmas",
+        "easy listening",
+        "hd",
+        "holiday",
+        "otr"
+      ],
+      "favicon": "https://icecast.walmradio.com:8443/christmas.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        40.7517,
+        -73.9754
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-walm-old-time-radio",
+      "name": "WALM - Old Time Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://icecast.walmradio.com:8443/otr",
+      "homepage": "https://walmradio.com/otr",
+      "country": "US",
+      "tags": [
+        "78",
+        "78-rpm",
+        "78rpm",
+        "classic",
+        "comedy",
+        "drama"
+      ],
+      "favicon": "https://icecast.walmradio.com:8443/otr.jpg",
+      "bitrate": 64,
+      "codec": "MP3",
+      "geo": [
+        40.7517,
+        -73.9754
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-classic-hits-radio-70-80-discofunk-modernsoul-bo",
+      "name": "CLASSIC HITS RADIO 70 80 DiscoFunk ModernSoul Boogie",
+      "broadcaster": "independent",
+      "streamUrl": "https://radiopanther.radiolebowski.com/play",
+      "homepage": "http://classichits.radio/",
+      "country": "US",
+      "tags": [
+        "1970s",
+        "1980s",
+        "70's",
+        "70s",
+        "70s disco",
+        "80"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-poptron-128k-mp3",
+      "name": "SomaFM PopTron (128k MP3)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice2.somafm.com/poptron-128-mp3",
+      "homepage": "https://somafm.com/poptron/",
+      "country": "US",
+      "tags": [
+        "electropop",
+        "indie",
+        "synthpop"
+      ],
+      "favicon": "https://somafm.com/img3/poptron-400.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-left-coast-70s-320k-mp3",
+      "name": "SomaFM Left Coast 70s (320k MP3)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice5.somafm.com/seventies-320-mp3",
+      "homepage": "https://somafm.com/seventies/",
+      "country": "US",
+      "tags": [
+        "easy listening",
+        "mellow album rock",
+        "rock",
+        "yacht rock"
+      ],
+      "favicon": "https://somafm.com/img3/seventies400.jpg",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-funky-radio-only-funk-music-60-s-70-s",
+      "name": "FUNKY RADIO - Only Funk Music (60's 70's)",
+      "broadcaster": "independent",
+      "streamUrl": "https://funkyradio.streamingmedia.it/play.mp3",
+      "homepage": "https://funky.radio/",
+      "country": "US",
+      "tags": [
+        "60s",
+        "70s",
+        "70s disco",
+        "80s",
+        "black",
+        "black music"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-miami-beach-radio",
+      "name": "Miami Beach Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.radiostreamlive.com/miamibeachradio_devices",
+      "homepage": "https://www.miamibeachradio.com/",
+      "country": "US",
+      "tags": [
+        "hits",
+        "ocean drive",
+        "rsl"
+      ],
+      "favicon": "https://cdn-elements.radiostreamlive.com/v1/images/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-marti",
+      "name": "Radio Marti",
+      "broadcaster": "independent",
+      "streamUrl": "https://ocb01.akacast.akamaistream.net/7/365/437903/v1/ibb.akacast.akamaistream.net/ocb01",
+      "homepage": "https://www.radiotelevisionmarti.com/",
+      "country": "US",
+      "tags": [
+        "news talk",
+        "talk show"
+      ],
+      "favicon": "https://www.radiotelevisionmarti.com/content/responsive/ocb/img/webapp/ico-128x128.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-lush-128k-mp3",
+      "name": "SomaFM Lush (128k MP3)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice2.somafm.com/lush-128-mp3",
+      "homepage": "https://somafm.com/lush/",
+      "country": "US",
+      "tags": [
+        "electronic",
+        "femalevocals",
+        "lounge",
+        "mellow",
+        "vocal"
+      ],
+      "favicon": "https://somafm.com/img3/lush-400.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-z-92-miami-92-3-fm-wcmq-fm-spanish-broadcasting-",
+      "name": "Z 92 (Miami) - 92.3 FM - WCMQ-FM - Spanish Broadcasting System - Miami, Florida",
+      "broadcaster": "independent",
+      "streamUrl": "https://liveaudio.lamusica.com/MIA_WCMQ_icy",
+      "homepage": "https://www.lamusica.com/stations/wcmq",
+      "country": "US",
+      "tags": [
+        "92.3 fm",
+        "entretenimiento",
+        "español",
+        "estación",
+        "florida",
+        "fm"
+      ],
+      "favicon": "https://cdn-profiles.tunein.com/s27943/images/logod.png",
+      "bitrate": 320,
+      "codec": "AAC",
+      "geo": [
+        25.7835,
+        -80.1899
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-70s-80s-disco-funk-modernsoul-boogie",
+      "name": "70s 80s Disco Funk ModernSoul Boogie",
+      "broadcaster": "independent",
+      "streamUrl": "https://discofunk.streamingmedia.it/usa",
+      "homepage": "https://funky.radio/discofunk_modernsoul_boogie",
+      "country": "US",
+      "tags": [
+        "1970s",
+        "1980s",
+        "70's",
+        "70er",
+        "70s",
+        "70s disco"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-metal-detector-128k-aac",
+      "name": "SomaFM Metal Detector (128k AAC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice4.somafm.com/metal-128-aac",
+      "homepage": "https://somafm.com/metal/",
+      "country": "US",
+      "tags": [
+        "black metal",
+        "doom metal",
+        "post-punk",
+        "progressive rock",
+        "sludge",
+        "stoner rock"
+      ],
+      "favicon": "https://somafm.com/img3/metal-400.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-metal-rock-radio",
+      "name": "metal rock radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://kathy.torontocast.com:2800/;",
+      "homepage": "http://www.metalrock.fm/",
+      "country": "US",
+      "tags": [
+        "classic rock",
+        "metal",
+        "rock"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-voa-learning-english",
+      "name": "VOA Learning English",
+      "broadcaster": "independent",
+      "streamUrl": "https://voa-ingest.akamaized.net/hls/live/2035234/160_342L/playlist.m3u8",
+      "homepage": "http://www.voanews.com/t/60.html",
+      "country": "US",
+      "tags": [
+        "learn english",
+        "learn language"
+      ],
+      "favicon": "http://www.voanews.com/content/responsive/voa/img/webapp/ico-128x128.png",
+      "bitrate": 140,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-smoothjazz-com-128k-mp3",
+      "name": "SmoothJazz.com 128k mp3",
+      "broadcaster": "independent",
+      "streamUrl": "https://smoothjazz.cdnstream1.com/2585_128.mp3",
+      "homepage": "https://www.smoothjazz.com/",
+      "country": "US",
+      "tags": [
+        "monterey",
+        "smooth jazz"
+      ],
+      "favicon": "https://www.smoothjazz.com/sites/default/files/theme/sj-circle-logo.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        36.6007,
+        -121.8769
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-fluid-128k-mp3",
+      "name": "SomaFM Fluid (128k MP3)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice4.somafm.com/fluid-128-mp3",
+      "homepage": "https://somafm.com/fluid/",
+      "country": "US",
+      "tags": [
+        "chilled trap",
+        "future soul",
+        "hiphop",
+        "woozy electronica"
+      ],
+      "favicon": "https://somafm.com/img3/fluid-400.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-country-live-new-york",
+      "name": "Radio Country Live New York",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.radiostreamlive.com/radiocountrylive_devices",
+      "homepage": "http://www.radiocountrylive.com/",
+      "country": "US",
+      "tags": [
+        "country",
+        "new york city",
+        "rsl"
+      ],
+      "favicon": "https://cdn-elements.radiostreamlive.com/v1/images/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-megarock-radio-320k",
+      "name": "Megarock Radio 320k",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream3.megarockradio.net:80/",
+      "homepage": "https://megarockradio.net/",
+      "country": "US",
+      "tags": [
+        "classic rock",
+        "hard rock",
+        "metal",
+        "requests"
+      ],
+      "favicon": "https://megarockradio.net/favicon.ico",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-heavyweight-reggae-256k-mp3",
+      "name": "SomaFM Heavyweight Reggae (256k MP3)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice6.somafm.com/reggae-256-mp3",
+      "homepage": "https://somafm.com/reggae/",
+      "country": "US",
+      "tags": [
+        "reggae",
+        "rocksteady",
+        "roots reggae",
+        "ska"
+      ],
+      "favicon": "https://somafm.com/img3/reggae400.jpg",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-msnbc",
+      "name": "MSNBC",
+      "broadcaster": "independent",
+      "streamUrl": "https://tunein.cdnstream1.com/3511_96.mp3",
+      "homepage": "https://www.msnbc.com/",
+      "country": "US",
+      "tags": [
+        "news"
+      ],
+      "favicon": "https://nodeassets.nbcnews.com/cdnassets/projects/ramen/favicon/msnbc/all-other-sizes-PNG.ico/favicon-96x96.png",
+      "bitrate": 96,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-love-live-new-york",
+      "name": "Radio Love Live New York",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.radiostreamlive.com/radiolovelive_devices",
+      "homepage": "http://www.radiolovelive.com/",
+      "country": "US",
+      "tags": [
+        "love songs",
+        "new york city",
+        "rsl"
+      ],
+      "favicon": "https://cdn-elements.radiostreamlive.com/v1/images/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-bluegrass-country",
+      "name": "Bluegrass Country",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice24.securenetsystems.net/WAMU",
+      "homepage": "https://bluegrasscountry.org/",
+      "country": "US",
+      "tags": [
+        "bluegrass",
+        "country"
+      ],
+      "favicon": "https://bluegrasscountry.org/favicon.ico",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-classical-kdfc",
+      "name": "Classical KDFC",
+      "broadcaster": "independent",
+      "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/KDFCFMAAC.aac",
+      "homepage": "https://www.kdfc.com/",
+      "country": "US",
+      "tags": [
+        "classical"
+      ],
+      "favicon": "https://radiostationusa.fm/assets/image/radio/180/KDFCFM.png",
+      "bitrate": 128,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-kpfa",
+      "name": "KPFA",
+      "broadcaster": "independent",
+      "streamUrl": "https://streams.kpfa.org:8443/kpfa",
+      "homepage": "https://kpfa.org/",
+      "country": "US",
+      "tags": [
+        "berkeley",
+        "community supported radio station"
+      ],
+      "favicon": "https://kpfa.org/favicon.ico",
+      "bitrate": 185,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-comedy-104-radiostorm",
+      "name": "Comedy 104 - Radiostorm",
+      "broadcaster": "independent",
+      "streamUrl": "https://ais-sa5.cdnstream1.com/b42761_64mp3",
+      "homepage": "https://radiostorm.com/",
+      "country": "US",
+      "tags": [
+        "comedy"
+      ],
+      "favicon": "https://radiostorm.com/wp-content/uploads/2018/01/cropped-imgpsh_fullsize2-180x180.png",
+      "bitrate": 96,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-trap-radio-trap-radio",
+      "name": "TRAP RADIO TRAP.radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://trapradio.streamingmedia.it/play",
+      "homepage": "http://trap.radio/",
+      "country": "US",
+      "tags": [
+        "trap"
+      ],
+      "bitrate": 128,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-station",
+      "name": "美国之音",
+      "broadcaster": "independent",
+      "streamUrl": "https://voa-ingest.akamaized.net/hls/live/2035206/151_124L/playlist.m3u8",
+      "homepage": "https://voa-ingest.akamaized.net/",
+      "country": "US",
+      "tags": [
+        "新闻"
+      ],
+      "bitrate": 140,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-secret-agent-32k-aac",
+      "name": "SomaFM Secret Agent (32k AAC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice6.somafm.com/secretagent-32-aac",
+      "homepage": "https://somafm.com/secretagent/",
+      "country": "US",
+      "tags": [
+        "ambient",
+        "downtempo",
+        "jazz",
+        "lounge",
+        "samba",
+        "sixties"
+      ],
+      "favicon": "https://somafm.com/img3/secretagent-400.jpg",
+      "bitrate": 32,
+      "codec": "AAC",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-classic-rock-109",
+      "name": "Classic Rock 109",
+      "broadcaster": "independent",
+      "streamUrl": "https://jenny.torontocast.com:2000/stream/ClassicRock109",
+      "homepage": "http://www.classicrock109.com/site/index.html",
+      "country": "US",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-deep-space-one-32k-aac",
+      "name": "SomaFM Deep Space One (32k AAC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice2.somafm.com/deepspaceone-32-aac",
+      "homepage": "https://somafm.com/deepspaceone/",
+      "country": "US",
+      "tags": [
+        "ambient",
+        "electronic",
+        "space"
+      ],
+      "favicon": "http://somafm.com/img3/deepspaceone-400.jpg",
+      "bitrate": 32,
+      "codec": "AAC",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-left-coast-70s-128k-mp3",
+      "name": "SomaFM Left Coast 70s (128k MP3)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice2.somafm.com/seventies-128-mp3",
+      "homepage": "https://somafm.com/seventiesr/",
+      "country": "US",
+      "tags": [
+        "easy listening",
+        "mellow album rock",
+        "rock",
+        "yacht rock"
+      ],
+      "favicon": "https://somafm.com/img3/seventies400.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-funky-radio-only-funk-music-60-s-70-s-439fafd7",
+      "name": "FUNKY RADIO - Only Funk Music (60's & 70's)",
+      "broadcaster": "independent",
+      "streamUrl": "https://funkyradio.streamingmedia.it/audio.aac",
+      "homepage": "https://funky.radio/",
+      "country": "US",
+      "tags": [
+        "60s",
+        "70s",
+        "70s disco",
+        "80s",
+        "black",
+        "black music"
+      ],
+      "bitrate": 128,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-boot-liquor-320k-mp3",
+      "name": "SomaFM Boot Liquor (320k MP3)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice4.somafm.com/bootliquor-320-mp3",
+      "homepage": "https://somafm.com/bootliquor/",
+      "country": "US",
+      "tags": [
+        "americana",
+        "country"
+      ],
+      "favicon": "https://somafm.com/img3/bootliquor-400.jpg",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-christian-life-radio",
+      "name": "Christian Life Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice64.securenetsystems.net/CLR1MP3",
+      "homepage": "https://www.communitynetradio.org/christianliferadio",
+      "country": "US",
+      "tags": [
+        "christian"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-sonic-universe-128k-mp3",
+      "name": "SomaFM Sonic Universe (128k MP3)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice5.somafm.com/sonicuniverse-128-mp3",
+      "homepage": "https://somafm.com/sonicuniverse/",
+      "country": "US",
+      "tags": [
+        "avant-garde",
+        "eclectic",
+        "jazz"
+      ],
+      "favicon": "https://somafm.com/img3/sonicuniverse-400.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-paradise-rock-mix-flac",
+      "name": "Radio Paradise Rock Mix FLAC",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radioparadise.com/rock-flac",
+      "homepage": "https://radioparadise.com/",
+      "country": "US",
+      "tags": [
+        "california",
+        "alternative",
+        "eclectic",
+        "rock",
+        "free",
+        "internet"
+      ],
+      "favicon": "https://radioparadise.com/apple-touch-icon.png",
+      "bitrate": 1441,
+      "codec": "OGG",
+      "geo": [
+        40.7851,
+        -124.1839
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-funky-corner-radio-usa",
+      "name": "_Funky Corner Radio (USA)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ais-sa2.cdnstream1.com/2447_192.mp3",
+      "homepage": "https://www.funkycorner.it/",
+      "country": "US",
+      "tags": [
+        "70s",
+        "70s disco",
+        "80s",
+        "black",
+        "black music",
+        "disco"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-america-s-country",
+      "name": "America's Country",
+      "broadcaster": "independent",
+      "streamUrl": "https://ais-sa2.cdnstream1.com/1976_128.mp3",
+      "homepage": "https://americascountry.us/",
+      "country": "US",
+      "tags": [
+        "2000's country",
+        "90's country",
+        "america's country",
+        "classic country",
+        "country",
+        "country music"
+      ],
+      "favicon": "https://marinifamily.files.wordpress.com/2015/08/favicon.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        40.393,
+        -111.7932
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-100-hip-hop-and-rnb-fm",
+      "name": ".100 Hip hop and RNB FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice64.securenetsystems.net/LFTM",
+      "homepage": "https://ice64.securenetsystems.net/LFTM",
+      "country": "US",
+      "tags": [
+        "hip hop",
+        "r&b",
+        "soul",
+        "urban"
+      ],
+      "bitrate": 32,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-beat-blender-128k-mp3",
+      "name": "SomaFM Beat Blender (128k MP3)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice6.somafm.com/beatblender-128-mp3",
+      "homepage": "https://somafm.com/beatblender/",
+      "country": "US",
+      "tags": [
+        "chillout",
+        "deep house",
+        "downtempo",
+        "electronica"
+      ],
+      "favicon": "https://somafm.com/img3/beatblender-400.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-suburbs-of-goa-128k-aac",
+      "name": "SomaFM Suburbs of Goa (128k AAC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice4.somafm.com/suburbsofgoa-128-aac",
+      "homepage": "https://somafm.com/suburbsofgoa/",
+      "country": "US",
+      "tags": [
+        "desi-influenced asian",
+        "world beats"
+      ],
+      "favicon": "https://somafm.com/img3/suburbsofgoa-400.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-christian-power-praise-dot-net",
+      "name": "Christian Power Praise Dot Net",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.christianrock.net/stream/13/",
+      "homepage": "https://www.christianpowerpraise.net/",
+      "country": "US",
+      "tags": [
+        "christian",
+        "praise",
+        "worship",
+        "christianpowerpraise.net",
+        "cppdn"
+      ],
+      "favicon": "https://www.christianpowerpraise.net/apple-touch-icon.png",
+      "bitrate": 120,
+      "codec": "AAC",
+      "geo": [
+        37.2116,
+        -93.2898
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-1460-espn-deportes",
+      "name": "1460 ESPN Deportes",
+      "broadcaster": "independent",
+      "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/KENOAMAAC.aac",
+      "homepage": "https://www.lvsportsnetwork.com/",
+      "country": "US",
+      "bitrate": 32,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-groove-salad-128k-aac",
+      "name": "SomaFM Groove Salad (128k AAC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice5.somafm.com/groovesalad-128-aac",
+      "homepage": "https://somafm.com/groovesalad/",
+      "country": "US",
+      "tags": [
+        "ambient",
+        "chillout",
+        "downtempo",
+        "groove",
+        "lounge",
+        "sleep"
+      ],
+      "favicon": "https://somafm.com/img3/groovesalad-400.jpg",
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-bloomberg-99-1-105-7-hd2",
+      "name": "Bloomberg 99.1/105.7 HD2",
+      "broadcaster": "independent",
+      "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/WBBRDCAAC.aac",
+      "homepage": "https://www.bloombergradio.com/",
+      "country": "US",
+      "tags": [
+        "business news"
+      ],
+      "favicon": "https://www.bloombergradio.com/content/plugins/bloomberg-favicon/dist/img/amber-120x120.png",
+      "bitrate": 32,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-red-state-talk-radio",
+      "name": "Red State Talk Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.radio.co/s572ad25f7/listen",
+      "homepage": "http://redstatetalkradio.com/",
+      "country": "US",
+      "tags": [
+        "conservative talk",
+        "constitutionalists",
+        "libertarian"
+      ],
+      "favicon": "https://redstatetalkradio.com/wp-content/uploads/2021/03/cropped-rstr588x588-180x180.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-the-independent-fm",
+      "name": "The Independent FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/293701/stream/340084",
+      "homepage": "https://www.radioking.com/radio/the-independent-fm-1",
+      "country": "US",
+      "tags": [
+        "indie",
+        "indie music",
+        "indie rock"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-smooth-r-b-105-7",
+      "name": "Smooth R&B 105.7",
+      "broadcaster": "independent",
+      "streamUrl": "https://ais-sa1.streamon.fm/7281_64k.aac",
+      "homepage": "https://krnb.com/",
+      "country": "US",
+      "tags": [
+        "urban adult contemporary"
+      ],
+      "favicon": "https://krnb.com/favicon.ico",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-chilltrax",
+      "name": "chilltrax",
+      "broadcaster": "independent",
+      "streamUrl": "https://streamssl.chilltrax.com/",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "US",
+      "tags": [
+        "electronic"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-seven-inch-soul-128k-mp3",
+      "name": "SomaFM Seven Inch Soul (128k MP3)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice5.somafm.com/7soul-128-mp3",
+      "homepage": "https://somafm.com/7soul/",
+      "country": "US",
+      "tags": [
+        "soul"
+      ],
+      "favicon": "https://somafm.com/img3/7soul-400.jpg",
+      "bitrate": 160,
+      "codec": "MP3",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-folk-forward-128k-mp3",
+      "name": "SomaFM Folk Forward (128k MP3)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice1.somafm.com/folkfwd-128-mp3",
+      "homepage": "https://somafm.com/folkfwd/",
+      "country": "US",
+      "tags": [
+        "alt-folk",
+        "indie folk",
+        "occasional folk classics"
+      ],
+      "favicon": "https://somafm.com/img3/folkfwd-400.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-folk-forward-128k-aac",
+      "name": "SomaFM Folk Forward (128k AAC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice5.somafm.com/folkfwd-128-aac",
+      "homepage": "https://somafm.com/folkfwd/",
+      "country": "US",
+      "tags": [
+        "alt-folk",
+        "indie folk",
+        "occasional folk classics"
+      ],
+      "favicon": "https://somafm.com/img3/folkfwd-400.jpg",
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-abiding-radio-instrumental",
+      "name": "Abiding Radio - Instrumental",
+      "broadcaster": "independent",
+      "streamUrl": "https://streams.abidingradio.com:7800/1",
+      "homepage": "https://www.abidingradio.com/",
+      "country": "US",
+      "tags": [
+        "christian"
+      ],
+      "favicon": "https://www.abidingradio.org/wp-content/uploads/2022/05/cropped-new_icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        30.76,
+        -86.57
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-paradise-main-mix-flac",
+      "name": "Radio Paradise Main Mix FLAC",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radioparadise.com/flac",
+      "homepage": "https://radioparadise.com/",
+      "country": "US",
+      "tags": [
+        "california",
+        "eclectic",
+        "free",
+        "internet",
+        "non-commercial",
+        "paradise"
+      ],
+      "favicon": "https://radioparadise.com/apple-touch-icon.png",
+      "bitrate": 1441,
+      "codec": "OGG",
+      "geo": [
+        40.7851,
+        -124.1839
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-dnb-edm",
+      "name": "DnB&EDM",
+      "broadcaster": "independent",
+      "streamUrl": "https://edmdnb.com:448/radio/8000/radio.mp3",
+      "homepage": "https://edmdnb.com/",
+      "country": "US",
+      "tags": [
+        "chillstep",
+        "dnb",
+        "drum & bass",
+        "drum and bass",
+        "dubstep",
+        "edm"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        51.2999,
+        10.1184
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-def-con-radio-128k-aac",
+      "name": "SomaFM DEF CON Radio (128k AAC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice6.somafm.com/defcon-128-aac",
+      "homepage": "https://somafm.com/defcon/",
+      "country": "US",
+      "tags": [
+        "ambient",
+        "chill",
+        "defcon",
+        "electronic",
+        "hacker",
+        "non-commercial"
+      ],
+      "favicon": "https://somafm.com/img3/defcon400.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-cnn-international-audio",
+      "name": "CNN International Audio",
+      "broadcaster": "independent",
+      "streamUrl": "https://tunein.cdnstream1.com/3519_96.aac",
+      "homepage": "https://www.cnn.com/",
+      "country": "US",
+      "tags": [
+        "news",
+        "tv audio",
+        "world news",
+        "world news channels"
+      ],
+      "favicon": "https://raw.githubusercontent.com/AusIPTV/IPTVLogos/master/CNN_International_Logo.png",
+      "bitrate": 98,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-fox-news",
+      "name": "Fox News",
+      "broadcaster": "independent",
+      "streamUrl": "https://247preview.foxnews.com/hls/live/2020027/fncv3preview/primary.m3u8",
+      "homepage": "https://superradio.cc/",
+      "country": "US",
+      "tags": [
+        "fox news",
+        "news",
+        "国家台",
+        "新闻",
+        "综合"
+      ],
+      "bitrate": 311,
+      "codec": "UNKNOWN",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-tu-94-9",
+      "name": "Tu 94.9",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc577",
+      "homepage": "https://tu949fm.iheart.com/",
+      "country": "US",
+      "tags": [
+        "spanish"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/5b3e27cde11698161e4ae966?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-underground-80s-256k-mp3",
+      "name": "SomaFM Underground 80s (256k MP3)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice6.somafm.com/u80s-256-mp3",
+      "homepage": "https://somafm.com/u80s/",
+      "country": "US",
+      "tags": [
+        "80s",
+        "new wave",
+        "uk synthpop"
+      ],
+      "favicon": "https://somafm.com/img3/u80s-400.png",
+      "bitrate": 256,
+      "codec": "MP3",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-new-york-live",
+      "name": "Radio New York Live",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.radiostreamlive.com/radionylive_devices",
+      "homepage": "http://www.radionylive.com/",
+      "country": "US",
+      "tags": [
+        "80s",
+        "90s",
+        "new york city",
+        "pop",
+        "rsl"
+      ],
+      "favicon": "https://cdn-elements.radiostreamlive.com/v1/images/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-paradise-world-etc-mix-320k-aac",
+      "name": "Radio Paradise World/Etc Mix 320k AAC",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radioparadise.com/world-etc-320",
+      "homepage": "https://radioparadise.com/",
+      "country": "US",
+      "tags": [
+        "california",
+        "eclectic",
+        "world music",
+        "free",
+        "internet",
+        "non-commercial"
+      ],
+      "favicon": "https://radioparadise.com/apple-touch-icon.png",
+      "bitrate": 320,
+      "codec": "AAC",
+      "geo": [
+        40.7851,
+        -124.1839
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-christian-rock-dot-net",
+      "name": "Christian Rock Dot Net",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.christianrock.net/stream/11/",
+      "homepage": "https://www.christianrock.net/",
+      "country": "US",
+      "tags": [
+        "christian",
+        "rock",
+        "christian rock",
+        "christianrock.net",
+        "crdn"
+      ],
+      "favicon": "https://www.christianrock.net/apple-touch-icon.png",
+      "bitrate": 120,
+      "codec": "AAC",
+      "geo": [
+        37.2116,
+        -93.2898
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-mega-96-3-los-angeles-96-3-fm-kxol-fm-spanish-br",
+      "name": "Mega 96.3 (Los Angeles) - 96.3 FM - KXOL-FM - Spanish Broadcasting System - Los Angeles, California",
+      "broadcaster": "independent",
+      "streamUrl": "https://liveaudio.lamusica.com/LA_KXOL_icy",
+      "homepage": "https://www.lamusica.com/stations/kxol",
+      "country": "US",
+      "tags": [
+        "96.3 fm",
+        "américa",
+        "california",
+        "entretenimiento",
+        "español",
+        "estación"
+      ],
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        34.0576,
+        -118.2469
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-groove-salad-classic-128k-mp3",
+      "name": "SomaFM Groove Salad Classic (128k MP3)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice2.somafm.com/gsclassic-128-mp3",
+      "homepage": "https://somafm.com/groovesalad/",
+      "country": "US",
+      "tags": [
+        "ambient",
+        "downtempo",
+        "early 2000s"
+      ],
+      "favicon": "https://somafm.com/img3/gsclassic400.jpg",
+      "bitrate": 160,
+      "codec": "MP3",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-groove-salad-hls-flac",
+      "name": "SomaFM Groove Salad (HLS FLAC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://hls.somafm.com/hls/groovesalad/FLAC/program.m3u8",
+      "homepage": "https://somafm.com/groovesalad/",
+      "country": "US",
+      "tags": [
+        "ambient",
+        "chillout",
+        "downtempo",
+        "groove",
+        "lounge",
+        "sleep"
+      ],
+      "favicon": "https://somafm.com/img3/groovesalad-400.jpg",
+      "codec": "MP4",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-disco-studio-54",
+      "name": "Disco Studio 54",
+      "broadcaster": "independent",
+      "streamUrl": "https://maiban00.radioca.st/stream",
+      "homepage": "https://discostudio54.com/",
+      "country": "US",
+      "tags": [
+        "disco"
+      ],
+      "favicon": "https://discostudio54.com/favicon.ico",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-red-state-talk-radio-encore",
+      "name": "Red State Talk Radio Encore",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.radio.co/sf03a6a4b2/listen",
+      "homepage": "http://redstatetalkradio.com/",
+      "country": "US",
+      "tags": [
+        "conservative talk",
+        "libertarian"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-cbs-news",
+      "name": "CBS News",
+      "broadcaster": "independent",
+      "streamUrl": "https://cbsn-us.cbsnstream.cbsnews.com/out/v1/55a8648e8f134e82a470f83d562deeca/master.m3u8",
+      "homepage": "https://superradio.cc/",
+      "country": "US",
+      "tags": [
+        "cbs",
+        "news",
+        "国家台",
+        "新闻",
+        "综合"
+      ],
+      "bitrate": 273,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-rock-on",
+      "name": "Radio Rock On",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.radiostreamlive.com/radiorockon_devices",
+      "homepage": "http://www.radiorockon.com/",
+      "country": "US",
+      "tags": [
+        "classic rock",
+        "los angeles",
+        "rsl"
+      ],
+      "favicon": "https://cdn-elements.radiostreamlive.com/v1/images/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-soma-fm-groove-salad-320k-aac-hls",
+      "name": "Soma FM Groove Salad 320K AAC HLS",
+      "broadcaster": "independent",
+      "streamUrl": "https://hls.somafm.com/hls/groovesalad/320k/program.m3u8",
+      "homepage": "https://www.somafm.com/",
+      "country": "US",
+      "tags": [
+        "groove",
+        "hls",
+        "somafm"
+      ],
+      "favicon": "https://somafm.com/img3/groovesalad-400.png",
+      "bitrate": 320000,
+      "codec": "MP4",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-wskq-mega-97-9",
+      "name": "WSKQ Mega 97.9",
+      "broadcaster": "independent",
+      "streamUrl": "https://liveaudio.lamusica.com/NY_WSKQ_icy?listenerid=94d1ac3bf877b65e4e17cd7e9bfec132&awparams=companionAds%3Atrue&aw_0_1st.version=1.1.12%3Ahtml5&aw_0_1st.playerid=lamusica.web.mobile&aw_0_1st.skey=1690194521&sw_bp=1",
+      "homepage": "https://www.lamusica.com/stations/wskq",
+      "country": "US",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-chill-lounge-florida-usa-128k-mp3",
+      "name": "Chill Lounge Florida (USA) 128k mp3",
+      "broadcaster": "independent",
+      "streamUrl": "https://vip2.fastcast4u.com/proxy/chillfla?mp=/1",
+      "homepage": "https://vip2.fastcast4u.com/proxy/chillfla?mp=/1",
+      "country": "US",
+      "tags": [
+        "ambient",
+        "chill",
+        "chillout",
+        "lounge"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-begoodradio-com-80s-metal",
+      "name": "Begoodradio.com 80s metal",
+      "broadcaster": "independent",
+      "streamUrl": "https://bigrradio.cdnstream1.com/5212_128",
+      "homepage": "http://begoodradio.com/",
+      "country": "US",
+      "tags": [
+        "metal",
+        "rock"
+      ],
+      "favicon": "http://begoodradio.com/images/logo.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-24-7-comedy",
+      "name": "24/7 Comedy",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc4902",
+      "homepage": "https://www.iheart.com/live/247-comedy-4902/",
+      "country": "US",
+      "tags": [
+        "comedy",
+        "talk"
+      ],
+      "favicon": "https://www.iheart.com/favicon.ico",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-dub-step-beyond-128k-mp3",
+      "name": "SomaFM Dub Step Beyond (128k MP3)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice2.somafm.com/dubstep-128-mp3",
+      "homepage": "https://somafm.com/dubstep/",
+      "country": "US",
+      "tags": [
+        "deep bass",
+        "dub",
+        "dubstep"
+      ],
+      "favicon": "https://somafm.com/img3/dubstep-400.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-frisky-radio",
+      "name": "Frisky Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.frisky.friskyradio.com/mp3_low",
+      "homepage": "https://www.friskyradio.com/",
+      "country": "US",
+      "favicon": "https://s3.amazonaws.com/media.friskyradio.com/favicon.png",
+      "bitrate": 96,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-werave-music-radio-01-dark-and-underground",
+      "name": "WeRave Music Radio 01 - Dark and Underground",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.zeno.fm/pjktyby8dn5tv",
+      "homepage": "https://werave.com.br/en",
+      "country": "US",
+      "tags": [
+        "dance",
+        "deep house",
+        "electro",
+        "electronica",
+        "house",
+        "iconyc"
+      ],
+      "favicon": "https://werave.com.br/wp-content/uploads/cropped-weravemusic-180x180.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-fox-sports-1260",
+      "name": "Fox Sports 1260",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc905",
+      "homepage": "https://foxsports1260.iheart.com/",
+      "country": "US",
+      "tags": [
+        "sports"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/5d262bd52a4b03e3a623f6a5?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-paradise-mellow-mix-64k-aac",
+      "name": "Radio Paradise Mellow Mix 64k AAC",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radioparadise.com/mellow-64",
+      "homepage": "https://radioparadise.com/",
+      "country": "US",
+      "tags": [
+        "california",
+        "alternative",
+        "eclectic",
+        "mellow",
+        "free",
+        "internet"
+      ],
+      "favicon": "https://radioparadise.com/apple-touch-icon.png",
+      "bitrate": 64,
+      "codec": "AAC",
+      "geo": [
+        40.7851,
+        -124.1839
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-104-9-max-country",
+      "name": "104.9 Max Country",
+      "broadcaster": "independent",
+      "streamUrl": "https://ais-sa1.streamon.fm/7246_48k.aac",
+      "homepage": "https://1049maxcountry.com/",
+      "country": "US",
+      "tags": [
+        "country"
+      ],
+      "favicon": "https://media.ruralradio.co/nrr/uploads/sites/12/2021/02/cropped-ktmx-2-180x180.png",
+      "bitrate": 48,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-soul-radio-classics",
+      "name": "SOUL RADIO Classics",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.soulradio.us/us",
+      "homepage": "https://soulradio.us/",
+      "country": "US",
+      "tags": [
+        "classic soul",
+        "soul"
+      ],
+      "bitrate": 192,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-your-classical-chamber-music",
+      "name": "Your Classical Chamber Music",
+      "broadcaster": "independent",
+      "streamUrl": "https://chambermusic.stream.publicradio.org/chambermusic.mp3",
+      "homepage": "https://www.yourclassical.org/",
+      "country": "US",
+      "tags": [
+        "chamber music",
+        "classical"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-the-blaze-radio",
+      "name": "The Blaze radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/BLZE_1.mp3",
+      "homepage": "http://theblaze.com/",
+      "country": "US",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-bloomberg-radio-boston",
+      "name": "Bloomberg Radio Boston",
+      "broadcaster": "independent",
+      "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/WRCAAMAAC.aac",
+      "homepage": "https://www.bloombergradio.com/",
+      "country": "US",
+      "tags": [
+        "talk"
+      ],
+      "favicon": "https://www.bloombergradio.com/content/plugins/bloomberg-favicon/dist/img/amber-120x120.png",
+      "bitrate": 112,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-chicago-house",
+      "name": "CHICAGO HOUSE",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radio.co/sae989fe39/listen",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "US",
+      "tags": [
+        "electronic"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-conyers-old-time-radio",
+      "name": "Conyers Old Time Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s8.yesstreaming.net:17011/stream",
+      "homepage": "http://www.conyersradio.net/",
+      "country": "US",
+      "tags": [
+        "christmas",
+        "d-day",
+        "halloween",
+        "old time radio",
+        "radio drama"
+      ],
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-illinois-street-lounge-128k-mp3",
+      "name": "SomaFM Illinois Street Lounge (128k MP3)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice4.somafm.com/illstreet-128-mp3",
+      "homepage": "https://somafm.com/illstreet/",
+      "country": "US",
+      "tags": [
+        "bachelor",
+        "lounge"
+      ],
+      "favicon": "https://somafm.com/img3/illstreet-400.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-vaporwaves-128k-aac",
+      "name": "SomaFM Vaporwaves (128k AAC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice6.somafm.com/vaporwaves-128-aac",
+      "homepage": "https://somafm.com/vaporwaves/",
+      "country": "US",
+      "tags": [
+        "vaporwave"
+      ],
+      "favicon": "https://somafm.com/img3/vaporwaves400.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-boot-liquor-128k-aac",
+      "name": "SomaFM Boot Liquor (128k AAC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice1.somafm.com/bootliquor-128-aac",
+      "homepage": "https://somafm.com/bootliquor/",
+      "country": "US",
+      "tags": [
+        "americana",
+        "country"
+      ],
+      "favicon": "https://somafm.com/img3/bootliquor-400.jpg",
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-104-5-latino-hits",
+      "name": "104.5 Latino Hits",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc4051",
+      "homepage": "https://1045latinohits.iheart.com/",
+      "country": "US",
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/5956ab6d089c9f13b01e4cc4?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-american-tamil-radio",
+      "name": "American Tamil Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://cp11.serverse.com/proxy/hgsmgluv?mp=/stream",
+      "homepage": "https://americantamilradio.com/",
+      "country": "US",
+      "tags": [
+        "tamil cinema music"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-cliqhop-idm-128k-mp3",
+      "name": "SomaFM CliqHop IDM (128k MP3)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice2.somafm.com/cliqhop-128-mp3",
+      "homepage": "https://somafm.com/cliqhop/",
+      "country": "US",
+      "tags": [
+        "idm"
+      ],
+      "favicon": "https://somafm.com/img3/cliqhop-400.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-la-mega-105-7",
+      "name": "La Mega 105.7",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice41.securenetsystems.net/WEMG",
+      "homepage": "https://www.lamega1057.com/",
+      "country": "US",
+      "tags": [
+        "spanish"
+      ],
+      "bitrate": 32,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-mission-control-128k-mp3",
+      "name": "SomaFM Mission Control (128k MP3)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice4.somafm.com/missioncontrol-128-mp3",
+      "homepage": "https://somafm.com/missioncontrol/",
+      "country": "US",
+      "tags": [
+        "ambient",
+        "experimental",
+        "sounds",
+        "space program"
+      ],
+      "favicon": "https://somafm.com/img3/missioncontrol-400.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-wosu-89-7-npr-news",
+      "name": "WOSU 89.7 NPR News",
+      "broadcaster": "independent",
+      "streamUrl": "https://wosu.streamguys1.com/NPR_128",
+      "homepage": "https://wosu.org/",
+      "country": "US",
+      "tags": [
+        "public radio"
+      ],
+      "favicon": "https://wosu.org/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-christmas-lounge-256k",
+      "name": "SomaFM Christmas Lounge 256k",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice2.somafm.com/christmas-256-mp3",
+      "homepage": "https://somafm.com/christmas/",
+      "country": "US",
+      "tags": [
+        "chillout",
+        "christmas"
+      ],
+      "favicon": "https://somafm.com/img3/christmas-400.jpg",
+      "bitrate": 256,
+      "codec": "MP3",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-paradise-world-etc-mix-flac",
+      "name": "Radio Paradise World/Etc Mix FLAC",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radioparadise.com/world-etc-flac",
+      "homepage": "https://radioparadise.com/",
+      "country": "US",
+      "tags": [
+        "california",
+        "eclectic",
+        "world music",
+        "free",
+        "internet",
+        "non-commercial"
+      ],
+      "favicon": "https://radioparadise.com/apple-touch-icon.png",
+      "bitrate": 1441,
+      "codec": "OGG",
+      "geo": [
+        40.7851,
+        -124.1839
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-2000-s-country-music-radio",
+      "name": "2000's Country Music Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://2.mystreaming.net/uber/cmr00scountry/icecast.audio",
+      "homepage": "https://mytuner-radio.com/radio/country-music-radio-00s-country-487904/",
+      "country": "US",
+      "favicon": "https://static2.mytuner.mobi/media/tvos_radios/904/country-music-radio-00s-country.5f83bb9f.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-free-texas",
+      "name": "Radio Free Texas",
+      "broadcaster": "independent",
+      "streamUrl": "https://server10.reliastream.com/proxy/damiller?mp=/stream",
+      "homepage": "https://radiofreetexas.com/",
+      "country": "US",
+      "tags": [
+        "americana",
+        "country"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-erotica-lounge",
+      "name": "EROTICA LOUNGE",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.zeno.fm/89asra0sfa0uv",
+      "homepage": "https://tunein.com/radio/EROTICA-LOUNGE-s260655/",
+      "country": "US",
+      "tags": [
+        "ambient",
+        "chillout",
+        "chillout+lounge",
+        "jazz fusion",
+        "nu jazz"
+      ],
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-sonic-universe-128k-aac",
+      "name": "SomaFM Sonic Universe (128k AAC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice2.somafm.com/sonicuniverse-128-aac",
+      "homepage": "https://somafm.com/sonicuniverse/",
+      "country": "US",
+      "tags": [
+        "avant-garde",
+        "eclectic",
+        "jazz"
+      ],
+      "favicon": "https://somafm.com/img3/sonicuniverse-400.jpg",
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-non-stop-oldies",
+      "name": "Non-Stop Oldies",
+      "broadcaster": "independent",
+      "streamUrl": "https://ais-sa2.cdnstream1.com/2383_128.mp3",
+      "homepage": "http://www.nonstopoldies.com/",
+      "country": "US",
+      "tags": [
+        "70's",
+        "decades",
+        "motown",
+        "oldies",
+        "oldies 50's/60's",
+        "soul & great rock n' roll"
+      ],
+      "favicon": "https://static.wixstatic.com/media/00a61a_a29da417d9ce44d18dc83e35a30c2f43.png/v1/crop/x_24,y_30,w_555,h_544/fill/w_136,h_133,al_c,q_85,usm_0.66_1.00_0.01,enc_auto/00a61a_a29da417d9ce44d18dc83e35a30c2f43.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-whisperings-solo-piano-radio",
+      "name": "Whisperings Solo Piano Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://pianosolo.streamguys1.com/live",
+      "homepage": "http://www.solopianoradio.com/",
+      "country": "US",
+      "tags": [
+        "classical",
+        "piano"
+      ],
+      "bitrate": 96,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-soma-fm-groove-salad-320k-aac-hls-surround",
+      "name": "Soma FM Groove Salad 320K AAC HLS Surround",
+      "broadcaster": "independent",
+      "streamUrl": "https://hls.somafm.com/hls//gs-surround/program.m3u8",
+      "homepage": "https://www.somafm.com/",
+      "country": "US",
+      "tags": [
+        "groove"
+      ],
+      "favicon": "https://www.somafm.com/apple-touch-icon.png",
+      "bitrate": 326,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-classic-hits-radio",
+      "name": "CLASSIC HITS RADIO",
+      "broadcaster": "independent",
+      "streamUrl": "https://classichitsradio.streamingmedia.it/usa",
+      "homepage": "https://classichits.radio/",
+      "country": "US",
+      "tags": [
+        "1970s",
+        "1980s",
+        "1990s",
+        "70's",
+        "70s",
+        "80's"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-cbs-sports-radio-105-3",
+      "name": "CBS Sports Radio 105.3",
+      "broadcaster": "independent",
+      "streamUrl": "https://crystalout.surfernetwork.com:8001/KINB-FM_MP3",
+      "homepage": "https://www.cbssportsradio1053.com/",
+      "country": "US",
+      "tags": [
+        "sports"
+      ],
+      "favicon": "https://www.cbssportsradio1053.com/favicon.ico",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-italo-disco",
+      "name": "Radio Italo Disco",
+      "broadcaster": "independent",
+      "streamUrl": "https://broadcast.miami/proxy/italodisco?mp=/stream/;",
+      "homepage": "https://www.radio-italodisco.com/",
+      "country": "US",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-sfliny-dance-music",
+      "name": "Sfliny Dance Music",
+      "broadcaster": "independent",
+      "streamUrl": "https://ec4.yesstreaming.net:3780/",
+      "homepage": "https://www.sfliny.com/",
+      "country": "US",
+      "tags": [
+        "club",
+        "dance",
+        "dance pop",
+        "gay",
+        "hi energy"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-smooth-jazz",
+      "name": "Smooth Jazz",
+      "broadcaster": "independent",
+      "streamUrl": "https://smoothjazz.cdnstream1.com/2585_320.mp3",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "US",
+      "tags": [
+        "classical"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-kusc-91-5-los-angeles-ca-96kbps-aac",
+      "name": "KUSC 91.5 Los Angeles, CA (96kbps AAC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://16603.live.streamtheworld.com/KUSCAAC96_SC",
+      "homepage": "http://www.kusc.org/",
+      "country": "US",
+      "tags": [
+        "classical",
+        "los angeles",
+        "public radio"
+      ],
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/e/e2/KUSC_Logo.jpg",
+      "bitrate": 96,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-free-fm-new-york",
+      "name": "Free FM New York",
+      "broadcaster": "independent",
+      "streamUrl": "https://rocafmadrid.radioca.st/",
+      "homepage": "http://freefmradio.net/",
+      "country": "US",
+      "tags": [
+        "#90s",
+        "#free",
+        "#freefm",
+        "#pop",
+        "80s",
+        "90s"
+      ],
+      "favicon": "https://3.bp.blogspot.com/-BTWauI1ML7o/XZOklz5WuRI/AAAAAAAAAeA/R8qBxhme8UEELRogqYOhtWG4p0BVhiwVgCK4BGAYYCw/s752/free%2Bancho.jpg",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        40.3722,
+        -74.2456
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-beat-blender-128k-aac",
+      "name": "SomaFM Beat Blender (128k AAC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice6.somafm.com/beatblender-128-aac",
+      "homepage": "https://somafm.com/beatblender/",
+      "country": "US",
+      "tags": [
+        "chillout",
+        "deep house",
+        "downtempo",
+        "electronica"
+      ],
+      "favicon": "https://somafm.com/img3/beatblender-400.jpg",
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-106-1-kiss-fm-seattle",
+      "name": "106.1 KISS FM Seattle",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc4257",
+      "homepage": "https://kissfmseattle.iheart.com/",
+      "country": "US",
+      "tags": [
+        "pop",
+        "top 40"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/5f3e24545eacd47f0c407f1b?ops=gravity(%22center%22),contain(32,32),quality(65)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-vision-cristiana-internacional",
+      "name": "Radio Visión Cristiana Internacional",
+      "broadcaster": "independent",
+      "streamUrl": "https://livestreamcdn.net:2000/stream/RadioVisionCristianaRadio/",
+      "homepage": "https://www.radiovision.net/",
+      "country": "US",
+      "tags": [
+        "christian",
+        "cristiana",
+        "gospel"
+      ],
+      "favicon": "https://static.wixstatic.com/media/6ddfc3_fba02465eaf5460d8452b49c8a599888%7emv2.png/v1/fill/w_180%2ch_180%2clg_1%2cusm_0.66_1.00_0.01/6ddfc3_fba02465eaf5460d8452b49c8a599888%7emv2.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-90-5-wesa",
+      "name": "90.5 WESA",
+      "broadcaster": "independent",
+      "streamUrl": "https://ais-sa3.cdnstream1.com/2556_128.mp3",
+      "homepage": "https://wesa.fm/",
+      "country": "US",
+      "favicon": "https://wesa.fm/apple-touch-icon.png",
+      "bitrate": 56,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-kpbs",
+      "name": "KPBS",
+      "broadcaster": "independent",
+      "streamUrl": "https://kpbs.streamguys1.com/kpbs-mp3",
+      "homepage": "https://www.kpbs.org/",
+      "country": "US",
+      "tags": [
+        "public radio"
+      ],
+      "favicon": "https://www.kpbs.org/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-the-disco-planet",
+      "name": "The Disco Planet",
+      "broadcaster": "independent",
+      "streamUrl": "https://broadcast.miami/proxy/thediscoplanet?mp=/stream/;",
+      "homepage": "https://www.thediscoplanet.com/",
+      "country": "US",
+      "tags": [
+        "disco"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-free-fm-80s-san-francisco",
+      "name": "Free FM 80s San Francisco",
+      "broadcaster": "independent",
+      "streamUrl": "https://freefm80.radioca.st/",
+      "homepage": "http://www.freefmworld.com/",
+      "country": "US",
+      "tags": [
+        "#80",
+        "#80s",
+        "80s"
+      ],
+      "favicon": "https://lh5.googleusercontent.com/h_uHjSxZZ4iir8iw8zBcv84t38DX33BPd0x1cG0RKw1wbWAwGwImnUhtfFepUDc_T_SLbuAdiLOSaageDeGoOnKyAEQxzPY9cH2neNhvxjIFAvnbzjs3E_zrw0xasWgj=w1280",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-outlaw-country-radio",
+      "name": "Outlaw Country Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://usa17.fastcast4u.com/proxy/kievradio?mp=/1",
+      "homepage": "https://www.outlaw.fm/",
+      "country": "US",
+      "favicon": "https://fastcast4u.com/player/kievradio/_user/cover/k/kievradio/ch0_permanent.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-cbn-classic-christian-radio",
+      "name": "CBN Classic Christian Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streams.cbnradio.com/Classic-Christian-128K?app=cbnplayer",
+      "homepage": "https://www1.cbn.com/radio/classicchristian",
+      "country": "US",
+      "tags": [
+        "70s",
+        "80s",
+        "90s",
+        "christian",
+        "christian contemporary",
+        "classic"
+      ],
+      "favicon": "https://www1.cbn.com//sites/all/themes/cbn_default/images/favicons/mstile-144x144.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-hot-93-5-old-school",
+      "name": "HOT 93.5 Old School",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc6841",
+      "homepage": "https://hotelpaso.iheart.com/",
+      "country": "US",
+      "tags": [
+        "hip hop"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/1f67e399b15c874f81d7a053b849ae5e?ops=gravity(%22center%22),contain(32,32),quality(65)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-christian-hard-rock-dot-net",
+      "name": "Christian Hard Rock Dot Net",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.christianrock.net/stream/15/",
+      "homepage": "https://www.christianhardrock.net/",
+      "country": "US",
+      "tags": [
+        "christian",
+        "hard rock",
+        "christian hard rock",
+        "christianhardrock.net",
+        "chrdn"
+      ],
+      "favicon": "https://www.christianhardrock.net/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        37.2116,
+        -93.2898
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-motown",
+      "name": "Radio Motown",
+      "broadcaster": "independent",
+      "streamUrl": "https://broadcast.miami/proxy/motown?mp=/stream/;",
+      "homepage": "https://www.radio-motown.com/",
+      "country": "US",
+      "tags": [
+        "disco",
+        "funk",
+        "soul"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        25.7832,
+        -80.2814
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-all-classical-portland",
+      "name": "All Classical Portland",
+      "broadcaster": "independent",
+      "streamUrl": "https://allclassical.streamguys1.com/ac96k",
+      "homepage": "https://www.allclassical.org/",
+      "country": "US",
+      "tags": [
+        "classical",
+        "portland"
+      ],
+      "favicon": "https://www.allclassical.org/wp-content/themes/acp-theme/img/acp_logo_600x600.jpg",
+      "bitrate": 96,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-folk-music-notebook",
+      "name": "Folk Music Notebook",
+      "broadcaster": "independent",
+      "streamUrl": "https://s3.radio.co/s0b5d4adb5/listen",
+      "homepage": "https://folkmusicnotebook.com/",
+      "country": "US",
+      "tags": [
+        "folk"
+      ],
+      "favicon": "https://img1.wsimg.com/isteam/ip/33ac2230-3451-4ad7-8894-0d3a839af97f/favicon/ed9ab985-710c-4588-afef-f6388e1a738a.png/:/rs=w:64,h:64,m",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-hd-radio-the-blues",
+      "name": "HD Radio - The Blues",
+      "broadcaster": "independent",
+      "streamUrl": "https://haradioblues-rfritschka.radioca.st/",
+      "homepage": "http://www.hd-radio.net/",
+      "country": "US",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-news-talk-560-klvi",
+      "name": "News Talk 560 KLVI",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc2197",
+      "homepage": "https://klvi.iheart.com/",
+      "country": "US",
+      "tags": [
+        "news",
+        "talk"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-wqxr-105-9-fm",
+      "name": "WQXR 105.9 FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.wqxr.org/wqxr-web?nyprBrowserId=32c67956bf1d5600",
+      "homepage": "https://www.wqxr.org/",
+      "country": "US",
+      "tags": [
+        "classical",
+        "new york city",
+        "new york public radio"
+      ],
+      "favicon": "https://media.wnyc.org/i/500/500/c/80/1/wqxr_1_1.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        40.7267,
+        -74.0053
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-wbgo-jazz-88-3-fm",
+      "name": "WBGO Jazz 88.3 FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://ais-sa8.cdnstream1.com/3629_128.mp3",
+      "homepage": "https://www.wbgo.org/",
+      "country": "US",
+      "tags": [
+        "jazz"
+      ],
+      "favicon": "https://npr.brightspotcdn.com/dims4/default/76ee71f/2147483647/strip/true/crop/200x100+0+0/resize/400x200!/format/webp/quality/90/?url=http%3A%2F%2Fnpr-brightspot.s3.amazonaws.com%2Fa7%2F2f%2Fbfa4b00449099118e45fefe81fe8%2Fwbgo-logo-200x100.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-100-3-kiss-fm",
+      "name": "100.3 KISS FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc1629",
+      "homepage": "https://1003kissfm.iheart.com/",
+      "country": "US",
+      "tags": [
+        "pop",
+        "top 40"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/603e5a2a4bb413272bf15fca?ops=gravity(%22center%22),contain(32,32),quality(65)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-poptron-128k-aac",
+      "name": "SomaFM PopTron (128k AAC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice5.somafm.com/poptron-128-aac",
+      "homepage": "https://somafm.com/poptron/",
+      "country": "US",
+      "tags": [
+        "electropop",
+        "indie",
+        "synthpop"
+      ],
+      "favicon": "https://somafm.com/img3/poptron-400.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-thistleradio-128k-aac",
+      "name": "SomaFM ThistleRadio (128k AAC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice6.somafm.com/thistle-128-aac",
+      "homepage": "https://somafm.com/thistle/",
+      "country": "US",
+      "tags": [
+        "celtic",
+        "folk"
+      ],
+      "favicon": "https://somafm.com/img3/thistle-400.jpg",
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-classical-kusc-mp3-256",
+      "name": "Classical KUSC MP3 256",
+      "broadcaster": "independent",
+      "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/KUSCMP256.mp3",
+      "homepage": "https://www.kusc.org/",
+      "country": "US",
+      "tags": [
+        "classical",
+        "classical california",
+        "los angeles"
+      ],
+      "favicon": "https://www.kusc.org/icons/kusc/apple-touch-icon-120x120.png",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-cliqhop-idm-256k-mp3",
+      "name": "SomaFM CliqHop IDM (256k MP3)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice6.somafm.com/cliqhop-256-mp3",
+      "homepage": "https://somafm.com/cliqhop/",
+      "country": "US",
+      "tags": [
+        "idm"
+      ],
+      "favicon": "https://somafm.com/img3/cliqhop-400.jpg",
+      "bitrate": 256,
+      "codec": "MP3",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-smooth-jazz-florida",
+      "name": "Smooth Jazz Florida",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.live365.com/a57422",
+      "homepage": "https://smoothjazzflorida.com/",
+      "country": "US",
+      "tags": [
+        "smooth jazz"
+      ],
+      "favicon": "https://img1.wsimg.com/isteam/ip/93edd3ac-b031-446a-99c8-fe88e7f00e40/smooth%20jazz%20logo%2012-20-2013%201400X1400%20(20-0002.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-smooth-jazz-global-radio",
+      "name": "Smooth Jazz Global Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://smoothjazz.cdnstream1.com/2585_256.mp3",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "US",
+      "tags": [
+        "jazz"
+      ],
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-gotradio-soft-rock-cafe",
+      "name": "GotRadio - Soft Rock Café",
+      "broadcaster": "independent",
+      "streamUrl": "https://pureplay.cdnstream1.com/6010_64.aac/playlist.m3u8",
+      "homepage": "https://gotradio.com/music/",
+      "country": "US",
+      "tags": [
+        "classic rock",
+        "soft rock"
+      ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/6/10096.v3.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-dub-step-beyond-256k-mp3",
+      "name": "SomaFM Dub Step Beyond (256k MP3)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice6.somafm.com/dubstep-256-mp3",
+      "homepage": "https://somafm.com/dubstep/",
+      "country": "US",
+      "tags": [
+        "deep bass",
+        "dub",
+        "dubstep"
+      ],
+      "favicon": "https://somafm.com/img3/dubstep-400.jpg",
+      "bitrate": 256,
+      "codec": "MP3",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-abiding-radio-bluegrass-hymns",
+      "name": "Abiding Radio - Bluegrass Hymns",
+      "broadcaster": "independent",
+      "streamUrl": "https://streams.abidingradio.com:7840/1",
+      "homepage": "https://www.abidingradio.com/",
+      "country": "US",
+      "tags": [
+        "christian"
+      ],
+      "favicon": "https://www.abidingradio.org/wp-content/uploads/2022/05/cropped-new_icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        30.76,
+        -86.57
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-country-gospel-radio",
+      "name": "Country Gospel Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://usa18.fastcast4u.com/proxy/loudcrymedia1?mp=/1",
+      "homepage": "https://fastcast4u.com/player/loudcrymedia1-tqqumpgu/",
+      "country": "US",
+      "favicon": "https://mytuner.global.ssl.fastly.net/media/tvos_radios/xfme9rznysxa.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-vaporwaves-128k-mp3",
+      "name": "SomaFM Vaporwaves (128k MP3)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice5.somafm.com/vaporwaves-128-mp3",
+      "homepage": "https://somafm.com/vaporwaves/",
+      "country": "US",
+      "tags": [
+        "vaporwave"
+      ],
+      "favicon": "https://somafm.com/img3/vaporwaves400.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-your-classical-favorites",
+      "name": "Your Classical - Favorites",
+      "broadcaster": "independent",
+      "streamUrl": "https://favorites.stream.publicradio.org/favorites.mp3",
+      "homepage": "https://www.yourclassical.org/",
+      "country": "US",
+      "tags": [
+        "classical"
+      ],
+      "favicon": "https://www.yourclassical.org/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-ambient-fm",
+      "name": "ambient.fm",
+      "broadcaster": "independent",
+      "streamUrl": "https://ambient.fm/live/",
+      "homepage": "https://ambient.fm/",
+      "country": "US",
+      "tags": [
+        "ambient",
+        "ambient and relaxation music",
+        "ambient easy listening",
+        "ambient lounge",
+        "ambient techno",
+        "deep ambient"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        38.0717,
+        -117.2316
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-hip-hop-workout-radio",
+      "name": " Hip Hop Workout Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc7785",
+      "homepage": "https://stream.revma/",
+      "country": "US",
+      "favicon": "https://zeno.fm/_ipx/q_100&fit_cover&s_160x160/https://images.zeno.fm/wwYkKshlr8K1X3i0JLV-I51b8dt3bzZXTKlYyMf6F-o/rs:fill:256:256/g:ce:0:0/aHR0cHM6Ly9wcm94eS56ZW5vLmZtL2NvbnRlbnQvc3RhdGlvbnMvYWd4emZucGxibTh0YzNSaGRITnlNZ3NTQ2tGMWRHaERiR2xsYm5RWWdJQ1E5SWJRdHdzTUN4SU9VM1JoZEdsdmJsQnliMlpwYkdVWWdJRFFvNFM2aWdvTW9nRUVlbVZ1YncvaW1hZ2UvP3U9MTY2MTM3NDkxOTAwMA.webp",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-kora-98-3-the-texas-country-original",
+      "name": "KORA 98.3 The Texas Country Original",
+      "broadcaster": "independent",
+      "streamUrl": "https://ais-sa1.streamon.fm/7410_48k.aac/playlist.m3u8?aw_0_1st.playerid=esPlayer&aw_0_1st.skey=1562173335",
+      "homepage": "https://www.983korafm.com/",
+      "country": "US",
+      "tags": [
+        "americana",
+        "country",
+        "red dirt",
+        "texas",
+        "texas country"
+      ],
+      "favicon": "https://dehayf5mhw1h7.cloudfront.net/wp-content/uploads/sites/218/2014/10/31194420/KORA-CLASSIC-HD2-Transparent.png",
+      "bitrate": 48,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-never-ending-radio-show",
+      "name": "Never Ending Radio Show",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.live365.com/a81246",
+      "homepage": "https://neverendingradioshow.com/",
+      "country": "US",
+      "tags": [
+        "timeless music",
+        "timeless principles"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        28.934,
+        -82.5409
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-classic-rock-florida",
+      "name": "Classic Rock Florida",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.live365.com/a06375",
+      "homepage": "https://classicrockflorida.com/",
+      "country": "US",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-kirn-670-am",
+      "name": "KIRN 670 AM",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.zeno.fm/0bybax2r3heuv",
+      "homepage": "https://www.670amkirn.com/",
+      "country": "US",
+      "tags": [
+        "ethnic"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-underground-80s-32k-aac",
+      "name": "SomaFM Underground 80s (32k AAC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice2.somafm.com/u80s-32-aac",
+      "homepage": "https://somafm.com/u80s/",
+      "country": "US",
+      "tags": [
+        "80s",
+        "new wave",
+        "uk synthpop"
+      ],
+      "favicon": "https://somafm.com/img3/u80s-400.png",
+      "bitrate": 32,
+      "codec": "AAC",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-90-s-country-music-radio",
+      "name": "90's Country Music Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://2.mystreaming.net/uber/cmr90scountry/icecast.audio",
+      "homepage": "https://mytuner-radio.com/radio/country-music-radio-90s-country-487905/",
+      "country": "US",
+      "favicon": "https://static2.mytuner.mobi/media/tvos_radios/905/country-music-radio-90s-country.5f83bb9f.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-deep-space-one-64k-aac",
+      "name": "SomaFM Deep Space One (64k AAC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice2.somafm.com/deepspaceone-64-aac",
+      "homepage": "https://somafm.com/deepspaceone/",
+      "country": "US",
+      "tags": [
+        "ambient",
+        "electronic",
+        "space"
+      ],
+      "favicon": "http://somafm.com/img3/deepspaceone-400.jpg",
+      "bitrate": 64,
+      "codec": "AAC",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-wls-94-7-fm-chicago-il",
+      "name": "WLS 94.7-FM Chicago, IL",
+      "broadcaster": "independent",
+      "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/WLSFM.mp3",
+      "homepage": "http://www.947wls.com/",
+      "country": "US",
+      "tags": [
+        "classic hits"
+      ],
+      "bitrate": 80,
+      "codec": "MP3",
+      "geo": [
+        41.8789,
+        -87.6359
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-classical-king-fm-evergreen-channel",
+      "name": "Classical King FM - Evergreen Channel",
+      "broadcaster": "independent",
+      "streamUrl": "https://classicalking.streamguys1.com/evergreen-aac-128k",
+      "homepage": "https://www.king.org/",
+      "country": "US",
+      "tags": [
+        "classical",
+        "classical music"
+      ],
+      "favicon": "https://dehayf5mhw1h7.cloudfront.net/wp-content/uploads/sites/1108/2019/05/15152826/cropped-favico-192x192.png",
+      "bitrate": 128,
+      "codec": "AAC+",
+      "geo": [
+        47.6241,
+        -122.3494
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-love-radio-only-love-songs-70s80s90s",
+      "name": "LOVE RADIO Only Love Songs 70s80s90s",
+      "broadcaster": "independent",
+      "streamUrl": "https://loveradio.streamingmedia.it/usa",
+      "homepage": "https://love.radio/",
+      "country": "US",
+      "tags": [
+        "love",
+        "love songs",
+        "lovesongs",
+        "romantic"
+      ],
+      "bitrate": 192,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-lush-128k-aac",
+      "name": "SomaFM Lush (128k AAC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice5.somafm.com/lush-128-aac",
+      "homepage": "https://somafm.com/lush/",
+      "country": "US",
+      "tags": [
+        "electronic",
+        "femalevocals",
+        "lounge",
+        "mellow",
+        "vocal"
+      ],
+      "favicon": "https://somafm.com/img3/lush-400.jpg",
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-classic-hits-109",
+      "name": "Classic Hits 109",
+      "broadcaster": "independent",
+      "streamUrl": "https://broadcast.classichits109.com/70s-90s",
+      "homepage": "https://www.classichits109.com/",
+      "country": "US",
+      "tags": [
+        "70s",
+        "80s",
+        "90s",
+        "classic hits",
+        "disco",
+        "pop"
+      ],
+      "favicon": "https://cdn-profiles.tunein.com/s297004/images/logog.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-vpr-vermont-public-radio-relay-bbc",
+      "name": "VPR(Vermont Public Radio) relay BBC",
+      "broadcaster": "independent",
+      "streamUrl": "https://vprbbc.streamguys1.com/vprbbc24.mp3",
+      "homepage": "https://www.vpr.org/",
+      "country": "US",
+      "tags": [
+        "news"
+      ],
+      "bitrate": 24,
+      "codec": "MP3",
+      "geo": [
+        44.2058,
+        -72.5482
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-digitalis-128k-mp3",
+      "name": "SomaFM Digitalis (128k MP3)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice5.somafm.com/digitalis-128-mp3",
+      "homepage": "https://somafm.com/digitalis/",
+      "country": "US",
+      "tags": [
+        "alternative rock",
+        "electronic rock"
+      ],
+      "favicon": "https://somafm.com/img3/digitalis-400.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-smooth-jazz-jjz",
+      "name": "Smooth Jazz JJZ",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc7390",
+      "homepage": "https://wjjz.iheart.com/",
+      "country": "US",
+      "tags": [
+        "smooth jazz"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/5a848c6b2b914714d7008912?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-rainwave-chiptune",
+      "name": "RainWave Chiptune",
+      "broadcaster": "independent",
+      "streamUrl": "https://relay.rainwave.cc/chiptune.ogg",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "US",
+      "tags": [
+        "electronic"
+      ],
+      "codec": "OGG",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-wtop-103-5-fm",
+      "name": "WTOP 103.5 FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/WTOPFM.mp3",
+      "homepage": "https://wtop.com/",
+      "country": "US",
+      "tags": [
+        "news",
+        "talk"
+      ],
+      "favicon": "https://wtop.com/wp-content/themes/wtop-new/assets/img/favicons/apple-touch-icon-120x120.png",
+      "bitrate": 96,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-wioe-oldies-101-1-south-whitley-indiana",
+      "name": "WIOE Oldies 101.1 South Whitley, Indiana",
+      "broadcaster": "independent",
+      "streamUrl": "https://audio-edge-w4d68.yul.o.radiomast.io/c9bc1a59",
+      "homepage": "https://wioe.com/site/",
+      "country": "US",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-art-acoustic-blues",
+      "name": "Radio Art Acoustic Blues",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.radioart.com/fAcoustic_blues.mp3",
+      "homepage": "https://radioart.com/",
+      "country": "US",
+      "tags": [
+        "acoustic",
+        "blues"
+      ],
+      "favicon": "https://radioart.com/templates/yootheme/vendor/yootheme/theme-joomla/assets/images/favicon.png",
+      "bitrate": 96,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-bloomberg-960",
+      "name": "Bloomberg 960",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc301",
+      "homepage": "https://www.bloombergradio.com/",
+      "country": "US",
+      "tags": [
+        "business news"
+      ],
+      "favicon": "https://www.bloombergradio.com/content/plugins/bloomberg-favicon/dist/img/amber-120x120.png",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-the-disco-paradise",
+      "name": "The Disco Paradise",
+      "broadcaster": "independent",
+      "streamUrl": "https://broadcast.miami/proxy/thediscoparadise?mp=/stream/;",
+      "homepage": "https://www.thediscoparadise.com/",
+      "country": "US",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-bible-broadcasting-network-english",
+      "name": "Bible Broadcasting Network English",
+      "broadcaster": "independent",
+      "streamUrl": "https://streams.radiomast.io/844b0a81-f4b9-485e-adaa-aab8d3ea9f7f",
+      "homepage": "https://bbn1.bbnradio.org/english/bbn-live-stream-url/",
+      "country": "US",
+      "tags": [
+        "bible",
+        "christian"
+      ],
+      "bitrate": 64,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-95-7-that-station",
+      "name": "95.7 That Station",
+      "broadcaster": "independent",
+      "streamUrl": "https://ais-sa8.cdnstream1.com/2749_64.aac",
+      "homepage": "https://thatstation.net/",
+      "country": "US",
+      "tags": [
+        "aaa",
+        "adult contemporary",
+        "alternative rock",
+        "indie rock"
+      ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/0/114200.v4.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "geo": [
+        35.7801,
+        -78.6396
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-a-strangely-isolated-place-9128",
+      "name": "A Strangely Isolated Place / 9128",
+      "broadcaster": "independent",
+      "streamUrl": "https://streams.radio.co/s0aa1e6f4a/listen",
+      "homepage": "https://9128.live/",
+      "country": "US",
+      "tags": [
+        "9128",
+        "a strangely isolated place",
+        "asip"
+      ],
+      "favicon": "https://9128.live/favicon.ico",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-whisperings-solo-piano-radio-aac-48",
+      "name": "Whisperings: Solo Piano Radio (AAC 48)",
+      "broadcaster": "independent",
+      "streamUrl": "https://pianosolo.streamguys1.com/pianosolo48.aac",
+      "homepage": "https://www.solopianoradio.com/",
+      "country": "US",
+      "tags": [
+        "classical",
+        "melodic",
+        "piano",
+        "relaxing"
+      ],
+      "bitrate": 48,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-art-vocal-lounge",
+      "name": "Radio Art Vocal Lounge",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.radioart.com/fVocal_lounge.mp3",
+      "homepage": "https://radioart.com/",
+      "country": "US",
+      "tags": [
+        "lounge",
+        "vocal lounge"
+      ],
+      "favicon": "https://radioart.com/favicon.ico",
+      "bitrate": 96,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-la-mega-1290",
+      "name": "La Mega 1290",
+      "broadcaster": "independent",
+      "streamUrl": "https://crystalout.surfernetwork.com:8001/WCHK-AM_MP3",
+      "homepage": "https://www.lamegatl.com/",
+      "country": "US",
+      "tags": [
+        "spanish"
+      ],
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-the-trip-128k-aac",
+      "name": "SomaFM The Trip (128k AAC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice2.somafm.com/thetrip-128-aac",
+      "homepage": "https://somafm.com/thetrip/",
+      "country": "US",
+      "tags": [
+        "house",
+        "progressive",
+        "trance"
+      ],
+      "favicon": "https://somafm.com/img3/thetrip-400.jpg",
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-groove-salad-64k-aac",
+      "name": "SomaFM Groove Salad (64k AAC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice2.somafm.com/groovesalad-64-aac",
+      "homepage": "https://somafm.com/groovesalad/",
+      "country": "US",
+      "tags": [
+        "ambient",
+        "chillout",
+        "downtempo",
+        "groove",
+        "lounge",
+        "sleep"
+      ],
+      "favicon": "https://somafm.com/img3/groovesalad-400.jpg",
+      "bitrate": 64,
+      "codec": "AAC",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-folk-alley-irish",
+      "name": "Folk Alley Irish",
+      "broadcaster": "independent",
+      "streamUrl": "https://freshgrass.streamguys1.com/irish-128mp3",
+      "homepage": "https://www.folkalley.com/music/playlist/today/irish",
+      "country": "US",
+      "tags": [
+        "irish folk"
+      ],
+      "favicon": "https://www.folkalley.com/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-covers-128k-mp3",
+      "name": "SomaFM Covers (128k MP3)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice5.somafm.com/covers-128-mp3",
+      "homepage": "https://somafm.com/covers/",
+      "country": "US",
+      "tags": [
+        "covers"
+      ],
+      "favicon": "https://somafm.com/img3/covers-400.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-1-oldies",
+      "name": "__1 oldies",
+      "broadcaster": "independent",
+      "streamUrl": "https://80sexitos.stream.laut.fm/80sexitos",
+      "homepage": "https://musica80.radioclub.es/",
+      "country": "US",
+      "tags": [
+        "70s",
+        "80s",
+        "90s",
+        "disco",
+        "musica romantica",
+        "oldies"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        40.6434,
+        -74.3005
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-sf-10-33-128k-mp3",
+      "name": "SomaFM SF 10-33 (128k MP3)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice2.somafm.com/sf1033-128-mp3",
+      "homepage": "https://somafm.com/sf1033/",
+      "country": "US",
+      "tags": [
+        "ambient",
+        "experimental",
+        "fire scanner",
+        "live",
+        "mix"
+      ],
+      "favicon": "https://somafm.com/img3/sf1033-400.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-crnet-hard-rock-128",
+      "name": "CRnet Hard Rock (128)",
+      "broadcaster": "independent",
+      "streamUrl": "https://shoutcast.christianrock.net/stream/3/",
+      "homepage": "https://www.christianhardrock.net/",
+      "country": "US",
+      "tags": [
+        "christian",
+        "hard rock",
+        "metal",
+        "rock"
+      ],
+      "favicon": "https://www.christianhardrock.net/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-iheartpodcast-am-1470",
+      "name": "iHeartPodcast AM 1470",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc3348",
+      "homepage": "https://podcastam1470.iheart.com/",
+      "country": "US",
+      "tags": [
+        "news",
+        "talk"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/61a9a007eb66236c043ab853?ops=gravity(%22center%22),contain(32,32),quality(65)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-magic-80s-florida-128-kbit-s",
+      "name": "Magic 80s Florida (128 kbit/s)",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.live365.com/a79417",
+      "homepage": "https://magicoldiesflorida.com/",
+      "country": "US",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-secret-agent-64k-aac",
+      "name": "SomaFM Secret Agent (64k AAC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice2.somafm.com/secretagent-64-aac",
+      "homepage": "https://somafm.com/secretagent/",
+      "country": "US",
+      "tags": [
+        "ambient",
+        "downtempo",
+        "jazz",
+        "lounge",
+        "samba",
+        "sixties"
+      ],
+      "favicon": "https://somafm.com/img3/secretagent-400.jpg",
+      "bitrate": 64,
+      "codec": "AAC",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-bbn-spanish",
+      "name": "BBN Spanish",
+      "broadcaster": "independent",
+      "streamUrl": "https://streams.radiomast.io/475ebed1-595e-4717-b888-64fe8fc6b09f",
+      "homepage": "https://bbn1.bbnradio.org/spanish/escuche-bbn/",
+      "country": "US",
+      "tags": [
+        "biblica",
+        "cristian"
+      ],
+      "bitrate": 56,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-classic-american-top-40",
+      "name": "Classic American Top 40",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc6545",
+      "homepage": "https://www.iheart.com/live/classic-american-top-40-6545/",
+      "country": "US",
+      "tags": [
+        "cassic american top 40 with casey kasem"
+      ],
+      "favicon": "https://www.iheart.com/favicon.ico",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-wxpn-88-5-philadelphia-pa",
+      "name": "WXPN 88.5 Philadelphia, PA",
+      "broadcaster": "independent",
+      "streamUrl": "https://wxpnhi.xpn.org/xpnhi",
+      "homepage": "http://www.xpn.org/",
+      "country": "US",
+      "tags": [
+        "blues",
+        "folk",
+        "public radio",
+        "rock"
+      ],
+      "favicon": "http://www.xpn.org/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-kexp-90-3-seattle-wa-aac-160k",
+      "name": "KEXP 90.3 Seattle, WA (AAC 160K)",
+      "broadcaster": "independent",
+      "streamUrl": "https://kexp.streamguys1.com/kexp160.aac",
+      "homepage": "https://www.kexp.org/",
+      "country": "US",
+      "favicon": "http://www.kexp.org/static/assets/img/favicon-32x32.png",
+      "bitrate": 162,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-cbn-cross-country-christmas",
+      "name": "CBN Cross Country Christmas",
+      "broadcaster": "independent",
+      "streamUrl": "https://streams.cbnradio.com/christmas-128K?%20Title1=CBN%20Cross%20Country%20Christmas",
+      "homepage": "http://www1.cbn.com/radio/crosscountrychristmas",
+      "country": "US",
+      "tags": [
+        "christmas",
+        "country"
+      ],
+      "favicon": "http://www1.cbn.com//sites/all/themes/cbn_default/images/favicons/mstile-144x144.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-hamrah",
+      "name": "Radio Hamrah رادیو همراه",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.zenolive.com/gxdq0awu30duv.aac",
+      "homepage": "http://www.radiohamrah.com/",
+      "country": "US",
+      "tags": [
+        "farsi",
+        "persian",
+        "public radio",
+        "talk",
+        "رادیو",
+        "فارسی"
+      ],
+      "favicon": "http://www.radiohamrah.com/favicon.ico",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-101-9-kiss-fm",
+      "name": "101.9 KISS FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc4864",
+      "homepage": "https://1019kissfm.iheart.com/",
+      "country": "US",
+      "tags": [
+        "pop",
+        "top 40"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/64550dbc69b3a602416192b8?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-smooth-lounge-global-radio",
+      "name": "Smooth Lounge Global Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://smoothjazz.cdnstream1.com/2586_256.mp3",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "US",
+      "tags": [
+        "jazz"
+      ],
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-oldies-93-5",
+      "name": "Oldies 93.5",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc5110",
+      "homepage": "https://oldies935.iheart.com/",
+      "country": "US",
+      "tags": [
+        "oldies"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/5ed665ad7531da667f4c89af?ops=gravity(%22center%22),contain(32,32),quality(65)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-abiding-radio-sacred",
+      "name": "Abiding Radio - Sacred",
+      "broadcaster": "independent",
+      "streamUrl": "https://streams.abidingradio.com:7820/1",
+      "homepage": "https://www.abidingradio.com/",
+      "country": "US",
+      "tags": [
+        "christian"
+      ],
+      "favicon": "https://www.abidingradio.org/wp-content/uploads/2022/05/cropped-new_icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        30.76,
+        -86.57
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-the-river-of-calm",
+      "name": "The River Of Calm",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/49831/stream/86743",
+      "homepage": "https://www.theriverofcalm.com/",
+      "country": "US",
+      "tags": [
+        "chillout",
+        "lounge",
+        "piano",
+        "smooth"
+      ],
+      "favicon": "https://play-lh.googleusercontent.com/HT2ucrf6Yvsfvt1yHz0TxD7JlMcj7-RhF4k6mkDISMesN0_rWv26av2NdURuakftH2U",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-dark-asylum",
+      "name": "Dark Asylum",
+      "broadcaster": "independent",
+      "streamUrl": "https://darkclubradio.stream.laut.fm/darkclubradio?t302=2017-10-06_10-10-19&uuid=04ef8081-69df-483f-b486-2b7cfc49a09d",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "US",
+      "tags": [
+        "international"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-mpr-classical-piano",
+      "name": "MPR Classical Piano",
+      "broadcaster": "independent",
+      "streamUrl": "https://holiday.stream.publicradio.org/peacefulpiano.mp3",
+      "homepage": "https://www.mpr.org/",
+      "country": "US",
+      "tags": [
+        "classical piano"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        44.9491,
+        -93.0955
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-art-vocal-jazz",
+      "name": "Radio Art Vocal Jazz",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.radioart.com/fVocal_jazz.mp3",
+      "homepage": "https://www.radioart.com/",
+      "country": "US",
+      "tags": [
+        "jazz",
+        "vocal jazz"
+      ],
+      "favicon": "https://www.radioart.com/templates/yootheme/vendor/yootheme/theme-joomla/assets/images/favicon.png",
+      "bitrate": 96,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-mast-chinese",
+      "name": "Radio Mast Chinese",
+      "broadcaster": "independent",
+      "streamUrl": "https://streams.radiomast.io/ce298b32-8776-4192-9900-092f44b63e7f",
+      "homepage": "https://bbn1.bbnradio.org/",
+      "country": "US",
+      "tags": [
+        "bible",
+        "christian"
+      ],
+      "bitrate": 56,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-christian-hits",
+      "name": "Christian Hits",
+      "broadcaster": "independent",
+      "streamUrl": "https://shoutcast.christianrock.net/stream/5/",
+      "homepage": "https://www.christianhits.net/",
+      "country": "US",
+      "tags": [
+        "christian",
+        "christian praise&worship",
+        "christianpowerpraise.net",
+        "modern praise",
+        "power praise",
+        "praise"
+      ],
+      "favicon": "https://www.christianhits.net/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-4u-classic-rock",
+      "name": "4u Classic Rock",
+      "broadcaster": "independent",
+      "streamUrl": "https://str4uice.streamakaci.com/4uclassicrock.mp3",
+      "homepage": "http://www.4urock.com/",
+      "country": "US",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/4/15394.v1.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        37.7781,
+        -122.4495
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-99-9-gator-country",
+      "name": "99.9 Gator Country",
+      "broadcaster": "independent",
+      "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/WGNEAAC.aac",
+      "homepage": "https://www.999gatorcountry.com/",
+      "country": "US",
+      "tags": [
+        "country"
+      ],
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-kdfc-classical-california-ultimate-playlist",
+      "name": "KDFC Classical California Ultimate Playlist",
+      "broadcaster": "independent",
+      "streamUrl": "https://19273.live.streamtheworld.com/CC1_S01AAC_96_SC",
+      "homepage": "https://classicalcalifornia.org/kdfc/streams/classicalcaliforniaultimateplaylist",
+      "country": "US",
+      "tags": [
+        "classical"
+      ],
+      "bitrate": 96,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-poptron-32k-aac",
+      "name": "SomaFM PopTron (32k AAC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice2.somafm.com/poptron-32-aac",
+      "homepage": "https://somafm.com/poptron/",
+      "country": "US",
+      "tags": [
+        "electropop",
+        "indie",
+        "synthpop"
+      ],
+      "favicon": "https://somafm.com/img3/poptron-400.png",
+      "bitrate": 32,
+      "codec": "AAC",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-salsoul",
+      "name": "Radio Salsoul",
+      "broadcaster": "independent",
+      "streamUrl": "https://broadcast.miami/proxy/salsoul?mp=/stream/;",
+      "homepage": "https://www.radiosalsoul.com/",
+      "country": "US",
+      "tags": [
+        "disco"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-rbn-republic-broadcastin-network",
+      "name": "RBN - Republic Broadcastin Network",
+      "broadcaster": "independent",
+      "streamUrl": "https://cast2.my-control-panel.com/proxy/rbn/stream;",
+      "homepage": "https://republicbroadcasting.org/",
+      "country": "US",
+      "tags": [
+        "political talk"
+      ],
+      "favicon": "https://uk.radio.net/images/broadcasts/17/89/17630/c300.png",
+      "bitrate": 32,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-metal-detector-32k-aac",
+      "name": "SomaFM Metal Detector (32k AAC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice4.somafm.com/metal-32-aac",
+      "homepage": "https://somafm.com/metal/",
+      "country": "US",
+      "tags": [
+        "black metal",
+        "doom metal",
+        "post-punk",
+        "progressive rock",
+        "sludge",
+        "stoner rock"
+      ],
+      "favicon": "https://somafm.com/img3/metal-400.png",
+      "bitrate": 40,
+      "codec": "AAC",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-bloomberg-tv",
+      "name": "Bloomberg TV",
+      "broadcaster": "independent",
+      "streamUrl": "https://liveprodeuwest.akamaized.net/eu1/Channel-EUTVqvs-AWS-ireland-1/Source-EUTVqvs-1000-1_live.m3u8",
+      "homepage": "https://www.bloomberg.com/live/europe",
+      "country": "US",
+      "tags": [
+        "tv"
+      ],
+      "favicon": "https://assets.bwbx.io/s3/multimedia/public/app/images/favicons/apple-touch-icon_120x120-34d187e11c.png",
+      "codec": "UNKNOWN",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-heavyweight-reggae-32k-aac",
+      "name": "SomaFM Heavyweight Reggae (32k AAC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice6.somafm.com/reggae-32-aac",
+      "homepage": "https://somafm.com/reggae/",
+      "country": "US",
+      "tags": [
+        "reggae",
+        "rocksteady",
+        "roots reggae",
+        "ska"
+      ],
+      "favicon": "https://somafm.com/img3/reggae400.jpg",
+      "bitrate": 32,
+      "codec": "AAC",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-kiye-88-7-fm-kamiah-id",
+      "name": "KIYE 88.7 FM Kamiah, ID",
+      "broadcaster": "independent",
+      "streamUrl": "https://ais-sa1.streamon.fm/7012_24k.aac",
+      "homepage": "https://kiye.org/",
+      "country": "US",
+      "tags": [
+        "aboriginal",
+        "aboriginal music",
+        "classic rock",
+        "variety"
+      ],
+      "favicon": "https://i2.wp.com/kiye.org/wp-content/uploads/2016/10/cropped-kiye-logo-small-1.png?fit=512%2C512&ssl=1",
+      "bitrate": 96,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-happy-rave-radio-90s-happy-hardcore",
+      "name": "Happy Rave Radio [90s Happy Hardcore]",
+      "broadcaster": "independent",
+      "streamUrl": "https://happyrave-rex.radioca.st/stream",
+      "homepage": "https://www.happyraveradio.com/",
+      "country": "US",
+      "tags": [
+        "happy hardcore",
+        "hardcore",
+        "rave"
+      ],
+      "favicon": "https://www.happyraveradio.com/wp-content/uploads/2021/03/happyraveradio_logo-e1615388979808.jpg",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-nbc-news-radio-https",
+      "name": "NBC News Radio (https)",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc6043",
+      "homepage": "https://www.iheart.com/live/nbc-news-radio-6043/",
+      "country": "US",
+      "tags": [
+        "news"
+      ],
+      "favicon": "https://iscale.iheart.com/catalog/live/6043",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-cape-christian-radio",
+      "name": "Cape Christian Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice64.securenetsystems.net/CCR1MP3",
+      "homepage": "https://www.communitynetradio.org/christianliferadio",
+      "country": "US",
+      "tags": [
+        "christian"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-drone-zone-64k-aac",
+      "name": "SomaFM Drone Zone (64k AAC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice6.somafm.com/dronezone-64-aac",
+      "homepage": "https://somafm.com/dronezone/",
+      "country": "US",
+      "tags": [
+        "ambient",
+        "atmospheric",
+        "chillout",
+        "drone"
+      ],
+      "favicon": "https://somafm.com/img3/dronezone-400.jpg",
+      "bitrate": 64,
+      "codec": "AAC",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-107-5-kiss-fm",
+      "name": "107.5 KISS FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc2740",
+      "homepage": "https://1075kissfm.iheart.com/",
+      "country": "US",
+      "tags": [
+        "pop",
+        "top 40"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/5c251d5a6395ee2ae15bf8f8?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-96-7-kiss-fm",
+      "name": "96.7 KISS FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc2173",
+      "homepage": "https://967kissfm.iheart.com/",
+      "country": "US",
+      "tags": [
+        "pop",
+        "top 40"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/new_assets/5935ef64fca9ad9f777a7778?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-smooth-jazz-cd-101-9",
+      "name": "Smooth Jazz CD 101.9",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.live365.com/a43749",
+      "homepage": "https://smoothjazzcd1019.com/",
+      "country": "US",
+      "tags": [
+        "easy listening",
+        "new york city",
+        "smooth jazz"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-paradise-world-etc-mix-64k-aac",
+      "name": "Radio Paradise World/Etc Mix 64k AAC",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radioparadise.com/world-etc-64",
+      "homepage": "https://radioparadise.com/",
+      "country": "US",
+      "tags": [
+        "california",
+        "eclectic",
+        "world music",
+        "free",
+        "internet",
+        "non-commercial"
+      ],
+      "favicon": "https://radioparadise.com/apple-touch-icon.png",
+      "bitrate": 64,
+      "codec": "AAC",
+      "geo": [
+        40.7851,
+        -124.1839
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-lush-64k-aac",
+      "name": "SomaFM Lush (64k AAC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice4.somafm.com/lush-64-aac",
+      "homepage": "https://somafm.com/lush/",
+      "country": "US",
+      "tags": [
+        "electronic",
+        "femalevocals",
+        "lounge",
+        "mellow",
+        "vocal"
+      ],
+      "favicon": "https://somafm.com/img3/lush-400.jpg",
+      "bitrate": 64,
+      "codec": "AAC",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-power-of-worship-radio",
+      "name": "Power of Worship Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://fwd.autopo.st/powerofworshipradio",
+      "homepage": "https://www.powerofworship.net/",
+      "country": "US",
+      "favicon": "https://mmo.aiircdn.com/177/61e36614722ca.png",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-wfmt-classical-aac-256",
+      "name": "WFMT Classical AAC 256",
+      "broadcaster": "independent",
+      "streamUrl": "https://wfmt.streamguys1.com/main-source",
+      "homepage": "https://www.wfmt.com/",
+      "country": "US",
+      "tags": [
+        "chicago",
+        "classical"
+      ],
+      "favicon": "https://static.mytuner.mobi/media/tvos_radios/XBEtTEnnMS.jpg",
+      "bitrate": 258,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-symphony",
+      "name": "Radio Symphony",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.radiostreamlive.com/radiosymphony_devices",
+      "homepage": "http://www.radiosymphony.com/",
+      "country": "US",
+      "tags": [
+        "classical",
+        "new york city",
+        "rsl",
+        "symphony"
+      ],
+      "favicon": "https://cdn-elements.radiostreamlive.com/v1/images/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-ah-fm",
+      "name": "AH.FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://air.unmixed.ru/ah192",
+      "homepage": "https://ah.fm/",
+      "country": "US",
+      "tags": [
+        "electronic"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-paradise-rock-mix-64k-aac",
+      "name": "Radio Paradise Rock Mix 64k AAC",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radioparadise.com/rock-64",
+      "homepage": "https://radioparadise.com/",
+      "country": "US",
+      "tags": [
+        "california",
+        "alternative",
+        "eclectic",
+        "rock",
+        "free",
+        "internet"
+      ],
+      "favicon": "https://radioparadise.com/apple-touch-icon.png",
+      "bitrate": 64,
+      "codec": "AAC",
+      "geo": [
+        40.7851,
+        -124.1839
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-nettalk-america",
+      "name": "NetTalk America",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.zeno.fm/st9bhqvgvceuv",
+      "homepage": "https://nettalkamerica.com/",
+      "country": "US",
+      "tags": [
+        "commentary",
+        "conservative talk",
+        "news talk",
+        "political talk",
+        "republican"
+      ],
+      "favicon": "https://img1.wsimg.com/isteam/ip/6e7215c5-5ca4-45c2-b61c-24421c4a5003/74cfc8bf-f67f-4e7d-ad46-0ac09ca2d362.gif.png/:/cr=t:0%25,l:0%25,w:100%25,h:100%25/rs=w:1536",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-indie-pop-rocks-64k-aac",
+      "name": "SomaFM Indie Pop Rocks! (64k AAC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice6.somafm.com/indiepop-64-aac",
+      "homepage": "https://somafm.com/indiepop/",
+      "country": "US",
+      "tags": [
+        "indie",
+        "indie pop",
+        "indie rock"
+      ],
+      "favicon": "https://somafm.com/img3/indiepop-400.jpg",
+      "bitrate": 64,
+      "codec": "AAC",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-christian-classic-rock-dot-net",
+      "name": "Christian Classic Rock Dot Net",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.christianrock.net/stream/14/",
+      "homepage": "https://www.christianclassicrock.net/",
+      "country": "US",
+      "tags": [
+        "christian",
+        "classic rock",
+        "christian classic rock",
+        "christianclassicrock.net",
+        "ccrdn"
+      ],
+      "favicon": "https://www.christianclassicrock.net/apple-touch-icon.png",
+      "bitrate": 112,
+      "codec": "AAC",
+      "geo": [
+        37.2116,
+        -93.2898
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-america-1",
+      "name": "Radio America 1",
+      "broadcaster": "independent",
+      "streamUrl": "https://s6.yesstreaming.net:18003/ra1",
+      "homepage": "https://www.radioamerica.com/",
+      "country": "US",
+      "tags": [
+        "conservative talk",
+        "entertainment",
+        "political talk",
+        "talk"
+      ],
+      "favicon": "https://www.radioamerica.com/wp-content/uploads/2024/11/cropped-favicon-180x180.png",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-sunny-99-9-el-paso",
+      "name": "Sunny 99.9 El Paso",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc3188",
+      "homepage": "https://sunny999fm.iheart.com/",
+      "country": "US",
+      "tags": [
+        "adult contemporary"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/5e595c77f75fa2234df660f1?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-el-nuevo-zol-106-7-fm",
+      "name": "El Nuevo Zol 106.7 FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://liveaudio.lamusica.com/MIA_WXDJ_icy",
+      "homepage": "https://www.lamusica.com/stations/wxdj",
+      "country": "US",
+      "tags": [
+        "bachata",
+        "dembow",
+        "entretenimiento",
+        "latino",
+        "merengue",
+        "music"
+      ],
+      "favicon": "https://radiostationusa.fm/assets/image/radio/180/WXDJ.png",
+      "bitrate": 320,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-indie-x-fm",
+      "name": "Indie X FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://kathy.torontocast.com:2695/stream",
+      "homepage": "https://indiexfm.com/",
+      "country": "US",
+      "tags": [
+        "alternative rock",
+        "alternative wave",
+        "classic alternative",
+        "edm",
+        "indie",
+        "indie pop"
+      ],
+      "favicon": "https://img1.wsimg.com/isteam/ip/6b751bf2-5843-4590-8843-d4025327a155/favicon/b60d118d-2ffa-4828-9955-afea07eb614f.png/:/rs=w:180,h:180,m",
+      "bitrate": 320,
+      "codec": "MP3",
+      "geo": [
+        34.0566,
+        -118.2556
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-bloomberg-tv-new",
+      "name": "Bloomberg TV new",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.bloomberg.com/media-manifest/streams/phoenix-us.m3u8",
+      "homepage": "https://www.bloomberg.com/live",
+      "country": "US",
+      "favicon": "https://www.bloomberg.com/favicon.ico",
+      "bitrate": 1500,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-wfed-federal-news-network",
+      "name": "WFED Federal News Network",
+      "broadcaster": "independent",
+      "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/WFEDAM.mp3",
+      "homepage": "https://federalnewsnetwork.com/",
+      "country": "US",
+      "tags": [
+        "government",
+        "talk",
+        "washington dc"
+      ],
+      "favicon": "https://federalnewsnetwork.com/wp-content/uploads/2017/12/cropped-icon-512x512-1.png",
+      "bitrate": 96,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-classical-kusc",
+      "name": "Classical KUSC",
+      "broadcaster": "independent",
+      "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/KUSCAAC64.aac",
+      "homepage": "https://www.kusc.org/",
+      "country": "US",
+      "tags": [
+        "classical"
+      ],
+      "favicon": "https://www.kusc.org/icons/kusc/apple-touch-icon-120x120.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-space-station-soma-64k-aac",
+      "name": "SomaFM Space Station Soma (64k AAC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice4.somafm.com/spacestation-64-aac",
+      "homepage": "https://somafm.com/spacestation/",
+      "country": "US",
+      "tags": [
+        "ambient",
+        "electronica",
+        "mid-tempo"
+      ],
+      "favicon": "https://somafm.com/img3/spacestation-400.png",
+      "bitrate": 64,
+      "codec": "AAC",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-94-7-kumu-128kbps",
+      "name": "94.7 KUMU (128kbps)",
+      "broadcaster": "independent",
+      "streamUrl": "https://pacificmedia.cdnstream1.com/2783_128.mp3",
+      "homepage": "https://kumu.com/",
+      "country": "US",
+      "tags": [
+        "alternative",
+        "ballads",
+        "chillout",
+        "classic hits",
+        "hawaii",
+        "hawaiian adult contemporary"
+      ],
+      "favicon": "https://kumu.com/wp-content/uploads/sites/14/KUMU-Web-Logo-180x115-1.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        21.3094,
+        -157.8589
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-smoothjazz-com-64k-aac",
+      "name": " SmoothJazz.com 64k aac+",
+      "broadcaster": "independent",
+      "streamUrl": "https://smoothjazz.cdnstream1.com/2585_64.aac",
+      "homepage": "https://www.smoothjazz.com/",
+      "country": "US",
+      "tags": [
+        "monterey",
+        "smooth jazz"
+      ],
+      "favicon": "https://www.smoothjazz.com/sites/default/files/theme/sj-circle-logo.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "geo": [
+        36.6007,
+        -121.8769
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-90-5-wicn-public-radio-jazz-for-new-england",
+      "name": "90.5 WICN Public Radio - Jazz+ for New England",
+      "broadcaster": "independent",
+      "streamUrl": "https://wicn-ice.streamguys1.com/live-mp3",
+      "homepage": "https://www.wicn.org/",
+      "country": "US",
+      "tags": [
+        "blues",
+        "classic jazz",
+        "folk",
+        "jazz",
+        "public radio"
+      ],
+      "favicon": "https://www.wicn.org/wp-content/uploads/2019/06/cropped-android-chrome-512x512-192x192.png",
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-jazz-wyoming",
+      "name": "Jazz Wyoming",
+      "broadcaster": "independent",
+      "streamUrl": "https://wyoming-public-ice.streamguys1.com/JZZ128MP3",
+      "homepage": "https://www.wyomingpublicmedia.org/show/jazz-wyoming",
+      "country": "US",
+      "favicon": "https://www.wyomingpublicmedia.org/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        41.3063,
+        -105.5786
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-progulus-online-progressive-rock-radio",
+      "name": "Progulus - Online Progressive Rock Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://centova.radioservers.biz/proxy/klemmer/stream",
+      "homepage": "https://progulus.com/rprweb/#page-playing",
+      "country": "US",
+      "favicon": "https://progulus.com/favicon.ico",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-wwoz-new-orleans-public-radio",
+      "name": "WWOZ - New Orleans Public Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.wwoz.org/listen/hi",
+      "homepage": "https://www.wwoz.org/",
+      "country": "US",
+      "tags": [
+        "jazz"
+      ],
+      "favicon": "https://www.wwoz.org//sites/default/files/favicons-bw/apple-touch-icon-57x57.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-electricfm-america-s-reals-dance",
+      "name": "ELECTRICFM - America's Reals Dance! ",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.electricfm.com/electricfm",
+      "homepage": "https://www.electricfm.com/",
+      "country": "US",
+      "tags": [
+        "dance",
+        "edm"
+      ],
+      "favicon": "https://www.electricfm.com/apple-icon-120x120.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-c-span",
+      "name": "C-SPAN",
+      "broadcaster": "independent",
+      "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/CSPANRADIO.mp3",
+      "homepage": "https://www.c-span.org/",
+      "country": "US",
+      "tags": [
+        "c-span",
+        "cspan",
+        "spanish pop"
+      ],
+      "favicon": "https://static.c-spanvideo.org/apple-touch-icon-iphone-retina-display.png",
+      "bitrate": 40,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-heady",
+      "name": "HEADY",
+      "broadcaster": "independent",
+      "streamUrl": "https://c22.radioboss.fm:18364/stream",
+      "homepage": "https://www.heady.fm/",
+      "country": "US",
+      "tags": [
+        "indie",
+        "indie rock",
+        "psychedelic rock",
+        "rock"
+      ],
+      "favicon": "https://cdn.prod.website-files.com/63222115e90f0d1c63a9e53a/63222115e90f0de32da9e58c_fav-20.png",
+      "bitrate": 320,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-new-wave-bestnet-radio",
+      "name": "New Wave - BestNet Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://bigrradio.cdnstream1.com/5162_128",
+      "homepage": "https://bestnetradio.com/",
+      "country": "US",
+      "tags": [
+        "new wave"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-kost-103-5",
+      "name": "KOST 103.5",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc193",
+      "homepage": "https://kost1035.iheart.com/",
+      "country": "US",
+      "tags": [
+        "adult contemporary"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/4f8b2d8763a2d58e545fa71e11b46bb2?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "codec": "AAC",
+      "geo": [
+        33.998,
+        -118.0481
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-ukulele-island",
+      "name": "Ukulele Island",
+      "broadcaster": "independent",
+      "streamUrl": "https://tunein-ondemand.cdnstream1.com/multi_bump_sonic_pre_pre.mp3?aw_0_1st.playerid=LogitechSqueeze&aw_0_1st.skey=1768433575&aw_0_1st.abtest=&partnerId=LogitechSqueeze&aw_0_1st.stationId=s205522&aw_0_1st.premium=false&source=TuneIn&aw_0_req.gdpr=true&aw_0_1st.platform=tunein&aw_0_1st.ads_partner_alias=ce.LogitechSqueezebox&aw_0_azn.planguage=en&aw_0_1st.is_ondemand=false&aw_0_1st.topicId=na&aw_0_1st.affiliateIds=a40075%2ca40276&aw_0_1st.bandId=16",
+      "homepage": "http://ukulele-island.com/",
+      "country": "US",
+      "tags": [
+        "hawaiian music",
+        "ukulele"
+      ],
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-rusrek",
+      "name": "Канал \"Русский ХИТ\" Radio Rusrek Радио Русская Реклама",
+      "broadcaster": "independent",
+      "streamUrl": "https://securestreams6.autopo.st:2130/onlyrussian",
+      "homepage": "https://radio.rusrek.com/",
+      "country": "US",
+      "tags": [
+        "russian",
+        "russian hits",
+        "russian pop"
+      ],
+      "favicon": "https://radio.rusrek.com/images/phocaopengraph/logo-2019-06.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        40.5908,
+        -73.9602
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-drone-zone-32k-aac",
+      "name": "SomaFM Drone Zone (32k AAC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice6.somafm.com/dronezone-32-aac",
+      "homepage": "https://somafm.com/dronezone/",
+      "country": "US",
+      "tags": [
+        "ambient",
+        "atmospheric",
+        "chillout",
+        "drone"
+      ],
+      "favicon": "https://somafm.com/img3/dronezone-400.jpg",
+      "bitrate": 32,
+      "codec": "AAC",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-92-5-and-93-3-the-bull",
+      "name": "92.5 and 93.3 The Bull",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc6168",
+      "homepage": "https://thebullcountry.iheart.com/",
+      "country": "US",
+      "tags": [
+        "country"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/593d4f30e7970b302d32a0f4?ops=gravity(%22center%22),contain(32,32),quality(65)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-vocaloid-radio-320kbps",
+      "name": "Vocaloid Radio (320kbps)",
+      "broadcaster": "independent",
+      "streamUrl": "https://vocaloid.radioca.st/stream",
+      "homepage": "https://vocaloidradio.com/",
+      "country": "US",
+      "tags": [
+        "anime",
+        "vocaloid"
+      ],
+      "favicon": "https://vocaloidradio.com/favicon.ico",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-cruisin-oldies-94-7-fm-1110-am",
+      "name": "Cruisin' Oldies 94.7 FM & 1110 AM",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice8.securenetsystems.net/KGFL",
+      "homepage": "https://www.kgflam.com/",
+      "country": "US",
+      "tags": [
+        "oldies"
+      ],
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-the-disco-palace",
+      "name": "The Disco Palace",
+      "broadcaster": "independent",
+      "streamUrl": "https://broadcast.miami/proxy/thediscopalace?mp=/stream/;",
+      "homepage": "https://www.thediscopalace.com/",
+      "country": "US",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-groovy-radio-60-s-and-70-s-oldies",
+      "name": "Groovy Radio - 60's and 70's Oldies",
+      "broadcaster": "independent",
+      "streamUrl": "https://r1.comcities.com/proxy/emogddug/stream",
+      "homepage": "https://groovyradio.us/",
+      "country": "US",
+      "tags": [
+        "60's",
+        "70's",
+        "oldies"
+      ],
+      "favicon": "https://kvkvi.com/wp-content/uploads/2024/02/luxa.org-bordered-Groovy-White-600x600-jpg.jpg",
+      "bitrate": 160,
+      "codec": "MP3",
+      "geo": [
+        39.967,
+        -82.9694
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-k-star-country-99-7-fm",
+      "name": "K-Star Country 99.7 FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice41.securenetsystems.net/KVST",
+      "homepage": "https://www.kstarcountry.com/",
+      "country": "US",
+      "tags": [
+        "country"
+      ],
+      "favicon": "https://www.kstarcountry.com/website/wp-content/uploads/2017/01/listenlive.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-ritmo-95",
+      "name": "RITMO 95",
+      "broadcaster": "independent",
+      "streamUrl": "https://liveaudio.lamusica.com/MIA_WRMA_icy?",
+      "homepage": "https://mytuner-radio.com/es/emisora/ritmo-957-441541/",
+      "country": "US",
+      "tags": [
+        "cubatón y ➕"
+      ],
+      "favicon": "https://firebasestorage.googleapis.com/v0/b/radiogalaxy-580f4.appspot.com/o/images%2FIMG_20240913_142656254.jpg?alt=media&token=443199c8-7964-4267-a4c9-bcf994223858",
+      "bitrate": 319,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-revolution-93-5",
+      "name": "Revolution 93.5",
+      "broadcaster": "independent",
+      "streamUrl": "https://centova87.shoutcastservices.com/proxy/revolution935/stream",
+      "homepage": "https://www.google.com/url?sa=t&source=web&cd=&cad=rja&uact=8&ved=2ahUKEwj1yd_XzJKDAxUrk4kEHehEDzIQFnoECA0QAQ&url=https%3A%2F%2Fwww.revolution935.com%2F&usg=AOvVaw3AuU1XL-Nq5ZSMh9C5HbYu&opi=89978449",
+      "country": "US",
+      "tags": [
+        "edm"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        25.848,
+        -80.1789
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-mytime-movie-network",
+      "name": "MyTime Movie Network",
+      "broadcaster": "independent",
+      "streamUrl": "https://appletree-mytime-samsungbrazil.amagi.tv/playlist.m3u8",
+      "homepage": "https://mytimemovienetwork.com/",
+      "country": "US",
+      "tags": [
+        "movie",
+        "tv",
+        "电视",
+        "电视伴音"
+      ],
+      "favicon": "https://mytimemovienetwork.com/favicon.ico",
+      "bitrate": 1020,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-kiro-fm",
+      "name": "KIRO -FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://bonneville.cdnstream1.com/2643_48.aac",
+      "homepage": "https://mynorthwest.com/",
+      "country": "US",
+      "favicon": "https://cdn.bonneville.cloud/i/KIRO-FM/square_600x600.webp",
+      "bitrate": 47,
+      "codec": "AAC+",
+      "geo": [
+        47.5985,
+        -122.3348
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-the-great-american-songbook-aac",
+      "name": "The Great American Songbook [aac]",
+      "broadcaster": "independent",
+      "streamUrl": "https://remote.selfip.net:8030/1",
+      "homepage": "https://greatamericansongbook.info/index.html",
+      "country": "US",
+      "tags": [
+        "evergreens",
+        "great american songbook"
+      ],
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-werave-music-radio-02-study-and-chillout",
+      "name": "WeRave Music Radio 02 - Study and Chillout",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.zeno.fm/cpnv07rjvp0vv",
+      "homepage": "https://werave.com.br/en",
+      "country": "US",
+      "tags": [
+        "ambient",
+        "best music for you",
+        "chill house",
+        "chillout",
+        "dance",
+        "deep house"
+      ],
+      "favicon": "https://werave.com.br/wp-content/uploads/2020/09/vinyl.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-90s-country",
+      "name": "90s Country",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc6870",
+      "homepage": "https://www.iheart.com/",
+      "country": "US",
+      "favicon": "https://i.iheart.com/v3/re/new_assets/fd6065ae-5f96-46fe-b70d-c3b2d791cb36",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-vintage-obscura-radio",
+      "name": "Vintage Obscura Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.vintageobscura.net/stream",
+      "homepage": "https://vintageobscura.net/",
+      "country": "US",
+      "tags": [
+        "obscure",
+        "rare groove",
+        "vintage music",
+        "vinyl"
+      ],
+      "favicon": "https://vintageobscura.net/./img/ms-icon-144x144.png",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-fox-sports-98-9fm-1340am",
+      "name": "FOX Sports 98.9FM / 1340AM",
+      "broadcaster": "independent",
+      "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/KRLVAMAAC.aac",
+      "homepage": "https://www.lvsportsnetwork.com/",
+      "country": "US",
+      "tags": [
+        "sports"
+      ],
+      "bitrate": 32,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-left-coast-70s-128k-aac",
+      "name": "SomaFM Left Coast 70s (128k AAC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice6.somafm.com/seventies-128-aac",
+      "homepage": "https://somafm.com/seventies/",
+      "country": "US",
+      "tags": [
+        "easy listening",
+        "mellow album rock",
+        "rock",
+        "yacht rock"
+      ],
+      "favicon": "https://somafm.com/img3/seventies400.jpg",
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-wfla-970-am-tampa-bay-fl",
+      "name": "WFLA 970 AM Tampa Bay, FL",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc2823",
+      "homepage": "https://wflanews.iheart.com/",
+      "country": "US",
+      "tags": [
+        "news",
+        "sports",
+        "talk"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/60675fb63e8b1ff06401afd2?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-105-9-fm-wmal",
+      "name": "105.9 FM WMAL",
+      "broadcaster": "independent",
+      "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/WMALFMAAC.aac",
+      "homepage": "https://www.wmal.com/",
+      "country": "US",
+      "tags": [
+        "news",
+        "talk"
+      ],
+      "bitrate": 48,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us--c16337ec",
+      "name": "自由亚洲",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-160.zeno.fm/ub3pfplpqbktv?zt=eyJhbGciOiJIUzI1NiJ9.eyJzdHJlYW0iOiJ1YjNwZnBscHFia3R2IiwiaG9zdCI6InN0cmVhbS0xNjAuemVuby5mbSIsInRtIjpmYWxzZSwicnR0bCI6NSwianRpIjoiWEYybFJHNTNUYS1hLWp1VWdiY3pBZyIsImlhdCI6MTc2ODQ0MjYxMSwiZXhwIjoxNzY4NDQyNjcxfQ.06_HWbLfxMfXVTmCHzGzYQ6e74o-ifU8nWoLPrgZwDE",
+      "homepage": "http://www.xsbnrtv.cn/",
+      "country": "US",
+      "tags": [
+        "information",
+        "news"
+      ],
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-n5md-128k-aac",
+      "name": "SomaFM n5MD (128k AAC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice6.somafm.com/n5md-128-aac",
+      "homepage": "https://somafm.com/n5md/",
+      "country": "US",
+      "tags": [
+        "ambient",
+        "experimental electronic music",
+        "modern composition",
+        "post-rock"
+      ],
+      "favicon": "https://somafm.com/img3/n5md-400.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-italy-live",
+      "name": "Radio Italy Live",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.radiostreamlive.com/radioitalylive_devices",
+      "homepage": "http://www.radioitalylive.com/",
+      "country": "US",
+      "tags": [
+        "italian pop",
+        "new york city",
+        "rsl"
+      ],
+      "favicon": "https://cdn-elements.radiostreamlive.com/v1/images/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-sunset-chillout-lounge",
+      "name": "Sunset Chillout Lounge",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/571682/stream/631712",
+      "homepage": "https://sunsetchilloutlounge.com/",
+      "country": "US",
+      "tags": [
+        "chillout",
+        "lounge",
+        "sunset"
+      ],
+      "favicon": "https://sunsetchilloutlounge.com/wp-content/uploads/2023/04/sunrise_sunset_captions_puns_quotes_instagram-7-300x225.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-hpr4-bluegrass-gospel",
+      "name": "HPR4 Bluegrass Gospel",
+      "broadcaster": "independent",
+      "streamUrl": "https://us2.maindigitalstream.com/ssl/7739",
+      "homepage": "https://hpr.org/",
+      "country": "US",
+      "tags": [
+        "country"
+      ],
+      "favicon": "http://www.hpr.org/icon-normal.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-mast-japanese",
+      "name": "Radio Mast Japanese",
+      "broadcaster": "independent",
+      "streamUrl": "https://streams.radiomast.io/a622d414-52a6-4426-b3b8-ed2a4dbb704b",
+      "homepage": "https://bbn1.bbnradio.org/japanese/",
+      "country": "US",
+      "tags": [
+        "bible",
+        "christian"
+      ],
+      "favicon": "https://bbn1.bbnradio.org/favicon.ico",
+      "bitrate": 64,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-smooth-groove-radio-the-vibe",
+      "name": "Smooth Groove Radio - The Vibe",
+      "broadcaster": "independent",
+      "streamUrl": "https://usa17.fastcast4u.com/proxy/smoothgr?mp=/1",
+      "homepage": "http://thevibesmoothgrooveradio.weebly.com/#",
+      "country": "US",
+      "tags": [
+        "funk",
+        "music",
+        "smooth jazz"
+      ],
+      "favicon": "http://thevibesmoothgrooveradio.weebly.com/uploads/9/7/3/1/97313354/published/jazz.jpeg?1494363671",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-abiding-radio-kids",
+      "name": "Abiding Radio - Kids",
+      "broadcaster": "independent",
+      "streamUrl": "https://streams.abidingradio.com:7810/1",
+      "homepage": "https://www.abidingradio.com/",
+      "country": "US",
+      "tags": [
+        "christian"
+      ],
+      "favicon": "https://www.abidingradio.org/wp-content/uploads/2022/05/cropped-new_icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        30.76,
+        -86.57
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-animenfo-radio",
+      "name": "AnimeNfo Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.zenolive.com/xwa8ckz7mzzuv",
+      "homepage": "https://www.listenonlineradio.com/japan/animenfo-radio",
+      "country": "US",
+      "tags": [
+        "anime",
+        "anime radio"
+      ],
+      "favicon": "https://listenonlineradio.com/wp-content/uploads/cropped-icon-180x180.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-cbs-sports-radio-on-am-1500",
+      "name": "CBS Sports Radio on AM 1500",
+      "broadcaster": "independent",
+      "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/KHKAAMAAC.aac",
+      "homepage": "https://nbcsportsradiohawaii.com/",
+      "country": "US",
+      "tags": [
+        "sports"
+      ],
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-groovewave-jazz",
+      "name": "GrooveWave Jazz",
+      "broadcaster": "independent",
+      "streamUrl": "https://stm1.srvif.com:7530/",
+      "homepage": "https://www.groovewave.com/jazz/jazz.htm",
+      "country": "US",
+      "favicon": "https://www.groovewave.com/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-exclusively-lana-del-rey",
+      "name": "Exclusively Lana Del Rey",
+      "broadcaster": "independent",
+      "streamUrl": "https://nl4.mystreaming.net/er/lanadelrey/icecast.audio",
+      "homepage": "https://play.exclusive.radio/",
+      "country": "US",
+      "tags": [
+        "americana",
+        "ballads",
+        "beautiful music",
+        "cinematic",
+        "downtempo",
+        "female vocalists"
+      ],
+      "favicon": "https://liveonlineradio.net/wp-content/uploads/2022/05/Exclusively-Lana-Del-Rey-220x108.webp",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-paradise-main-mix-flac-meta",
+      "name": "Radio Paradise Main Mix FLAC+Meta",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radioparadise.com/flacm",
+      "homepage": "https://radioparadise.com/home",
+      "country": "US",
+      "tags": [
+        "california",
+        "eclectic",
+        "free",
+        "internet",
+        "non-commercial",
+        "paradise"
+      ],
+      "favicon": "https://radioparadise.com/apple-touch-icon.png",
+      "bitrate": 1442,
+      "codec": "OGG",
+      "geo": [
+        40.7851,
+        -124.1839
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-country-90s-radio",
+      "name": "Country 90s Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc6870/hls.m3u8",
+      "homepage": "https://www.iheart.com/",
+      "country": "US",
+      "tags": [
+        "country"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/new_assets/fd6065ae-5f96-46fe-b70d-c3b2d791cb36",
+      "bitrate": 24,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-wbz-news-radio-1030",
+      "name": "WBZ News Radio 1030",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc7729",
+      "homepage": "https://wbznewsradio.iheart.com/",
+      "country": "US",
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/622f5be7b4c3b4cfaf1dc63d?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "codec": "AAC",
+      "geo": [
+        42.3539,
+        -71.0609
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-drumbases-pace",
+      "name": "drumbases.pace",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.drumbase.space/listen/drumbase.space/radio.mp3",
+      "homepage": "https://drumbase.space/",
+      "country": "US",
+      "tags": [
+        "drum & bass",
+        "jungle"
+      ],
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-old-time-radio-usa",
+      "name": "Old Time Radio  USA",
+      "broadcaster": "independent",
+      "streamUrl": "https://ais-sa3.cdnstream1.com/2607_128.mp3",
+      "homepage": "https://www.wotrradionetwork.com/",
+      "country": "US",
+      "tags": [
+        "drama"
+      ],
+      "favicon": "https://static.wixstatic.com/media/7d32c5_2a0e314736a54369a945724dd2c84980%7emv2.png/v1/fill/w_180%2ch_180%2clg_1%2cusm_0.66_1.00_0.01/7d32c5_2a0e314736a54369a945724dd2c84980%7emv2.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-yourclassical-relax",
+      "name": "YourClassical relax",
+      "broadcaster": "independent",
+      "streamUrl": "https://relax.stream.publicradio.org/relax.aac",
+      "homepage": "https://www.yourclassical.org/playlist/relax-stream",
+      "country": "US",
+      "favicon": "https://www.yourclassical.org/apple-touch-icon.png",
+      "bitrate": 47,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-power-99",
+      "name": "Power 99",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc2009",
+      "homepage": "https://power99.iheart.com/",
+      "country": "US",
+      "tags": [
+        "urban contemporary"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/593f129c04f04dd9141a0b46?ops=gravity(%22center%22),contain(32,32),quality(65)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-95-7-big-fm",
+      "name": "95.7 BIG FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc2689",
+      "homepage": "https://957bigfm.iheart.com/",
+      "country": "US",
+      "tags": [
+        "oldies"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-joy-fm",
+      "name": "Joy FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://positivealtradio.streamguys1.com/wxrimp3",
+      "homepage": "https://joyfm.org/",
+      "country": "US",
+      "tags": [
+        "christian",
+        "christian praise&worship",
+        "god",
+        "jesus"
+      ],
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-930-am-wky-espn-deportes",
+      "name": "930 AM WKY ESPN Deportes",
+      "broadcaster": "independent",
+      "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/WKYAMAAC.aac",
+      "homepage": "https://www.wkydeportes.com/",
+      "country": "US",
+      "bitrate": 48,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-yourclassical-guitar",
+      "name": "YourClassical Guitar",
+      "broadcaster": "independent",
+      "streamUrl": "https://favorites.stream.publicradio.org/guitar.aac",
+      "homepage": "https://www.yourclassical.org/playlist/guitar-stream",
+      "country": "US",
+      "tags": [
+        "classical guitar",
+        "guitar"
+      ],
+      "favicon": "https://www.yourclassical.org/apple-touch-icon.png",
+      "bitrate": 47,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-christian-talk-fm",
+      "name": "Christian Talk FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://n07.radiojar.com/cm4by4kt2ceuv?rj-ttl=5&rj-tok=AAABel9L5qIAT_t_lI31ovcv0A",
+      "homepage": "https://www.christiantalkfm.com/",
+      "country": "US",
+      "tags": [
+        "christian",
+        "talk"
+      ],
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-taylor-swift",
+      "name": "Taylor Swift",
+      "broadcaster": "independent",
+      "streamUrl": "https://nl4.mystreaming.net/er/taylorswift/icecast.audio",
+      "homepage": "https://www.exclusive.radio/",
+      "country": "US",
+      "favicon": "https://e1.pngegg.com/pngimages/630/656/png-clipart-taylor-swift-taylor-swift-1-thumbnail.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-lofi-afrobeats-radio",
+      "name": "LoFi Afrobeats Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.zeno.fm/34vsiqt1kaktv",
+      "homepage": "https://zeno.fm/radio/lofi-afrobeats/",
+      "country": "US",
+      "tags": [
+        "afrobeats",
+        "chill",
+        "easy listening",
+        "lofi",
+        "r&b"
+      ],
+      "favicon": "https://zeno.fm/_next/image/?url=https%3A%2F%2Fimages.zeno.fm%2FzZe3OLAP0usX0Z0Q53XrrFuLKaNHO50zZ0gS3s8578k%2Frs%3Afit%3A240%3A240%2Fg%3Ace%3A0%3A0%2FaHR0cHM6Ly9zdHJlYW0tdG9vbHMuemVub21lZGlhLmNvbS9jb250ZW50L3N0YXRpb25zLzc1MTZmNTdlLTQ3ZTctNDQ1My1hYzFkLWRkNDliZGE5OWExZS9pbWFnZS8_dXBkYXRlZD0xNjk4NzExMzA2MDAw.webp&w=1920&q=100",
+      "codec": "MP3",
+      "geo": [
+        40.6509,
+        -73.9495
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-exclusively-mike-oldfield",
+      "name": "Exclusively Mike Oldfield",
+      "broadcaster": "independent",
+      "streamUrl": "https://nl4.mystreaming.net/er/mikeoldfield/icecast.audio",
+      "homepage": "https://play.you.radio/station/18/1518",
+      "country": "US",
+      "favicon": "https://you.radio/cdn-cgi/image/width=400,quality=75/https://manager.uber.radio/static/uploads/station/e10b5af0-38e5-4592-9343-aa75bdc05fb7.jpg",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-99-1-the-ranch",
+      "name": "99.1 The Ranch",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice9.securenetsystems.net/KWSV",
+      "homepage": "https://www.991theranch.com/",
+      "country": "US",
+      "tags": [
+        "country"
+      ],
+      "favicon": "https://www.991theranch.com/images/favicon/apple-touch-icon.png",
+      "bitrate": 32,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-107-5-wgci",
+      "name": "107.5 WGCI",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc841",
+      "homepage": "https://wgci.iheart.com/",
+      "country": "US",
+      "tags": [
+        "urban contemporary"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/5a03593628adca546d27a748?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-exa-fm-pop-music-in-spanish-and-english",
+      "name": "  EXA FM: POP MUSIC in Spanish and English",
+      "broadcaster": "independent",
+      "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/XHPSFMAAC.aac",
+      "homepage": "https://exafm.com/plaza/veracruz/",
+      "country": "US",
+      "tags": [
+        "contemporary hits",
+        "entertainment",
+        "music",
+        "news",
+        "pop",
+        "pop music"
+      ],
+      "favicon": "https://exafm.com/u/plantillas/p/exa-fm/imgs/favicons//apple-touch-icon.png?v2",
+      "bitrate": 48,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-wkdm",
+      "name": "WKDM 纽约华语广播国语台",
+      "broadcaster": "independent",
+      "streamUrl": "https://video1.getstreamhosting.com:8292/stream?.mp3",
+      "homepage": "https://nysino.com/am1380/",
+      "country": "US",
+      "tags": [
+        "full service",
+        "information",
+        "lifestyle",
+        "new york",
+        "new york city"
+      ],
+      "favicon": "http://gbm.123tv.cn/file/2023/08-1690893620.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-wrte-90-7-fm",
+      "name": "WRTE 90.7 FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://wdcb-ice.streamguys1.com/wdcb128",
+      "homepage": "https://wdcb.org/",
+      "country": "US",
+      "tags": [
+        "jazz"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-heart-soul-92-1-1140",
+      "name": "Heart & Soul 92.1 & 1140",
+      "broadcaster": "independent",
+      "streamUrl": "https://crystalout.surfernetwork.com:8001/KRMP_MP3",
+      "homepage": "https://www.okcheartandsoul.com/",
+      "country": "US",
+      "tags": [
+        "urban contemporary"
+      ],
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-texas-rebel-radio",
+      "name": "Texas Rebel Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice41.securenetsystems.net/KNAF?playSessionID=6CC4A665-B891-1B7E-1922BD6BD5D4109F",
+      "homepage": "https://texasrebelradio.com/",
+      "country": "US",
+      "tags": [
+        "blues",
+        "country",
+        "sports"
+      ],
+      "bitrate": 32,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-wkyu-88-9-wku-public-radio-bowling-green-ky",
+      "name": "WKYU 88.9 \"WKU Public Radio\" Bowling Green, KY",
+      "broadcaster": "independent",
+      "streamUrl": "https://dal-wku-stream-1.neighborhoodca.com/stream",
+      "homepage": "http://wkyufm.org/",
+      "country": "US",
+      "tags": [
+        "apm",
+        "bowling green",
+        "kentucky public radio",
+        "npr",
+        "pri",
+        "public radio"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-klou-103-3-stl-s-best-variety-of-the-70s-80s-90s",
+      "name": "KLOU 103.3 - STL's Best Variety of the 70s, 80s & 90s",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc3463",
+      "homepage": "https://klou.iheart.com/",
+      "country": "US",
+      "tags": [
+        "70s",
+        "80s",
+        "90s"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/6639ff25b916cb55e5b14c02a1078758?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-your-classical-radio",
+      "name": "Your Classical - Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ycradio.stream.publicradio.org/ycradio.mp3",
+      "homepage": "https://www.yourclassical.org/",
+      "country": "US",
+      "tags": [
+        "classical"
+      ],
+      "favicon": "https://www.yourclassical.org/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-christian-industrial-radio",
+      "name": "Christian Industrial Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://christianindustrial.net/listen/radio/radio.mp3",
+      "homepage": "https://christianindustrial.net/",
+      "country": "US",
+      "tags": [
+        "christian",
+        "industrial"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-light-favorites-easy-108",
+      "name": "Light Favorites Easy 108",
+      "broadcaster": "independent",
+      "streamUrl": "https://ais-sa2.cdnstream1.com/1299_128",
+      "homepage": "http://easy108.net/",
+      "country": "US",
+      "tags": [
+        "00s",
+        "10s",
+        "20s",
+        "60s",
+        "70s",
+        "80s"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        39.9866,
+        -82.8089
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-sunny-99-1",
+      "name": "SUNNY 99.1",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc2273",
+      "homepage": "https://sunny99.iheart.com/",
+      "country": "US",
+      "tags": [
+        "adult contemporary"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/5c6c7ebe564112eb3f91819d?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-cbs-sports-1430-am",
+      "name": "CBS Sports 1430 AM",
+      "broadcaster": "independent",
+      "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/WXNTAMAAC.aac",
+      "homepage": "https://www.cbssportsradio1430.com/",
+      "country": "US",
+      "tags": [
+        "sports"
+      ],
+      "bitrate": 80,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-ancient-faith-radio",
+      "name": "Ancient Faith Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ancientfaith.streamguys1.com/music",
+      "homepage": "http://www.ancientfaith.com/",
+      "country": "US",
+      "tags": [
+        "classical",
+        "medieval",
+        "religious"
+      ],
+      "bitrate": 96,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-deep-space-one-128k-mp3",
+      "name": "SomaFM Deep Space One (128k MP3)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice6.somafm.com/deepspaceone-128-mp3",
+      "homepage": "https://somafm.com/deepspaceone/",
+      "country": "US",
+      "tags": [
+        "ambient",
+        "electronic",
+        "space"
+      ],
+      "favicon": "http://somafm.com/img3/deepspaceone-400.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-fox-sports-1360",
+      "name": "Fox Sports 1360",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc4688",
+      "homepage": "https://foxsports1360.iheart.com/",
+      "country": "US",
+      "tags": [
+        "sports"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/c54a5ffebe8db4757ebbe6dd81f187fd?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-94-5-the-buzz",
+      "name": "94.5 The Buzz",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc2281",
+      "homepage": "https://thebuzz.iheart.com/",
+      "country": "US",
+      "tags": [
+        "alternative",
+        "rock"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/604a7bfd7e474524b9ae1a16?ops=gravity(%22center%22),contain(300,300)&quality=80",
+      "codec": "AAC",
+      "geo": [
+        29.7628,
+        -95.3675
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-hot-95-9",
+      "name": "Hot 95.9",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice.zradio.org/h/high.mp3",
+      "homepage": "https://zradio.org/listen/",
+      "country": "US",
+      "tags": [
+        "gospel",
+        "hiphop"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-smooth-jazz-101-1",
+      "name": "Smooth Jazz 101.1",
+      "broadcaster": "independent",
+      "streamUrl": "https://crystalout.surfernetwork.com:8001/WJZA-AM_MP3",
+      "homepage": "https://www.smoothjazzatl.com/",
+      "country": "US",
+      "tags": [
+        "smooth jazz"
+      ],
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-paradise-main-mix-64k-aac",
+      "name": "Radio Paradise Main Mix 64k AAC",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radioparadise.com/aac-64",
+      "homepage": "https://radioparadise.com/",
+      "country": "US",
+      "tags": [
+        "california",
+        "eclectic",
+        "free",
+        "internet",
+        "non-commercial",
+        "paradise"
+      ],
+      "favicon": "https://radioparadise.com/apple-touch-icon.png",
+      "bitrate": 64,
+      "codec": "AAC",
+      "geo": [
+        40.7851,
+        -124.1839
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-big-b-radio-asian-pop",
+      "name": "Big B Radio - Asian pop",
+      "broadcaster": "independent",
+      "streamUrl": "https://antares.dribbcast.com/proxy/apop?mp=/s?",
+      "homepage": "https://bigbradio.net/",
+      "country": "US",
+      "tags": [
+        "music",
+        "pop",
+        "rock"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-yar-plus",
+      "name": "Radio Yar Plus",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-171.zeno.fm/2jwyo983y49vv?zt=eyJhbGciOiJIUzI1NiJ9.eyJzdHJlYW0iOiIyand5bzk4M3k0OXZ2IiwiaG9zdCI6InN0cmVhbS0xNzEuemVuby5mbSIsInJ0dGwiOjUsImp0aSI6ImxuWlJyYXZfUS1TamI0MXJEUGFZSWciLCJpYXQiOjE3MzgxMDczNzUsImV4cCI6MTczODEwNzQzNX0.s37s0rmtffdTaKEhQMIwFMUl6mxQZ6C-O54FMSjDm-8&an-uid=975551466766821786&triton-uid=cookie%3Aaa378a8e-a987-4993-9848-db8cf7da7bd4&adtonosListenerId=01JJQMBBZVVS1YHWMJMFDSY4Q4&aw_0_req_lsid=609a2ec3b6fcae06b387373c64032f16",
+      "homepage": "https://radioyar.com/",
+      "country": "US",
+      "favicon": "https://zeno.fm/_ipx/q_85&fit_cover&s_288x288/https://images.zeno.fm/7XCVsr_ZE1q3fpPcrCpQD1prYmMrjHoCWo2u7sHhGYU/rs:fill:288:288/g:ce:0:0/aHR0cHM6Ly9wcm94eS56ZW5vLmZtL2NvbnRlbnQvc3RhdGlvbnMvZDYxZWM4ZjMtZTI1NC00ODBmLWE1NzAtNTZhNjYxYjY0ZTllL2ltYWdlLz91PTE3MzgxNTc4NTMwMDA.webp",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-t-k-disco",
+      "name": "Radio T.K. Disco",
+      "broadcaster": "independent",
+      "streamUrl": "https://broadcast.miami/proxy/tkdisco?mp=/stream/;",
+      "homepage": "https://www.radiotkdisco.com/",
+      "country": "US",
+      "tags": [
+        "disco"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-106-9-the-eagle",
+      "name": "106.9 The Eagle",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice9.securenetsystems.net/KEGK",
+      "homepage": "https://1069eagle.com/",
+      "country": "US",
+      "tags": [
+        "classic hits"
+      ],
+      "bitrate": 32,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-classical-piano",
+      "name": "classical piano",
+      "broadcaster": "independent",
+      "streamUrl": "https://cms.stream.publicradio.org/cms.aac",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "US",
+      "tags": [
+        "classical"
+      ],
+      "bitrate": 47,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radiogpt",
+      "name": "RadioGPT",
+      "broadcaster": "independent",
+      "streamUrl": "https://ais-sa1.streamon.fm/7838_128k.aac/playlist.m3u8",
+      "homepage": "https://listen.streamon.fm/radiogpt",
+      "country": "US",
+      "favicon": "https://listen.streamon.fm/favicon.ico",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-the-trip-64k-aac",
+      "name": "SomaFM The Trip (64k AAC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice2.somafm.com/thetrip-64-aac",
+      "homepage": "https://somafm.com/thetrip/",
+      "country": "US",
+      "tags": [
+        "house",
+        "progressive",
+        "trance"
+      ],
+      "favicon": "https://somafm.com/img3/thetrip-400.jpg",
+      "bitrate": 64,
+      "codec": "AAC",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-yoto-sleep-radio",
+      "name": "Yoto Sleep Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s3.radio.co/s74390585c/listen",
+      "homepage": "https://us.yotoplay.com/sleep",
+      "country": "US",
+      "favicon": "https://www.datocms-assets.com/48136/1666621552-sleep_sounds_icon.png",
+      "bitrate": 96,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-94-7-alternative-anchorage",
+      "name": "94.7 Alternative Anchorage",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice10.securenetsystems.net/KZND",
+      "homepage": "https://alternativeanchorage.com/",
+      "country": "US",
+      "tags": [
+        "alternative"
+      ],
+      "favicon": "https://radiostationusa.fm/assets/image/radio/180/KZND-FM.jpeg",
+      "bitrate": 32,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-gospel-highway-11",
+      "name": "Gospel Highway 11",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice23.securenetsystems.net/WNAP",
+      "homepage": "https://www.mygospelhighway11.com/",
+      "country": "US",
+      "tags": [
+        "gospel"
+      ],
+      "bitrate": 48,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-kvto-am1400-fm93-7",
+      "name": "KVTO AM1400 FM93.7 旧金山湾区中文电台",
+      "broadcaster": "independent",
+      "streamUrl": "https://us2.maindigitalstream.com/ssl/KVTO",
+      "homepage": "https://kvto.net/",
+      "country": "US",
+      "tags": [
+        "information"
+      ],
+      "favicon": "https://kvto.net/assets/img/basic/AM1400logo.png",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-sangeet-radio-fm-95-1-am-1460-houston-tx-us",
+      "name": "Sangeet Radio FM 95.1 AM 1460 Houston, TX, US",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice8.securenetsystems.net/SGTRADIO",
+      "homepage": "https://sangeetradio.com/",
+      "country": "US",
+      "tags": [
+        "hindi",
+        "music",
+        "sangeet radio fm 95.1 am 1460 houston",
+        "talks",
+        "tx",
+        "urdu"
+      ],
+      "favicon": "https://i0.wp.com/sangeetradio.com/wp-content/uploads/2020/05/cropped-512x512-1.png?fit=180%2c180&#038;ssl=1",
+      "bitrate": 32,
+      "codec": "AAC+",
+      "geo": [
+        29.759,
+        -95.3462
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-alt-98-7",
+      "name": "ALT 98.7",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc201",
+      "homepage": "https://alt987fm.iheart.com/",
+      "country": "US",
+      "favicon": "https://i.iheart.com/v3/re/assets/images/08e927dc-5949-41d6-972b-b5581a0850f3.png",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-news-talk-99-5-wrno",
+      "name": "News Talk 99.5 WRNO",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc1033",
+      "homepage": "https://wrno.iheart.com/",
+      "country": "US",
+      "tags": [
+        "news",
+        "talk"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/66e48d2c709d7268702bcb1c?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-70s-80s-hits",
+      "name": "70s 80s Hits",
+      "broadcaster": "independent",
+      "streamUrl": "https://azuracast.streams.gr/listen/oldieswebradio/hits70s80sradio.mp3?",
+      "homepage": "https://hits70s80s.weebly.com/",
+      "country": "US",
+      "tags": [
+        "hits 70s 80s"
+      ],
+      "favicon": "https://cdn-web.tunein.com/assets/img/apple-touch-icon-180.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        38.4932,
+        -90.7031
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-vip-radio-dance",
+      "name": "VIP Radio Dance",
+      "broadcaster": "independent",
+      "streamUrl": "https://usa11.fastcast4u.com/proxy/vipdance?mp=/;",
+      "homepage": "https://vipdance.com/",
+      "country": "US",
+      "tags": [
+        "club dance",
+        "dance",
+        "dj mixes",
+        "house"
+      ],
+      "favicon": "https://vipdance.com/assets/images/android-chrome-192x192-128x128-1.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-100-hip-hop-and-rnb-fm-official",
+      "name": "100 Hip Hop and RNB FM (Official)",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.shoutcast.com/100-hip-hop-and-rnb-fm",
+      "homepage": "https://uk.radio.net/s/100hiphopandrnb",
+      "country": "US",
+      "tags": [
+        "hip-hop",
+        "rap hiphop rnb",
+        "ridwan",
+        "rnb"
+      ],
+      "favicon": "https://static.mytuner.mobi/media/tvos_radios/887/rnb-and-hip-hop-radio.51c457d0.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        27.2468,
+        -81.7726
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-93-7-el-patron-pura-musica-perrona",
+      "name": "93.7 El Patron (Pura Música Perróna)",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc53/hls.m3u8",
+      "homepage": "https://elpatronphoenix.iheart.com/",
+      "country": "US",
+      "tags": [
+        "banda",
+        "mex",
+        "mexican music",
+        "regional mexican"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/6421b1c32608d1fa904eecae",
+      "bitrate": 24,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-mast-russian",
+      "name": "Radio Mast Russian",
+      "broadcaster": "independent",
+      "streamUrl": "https://streams.radiomast.io/1f7e18dd-42dc-4869-9785-a9800456b9e3",
+      "homepage": "https://bbn1.bbnradio.org/russian/",
+      "country": "US",
+      "tags": [
+        "bible",
+        "christian"
+      ],
+      "bitrate": 64,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-softrockradio-net",
+      "name": "SoftRockRadio.net",
+      "broadcaster": "independent",
+      "streamUrl": "https://gold.streamguys1.com/softrock.mp3",
+      "homepage": "https://softrockradio.net/",
+      "country": "US",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-department-store-christmas",
+      "name": "SomaFM Department Store Christmas",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice4.somafm.com/deptstore-128-aac",
+      "homepage": "https://somafm.com/deptstore/",
+      "country": "US",
+      "tags": [
+        "christmas"
+      ],
+      "favicon": "https://somafm.com/img3/deptstore400.jpg",
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-100-7-the-bay",
+      "name": "100.7 The Bay",
+      "broadcaster": "independent",
+      "streamUrl": "https://ais-sa1.streamon.fm/7225_48k.aac",
+      "homepage": "https://www.thebayonline.com/",
+      "country": "US",
+      "tags": [
+        "classic rock"
+      ],
+      "favicon": "https://www.thebayonline.com/apple-touch-icon.png",
+      "bitrate": 48,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-folk-forward-64k-aac",
+      "name": "SomaFM Folk Forward (64k AAC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice2.somafm.com/folkfwd-64-aac",
+      "homepage": "https://somafm.com/folkfwd/",
+      "country": "US",
+      "tags": [
+        "alt-folk",
+        "indie folk",
+        "occasional folk classics"
+      ],
+      "favicon": "https://somafm.com/img3/folkfwd-400.jpg",
+      "bitrate": 64,
+      "codec": "AAC",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-good-news-tv",
+      "name": "Good News TV",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.eleden.com/livegntv/ngrp:livegntv_all/chunklist_w1882925524_b484144.m3u8",
+      "homepage": "https://www.mygoodnewstv.com/live",
+      "country": "US",
+      "tags": [
+        "christian",
+        "tv"
+      ],
+      "codec": "UNKNOWN",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-gotradio-og-s-hip-hop-and-rnb",
+      "name": "GotRadio - OG's Hip Hop and RnB",
+      "broadcaster": "independent",
+      "streamUrl": "https://pureplay.cdnstream1.com/6045_128.mp3",
+      "homepage": "https://pureplay.cdnstream1.com/6045_128.mp3",
+      "country": "US",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/5/10155.v2.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-uctv-university-of-california",
+      "name": "UCTV - University of California",
+      "broadcaster": "independent",
+      "streamUrl": "https://59e8e1c60a2b2.streamlock.net/509/509.stream/playlist.m3u8",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "US",
+      "tags": [
+        "education",
+        "tv",
+        "university",
+        "university of california",
+        "教育",
+        "电视"
+      ],
+      "bitrate": 1080,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-talk-radio-1190",
+      "name": "Talk Radio 1190",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc4276",
+      "homepage": "https://1190talkradio.iheart.com/",
+      "country": "US",
+      "tags": [
+        "talk"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/9b2473c277a06bf9ee69139dab0f80d6?ops=gravity(%22center%22),contain(32,32),quality(65)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-wrko-am-680",
+      "name": "WRKO-AM 680",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc7750",
+      "homepage": "https://wrko.iheart.com/",
+      "country": "US",
+      "tags": [
+        "news",
+        "talk"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/623b3302f27ef877e7867576?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-exclusive-jj-cale",
+      "name": "Exclusive JJ Cale",
+      "broadcaster": "independent",
+      "streamUrl": "https://2.mystreaming.net/er/jjcale/icecast.audio",
+      "homepage": "https://play.you.radio/station/362",
+      "country": "US",
+      "favicon": "https://you.radio/cdn-cgi/image/width=400,quality=75/https://manager.uber.radio/static/uploads/station/38e9316d-592d-4836-a90d-1488afd7bfe1.jpg",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-grace-fm",
+      "name": "GRACE Fm",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice23.securenetsystems.net/KXGRFM",
+      "homepage": "https://www.gracefm.com/",
+      "country": "US",
+      "tags": [
+        "christian contemporary"
+      ],
+      "favicon": "https://cloud-1de12d.b-cdn.net/media/iw=192&ih=any/3042768b3e79292c36a9508094eafafc.ico",
+      "bitrate": 32,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-magic-107-7",
+      "name": "Magic 107.7",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc597",
+      "homepage": "https://magic107.iheart.com/",
+      "country": "US",
+      "tags": [
+        "adult contemporary"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/5f203df69dad71e167e50793?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-3abn-music-channel",
+      "name": "3ABN Music Channel",
+      "broadcaster": "independent",
+      "streamUrl": "https://war.streamguys1.com:7185/MC01",
+      "homepage": "https://3abn.org/3abn-music-channel.html",
+      "country": "US",
+      "tags": [
+        "adventist",
+        "christian",
+        "music"
+      ],
+      "favicon": "https://3abn.org/icons/3abn-apple-icon-180x180.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-la-talk-radio",
+      "name": "LA Talk Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://securestreams2.autopo.st:1185/;stream/1",
+      "homepage": "https://www.latalkradio.com/",
+      "country": "US",
+      "tags": [
+        "podcast",
+        "talk"
+      ],
+      "bitrate": 112,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somali-super-sport",
+      "name": "Somali Super Sport",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.zeno.fm/7ytz1pedps8uv",
+      "homepage": "https://somalisupersport.com/",
+      "country": "US",
+      "tags": [
+        "somali",
+        "sport",
+        "sports"
+      ],
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-american-family-radio-talk",
+      "name": "American Family Radio: Talk",
+      "broadcaster": "independent",
+      "streamUrl": "https://mediaserver3.afa.net:8443/talk.mp3",
+      "homepage": "https://afr.net/",
+      "country": "US",
+      "tags": [
+        "christian talk",
+        "conservative talk",
+        "talk radio"
+      ],
+      "favicon": "https://afr.net/media/nxrpxumw/afr-logo-800x500.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-104-1-the-edge",
+      "name": "104.1 The Edge",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc1397",
+      "homepage": "https://1041theedge.iheart.com/",
+      "country": "US",
+      "tags": [
+        "alternative"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/5c2fd80baebb07ba9ae0033f?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-fox-sports-radio-1400",
+      "name": "Fox Sports Radio 1400",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc2089",
+      "homepage": "https://foxsportsradio1400.iheart.com/",
+      "country": "US",
+      "tags": [
+        "sports"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/5ef24439f789c41536f7fe2b?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-jesus-worship-club-radio",
+      "name": "Jesus Worship Club Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radio.co/s08b6706bd/low",
+      "homepage": "http://www.jesusworshipclub.com/",
+      "country": "US",
+      "favicon": "http://www.jesusworshipclub.com/uploads/9/6/3/0/96302130/editor/paypal.png?1592327061",
+      "bitrate": 64,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-oldies-103-3-fm-1170-am",
+      "name": "Oldies 103.3 FM/1170 AM",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice24.securenetsystems.net/WFDLAM?&playSessionID=797937C8-FCF5-342C-87990F68DDABEC5D",
+      "homepage": "https://www.am1170radio.com/",
+      "country": "US",
+      "tags": [
+        "oldies"
+      ],
+      "favicon": "https://dehayf5mhw1h7.cloudfront.net/wp-content/uploads/sites/1442/2020/06/05150844/cropped-radioplus-logo-180x180.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-casablanca",
+      "name": "Radio Casablanca",
+      "broadcaster": "independent",
+      "streamUrl": "https://broadcast.miami/proxy/casablanca?mp=/stream/;",
+      "homepage": "https://www.radio-casablanca.com/",
+      "country": "US",
+      "tags": [
+        "disco"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-bay-smooth-jazz",
+      "name": "Bay Smooth Jazz",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio2.vip-radios.fm:18039/stream-192kmp3-BaySmoothJazz",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "US",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-mega-97-1-1-para-latino-hits",
+      "name": "Mega 97.1 (#1 Para Latino Hits )",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc69/hls.m3u8",
+      "homepage": "https://megatucson.iheart.com/",
+      "country": "US",
+      "tags": [
+        "entretenimiento",
+        "hits",
+        "latin",
+        "latino urbano",
+        "music",
+        "musica"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/6330fb8345c37fdb34215c51",
+      "bitrate": 24,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-mia-92-1",
+      "name": "Mia 92.1",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc3633",
+      "homepage": "https://mia921.iheart.com/",
+      "country": "US",
+      "tags": [
+        "spanish"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-z100-whtz-fm-100-3-new-york",
+      "name": "Z100 - WHTZ-FM 100.3 New York",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc2509",
+      "homepage": "https://z100.iheart.com/",
+      "country": "US",
+      "tags": [
+        "pop",
+        "top 40"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/5e7b5d50bee47a8a2b396059?ops=gravity(%22center%22),contain(360,360)&quality=80",
+      "codec": "AAC",
+      "geo": [
+        40.7484,
+        -73.9857
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-kalx-90-7fm-berkeley",
+      "name": "KALX 90.7FM Berkeley",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.kalx.berkeley.edu:8443/kalx-320.aac",
+      "homepage": "https://www.kalx.berkeley.edu/",
+      "country": "US",
+      "tags": [
+        "aac",
+        "berkeley",
+        "uc berkeley",
+        "university radio"
+      ],
+      "favicon": "https://www.kalx.berkeley.edu/favicon.ico",
+      "bitrate": 320,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-wild-94-3",
+      "name": "Wild 94.3",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice8.securenetsystems.net/KWDD",
+      "homepage": "https://wild943.com/",
+      "country": "US",
+      "tags": [
+        "country"
+      ],
+      "bitrate": 32,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-100-7-wzlx",
+      "name": "100.7 WZLX",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc7730",
+      "homepage": "https://wzlx.iheart.com/",
+      "country": "US",
+      "tags": [
+        "classic rock"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/new_assets/5e4febcf88989f180366cffc?ops=gravity(%22center%22),contain(32,32),quality(65)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-indie-pop-rocks-32k-aac",
+      "name": "SomaFM Indie Pop Rocks! (32k AAC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice5.somafm.com/indiepop-32-aac",
+      "homepage": "https://somafm.com/indiepop/",
+      "country": "US",
+      "tags": [
+        "indie",
+        "indie pop",
+        "indie rock"
+      ],
+      "favicon": "https://somafm.com/img3/indiepop-400.jpg",
+      "bitrate": 32,
+      "codec": "AAC",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-salsa-warriors",
+      "name": "Salsa Warriors",
+      "broadcaster": "independent",
+      "streamUrl": "https://usa7.fastcast4u.com/proxy/salsawarrior?mp=/1",
+      "homepage": "https://www.salsawarriors.com/",
+      "country": "US",
+      "tags": [
+        "salsa"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-highfi-dream",
+      "name": "HighFi Dream",
+      "broadcaster": "independent",
+      "streamUrl": "https://cdn06-us-east.radio.cloud/80ba63862a97bd69c593cc7a2ccaab1c_hq",
+      "homepage": "https://highfidream.com/",
+      "country": "US",
+      "tags": [
+        "new wave",
+        "shoegaze",
+        "melodic house",
+        "alternative / indie",
+        "dream pop",
+        "neo soul"
+      ],
+      "favicon": "https://img1.wsimg.com/isteam/ip/56a4969b-e591-4c57-b68b-f6a75cf900d2/blob-c3b0c70.png",
+      "bitrate": 1200,
+      "codec": "OGG",
+      "geo": [
+        37.3244,
+        -121.8713
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-groove-salad-16k-aac",
+      "name": "SomaFM Groove Salad (16k AAC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice1.somafm.com/groovesalad-16-aac",
+      "homepage": "https://somafm.com/groovesalad/",
+      "country": "US",
+      "tags": [
+        "ambient",
+        "chillout",
+        "downtempo",
+        "groove",
+        "lounge",
+        "sleep"
+      ],
+      "favicon": "https://somafm.com/img3/groovesalad-400.jpg",
+      "bitrate": 16,
+      "codec": "AAC",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-dopephonk",
+      "name": "DOPEPHONK",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.atomic.radio/dopephonk/middlequality",
+      "homepage": "https://dopephonk.com/",
+      "country": "US",
+      "favicon": "https://dopephonk.com/icons/android-chrome-192x192.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-synthwave-radio",
+      "name": "Synthwave Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.synthwaveradio.eu/listen/synthwaveradio.eu/radio.mp3",
+      "homepage": "https://www.synthwaveradio.eu/",
+      "country": "US",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-96-1-kiss-fm",
+      "name": "96.1 KISS FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc1333",
+      "homepage": "https://961kissonline.iheart.com/",
+      "country": "US",
+      "tags": [
+        "pop",
+        "top 40"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/609980bbc5876abd3347a3b9?ops=gravity(%22center%22),contain(32,32),quality(65)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-columbia",
+      "name": "Radio Columbia",
+      "broadcaster": "independent",
+      "streamUrl": "https://broadcast.miami/proxy/columbia?mp=/stream/;",
+      "homepage": "https://www.radio-columbia.com/",
+      "country": "US",
+      "tags": [
+        "disco",
+        "funk",
+        "soul"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-classic-hits-104-5-wjjk",
+      "name": "Classic Hits 104.5 WJJK",
+      "broadcaster": "independent",
+      "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/WJJKFMAAC.aac",
+      "homepage": "https://www.1045wjjk.com/",
+      "country": "US",
+      "tags": [
+        "classic hits"
+      ],
+      "favicon": "https://www.1045wjjk.com/favicon.ico",
+      "bitrate": 48,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-conyers-old-time-radio-2nd-stream",
+      "name": "Conyers Old Time Radio 2nd Stream",
+      "broadcaster": "independent",
+      "streamUrl": "https://s6.yesstreaming.net:17082/stream",
+      "homepage": "https://conyersradio.net/",
+      "country": "US",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-kfm-radio",
+      "name": "KFM Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.zeno.fm/1adz268xt98uv",
+      "homepage": "http://kfm-radio.org/",
+      "country": "US",
+      "codec": "AAC",
+      "geo": [
+        37.1603,
+        -121.068
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-classical-jazz-radio",
+      "name": "Classical Jazz Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ec1.yesstreaming.net:2905/stream",
+      "homepage": "https://jazzradionetwork.com/classical-jazz-radio/",
+      "country": "US",
+      "tags": [
+        "jazz"
+      ],
+      "bitrate": 256,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-classical-king-fm",
+      "name": "Classical KING FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://classicalking.streamguys1.com/king-fm-aac-128k",
+      "homepage": "https://www.king.org/",
+      "country": "US",
+      "favicon": "https://dehayf5mhw1h7.cloudfront.net/wp-content/uploads/sites/1108/2022/10/22131738/ClassicalKING_Streaming_Main_125x125rnd.png",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-groove-salad-classic-64k-aac",
+      "name": "SomaFM Groove Salad Classic (64k AAC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice2.somafm.com/gsclassic-64-aac",
+      "homepage": "https://somafm.com/groovesalad/",
+      "country": "US",
+      "tags": [
+        "ambient",
+        "downtempo",
+        "early 2000s"
+      ],
+      "favicon": "https://somafm.com/img3/gsclassic400.jpg",
+      "bitrate": 64,
+      "codec": "AAC",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-smooth-jazz-tampa-bay-hd",
+      "name": "Smooth Jazz - Tampa Bay HD",
+      "broadcaster": "independent",
+      "streamUrl": "https://vip2.fastcast4u.com/proxy/sjtbhd?mp=/1",
+      "homepage": "https://smoothjazztampabay.com/",
+      "country": "US",
+      "favicon": "https://radio.zone/wp-content/uploads/2024/02/cropped-favicon-1-180x180.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-fox-sports-radio-1380",
+      "name": "FOX Sports Radio 1380",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc5169",
+      "homepage": "https://khey1380.iheart.com/",
+      "country": "US",
+      "tags": [
+        "sports"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/e22e222b4a92e441adc4fdfd68b621db?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-50-s-science-fiction-kotr",
+      "name": "50's Science Fiction KOTR",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.kf7k.com/listen/scifi/radio.mp3",
+      "homepage": "https://stream.kf7k.com/public/scifi",
+      "country": "US",
+      "tags": [
+        "old time radio",
+        "otr"
+      ],
+      "favicon": "https://stream.kf7k.com/api/station/scifi/art/e89f8ef8f1b445020733f7a0",
+      "bitrate": 64,
+      "codec": "MP3",
+      "geo": [
+        40.2694,
+        -111.7104
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-big-105-9-south-florida-s-classic-rock",
+      "name": "BIG 105.9 – South Florida's Classic Rock!",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc557",
+      "homepage": "https://big1059.iheart.com/",
+      "country": "US",
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/63d7c12a09346a332020b492?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-moody-radio-wmbi-90-1-fm",
+      "name": "Moody Radio WMBI 90.1 FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://14123.live.streamtheworld.com/WMBIFM.mp3",
+      "homepage": "https://www.moodyradio.org/stations/chicago/",
+      "country": "US",
+      "favicon": "https://impact.moodybible.org/contentassets/a6a563d3318a44e783d8810875b5ad06/moody-radio-chicago_230px.png",
+      "bitrate": 96,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-sda-radio",
+      "name": "SDA Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://usa18.fastcast4u.com/proxy/loudcrymedia6?mp=/1",
+      "homepage": "https://www.loudcrymedia.com/sda-radio/",
+      "country": "US",
+      "tags": [
+        "ccm",
+        "gospel"
+      ],
+      "favicon": "https://loudcrymedia.com/wp-content/uploads/2018/06/cropped-logo-web-icon22-180x180.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-news-talk-630-wpro",
+      "name": "News Talk 630 WPRO",
+      "broadcaster": "independent",
+      "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/WPROAMAAC.aac",
+      "homepage": "https://www.630wpro.com/",
+      "country": "US",
+      "tags": [
+        "news",
+        "talk"
+      ],
+      "bitrate": 48,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-thistleradio-32k-aac",
+      "name": "SomaFM ThistleRadio (32k AAC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice6.somafm.com/thistle-32-aac",
+      "homepage": "https://somafm.com/thistle/",
+      "country": "US",
+      "tags": [
+        "celtic",
+        "folk"
+      ],
+      "favicon": "https://somafm.com/img3/thistle-400.jpg",
+      "bitrate": 32,
+      "codec": "AAC",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-espn-radio-101-7-the-team",
+      "name": "ESPN Radio 101.7 The TEAM",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice8.securenetsystems.net/KQTM",
+      "homepage": "https://www.1017theteam.com/",
+      "country": "US",
+      "tags": [
+        "sports"
+      ],
+      "bitrate": 32,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-hot-tejano-austin-online-www-hottejano-com-hotte",
+      "name": "Hot Tejano (Austin) - Online - www.hottejano.com - hottejano.com LLC - Austin, Texas",
+      "broadcaster": "independent",
+      "streamUrl": "https://ithaca.cdnstream.com/1113_96",
+      "homepage": "https://hottejano.com/",
+      "country": "US",
+      "tags": [
+        "austin",
+        "country",
+        "country music",
+        "entretenimiento",
+        "estación",
+        "inglés"
+      ],
+      "favicon": "https://hottejano.com/wp-content/uploads/2020/11/hottejano250x250-140x140.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        30.2732,
+        -97.7421
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-1460-am-deportes-vegas",
+      "name": "1460 AM Deportes Vegas",
+      "broadcaster": "independent",
+      "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/KENOAM.mp3",
+      "homepage": "https://www.deportesvegas.com/",
+      "country": "US",
+      "tags": [
+        "deportes",
+        "entretenimiento",
+        "radio hablada"
+      ],
+      "favicon": "https://dehayf5mhw1h7.cloudfront.net/wp-content/uploads/sites/2227/2020/10/12160146/keno-logo.png",
+      "bitrate": 24,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-live-128k-mp3",
+      "name": "SomaFM Live (128k MP3)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice5.somafm.com/live-128-mp3",
+      "homepage": "https://somafm.com/live/",
+      "country": "US",
+      "tags": [
+        "live"
+      ],
+      "favicon": "https://somafm.com/img3/live-400.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-instrumental-hop-radio",
+      "name": "Instrumental Hop Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://cheetah.streemlion.com:2670/stream",
+      "homepage": "https://www.instrumentalhopradio.com/",
+      "country": "US",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-koke-99-3-98-5-fm-austin-tx",
+      "name": "KOKE 99.3 & 98.5 FM - Austin, TX",
+      "broadcaster": "independent",
+      "streamUrl": "https://arn.leanstream.co/KOKEFM",
+      "homepage": "https://kokefm.com/",
+      "country": "US",
+      "tags": [
+        "americana",
+        "country",
+        "red dirt",
+        "texas",
+        "texas country"
+      ],
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-96-9-bob-fm",
+      "name": "96.9 BOB FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://ais-sa1.streamon.fm/7215_48k.aac",
+      "homepage": "https://www.bobfm969.com/",
+      "country": "US",
+      "bitrate": 96,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-no-agenda-show-stream-pls",
+      "name": "No Agenda Show Stream (pls)",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.noagendastream.com/noagenda",
+      "homepage": "http://www.noagendashow.com/",
+      "country": "US",
+      "tags": [
+        "best podcast in the universe",
+        "buzzkill",
+        "comedy",
+        "crackpot",
+        "curry",
+        "dvorak"
+      ],
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-96-9-hits-fm",
+      "name": "96.9 Hits FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice9.securenetsystems.net/KLTAHD2",
+      "homepage": "https://www.969hitsfm.com/",
+      "country": "US",
+      "tags": [
+        "adult contemporary"
+      ],
+      "bitrate": 32,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-102-3-the-beat",
+      "name": "102.3 The Beat",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc2169",
+      "homepage": "https://thebeatatx.iheart.com/",
+      "country": "US",
+      "tags": [
+        "pop",
+        "top 40"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/593da8dee7970b302d32a0f8?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us--1bd81fe9",
+      "name": "白猿道广播电台",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.zeno.fm/5uyxq85zm7zuv",
+      "homepage": "https://baiyuandao.com/",
+      "country": "US",
+      "tags": [
+        "religion",
+        "taoism"
+      ],
+      "favicon": "https://baiyuandao.com/favicon.ico",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-94-9-news-now",
+      "name": "94.9 News Now",
+      "broadcaster": "independent",
+      "streamUrl": "https://crystalout.surfernetwork.com:8001/WJJF-FM_MP3",
+      "homepage": "https://949newsnow.com/",
+      "country": "US",
+      "tags": [
+        "news",
+        "talk"
+      ],
+      "favicon": "https://dehayf5mhw1h7.cloudfront.net/wp-content/uploads/sites/1623/2021/05/25072657/cropped-logo-180x180.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-wjmj",
+      "name": "WJMJ",
+      "broadcaster": "independent",
+      "streamUrl": "https://www.ophanim.net:8444/s/7760/",
+      "homepage": "https://ortv.org/WJMJ/wjmj.htm",
+      "country": "US",
+      "favicon": "https://ortv.org/images/Logos/WJMJ_logo_R.png",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-kogo-am-600",
+      "name": "KOGO AM 600",
+      "broadcaster": "independent",
+      "streamUrl": "https://ample.revma.ihrhls.com/zc257",
+      "homepage": "https://www.iheart.com/live/am-600-257/",
+      "country": "US",
+      "tags": [
+        "conservative",
+        "conservative talk",
+        "news talk",
+        "san diego"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-iq",
+      "name": "Radio IQ",
+      "broadcaster": "independent",
+      "streamUrl": "https://wvtf.streamguys1.com/wvtf-edge/radioiq-aac-64/icecast.audio",
+      "homepage": "https://www.wvtf.org/",
+      "country": "US",
+      "favicon": "https://www.wvtf.org/apple-touch-icon.png",
+      "bitrate": 56,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-91-7-kxt-the-republic-of-music",
+      "name": "91.7 KXT The Republic of Music ",
+      "broadcaster": "independent",
+      "streamUrl": "https://kera.streamguys1.com/kxtlive128",
+      "homepage": "https://kxt.org/",
+      "country": "US",
+      "favicon": "https://kxt.org/wp-content/themes/kxt-joints/favicon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        32.7968,
+        -96.812
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-rusrek-bbe2c59a",
+      "name": "Канал \"Музыка без слов\" Radio Rusrek Радио Русская Реклама",
+      "broadcaster": "independent",
+      "streamUrl": "https://securestreams6.autopo.st:2130/instrumental",
+      "homepage": "https://radio.rusrek.com/",
+      "country": "US",
+      "tags": [
+        "instrumental",
+        "russian"
+      ],
+      "favicon": "https://radio.rusrek.com/templates/rusrek/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        40.5908,
+        -73.9603
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-93-3-wbzd-classic-hits",
+      "name": "93.3 WBZD Classic Hits",
+      "broadcaster": "independent",
+      "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/WBZDFMAAC.aac",
+      "homepage": "https://www.wbzd.com/",
+      "country": "US",
+      "tags": [
+        "classic hits"
+      ],
+      "favicon": "https://express-images.franklymedia.com/8949/sites/4/2022/11/22153124/wbzdfavicon64.png",
+      "bitrate": 32,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-afrobeats-rising-radio",
+      "name": "Afrobeats Rising Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.zeno.fm/fmf6pyudu3kvv",
+      "homepage": "https://zeno.fm/radio/afrobeats-rising-radio/",
+      "country": "US",
+      "tags": [
+        "afrobeats",
+        "afrofusion",
+        "afropop",
+        "alte",
+        "amapiano",
+        "hip hop"
+      ],
+      "favicon": "https://zeno.fm/_next/image/?url=https%3A%2F%2Fimages.zeno.fm%2FWUCzymdyj6ONlEodR_rKPcNI6PEDrfvP794nkeqYIew%2Frs%3Afit%3A240%3A240%2Fg%3Ace%3A0%3A0%2FaHR0cHM6Ly9zdHJlYW0tdG9vbHMuemVub21lZGlhLmNvbS9jb250ZW50L3N0YXRpb25zL2RjYmE5MDRlLWZlYzQtNDZjNy1iNDZhLTMwMDEyNmNjYjRmMS9pbWFnZS8_dXBkYXRlZD0xNzA3Njc2MTg3MDAw.webp&w=1920&q=100",
+      "codec": "MP3",
+      "geo": [
+        40.6971,
+        -73.87
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-cruisin-country-93-5",
+      "name": "Cruisin Country 93.5",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radio.co/s4867e9e93/listen",
+      "homepage": "https://cruisinmaine.com/",
+      "country": "US",
+      "tags": [
+        "country"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-american-road-radio",
+      "name": "American Road Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://c5.radioboss.fm:18224/stream",
+      "homepage": "https://www.americanroadradio.com/",
+      "country": "US",
+      "tags": [
+        "blues rock",
+        "classic rock",
+        "rhythm and blues (1960s randb (eg. the rolling stones))",
+        "rock"
+      ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/9/9549.v2.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        34.0659,
+        -118.2445
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-wguc-cincinnati-classical-music-radio",
+      "name": "WGUC Cincinnati Classical Music Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.cinradio.org/wguc",
+      "homepage": "https://www.wguc.org/",
+      "country": "US",
+      "favicon": "https://wguc.org/wp-content/themes/wguc/favicon.ico",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-legends-radio",
+      "name": "Legends Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice3.securenetsystems.net/WLML",
+      "homepage": "https://legendsradio.com/",
+      "country": "US",
+      "tags": [
+        "adult standards"
+      ],
+      "favicon": "https://legendsradio.com/favicon.ico",
+      "bitrate": 48,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-102-9-now",
+      "name": "102.9 NOW",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc2237",
+      "homepage": "https://1029now.iheart.com/",
+      "country": "US",
+      "tags": [
+        "adult contemporary"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/648373b015630e856cd84951?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-spirit-catholic-radio",
+      "name": "Spirit Catholic Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice7.securenetsystems.net/KVSS",
+      "homepage": "https://spiritcatholicradio.com/",
+      "country": "US",
+      "tags": [
+        "religious"
+      ],
+      "favicon": "https://spiritcatholicradio.com/wp-content/themes/spirit-catholic-radio/favicon.png",
+      "bitrate": 32,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-cajun-country-radio",
+      "name": "Cajun Country Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.live365.com/a18002",
+      "homepage": "https://www.cajuncountryradio.com/",
+      "country": "US",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-la-raza-102-3-107-1",
+      "name": "La Raza 102.3/107.1",
+      "broadcaster": "independent",
+      "streamUrl": "https://crystalout.surfernetwork.com:8001/WLKQ-FM_MP3",
+      "homepage": "https://www.laraza1023.com/",
+      "country": "US",
+      "tags": [
+        "regional mexican"
+      ],
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-1200-woai-talk-radio",
+      "name": "1200 WOAI Talk Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc2361/hls.m3u8",
+      "homepage": "https://www.iheart.com/live/1200-woai-2361/",
+      "country": "US",
+      "favicon": "https://www.iheart.com/favicon.ico",
+      "bitrate": 24,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-93-7-the-ticket",
+      "name": "93.7 The Ticket",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice8.securenetsystems.net/KNTK",
+      "homepage": "https://theticketfm.com/",
+      "country": "US",
+      "tags": [
+        "sports"
+      ],
+      "bitrate": 32,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-bagel-radio",
+      "name": "BAGeL RADIO",
+      "broadcaster": "independent",
+      "streamUrl": "https://ais-sa3.cdnstream1.com/2606_128.aac",
+      "homepage": "https://www.bagelradio.com/",
+      "country": "US",
+      "tags": [
+        "rock"
+      ],
+      "favicon": "https://images.squarespace-cdn.com/content/v1/616462d943ce4468804f598c/6ed86b2b-86ba-4ba3-995c-c150b6e15832/bagel_logo_sutro_8_flat.jpg",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-nepa-s-espn-radio",
+      "name": "NEPA's ESPN Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ais-sa1.streamon.fm/7284_48k.aac",
+      "homepage": "https://www.nepasespnradio.com/",
+      "country": "US",
+      "tags": [
+        "sports"
+      ],
+      "favicon": "https://dehayf5mhw1h7.cloudfront.net/wp-content/uploads/sites/2358/2025/01/04195002/wejl-logo-good-1-150x150.png",
+      "bitrate": 48,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-mirchi-bay-area",
+      "name": "Radio Mirchi Bay Area",
+      "broadcaster": "independent",
+      "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/SFO_HIN_PSTAAC.aac",
+      "homepage": "https://mirchi.in/radio/SFO_HIN_PST",
+      "country": "US",
+      "tags": [
+        "bollywood",
+        "hindi"
+      ],
+      "favicon": "https://static-media.streema.com/media/cache/6c/23/6c23aa893f7a781a098f50d1a56a39a4.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "geo": [
+        37.3301,
+        -121.9098
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-metal-detector-128k-mp3",
+      "name": "SomaFM Metal Detector (128k MP3)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice5.somafm.com/metal-128-mp3",
+      "homepage": "https://somafm.com/metal/",
+      "country": "US",
+      "tags": [
+        "black metal",
+        "doom metal",
+        "post-punk",
+        "progressive rock",
+        "sludge",
+        "stoner rock"
+      ],
+      "favicon": "https://somafm.com/img3/metal-400.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-wgbh-89-7",
+      "name": "WGBH 89.7",
+      "broadcaster": "independent",
+      "streamUrl": "https://streams.audio.wgbh.org/wgbh",
+      "homepage": "https://wgbh.org/",
+      "country": "US",
+      "favicon": "https://wgbh.org/apple-touch-icon.png",
+      "bitrate": 96,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-24-7-dance",
+      "name": "24/7 - Dance",
+      "broadcaster": "independent",
+      "streamUrl": "https://ip39.ip-178-33-37.eu/radio/8010/radio.mp3",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "US",
+      "tags": [
+        "electronic"
+      ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/9/84659.v2.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-the-peach",
+      "name": "The Peach",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice3.securenetsystems.net/PEACH",
+      "homepage": "https://tunein.com/radio/The-Peach-s309559/",
+      "country": "US",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-wabc-770-am-newyork-ny",
+      "name": "WABC 770 AM - NewYork, NY",
+      "broadcaster": "independent",
+      "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/WABCAM.mp3",
+      "homepage": "https://wabcradio.com/",
+      "country": "US",
+      "tags": [
+        "local talk",
+        "news",
+        "news talk",
+        "oldies music radio weekeds"
+      ],
+      "favicon": "https://dehayf5mhw1h7.cloudfront.net/wp-content/uploads/sites/1494/2022/01/21131743/77-WABC-Gold_narrow_4.png",
+      "bitrate": 96,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-yourclassical-guitar-stream",
+      "name": "YourClassical Guitar Stream",
+      "broadcaster": "independent",
+      "streamUrl": "https://guitar.stream.publicradio.org/guitar.mp3",
+      "homepage": "https://www.yourclassical.org/playlist/guitar-stream",
+      "country": "US",
+      "tags": [
+        "classical",
+        "guitar"
+      ],
+      "favicon": "https://img.apmcdn.org/149a09c7f10962db985fc19a2eb503156a7dfc1f/uncropped/a6e58f-20221003-guitar-stream-tile-3000.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-flashback-alternatives",
+      "name": "Flashback Alternatives ",
+      "broadcaster": "independent",
+      "streamUrl": "https://puma.streemlion.com/fa64",
+      "homepage": "https://www.flashbackalternatives.com/",
+      "country": "US",
+      "tags": [
+        "80s",
+        "alternative"
+      ],
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-iheart-radio-smells-like-the-90s",
+      "name": "iHeart Radio Smells Like the 90s",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc6437",
+      "homepage": "http://www.iheart.com/live/smells-like-the-90s-6437",
+      "country": "US",
+      "favicon": "http://www.iheart.com/favicon.ico",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-kcmo-talk-radio",
+      "name": "KCMO Talk Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/KCMOAMAAC.aac",
+      "homepage": "https://www.kcmotalkradio.com/",
+      "country": "US",
+      "tags": [
+        "news",
+        "talk"
+      ],
+      "favicon": "https://www.kcmotalkradio.com/favicon.ico",
+      "bitrate": 48,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-gotradio-the-50-s",
+      "name": "GotRadio - the 50's",
+      "broadcaster": "independent",
+      "streamUrl": "https://pureplay.cdnstream1.com/6005_128.mp3",
+      "homepage": "https://gotradio.com/radiochannel/the-50s/",
+      "country": "US",
+      "favicon": "https://gotradio.com/wp-content/uploads/2023/04/Gotradio.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-wisconsin-public-radio-npr-news-music-network",
+      "name": "Wisconsin Public Radio: NPR News & Music Network",
+      "broadcaster": "independent",
+      "streamUrl": "https://wpr-ice.streamguys1.com/wpr-music-mp3-96",
+      "homepage": "https://www.wpr.org/",
+      "country": "US",
+      "favicon": "https://www.wpr.org/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        43.0697,
+        -89.4074
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-abiding-radio-seasonal",
+      "name": "Abiding Radio - Seasonal",
+      "broadcaster": "independent",
+      "streamUrl": "https://streams.abidingradio.com:7830/1",
+      "homepage": "https://www.abidingradio.com/",
+      "country": "US",
+      "tags": [
+        "christian"
+      ],
+      "favicon": "https://www.abidingradio.org/wp-content/uploads/2022/05/cropped-new_icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        30.76,
+        -86.57
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-oldies-wttf",
+      "name": "Oldies WTTF",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice64.securenetsystems.net/WTTF",
+      "homepage": "https://www.wttf.com/",
+      "country": "US",
+      "tags": [
+        "oldies",
+        "sports",
+        "talk"
+      ],
+      "bitrate": 32,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-twin-cities-news-talk",
+      "name": "Twin Cities News Talk",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc1213",
+      "homepage": "https://twincitiesnewstalk.iheart.com/",
+      "country": "US",
+      "tags": [
+        "news",
+        "talk"
+      ],
+      "favicon": "https://radiostationusa.fm/assets/image/radio/180/KTLK.png",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-95-7-the-party",
+      "name": "95.7 The Party",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc2795/hls.m3u8",
+      "homepage": "https://957theparty.iheart.com/",
+      "country": "US",
+      "tags": [
+        "denver",
+        "hits",
+        "pop"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/60f0775933b6574da5ac3308?ops=gravity(%22center%22),contain(32,32),quality(65)",
+      "bitrate": 24,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-jan-usa",
+      "name": "Radio Jan USA",
+      "broadcaster": "independent",
+      "streamUrl": "https://s4.voscast.com:8865/stream",
+      "homepage": "http://radiojan.com/",
+      "country": "US",
+      "tags": [
+        "armenian"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        34.0536,
+        -118.2436
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-paradise-world-etc-flac-meta",
+      "name": "Radio Paradise World/etc FLAC+meta",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.radioparadise.com/world-etc-flacm",
+      "homepage": "http://radioparadise.com/",
+      "country": "US",
+      "tags": [
+        "california",
+        "eclectic",
+        "world music",
+        "free",
+        "internet",
+        "non-commercial"
+      ],
+      "favicon": "https://radioparadise.com/apple-touch-icon.png",
+      "bitrate": 1442,
+      "codec": "OGG",
+      "geo": [
+        40.7851,
+        -124.1839
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-smooth-jazz-wnua-chicago",
+      "name": "Smooth Jazz WNUA Chicago",
+      "broadcaster": "independent",
+      "streamUrl": "https://vip2.fastcast4u.com/proxy/wnua?mp=/1",
+      "homepage": "https://smoothjazzwnua.com/",
+      "country": "US",
+      "favicon": "https://img1.wsimg.com/isteam/ip/static/pwa-app/logo-default.png/:/rs=w:180,h:180,m",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-disney-country-fm-99-1",
+      "name": "Radio Disney Country FM 99.1",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.radioking.com/radio/453221/stream/508076",
+      "homepage": "https://www.radiodisney.com/",
+      "country": "US",
+      "tags": [
+        "county music",
+        "pop"
+      ],
+      "favicon": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSiSNzAYoI5Femhuri7WV9SNYheO4GO_Ovr_MUzgWIWYg&s/favicon.ico",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-new-york-yt",
+      "name": "Radio New York - YT",
+      "broadcaster": "independent",
+      "streamUrl": "https://hoth.alonhosting.com:1425/stream",
+      "homepage": "https://hoth.alonhosting.com:1425/stream",
+      "country": "US",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-afrobeats-jazz",
+      "name": "Afrobeats jazz",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.zeno.fm/iaf1anrme20vv",
+      "homepage": "https://zeno.fm/radio/afrobeats-jazz/",
+      "country": "US",
+      "tags": [
+        "afrobeats",
+        "amapiano",
+        "jazz",
+        "r&b",
+        "smooth jazz"
+      ],
+      "favicon": "https://zenoimages.s3.us-west-001.backblazeb2.com/agxzfnplbm8tc3RhdHNyMgsSCkF1dGhDbGllbnQYgICIpfi21gsMCxIOU3RhdGlvblByb2ZpbGUYgICIpYGfuQoMogEEemVubw/images/logo?updated=1715828780462",
+      "codec": "MP3",
+      "geo": [
+        36.0014,
+        -78.9016
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-cbs-sports-radio-lynchburg",
+      "name": "CBS SPORTS Radio Lynchburg",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice66.securenetsystems.net/WVGM",
+      "homepage": "https://virginiatalkradionetwork.com/cbssportslynchburg-2/",
+      "country": "US",
+      "tags": [
+        "cbs sports radio",
+        "sports",
+        "wvgm"
+      ],
+      "bitrate": 32,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-chris-tdl-radio-asmr",
+      "name": "Chris TDL Radio - ASMR",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.zeno.fm/mwpb4ea6qs8uv",
+      "homepage": "https://onlineradiobox.com/ca/christdlasmr/",
+      "country": "US",
+      "tags": [
+        "asmr",
+        "chill",
+        "music",
+        "relax",
+        "smooth"
+      ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/7/102307.v1.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-95-1-hot-oldschool",
+      "name": "95.1 HOT OLDSCHOOL",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc1393",
+      "homepage": "https://hotabq.iheart.com/",
+      "country": "US",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-mpr-classical-24-7",
+      "name": "MPR Classical 24/7",
+      "broadcaster": "independent",
+      "streamUrl": "https://cms.stream.publicradio.org/cms.mp3",
+      "homepage": "https://www.yourclassical.org/playlist/classical-mpr",
+      "country": "US",
+      "tags": [
+        "classical baroque",
+        "classical music"
+      ],
+      "favicon": "https://www.yourclassical.org/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        44.949,
+        -93.0954
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-dub-step-beyond-128k-aac",
+      "name": "SomaFM Dub Step Beyond (128k AAC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice6.somafm.com/dubstep-128-aac",
+      "homepage": "https://somafm.com/dubstep/",
+      "country": "US",
+      "tags": [
+        "deep bass",
+        "dub",
+        "dubstep"
+      ],
+      "favicon": "https://somafm.com/img3/dubstep-400.jpg",
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-soul-cafe-radio",
+      "name": "Soul Cafe Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://usa10.fastcast4u.com:8960/",
+      "homepage": "https://www.soulcaferadio.com/",
+      "country": "US",
+      "favicon": "https://static.wixstatic.com/media/1d954e_c3026edf00f74d55bcd9b238ce7f24cf~mv2.jpg/v1/fill/w_455,h_413,al_c,q_80,usm_0.66_1.00_0.01,enc_auto/Soul%20Cafe%20Logo%20with%20Site.jpg",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-rca",
+      "name": "Radio RCA",
+      "broadcaster": "independent",
+      "streamUrl": "https://broadcast.miami/proxy/rca?mp=/stream/;",
+      "homepage": "https://www.radio-rca.com/",
+      "country": "US",
+      "tags": [
+        "disco",
+        "funk",
+        "soul"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-wktu-ktu-103-5-the-beat-of-new-york-lake-success",
+      "name": "WKTU \"KTU 103.5 The Beat of New York\" - Lake Success, NY",
+      "broadcaster": "independent",
+      "streamUrl": "https://ample.revma.ihrhls.com/zc1473/47_1rikugy8mw9th02/playlist.m3u8",
+      "homepage": "https://ktu.iheart.com/",
+      "country": "US",
+      "tags": [
+        "iheart radio",
+        "rhythmic adult contemporary"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/5e7b5ddfbee47a8a2b39605d?ops=gravity(%22center%22),contain(300,300)&quality=80",
+      "codec": "UNKNOWN",
+      "geo": [
+        40.7687,
+        -73.7189
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-lofi-girl",
+      "name": "lofi girl",
+      "broadcaster": "independent",
+      "streamUrl": "https://play.streamafrica.net/lofiradio",
+      "homepage": "https://play.streamafrica.net/lofiradio",
+      "country": "US",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-wtam-1100-cleveland-ohio",
+      "name": "WTAM 1100 - Cleveland, Ohio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc1749",
+      "homepage": "https://wtam.iheart.com/",
+      "country": "US",
+      "tags": [
+        "local news",
+        "local talk",
+        "news",
+        "news talk",
+        "talk",
+        "talk radio"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/5be5a5068788fad5368c18e9?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "codec": "AAC",
+      "geo": [
+        41.2803,
+        -81.5786
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-edm-sessions",
+      "name": "EDM Sessions",
+      "broadcaster": "independent",
+      "streamUrl": "https://s2.radio.co/s30844a0f4/low",
+      "homepage": "https://edmsessions.com/",
+      "country": "US",
+      "favicon": "https://edmsessions.com/sites/default/files/website-logo.png",
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-free-fm-chill-new-york",
+      "name": "Free FM Chill New York",
+      "broadcaster": "independent",
+      "streamUrl": "https://freefmchill.radioca.st/",
+      "homepage": "http://www.freefmworld.com/",
+      "country": "US",
+      "tags": [
+        "#80s",
+        "#90s",
+        "#chill",
+        "#freefm",
+        "#freefmchill",
+        "90's"
+      ],
+      "favicon": "https://lh3.googleusercontent.com/lqUvzW7kJu0P5C9RGWHvuTLMa9rLl8KcMkhTUHbN9MadQ1zWCYkK716Hojtl1z2VMmZy59zEbUcPw6tnTGZWk2gJBTGGlKGbJ2DUhDuZ2t8eoj5JirGQyUE_s1O6mZJgLg=w1280",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-doomed-256k-mp3",
+      "name": "SomaFM Doomed (256k MP3)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice2.somafm.com/doomed-256-mp3",
+      "homepage": "https://somafm.com/doomed/",
+      "country": "US",
+      "tags": [
+        "ambient",
+        "dark",
+        "industrial"
+      ],
+      "favicon": "https://somafm.com/img3/doomed-400.png",
+      "bitrate": 256,
+      "codec": "MP3",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-my-country-99-3",
+      "name": "My Country 99.3",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice10.securenetsystems.net/WCON",
+      "homepage": "https://www.mycountry993.com/",
+      "country": "US",
+      "tags": [
+        "country"
+      ],
+      "bitrate": 32,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-atlantic",
+      "name": "Radio Atlantic",
+      "broadcaster": "independent",
+      "streamUrl": "https://broadcast.miami/proxy/atlantic?mp=/stream/;",
+      "homepage": "https://www.radio-atlantic.com/",
+      "country": "US",
+      "tags": [
+        "disco",
+        "funk",
+        "soul"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-viva-fm-orlando-99-5-orange-county-103-7-osceola",
+      "name": "Viva FM Orlando 99.5 Orange County/103.7 Osceola County",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.broadcastserver.net:2020/stream/wvvo?_=23526",
+      "homepage": "https://vivafmorlando.com/player",
+      "country": "US",
+      "tags": [
+        "classic salsa",
+        "latin",
+        "salsa"
+      ],
+      "favicon": "https://mmo.aiircdn.com/297/6544fa9112c3f.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        28.6636,
+        -81.3474
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-101-the-fox",
+      "name": "101 The Fox",
+      "broadcaster": "independent",
+      "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/KCFXFMAAC.aac",
+      "homepage": "https://www.101thefox.net/",
+      "country": "US",
+      "tags": [
+        "classic rock"
+      ],
+      "bitrate": 48,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-classical-california-kdfc",
+      "name": "Classical California KDFC",
+      "broadcaster": "independent",
+      "streamUrl": "https://14093.live.streamtheworld.com/KDFCFM_SC",
+      "homepage": "https://www.kdfc.com/",
+      "country": "US",
+      "tags": [
+        "classical"
+      ],
+      "favicon": "https://www.kdfc.com/icons/kdfc/apple-touch-icon-120x120.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        37.7485,
+        -122.4492
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-dclm-radio-hausa",
+      "name": "DCLM Radio - Hausa",
+      "broadcaster": "independent",
+      "streamUrl": "https://airtime.dclm.org/radio/8070/hausa",
+      "homepage": "https://radio.dclm.org/hausa",
+      "country": "US",
+      "tags": [
+        "christian"
+      ],
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-west-end",
+      "name": "Radio West End",
+      "broadcaster": "independent",
+      "streamUrl": "https://broadcast.miami/proxy/westend?mp=/stream/;",
+      "homepage": "https://www.radiowestend.com/",
+      "country": "US",
+      "tags": [
+        "disco"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-sfliny-christmas",
+      "name": "Sfliny Christmas",
+      "broadcaster": "independent",
+      "streamUrl": "https://ec4.yesstreaming.net:3790/",
+      "homepage": "http://www.sfliny.com/",
+      "country": "US",
+      "tags": [
+        "christmas"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-wlw-700-am-cincinnati-oh",
+      "name": "WLW - 700 AM - Cincinnati, OH",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc1713/hls.m3u8",
+      "homepage": "https://www.iheart.com/live/700wlw-1713",
+      "country": "US",
+      "tags": [
+        "news",
+        "right winger",
+        "talk"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/new_assets/2f71b3f2-773d-48a3-892f-a6f72850d704?ops=fit(75%2C75)",
+      "bitrate": 22,
+      "codec": "AAC",
+      "geo": [
+        39.1122,
+        -84.5096
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-northwest-public-broadcasting-news",
+      "name": "Northwest Public Broadcasting - News",
+      "broadcaster": "independent",
+      "streamUrl": "https://nwpb.streamguys1.com/nwprnews-aac-128-icy",
+      "homepage": "https://nwpb.org/",
+      "country": "US",
+      "tags": [
+        "news talk"
+      ],
+      "bitrate": 130,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-101-9-the-twister",
+      "name": "101.9 The Twister",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc1913",
+      "homepage": "https://thetwister.iheart.com/",
+      "country": "US",
+      "tags": [
+        "country"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/d3b3ea51ca0abb6b6417b68aaa730c6a?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-wgbh-wcrb-bach-channel",
+      "name": "WGBH-WCRB Bach Channel",
+      "broadcaster": "independent",
+      "streamUrl": "https://audio.wgbh.org/Bach-8108",
+      "homepage": "https://www.classicalwcrb.org/ways-to-listen",
+      "country": "US",
+      "tags": [
+        "bach"
+      ],
+      "favicon": "https://www.classicalwcrb.org/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-1oldies",
+      "name": "__1oldies",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.laut.fm/80sexitos",
+      "homepage": "https://laut.fm/80sexitos",
+      "country": "US",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-98-9-magic-fm",
+      "name": "98.9 Magic FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/KKMGFMAAC.aac",
+      "homepage": "https://www.989magicfm.com/",
+      "country": "US",
+      "tags": [
+        "pop",
+        "top 40"
+      ],
+      "favicon": "https://radiostationusa.fm/assets/image/radio/180/98.9 Magic FM.png",
+      "bitrate": 48,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-classical-catholic-radio",
+      "name": "Classical Catholic Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.live365.com/a64105",
+      "homepage": "https://classicalliberalarts.com/category/classical-catholic-radio/",
+      "country": "US",
+      "tags": [
+        "catholic",
+        "choral",
+        "classical",
+        "liturgical",
+        "religious",
+        "sacred"
+      ],
+      "favicon": "https://classicalliberalarts.com/wp-content/uploads/classical-catholic-radio.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-gaslight-square-folk-united-states-folk-320kbps",
+      "name": "Gaslight Square Folk  [United States Folk 320Kbps]",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream-12.zeno.fm/bgu8g47ycg0uv",
+      "homepage": "https://superradio.cc/",
+      "country": "US",
+      "tags": [
+        "folk",
+        "music"
+      ],
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-country-107-3-wrwd",
+      "name": "Country 107.3 WRWD",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc1497",
+      "homepage": "https://wrwdcountry.iheart.com/",
+      "country": "US",
+      "tags": [
+        "country"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/5e66aa553cce92f1f6a70865?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-80s-90s-mix-bestnet-radio",
+      "name": "80s & 90s Mix - BestNet Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://bigrradio.cdnstream1.com/5143_128",
+      "homepage": "https://bestnetradio.com/#",
+      "country": "US",
+      "tags": [
+        "80s",
+        "90s",
+        "music 80s 90s"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-hot-107-1",
+      "name": "HOT 107.1",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream1.flinn.com:8443/1071FM.aac",
+      "homepage": "https://www.hot1071.com/",
+      "country": "US",
+      "tags": [
+        "hip hop",
+        "hiphop",
+        "r&b",
+        "rap",
+        "rnb",
+        "urban"
+      ],
+      "bitrate": 48,
+      "codec": "AAC+",
+      "geo": [
+        35.1209,
+        -90.0588
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-iheartradio-christmas-jazz",
+      "name": "iHeartRadio Christmas Jazz",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc7251/hls.m3u8",
+      "homepage": "https://www.iheart.com/live/christmas-jazz-7251/",
+      "country": "US",
+      "favicon": "https://www.iheart.com/static/assets/favicon.ico",
+      "bitrate": 24,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-christmas-lounge-64k",
+      "name": "SomaFM Christmas Lounge 64k",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice5.somafm.com/christmas-64-aac",
+      "homepage": "https://somafm.com/christmas/",
+      "country": "US",
+      "tags": [
+        "chillout",
+        "christmas"
+      ],
+      "favicon": "https://somafm.com/img3/christmas-400.jpg",
+      "bitrate": 64,
+      "codec": "AAC",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-sanctuary-radio-dark-electro-channel",
+      "name": "Sanctuary Radio (Dark Electro Channel)",
+      "broadcaster": "independent",
+      "streamUrl": "https://patmos.cdnstream.com/proxy/sanctua1?mp=/stream",
+      "homepage": "https://www.sanctuaryradio.com/",
+      "country": "US",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-gotradio-the-60s",
+      "name": "GotRadio - The 60s",
+      "broadcaster": "independent",
+      "streamUrl": "https://pureplay.cdnstream1.com/6032_128.mp3",
+      "homepage": "https://gotradio.com/radiochannel/the-60s/",
+      "country": "US",
+      "tags": [
+        "60s",
+        "classic rock"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-octave-radio",
+      "name": "Octave Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://octaverecords.out.airtime.pro/octaverecords_a?_ga=2.139116787.1781832620.1687634712-199058362.1687634712",
+      "homepage": "https://www.psaudio.com/blogs/pauls-posts/octave-radio",
+      "country": "US",
+      "favicon": "https://www.psaudio.com/cdn/shop/files/download__6_-removebg-preview.png?crop=center&height=32&v=1667600396&width=32",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-thistleradio-128k-mp3",
+      "name": "SomaFM ThistleRadio (128k MP3)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice5.somafm.com/thistle-128-mp3",
+      "homepage": "https://somafm.com/thistle/",
+      "country": "US",
+      "tags": [
+        "celtic",
+        "folk"
+      ],
+      "favicon": "https://somafm.com/img3/thistle-400.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-talk-radio-102-3",
+      "name": "Talk Radio 102.3",
+      "broadcaster": "independent",
+      "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/WGOWFMAAC.aac",
+      "homepage": "https://www.wgow.com/",
+      "country": "US",
+      "tags": [
+        "news",
+        "talk"
+      ],
+      "favicon": "https://express-images.franklymedia.com/6616/sites/80/2023/07/20030055/wgow-fm-logo-1.png",
+      "bitrate": 48,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-the-beat-dance-hits",
+      "name": "The Beat - Dance Hits",
+      "broadcaster": "independent",
+      "streamUrl": "https://us2.maindigitalstream.com/ssl/7743",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "US",
+      "tags": [
+        "electronic"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-wcpt-820-heartland-signal-progresive-talk-willow",
+      "name": "WCPT 820 Heartland Signal Progresive Talk, Willow Springs IL",
+      "broadcaster": "independent",
+      "streamUrl": "https://26183.live.streamtheworld.com/WCPTAM.mp3",
+      "homepage": "https://heartlandsignal.com/",
+      "country": "US",
+      "tags": [
+        "chicago",
+        "illinois",
+        "progressive talk",
+        "talk",
+        "willow spings"
+      ],
+      "favicon": "https://heartlandsignal.com/wp-content/themes/landslide/img/logo.png",
+      "bitrate": 64,
+      "codec": "MP3",
+      "geo": [
+        41.7423,
+        -87.8578
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-cc-nuestra-musica-en-espanol",
+      "name": "CC - Nuestra Música [En Español]",
+      "broadcaster": "independent",
+      "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/CC6_S01AAC_96.aac",
+      "homepage": "https://classicalcalifornia.org/",
+      "country": "US",
+      "tags": [
+        "classical",
+        "classical california"
+      ],
+      "favicon": "https://classicalcalifornia.org/apple-touch-icon.png",
+      "bitrate": 96,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-fox-sports-1450",
+      "name": "Fox Sports 1450",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc3286",
+      "homepage": "https://foxsports1450.iheart.com/",
+      "country": "US",
+      "tags": [
+        "sports"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/5972568b82f0d41e6902d14d?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-gator-107-9",
+      "name": "Gator 107.9",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc6855",
+      "homepage": "https://gator1079.iheart.com/",
+      "country": "US",
+      "tags": [
+        "country"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/9274387d8a2c3ba7dc3f66e976e8ebe8?ops=gravity(%22center%22),contain(32,32),quality(65)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-indie-disco",
+      "name": "Radio Indie Disco",
+      "broadcaster": "independent",
+      "streamUrl": "https://broadcast.miami/proxy/indiedisco?mp=/stream/;",
+      "homepage": "https://www.radio-indiedisco.com/",
+      "country": "US",
+      "tags": [
+        "disco",
+        "funk",
+        "soul"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-wsrb-106-3-fm-chicago-s-r-b-lansing-il",
+      "name": "WSRB 106.3 FM Chicago's R&B - Lansing, IL",
+      "broadcaster": "independent",
+      "streamUrl": "https://ais-sa8.cdnstream1.com/phvh2qaosfo/c2ebyqqdqjx",
+      "homepage": "https://www.1063chicago.com/",
+      "country": "US",
+      "tags": [
+        "rap hiphop rnb",
+        "soul",
+        "urban adult contemporary"
+      ],
+      "favicon": "https://dehayf5mhw1h7.cloudfront.net/wp-content/uploads/sites/1370/2020/03/19092432/wsrb-logo.png",
+      "bitrate": 64,
+      "codec": "AAC",
+      "geo": [
+        41.5789,
+        -87.5462
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-96-1-now",
+      "name": "96.1 NOW",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc2357",
+      "homepage": "https://961now.iheart.com/",
+      "country": "US",
+      "tags": [
+        "pop",
+        "top 40"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/5956a84d119bce55968b6240?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-halloween-radio",
+      "name": "Halloween Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc7001/hls.m3u8?streamid=7001",
+      "homepage": "https://www.iheart.com/live/halloween-radio-7001/",
+      "country": "US",
+      "favicon": "https://i.iheart.com/v3/re/new_assets/12fbe317-623c-4596-8fb6-b9d01f39c72d",
+      "bitrate": 24,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-107-9-the-bull",
+      "name": "107.9 The Bull",
+      "broadcaster": "independent",
+      "streamUrl": "https://ais-sa1.streamon.fm/7283_48k.aac",
+      "homepage": "https://kticradio.com/",
+      "country": "US",
+      "tags": [
+        "country"
+      ],
+      "favicon": "https://media.ruralradio.co/nrr/uploads/sites/4/2021/02/cropped-ktic-1-180x180.png",
+      "bitrate": 48,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-ahfm",
+      "name": "AHFM",
+      "broadcaster": "independent",
+      "streamUrl": "https://us.ah.fm/live",
+      "homepage": "http://ah.fm/player/",
+      "country": "US",
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-downtown-radio-97-7",
+      "name": "Downtown Radio 97.7",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc5235",
+      "homepage": "https://downtown977.iheart.com/",
+      "country": "US",
+      "tags": [
+        "classic hits"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/5efe61e920a313a2d124adf1?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-q107-5",
+      "name": "Q107.5",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream1.flinn.com:8443/1075FM.aac",
+      "homepage": "https://www.q1075.com/",
+      "country": "US",
+      "tags": [
+        "pop",
+        "top 40"
+      ],
+      "favicon": "https://www.q1075.com/favicon.ico",
+      "bitrate": 56,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-z106-7",
+      "name": "Z106.7",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc1245",
+      "homepage": "https://z106.iheart.com/",
+      "country": "US",
+      "tags": [
+        "classic rock"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-yacht-rock-radio",
+      "name": "Yacht Rock Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc8681/hls.m3u8",
+      "homepage": "https://www.iheart.com/live/yacht-rock-radio-8681/",
+      "country": "US",
+      "favicon": "https://www.iheart.com/favicon.ico",
+      "bitrate": 24,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-crnet-classic-rock-128",
+      "name": "CRnet Classic Rock (128)",
+      "broadcaster": "independent",
+      "streamUrl": "https://shoutcast.christianrock.net/stream/9/",
+      "homepage": "https://www.christianclassicrock.net/",
+      "country": "US",
+      "tags": [
+        "christian",
+        "classic rock",
+        "rock"
+      ],
+      "favicon": "https://www.christianclassicrock.net/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-aftermath-fm",
+      "name": "AFTERMATH.FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://s4.citrus3.com:8232/stream.mp3",
+      "homepage": "https://aftermath.fm/",
+      "country": "US",
+      "tags": [
+        "conspiracies",
+        "talk"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-z92-7-wdzz",
+      "name": "Z92.7 WDZZ",
+      "broadcaster": "independent",
+      "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/WDZZFMAAC.aac",
+      "homepage": "https://www.wdzz.com/",
+      "country": "US",
+      "tags": [
+        "urban contemporary"
+      ],
+      "favicon": "https://www.wdzz.com/favicon.ico",
+      "bitrate": 48,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-100-1-the-beat",
+      "name": "100.1 The Beat",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc2069",
+      "homepage": "https://thebeatcolumbia.iheart.com/",
+      "country": "US",
+      "tags": [
+        "urban contemporary"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/5e5ea8306a4afbbaec08fb07?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-maxima-95-3",
+      "name": "Maxima 95.3",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice66.securenetsystems.net/WKDB",
+      "homepage": "https://www.max953.com/",
+      "country": "US",
+      "tags": [
+        "spanish"
+      ],
+      "favicon": "https://www.max953.com/favicon.ico",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-the-joy-fm-worship",
+      "name": "The JOY FM (Worship)",
+      "broadcaster": "independent",
+      "streamUrl": "https://rtn.cdnstream1.com/2581_96.aac?rand=95348",
+      "homepage": "https://florida.thejoyfm.com/",
+      "country": "US",
+      "tags": [
+        "worship"
+      ],
+      "favicon": "https://florida.thejoyfm.com/sites/joyfl/images/logos/joyfm_icon128.png",
+      "bitrate": 96,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-100-3-the-bus",
+      "name": "100.3 The Bus",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc2744",
+      "homepage": "https://thebusfm.iheart.com/",
+      "country": "US",
+      "tags": [
+        "adult hits"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/641b6a567790465c985e31c1?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-93-5-the-mix",
+      "name": "93.5 The Mix",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice7.securenetsystems.net/THEMIX",
+      "homepage": "https://www.935themix.com/",
+      "country": "US",
+      "tags": [
+        "adult contemporary"
+      ],
+      "favicon": "https://www.935themix.com/favicon.ico",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-k97-1",
+      "name": "K97.1",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc2141",
+      "homepage": "https://k97fm.iheart.com/",
+      "country": "US",
+      "tags": [
+        "urban contemporary"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-mystery-theater-usa",
+      "name": "Radio Mystery Theater USA",
+      "broadcaster": "independent",
+      "streamUrl": "https://ais-sa3.cdnstream1.com/2800_128.mp3",
+      "homepage": "https://www.wotrradionetwork.com/",
+      "country": "US",
+      "tags": [
+        "cbsrmt",
+        "mystery",
+        "old time radio",
+        "old time radio shows",
+        "otr"
+      ],
+      "favicon": "https://static.wixstatic.com/media/7d32c5_12b386b9d6c147f28d7952c9d466bc06~mv2.png/v1/fill/w_1132,h_789,al_c,q_90,usm_0.66_1.00_0.01,enc_auto/317590051_5176753955758743_1784250402823184359_n.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        39.701,
+        -86.1308
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-suburbs-of-goa-64k-aac",
+      "name": "SomaFM Suburbs of Goa (64k AAC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice5.somafm.com/suburbsofgoa-64-aac",
+      "homepage": "https://somafm.com/suburbsofgoa/",
+      "country": "US",
+      "tags": [
+        "desi-influenced asian",
+        "world beats"
+      ],
+      "favicon": "https://somafm.com/img3/suburbsofgoa-400.png",
+      "bitrate": 64,
+      "codec": "AAC",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-talk-radio-1080",
+      "name": "Talk Radio 1080",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc4908",
+      "homepage": "https://talkradio1080.iheart.com/",
+      "country": "US",
+      "tags": [
+        "talk"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/641b4511de66c5274866b3e4?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-your-classical-holiday",
+      "name": "Your Classical - Holiday",
+      "broadcaster": "independent",
+      "streamUrl": "https://holiday.stream.publicradio.org/holiday_yc.mp3?cb=8282040137",
+      "homepage": "https://www.yourclassical.org/",
+      "country": "US",
+      "tags": [
+        "christmas music",
+        "classical",
+        "holiday",
+        "seasonal"
+      ],
+      "favicon": "https://www.yourclassical.org/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-new-sounds-radio",
+      "name": "New Sounds Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://q2stream.wqxr.org/q2-web",
+      "homepage": "https://www.newsounds.org/",
+      "country": "US",
+      "favicon": "https://media.wnyc.org/i/600/600/l/80/1/ns_showcard-newsounds-radio-1.jpg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-warner-bros",
+      "name": "Radio Warner Bros.",
+      "broadcaster": "independent",
+      "streamUrl": "https://broadcast.miami/proxy/warnerbros?mp=/stream/;",
+      "homepage": "https://www.radio-warnerbros.com/",
+      "country": "US",
+      "tags": [
+        "disco",
+        "funk",
+        "soul"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-thistleradio-64k-aac",
+      "name": "SomaFM ThistleRadio (64k AAC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice5.somafm.com/thistle-64-aac",
+      "homepage": "https://somafm.com/thistle/",
+      "country": "US",
+      "tags": [
+        "celtic",
+        "folk"
+      ],
+      "favicon": "https://somafm.com/img3/thistle-400.jpg",
+      "bitrate": 64,
+      "codec": "AAC",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-92-1-the-beat",
+      "name": "92.1 The Beat",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc2449",
+      "homepage": "https://thebeatva.iheart.com/",
+      "country": "US",
+      "tags": [
+        "hip hop"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/5bdbaf635c185972cb54e597?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-hawk-country-106-9",
+      "name": "Hawk Country 106.9",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice24.securenetsystems.net/KIHK",
+      "homepage": "https://www.siouxcountyradio.com/",
+      "country": "US",
+      "tags": [
+        "country"
+      ],
+      "favicon": "https://www.siouxcountyradio.com/favicon.ico",
+      "bitrate": 32,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-iheart-indie-radio",
+      "name": "iHeart Indie Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc7189/hls.m3u8",
+      "homepage": "https://www.iheart.com/live/indie-radio-7189/",
+      "country": "US",
+      "tags": [
+        "indie electronic",
+        "indie pop",
+        "indie rock"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/new_assets/6ad7b9ac-b9e6-460d-8336-811ce8f84efa",
+      "bitrate": 24,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-kexp-90-3-fm-seattle",
+      "name": "KEXP 90.3 FM Seattle",
+      "broadcaster": "independent",
+      "streamUrl": "https://kexp-mp3-128.streamguys1.com/kexp128.mp3",
+      "homepage": "https://www.kexp.org/",
+      "country": "US",
+      "tags": [
+        "alternative",
+        "eclectic",
+        "electronic",
+        "folk",
+        "indie",
+        "jazz"
+      ],
+      "favicon": "https://www.kexp.org/static/assets/img/logo-black.svg",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-jose",
+      "name": "Radio Jose",
+      "broadcaster": "independent",
+      "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/KLYYFMAAC.aac",
+      "homepage": "https://www.joseradio.com/",
+      "country": "US",
+      "favicon": "https://elboton.com/wp-content/uploads/sites/6/2024/04/fav_96x96.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-103-5-kiss-fm-wksc-fm-chicago",
+      "name": "103.5 KISS FM - WKSC-FM Chicago",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc849",
+      "homepage": "https://1035kissfm.iheart.com/",
+      "country": "US",
+      "tags": [
+        "pop",
+        "top 40"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/6040110a9538edc2d6937e84?ops=gravity(%22center%22),contain(360,360)&quality=80",
+      "codec": "AAC",
+      "geo": [
+        41.8871,
+        -87.6241
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-christiancountrygospel-net",
+      "name": "ChristianCountryGospel.Net",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.christianrock.net/stream/18/",
+      "homepage": "https://www.christiancountrygospel.net/",
+      "country": "US",
+      "bitrate": 120,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-ih-country-radio",
+      "name": "iH Country Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc4418",
+      "homepage": "https://www.iheart.com/",
+      "country": "US",
+      "tags": [
+        "country"
+      ],
+      "favicon": "https://www.iheart.com/static/assets/favicon.ico",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-onlyhit-k-pop",
+      "name": "OnlyHit K-Pop",
+      "broadcaster": "independent",
+      "streamUrl": "https://kpop.onlyhit.us/play",
+      "homepage": "https://onlyhit.us/",
+      "country": "US",
+      "tags": [
+        "hits",
+        "k-pop",
+        "korean",
+        "korean music",
+        "korean pop",
+        "kpop"
+      ],
+      "favicon": "https://kpop.onlyhit.us/logo.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-q105-1-rocks",
+      "name": "Q105.1 Rocks",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice3.securenetsystems.net/KQWB",
+      "homepage": "https://www.q1051rocks.com/",
+      "country": "US",
+      "tags": [
+        "rock"
+      ],
+      "bitrate": 32,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-100hitz-alternative-hitz",
+      "name": "100Hitz - Alternative Hitz",
+      "broadcaster": "independent",
+      "streamUrl": "https://pureplay.cdnstream1.com/6034_64.aac/playlist.m3u8",
+      "homepage": "https://100hitz.com/",
+      "country": "US",
+      "tags": [
+        "aaa"
+      ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/1/10181.v5.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-105-3-kznn",
+      "name": "105.3 KZNN",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice5.securenetsystems.net/KZNNFM",
+      "homepage": "https://resultsradioonline.com/",
+      "country": "US",
+      "tags": [
+        "country"
+      ],
+      "favicon": "https://resultsradioonline.com/images/favicon/apple-touch-icon.png",
+      "bitrate": 32,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-the-patriot-am-1150",
+      "name": "The Patriot AM 1150",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc197",
+      "homepage": "https://patriotla.iheart.com/",
+      "country": "US",
+      "tags": [
+        "news",
+        "talk"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/e0eca5d8d587c993be4872beadd83963?ops=gravity(%22center%22),contain(32,32),quality(65)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-wksu-classical",
+      "name": "WKSU Classical",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.wksu.org/wksu3.mp3.128",
+      "homepage": "http://wksu.org/#stream/0",
+      "country": "US",
+      "tags": [
+        "classical music"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-98-5-el-patron",
+      "name": "98.5 El Patron",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc6969",
+      "homepage": "https://985elpatron.iheart.com/",
+      "country": "US",
+      "tags": [
+        "regional mexican"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/64c483fd15cf1a701f2a697822f910f8?ops=gravity(%22center%22),contain(32,32),quality(65)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-metallica",
+      "name": "Metallica Радио",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.pcradio.ru/Metallica-hi",
+      "homepage": "https://pcradio.ru/",
+      "country": "US",
+      "tags": [
+        "discography"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-bible-radio-network-english-channel",
+      "name": "Bible Radio Network - English Channel",
+      "broadcaster": "independent",
+      "streamUrl": "https://shout2.brnstream.com/proxy/brnradio1?mp=/stream",
+      "homepage": "https://brnradio.com/",
+      "country": "US",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-kmhd-adaptive-aac",
+      "name": "KMHD Adaptive AAC",
+      "broadcaster": "independent",
+      "streamUrl": "https://ais-sa3.cdnstream1.com/2442_128.aac/playlist.m3u8",
+      "homepage": "https://kmhd.org/",
+      "country": "US",
+      "tags": [
+        "blues",
+        "funk",
+        "jazz"
+      ],
+      "favicon": "https://kmhd.org/favicon.ico",
+      "bitrate": 256,
+      "codec": "AAC",
+      "geo": [
+        45.472,
+        -122.6711
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-kvkvi-classic-hits",
+      "name": "KVKVI - Classic Hits",
+      "broadcaster": "independent",
+      "streamUrl": "https://dc1.serverse.com/proxy/gjlrjfhp/stream",
+      "homepage": "https://www.kvkvi.com/",
+      "country": "US",
+      "tags": [
+        "60's",
+        "70's",
+        "80's",
+        "classic hits",
+        "oldies"
+      ],
+      "favicon": "https://www.kvkvi.com/wp-content/uploads/fbrfg/apple-touch-icon.png",
+      "bitrate": 160,
+      "codec": "MP3",
+      "geo": [
+        39.9653,
+        -82.9921
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-senshiphop",
+      "name": "senshiphop",
+      "broadcaster": "independent",
+      "streamUrl": "https://sensihiphop.radioca.st/stream",
+      "homepage": "https://sensimedia.net/radio/stations/hiphop",
+      "country": "US",
+      "tags": [
+        "hip hop",
+        "hip-hop",
+        "oldschool",
+        "rap"
+      ],
+      "favicon": "https://m.media-amazon.com/images/I/51QYpQ9cA3L._UX250_FMwebp_QL85_.jpg",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        34.0292,
+        -118.3188
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-99-5-the-word",
+      "name": "99.5 The Word",
+      "broadcaster": "independent",
+      "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/KGUFMAAC.aac",
+      "homepage": "https://995theword.com/",
+      "country": "US",
+      "tags": [
+        "religious"
+      ],
+      "favicon": "https://cdn.saleminteractivemedia.com/shared/images/favicons/cross-32x32.ico",
+      "bitrate": 48,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-kissin-99-3",
+      "name": "Kissin' 99.3",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice66.securenetsystems.net/WKCNFM",
+      "homepage": "https://www.kissin993.com/",
+      "country": "US",
+      "tags": [
+        "country"
+      ],
+      "bitrate": 32,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-94-1-the-beat",
+      "name": "94.1 The Beat",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc805",
+      "homepage": "https://941thebeat.iheart.com/",
+      "country": "US",
+      "tags": [
+        "urban contemporary"
+      ],
+      "favicon": "https://radiostationusa.fm/assets/image/radio/180/WQBT.png",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-audiobook-radio-audio-book-radio",
+      "name": "AudioBook Radio Audio Book Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://audiobookradio.out.airtime.pro/audiobookradio_a",
+      "homepage": "https://audiobookradio.net/listen/",
+      "country": "US",
+      "tags": [
+        "audio book",
+        "audio books",
+        "drama",
+        "play",
+        "plays",
+        "podcast"
+      ],
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-new-wave-radio",
+      "name": "New Wave Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://digitalaudiobroadcasting.net:1085/stream",
+      "homepage": "https://newwave.radio/",
+      "country": "US",
+      "tags": [
+        "new wave"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-woodstock-100-1-wdst",
+      "name": "Radio Woodstock 100.1 WDST",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc7332",
+      "homepage": "https://www.radiowoodstock.com/",
+      "country": "US",
+      "tags": [
+        "adult album alternative"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-san-diego-s-jazz",
+      "name": "San Diego's Jazz",
+      "broadcaster": "independent",
+      "streamUrl": "https://ksds-ice.streamguys1.com/ksds.mp3",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "US",
+      "tags": [
+        "jazz"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-70-s-hits-dj-jan-the-man",
+      "name": "70's Hits DJ Jan The Man",
+      "broadcaster": "independent",
+      "streamUrl": "https://quincy.torontocast.com:2500/stream",
+      "homepage": "http://www.djjandaman.com/",
+      "country": "US",
+      "tags": [
+        "70s",
+        "classic hits",
+        "dance",
+        "disco",
+        "oldies"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        40.0558,
+        -74.159
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-99-7-the-fox-charlotte-s-classic-rock-wrfx",
+      "name": "99.7 The Fox - Charlotte's Classic Rock WRFX",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc1613/hls.m3u8",
+      "homepage": "https://www.wrfx.com/",
+      "country": "US",
+      "tags": [
+        "classic rock"
+      ],
+      "bitrate": 24,
+      "codec": "AAC",
+      "geo": [
+        35.234,
+        -80.8456
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-praise-106-5",
+      "name": "Praise 106.5",
+      "broadcaster": "independent",
+      "streamUrl": "https://crista-kwpz.streamguys1.com/kwpzmp3",
+      "homepage": "https://www.praise1065.com/",
+      "country": "US",
+      "tags": [
+        "christian contemporary"
+      ],
+      "bitrate": 64,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-progradio",
+      "name": "ProgRadio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s4.radio.co/s1e0b382a0/listen",
+      "homepage": "https://www.progradio.com/",
+      "country": "US",
+      "tags": [
+        "progressive rock"
+      ],
+      "favicon": "https://static.wixstatic.com/media/392d7d_6d4b9892efd641c18eebe0492a5e30a3~mv2.png",
+      "bitrate": 320,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-suburbs-of-goa-32k-aac",
+      "name": "SomaFM Suburbs of Goa (32k AAC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice4.somafm.com/suburbsofgoa-32-aac",
+      "homepage": "https://somafm.com/suburbsofgoa/",
+      "country": "US",
+      "tags": [
+        "desi-influenced asian",
+        "world beats"
+      ],
+      "favicon": "https://somafm.com/img3/suburbsofgoa-400.png",
+      "bitrate": 32,
+      "codec": "AAC",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-nu-metal-radio",
+      "name": "Nu Metal Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc9483/hls.m3u8",
+      "homepage": "https://www.iheart.com/live/nu-metal-radio-9483/",
+      "country": "US",
+      "tags": [
+        "alternative rock",
+        "nu metal",
+        "rock"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.streams/645295e48320086d02de7ca3",
+      "bitrate": 24,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-680-the-fan",
+      "name": "680 The Fan",
+      "broadcaster": "independent",
+      "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/WCNNAMAAC.aac",
+      "homepage": "https://www.680thefan.com/",
+      "country": "US",
+      "tags": [
+        "news",
+        "talk"
+      ],
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-wcrb",
+      "name": "WCRB",
+      "broadcaster": "independent",
+      "streamUrl": "https://wgbh-live.streamguys1.com/classical-hi",
+      "homepage": "https://www.classicalwcrb.org/",
+      "country": "US",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        42.5566,
+        -73.7215
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-etoile-tv",
+      "name": "Etoile TV",
+      "broadcaster": "independent",
+      "streamUrl": "https://estrellanews-roku.amagi.tv/playlist.m3u8",
+      "homepage": "http://www.estrellatv.com/",
+      "country": "US",
+      "tags": [
+        "news",
+        "noticias"
+      ],
+      "favicon": "https://static-ottera.com/prod/est/s3fs-public/favicon-32x32.png?7eu3pvdazdntt8kuqtdkxrkutgyf2mwl",
+      "bitrate": 1478,
+      "codec": "AAC,H.264",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-knbr-1050",
+      "name": "KNBR 1050",
+      "broadcaster": "independent",
+      "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/KTCTAMAAC.aac",
+      "homepage": "https://www.knbr.com/",
+      "country": "US",
+      "tags": [
+        "sports"
+      ],
+      "bitrate": 48,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-kzsc-88-1-santa-cruz-ca",
+      "name": "KZSC 88.1 Santa Cruz, CA",
+      "broadcaster": "independent",
+      "streamUrl": "https://kzscfms1-geckohost.radioca.st/kzschigh?type=.mp3",
+      "homepage": "https://www.kzsc.org/",
+      "country": "US",
+      "tags": [
+        "college radio",
+        "santa cruz"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-classic-christian-rock-radio",
+      "name": "Classic Christian Rock Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s20.reliastream.com/stream/8004",
+      "homepage": "https://www.classicchristianrock.net/",
+      "country": "US",
+      "favicon": "https://www.classicchristianrock.net/images/Classic%20Christian%20Rock%20Radio%20text.jpg",
+      "bitrate": 128,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-classic-rock-legends-radio",
+      "name": "Classic Rock Legends Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://puma.streemlion.com:3130/stream",
+      "homepage": "https://classic-rock-legends-radio.yolasite.com/",
+      "country": "US",
+      "tags": [
+        "classic rock",
+        "rock"
+      ],
+      "favicon": "https://classic-rock-legends-radio.yolasite.com/ws/media-library/76cb251b1188401199fda1e21afdce36/628d47596f5f4259b47d3db7aeaf45b3.png",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-105-3-wdas-fm",
+      "name": "105.3 WDAS FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc1993",
+      "homepage": "https://wdasfm.iheart.com/",
+      "country": "US",
+      "tags": [
+        "urban adult contemporary"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/new_assets/5e6058606c31dcbb42808f70?ops=gravity(%22center%22),contain(32,32),quality(65)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-97-5-wcos",
+      "name": "97.5 WCOS",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc2073",
+      "homepage": "https://975wcos.iheart.com/",
+      "country": "US",
+      "tags": [
+        "country"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/5e5ffdb3923e9a943a0dbed0?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-espn-1100am-100-9fm",
+      "name": "ESPN 1100AM / 100.9FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/KWWNAMAAC.aac",
+      "homepage": "https://www.lvsportsnetwork.com/",
+      "country": "US",
+      "tags": [
+        "sports"
+      ],
+      "bitrate": 32,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-klove",
+      "name": "Klove",
+      "broadcaster": "independent",
+      "streamUrl": "https://maestro.emfcdn.com/stream_for/k-love/iheart/aac",
+      "homepage": "https://www.klove.com/",
+      "country": "US",
+      "tags": [
+        "gospel"
+      ],
+      "favicon": "https://cdn-profiles.tunein.com/s22561/images/bannerx.jpg?t=637102372250000000",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-wbor-91-1-fm",
+      "name": "WBOR 91.1 FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.wbor.org/",
+      "homepage": "https://wbor.org/",
+      "country": "US",
+      "tags": [
+        "college"
+      ],
+      "favicon": "https://wbor.org/assets/images/favicon.png?v=7be406e9",
+      "bitrate": 192,
+      "codec": "MP3",
+      "geo": [
+        43.906,
+        -69.9634
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-102-5-kzok",
+      "name": "102.5 KZOK",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc7787",
+      "homepage": "https://kzok.iheart.com/",
+      "country": "US",
+      "tags": [
+        "classic rock"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/5e3b423a10b101a0ff3406d6?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-93-9-wlit-fm-lite-fm",
+      "name": "93.9 WLIT-FM LITE FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc853",
+      "homepage": "https://939litefm.iheart.com/",
+      "country": "US",
+      "tags": [
+        "pop"
+      ],
+      "codec": "AAC",
+      "geo": [
+        41.7926,
+        -87.6558
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-fm106-1",
+      "name": "FM106.1",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc2677",
+      "homepage": "https://fm106.iheart.com/",
+      "country": "US",
+      "tags": [
+        "country"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/15c66fedb2bddab6309531a5dcf75949?ops=gravity(%22center%22),contain(32,32),quality(65)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-i-hate-free-speech-radio",
+      "name": "I Hate Free Speech Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s22.myradiostream.com/15152/listen.mp3",
+      "homepage": "http://ihatefreespeech.com/",
+      "country": "US",
+      "tags": [
+        "bizzare",
+        "comedy",
+        "experimental",
+        "freeform",
+        "metal",
+        "punk"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        41.5043,
+        -81.6674
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-kbrh-am-1260",
+      "name": "KBRH AM 1260",
+      "broadcaster": "independent",
+      "streamUrl": "https://wbrh.streamguys1.com/kbrh-mp3",
+      "homepage": "https://www.wbrh.org/",
+      "country": "US",
+      "tags": [
+        "blues",
+        "r&b",
+        "soul"
+      ],
+      "favicon": "https://wbrh.org/wp-content/uploads/2023/03/favicon2-100x100.gif",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        30.4453,
+        -91.1595
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-kmfa",
+      "name": "KMFA",
+      "broadcaster": "independent",
+      "streamUrl": "https://kmfa.streamguys1.com/KMFA-mp3",
+      "homepage": "https://www.kmfa.org/",
+      "country": "US",
+      "tags": [
+        "classical"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-relevant-radio",
+      "name": "Relevant Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/RR_MAIN.mp3",
+      "homepage": "https://relevantradio.com/",
+      "country": "US",
+      "tags": [
+        "bible",
+        "bible teaching",
+        "books",
+        "catholic",
+        "catholic radio",
+        "catholic talk"
+      ],
+      "favicon": "https://t3.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=http://relevantradio.com&size=64",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-93-1-amor-bachata-y-mas",
+      "name": "93.1 AMOR (Bachata y Más )",
+      "broadcaster": "independent",
+      "streamUrl": "https://liveaudio.lamusica.com/NY_WPAT_icy",
+      "homepage": "https://www.lamusica.com/stations/wpat",
+      "country": "US",
+      "tags": [
+        "bachata",
+        "latino",
+        "latino urbano",
+        "top 40"
+      ],
+      "favicon": "https://www.lamusica.com/lamusica-white.svg",
+      "bitrate": 127,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-b101",
+      "name": "B101",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc3217",
+      "homepage": "https://b101.iheart.com/",
+      "country": "US",
+      "tags": [
+        "classic hits"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/5e5eb7de6acdd8e31fb6117f?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-big-dog-103-5",
+      "name": "Big Dog 103.5",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice66.securenetsystems.net/WUUF",
+      "homepage": "https://www.bigdog1035.com/",
+      "country": "US",
+      "tags": [
+        "country"
+      ],
+      "bitrate": 32,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-power-101-1-fm",
+      "name": "Power 101.1 FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice3.securenetsystems.net/WHJA2",
+      "homepage": "https://powerstation101.com/",
+      "country": "US",
+      "tags": [
+        "hip hop"
+      ],
+      "bitrate": 32,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-real-talk-910",
+      "name": "Real Talk 910",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc297",
+      "homepage": "https://realtalk910.iheart.com/",
+      "country": "US",
+      "tags": [
+        "news",
+        "talk"
+      ],
+      "favicon": "https://www.iheart.com/static/assets/favicon.ico",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-the-joy-fm-88-1fm-jacksonville",
+      "name": "The JOY FM 88.1FM Jacksonville",
+      "broadcaster": "independent",
+      "streamUrl": "https://rtn.cdnstream1.com/2579_96.aac?rand=10817",
+      "homepage": "https://florida.thejoyfm.com/",
+      "country": "US",
+      "tags": [
+        "christian contemporary"
+      ],
+      "favicon": "https://florida.thejoyfm.com/sites/joyfl/images/logos/joyfm_icon128.png",
+      "bitrate": 96,
+      "codec": "AAC+",
+      "geo": [
+        30.3316,
+        -81.6552
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-1043-myfm",
+      "name": "1043 MYfm",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc173",
+      "homepage": "https://1043myfm.iheart.com/",
+      "country": "US",
+      "tags": [
+        "adult contemporary"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/646249b860898f1d0cc3967d?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "codec": "AAC",
+      "geo": [
+        33.8704,
+        -118.1909
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-buckeye-country-94-3",
+      "name": "Buckeye Country 94.3",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc3973",
+      "homepage": "https://buckeyecountry943.iheart.com/",
+      "country": "US",
+      "tags": [
+        "country"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/3e4367cb5fe014ebc7654bead10d28a7?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-exa-fm-las-vegas-94-5-fm-kxli-radio-activo-broad",
+      "name": "Exa FM Las Vegas - 94.5 FM - KXLI - Radio Activo Broadcasting, LLC - Las Vegas, Nevada",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice9.securenetsystems.net/KXLI",
+      "homepage": "https://exafm.com/lasvegas/",
+      "country": "US",
+      "tags": [
+        "94.5 fm",
+        "américa",
+        "entretenimiento",
+        "español",
+        "estación",
+        "exa"
+      ],
+      "favicon": "https://exafm.com/favicon.ico",
+      "bitrate": 32,
+      "codec": "AAC+",
+      "geo": [
+        36.1727,
+        -115.1522
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-hpr1-traditional-classic-country",
+      "name": "HPR1: Traditional Classic Country",
+      "broadcaster": "independent",
+      "streamUrl": "https://us2.maindigitalstream.com/ssl/7713",
+      "homepage": "https://hpr.org/",
+      "country": "US",
+      "tags": [
+        "country"
+      ],
+      "favicon": "http://www.hpr.org/icon-normal.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        36.647,
+        -93.2238
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-metal-devastation-radio",
+      "name": "Metal Devastation Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://c13.radioboss.fm:18099/stream",
+      "homepage": "https://metaldevastationradio.com/",
+      "country": "US",
+      "favicon": "https://metaldevastationradio.com/data/media/0/0/favicon_120.png?v=2",
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-slack-radio",
+      "name": "Slack Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://s4.radio.co/s62c60f538/listen",
+      "homepage": "http://www.slackradio.org/",
+      "country": "US",
+      "tags": [
+        "\"bob\"",
+        "\"bob\"dobbs",
+        "heavy metal",
+        "jazz",
+        "metal",
+        "new wave"
+      ],
+      "bitrate": 320,
+      "codec": "AAC",
+      "geo": [
+        39.7964,
+        -85.7659
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-sports-talk-1050-wtka",
+      "name": "Sports Talk 1050 WTKA",
+      "broadcaster": "independent",
+      "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/WTKAAMAAC.aac",
+      "homepage": "https://www.wtka.com/",
+      "country": "US",
+      "tags": [
+        "sports"
+      ],
+      "favicon": "https://express-images.franklymedia.com/6616/sites/283/2023/09/11060800/wtka-mastheadlogo.png",
+      "bitrate": 48,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-wfms-95-5",
+      "name": "WFMS 95.5",
+      "broadcaster": "independent",
+      "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/WFMSFM_SC",
+      "homepage": "https://www.wfms.com/",
+      "country": "US",
+      "tags": [
+        "country"
+      ],
+      "favicon": "https://www.wfms.com/favicon.ico",
+      "bitrate": 80,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-101-5-kgb",
+      "name": "101.5 KGB",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc237",
+      "homepage": "https://101kgb.iheart.com/",
+      "country": "US",
+      "tags": [
+        "classic rock"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/289e7a9c2382e8410a86b780804a6945?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-kiss-98-3",
+      "name": "Kiss 98.3",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice64.securenetsystems.net/WKEMLP",
+      "homepage": "https://www.wkemkiss983.org/",
+      "country": "US",
+      "tags": [
+        "oldies"
+      ],
+      "bitrate": 32,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-magic-93-1",
+      "name": "Magic 93.1",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice66.securenetsystems.net/WBBK",
+      "homepage": "https://mymagic93.com/",
+      "country": "US",
+      "tags": [
+        "urban adult contemporary"
+      ],
+      "bitrate": 64,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-181-fm-good-time-oldies",
+      "name": "181.fm good time oldies",
+      "broadcaster": "independent",
+      "streamUrl": "https://listen.181fm.com/181-goodtime_128k.mp3",
+      "homepage": "https://www.radio-browser.info/",
+      "country": "US",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-lounge-motion-fm",
+      "name": "Lounge Motion FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://vm.motionfm.com/motionthree_aacp",
+      "homepage": "http://www.motionfm.com/",
+      "country": "US",
+      "tags": [
+        "chillout",
+        "downtempo",
+        "lounge"
+      ],
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-n5md-32k-aac",
+      "name": "SomaFM n5MD (32k AAC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice2.somafm.com/n5md-32-aac",
+      "homepage": "https://somafm.com/n5md/",
+      "country": "US",
+      "tags": [
+        "ambient",
+        "experimental electronic music",
+        "modern composition",
+        "post-rock"
+      ],
+      "favicon": "https://somafm.com/img3/n5md-400.png",
+      "bitrate": 32,
+      "codec": "AAC",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-alt-101-5-the-desert-s-alternative",
+      "name": "Alt 101.5 - The Desert's Alternative",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice9.securenetsystems.net/ALT1015",
+      "homepage": "https://alt1015fm.com/",
+      "country": "US",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "geo": [
+        33.8241,
+        -116.5337
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-america-s-otr-gunsmoke",
+      "name": "America's OTR - Gunsmoke",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.live365.com/a68303",
+      "homepage": "https://americasotr.com/",
+      "country": "US",
+      "tags": [
+        "1950s",
+        "drama",
+        "old time radio",
+        "oldies",
+        "otr",
+        "vintage"
+      ],
+      "favicon": "https://media.live365.com/download/2b93fa33-3af5-4aff-9cd5-78c288c71f69.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-jazz24",
+      "name": "Jazz24",
+      "broadcaster": "independent",
+      "streamUrl": "https://knkx-live-a.edge.audiocdn.com/6285_256k",
+      "homepage": "https://www.jazz24.org/",
+      "country": "US",
+      "favicon": "https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse1.mm.bing.net%2Fth%2Fid%2FOIP.ugUKdyft-8Fo--PIPAXzGgAAAA%3Fpid%3DApi&f=1&ipt=f09f5c58d86f560fb392db2af56b9af0d7f4c9f2ae3401b90488c35484eba2cb&ipo=images",
+      "bitrate": 256,
+      "codec": "AAC",
+      "geo": [
+        47.2384,
+        -122.465
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-sl100",
+      "name": "SL100",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc5112",
+      "homepage": "https://sl100.iheart.com/",
+      "country": "US",
+      "tags": [
+        "pop",
+        "top 40"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/5b733d7ac86aa1d1bdff5100?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-hawaii-reggae-network",
+      "name": "Hawaii Reggae Network",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice8.securenetsystems.net/HRNO",
+      "homepage": "https://hawaiireggaenetwork.com/",
+      "country": "US",
+      "tags": [
+        "reggae"
+      ],
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-hot-103-jamz",
+      "name": "Hot 103 Jamz",
+      "broadcaster": "independent",
+      "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/KPRSFMAAC.aac",
+      "homepage": "https://www.kprs.com/",
+      "country": "US",
+      "tags": [
+        "urban contemporary"
+      ],
+      "favicon": "https://dehayf5mhw1h7.cloudfront.net/wp-content/uploads/sites/962/2018/03/14144206/cropped-jamz-logo-180x180.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-kmlb",
+      "name": "KMLB",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice66.securenetsystems.net/KMLB",
+      "homepage": "https://kmlb.com/",
+      "country": "US",
+      "tags": [
+        "news",
+        "talk"
+      ],
+      "bitrate": 96,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-star-102-1",
+      "name": "Star 102.1",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc2815",
+      "homepage": "https://star1021.iheart.com/",
+      "country": "US",
+      "tags": [
+        "adult contemporary"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/5fe97892e9b7f0baf76383eb?ops=gravity(%22center%22),contain(32,32),quality(65)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-ultimate-oldies-radio-musical-history-of-the-50-",
+      "name": "Ultimate Oldies Radio! Musical History of the 50's, 60's, 70's & More!",
+      "broadcaster": "independent",
+      "streamUrl": "https://puma.streemlion.com:1785/stream",
+      "homepage": "https://www.ultimateoldiesradio.com/",
+      "country": "US",
+      "favicon": "https://www.ultimateoldiesradio.com/uploads/2/5/3/5/25355864/editor/oldies700-500x500.png?1630372797",
+      "bitrate": 128,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-92-3-wcol",
+      "name": "92.3 WCOL",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc1757",
+      "homepage": "https://wcol.iheart.com/",
+      "country": "US",
+      "tags": [
+        "country"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.eeo/59382154af0fd78f0d5d6a57?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-adoration-from-family-life",
+      "name": "Adoration from Family Life",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.live365.com/a59117_2",
+      "homepage": "https://www.familylife.org/",
+      "country": "US",
+      "tags": [
+        "christian",
+        "christian contemporary",
+        "praise"
+      ],
+      "bitrate": 128,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-classic-metal-radio",
+      "name": "Classic Metal Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://quincy.torontocast.com:2100/",
+      "homepage": "http://classicmetalradio.net/",
+      "country": "US",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-crb-classical-99-5-aac-256",
+      "name": "CRB Classical 99.5 AAC 256",
+      "broadcaster": "independent",
+      "streamUrl": "https://wgbh-live.streamguys1.com/wcrb-itunes-256k",
+      "homepage": "https://www.classicalwcrb.org/",
+      "country": "US",
+      "tags": [
+        "boston",
+        "classical",
+        "gbh",
+        "npr",
+        "public radio"
+      ],
+      "favicon": "https://www.classicalwcrb.org/apple-touch-icon.png",
+      "bitrate": 255,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-espn-99-5-northwest-arkansas",
+      "name": "ESPN 99.5 Northwest Arkansas",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice5.securenetsystems.net/KAKSFM",
+      "homepage": "https://www.espn995.com/",
+      "country": "US",
+      "tags": [
+        "sports"
+      ],
+      "favicon": "https://img.sedoparking.com/templates/logos/sedo_logo.png",
+      "bitrate": 32,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-beach-105-5",
+      "name": "Beach 105.5",
+      "broadcaster": "independent",
+      "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/WBHUFMAAC.aac",
+      "homepage": "https://www.beach1055.com/",
+      "country": "US",
+      "tags": [
+        "adult hits"
+      ],
+      "bitrate": 32,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-exclusively-kylie-minogue",
+      "name": "Exclusively Kylie Minogue",
+      "broadcaster": "independent",
+      "streamUrl": "https://streaming.exclusive.radio/er-app/kylie/icecast.audio",
+      "homepage": "https://play.exclusive.radio/",
+      "country": "US",
+      "tags": [
+        "80s",
+        "club dance",
+        "dance & electronic",
+        "dance-pop",
+        "electro-pop",
+        "female vocalists"
+      ],
+      "favicon": "https://play.exclusive.radio/static/assets/img/apple-icon-120x120.png",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-folk-alley-freshgrass",
+      "name": "Folk Alley FreshGrass",
+      "broadcaster": "independent",
+      "streamUrl": "https://freshgrass.streamguys1.com/ss1-128mp3",
+      "homepage": "https://www.folkalley.com/music/playlist/today/freshgrass",
+      "country": "US",
+      "tags": [
+        "bluegrass",
+        "folk"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-jammin-oldies-radio-jammin-105",
+      "name": "Jammin Oldies Radio - Jammin 105",
+      "broadcaster": "independent",
+      "streamUrl": "https://tlawler2.radioca.st/;",
+      "homepage": "http://jamminoldiesradio.com/",
+      "country": "US",
+      "tags": [
+        "oldies"
+      ],
+      "bitrate": 128,
+      "codec": "AAC+",
+      "geo": [
+        40.7201,
+        -74.047
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-pure-country-89-3",
+      "name": "Pure Country 89.3",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice23.securenetsystems.net/QXFM",
+      "homepage": "https://qxfm.com/",
+      "country": "US",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-wqxr-q2-stream-new-york-public-radio-newark-nj",
+      "name": "WQXR \"Q2 Stream\" New York Public Radio - Newark, NJ",
+      "broadcaster": "independent",
+      "streamUrl": "https://q2stream.wqxr.org/q2.aac",
+      "homepage": "http://www.wqxr.org/series/q2/",
+      "country": "US",
+      "tags": [
+        "contemporary classical",
+        "new jersey",
+        "new york city",
+        "new york public radio",
+        "newark"
+      ],
+      "bitrate": 47,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-96-5-jack-fm",
+      "name": "96.5 JACK-FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc7788",
+      "homepage": "https://jackseattle.iheart.com/",
+      "country": "US",
+      "tags": [
+        "adult hits"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/609c1d56e9956f81bdb9f27f?ops=gravity(%22center%22),contain(32,32),quality(65)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-am-950-the-progressive-voice-of-minnesota",
+      "name": "AM 950 The Progressive Voice of Minnesota",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice25.securenetsystems.net/KTNF",
+      "homepage": "https://www.am950radio.com/",
+      "country": "US",
+      "bitrate": 32,
+      "codec": "AAC+",
+      "geo": [
+        44.999,
+        -93.3151
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-crnet-hard-rock-32",
+      "name": "CRnet Hard Rock (32)",
+      "broadcaster": "independent",
+      "streamUrl": "https://shoutcast.christianrock.net/stream/4/",
+      "homepage": "https://www.christianhardrock.net/",
+      "country": "US",
+      "tags": [
+        "christian",
+        "hard rock",
+        "metal",
+        "rock"
+      ],
+      "favicon": "https://www.christianhardrock.net/apple-touch-icon.png",
+      "bitrate": 32,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-fox-sports-pueblo",
+      "name": "Fox Sports Pueblo",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc4015",
+      "homepage": "https://foxsportspueblo.iheart.com/",
+      "country": "US",
+      "tags": [
+        "sports"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/5bdb13e742f2b3f9adfcf0fd?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-litt-live-grunge",
+      "name": "LITT Live - Grunge",
+      "broadcaster": "independent",
+      "streamUrl": "https://das-sa39.cdnstream1.com/5570_128",
+      "homepage": "https://littlive.com/grunge",
+      "country": "US",
+      "tags": [
+        "90s",
+        "grunge",
+        "rock"
+      ],
+      "favicon": "https://dashradio-files.s3.amazonaws.com/development/icon_logos/164/logos/0e64637e-7b29-477e-883b-ae7408d275ee.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-more-fm-98-9",
+      "name": "More FM 98.9",
+      "broadcaster": "independent",
+      "streamUrl": "https://radio.cadenanoticias.com/proxy/morefm989?mp=/morefm989",
+      "homepage": "https://morefmonline.com/",
+      "country": "US",
+      "tags": [
+        "rock"
+      ],
+      "bitrate": 192,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-phcc-gospel-radio",
+      "name": "PHCC Gospel Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://c25.radioboss.fm:8130/4rm8tzo7qirtv",
+      "homepage": "https://c25.radioboss.fm/u/130",
+      "country": "US",
+      "tags": [
+        "christian",
+        "gospel"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-wcbm-680",
+      "name": "WCBM 680",
+      "broadcaster": "independent",
+      "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/WCBMAM.mp3",
+      "homepage": "https://www.wcbm.com/",
+      "country": "US",
+      "tags": [
+        "news",
+        "talk"
+      ],
+      "bitrate": 32,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-wets-89-5-johnson-city-tn",
+      "name": "WETS 89.5 Johnson City, TN",
+      "broadcaster": "independent",
+      "streamUrl": "https://wets-fm.streamguys1.com/live-1",
+      "homepage": "http://www.etsu.edu/wets/",
+      "country": "US",
+      "tags": [
+        "local news",
+        "news",
+        "npr",
+        "public radio"
+      ],
+      "bitrate": 90,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-cat-country-98-7-wyct",
+      "name": "Cat Country 98.7 (WYCT)",
+      "broadcaster": "independent",
+      "streamUrl": "https://adxc-live.streamguys1.com/catcountry987",
+      "homepage": "https://catcountry987.com/",
+      "country": "US",
+      "favicon": "https://cdn-profiles.tunein.com/s41848/images/logod.png?t=637191341190000000",
+      "bitrate": 96,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-concord",
+      "name": "Radio Concord",
+      "broadcaster": "independent",
+      "streamUrl": "https://broadcast.miami/proxy/concord?mp=/stream/;",
+      "homepage": "https://www.radio-concord.com/",
+      "country": "US",
+      "tags": [
+        "disco",
+        "funk",
+        "soul"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-106-5-the-end",
+      "name": "106.5 The END",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc1597",
+      "homepage": "https://1065.iheart.com/",
+      "country": "US",
+      "tags": [
+        "alternative"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/628c71139061c04f16dc01c9?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-95-5-the-bull",
+      "name": "95.5 The Bull",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc1345",
+      "homepage": "https://955thebull.iheart.com/",
+      "country": "US",
+      "tags": [
+        "country"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/81ab990f60deaac4a511ff33ad8c6087?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-98-5-wyld",
+      "name": "98.5 WYLD",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc1053",
+      "homepage": "https://wyldfm.iheart.com/",
+      "country": "US",
+      "tags": [
+        "urban adult contemporary"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/5aea268408c82e0c34ad95f4?ops=gravity(%22center%22),contain(32,32),quality(65)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-99-7-the-fox",
+      "name": "99.7 The Fox",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc1613",
+      "homepage": "https://997thefox.iheart.com/",
+      "country": "US",
+      "tags": [
+        "classic rock"
+      ],
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-dc101-dc-s-alternative-rock-radio-station",
+      "name": "DC101 / DC's Alternative Rock Radio Station",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc2525",
+      "homepage": "https://dc101.iheart.com/",
+      "country": "US",
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/5e5d35f7ca55c01f9bfdc41f?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "codec": "AAC",
+      "geo": [
+        38.8947,
+        -77.0361
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-espn-710-los-angeles",
+      "name": "ESPN 710 Los Angeles",
+      "broadcaster": "independent",
+      "streamUrl": "https://live.amperwave.net/direct/goodkarma-kspnamaac-ibc",
+      "homepage": "https://www.espn.com/radio/play/_/s/la",
+      "country": "US",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-hd-radio-rock-roll",
+      "name": "HD Radio - Rock & Roll",
+      "broadcaster": "independent",
+      "streamUrl": "https://hdrockandroll-rfritschka.radioca.st/;",
+      "homepage": "https://www.hd-radio.net/",
+      "country": "US",
+      "tags": [
+        "50s",
+        "60s",
+        "rock"
+      ],
+      "bitrate": 128,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-news-talk-550-wdun",
+      "name": "News/Talk 550 WDUN",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice42.securenetsystems.net/WDUN",
+      "homepage": "https://www.wdun.com/",
+      "country": "US",
+      "tags": [
+        "news",
+        "talk"
+      ],
+      "favicon": "https://radiostationusa.fm/assets/image/radio/180/WDUN.jpg",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-bmg",
+      "name": "Radio BMG",
+      "broadcaster": "independent",
+      "streamUrl": "https://broadcast.miami/proxy/bmg?mp=/stream/;",
+      "homepage": "https://www.radio-bmg.com/",
+      "country": "US",
+      "tags": [
+        "disco",
+        "funk",
+        "soul"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-xmas-in-frisco-64k-aac",
+      "name": "SomaFM Xmas in Frisco (64k AAC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice5.somafm.com/xmasinfrisko-64-aac",
+      "homepage": "https://somafm.com/xmasinfrisko/",
+      "country": "US",
+      "tags": [
+        "christmas music",
+        "nsfw",
+        "san francisco",
+        "seasonal"
+      ],
+      "favicon": "https://somafm.com/img3/xmasinfrisko-400.jpg",
+      "bitrate": 64,
+      "codec": "AAC",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-98-9-kiss-fm",
+      "name": "98.9 KISS-FM",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc3387",
+      "homepage": "https://kisslouisville.iheart.com/",
+      "country": "US",
+      "tags": [
+        "pop",
+        "top 40"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/5e1e38c8a5c5b9a85dbf29f6?ops=gravity(%22center%22),contain(32,32),quality(65)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-kfan-fm-sports",
+      "name": "KFAN FM Sports",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc1209",
+      "homepage": "https://kfan.iheart.com/",
+      "country": "US",
+      "tags": [
+        "sports"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/7abeb696904580c44cd523e678ac767c?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-digitalis-128k-aac",
+      "name": "SomaFM Digitalis (128k AAC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice6.somafm.com/digitalis-128-aac",
+      "homepage": "https://somafm.com/digitalis/",
+      "country": "US",
+      "tags": [
+        "alternative rock",
+        "electronic rock"
+      ],
+      "favicon": "https://somafm.com/img3/digitalis-400.jpg",
+      "bitrate": 128,
+      "codec": "AAC",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-air1",
+      "name": "AIR1",
+      "broadcaster": "independent",
+      "streamUrl": "https://maestro.emfcdn.com/stream_for/air1/airable/aac",
+      "homepage": "https://www.air1.com/",
+      "country": "US",
+      "tags": [
+        "christian",
+        "worship"
+      ],
+      "favicon": "https://cdn.corpemf.com/www/waf/air1/logo.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-ancient-faith-ministries-english-language-music",
+      "name": "Ancient Faith Ministries English language Music",
+      "broadcaster": "independent",
+      "streamUrl": "https://ancientfaith.streamguys1.com/ancientfaith3",
+      "homepage": "https://www.ancientfaith.com/radio",
+      "country": "US",
+      "tags": [
+        "christian"
+      ],
+      "bitrate": 96,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-crb-boston-early-music",
+      "name": "CRB - Boston Early Music",
+      "broadcaster": "independent",
+      "streamUrl": "https://wgbh-live.streamguys1.com/BostonEarlyMusic-8112-aac",
+      "homepage": "https://www.classicalwcrb.org/",
+      "country": "US",
+      "tags": [
+        "boston",
+        "classical",
+        "early music",
+        "gbh"
+      ],
+      "favicon": "https://www.classicalwcrb.org/apple-touch-icon.png",
+      "bitrate": 128,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-freedom-93-7",
+      "name": "Freedom 93.7",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc381",
+      "homepage": "https://freedom937.iheart.com/",
+      "country": "US",
+      "tags": [
+        "news",
+        "talk"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/5e6a4dec4b5295736a8f19f6?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-polydor",
+      "name": "Radio Polydor",
+      "broadcaster": "independent",
+      "streamUrl": "https://broadcast.miami/proxy/polydor?mp=/stream/;",
+      "homepage": "https://www.radio-polydor.com/",
+      "country": "US",
+      "tags": [
+        "disco",
+        "funk",
+        "soul"
+      ],
+      "bitrate": 320,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-97-9-wjlb",
+      "name": "97.9 WJLB",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc1141",
+      "homepage": "https://wjlbdetroit.iheart.com/",
+      "country": "US",
+      "tags": [
+        "urban contemporary"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/59ceb6e9636154b7b7a9cf6c?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-news-radio-810-wgy",
+      "name": "News Radio 810 WGY",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc1413/hls.m3u8",
+      "homepage": "https://wgy.iheart.com/",
+      "country": "US",
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/5a43a4734d834fc016ebadf1?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "bitrate": 24,
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-p-funk-radio",
+      "name": "P-Funk Radio",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice66.securenetsystems.net/PFR",
+      "homepage": "https://www.pfunkradio.com/",
+      "country": "US",
+      "tags": [
+        "funk",
+        "p-funk"
+      ],
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-real-98-3",
+      "name": "Real 98.3",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc6944",
+      "homepage": "https://real983.iheart.com/",
+      "country": "US",
+      "tags": [
+        "hip hop"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/a1b14584587afc32d324600db6bc4d9f?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "codec": "AAC",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-beach-95-1",
+      "name": "Beach 95.1",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice3.securenetsystems.net/WBPC",
+      "homepage": "https://beach951.com/",
+      "country": "US",
+      "tags": [
+        "classic hits"
+      ],
+      "favicon": "https://beach951.com/images/favicon/apple-touch-icon.png",
+      "bitrate": 64,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-sonic-universe-32k-aac",
+      "name": "SomaFM Sonic Universe (32k AAC)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice2.somafm.com/sonicuniverse-32-aac",
+      "homepage": "https://somafm.com/sonicuniverse/",
+      "country": "US",
+      "tags": [
+        "avant-garde",
+        "eclectic",
+        "jazz"
+      ],
+      "favicon": "https://somafm.com/img3/sonicuniverse-400.jpg",
+      "bitrate": 32,
+      "codec": "AAC",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-100-7-wmms-cleveland-ohio",
+      "name": "100.7 WMMS - Cleveland, Ohio",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.revma.ihrhls.com/zc1741",
+      "homepage": "https://wmms.iheart.com/",
+      "country": "US",
+      "tags": [
+        "alternative rock",
+        "hard rock",
+        "rock",
+        "talk"
+      ],
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/59ba8c6becb804a54e71c0ca?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "codec": "AAC",
+      "geo": [
+        41.3801,
+        -81.6993
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-abn-antioch-otr",
+      "name": "ABN Antioch OTR",
+      "broadcaster": "independent",
+      "streamUrl": "https://s6.yesstreaming.net:18000/listen",
+      "homepage": "https://radio.macinmind.com/mobile/index.php#listen",
+      "country": "US",
+      "favicon": "https://radio.macinmind.com/mobile/abn-radio256-2x.png",
+      "bitrate": 32,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-desi-world-radio-usa",
+      "name": "desi world radio (USA)",
+      "broadcaster": "independent",
+      "streamUrl": "https://stream.zeno.fm/4mbfcn4mf24tv",
+      "homepage": "http://desiworldradio.com/",
+      "country": "US",
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-knbt-radio-new-braunfels",
+      "name": "KNBT Radio New Braunfels",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice5.securenetsystems.net/KNBT?playSessionID=7FECF4B8-DA9A-8B7C-5437CC2940B447FA",
+      "homepage": "https://www.radionb.com/knbt",
+      "country": "US",
+      "bitrate": 32,
+      "codec": "AAC+",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-polskie-radio-1030-chicago-wnvr",
+      "name": "Polskie Radio 1030 Chicago WNVR",
+      "broadcaster": "independent",
+      "streamUrl": "https://s1.reliastream.com/proxy/polskieradio?mp=/stream",
+      "homepage": "https://polskieradio.com/",
+      "country": "US",
+      "tags": [
+        "community",
+        "entertainment",
+        "news",
+        "polish",
+        "talk"
+      ],
+      "favicon": "https://polskieradio.com/wp-content/uploads/2019/11/polskie-radio-logo.png",
+      "bitrate": 128,
+      "codec": "MP3",
+      "geo": [
+        41.9395,
+        -87.7196
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-radio-is-a-foreign-country",
+      "name": "Radio is a Foreign Country",
+      "broadcaster": "independent",
+      "streamUrl": "https://s5.radio.co/s20251311a/listen",
+      "homepage": "https://www.radioisaforeigncountry.org/",
+      "country": "US",
+      "tags": [
+        "ethnic",
+        "field recording",
+        "folk",
+        "forgotten classics",
+        "global",
+        "international"
+      ],
+      "bitrate": 192,
+      "codec": "MP3",
+      "status": "stream-only"
+    },
+    {
+      "id": "us-somafm-digitalis-256k-mp3",
+      "name": "SomaFM Digitalis (256k MP3)",
+      "broadcaster": "independent",
+      "streamUrl": "https://ice2.somafm.com/digitalis-256-mp3",
+      "homepage": "https://somafm.com/digitalis/",
+      "country": "US",
+      "tags": [
+        "alternative rock",
+        "electronic rock"
+      ],
+      "favicon": "https://somafm.com/img3/digitalis-400.jpg",
+      "bitrate": 256,
+      "codec": "MP3",
+      "geo": [
+        37.8098,
+        -121.2863
+      ],
+      "status": "stream-only"
+    },
+    {
+      "id": "us-wuky-npr-rocks",
+      "name": "WUKY - NPR Rocks ",
+      "broadcaster": "independent",
+      "streamUrl": "https://wuky.streamguys1.com/wuky",
+      "homepage": "https://www.wuky.org/",
+      "country": "US",
+      "tags": [
+        "folk",
+        "public",
+        "rock"
+      ],
+      "favicon": "https://www.wuky.org/favicon.ico",
+      "bitrate": 98,
+      "codec": "AAC",
+      "geo": [
+        38.0348,
+        -84.505
+      ],
+      "status": "stream-only"
     }
   ]
 }


### PR DESCRIPTION
## US Tier 1 — Radio Browser sweep (votes ≥ 100)

**Vote range:** ≥ 100 votes  
**Imported:** 641 stations  
**Status:** all `stream-only` with `stationuuid` binding, `reviewedAt: 2026-05-04`

### Top 3 stations by votes
| Station | Votes |
|---|---|
| Classic Vinyl HD | 270,169 |
| Christmas Vinyl HD | 154,792 |
| WALM - Old Time Radio | 140,228 |

### Skipped (reasons)
- `bad-verdict` (broken-mixed / broken-network / etc): 3,118 stations
- `duplicate-of` (lower-voted dupe per RB): 868 stations
- `existing-uuid` (already in catalog): 16 stations
- `within-tier-name-dupe`: 5 stations
- `within-tier-url-dupe`: 0 stations

### Verification
- `npm run catalog` ✓ (3,206 stations published)
- `npm run check-catalog` ✓ (0 violations)
- `npm run check-duplicates` ✓ (0 collisions)
- `npm test -- --run` ✓ (294 tests passing)

Part 1 of 5 in the US tier sweep. Tier 2 (votes 20–99, ~1148) branches from this PR.