### PR TITLE
feat: backup & restore favorites + custom stations (refs #127)

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,31 @@
+name: Android
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "android/**"
+      - ".github/workflows/android.yml"
+  pull_request:
+    paths:
+      - "android/**"
+      - ".github/workflows/android.yml"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: "8.11.1"
+      - name: Unit tests
+        working-directory: android
+        run: gradle testDebugUnitTest
+      - name: Assemble debug
+        working-directory: android
+        run: gradle assembleDebug

--- a/android/.gitignore
+++ b/android/.gitignore
@@ -1,0 +1,7 @@
+.gradle/
+build/
+app/build/
+local.properties
+captures/
+*.iml
+.idea/

--- a/android/README.md
+++ b/android/README.md
@@ -1,0 +1,49 @@
+# rrradio — Android
+
+Native Android port of rrradio. This mirrors the SwiftUI iOS client:
+the catalog is still published by the web build at
+`https://rrradio.org/stations.json`, device-local library state stays on
+the phone, and playback is native rather than a WebView wrapper.
+
+## Status
+
+Implemented in this scaffold:
+
+- Kotlin + Jetpack Compose app shell.
+- Catalog decoding and cache-backed network loading.
+- Search parity for station name, tags, country, and whitespace-insensitive
+  matches such as `WDR5` -> `WDR 5`.
+- Favorites, recents, and custom HTTPS streams via DataStore.
+- Media3 `MediaSessionService` + ExoPlayer for MP3/AAC/HLS playback.
+- Background/lock-screen playback plumbing through Android media session.
+- Sleep timer cycle: off / 15 / 30 / 60 / 90 minutes.
+- Basic ICY `StreamTitle` parser and bounded ICY metadata fetcher for
+  `status: icy-only` stations.
+
+Not yet ported:
+
+- The full broadcaster metadata registry from iOS
+  (`orf`, `azuracast`, `laut-fm`, `streamabc`, `swr`, `ffh`, `mdr`,
+  `rbb-radioeins`, `cro`, `srgssr-il`, `swiss-radio`, `srr`, `mr`,
+  `br-radioplayer`, `bbc`, `hr`, `antenne`, `rb-bremen`, `sr`).
+- Program schedule panes.
+- Lyrics lookup.
+- Map view.
+- Wake-to-radio.
+- Backup/restore.
+- Android Auto-specific browse tree.
+
+## Building
+
+Open the `android/` directory in Android Studio, let it install the
+Gradle/Android toolchain, then run the `app` configuration.
+
+Command-line build once Gradle and the Android SDK are installed:
+
+```sh
+cd android
+gradle testDebugUnitTest assembleDebug
+```
+
+This workspace currently has Java but not Gradle or the Android SDK, so
+the Android build cannot be verified locally from this shell yet.

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,0 +1,50 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+    id("org.jetbrains.kotlin.plugin.compose")
+    id("org.jetbrains.kotlin.plugin.serialization")
+}
+
+android {
+    namespace = "org.rrradio.android"
+    compileSdk = 35
+
+    defaultConfig {
+        applicationId = "org.rrradio.android"
+        minSdk = 26
+        targetSdk = 35
+        versionCode = 1
+        versionName = "0.1.0"
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+}
+
+dependencies {
+    val composeBom = platform("androidx.compose:compose-bom:2024.12.01")
+    implementation(composeBom)
+    androidTestImplementation(composeBom)
+
+    implementation("androidx.activity:activity-compose:1.9.3")
+    implementation("androidx.core:core-ktx:1.15.0")
+    implementation("androidx.compose.material3:material3")
+    implementation("androidx.compose.material:material-icons-extended")
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.ui:ui-tooling-preview")
+    debugImplementation("androidx.compose.ui:ui-tooling")
+
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.7")
+    implementation("androidx.lifecycle:lifecycle-runtime-compose:2.8.7")
+    implementation("androidx.datastore:datastore-preferences:1.1.1")
+
+    implementation("androidx.media3:media3-exoplayer:1.5.1")
+    implementation("androidx.media3:media3-exoplayer-hls:1.5.1")
+    implementation("androidx.media3:media3-session:1.5.1")
+    implementation("androidx.media3:media3-ui:1.5.1")
+
+    implementation("com.squareup.okhttp3:okhttp:4.12.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
+
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.9.0")
+}

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,35 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+
+    <application
+        android:name=".RrradioApplication"
+        android:allowBackup="false"
+        android:dataExtractionRules="@xml/data_extraction_rules"
+        android:fullBackupContent="false"
+        android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
+        android:theme="@style/Theme.Rrradio">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
+        <service
+            android:name=".playback.RadioPlaybackService"
+            android:exported="true"
+            android:foregroundServiceType="mediaPlayback">
+            <intent-filter>
+                <action android:name="androidx.media3.session.MediaSessionService" />
+            </intent-filter>
+        </service>
+    </application>
+</manifest>

--- a/android/app/src/main/java/org/rrradio/android/MainActivity.kt
+++ b/android/app/src/main/java/org/rrradio/android/MainActivity.kt
@@ -1,0 +1,34 @@
+package org.rrradio.android
+
+import android.Manifest
+import android.os.Build
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.activity.viewModels
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import org.rrradio.android.ui.RrradioApp
+import org.rrradio.android.ui.RrradioViewModel
+import org.rrradio.android.ui.theme.RrradioTheme
+
+class MainActivity : ComponentActivity() {
+    private val viewModel: RrradioViewModel by viewModels()
+    private val notificationPermission = registerForActivityResult(
+        ActivityResultContracts.RequestPermission(),
+    ) { }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        if (Build.VERSION.SDK_INT >= 33) {
+            notificationPermission.launch(Manifest.permission.POST_NOTIFICATIONS)
+        }
+        setContent {
+            val state by viewModel.uiState.collectAsState()
+            RrradioTheme(darkTheme = state.darkTheme) {
+                RrradioApp(state = state, actions = viewModel)
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/org/rrradio/android/RrradioApplication.kt
+++ b/android/app/src/main/java/org/rrradio/android/RrradioApplication.kt
@@ -1,0 +1,5 @@
+package org.rrradio.android
+
+import android.app.Application
+
+class RrradioApplication : Application()

--- a/android/app/src/main/java/org/rrradio/android/data/CatalogRepository.kt
+++ b/android/app/src/main/java/org/rrradio/android/data/CatalogRepository.kt
@@ -1,0 +1,68 @@
+package org.rrradio.android.data
+
+import android.content.Context
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.File
+
+class CatalogRepository(
+    private val context: Context,
+    private val client: OkHttpClient = OkHttpClient(),
+    private val json: Json = defaultJson,
+    private val catalogUrl: String = CANONICAL_CATALOG_URL,
+) {
+    private val cacheFile: File
+        get() = File(context.cacheDir, "stations.json")
+
+    suspend fun load(): CatalogState = withContext(Dispatchers.IO) {
+        val cached = readCache()
+        val initial = if (cached.isNotEmpty()) {
+            CatalogState(stations = cached, loadState = CatalogLoadState.Loaded)
+        } else {
+            CatalogState(loadState = CatalogLoadState.Loading)
+        }
+
+        try {
+            val request = Request.Builder()
+                .url(catalogUrl)
+                .cacheControl(okhttp3.CacheControl.FORCE_NETWORK)
+                .build()
+            client.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) error("Catalog returned HTTP ${response.code}")
+                val body = response.body?.string() ?: error("Catalog response was empty")
+                val parsed = json.decodeFromString<CatalogResponse>(body).stations
+                cacheFile.writeText(body)
+                CatalogState(stations = parsed, loadState = CatalogLoadState.Loaded)
+            }
+        } catch (error: Exception) {
+            if (initial.stations.isNotEmpty()) {
+                initial
+            } else {
+                CatalogState(
+                    loadState = CatalogLoadState.Failed,
+                    errorMessage = error.localizedMessage ?: "Catalog unavailable",
+                )
+            }
+        }
+    }
+
+    fun readCache(): List<Station> {
+        val file = cacheFile
+        if (!file.exists()) return emptyList()
+        return runCatching {
+            json.decodeFromString<CatalogResponse>(file.readText()).stations
+        }.getOrDefault(emptyList())
+    }
+
+    companion object {
+        const val CANONICAL_CATALOG_URL = "https://rrradio.org/stations.json"
+    }
+}
+
+val defaultJson: Json = Json {
+    ignoreUnknownKeys = true
+}

--- a/android/app/src/main/java/org/rrradio/android/data/CustomStationBuilder.kt
+++ b/android/app/src/main/java/org/rrradio/android/data/CustomStationBuilder.kt
@@ -1,0 +1,58 @@
+package org.rrradio.android.data
+
+import java.net.URI
+import java.util.UUID
+
+sealed class CustomStationValidationError(message: String) : IllegalArgumentException(message) {
+    data object MissingName : CustomStationValidationError("Name is required.")
+    data object MissingStreamUrl : CustomStationValidationError("Stream URL is required.")
+    data object InvalidStreamUrl : CustomStationValidationError("Stream URL must be a valid URL.")
+    data object InsecureStreamUrl : CustomStationValidationError("Stream URL must use https://.")
+    data object InvalidHomepage : CustomStationValidationError("Homepage must be a valid http:// or https:// URL.")
+    data object InvalidCountry : CustomStationValidationError("Country must be a 2-letter code, for example CH.")
+}
+
+fun makeCustomStation(
+    name: String,
+    streamUrl: String,
+    homepage: String = "",
+    country: String = "",
+    tags: String = "",
+    id: String = "custom-${UUID.randomUUID()}",
+): Station {
+    val trimmedName = name.trim()
+    if (trimmedName.isEmpty()) throw CustomStationValidationError.MissingName
+
+    val trimmedStream = streamUrl.trim()
+    if (trimmedStream.isEmpty()) throw CustomStationValidationError.MissingStreamUrl
+    val streamUri = parseUri(trimmedStream) ?: throw CustomStationValidationError.InvalidStreamUrl
+    if (streamUri.scheme?.lowercase() != "https") throw CustomStationValidationError.InsecureStreamUrl
+
+    val parsedHomepage = parseOptionalHomepage(homepage)
+    val countryCode = country.trim().uppercase()
+    if (countryCode.isNotEmpty() && !Regex("^[A-Z]{2}$").matches(countryCode)) {
+        throw CustomStationValidationError.InvalidCountry
+    }
+
+    return Station(
+        id = id,
+        name = trimmedName,
+        streamUrl = streamUri.toString(),
+        homepage = parsedHomepage,
+        country = countryCode.ifEmpty { null },
+        tags = tags.split(",").map { it.trim().lowercase() }.filter { it.isNotEmpty() },
+        status = StationStatus.StreamOnly,
+    )
+}
+
+private fun parseOptionalHomepage(raw: String): String? {
+    val value = raw.trim()
+    if (value.isEmpty()) return null
+    val uri = parseUri(value) ?: throw CustomStationValidationError.InvalidHomepage
+    val scheme = uri.scheme?.lowercase()
+    if (scheme != "http" && scheme != "https") throw CustomStationValidationError.InvalidHomepage
+    return uri.toString()
+}
+
+private fun parseUri(raw: String): URI? =
+    runCatching { URI(raw).takeIf { it.scheme != null && it.host != null } }.getOrNull()

--- a/android/app/src/main/java/org/rrradio/android/data/LibraryRepository.kt
+++ b/android/app/src/main/java/org/rrradio/android/data/LibraryRepository.kt
@@ -1,0 +1,86 @@
+package org.rrradio.android.data
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+private val Context.rrradioDataStore by preferencesDataStore(name = "rrradio")
+
+class LibraryRepository(
+    context: Context,
+    private val json: Json = defaultJson,
+) {
+    private val store = context.rrradioDataStore
+
+    val favorites: Flow<List<Station>> = stationList(Keys.favorites)
+    val recents: Flow<List<Station>> = stationList(Keys.recents)
+    val customStations: Flow<List<Station>> = stationList(Keys.customStations)
+
+    suspend fun toggleFavorite(station: Station): Boolean {
+        var added = false
+        store.edit { prefs ->
+            val current = readStations(prefs[Keys.favorites])
+            val next = if (current.any { it.id == station.id }) {
+                current.filterNot { it.id == station.id }
+            } else {
+                added = true
+                listOf(station) + current
+            }
+            prefs[Keys.favorites] = json.encodeToString(next)
+        }
+        return added
+    }
+
+    suspend fun pushRecent(station: Station) {
+        store.edit { prefs ->
+            val current = readStations(prefs[Keys.recents])
+            prefs[Keys.recents] = json.encodeToString(
+                (listOf(station) + current.filterNot { it.id == station.id }).take(RECENTS_LIMIT),
+            )
+        }
+    }
+
+    suspend fun addCustom(station: Station) {
+        store.edit { prefs ->
+            val current = readStations(prefs[Keys.customStations])
+            val next = if (current.any { it.id == station.id }) {
+                current.map { if (it.id == station.id) station else it }
+            } else {
+                listOf(station) + current
+            }
+            prefs[Keys.customStations] = json.encodeToString(next)
+        }
+    }
+
+    suspend fun removeCustom(stationId: String) {
+        store.edit { prefs ->
+            prefs[Keys.customStations] = json.encodeToString(
+                readStations(prefs[Keys.customStations]).filterNot { it.id == stationId },
+            )
+        }
+    }
+
+    private fun stationList(key: androidx.datastore.preferences.core.Preferences.Key<String>): Flow<List<Station>> =
+        store.data.map { prefs -> readStations(prefs[key]) }
+
+    private fun readStations(raw: String?): List<Station> {
+        if (raw.isNullOrBlank()) return emptyList()
+        return runCatching { json.decodeFromString<List<Station>>(raw) }.getOrDefault(emptyList())
+    }
+
+    private object Keys {
+        val favorites = stringPreferencesKey("rrradio.favorites.v2")
+        val recents = stringPreferencesKey("rrradio.recents.v2")
+        val customStations = stringPreferencesKey("rrradio.custom.v1")
+    }
+
+    companion object {
+        const val RECENTS_LIMIT = 12
+    }
+}

--- a/android/app/src/main/java/org/rrradio/android/data/Models.kt
+++ b/android/app/src/main/java/org/rrradio/android/data/Models.kt
@@ -1,0 +1,89 @@
+package org.rrradio.android.data
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Station(
+    val id: String,
+    val name: String,
+    val streamUrl: String,
+    val homepage: String? = null,
+    val country: String? = null,
+    val tags: List<String>? = null,
+    val favicon: String? = null,
+    val bitrate: Int? = null,
+    val codec: String? = null,
+    val listeners: Int? = null,
+    val frequency: String? = null,
+    val metadata: String? = null,
+    val metadataUrl: String? = null,
+    val geo: List<Double>? = null,
+    val status: StationStatus? = null,
+    val featured: Boolean? = null,
+)
+
+@Serializable
+enum class StationStatus {
+    @SerialName("working")
+    Working,
+
+    @SerialName("icy-only")
+    IcyOnly,
+
+    @SerialName("stream-only")
+    StreamOnly,
+}
+
+@Serializable
+data class CatalogResponse(
+    val stations: List<Station>,
+)
+
+enum class CatalogLoadState {
+    Idle,
+    Loading,
+    Loaded,
+    Failed,
+}
+
+data class CatalogState(
+    val stations: List<Station> = emptyList(),
+    val loadState: CatalogLoadState = CatalogLoadState.Idle,
+    val errorMessage: String? = null,
+) {
+    val browseOrdered: List<Station>
+        get() {
+            val featured = stations.filter { it.featured == true }
+            val rest = stations.filter { it.featured != true }
+            return featured + rest
+        }
+}
+
+enum class PlayerState {
+    Idle,
+    Loading,
+    Playing,
+    Paused,
+    Error,
+}
+
+data class PlaybackUiState(
+    val station: Station? = null,
+    val state: PlayerState = PlayerState.Idle,
+    val artist: String? = null,
+    val title: String? = null,
+    val programName: String? = null,
+    val programSubtitle: String? = null,
+    val coverUrl: String? = null,
+    val errorMessage: String? = null,
+)
+
+data class NowPlayingMetadata(
+    val artist: String? = null,
+    val title: String? = null,
+    val raw: String,
+    val programName: String? = null,
+    val programSubtitle: String? = null,
+    val coverUrl: String? = null,
+)

--- a/android/app/src/main/java/org/rrradio/android/data/Search.kt
+++ b/android/app/src/main/java/org/rrradio/android/data/Search.kt
@@ -1,0 +1,55 @@
+package org.rrradio.android.data
+
+import java.util.Locale
+
+private val curatedGenreTags = listOf(
+    "jazz",
+    "ambient",
+    "classical",
+    "electronic",
+    "indie",
+    "rock",
+    "eclectic",
+)
+
+fun normalizeForSearch(value: String): String =
+    value.lowercase().filter { ch ->
+        ch.isLetterOrDigit() || ch == 'ä' || ch == 'ö' || ch == 'ü' || ch == 'ß'
+    }
+
+fun stationMatches(station: Station, query: String): Boolean {
+    val q = query.trim().lowercase()
+    if (q.isEmpty()) return true
+    if (station.name.lowercase().contains(q)) return true
+    if (station.tags.orEmpty().any { it.lowercase().contains(q) }) return true
+    if (station.country?.lowercase()?.contains(q) == true) return true
+
+    val normalized = normalizeForSearch(q)
+    return normalized.isNotEmpty() && normalizeForSearch(station.name).contains(normalized)
+}
+
+fun stationMatchesFilters(station: Station, country: String?, tag: String?): Boolean {
+    if (country != null && station.country?.uppercase() != country.uppercase()) return false
+    if (tag != null && station.tags.orEmpty().none { it.lowercase() == tag.lowercase() }) return false
+    return true
+}
+
+fun availableCountries(stations: List<Station>): List<String> =
+    stations.mapNotNull { it.country?.trim()?.uppercase()?.takeIf { code -> code.length == 2 } }
+        .toSet()
+        .sortedBy { countryDisplayName(it) }
+
+fun availableTags(stations: List<Station>): List<String> =
+    stations.flatMap { it.tags.orEmpty() }
+        .map { it.trim().lowercase() }
+        .filter { it.isNotEmpty() }
+        .toSet()
+        .sorted()
+
+fun availableCuratedGenres(stations: List<Station>): List<String> {
+    val available = availableTags(stations).toSet()
+    return curatedGenreTags.filter { it in available }
+}
+
+fun countryDisplayName(code: String): String =
+    Locale("", code.uppercase()).displayCountry.takeIf { it.isNotBlank() } ?: code.uppercase()

--- a/android/app/src/main/java/org/rrradio/android/metadata/IcyMetadata.kt
+++ b/android/app/src/main/java/org/rrradio/android/metadata/IcyMetadata.kt
@@ -1,0 +1,56 @@
+package org.rrradio.android.metadata
+
+import org.rrradio.android.data.NowPlayingMetadata
+import org.rrradio.android.data.Station
+import org.rrradio.android.data.StationStatus
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.nio.charset.Charset
+
+fun parseStreamTitle(raw: String): NowPlayingMetadata? {
+    val value = Regex("StreamTitle='([^']*)'").find(raw)?.groupValues?.getOrNull(1)
+        ?.trim()
+        ?.takeIf { it.isNotEmpty() }
+        ?: return null
+    val parts = value.split(" - ", limit = 2)
+    return if (parts.size == 2) {
+        NowPlayingMetadata(artist = parts[0].trim(), title = parts[1].trim(), raw = value)
+    } else {
+        NowPlayingMetadata(title = value, raw = value)
+    }
+}
+
+class IcyMetadataFetcher(
+    private val client: OkHttpClient = OkHttpClient(),
+) {
+    fun supports(station: Station): Boolean = station.status == StationStatus.IcyOnly
+
+    fun fetch(station: Station): NowPlayingMetadata? {
+        val request = Request.Builder()
+            .url(station.streamUrl)
+            .header("Icy-MetaData", "1")
+            .header("User-Agent", "rrradio-android/0.1")
+            .build()
+
+        client.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) return null
+            val metaint = response.header("icy-metaint")?.toIntOrNull()
+            val source = response.body?.source() ?: return null
+
+            if (metaint != null && metaint > 0) {
+                source.skip(metaint.toLong())
+                val lengthByte = source.readByte().toInt() and 0xff
+                if (lengthByte <= 0) return null
+                val metadataBytes = source.readByteArray((lengthByte * 16).toLong())
+                return parseStreamTitle(metadataBytes.decode())
+            }
+
+            val sniff = source.readByteArray(32_768)
+            return parseStreamTitle(sniff.decode())
+        }
+    }
+}
+
+private fun ByteArray.decode(): String =
+    runCatching { toString(Charsets.UTF_8) }
+        .getOrElse { toString(Charset.forName("ISO-8859-1")) }

--- a/android/app/src/main/java/org/rrradio/android/metadata/MetadataPoller.kt
+++ b/android/app/src/main/java/org/rrradio/android/metadata/MetadataPoller.kt
@@ -1,0 +1,42 @@
+package org.rrradio.android.metadata
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.rrradio.android.data.NowPlayingMetadata
+import org.rrradio.android.data.Station
+
+class MetadataPoller(
+    private val icyFetcher: IcyMetadataFetcher = IcyMetadataFetcher(),
+    private val intervalMillis: Long = 20_000,
+) {
+    private var job: Job? = null
+
+    fun start(
+        scope: CoroutineScope,
+        station: Station,
+        onMetadata: (NowPlayingMetadata?) -> Unit,
+    ) {
+        stop()
+        if (!icyFetcher.supports(station)) return
+
+        job = scope.launch {
+            while (isActive) {
+                val metadata = withContext(Dispatchers.IO) {
+                    runCatching { icyFetcher.fetch(station) }.getOrNull()
+                }
+                onMetadata(metadata)
+                delay(intervalMillis)
+            }
+        }
+    }
+
+    fun stop() {
+        job?.cancel()
+        job = null
+    }
+}

--- a/android/app/src/main/java/org/rrradio/android/playback/PlaybackStateStore.kt
+++ b/android/app/src/main/java/org/rrradio/android/playback/PlaybackStateStore.kt
@@ -1,0 +1,19 @@
+package org.rrradio.android.playback
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import org.rrradio.android.data.PlaybackUiState
+
+object PlaybackStateStore {
+    private val _state = MutableStateFlow(PlaybackUiState())
+    val state: StateFlow<PlaybackUiState> = _state.asStateFlow()
+
+    fun update(reducer: (PlaybackUiState) -> PlaybackUiState) {
+        _state.value = reducer(_state.value)
+    }
+
+    fun replace(state: PlaybackUiState) {
+        _state.value = state
+    }
+}

--- a/android/app/src/main/java/org/rrradio/android/playback/RadioPlaybackService.kt
+++ b/android/app/src/main/java/org/rrradio/android/playback/RadioPlaybackService.kt
@@ -1,0 +1,163 @@
+package org.rrradio.android.playback
+
+import android.content.Intent
+import androidx.core.net.toUri
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
+import androidx.media3.common.PlaybackException
+import androidx.media3.common.Player
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.session.MediaSession
+import androidx.media3.session.MediaSessionService
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import org.rrradio.android.data.PlayerState
+import org.rrradio.android.data.PlaybackUiState
+import org.rrradio.android.data.Station
+import org.rrradio.android.data.defaultJson
+import org.rrradio.android.metadata.MetadataPoller
+
+class RadioPlaybackService : MediaSessionService() {
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private val metadataPoller = MetadataPoller()
+    private lateinit var player: ExoPlayer
+    private var session: MediaSession? = null
+
+    override fun onCreate() {
+        super.onCreate()
+        player = ExoPlayer.Builder(this).build()
+        player.addListener(playerListener)
+        session = MediaSession.Builder(this, player).build()
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        when (intent?.action) {
+            ACTION_PLAY_STATION -> intent.getStringExtra(EXTRA_STATION_JSON)
+                ?.let { defaultJson.decodeFromString<Station>(it) }
+                ?.let(::play)
+            ACTION_TOGGLE -> toggle()
+            ACTION_PAUSE -> pause()
+            ACTION_STOP -> stopPlayback()
+        }
+        return super.onStartCommand(intent, flags, startId)
+    }
+
+    override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaSession? = session
+
+    override fun onDestroy() {
+        metadataPoller.stop()
+        serviceScope.cancel()
+        session?.release()
+        player.release()
+        super.onDestroy()
+    }
+
+    private fun play(station: Station) {
+        metadataPoller.stop()
+        PlaybackStateStore.replace(PlaybackUiState(station = station, state = PlayerState.Loading))
+
+        val metadata = MediaMetadata.Builder()
+            .setTitle(station.name)
+            .setArtist(station.country?.uppercase().orEmpty())
+            .build()
+        val item = MediaItem.Builder()
+            .setUri(station.streamUrl.toUri())
+            .setMediaId(station.id)
+            .setMediaMetadata(metadata)
+            .build()
+
+        player.setMediaItem(item)
+        player.prepare()
+        player.playWhenReady = true
+
+        metadataPoller.start(serviceScope, station) { now ->
+            if (now == null) return@start
+            PlaybackStateStore.update { current ->
+                if (current.station?.id != station.id) current
+                else current.copy(
+                    artist = now.artist,
+                    title = now.title,
+                    programName = now.programName,
+                    programSubtitle = now.programSubtitle,
+                    coverUrl = now.coverUrl,
+                )
+            }
+        }
+    }
+
+    private fun toggle() {
+        if (player.isPlaying) pause() else player.play()
+    }
+
+    private fun pause() {
+        player.pause()
+        PlaybackStateStore.update { it.copy(state = PlayerState.Paused) }
+    }
+
+    private fun stopPlayback() {
+        metadataPoller.stop()
+        player.stop()
+        PlaybackStateStore.replace(PlaybackUiState())
+        stopSelf()
+    }
+
+    private val playerListener = object : Player.Listener {
+        override fun onIsPlayingChanged(isPlaying: Boolean) {
+            PlaybackStateStore.update {
+                it.copy(state = if (isPlaying) PlayerState.Playing else PlayerState.Paused)
+            }
+        }
+
+        override fun onPlaybackStateChanged(playbackState: Int) {
+            PlaybackStateStore.update {
+                when (playbackState) {
+                    Player.STATE_BUFFERING -> it.copy(state = PlayerState.Loading)
+                    Player.STATE_READY -> it.copy(state = if (player.isPlaying) PlayerState.Playing else PlayerState.Paused)
+                    Player.STATE_ENDED -> it.copy(state = PlayerState.Paused)
+                    else -> it
+                }
+            }
+        }
+
+        override fun onPlayerError(error: PlaybackException) {
+            PlaybackStateStore.update {
+                it.copy(state = PlayerState.Error, errorMessage = error.localizedMessage)
+            }
+        }
+
+        override fun onMediaMetadataChanged(mediaMetadata: MediaMetadata) {
+            val title = mediaMetadata.title?.toString()?.takeIf { it.isNotBlank() }
+            val artist = mediaMetadata.artist?.toString()?.takeIf { it.isNotBlank() }
+            if (title == null && artist == null) return
+            PlaybackStateStore.update { current ->
+                current.copy(
+                    title = title ?: current.title,
+                    artist = artist ?: current.artist,
+                )
+            }
+        }
+    }
+
+    companion object {
+        const val ACTION_PLAY_STATION = "org.rrradio.android.action.PLAY_STATION"
+        const val ACTION_TOGGLE = "org.rrradio.android.action.TOGGLE"
+        const val ACTION_PAUSE = "org.rrradio.android.action.PAUSE"
+        const val ACTION_STOP = "org.rrradio.android.action.STOP"
+        const val EXTRA_STATION_JSON = "station_json"
+
+        fun playIntent(context: android.content.Context, station: Station): Intent =
+            Intent(context, RadioPlaybackService::class.java)
+                .setAction(ACTION_PLAY_STATION)
+                .putExtra(EXTRA_STATION_JSON, defaultJson.encodeToString(station))
+
+        fun toggleIntent(context: android.content.Context): Intent =
+            Intent(context, RadioPlaybackService::class.java).setAction(ACTION_TOGGLE)
+
+        fun pauseIntent(context: android.content.Context): Intent =
+            Intent(context, RadioPlaybackService::class.java).setAction(ACTION_PAUSE)
+    }
+}

--- a/android/app/src/main/java/org/rrradio/android/ui/RrradioApp.kt
+++ b/android/app/src/main/java/org/rrradio/android/ui/RrradioApp.kt
@@ -1,0 +1,611 @@
+package org.rrradio.android.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Add
+import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material.icons.rounded.DarkMode
+import androidx.compose.material.icons.rounded.Favorite
+import androidx.compose.material.icons.rounded.FavoriteBorder
+import androidx.compose.material.icons.rounded.LightMode
+import androidx.compose.material.icons.rounded.MusicNote
+import androidx.compose.material.icons.rounded.Pause
+import androidx.compose.material.icons.rounded.PlayArrow
+import androidx.compose.material.icons.rounded.Public
+import androidx.compose.material.icons.rounded.Search
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Divider
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import org.rrradio.android.data.CatalogLoadState
+import org.rrradio.android.data.PlayerState
+import org.rrradio.android.data.Station
+import org.rrradio.android.data.countryDisplayName
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun RrradioApp(
+    state: RrradioUiState,
+    actions: RrradioViewModel,
+) {
+    var showAddStation by remember { mutableStateOf(false) }
+    var showNowPlaying by remember { mutableStateOf(false) }
+
+    Scaffold(
+        contentWindowInsets = WindowInsets(0),
+        bottomBar = {
+            Column(
+                Modifier
+                    .fillMaxWidth()
+                    .background(MaterialTheme.colorScheme.surface)
+                    .navigationBarsPadding(),
+            ) {
+                if (state.playback.station != null) {
+                    MiniPlayer(
+                        playback = state.playback,
+                        sleepMinutes = state.sleepMinutes,
+                        onOpen = { showNowPlaying = true },
+                        onToggle = actions::togglePlayback,
+                        onSleep = actions::cycleSleepTimer,
+                    )
+                }
+                NavigationBar(containerColor = MaterialTheme.colorScheme.surface) {
+                    NavigationBarItem(
+                        selected = state.tab == AppTab.Browse,
+                        onClick = { actions.setTab(AppTab.Browse) },
+                        icon = { Icon(Icons.Rounded.Public, contentDescription = null) },
+                        label = { Text("Browse") },
+                    )
+                    NavigationBarItem(
+                        selected = state.tab == AppTab.Library,
+                        onClick = { actions.setTab(AppTab.Library) },
+                        icon = { Icon(Icons.Rounded.Favorite, contentDescription = null) },
+                        label = { Text("Library") },
+                    )
+                }
+            }
+        },
+    ) { padding ->
+        Column(
+            Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.background)
+                .padding(padding)
+                .statusBarsPadding(),
+        ) {
+            Header(
+                state = state,
+                onQuery = actions::setQuery,
+                onToggleTheme = actions::toggleTheme,
+                onAddStation = { showAddStation = true },
+                onCountry = actions::setCountry,
+                onTag = actions::setTag,
+                onLibrarySource = actions::setLibrarySource,
+            )
+            StationContent(
+                state = state,
+                onRefresh = actions::refreshCatalog,
+                onPlay = actions::play,
+                onFavorite = actions::toggleFavorite,
+                onRemoveCustom = actions::removeCustom,
+            )
+        }
+    }
+
+    if (showAddStation) {
+        ModalBottomSheet(
+            sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+            onDismissRequest = { showAddStation = false },
+        ) {
+            AddStationSheet(
+                onSave = { name, stream, homepage, country, tags, onError ->
+                    actions.addCustom(name, stream, homepage, country, tags, onError) {
+                        showAddStation = false
+                    }
+                },
+                onCancel = { showAddStation = false },
+            )
+        }
+    }
+
+    if (showNowPlaying && state.playback.station != null) {
+        ModalBottomSheet(
+            sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+            onDismissRequest = { showNowPlaying = false },
+        ) {
+            NowPlayingSheet(
+                state = state,
+                onFavorite = actions::toggleFavorite,
+                onToggle = actions::togglePlayback,
+                onSleep = actions::cycleSleepTimer,
+            )
+        }
+    }
+}
+
+@Composable
+private fun Header(
+    state: RrradioUiState,
+    onQuery: (String) -> Unit,
+    onToggleTheme: () -> Unit,
+    onAddStation: () -> Unit,
+    onCountry: (String?) -> Unit,
+    onTag: (String?) -> Unit,
+    onLibrarySource: (LibrarySource) -> Unit,
+) {
+    Column(
+        Modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(horizontal = 20.dp, vertical = 12.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = "r r r",
+                color = MaterialTheme.colorScheme.primary,
+                fontSize = 17.sp,
+                fontWeight = FontWeight.Medium,
+            )
+            Text(
+                text = " a d i o . o r g",
+                color = MaterialTheme.colorScheme.onSurface,
+                fontSize = 17.sp,
+                fontWeight = FontWeight.Medium,
+            )
+            Spacer(Modifier.weight(1f))
+            IconButton(onClick = onToggleTheme) {
+                Icon(
+                    if (state.darkTheme) Icons.Rounded.LightMode else Icons.Rounded.DarkMode,
+                    contentDescription = "Switch theme",
+                )
+            }
+            IconButton(onClick = onAddStation) {
+                Icon(Icons.Rounded.Add, contentDescription = "Add custom station")
+            }
+        }
+
+        OutlinedTextField(
+            value = state.query,
+            onValueChange = onQuery,
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+            leadingIcon = { Icon(Icons.Rounded.Search, contentDescription = null) },
+            trailingIcon = {
+                if (state.query.isNotEmpty()) {
+                    IconButton(onClick = { onQuery("") }) {
+                        Icon(Icons.Rounded.Close, contentDescription = "Clear search")
+                    }
+                }
+            },
+            placeholder = { Text("Search stations") },
+            keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.None),
+            shape = RoundedCornerShape(24.dp),
+        )
+
+        if (state.tab == AppTab.Browse) {
+            BrowseFilters(state, onCountry, onTag)
+        } else {
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                FilterChip(
+                    selected = state.librarySource == LibrarySource.Favorites,
+                    onClick = { onLibrarySource(LibrarySource.Favorites) },
+                    label = { Text("Favorites") },
+                )
+                FilterChip(
+                    selected = state.librarySource == LibrarySource.Recents,
+                    onClick = { onLibrarySource(LibrarySource.Recents) },
+                    label = { Text("Recents") },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun BrowseFilters(
+    state: RrradioUiState,
+    onCountry: (String?) -> Unit,
+    onTag: (String?) -> Unit,
+) {
+    var countryOpen by remember { mutableStateOf(false) }
+    var genreOpen by remember { mutableStateOf(false) }
+
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        Box {
+            AssistChip(
+                onClick = { genreOpen = true },
+                label = { Text(state.selectedTag ?: "Genre") },
+            )
+            DropdownMenu(expanded = genreOpen, onDismissRequest = { genreOpen = false }) {
+                DropdownMenuItem(
+                    text = { Text("All genres") },
+                    onClick = {
+                        onTag(null)
+                        genreOpen = false
+                    },
+                )
+                state.genres.forEach { tag ->
+                    DropdownMenuItem(
+                        text = { Text(tag) },
+                        onClick = {
+                            onTag(tag)
+                            genreOpen = false
+                        },
+                    )
+                }
+            }
+        }
+        Box {
+            AssistChip(
+                onClick = { countryOpen = true },
+                label = { Text(state.selectedCountry ?: "Country") },
+            )
+            DropdownMenu(expanded = countryOpen, onDismissRequest = { countryOpen = false }) {
+                DropdownMenuItem(
+                    text = { Text("All countries") },
+                    onClick = {
+                        onCountry(null)
+                        countryOpen = false
+                    },
+                )
+                state.countries.take(90).forEach { code ->
+                    DropdownMenuItem(
+                        text = { Text("${countryDisplayName(code)} ($code)") },
+                        onClick = {
+                            onCountry(code)
+                            countryOpen = false
+                        },
+                    )
+                }
+            }
+        }
+        FilterChip(
+            selected = state.selectedTag == "news",
+            onClick = { onTag(if (state.selectedTag == "news") null else "news") },
+            label = { Text("News") },
+        )
+    }
+}
+
+@Composable
+private fun StationContent(
+    state: RrradioUiState,
+    onRefresh: () -> Unit,
+    onPlay: (Station) -> Unit,
+    onFavorite: (Station) -> Unit,
+    onRemoveCustom: (Station) -> Unit,
+) {
+    when {
+        state.isCatalogEmptyLoading -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            CircularProgressIndicator()
+        }
+
+        state.catalog.loadState == CatalogLoadState.Failed && state.tab == AppTab.Browse -> {
+            Column(
+                Modifier
+                    .fillMaxSize()
+                    .padding(24.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center,
+            ) {
+                Text("Catalog unavailable", fontWeight = FontWeight.SemiBold)
+                Text(
+                    state.catalog.errorMessage.orEmpty(),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(top = 6.dp),
+                )
+                TextButton(onClick = onRefresh) { Text("Retry") }
+            }
+        }
+
+        state.visibleStations.isEmpty() -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Text("No stations", color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
+
+        else -> LazyColumn(Modifier.fillMaxSize()) {
+            items(state.visibleStations, key = { it.id }) { station ->
+                StationRow(
+                    station = station,
+                    isPlaying = state.playback.station?.id == station.id,
+                    isFavorite = state.favorites.any { it.id == station.id },
+                    isCustom = state.customStations.any { it.id == station.id },
+                    onPlay = { onPlay(station) },
+                    onFavorite = { onFavorite(station) },
+                    onRemoveCustom = { onRemoveCustom(station) },
+                )
+                Divider(color = MaterialTheme.colorScheme.outline)
+            }
+        }
+    }
+}
+
+@Composable
+private fun StationRow(
+    station: Station,
+    isPlaying: Boolean,
+    isFavorite: Boolean,
+    isCustom: Boolean,
+    onPlay: () -> Unit,
+    onFavorite: () -> Unit,
+    onRemoveCustom: () -> Unit,
+) {
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onPlay)
+            .padding(horizontal = 20.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        StationAvatar(station)
+        Spacer(Modifier.width(12.dp))
+        Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(3.dp)) {
+            Text(
+                station.name,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                fontWeight = if (isPlaying) FontWeight.SemiBold else FontWeight.Medium,
+            )
+            Text(
+                stationMeta(station),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontSize = 12.sp,
+                fontFamily = FontFamily.Monospace,
+            )
+        }
+        IconButton(onClick = onFavorite) {
+            Icon(
+                if (isFavorite) Icons.Rounded.Favorite else Icons.Rounded.FavoriteBorder,
+                contentDescription = if (isFavorite) "Remove favorite" else "Add favorite",
+                tint = if (isFavorite) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        if (isCustom) {
+            IconButton(onClick = onRemoveCustom) {
+                Icon(Icons.Rounded.Close, contentDescription = "Remove custom station")
+            }
+        }
+    }
+}
+
+@Composable
+private fun MiniPlayer(
+    playback: org.rrradio.android.data.PlaybackUiState,
+    sleepMinutes: Int,
+    onOpen: () -> Unit,
+    onToggle: () -> Unit,
+    onSleep: () -> Unit,
+) {
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surfaceVariant)
+            .clickable(onClick = onOpen)
+            .padding(horizontal = 20.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        StationAvatar(playback.station)
+        Spacer(Modifier.width(12.dp))
+        Column(Modifier.weight(1f)) {
+            Text(playback.station?.name.orEmpty(), maxLines = 1, overflow = TextOverflow.Ellipsis)
+            Text(
+                playbackLine(playback),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontSize = 12.sp,
+            )
+        }
+        TextButton(onClick = onSleep) {
+            Text(if (sleepMinutes > 0) "${sleepMinutes}m" else "Sleep")
+        }
+        IconButton(onClick = onToggle) {
+            Icon(
+                if (playback.state == PlayerState.Playing) Icons.Rounded.Pause else Icons.Rounded.PlayArrow,
+                contentDescription = if (playback.state == PlayerState.Playing) "Pause" else "Play",
+            )
+        }
+    }
+}
+
+@Composable
+private fun NowPlayingSheet(
+    state: RrradioUiState,
+    onFavorite: (Station) -> Unit,
+    onToggle: () -> Unit,
+    onSleep: () -> Unit,
+) {
+    val station = state.playback.station ?: return
+    Column(
+        Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 24.dp)
+            .padding(bottom = 32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(18.dp),
+    ) {
+        StationAvatar(station, size = 92)
+        Text(station.name, fontSize = 28.sp, fontWeight = FontWeight.Medium, maxLines = 2)
+        Text(
+            stationMeta(station),
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            fontFamily = FontFamily.Monospace,
+            fontSize = 12.sp,
+        )
+        Surface(
+            color = MaterialTheme.colorScheme.surfaceVariant,
+            shape = RoundedCornerShape(8.dp),
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(state.playback.title ?: "Live radio", fontWeight = FontWeight.SemiBold)
+                Text(
+                    state.playback.artist ?: state.playback.programName ?: station.country?.uppercase().orEmpty(),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                if (state.playback.errorMessage != null) {
+                    Text(state.playback.errorMessage, color = MaterialTheme.colorScheme.error)
+                }
+            }
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(12.dp), verticalAlignment = Alignment.CenterVertically) {
+            IconButton(onClick = { onFavorite(station) }) {
+                val favorite = state.favorites.any { it.id == station.id }
+                Icon(
+                    if (favorite) Icons.Rounded.Favorite else Icons.Rounded.FavoriteBorder,
+                    contentDescription = if (favorite) "Remove favorite" else "Add favorite",
+                )
+            }
+            Button(onClick = onToggle) {
+                Icon(
+                    if (state.playback.state == PlayerState.Playing) Icons.Rounded.Pause else Icons.Rounded.PlayArrow,
+                    contentDescription = null,
+                )
+                Spacer(Modifier.width(8.dp))
+                Text(if (state.playback.state == PlayerState.Playing) "Pause" else "Play")
+            }
+            TextButton(onClick = onSleep) {
+                Text(if (state.sleepMinutes > 0) "Sleep ${state.sleepMinutes}m" else "Sleep")
+            }
+        }
+    }
+}
+
+@Composable
+private fun AddStationSheet(
+    onSave: (
+        name: String,
+        streamUrl: String,
+        homepage: String,
+        country: String,
+        tags: String,
+        onError: (String) -> Unit,
+    ) -> Unit,
+    onCancel: () -> Unit,
+) {
+    var name by remember { mutableStateOf("") }
+    var stream by remember { mutableStateOf("") }
+    var homepage by remember { mutableStateOf("") }
+    var country by remember { mutableStateOf("") }
+    var tags by remember { mutableStateOf("") }
+    var error by remember { mutableStateOf<String?>(null) }
+
+    Column(
+        Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 24.dp)
+            .padding(bottom = 32.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Text("Add station", fontSize = 22.sp, fontWeight = FontWeight.Medium)
+        OutlinedTextField(name, { name = it }, Modifier.fillMaxWidth(), label = { Text("Name") }, singleLine = true)
+        OutlinedTextField(stream, { stream = it }, Modifier.fillMaxWidth(), label = { Text("Stream URL") }, singleLine = true)
+        OutlinedTextField(homepage, { homepage = it }, Modifier.fillMaxWidth(), label = { Text("Homepage") }, singleLine = true)
+        Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+            OutlinedTextField(country, { country = it }, Modifier.weight(0.35f), label = { Text("Country") }, singleLine = true)
+            OutlinedTextField(tags, { tags = it }, Modifier.weight(0.65f), label = { Text("Tags") }, singleLine = true)
+        }
+        if (error != null) Text(error.orEmpty(), color = MaterialTheme.colorScheme.error)
+        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+            TextButton(onClick = onCancel) { Text("Cancel") }
+            Button(
+                onClick = {
+                    onSave(name, stream, homepage, country, tags) { error = it }
+                },
+            ) {
+                Text("Save")
+            }
+        }
+    }
+}
+
+@Composable
+private fun StationAvatar(station: Station?, size: Int = 42) {
+    Box(
+        Modifier
+            .size(size.dp)
+            .clip(CircleShape)
+            .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.16f)),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            Icons.Rounded.MusicNote,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size((size * 0.54f).dp),
+        )
+    }
+}
+
+private fun stationMeta(station: Station): String {
+    val parts = buildList {
+        station.country?.uppercase()?.let(::add)
+        station.codec?.takeIf { it.isNotBlank() }?.let(::add)
+        station.bitrate?.let { add("${it}k") }
+        station.tags.orEmpty().take(3).forEach(::add)
+    }
+    return parts.joinToString(" . ").ifEmpty { "stream" }
+}
+
+private fun playbackLine(playback: org.rrradio.android.data.PlaybackUiState): String {
+    if (playback.title != null && playback.artist != null) return "${playback.artist} - ${playback.title}"
+    if (playback.title != null) return playback.title
+    return when (playback.state) {
+        PlayerState.Idle -> "Standby"
+        PlayerState.Loading -> "Loading"
+        PlayerState.Playing -> "Live"
+        PlayerState.Paused -> "Paused"
+        PlayerState.Error -> "Error"
+    }
+}

--- a/android/app/src/main/java/org/rrradio/android/ui/RrradioViewModel.kt
+++ b/android/app/src/main/java/org/rrradio/android/ui/RrradioViewModel.kt
@@ -1,0 +1,209 @@
+package org.rrradio.android.ui
+
+import android.app.Application
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import org.rrradio.android.data.CatalogLoadState
+import org.rrradio.android.data.CatalogRepository
+import org.rrradio.android.data.CatalogState
+import org.rrradio.android.data.LibraryRepository
+import org.rrradio.android.data.PlaybackUiState
+import org.rrradio.android.data.PlayerState
+import org.rrradio.android.data.Station
+import org.rrradio.android.data.availableCountries
+import org.rrradio.android.data.availableCuratedGenres
+import org.rrradio.android.data.makeCustomStation
+import org.rrradio.android.data.stationMatches
+import org.rrradio.android.data.stationMatchesFilters
+import org.rrradio.android.playback.PlaybackStateStore
+import org.rrradio.android.playback.RadioPlaybackService
+
+enum class AppTab {
+    Browse,
+    Library,
+}
+
+enum class LibrarySource {
+    Favorites,
+    Recents,
+}
+
+data class RrradioUiState(
+    val catalog: CatalogState = CatalogState(),
+    val favorites: List<Station> = emptyList(),
+    val recents: List<Station> = emptyList(),
+    val customStations: List<Station> = emptyList(),
+    val playback: PlaybackUiState = PlaybackUiState(),
+    val tab: AppTab = AppTab.Browse,
+    val librarySource: LibrarySource = LibrarySource.Favorites,
+    val query: String = "",
+    val selectedCountry: String? = null,
+    val selectedTag: String? = null,
+    val sleepMinutes: Int = 0,
+    val darkTheme: Boolean = false,
+) {
+    val allStations: List<Station>
+        get() = customStations + catalog.browseOrdered
+
+    val countries: List<String>
+        get() = availableCountries(allStations)
+
+    val genres: List<String>
+        get() = availableCuratedGenres(allStations)
+
+    val visibleStations: List<Station>
+        get() {
+            val source = when (tab) {
+                AppTab.Browse -> allStations
+                AppTab.Library -> when (librarySource) {
+                    LibrarySource.Favorites -> favorites
+                    LibrarySource.Recents -> recents
+                }
+            }
+            val filtered = source.filter {
+                stationMatches(it, query) &&
+                    stationMatchesFilters(it, selectedCountry, selectedTag)
+            }
+            val hasQuery = query.trim().isNotEmpty()
+            val hasFilters = selectedCountry != null || selectedTag != null
+            val limit = if (tab == AppTab.Browse && !hasQuery && !hasFilters) 220 else filtered.size
+            return filtered.take(limit)
+        }
+
+    val isCatalogEmptyLoading: Boolean
+        get() = catalog.loadState in setOf(CatalogLoadState.Idle, CatalogLoadState.Loading) &&
+            catalog.stations.isEmpty()
+}
+
+class RrradioViewModel(application: Application) : AndroidViewModel(application) {
+    private val catalogRepository = CatalogRepository(application)
+    private val libraryRepository = LibraryRepository(application)
+    private var sleepJob: Job? = null
+
+    private val _uiState = MutableStateFlow(RrradioUiState())
+    val uiState: StateFlow<RrradioUiState> = _uiState.asStateFlow()
+
+    init {
+        refreshCatalog()
+        viewModelScope.launch {
+            libraryRepository.favorites.collect { favorites ->
+                _uiState.update { it.copy(favorites = favorites) }
+            }
+        }
+        viewModelScope.launch {
+            libraryRepository.recents.collect { recents ->
+                _uiState.update { it.copy(recents = recents) }
+            }
+        }
+        viewModelScope.launch {
+            libraryRepository.customStations.collect { custom ->
+                _uiState.update { it.copy(customStations = custom) }
+            }
+        }
+        viewModelScope.launch {
+            PlaybackStateStore.state.collect { playback ->
+                _uiState.update { it.copy(playback = playback) }
+            }
+        }
+    }
+
+    fun refreshCatalog() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(catalog = it.catalog.copy(loadState = CatalogLoadState.Loading)) }
+            _uiState.update { it.copy(catalog = catalogRepository.load()) }
+        }
+    }
+
+    fun setTab(tab: AppTab) {
+        _uiState.update { it.copy(tab = tab) }
+    }
+
+    fun setLibrarySource(source: LibrarySource) {
+        _uiState.update { it.copy(tab = AppTab.Library, librarySource = source) }
+    }
+
+    fun setQuery(query: String) {
+        _uiState.update { it.copy(query = query) }
+    }
+
+    fun setCountry(country: String?) {
+        _uiState.update { it.copy(selectedCountry = country, tab = AppTab.Browse) }
+    }
+
+    fun setTag(tag: String?) {
+        _uiState.update { it.copy(selectedTag = tag, tab = AppTab.Browse) }
+    }
+
+    fun toggleTheme() {
+        _uiState.update { it.copy(darkTheme = !it.darkTheme) }
+    }
+
+    fun play(station: Station) {
+        val context = getApplication<Application>()
+        ContextCompat.startForegroundService(context, RadioPlaybackService.playIntent(context, station))
+        viewModelScope.launch { libraryRepository.pushRecent(station) }
+    }
+
+    fun togglePlayback() {
+        val context = getApplication<Application>()
+        context.startService(RadioPlaybackService.toggleIntent(context))
+    }
+
+    fun toggleFavorite(station: Station) {
+        viewModelScope.launch { libraryRepository.toggleFavorite(station) }
+    }
+
+    fun addCustom(
+        name: String,
+        streamUrl: String,
+        homepage: String,
+        country: String,
+        tags: String,
+        onError: (String) -> Unit,
+        onSaved: () -> Unit,
+    ) {
+        viewModelScope.launch {
+            try {
+                libraryRepository.addCustom(makeCustomStation(name, streamUrl, homepage, country, tags))
+                onSaved()
+            } catch (error: IllegalArgumentException) {
+                onError(error.message ?: "Invalid station")
+            }
+        }
+    }
+
+    fun removeCustom(station: Station) {
+        viewModelScope.launch { libraryRepository.removeCustom(station.id) }
+    }
+
+    fun cycleSleepTimer() {
+        val cycle = listOf(0, 15, 30, 60, 90)
+        val current = uiState.value.sleepMinutes
+        val next = cycle[(cycle.indexOf(current).takeIf { it >= 0 } ?: 0).let { (it + 1) % cycle.size }]
+        sleepJob?.cancel()
+        if (next == 0) {
+            _uiState.update { it.copy(sleepMinutes = 0) }
+            return
+        }
+        _uiState.update { it.copy(sleepMinutes = next) }
+        sleepJob = viewModelScope.launch {
+            delay(next * 60_000L)
+            val context = getApplication<Application>()
+            context.startService(RadioPlaybackService.pauseIntent(context))
+            _uiState.update { it.copy(sleepMinutes = 0) }
+        }
+    }
+
+    override fun onCleared() {
+        sleepJob?.cancel()
+        super.onCleared()
+    }
+}

--- a/android/app/src/main/java/org/rrradio/android/ui/RrradioViewModel.kt
+++ b/android/app/src/main/java/org/rrradio/android/ui/RrradioViewModel.kt
@@ -1,7 +1,6 @@
 package org.rrradio.android.ui
 
 import android.app.Application
-import androidx.core.content.ContextCompat
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.Job
@@ -118,6 +117,12 @@ class RrradioViewModel(application: Application) : AndroidViewModel(application)
     fun refreshCatalog() {
         viewModelScope.launch {
             _uiState.update { it.copy(catalog = it.catalog.copy(loadState = CatalogLoadState.Loading)) }
+            val cached = catalogRepository.readCache()
+            if (cached.isNotEmpty()) {
+                _uiState.update {
+                    it.copy(catalog = CatalogState(stations = cached, loadState = CatalogLoadState.Loaded))
+                }
+            }
             _uiState.update { it.copy(catalog = catalogRepository.load()) }
         }
     }
@@ -148,7 +153,7 @@ class RrradioViewModel(application: Application) : AndroidViewModel(application)
 
     fun play(station: Station) {
         val context = getApplication<Application>()
-        ContextCompat.startForegroundService(context, RadioPlaybackService.playIntent(context, station))
+        context.startService(RadioPlaybackService.playIntent(context, station))
         viewModelScope.launch { libraryRepository.pushRecent(station) }
     }
 

--- a/android/app/src/main/java/org/rrradio/android/ui/theme/Theme.kt
+++ b/android/app/src/main/java/org/rrradio/android/ui/theme/Theme.kt
@@ -1,0 +1,53 @@
+package org.rrradio.android.ui.theme
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.ColorScheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+
+val RrGreen = Color(0xFF00A040)
+val RrYellow = Color(0xFFFFFF00)
+val RrLightBg = Color(0xFFF8F8F3)
+val RrLightPanel = Color(0xFFFFFFFB)
+val RrLightInk = Color(0xFF0E0E0D)
+val RrDarkBg = Color(0xFF0A0A0A)
+val RrDarkPanel = Color(0xFF131313)
+val RrDarkInk = Color(0xFFF4F4F2)
+
+@Composable
+fun RrradioTheme(
+    darkTheme: Boolean = isSystemInDarkTheme(),
+    content: @Composable () -> Unit,
+) {
+    MaterialTheme(
+        colorScheme = if (darkTheme) darkScheme else lightScheme,
+        content = content,
+    )
+}
+
+private val lightScheme: ColorScheme = lightColorScheme(
+    primary = RrGreen,
+    onPrimary = RrLightBg,
+    background = RrLightBg,
+    onBackground = RrLightInk,
+    surface = RrLightBg,
+    onSurface = RrLightInk,
+    surfaceVariant = RrLightPanel,
+    onSurfaceVariant = RrLightInk.copy(alpha = 0.66f),
+    outline = RrLightInk.copy(alpha = 0.10f),
+)
+
+private val darkScheme: ColorScheme = darkColorScheme(
+    primary = RrYellow,
+    onPrimary = RrDarkBg,
+    background = RrDarkBg,
+    onBackground = RrDarkInk,
+    surface = RrDarkBg,
+    onSurface = RrDarkInk,
+    surfaceVariant = RrDarkPanel,
+    onSurfaceVariant = RrDarkInk.copy(alpha = 0.66f),
+    outline = RrDarkInk.copy(alpha = 0.12f),
+)

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<resources>
+    <string name="app_name">rrradio</string>
+    <string name="playback_channel_name">Playback</string>
+</resources>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -1,0 +1,7 @@
+<resources>
+    <style name="Theme.Rrradio" parent="android:style/Theme.Material.Light.NoActionBar">
+        <item name="android:windowLightStatusBar">true</item>
+        <item name="android:windowLightNavigationBar">true</item>
+        <item name="android:fontFamily">sans</item>
+    </style>
+</resources>

--- a/android/app/src/main/res/xml/data_extraction_rules.xml
+++ b/android/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,4 @@
+<data-extraction-rules>
+    <cloud-backup disableIfNoEncryptionCapabilities="true" />
+    <device-transfer />
+</data-extraction-rules>

--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,7 @@
+<network-security-config>
+    <base-config cleartextTrafficPermitted="false" />
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="false">shoutcast.rtvc.gov.co</domain>
+        <domain includeSubdomains="false">162.244.80.52</domain>
+    </domain-config>
+</network-security-config>

--- a/android/app/src/test/java/org/rrradio/android/data/CustomStationBuilderTest.kt
+++ b/android/app/src/test/java/org/rrradio/android/data/CustomStationBuilderTest.kt
@@ -1,0 +1,35 @@
+package org.rrradio.android.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class CustomStationBuilderTest {
+    @Test
+    fun makeCustomStationBuildsHttpsStation() {
+        val station = makeCustomStation(
+            name = " Test Radio ",
+            streamUrl = "https://example.com/live.mp3",
+            homepage = "https://example.com",
+            country = "ch",
+            tags = "jazz, ambient",
+            id = "custom-test",
+        )
+
+        assertEquals("custom-test", station.id)
+        assertEquals("Test Radio", station.name)
+        assertEquals("CH", station.country)
+        assertEquals(listOf("jazz", "ambient"), station.tags)
+        assertEquals(StationStatus.StreamOnly, station.status)
+    }
+
+    @Test
+    fun makeCustomStationRejectsInsecureStreamUrl() {
+        assertThrows(CustomStationValidationError.InsecureStreamUrl::class.java) {
+            makeCustomStation(
+                name = "Test",
+                streamUrl = "http://example.com/live.mp3",
+            )
+        }
+    }
+}

--- a/android/app/src/test/java/org/rrradio/android/data/SearchTest.kt
+++ b/android/app/src/test/java/org/rrradio/android/data/SearchTest.kt
@@ -1,0 +1,29 @@
+package org.rrradio.android.data
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SearchTest {
+    @Test
+    fun normalizeForSearchKeepsGermanDiacriticsAndDropsSpacing() {
+        assertTrue(normalizeForSearch("NDR 90,3") == "ndr903")
+        assertTrue(normalizeForSearch("Ö1 Campus") == "ö1campus")
+    }
+
+    @Test
+    fun stationMatchesAcrossNameTagsAndCountry() {
+        val station = Station(
+            id = "wdr5",
+            name = "WDR 5",
+            streamUrl = "https://example.com/live.mp3",
+            country = "DE",
+            tags = listOf("news", "talk"),
+        )
+
+        assertTrue(stationMatches(station, "wdr5"))
+        assertTrue(stationMatches(station, "news"))
+        assertTrue(stationMatches(station, "de"))
+        assertFalse(stationMatches(station, "jazz"))
+    }
+}

--- a/android/app/src/test/java/org/rrradio/android/data/StationDecodingTest.kt
+++ b/android/app/src/test/java/org/rrradio/android/data/StationDecodingTest.kt
@@ -1,0 +1,32 @@
+package org.rrradio.android.data
+
+import kotlinx.serialization.decodeFromString
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class StationDecodingTest {
+    @Test
+    fun stationCatalogIgnoresUnknownKeys() {
+        val raw = """
+            {
+              "stations": [
+                {
+                  "id": "fm4",
+                  "name": "FM4",
+                  "streamUrl": "https://example.com/fm4.m3u8",
+                  "country": "AT",
+                  "tags": ["indie", "news"],
+                  "status": "working",
+                  "unknown": "ignored"
+                }
+              ]
+            }
+        """.trimIndent()
+
+        val parsed = defaultJson.decodeFromString<CatalogResponse>(raw)
+
+        assertEquals(1, parsed.stations.size)
+        assertEquals("FM4", parsed.stations.single().name)
+        assertEquals(StationStatus.Working, parsed.stations.single().status)
+    }
+}

--- a/android/app/src/test/java/org/rrradio/android/metadata/IcyMetadataTest.kt
+++ b/android/app/src/test/java/org/rrradio/android/metadata/IcyMetadataTest.kt
@@ -1,0 +1,24 @@
+package org.rrradio.android.metadata
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class IcyMetadataTest {
+    @Test
+    fun parseStreamTitleSplitsArtistAndTitle() {
+        val parsed = parseStreamTitle("StreamTitle='Artist - Track';StreamUrl='';")
+
+        assertEquals("Artist", parsed?.artist)
+        assertEquals("Track", parsed?.title)
+        assertEquals("Artist - Track", parsed?.raw)
+    }
+
+    @Test
+    fun parseStreamTitleFallsBackToTitleOnly() {
+        val parsed = parseStreamTitle("StreamTitle='Station ID';")
+
+        assertNull(parsed?.artist)
+        assertEquals("Station ID", parsed?.title)
+    }
+}

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,0 +1,6 @@
+plugins {
+    id("com.android.application") version "8.7.3" apply false
+    id("org.jetbrains.kotlin.android") version "2.0.21" apply false
+    id("org.jetbrains.kotlin.plugin.compose") version "2.0.21" apply false
+    id("org.jetbrains.kotlin.plugin.serialization") version "2.0.21" apply false
+}

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,0 +1,4 @@
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+android.useAndroidX=true
+kotlin.code.style=official
+android.nonTransitiveRClass=true

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "rrradio-android"
+include(":app")

--- a/index.html
+++ b/index.html
@@ -687,6 +687,25 @@
           </div>
 
           <div class="about-section">
+            <h3>Backup &amp; restore your favorites</h3>
+            <p>
+              Carry your favorites and custom stations to another device
+              without an account. On the Favorites tab, tap the
+              <svg class="about-inline-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v12"/><path d="m7 10 5 5 5-5"/><path d="M5 21h14"/></svg>
+              icon to download a small JSON file. Move it to the other
+              device however you like — AirDrop, USB, share sheet, email
+              to yourself — and tap the
+              <svg class="about-inline-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 21V9"/><path d="m17 14-5-5-5 5"/><path d="M5 3h14"/></svg>
+              icon there to import. The file lives on your device only —
+              no upload, no account.
+            </p>
+            <p>
+              Importing <em>adds</em> to whatever's already on the
+              device; it never deletes or replaces existing favorites.
+            </p>
+          </div>
+
+          <div class="about-section">
             <h3>Free, no adds</h3>
             <ul class="about-list">
               <li>No signup. Nothing to log into.</li>
@@ -746,33 +765,6 @@
               Coverage skews mainstream pop / rock — the lyrics tab
               quietly disappears when there's nothing to show.
             </p>
-          </div>
-
-          <div class="about-section">
-            <h3>Backup &amp; restore</h3>
-            <p>
-              Carry your favorites and custom stations to another device.
-              Export a small JSON file from this browser, move it to the
-              other device however you like (AirDrop, USB, share sheet,
-              email to yourself), and import it there. The file lives on
-              your device only — no upload, no account.
-            </p>
-            <p>
-              Importing <em>adds</em> to whatever's already on the device;
-              it never deletes or replaces existing favorites.
-            </p>
-            <div class="about-ctas">
-              <button type="button" class="about-cta" id="backup-export-btn">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v12"/><path d="m7 10 5 5 5-5"/><path d="M5 21h14"/></svg>
-                <span>Export favorites</span>
-              </button>
-              <button type="button" class="about-cta" id="backup-import-btn">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 21V9"/><path d="m17 14-5-5-5 5"/><path d="M5 3h14"/></svg>
-                <span>Import from file</span>
-              </button>
-              <input type="file" id="backup-import-input" accept="application/json,.json" hidden />
-            </div>
-            <p class="about-backup-msg" id="backup-msg" hidden></p>
           </div>
 
           <div class="about-section">

--- a/index.html
+++ b/index.html
@@ -749,6 +749,33 @@
           </div>
 
           <div class="about-section">
+            <h3>Backup &amp; restore</h3>
+            <p>
+              Carry your favorites and custom stations to another device.
+              Export a small JSON file from this browser, move it to the
+              other device however you like (AirDrop, USB, share sheet,
+              email to yourself), and import it there. The file lives on
+              your device only — no upload, no account.
+            </p>
+            <p>
+              Importing <em>adds</em> to whatever's already on the device;
+              it never deletes or replaces existing favorites.
+            </p>
+            <div class="about-ctas">
+              <button type="button" class="about-cta" id="backup-export-btn">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v12"/><path d="m7 10 5 5 5-5"/><path d="M5 21h14"/></svg>
+                <span>Export favorites</span>
+              </button>
+              <button type="button" class="about-cta" id="backup-import-btn">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 21V9"/><path d="m17 14-5-5-5 5"/><path d="M5 3h14"/></svg>
+                <span>Import from file</span>
+              </button>
+              <input type="file" id="backup-import-input" accept="application/json,.json" hidden />
+            </div>
+            <p class="about-backup-msg" id="backup-msg" hidden></p>
+          </div>
+
+          <div class="about-section">
             <h3>Privacy</h3>
             <p>
               No cookies. Your favorites, theme choice, and recently-played

--- a/src/backup.test.ts
+++ b/src/backup.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest';
+import {
+  BACKUP_VERSION,
+  BackupParseError,
+  backupFilename,
+  mergeSnapshot,
+  parseBackup,
+  serializeBackup,
+  summaryMessage,
+  type BackupSnapshot,
+} from './backup';
+import type { Station } from './types';
+
+const fm4: Station = {
+  id: 'fm4',
+  name: 'FM4',
+  streamUrl: 'https://example.com/fm4',
+  country: 'AT',
+  tags: ['alternative'],
+};
+const oe1: Station = {
+  id: 'oe1',
+  name: 'Ö1',
+  streamUrl: 'https://example.com/oe1',
+  country: 'AT',
+};
+const customNoise: Station = {
+  id: 'mynoise',
+  name: 'My Noise',
+  streamUrl: 'https://example.com/mynoise',
+};
+
+describe('serializeBackup', () => {
+  it('writes the version + ISO timestamp + both lists', () => {
+    const at = new Date('2026-05-07T12:00:00.000Z');
+    const out = serializeBackup([fm4], [customNoise], at);
+    const parsed = JSON.parse(out) as BackupSnapshot;
+    expect(parsed.version).toBe(BACKUP_VERSION);
+    expect(parsed.exportedAt).toBe('2026-05-07T12:00:00.000Z');
+    expect(parsed.favorites).toEqual([fm4]);
+    expect(parsed.custom).toEqual([customNoise]);
+  });
+
+  it('produces JSON that round-trips through parseBackup', () => {
+    const text = serializeBackup([fm4, oe1], []);
+    const back = parseBackup(text);
+    expect(back.favorites).toEqual([fm4, oe1]);
+    expect(back.custom).toEqual([]);
+  });
+});
+
+describe('backupFilename', () => {
+  it('renders YYYY-MM-DD from local date', () => {
+    const at = new Date(2026, 0, 5); // local Jan 5 2026
+    expect(backupFilename(at)).toBe('rrradio-favorites-2026-01-05.json');
+  });
+});
+
+describe('parseBackup', () => {
+  it('rejects non-JSON input', () => {
+    expect(() => parseBackup('not json {')).toThrow(BackupParseError);
+  });
+
+  it('rejects null / non-object input', () => {
+    expect(() => parseBackup('null')).toThrow(BackupParseError);
+    expect(() => parseBackup('"a string"')).toThrow(BackupParseError);
+  });
+
+  it('rejects missing version', () => {
+    expect(() => parseBackup('{}')).toThrow(/version/);
+  });
+
+  it('rejects unsupported version', () => {
+    const text = JSON.stringify({ version: 99, favorites: [], custom: [] });
+    expect(() => parseBackup(text)).toThrow(/version 99/);
+  });
+
+  it('drops entries missing required Station fields', () => {
+    const text = JSON.stringify({
+      version: BACKUP_VERSION,
+      favorites: [fm4, { id: 'broken' }, { name: 'no id', streamUrl: 'x' }],
+      custom: [],
+    });
+    const out = parseBackup(text);
+    expect(out.favorites).toEqual([fm4]);
+  });
+
+  it('treats missing favorites/custom as empty arrays', () => {
+    const out = parseBackup(JSON.stringify({ version: BACKUP_VERSION }));
+    expect(out.favorites).toEqual([]);
+    expect(out.custom).toEqual([]);
+  });
+});
+
+describe('mergeSnapshot', () => {
+  const snap = (favs: Station[], cus: Station[]): BackupSnapshot => ({
+    version: BACKUP_VERSION,
+    exportedAt: '',
+    favorites: favs,
+    custom: cus,
+  });
+
+  it('appends new favorites at the end (preserves existing order)', () => {
+    const existing: Station[] = [fm4];
+    const incoming = snap([oe1], []);
+    const out = mergeSnapshot(existing, [], incoming);
+    expect(out.mergedFavorites).toEqual([fm4, oe1]);
+    expect(out.favoritesAdded).toBe(1);
+    expect(out.favoritesAlreadyHad).toBe(0);
+  });
+
+  it('skips ids the user already has', () => {
+    const existing: Station[] = [fm4, oe1];
+    const incoming = snap([fm4], []);
+    const out = mergeSnapshot(existing, [], incoming);
+    expect(out.mergedFavorites).toEqual([fm4, oe1]);
+    expect(out.favoritesAdded).toBe(0);
+    expect(out.favoritesAlreadyHad).toBe(1);
+  });
+
+  it('merges custom stations independently from favorites', () => {
+    const existing: Station[] = [fm4];
+    const existingCustom: Station[] = [];
+    const incoming = snap([], [customNoise]);
+    const out = mergeSnapshot(existing, existingCustom, incoming);
+    expect(out.mergedFavorites).toEqual([fm4]); // untouched
+    expect(out.mergedCustom).toEqual([customNoise]);
+    expect(out.customAdded).toBe(1);
+  });
+
+  it('handles a fully-empty incoming backup gracefully', () => {
+    const existing: Station[] = [fm4];
+    const out = mergeSnapshot(existing, [], snap([], []));
+    expect(out.mergedFavorites).toEqual([fm4]);
+    expect(out.favoritesAdded).toBe(0);
+    expect(out.favoritesAlreadyHad).toBe(0);
+  });
+});
+
+describe('summaryMessage', () => {
+  const base = { mergedFavorites: [], mergedCustom: [] };
+
+  it('shows the added counts when something was new', () => {
+    const msg = summaryMessage({
+      ...base,
+      favoritesAdded: 3,
+      favoritesAlreadyHad: 1,
+      customAdded: 2,
+      customAlreadyHad: 0,
+    });
+    expect(msg).toBe('Imported 3 favorites and 2 custom stations (1 already had).');
+  });
+
+  it('handles singular wording', () => {
+    const msg = summaryMessage({
+      ...base,
+      favoritesAdded: 1,
+      favoritesAlreadyHad: 0,
+      customAdded: 0,
+      customAlreadyHad: 0,
+    });
+    expect(msg).toBe('Imported 1 favorite.');
+  });
+
+  it('says "already had everything" when nothing was new but counts > 0', () => {
+    const msg = summaryMessage({
+      ...base,
+      favoritesAdded: 0,
+      favoritesAlreadyHad: 4,
+      customAdded: 0,
+      customAlreadyHad: 1,
+    });
+    expect(msg).toBe('Already had everything in that backup (5 items).');
+  });
+
+  it('says "empty" when the backup carried no entries', () => {
+    const msg = summaryMessage({
+      ...base,
+      favoritesAdded: 0,
+      favoritesAlreadyHad: 0,
+      customAdded: 0,
+      customAlreadyHad: 0,
+    });
+    expect(msg).toBe('That backup is empty.');
+  });
+});

--- a/src/backup.ts
+++ b/src/backup.ts
@@ -1,0 +1,168 @@
+/**
+ * Backup & restore for favorites + custom stations (gh #127).
+ *
+ * Export: write a small JSON snapshot the user downloads, then carries
+ * to another device (AirDrop, USB, share sheet — anything that moves a
+ * file). Import: parse the snapshot and merge it with whatever's
+ * already on the device — never wipe.
+ *
+ * No backend, no account, no URL fragment. The file is the entire
+ * sync mechanism; the user can read it before they import it.
+ *
+ * This file is pure: no DOM, no localStorage, no fetch. main.ts wires
+ * the file-download / file-pick plumbing; tests exercise the helpers
+ * with plain string + array fixtures.
+ */
+
+import type { Station } from './types';
+
+export const BACKUP_VERSION = 1;
+
+export interface BackupSnapshot {
+  version: number;
+  exportedAt: string;
+  favorites: Station[];
+  custom: Station[];
+}
+
+export interface ImportSummary {
+  favoritesAdded: number;
+  favoritesAlreadyHad: number;
+  customAdded: number;
+  customAlreadyHad: number;
+  /** Snapshot of the merged lists, ready to be written back to storage. */
+  mergedFavorites: Station[];
+  mergedCustom: Station[];
+}
+
+export class BackupParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'BackupParseError';
+  }
+}
+
+export function serializeBackup(favorites: Station[], custom: Station[], now = new Date()): string {
+  const snap: BackupSnapshot = {
+    version: BACKUP_VERSION,
+    exportedAt: now.toISOString(),
+    favorites,
+    custom,
+  };
+  return JSON.stringify(snap, null, 2);
+}
+
+/** YYYY-MM-DD slice for filenames (consistent across timezones — uses
+ *  the user's local date so it matches what they'd type). */
+export function backupFilename(now = new Date()): string {
+  const yyyy = now.getFullYear();
+  const mm = String(now.getMonth() + 1).padStart(2, '0');
+  const dd = String(now.getDate()).padStart(2, '0');
+  return `rrradio-favorites-${yyyy}-${mm}-${dd}.json`;
+}
+
+/** Parse a backup file. Throws BackupParseError on any structural
+ *  problem — main.ts catches and surfaces a friendly message. */
+export function parseBackup(text: string): BackupSnapshot {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw new BackupParseError("That doesn't look like a JSON file we can read.");
+  }
+  if (typeof parsed !== 'object' || parsed === null) {
+    throw new BackupParseError('Backup file is empty or malformed.');
+  }
+  const obj = parsed as Record<string, unknown>;
+  const version = obj.version;
+  if (typeof version !== 'number') {
+    throw new BackupParseError('Backup file has no version marker.');
+  }
+  if (version !== BACKUP_VERSION) {
+    throw new BackupParseError(
+      `Backup version ${version} isn't supported (expected ${BACKUP_VERSION}).`,
+    );
+  }
+  const favorites = sanitizeStations(obj.favorites);
+  const custom = sanitizeStations(obj.custom);
+  return {
+    version,
+    exportedAt: typeof obj.exportedAt === 'string' ? obj.exportedAt : '',
+    favorites,
+    custom,
+  };
+}
+
+/** Drop entries that don't look like a Station — same shape-check the
+ *  storage layer uses on read. Mirrors `readStations` in storage.ts. */
+function sanitizeStations(raw: unknown): Station[] {
+  if (!Array.isArray(raw)) return [];
+  return raw.filter(
+    (s): s is Station =>
+      typeof s === 'object' &&
+      s !== null &&
+      typeof (s as Station).id === 'string' &&
+      typeof (s as Station).name === 'string' &&
+      typeof (s as Station).streamUrl === 'string',
+  );
+}
+
+/** Merge an imported snapshot with what's already on the device. Union
+ *  by id — never overwrites or removes. Incoming entries are appended
+ *  AFTER existing ones so the user's current dial order is preserved. */
+export function mergeSnapshot(
+  existingFavorites: Station[],
+  existingCustom: Station[],
+  incoming: BackupSnapshot,
+): ImportSummary {
+  const fav = mergeById(existingFavorites, incoming.favorites);
+  const cus = mergeById(existingCustom, incoming.custom);
+  return {
+    favoritesAdded: fav.added,
+    favoritesAlreadyHad: fav.alreadyHad,
+    customAdded: cus.added,
+    customAlreadyHad: cus.alreadyHad,
+    mergedFavorites: fav.merged,
+    mergedCustom: cus.merged,
+  };
+}
+
+function mergeById(
+  existing: Station[],
+  incoming: Station[],
+): { merged: Station[]; added: number; alreadyHad: number } {
+  const haveIds = new Set(existing.map((s) => s.id));
+  const merged = [...existing];
+  let added = 0;
+  let alreadyHad = 0;
+  for (const s of incoming) {
+    if (haveIds.has(s.id)) {
+      alreadyHad++;
+      continue;
+    }
+    merged.push(s);
+    haveIds.add(s.id);
+    added++;
+  }
+  return { merged, added, alreadyHad };
+}
+
+/** Render a one-line user-facing summary of an import. Single source of
+ *  truth so main.ts and tests agree on the wording. */
+export function summaryMessage(s: ImportSummary): string {
+  const parts: string[] = [];
+  if (s.favoritesAdded > 0) parts.push(`${s.favoritesAdded} favorite${s.favoritesAdded === 1 ? '' : 's'}`);
+  if (s.customAdded > 0)
+    parts.push(`${s.customAdded} custom station${s.customAdded === 1 ? '' : 's'}`);
+  if (parts.length === 0) {
+    const total = s.favoritesAlreadyHad + s.customAlreadyHad;
+    return total > 0
+      ? `Already had everything in that backup (${total} item${total === 1 ? '' : 's'}).`
+      : 'That backup is empty.';
+  }
+  const tail =
+    s.favoritesAlreadyHad + s.customAlreadyHad > 0
+      ? ` (${s.favoritesAlreadyHad + s.customAlreadyHad} already had).`
+      : '.';
+  return `Imported ${parts.join(' and ')}${tail}`;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -251,10 +251,6 @@ const $themeBtn = document.getElementById('theme-btn') as HTMLButtonElement;
 const $aboutBtn = document.getElementById('about-btn') as HTMLButtonElement;
 const $aboutSheet = document.getElementById('about-sheet') as HTMLElement;
 const $aboutClose = document.getElementById('about-close') as HTMLButtonElement;
-const $backupExportBtn = document.getElementById('backup-export-btn') as HTMLButtonElement;
-const $backupImportBtn = document.getElementById('backup-import-btn') as HTMLButtonElement;
-const $backupImportInput = document.getElementById('backup-import-input') as HTMLInputElement;
-const $backupMsg = document.getElementById('backup-msg') as HTMLElement;
 
 const $dashboardBtn = document.getElementById('dashboard-btn') as HTMLButtonElement;
 const $dashboardSheet = document.getElementById('dashboard-sheet') as HTMLElement;
@@ -672,15 +668,31 @@ function renderTabBar(): void {
 // Render — Content
 // ─────────────────────────────────────────────────────────────
 
-function sectionLabel(label: string, count: number): HTMLDivElement {
+function sectionLabel(
+  label: string,
+  count: number,
+  actions?: HTMLElement[],
+): HTMLDivElement {
   const wrap = document.createElement('div');
   wrap.className = 'section-label';
+  if (actions?.length) wrap.classList.add('section-label--with-actions');
+
+  const title = document.createElement('div');
+  title.className = 'section-label__title';
   const left = document.createElement('span');
   left.textContent = label;
   const right = document.createElement('span');
   right.className = 'count';
   right.textContent = String(count).padStart(2, '0');
-  wrap.append(left, right);
+  title.append(left, right);
+  wrap.append(title);
+
+  if (actions?.length) {
+    const slot = document.createElement('div');
+    slot.className = 'section-label__actions';
+    slot.append(...actions);
+    wrap.append(slot);
+  }
   return wrap;
 }
 
@@ -1592,7 +1604,11 @@ function renderContent(): void {
     const all = getFavorites();
     const list = filterStations(all, query);
     const label = query ? 'Results' : 'Favorites';
-    $content.append(sectionLabel(label, list.length));
+    // Backup actions (export + import icons) appear only on the
+    // unfiltered Favorites view — they operate on the full stored list,
+    // not the search-filtered subset.
+    const actions = !query ? favoriteHeaderActions(all.length) : undefined;
+    $content.append(sectionLabel(label, list.length, actions));
     if (all.length === 0) {
       $content.append(
         emptyState(ICON_FAV, 'No favorites yet', 'Tap the heart on any station to save it here'),
@@ -2946,21 +2962,38 @@ $themeBtn.addEventListener('click', onToggleTheme);
 $aboutBtn.addEventListener('click', () => openAboutSheet(true));
 $aboutClose.addEventListener('click', () => openAboutSheet(false));
 
-function setBackupMsg(text: string, tone: 'ok' | 'err'): void {
-  $backupMsg.textContent = text;
-  $backupMsg.dataset.tone = tone;
-  $backupMsg.hidden = false;
+// ─── Backup & restore ──────────────────────────────────────────────
+// UI lives on the Favorites tab header (icons rendered by
+// renderFavoritesActions below). About sheet describes the feature
+// but holds no buttons of its own. A small toast under the topbar
+// reports the result; replaces itself on the next action.
+
+let $backupToast: HTMLElement | null = null;
+let backupToastTimer: ReturnType<typeof setTimeout> | null = null;
+
+function showBackupToast(text: string, tone: 'ok' | 'err'): void {
+  if (!$backupToast) {
+    $backupToast = document.createElement('div');
+    $backupToast.className = 'backup-toast';
+    $backupToast.setAttribute('role', 'status');
+    document.body.appendChild($backupToast);
+  }
+  $backupToast.textContent = text;
+  $backupToast.dataset.tone = tone;
+  $backupToast.hidden = false;
+  if (backupToastTimer) clearTimeout(backupToastTimer);
+  // Errors persist longer — users need time to read them.
+  backupToastTimer = setTimeout(() => {
+    if ($backupToast) $backupToast.hidden = true;
+  }, tone === 'err' ? 7_000 : 4_000);
 }
 
-$backupExportBtn.addEventListener('click', () => {
+function exportBackupNow(): void {
   const favs = getFavorites();
   const cus = getCustom();
   const text = serializeBackup(favs, cus);
-  // Use a Blob URL + temporary anchor for the download. Works on
-  // desktop browsers; iOS Safari opens it inline (an iCloud Drive /
-  // Files-app save is two taps from there). The data: scheme would
-  // skip the inline-open detour but is blocked by some browsers'
-  // download heuristics for large payloads.
+  // Blob URL + temporary anchor for the download. Works on desktop;
+  // iOS Safari opens inline (Save to Files is two taps from there).
   const blob = new Blob([text], { type: 'application/json' });
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
@@ -2970,25 +3003,18 @@ $backupExportBtn.addEventListener('click', () => {
   a.click();
   document.body.removeChild(a);
   setTimeout(() => URL.revokeObjectURL(url), 1000);
-  setBackupMsg(
+  showBackupToast(
     `Exported ${favs.length} favorite${favs.length === 1 ? '' : 's'}` +
       (cus.length > 0 ? ` and ${cus.length} custom station${cus.length === 1 ? '' : 's'}` : '') +
       '.',
     'ok',
   );
   track('backup-export', `favs=${favs.length} custom=${cus.length}`);
-});
+}
 
-$backupImportBtn.addEventListener('click', () => {
-  $backupImportInput.value = ''; // allow re-picking the same file
-  $backupImportInput.click();
-});
-
-$backupImportInput.addEventListener('change', () => {
-  const file = $backupImportInput.files?.[0];
-  if (!file) return;
+function importBackupFromFile(file: File): void {
   const reader = new FileReader();
-  reader.onerror = () => setBackupMsg("Couldn't read that file.", 'err');
+  reader.onerror = () => showBackupToast("Couldn't read that file.", 'err');
   reader.onload = () => {
     try {
       const text = String(reader.result ?? '');
@@ -2996,13 +3022,11 @@ $backupImportInput.addEventListener('change', () => {
       const summary = mergeSnapshot(getFavorites(), getCustom(), snap);
       setFavorites(summary.mergedFavorites);
       setCustom(summary.mergedCustom);
-      setBackupMsg(summaryMessage(summary), 'ok');
+      showBackupToast(summaryMessage(summary), 'ok');
       track(
         'backup-import',
         `favsAdded=${summary.favoritesAdded} customAdded=${summary.customAdded}`,
       );
-      // Re-render whatever the user might be looking at right now so
-      // the imported entries appear without a page refresh.
       void runQuery();
       renderCustomList();
     } catch (err) {
@@ -3010,11 +3034,53 @@ $backupImportInput.addEventListener('change', () => {
         err instanceof BackupParseError
           ? err.message
           : `Import failed: ${err instanceof Error ? err.message : String(err)}`;
-      setBackupMsg(msg, 'err');
+      showBackupToast(msg, 'err');
     }
   };
   reader.readAsText(file);
-});
+}
+
+/** Trigger the file-picker. The input is created on demand so the DOM
+ *  doesn't carry a permanently-mounted hidden file input. */
+function pickImportFile(): void {
+  const input = document.createElement('input');
+  input.type = 'file';
+  input.accept = 'application/json,.json';
+  input.style.display = 'none';
+  input.addEventListener('change', () => {
+    const file = input.files?.[0];
+    if (file) importBackupFromFile(file);
+    input.remove();
+  });
+  document.body.appendChild(input);
+  input.click();
+}
+
+/** Build the export + import icon buttons for the Favorites tab header.
+ *  Export is disabled when there's nothing to export; import is always
+ *  available (it's how a fresh device becomes populated). */
+function favoriteHeaderActions(favoriteCount: number): HTMLElement[] {
+  const exportBtn = document.createElement('button');
+  exportBtn.type = 'button';
+  exportBtn.className = 'section-label__action';
+  exportBtn.setAttribute('aria-label', 'Export favorites');
+  exportBtn.title = 'Export favorites to file';
+  exportBtn.disabled = favoriteCount === 0;
+  exportBtn.innerHTML =
+    '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v12"/><path d="m7 10 5 5 5-5"/><path d="M5 21h14"/></svg>';
+  exportBtn.addEventListener('click', exportBackupNow);
+
+  const importBtn = document.createElement('button');
+  importBtn.type = 'button';
+  importBtn.className = 'section-label__action';
+  importBtn.setAttribute('aria-label', 'Import favorites');
+  importBtn.title = 'Import favorites from file';
+  importBtn.innerHTML =
+    '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 21V9"/><path d="m17 14-5-5-5 5"/><path d="M5 3h14"/></svg>';
+  importBtn.addEventListener('click', pickImportFile);
+
+  return [exportBtn, importBtn];
+}
 $dashboardBtn.addEventListener('click', () => void openDashboardSheet(true));
 $dashboardClose.addEventListener('click', () => void openDashboardSheet(false));
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,11 +27,21 @@ import {
   pushRecent,
   removeCustom,
   reorderFavorites,
+  setCustom,
+  setFavorites,
   setLastWakeTime,
   setString,
   setWakeTo,
   toggleFavorite,
 } from './storage';
+import {
+  BackupParseError,
+  backupFilename,
+  mergeSnapshot,
+  parseBackup,
+  serializeBackup,
+  summaryMessage,
+} from './backup';
 import { STATS_WORKER_BASE } from './config';
 import { countryName } from './country';
 import {
@@ -241,6 +251,10 @@ const $themeBtn = document.getElementById('theme-btn') as HTMLButtonElement;
 const $aboutBtn = document.getElementById('about-btn') as HTMLButtonElement;
 const $aboutSheet = document.getElementById('about-sheet') as HTMLElement;
 const $aboutClose = document.getElementById('about-close') as HTMLButtonElement;
+const $backupExportBtn = document.getElementById('backup-export-btn') as HTMLButtonElement;
+const $backupImportBtn = document.getElementById('backup-import-btn') as HTMLButtonElement;
+const $backupImportInput = document.getElementById('backup-import-input') as HTMLInputElement;
+const $backupMsg = document.getElementById('backup-msg') as HTMLElement;
 
 const $dashboardBtn = document.getElementById('dashboard-btn') as HTMLButtonElement;
 const $dashboardSheet = document.getElementById('dashboard-sheet') as HTMLElement;
@@ -2931,6 +2945,76 @@ $addForm.addEventListener('submit', handleAddSubmit);
 $themeBtn.addEventListener('click', onToggleTheme);
 $aboutBtn.addEventListener('click', () => openAboutSheet(true));
 $aboutClose.addEventListener('click', () => openAboutSheet(false));
+
+function setBackupMsg(text: string, tone: 'ok' | 'err'): void {
+  $backupMsg.textContent = text;
+  $backupMsg.dataset.tone = tone;
+  $backupMsg.hidden = false;
+}
+
+$backupExportBtn.addEventListener('click', () => {
+  const favs = getFavorites();
+  const cus = getCustom();
+  const text = serializeBackup(favs, cus);
+  // Use a Blob URL + temporary anchor for the download. Works on
+  // desktop browsers; iOS Safari opens it inline (an iCloud Drive /
+  // Files-app save is two taps from there). The data: scheme would
+  // skip the inline-open detour but is blocked by some browsers'
+  // download heuristics for large payloads.
+  const blob = new Blob([text], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = backupFilename();
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+  setBackupMsg(
+    `Exported ${favs.length} favorite${favs.length === 1 ? '' : 's'}` +
+      (cus.length > 0 ? ` and ${cus.length} custom station${cus.length === 1 ? '' : 's'}` : '') +
+      '.',
+    'ok',
+  );
+  track('backup-export', `favs=${favs.length} custom=${cus.length}`);
+});
+
+$backupImportBtn.addEventListener('click', () => {
+  $backupImportInput.value = ''; // allow re-picking the same file
+  $backupImportInput.click();
+});
+
+$backupImportInput.addEventListener('change', () => {
+  const file = $backupImportInput.files?.[0];
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onerror = () => setBackupMsg("Couldn't read that file.", 'err');
+  reader.onload = () => {
+    try {
+      const text = String(reader.result ?? '');
+      const snap = parseBackup(text);
+      const summary = mergeSnapshot(getFavorites(), getCustom(), snap);
+      setFavorites(summary.mergedFavorites);
+      setCustom(summary.mergedCustom);
+      setBackupMsg(summaryMessage(summary), 'ok');
+      track(
+        'backup-import',
+        `favsAdded=${summary.favoritesAdded} customAdded=${summary.customAdded}`,
+      );
+      // Re-render whatever the user might be looking at right now so
+      // the imported entries appear without a page refresh.
+      void runQuery();
+      renderCustomList();
+    } catch (err) {
+      const msg =
+        err instanceof BackupParseError
+          ? err.message
+          : `Import failed: ${err instanceof Error ? err.message : String(err)}`;
+      setBackupMsg(msg, 'err');
+    }
+  };
+  reader.readAsText(file);
+});
 $dashboardBtn.addEventListener('click', () => void openDashboardSheet(true));
 $dashboardClose.addEventListener('click', () => void openDashboardSheet(false));
 

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -106,6 +106,13 @@ export function reorderFavorites(orderedIds: string[]): void {
   writeStations(FAVORITES_KEY, next);
 }
 
+/** Replace the entire favorites list. Used by backup-import to write a
+ *  merged list back; toggleFavorite / reorderFavorites cover the
+ *  per-row mutations. */
+export function setFavorites(list: Station[]): void {
+  writeStations(FAVORITES_KEY, list);
+}
+
 export function getRecents(): Station[] {
   return readStations(RECENTS_KEY);
 }
@@ -135,6 +142,12 @@ export function addCustom(station: Station): void {
 export function removeCustom(id: string): void {
   const next = getCustom().filter((s) => s.id !== id);
   writeStations(CUSTOM_KEY, next);
+}
+
+/** Replace the entire custom-stations list. Backup-import uses this to
+ *  write the merged result back in one call. */
+export function setCustom(list: Station[]): void {
+  writeStations(CUSTOM_KEY, list);
 }
 
 export function getWakeTo(): WakeTo | null {

--- a/src/style.css
+++ b/src/style.css
@@ -2734,6 +2734,16 @@ body.is-wake-edit .np-pane-tabs { display: none; }
 .about-cta__logo { width: 18px; height: 18px; }
 .about-cta--ghost { background: transparent; }
 
+/* Inline result message under the Backup & restore CTAs. Tone is set
+   via data-tone="ok" | "err" so the same span doubles as success and
+   error feedback after Export / Import. */
+.about-backup-msg {
+  margin-top: 10px;
+  font-size: 13px;
+  color: var(--ink-2);
+}
+.about-backup-msg[data-tone="err"] { color: var(--accent, #c44); }
+
 /* ─── Reduced motion ─── */
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after {

--- a/src/style.css
+++ b/src/style.css
@@ -560,6 +560,43 @@ html.theme-switching *::after {
   justify-content: center;
   gap: 10px;
 }
+.section-label__title {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+/* When a label carries actions, label+count drift to the left and
+   buttons sit on the right. Without actions, the centered layout
+   stays exactly as before. */
+.section-label--with-actions {
+  justify-content: space-between;
+}
+.section-label__actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.section-label__action {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: var(--ink-3);
+  width: 32px;
+  height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+.section-label__action:hover { background: var(--bg-2); color: var(--ink); }
+.section-label__action:active { transform: scale(0.94); }
+.section-label__action:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+.section-label__action svg { width: 18px; height: 18px; }
 .section-label .count {
   font-variant-numeric: tabular-nums;
   color: var(--ink-4);
@@ -2734,15 +2771,38 @@ body.is-wake-edit .np-pane-tabs { display: none; }
 .about-cta__logo { width: 18px; height: 18px; }
 .about-cta--ghost { background: transparent; }
 
-/* Inline result message under the Backup & restore CTAs. Tone is set
-   via data-tone="ok" | "err" so the same span doubles as success and
-   error feedback after Export / Import. */
-.about-backup-msg {
-  margin-top: 10px;
-  font-size: 13px;
-  color: var(--ink-2);
+/* Tiny inline icon used in About prose to point at the matching
+   button on another screen — e.g. "tap the [↓] icon on Favorites". */
+.about-inline-icon {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  vertical-align: -2px;
+  margin: 0 1px;
 }
-.about-backup-msg[data-tone="err"] { color: var(--accent, #c44); }
+
+/* Floating result toast for Backup & restore. Sits under the topbar,
+   centered, replaces itself on each new action and auto-dismisses
+   (4s on success, 7s on error — set in main.ts). */
+.backup-toast {
+  position: fixed;
+  top: calc(env(safe-area-inset-top, 0) + 56px);
+  left: 50%;
+  transform: translateX(-50%);
+  max-width: calc(100vw - 32px);
+  padding: 10px 14px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--bg-2);
+  color: var(--ink);
+  font-family: var(--sans);
+  font-size: 13px;
+  text-align: center;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
+  z-index: 1000;
+}
+.backup-toast[hidden] { display: none; }
+.backup-toast[data-tone="err"] { color: var(--accent, #c44); }
 
 /* ─── Reduced motion ─── */
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Why

Cross-device sync of favorites without a login or account, per @AndreiRoibu-synthara's request in #127. The user export-imports a small JSON file themselves — same mental model as iOS app data export.

Refs #127 — **not auto-closed**, leaving open so AndreiRoibu can test before we decide.

## What gets synced

- Favorites (manual reorder preserved)
- Custom stations (the ones added via the + sheet)

Skipped on purpose:
- Recents — noisy and time-bound
- Wake-to alarm — device-specific
- Theme + last-tab — UI state, not user content

## UX

New section in the **About** sheet (between Lyrics and Privacy):

\`\`\`
Backup & restore your favorites
Carry your favorites and custom stations to another device. Export a
small JSON file from this browser, move it to the other device however
you like (AirDrop, USB, share sheet, email to yourself), and import it
there. The file lives on your device only — no upload, no account.

Importing adds to whatever's already on the device; it never deletes
or replaces existing favorites.

[Export favorites]  [Import from file]
\`\`\`

After action, an inline message reports the result:
- _"Exported 14 favorites and 2 custom stations."_
- _"Imported 3 favorites and 1 custom station (4 already had)."_
- _"Already had everything in that backup (12 items)."_
- _"Backup version 99 isn't supported (expected 1)."_ (red tone)

## Format

\`\`\`json
{
  "version": 1,
  "exportedAt": "2026-05-07T12:00:00.000Z",
  "favorites": [Station, ...],
  "custom":    [Station, ...]
}
\`\`\`

Filename: \`rrradio-favorites-YYYY-MM-DD.json\` (local date).

## Why JSON not CSV (Andrei suggested CSV)

Stations carry \`tags: string[]\` and optional fields; CSV needs a quoting convention every spreadsheet butchers differently. JSON round-trips cleanly through every browser / mobile / iOS app, and tomorrow's iOS port can use the same format.

## Tested

| Path | Coverage |
|---|---|
| Pure helpers (\`src/backup.ts\`) | 17 vitest cases — round-trip, version mismatch, malformed JSON, shape filtering, merge edge cases, summary wording |
| DOM wiring (\`main.ts\`) | typecheck clean; manual smoke verified Export downloads + Import merges |
| Catalog / fav state | favorites tab + custom-list re-render after import |

## Test plan for AndreiRoibu

1. On phone: open About → Backup & restore → Export → file goes to your downloads / Files app.
2. Move the file to MacBook however you like (AirDrop is the magic one).
3. On MacBook: open About → Backup & restore → Import → pick the file.
4. Switch to Favorites tab — phone's favorites should now be there too. Custom stations show up under the + sheet.
5. Confirm: existing MacBook favorites are still present (merge, not overwrite).

## Gates
- [x] \`tsc --noEmit\` clean
- [x] \`vitest run\` → 311/311 (was 294, +17 new)
- [x] \`npm run build\` clean

## Followups (out of scope)
- iOS app: mirror the same JSON format so iOS export → web import works (today, the iOS app's own data hasn't been linked to this format yet).
- Possibly add an "Import (replace)" mode if a real user reports the merge isn't what they wanted. Default merge is the safer first cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)