### PR TITLE
chore: agent-discovered station logos (173 stations)

### DIFF
--- a/data/stations.yaml
+++ b/data/stations.yaml
@@ -769,6 +769,7 @@
   country: CH
   status: working
 - id: ch-kontrafunk
+  favicon: "https://shop.kontrafunk.radio/wp-content/themes/yootheme/cache/16/Kontrafunk_Logo_Shop-167778cd.jpeg"
   stationuuid: 92c3f2bd-d985-4998-9632-2e16fbfcab0e
   changeuuid: b298e5de-b67a-4f84-93a3-6cbbe9868c31
   reviewedAt: 2026-05-02
@@ -971,6 +972,7 @@
   country: CH
   status: stream-only
 - id: ch-one-dance-ticino
+  favicon: "https://radio.streamitter.com/uploads/stations/radio-one-dance-ticino-wup9ke-migrated-42972-500.webp"
   stationuuid: b9660eb9-34f9-11e9-8f31-52543be04c81
   changeuuid: 33e4ea93-7c31-4bbc-8c50-7b85e26472ee
   reviewedAt: 2026-05-04
@@ -1047,6 +1049,7 @@
   country: CH
   status: stream-only
 - id: ch-skuizz-hits-90s-00s
+  favicon: "https://images.zeno.fm/oZMC-mGbvBMmhdx0Cc8V4SK29NmzGmoKhdpi2iAtfSU/rs:fill:288:288/g:ce:0:0/aHR0cHM6Ly9wcm94eS56ZW5vLmZtL2NvbnRlbnQvc3RhdGlvbnMvYWE5OGU1ZTYtNjNkMy00NDY5LWEwZjctZTI4NjhlZmQ5NmEwL2ltYWdlLz91PTE3MDE2OTg2ODIwMDA.webp"
   stationuuid: aa98e5e6-63d3-4469-a0f7-e2868efd96a0
   changeuuid: eda453bd-95a8-4c6e-8fca-cb51fd6bb8a0
   reviewedAt: 2026-05-04
@@ -1104,6 +1107,7 @@
   country: CH
   status: stream-only
 - id: ch-rtn
+  favicon: "https://bnj.blob.core.windows.net/assets/Htdocs/Images/Theme/rtn/logo-rtn.svg"
   stationuuid: 96094a59-0601-11e8-ae97-52543be04c81
   changeuuid: a48a88e6-b2c0-4f05-b1ca-b44f25e3fefd
   reviewedAt: 2026-05-04
@@ -1349,6 +1353,7 @@
   country: CH
   status: stream-only
 - id: ch-arc-musique
+  favicon: "https://bnj.ch/img/logos/top/francophonie.svg"
   stationuuid: 96205a50-0601-11e8-ae97-52543be04c81
   changeuuid: 90972f8c-74a6-41ef-a7ed-0e09784821d9
   reviewedAt: 2026-05-04
@@ -1478,6 +1483,7 @@
   country: CH
   status: stream-only
 - id: ch-rfj
+  favicon: "https://bnj.blob.core.windows.net/assets/Htdocs/Images/Theme/rfj/logo-rfj.svg"
   stationuuid: 960a893c-0601-11e8-ae97-52543be04c81
   changeuuid: d89085a6-aca9-49a1-891e-264c6f95db7d
   reviewedAt: 2026-05-04
@@ -1603,6 +1609,7 @@
   country: CH
   status: stream-only
 - id: ch-radio-drachenblut
+  favicon: "https://radio-drachenblut.ch/radio-logo-footer.svg"
   stationuuid: 4992d90f-2bed-445d-abc6-6065e7faa38e
   changeuuid: eeeba9db-ba66-4da0-82e3-d24393725283
   reviewedAt: 2026-05-04
@@ -1621,6 +1628,7 @@
   country: CH
   status: stream-only
 - id: ch-bachata-nation-radio
+  favicon: "https://images.zeno.fm/FgFUhWISvzVy9yXimBFjp_t6XXIKTNROD1ImcXF0LsI/rs:fill:288:288/g:ce:0:0/aHR0cHM6Ly9wcm94eS56ZW5vLmZtL2NvbnRlbnQvc3RhdGlvbnMvYWd4emZucGxibTh0YzNSaGRITnlNZ3NTQ2tGMWRHaERiR2xsYm5RWWdJQ0luYkxneXdrTUN4SU9VM1JoZEdsdmJsQnliMlpwYkdVWWdJREk1Smo0OVFrTW9nRUVlbVZ1YncvaW1hZ2UvP3U9MTc0NDY3Mjk5NDAwMA.webp"
   stationuuid: 1eaa7a2e-8fbe-4936-b71c-18190cfb25e8
   changeuuid: 40d3d674-a051-4014-9110-791922341f53
   reviewedAt: 2026-05-04
@@ -2272,6 +2280,7 @@
   country: CH
   status: stream-only
 - id: ch-traxx-fm-hits
+  favicon: "https://cdn.onlineradiobox.com/img/l/1/2961.v4.png"
   stationuuid: 42aab7fd-98d5-4816-bcf4-30dd2e563abd
   changeuuid: a96a5e0b-114d-495b-a31a-ff37b4687dcb
   reviewedAt: 2026-05-04
@@ -2753,6 +2762,7 @@
   country: CH
   status: stream-only
 - id: ch-anntenne-jesus-live
+  favicon: "https://glaubesiegt.ch/wp-content/uploads/2026/02/Antenne-Jesus-Live-Logo-2-pp-effekt2.png"
   stationuuid: 6f774e8a-12d1-4835-acfe-9d398075aaed
   changeuuid: 126d708f-adda-4577-9654-04b40b9689e2
   reviewedAt: 2026-05-04
@@ -2789,6 +2799,7 @@
   country: CH
   status: stream-only
 - id: ch-radio-freundes-dienst-schweiz
+  favicon: "https://www.radiofd.ch/images/radiofd_player.png"
   stationuuid: 015d2e92-e261-450a-8fe0-8f62b11d4a6e
   changeuuid: bfdd5561-87da-4e28-bf78-6c77d64bd0ef
   reviewedAt: 2026-05-04
@@ -5415,6 +5426,7 @@
   country: IT
   status: stream-only
 - id: it-virgin-rock-70
+  favicon: "https://img-api.cloud.mediaset.net/api/images/rd/v1/ita/aHR0cHM6Ly93d3cudmlyZ2lucmFkaW8uaXQvd3AtY29udGVudC91cGxvYWRzLzIwMjUvMTEvV2VicmFkaW8tVmlyZ2luLTIwMjAtUm9jazcwLTE1ODgwNjI5MzA4OTlwbmctd2VicmFkaW9fdmlyZ2luX3JhZGlvX3JvY2tfXzcwLnBuZw/-/0/0?r=df74e68abb0949dd1d692d0c7e297095"
   stationuuid: 9619ec45-0601-11e8-ae97-52543be04c81
   changeuuid: 3a2d16cb-751d-42be-821c-158171fed90e
   reviewedAt: 2026-04-29
@@ -5654,6 +5666,7 @@
   country: IT
   status: stream-only
 - id: it-venice-classic
+  favicon: "https://www.veniceclassicradio.eu/logo/logo-vcr-white.svg"
   stationuuid: 6b4d2d9d-1435-44aa-b5ee-1db50f833ddc
   changeuuid: 1aacaa57-b7aa-42b6-9dd2-0815bb1fe6f7
   reviewedAt: 2026-04-29
@@ -5672,6 +5685,7 @@
   country: IT
   status: stream-only
 - id: builtin-rne-r1
+  favicon: "https://img.rtve.es/css/style2011/i/PG_logo_RNE.png"
   stationuuid: db656299-a63e-4b7b-ac5a-ac2444459ae4
   changeuuid: 02ca2824-0e7f-473e-9ea8-380d74202421
   reviewedAt: 2026-04-29
@@ -5750,6 +5764,7 @@
   country: ES
   status: stream-only
 - id: es-cadena-ser
+  favicon: "https://cdn-profiles.tunein.com/s9031/images/logod.jpg"
   stationuuid: 692a3b69-0f68-11ea-a87e-52543be04c81
   changeuuid: 96574f41-d990-4a9b-87bb-b5552f8e2fe4
   reviewedAt: 2026-04-29
@@ -5811,6 +5826,7 @@
   status: stream-only
   featured: true
 - id: es-los40-urban
+  favicon: "https://los40es00.epimg.net/estaticos/recursosgraficos/html/img/l-los40-urban-hor.svg"
   stationuuid: 8cc2da8b-ae85-4e37-9027-9ad765a1ea7a
   changeuuid: 332678d6-1ec2-4a98-b040-b7164c47eb58
   reviewedAt: 2026-04-29
@@ -5830,6 +5846,7 @@
   country: ES
   status: stream-only
 - id: es-los40-dance
+  favicon: "https://los40es00.epimg.net/estaticos/recursosgraficos/html/img/l-los40-dance-hor.svg"
   stationuuid: 777d14b2-f344-11e9-a96c-52543be04c81
   changeuuid: 90063ac8-68b7-4045-9dfb-3904ffa40639
   reviewedAt: 2026-04-29
@@ -5849,6 +5866,7 @@
   country: ES
   status: stream-only
 - id: es-los40-classic
+  favicon: "https://los40es00.epimg.net/estaticos/recursosgraficos/html/img/l-los40-classic-hor.svg"
   stationuuid: de39fc19-0636-4d05-acbb-2aba2c0d1f7a
   changeuuid: 52527d4b-5b9d-415f-8bc4-7916f2baf2b0
   reviewedAt: 2026-04-29
@@ -6436,6 +6454,7 @@
   country: NL
   status: stream-only
 - id: nl-bnr
+  favicon: "https://www.radiozenders.fm/media/images/stations-large/bnr-nieuwsradio.png"
   stationuuid: f31ae7e2-d5e6-4c88-9445-edf00f6cba40
   changeuuid: 92252dc0-aa22-465c-b2d7-ec9cba9b1929
   reviewedAt: 2026-04-29
@@ -6576,6 +6595,7 @@
   country: DE
   status: working
 - id: rbb-inforadio
+  favicon: "https://www.inforadio.de/content/dam/rbb/inf/standardbilder/rbb24-inforadio_logo.svg.svg/img.svg"
   stationuuid: 960b77af-0601-11e8-ae97-52543be04c81
   changeuuid: f58f7c19-ed24-4568-a2a4-c0d732ff6a4b
   reviewedAt: 2026-05-02
@@ -6654,6 +6674,7 @@
   country: DE
   status: icy-only
 - id: rbb-radio3
+  favicon: "https://www.radiodrei.de/content/dam/rbb/kul/layout/radio3.svg.svg/img.svg"
   stationuuid: 960c1c0e-0601-11e8-ae97-52543be04c81
   changeuuid: e5fc5677-5188-47f8-8f53-44124a8b8e04
   reviewedAt: 2026-05-02
@@ -6716,6 +6737,7 @@
   country: DE
   status: working
 - id: de-antenne-bayern-chillout
+  favicon: "https://cdn.onlineradiobox.com/img/fblogo/6/34466.v9.png"
   stationuuid: 9610c454-0601-11e8-ae97-52543be04c81
   changeuuid: 2a5f5baf-ca59-4042-bd7e-7bb1c09a5687
   reviewedAt: 2026-05-02
@@ -6736,6 +6758,7 @@
   country: DE
   status: working
 - id: de-antenne-bayern-classic-rock-live
+  favicon: "https://cdn.onlineradiobox.com/img/fblogo/6/34476.v7.png"
   stationuuid: 9615dc04-0601-11e8-ae97-52543be04c81
   changeuuid: d4fed5ef-f03b-4c80-a5bf-bee39771851e
   reviewedAt: 2026-05-02
@@ -6756,6 +6779,7 @@
   country: DE
   status: working
 - id: de-antenne-bayern-80er-kulthits
+  favicon: "https://cdn.onlineradiobox.com/img/fblogo/9/34469.v8.png"
   stationuuid: 960ce338-0601-11e8-ae97-52543be04c81
   changeuuid: 2a94b3f4-2356-4013-81bb-a32aa222dce6
   reviewedAt: 2026-05-02
@@ -6776,6 +6800,7 @@
   country: DE
   status: working
 - id: de-antenne-bayern-90er-hits
+  favicon: "https://cdn.onlineradiobox.com/img/fblogo/0/34470.v7.png"
   geo:
     - 48.137
     - 11.575
@@ -6793,6 +6818,7 @@
   country: DE
   status: working
 - id: de-antenne-bayern-70er-hits
+  favicon: "https://cdn.onlineradiobox.com/img/fblogo/1/102891.v3.png"
   stationuuid: 6755fcec-4752-4f69-962e-46c43e227542
   changeuuid: e8d4b393-b1ce-44e2-bbb9-6c2ecdc2eb92
   reviewedAt: 2026-05-02
@@ -6813,6 +6839,7 @@
   country: DE
   status: working
 - id: de-antenne-bayern-lovesongs
+  favicon: "https://cdn.onlineradiobox.com/img/fblogo/9/34479.v8.png"
   stationuuid: 960df2cd-0601-11e8-ae97-52543be04c81
   changeuuid: 133dffcb-004a-4b04-9012-ce8c5895352a
   reviewedAt: 2026-05-02
@@ -6833,6 +6860,7 @@
   country: DE
   status: working
 - id: de-antenne-bayern-top-40
+  favicon: "https://cdn.onlineradiobox.com/img/fblogo/3/34463.v9.png"
   stationuuid: 9615de2d-0601-11e8-ae97-52543be04c81
   changeuuid: 89ed6c54-be72-4356-a44d-c72bbf5c7c01
   reviewedAt: 2026-05-02
@@ -7318,6 +7346,7 @@
   country: DE
   status: icy-only
 - id: de-rautemusik-trance
+  favicon: "https://images.zeno.fm/ZR8Ke7RjRKqi6YjTQbilYLcupY8OkX86cGLrkp6Hgyw/rs:fill:288:288/g:ce:0:0/aHR0cHM6Ly9wcm94eS56ZW5vLmZtL2NvbnRlbnQvc3RhdGlvbnMvOGYxZThhY2YtMmNlNi00NTQyLWE0MjMtYmMyOWVhNTE0ZTRhL2ltYWdlLz91PTE3NzAwNDMyNzkwMDA.webp"
   stationuuid: 8f1e8acf-2ce6-4542-a423-bc29ea514e4a
   changeuuid: 1d09f99a-34c5-466d-80ea-2948ebd5d5ce
   reviewedAt: 2026-05-02
@@ -7439,6 +7468,7 @@
   country: DE
   status: working
 - id: de-ffh-80er
+  favicon: "https://static.ffh.de/fileadmin/_processed_/2/e/csm_ffh_80er_600x600_9d247e2c21.jpg"
   stationuuid: 9605d022-0601-11e8-ae97-52543be04c81
   changeuuid: b6b61875-b743-43d7-9123-1442fd318b7c
   reviewedAt: 2026-05-02
@@ -7459,6 +7489,7 @@
   country: DE
   status: working
 - id: de-ffh-90er
+  favicon: "https://static.ffh.de/fileadmin/_processed_/6/1/csm_ffh_90er_600x600_a417d2fdf9.jpg"
   stationuuid: 960daef6-0601-11e8-ae97-52543be04c81
   changeuuid: 8cb1a126-70f0-4ae6-923c-68144d7df7a2
   reviewedAt: 2026-05-02
@@ -7479,6 +7510,7 @@
   country: DE
   status: working
 - id: de-ffh-2000er
+  favicon: "https://static.ffh.de/fileadmin/_processed_/d/6/csm_ffh2000er_600x600_7986e7cff4.jpg"
   geo:
     - 50.11
     - 8.682
@@ -7496,6 +7528,7 @@
   country: DE
   status: working
 - id: de-ffh-eurodance
+  favicon: "https://static.ffh.de/fileadmin/_processed_/c/b/csm_ffh_eurodance_600x600_d8e5d073f8.jpg"
   stationuuid: 960567ca-0601-11e8-ae97-52543be04c81
   changeuuid: fb903e81-ab47-4deb-b4f3-6f0f5e7eaa9e
   reviewedAt: 2026-05-02
@@ -7517,6 +7550,7 @@
   country: DE
   status: working
 - id: de-ffh-lounge
+  favicon: "https://static.ffh.de/fileadmin/_processed_/7/a/csm_ffh_lounge_600x600_4f432dd4b1.jpg"
   stationuuid: 9607ac72-0601-11e8-ae97-52543be04c81
   changeuuid: 69acf186-b6d5-49e3-b8f0-0f2e83bbc948
   reviewedAt: 2026-05-02
@@ -7537,6 +7571,7 @@
   country: DE
   status: working
 - id: de-harmony-fm
+  favicon: "https://static.ffh.de/fileadmin/_processed_/8/d/csm_harmony_simulcast_1400x1400_2424c1e327.jpg"
   stationuuid: 961449d4-0601-11e8-ae97-52543be04c81
   changeuuid: 97c5ba58-7f95-46de-8e12-00d5316f698c
   reviewedAt: 2026-05-02
@@ -7813,6 +7848,7 @@
   country: DE
   status: stream-only
 - id: de-0nlineradio-remix
+  favicon: "https://images.zeno.fm/brCD08_FGp-vj1byJ8-kyBM_wJZl6QarIrv19X94NI8/rs:fill:288:288/g:ce:0:0/aHR0cHM6Ly9wcm94eS56ZW5vLmZtL2NvbnRlbnQvc3RhdGlvbnMvZmE2OGViNjEtYzQ4Ni00ODBjLThjNmEtYWNhY2YyYTNiNDcxL2ltYWdlLz91PTE3MzM5MjcxMzQwMDA.webp"
   stationuuid: a8c1c86e-e1c0-4e86-ba15-74c258ac0af9
   changeuuid: 6f1c9806-23d8-4c8b-8407-4c4865e5139b
   reviewedAt: 2026-05-04
@@ -7912,6 +7948,7 @@
   country: DE
   status: stream-only
 - id: de-epic-classical-classical-music-for-sleep
+  favicon: "https://images.zeno.fm/FqS92XriO2CCQJVQF8154WQh3bgn7DwGGr3nlUmfWrA/rs:fill:288:288/g:ce:0:0/aHR0cHM6Ly9wcm94eS56ZW5vLmZtL2NvbnRlbnQvc3RhdGlvbnMvMTY2NWFlNGMtNzRkYy00NGYwLWJkMGEtN2EwZDAyOTFhYThjL2ltYWdlLz91PTE3MDE2OTUyNjUwMDA.webp"
   stationuuid: 1665ae4c-74dc-44f0-bd0a-7a0d0291aa8c
   changeuuid: a905e808-e183-40dd-beb5-c7f8fd48b183
   reviewedAt: 2026-05-04
@@ -8043,6 +8080,7 @@
   country: DE
   status: stream-only
 - id: de-epic-lounge-sleep-meditation
+  favicon: "https://cdn.onlineradiobox.com/img/l/6/120536.v3.png"
   stationuuid: 4c0118e7-97d9-4657-9bb8-427758a4aa85
   changeuuid: 88fcf0bd-c0be-45fc-99fc-9684a6870d1c
   reviewedAt: 2026-05-04
@@ -8124,6 +8162,7 @@
   country: DE
   status: stream-only
 - id: de-technolovers-eurodance
+  favicon: "https://technolovers.fm/assets/img/streamlogos/eurodance.jpg"
   stationuuid: ee6043f7-124d-4f20-b020-c1a77ca8383e
   changeuuid: f78ac9b5-89aa-4a0d-b6c8-0775cc86b288
   reviewedAt: 2026-05-04
@@ -8143,6 +8182,7 @@
   country: DE
   status: stream-only
 - id: de-technolovers-funky-house
+  favicon: "https://cdn-profiles.tunein.com/s310358/images/logod.jpg?t=637815398970000000"
   stationuuid: 57df1d35-5943-46e6-a76c-f9ef35ea73e7
   changeuuid: 15c870e5-7312-4e2a-a8f2-fb5f0886bb8f
   reviewedAt: 2026-05-04
@@ -8180,6 +8220,7 @@
   country: DE
   status: stream-only
 - id: de-technolovers-vocal-trance
+  favicon: "https://technolovers.fm/assets/img/streamlogos/vocal-trance.jpg"
   stationuuid: 00c4c0c7-bf13-4a8b-b14f-05f9e5a4a116
   changeuuid: 4514d297-7508-4f27-87bb-e06e042c4edf
   reviewedAt: 2026-05-04
@@ -8295,6 +8336,7 @@
   country: DE
   status: stream-only
 - id: de-epic-rock-radio
+  favicon: "https://www.epicrockradio.com/images/ERR_Banner_Transparent_2024.png"
   stationuuid: ddf0a603-ed3a-4d52-8d1b-cc11357734f3
   changeuuid: 8915ad8e-b213-4bb5-8835-ca627a8b0ff5
   reviewedAt: 2026-05-04
@@ -8332,6 +8374,7 @@
   country: DE
   status: stream-only
 - id: de-technolovers-drum-n-bass
+  favicon: "https://technolovers.fm/assets/img/streamlogos/drummnbass.jpg"
   stationuuid: cbcff885-49bb-4db1-8b78-7060e70ff06d
   changeuuid: 771913f2-0478-4991-ada5-8a7cbdb30e69
   reviewedAt: 2026-05-04
@@ -8350,6 +8393,7 @@
   country: DE
   status: stream-only
 - id: de-chillout-piano-by-epic-piano
+  favicon: "https://cdn.onlineradiobox.com/img/l/4/147044.v1.png"
   stationuuid: 5143bb9a-3c5e-4c53-a6ec-0108435caf5a
   changeuuid: 27e1d142-fb95-4f31-afd8-70eff86bace2
   reviewedAt: 2026-05-04
@@ -8410,6 +8454,7 @@
   country: DE
   status: stream-only
 - id: de-epic-lounge-ibiza-chillout-lounge
+  favicon: "https://cdn.onlineradiobox.com/img/l/1/120551.v4.png"
   stationuuid: bc0fc480-9229-4d6a-85b8-b91f38191f43
   changeuuid: 03374158-4af2-44df-b1da-344ad236dbb6
   reviewedAt: 2026-05-04
@@ -8486,6 +8531,7 @@
   country: DE
   status: stream-only
 - id: de-technolovers-psytrance
+  favicon: "https://technolovers.fm/assets/img/technolovers-dark.png"
   stationuuid: 27d331f9-6685-47d4-a9e8-7fd16d91b66d
   changeuuid: ca15902f-07e8-4484-878b-cfbe14d70f87
   reviewedAt: 2026-05-04
@@ -8888,6 +8934,7 @@
   country: CA
   status: stream-only
 - id: builtin-ici-premiere
+  favicon: "https://upload.wikimedia.org/wikipedia/commons/thumb/8/8d/ICI_Radio-Canada_Premi%C3%A8re.svg/960px-ICI_Radio-Canada_Premi%C3%A8re.svg.png"
   stationuuid: cc527ea6-060f-4fe8-b31a-cad732ff7d3e
   changeuuid: 918b269d-de1e-4634-ad93-a67cfeb521c1
   reviewedAt: 2026-04-29
@@ -8909,6 +8956,7 @@
   country: CA
   status: stream-only
 - id: builtin-ici-musique
+  favicon: "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9f/Ici_Musique_logo.svg/960px-Ici_Musique_logo.svg.png"
   stationuuid: b6aa8287-0e8c-4780-b882-d7a7e4b1226d
   changeuuid: e921370a-1ba7-4dc4-95fc-dd5645ba1628
   reviewedAt: 2026-04-29
@@ -9217,6 +9265,7 @@
   country: AU
   status: stream-only
 - id: builtin-sbs-chill
+  favicon: "https://assets.sbs.com.au/55/8c/c3735cb8469d862c1522c86db678/chill-white-blue.svg?imwidth=256"
   stationuuid: 0ed4232a-a293-11e8-abb8-52543be04c81
   changeuuid: 8455cb4d-e3c1-4708-8fc9-b7f2fe6bbff0
   reviewedAt: 2026-04-29
@@ -9507,6 +9556,7 @@
   country: PL
   status: stream-only
 - id: pl-rmf-classic
+  favicon: "https://www.rmfclassic.pl/dist-v2021/images/logo-rmf-classic-2022.png"
   stationuuid: 960dc513-0601-11e8-ae97-52543be04c81
   changeuuid: c766c70f-749b-4923-aa14-1313d91929e4
   reviewedAt: 2026-04-29
@@ -10084,6 +10134,7 @@
   country: US
   status: stream-only
 - id: us-power-105
+  favicon: "https://upload.wikimedia.org/wikipedia/en/thumb/f/f4/Power1051newyork.png/250px-Power1051newyork.png"
   stationuuid: d5f76b95-7507-487e-ad3f-48ba15cd3cce
   changeuuid: f4f06058-a16c-438c-b079-03e050fd5584
   reviewedAt: 2026-04-30
@@ -10298,6 +10349,7 @@
   country: DK
   status: stream-only
 - id: dk-nova-fm
+  favicon: "https://impro.usercontent.one/appid/oneComWsb/domain/nova.dk/media/nova.dk/onewebmedia/Nova%20logo%2017-02%20gr%C3%B8nnere.png"
   stationuuid: 4bcb11ad-0ac0-4bb6-8b36-603ba1a4effd
   changeuuid: 26d3991f-7709-40c5-9f99-59a65a6b8cd8
   reviewedAt: 2026-04-30
@@ -10334,6 +10386,7 @@
   country: DK
   status: stream-only
 - id: dk-myrock
+  favicon: "https://assets.planetradio.co.uk/img/ConfigWebHeaderLogoSVGImageUrl/176.svg?ver=1490690852"
   stationuuid: b4d7f87f-89c8-4d1b-af0b-fc2fcafd8d66
   changeuuid: e01d18bf-9b55-4fe9-94cf-8e79137f1347
   reviewedAt: 2026-04-30
@@ -10352,6 +10405,7 @@
   country: DK
   status: stream-only
 - id: dk-radio-soft
+  favicon: "https://assets.planetradio.co.uk/img/ConfigWebHeaderLogoSVGImageUrl/212.svg?ver=1490689918"
   stationuuid: 963cba5e-0601-11e8-ae97-52543be04c81
   changeuuid: 963cba63-0601-11e8-ae97-52543be04c81
   reviewedAt: 2026-04-30
@@ -10546,6 +10600,7 @@
   country: SE
   status: stream-only
 - id: se-bandit-rock
+  favicon: "https://upload.wikimedia.org/wikipedia/commons/thumb/4/49/Logo_Bandit_Rock.svg/960px-Logo_Bandit_Rock.svg.png"
   stationuuid: 168e0796-3b97-479c-949d-b1871ef07379
   changeuuid: e03729d0-c10e-4078-a239-0dd001525a7d
   reviewedAt: 2026-04-30
@@ -10602,6 +10657,7 @@
   country: SE
   status: stream-only
 - id: se-retro-fm-skane
+  favicon: "https://media.bauerradio.com/image/upload/c_crop,g_custom/v1588755869/brand_manager/stations/t9dopkx2fxswjvppxbiw.svg"
   stationuuid: 8b00bcfc-4d94-11ea-b877-52543be04c81
   changeuuid: 193aff35-5d55-456c-ab25-07d0b66b2fc1
   reviewedAt: 2026-04-30
@@ -11207,6 +11263,7 @@
   status: stream-only
   featured: true
 - id: pt-radio-comercial
+  favicon: "https://radiocomercial.pt/images/svg/logoRC_white.svg?v=0.1"
   stationuuid: 2b501db4-e4b6-4106-9670-9875536f70f1
   changeuuid: 4df83804-a8b8-4afa-8567-e44fbebf6b14
   reviewedAt: 2026-04-30
@@ -11225,6 +11282,7 @@
   country: PT
   status: stream-only
 - id: pt-m80
+  favicon: "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b0/M80_Radio_2025.svg/250px-M80_Radio_2025.svg.png"
   stationuuid: c6ed0be5-21dd-4b03-aa18-0dbc9a0c3f87
   changeuuid: 506ed3cb-e9ce-47f0-99eb-16e0e86eaa5b
   reviewedAt: 2026-04-30
@@ -11281,6 +11339,7 @@
   country: PT
   status: stream-only
 - id: pt-renascenca
+  favicon: "https://rr.pt/img/logoRR-n.svg"
   stationuuid: 9618e7a0-0601-11e8-ae97-52543be04c81
   changeuuid: 552e97e7-d79f-47d2-afab-df9ab22767e1
   reviewedAt: 2026-04-30
@@ -11299,6 +11358,7 @@
   country: PT
   status: stream-only
 - id: builtin-vrt-radio-1
+  favicon: "https://upload.wikimedia.org/wikipedia/commons/thumb/0/08/VRT_Radio_1_logo.svg/960px-VRT_Radio_1_logo.svg.png"
   stationuuid: 960ef35c-0601-11e8-ae97-52543be04c81
   changeuuid: 36b38e0b-dd38-4ad5-9414-4f1f9ee1acdf
   reviewedAt: 2026-04-30
@@ -11320,6 +11380,7 @@
   status: stream-only
   featured: true
 - id: builtin-vrt-radio-2
+  favicon: "https://upload.wikimedia.org/wikipedia/commons/thumb/6/6f/VRT_Radio_2_2025.svg/960px-VRT_Radio_2_2025.svg.png"
   stationuuid: 960cf504-0601-11e8-ae97-52543be04c81
   changeuuid: f88f2109-11d2-400e-b091-85168590c4a6
   reviewedAt: 2026-04-30
@@ -11360,6 +11421,7 @@
   country: BE
   status: stream-only
 - id: builtin-vrt-klara
+  favicon: "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/VRT_Klara_2020.svg/960px-VRT_Klara_2020.svg.png"
   stationuuid: 960ef421-0601-11e8-ae97-52543be04c81
   changeuuid: 3f94ac8a-3a69-4131-8b22-fb3e00f37416
   reviewedAt: 2026-04-30
@@ -11380,6 +11442,7 @@
   country: BE
   status: stream-only
 - id: builtin-vrt-klara-continuo
+  favicon: "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/VRT_Klara_2020.svg/960px-VRT_Klara_2020.svg.png"
   stationuuid: 960eb6af-0601-11e8-ae97-52543be04c81
   changeuuid: 10d89f91-be79-4077-bc9e-4382fc99dfcc
   reviewedAt: 2026-04-30
@@ -11646,6 +11709,7 @@
   country: BE
   status: stream-only
 - id: be-qmusic-q-allstars
+  favicon: "https://upload.wikimedia.org/wikipedia/commons/thumb/7/70/Qmusic_logo.svg/330px-Qmusic_logo.svg.png"
   stationuuid: 5f1da2ec-e53e-45e3-9df4-54622bb90537
   changeuuid: 4694207c-8303-4d4a-913a-6162b7843cf5
   reviewedAt: 2026-05-01
@@ -12136,6 +12200,7 @@
   country: CZ
   status: stream-only
 - id: cz-rock-radio
+  favicon: "https://rockovyradio.cz/design/img/logo.svg"
   stationuuid: c15295f4-561f-47a5-8c4f-9bdb40210582
   changeuuid: 035f8f90-c784-4352-87c5-2491db903fb0
   reviewedAt: 2026-04-30
@@ -12574,6 +12639,7 @@
   country: RO
   status: stream-only
 - id: ro-realitatea-fm
+  favicon: "https://radiorfm.ro/wp-content/uploads/logo-radio.png"
   stationuuid: fbf65b83-6883-4b09-8f8b-5205cdbd509d
   changeuuid: bcebe03e-5fa7-4395-96a0-b7afd5216dae
   reviewedAt: 2026-04-30
@@ -12863,6 +12929,7 @@
   country: SK
   status: stream-only
 - id: sk-radio-melody
+  favicon: "https://www.radiomelody.sk/wp-content/themes/melody/assets/logo.svg"
   stationuuid: f75cc3d3-10eb-40e3-926a-a9030eae3bba
   changeuuid: e00f2baa-5865-46cd-99ee-aa743cde6384
   reviewedAt: 2026-04-30
@@ -12960,6 +13027,7 @@
   country: BG
   status: stream-only
 - id: bg-bg-estrada
+  favicon: "https://media.metacast.eu/pictures/01_2021/DWbGdwO2ntMCels09JiL-63902.png"
   stationuuid: 96163d8b-0601-11e8-ae97-52543be04c81
   changeuuid: 5b54e88f-5e3d-4292-9883-9aad3a99f2d5
   reviewedAt: 2026-04-30
@@ -13090,6 +13158,7 @@
   country: UA
   status: stream-only
 - id: ua-lux-fm
+  favicon: "https://lux.fm/assets/img/common/logo-lux.svg"
   stationuuid: 02aa69ab-0485-4ff1-a0f1-a6c4be29a8bb
   changeuuid: 0153a46b-4765-40eb-9a00-f55f8f516e62
   reviewedAt: 2026-04-30
@@ -13182,6 +13251,7 @@
   country: UA
   status: stream-only
 - id: ua-radio-maksymum
+  favicon: "https://maximum.fm/assets/images/logo.svg"
   stationuuid: 55275efc-1ee2-4a52-9aef-7fb632c7f3e8
   changeuuid: 2ce0ff5e-2a64-4da1-a7f2-7fa33e78222f
   reviewedAt: 2026-04-30
@@ -13370,6 +13440,7 @@
   country: RS
   status: stream-only
 - id: rs-radio-in
+  favicon: "https://radioin.co.rs/wp-content/uploads/2019/02/logo.png"
   stationuuid: 1fd1da76-f0a8-4dfc-a208-baa9755cff86
   changeuuid: d0436a8f-dfaa-4f6b-880f-0050a89fe5ab
   reviewedAt: 2026-04-30
@@ -13457,6 +13528,7 @@
   country: BA
   status: stream-only
 - id: ba-federalni-radio
+  favicon: "https://upload.wikimedia.org/wikipedia/en/thumb/c/c3/Federalni_radio_logo.png/250px-Federalni_radio_logo.png"
   stationuuid: 097b746e-cc96-4432-99f2-9d33b0a5137c
   changeuuid: 23166769-d969-4004-a836-1df185a3d67c
   reviewedAt: 2026-04-30
@@ -13530,6 +13602,7 @@
   country: BA
   status: stream-only
 - id: ba-radiopostaja-mir
+  favicon: "https://radio-medjugorje.com/wp-content/uploads/2020/04/mir-logo-90-border.png"
   stationuuid: 60607676-de23-44cd-8e05-aecbce5332c9
   changeuuid: c25aa0e6-ba90-4da5-be45-80accba8bd12
   reviewedAt: 2026-04-30
@@ -13606,6 +13679,7 @@
   country: JP
   status: stream-only
 - id: jp-box-japan-citypop
+  favicon: "https://r2.streamafrica.net/radios/01J65CR99GVHS3A7CT7D53C415.jpg"
   stationuuid: 30b09043-9b67-43d7-b9c6-b4401e5cb636
   changeuuid: 7bde6139-f287-4549-ab60-d65f600484bd
   reviewedAt: 2026-04-30
@@ -13675,6 +13749,7 @@
   country: JP
   status: stream-only
 - id: jp-jazz-sakura
+  favicon: "https://asiadreamradio.torontocast.stream/stations/images/jazzsakuraplayer/JazzSakuraLogo512jp.png"
   stationuuid: 9766d47a-68a3-4a30-8aec-c026f1ec6020
   changeuuid: 557da4f0-24fc-462b-9525-7d7fa2a79a2d
   reviewedAt: 2026-04-30
@@ -13694,6 +13769,7 @@
   country: JP
   status: stream-only
 - id: jp-j1-gold
+  favicon: "https://mmo.aiircdn.com/387/5ff1f48287927.jpg"
   stationuuid: 32d5e5ac-e196-4451-9193-bd41a7961556
   changeuuid: 86e0b12c-914e-4230-aca8-be0327914c71
   reviewedAt: 2026-04-30
@@ -13713,6 +13789,7 @@
   country: JP
   status: stream-only
 - id: jp-j1-hits
+  favicon: "https://mmo.aiircdn.com/387/5ff1f49652efd.jpg"
   stationuuid: 3c5dc353-b1ce-43be-a361-ae555535a2b0
   changeuuid: ee0f5d62-99ad-45d5-b50a-a90c774b2c49
   reviewedAt: 2026-04-30
@@ -13732,6 +13809,7 @@
   country: JP
   status: stream-only
 - id: jp-shonan-beach-fm
+  favicon: "https://www.beachfm.co.jp/wp-content/themes/welcart_basic-voll-beachfm/img/common/logo.png"
   stationuuid: 9f66a5b4-66c0-4389-88f3-f8285ad4239a
   changeuuid: 87997560-4fa1-493d-b0bf-b3b64e6c92b7
   reviewedAt: 2026-04-30
@@ -13770,6 +13848,7 @@
   country: JP
   status: stream-only
 - id: jp-gensokyo
+  favicon: "https://gensokyoradio.net/images/gr8_logo.png"
   stationuuid: 248a7684-7e28-4912-9812-efefc2bba2e1
   changeuuid: c060b95e-3f15-462d-8f6d-89e663b5cc76
   reviewedAt: 2026-04-30
@@ -13825,6 +13904,7 @@
   country: JP
   status: stream-only
 - id: jp-fred-film
+  favicon: "https://www.fred.fm/wp-content/uploads/2014/12/Fred-Logo_trasp_-copia.png"
   stationuuid: 5a2cbfe7-0518-44e9-aca6-0fd41e466ff0
   changeuuid: 6f1a8b12-09df-467e-95fc-60ac68d612a8
   reviewedAt: 2026-04-30
@@ -13860,6 +13940,7 @@
   country: JP
   status: stream-only
 - id: tw-rti-cbs
+  favicon: "https://www.rti.org.tw/Static/tw/image/classifyLogo.png"
   stationuuid: b40c66c7-c7d1-498d-8a06-375fa94c03fc
   changeuuid: 4e40ea96-7afb-422a-97f0-44495be7b9ec
   reviewedAt: 2026-04-30
@@ -13879,6 +13960,7 @@
   country: TW
   status: stream-only
 - id: tw-rti-vot
+  favicon: "https://www.rti.org.tw/Static/tw/image/classifyLogo.png"
   stationuuid: a598b0a8-6863-4dac-9a62-74ceb084f39f
   changeuuid: cfc22c81-82ba-49c8-b26e-8a14f8c9b13f
   reviewedAt: 2026-04-30
@@ -13955,6 +14037,7 @@
   country: TW
   status: stream-only
 - id: tw-good-news-fm909
+  favicon: "https://cdn.instant.audio/images/logos/radios-tw/good-news-fm.png"
   stationuuid: bf3382fb-d8b8-448c-b69f-35e2e39a4904
   changeuuid: c0aa3210-8906-4b6f-bfcb-49c0e53aa439
   reviewedAt: 2026-04-30
@@ -13973,6 +14056,7 @@
   country: TW
   status: stream-only
 - id: tw-good-news-classic
+  favicon: "https://cdn.instant.audio/images/logos/radios-tw/good-news-fm.png"
   stationuuid: 7a27042e-94ef-46aa-835d-dfa408bcca04
   changeuuid: 6fe2d9a6-defa-4ffa-8ac7-9f061b17424c
   reviewedAt: 2026-04-30
@@ -14173,6 +14257,7 @@
   country: IL
   status: stream-only
 - id: il-glglz
+  favicon: "https://upload.wikimedia.org/wikipedia/commons/thumb/e/e2/GLGLZ.svg/250px-GLGLZ.svg.png"
   stationuuid: 29cd4b62-14e2-11e9-a80b-52543be04c81
   changeuuid: 955193c2-bed7-47ee-9c9d-de9e0dafdf47
   reviewedAt: 2026-04-30
@@ -14191,6 +14276,7 @@
   country: IL
   status: stream-only
 - id: il-galei-zahal
+  favicon: "https://upload.wikimedia.org/wikipedia/commons/thumb/3/30/GaltzLogo.svg/120px-GaltzLogo.svg.png"
   stationuuid: 962326cb-0601-11e8-ae97-52543be04c81
   changeuuid: a5ef4549-ed99-4fde-8219-7110a12642e7
   reviewedAt: 2026-04-30
@@ -14251,6 +14337,7 @@
   country: IL
   status: stream-only
 - id: il-radio-100fm
+  favicon: "https://d20x387xvo6jlt.cloudfront.net/wp-content/uploads/2020/12/SmallLogo.png"
   stationuuid: 962f863e-0601-11e8-ae97-52543be04c81
   changeuuid: b124df12-c0c0-46a7-b7cc-f030086efd36
   reviewedAt: 2026-04-30
@@ -14270,6 +14357,7 @@
   country: IL
   status: stream-only
 - id: il-a-shams
+  favicon: "https://upload.wikimedia.org/wikipedia/commons/thumb/2/22/Ashams_radio.png/250px-Ashams_radio.png"
   stationuuid: 3b20727f-de34-40b3-84ba-f7ba1ed9821b
   changeuuid: 8474ecc8-9800-4e6f-a74f-e40a56a8d0c2
   reviewedAt: 2026-04-30
@@ -14287,6 +14375,7 @@
   country: IL
   status: stream-only
 - id: il-galey-yisrael
+  favicon: "https://cdn.onlineradiobox.com/img/l/4/118774.v1.png"
   stationuuid: c7a3001d-f31b-4f7a-90fe-ea4b689150e9
   changeuuid: 91ea6cc0-f36f-44c1-ac2f-c3a630bfb3cd
   reviewedAt: 2026-04-30
@@ -14304,6 +14393,7 @@
   country: IL
   status: stream-only
 - id: ve-adulto-joven-881
+  favicon: "https://cdn.onlineradiobox.com/img/l/6/31866.v6.png"
   stationuuid: 480bceac-3218-405e-9163-ba1673225a2e
   changeuuid: 14d5688b-a68c-429e-9ec6-bc0f701e4d52
   reviewedAt: 2026-04-30
@@ -14362,6 +14452,7 @@
   country: VE
   status: stream-only
 - id: ve-rumba-981
+  favicon: "https://cdn.onlineradiobox.com/img/l/8/29838.v14.png"
   stationuuid: d97e2054-1835-4e45-a088-608a65e063c6
   changeuuid: c8f2e42b-3d07-4b2f-bc77-da706a0c0ea8
   reviewedAt: 2026-04-30
@@ -14495,6 +14586,7 @@
   country: UY
   status: stream-only
 - id: uy-fm-inolvidable
+  favicon: "https://cdn.onlineradiobox.com/img/l/0/80340.v9.png"
   stationuuid: d920b239-2c22-4913-92f2-555973548dd5
   changeuuid: 5710f3be-166b-4d6e-a4a2-2bcc3b3a9087
   reviewedAt: 2026-04-30
@@ -14533,6 +14625,7 @@
   country: UY
   status: stream-only
 - id: uy-el-espectador-810
+  favicon: "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b4/Elespectadoram850.png/250px-Elespectadoram850.png"
   stationuuid: 74cb6221-f1ad-45a3-99d1-34ecf7ad5a9b
   changeuuid: 69df6380-8005-4212-a797-e6b78f6c532a
   reviewedAt: 2026-04-30
@@ -14607,6 +14700,7 @@
   country: UY
   status: stream-only
 - id: uy-colonia-am-550
+  favicon: "https://radiocolonia.com/wp-content/uploads/2021/02/Logo-color.png"
   stationuuid: 9fe7190b-687b-40f2-bdfc-51530c57f0b2
   changeuuid: e58596b0-fecf-4f2c-87ba-b3880afb8fa3
   reviewedAt: 2026-04-30
@@ -14625,6 +14719,7 @@
   country: UY
   status: stream-only
 - id: ec-canela-pichincha
+  favicon: "https://web.canelaradio.com/wp-content/uploads/2021/02/LOGO-CANELA_Mesa-de-trabajo-1-min.png"
   stationuuid: 4402d9dc-6092-418a-8d6f-a837fd2d0cc5
   changeuuid: fd52c2b7-8004-4055-899c-6e3db505d87b
   reviewedAt: 2026-04-30
@@ -14643,6 +14738,7 @@
   country: EC
   status: stream-only
 - id: ec-canela-guayas
+  favicon: "https://web.canelaradio.com/wp-content/uploads/2021/02/LOGO-CANELA_Mesa-de-trabajo-1-min.png"
   stationuuid: 2730de1b-dcd9-41aa-adcb-ff202d4cad22
   changeuuid: 0268ff80-e04c-4a7f-95c7-ac329f73a92e
   reviewedAt: 2026-04-30
@@ -14661,6 +14757,7 @@
   country: EC
   status: stream-only
 - id: ec-la-otra-913
+  favicon: "https://cdn.onlineradiobox.com/img/l/1/30721.v15.png"
   stationuuid: 133abe4f-85e5-4a3c-9752-d46efd03cad4
   changeuuid: b368606a-853e-48a5-b426-bc31498f8e70
   reviewedAt: 2026-04-30
@@ -14679,6 +14776,7 @@
   country: EC
   status: stream-only
 - id: ec-america-1045
+  favicon: "https://www.americaestereo.com/wp-content/uploads/2023/10/NuevoLogo2024.png"
   stationuuid: e046653f-0b37-42b8-a52d-e8ae6ed6ab5f
   changeuuid: 472d0f2d-acb7-4d5f-8aec-90e0f4d5e38c
   reviewedAt: 2026-04-30
@@ -14697,6 +14795,7 @@
   country: EC
   status: stream-only
 - id: ec-onda-positiva-941
+  favicon: "https://radioondapositiva.com/wp-content/uploads/2019/07/logo-radio-onda-positiva.png"
   stationuuid: 6509e1cc-5ca3-11e9-a622-52543be04c81
   changeuuid: 139ae9f0-6004-47dc-9aa9-ab718d75d31a
   reviewedAt: 2026-04-30
@@ -14715,6 +14814,7 @@
   country: EC
   status: stream-only
 - id: ec-hcjb
+  favicon: "https://hcjb.org/wp-content/uploads/2025/01/cropped-cropped-cropped-HCJB-Logo-Official-1.png"
   stationuuid: 2ebf90c6-5cb2-11e9-a622-52543be04c81
   changeuuid: 26bd63ec-b968-4bb4-8a50-af15537553b8
   reviewedAt: 2026-04-30
@@ -14752,6 +14852,7 @@
   country: EC
   status: stream-only
 - id: ec-diblu
+  favicon: "https://cdn.onlineradiobox.com/img/l/8/29348.v10.png"
   stationuuid: 4eaf7c6f-8fb0-46a5-858f-2e9337aa2046
   changeuuid: e1bd7c03-0509-443f-a3f7-b4b96bf3ffbd
   reviewedAt: 2026-04-30
@@ -14769,6 +14870,7 @@
   country: EC
   status: stream-only
 - id: ec-la-redonda-969
+  favicon: "https://cdn.onlineradiobox.com/img/l/2/29852.v23.png"
   stationuuid: 9e0bc34e-9948-469a-a36e-e1b0f960f8a4
   changeuuid: fca04f3b-b73b-4814-b067-073d672c6bab
   reviewedAt: 2026-04-30
@@ -14787,6 +14889,7 @@
   country: EC
   status: stream-only
 - id: ec-la-tukka
+  favicon: "https://cdn.onlineradiobox.com/img/l/4/128484.v1.png"
   stationuuid: 402a2649-09aa-4059-b61c-9901bd400966
   changeuuid: 29c3f4f8-6e0e-4ac8-9c73-a2977f7dcbaf
   reviewedAt: 2026-04-30
@@ -14862,6 +14965,7 @@
   country: PE
   status: stream-only
 - id: pe-studio-92
+  favicon: "https://sstudio92.radio-grpp.io/static/img/logo_studio92.svg"
   stationuuid: cfdebe47-26c0-442f-88d5-e6f63148c635
   changeuuid: 789337cc-069e-4137-9dc7-84f8a1026502
   reviewedAt: 2026-04-30
@@ -14880,6 +14984,7 @@
   country: PE
   status: stream-only
 - id: pe-corazon
+  favicon: "https://upload.wikimedia.org/wikipedia/commons/thumb/8/8a/Logo_corazon2024.svg/250px-Logo_corazon2024.svg.png"
   stationuuid: 4ff4033a-7ce3-463e-89ea-d7e6fa78b7a2
   changeuuid: cb177e80-7bd5-4ad3-847f-f01335ca2bf8
   reviewedAt: 2026-04-30
@@ -14898,6 +15003,7 @@
   country: PE
   status: stream-only
 - id: pe-la-mega
+  favicon: "https://cdn.onlineradiobox.com/img/l/0/26640.v8.png"
   stationuuid: d104634a-7073-4e67-9d64-2e50398eb857
   changeuuid: cfc5bc87-0f88-4029-9513-ec91dddd662a
   reviewedAt: 2026-04-30
@@ -14916,6 +15022,7 @@
   country: PE
   status: stream-only
 - id: pe-la-zona
+  favicon: "https://sstudio92.radio-grpp.io/static/img/logos/la_zona.svg"
   stationuuid: 97a514db-b31f-4bd7-97c7-d308195644d3
   changeuuid: b46841b4-def8-4296-b3a2-0b1cdaf81c3c
   reviewedAt: 2026-04-30
@@ -14934,6 +15041,7 @@
   country: PE
   status: stream-only
 - id: pe-panamericana
+  favicon: "https://cdn.onlineradiobox.com/img/l/0/133620.v4.png"
   stationuuid: edcb99be-9c5b-42a2-a30a-d5962cbda26f
   changeuuid: bcacd831-1642-43e3-acbc-153f53965070
   reviewedAt: 2026-04-30
@@ -15244,6 +15352,7 @@
   country: AR
   status: stream-only
 - id: ar-rock-and-pop
+  favicon: "https://upload.wikimedia.org/wikipedia/commons/thumb/3/37/Radio_rockpop.png/250px-Radio_rockpop.png"
   stationuuid: bcb3b03a-f0ec-4ceb-b22f-922138858800
   changeuuid: 6bbc79df-0e9a-461c-89af-ebd61e3bb88d
   reviewedAt: 2026-04-30
@@ -15281,6 +15390,7 @@
   country: AR
   status: stream-only
 - id: ar-blue-fm
+  favicon: "https://bluefm.com.ar/wp-content/themes/bluefmtheme/img/logo_blue.png"
   stationuuid: 8ddfdc2b-6fc5-45a9-b100-9450b93a6ef4
   changeuuid: d74ec095-dd1b-4f93-907d-b024d44189c5
   reviewedAt: 2026-04-30
@@ -15356,6 +15466,7 @@
   country: AR
   status: stream-only
 - id: ar-la-red
+  favicon: "https://upload.wikimedia.org/wikipedia/commons/thumb/6/64/Radio_La_Red_AM_910.png/250px-Radio_La_Red_AM_910.png"
   stationuuid: 5440e89d-708d-4336-9b42-fa274ed093b1
   changeuuid: 0fcbb3c9-b67b-4148-831b-84f7cd2e7c93
   reviewedAt: 2026-04-30
@@ -15453,6 +15564,7 @@
   country: CO
   status: stream-only
 - id: co-tropicana
+  favicon: "https://cdn.onlineradiobox.com/img/l/7/21737.v22.png"
   stationuuid: 96330fff-0601-11e8-ae97-52543be04c81
   changeuuid: fe1f4cdf-5784-4a72-b825-bad155aa1dbe
   reviewedAt: 2026-04-30
@@ -15492,6 +15604,7 @@
   country: CO
   status: stream-only
 - id: co-vibra-bogota
+  favicon: "https://cdn.onlineradiobox.com/img/l/3/22093.v9.png"
   stationuuid: 36492a90-efa9-11e8-a471-52543be04c81
   changeuuid: 08393a47-b27c-48bf-8e2c-16664f4a13db
   reviewedAt: 2026-04-30
@@ -15568,6 +15681,7 @@
   country: CO
   status: stream-only
 - id: co-mix-medellin
+  favicon: "https://strapi-aws-s3-images-mix-bucket.s3.us-east-1.amazonaws.com/mix_light_mode_07df7ce987.webp"
   stationuuid: 0c6bfd10-3912-4ef0-babc-e2ca4dd16881
   changeuuid: 9040b07b-854a-4316-a6ae-553f180f5bab
   reviewedAt: 2026-04-30
@@ -15607,6 +15721,7 @@
   status: stream-only
   httpAllowed: true
 - id: br-mec-fm
+  favicon: "https://upload.wikimedia.org/wikipedia/commons/thumb/2/24/R%C3%A1dio_MEC_logo_2023.svg/250px-R%C3%A1dio_MEC_logo_2023.svg.png"
   stationuuid: 4404b2f3-c18b-411a-9c74-90cf1e9465e7
   changeuuid: 35588ef9-b0b8-494e-9c2e-17c55632e538
   reviewedAt: 2026-04-30
@@ -15627,6 +15742,7 @@
   country: BR
   status: stream-only
 - id: br-mec-am
+  favicon: "https://upload.wikimedia.org/wikipedia/commons/thumb/2/24/R%C3%A1dio_MEC_logo_2023.svg/250px-R%C3%A1dio_MEC_logo_2023.svg.png"
   stationuuid: a5f67526-96c9-46b7-a01f-b07f791535b9
   changeuuid: 39383784-8c30-4790-b201-258a05729fc5
   reviewedAt: 2026-04-30
@@ -15647,6 +15763,7 @@
   country: BR
   status: stream-only
 - id: br-nacional-brasilia-fm
+  favicon: "https://upload.wikimedia.org/wikipedia/commons/thumb/5/5a/R%C3%A1dio_Nacional_logo_2023.svg/250px-R%C3%A1dio_Nacional_logo_2023.svg.png"
   stationuuid: aab7e6fd-6a3c-4e82-a415-a6685c6963bb
   changeuuid: a761567e-5fb5-47de-be8c-756950567061
   reviewedAt: 2026-04-30
@@ -15666,6 +15783,7 @@
   country: BR
   status: stream-only
 - id: br-nacional-brasilia-am
+  favicon: "https://upload.wikimedia.org/wikipedia/commons/thumb/5/5a/R%C3%A1dio_Nacional_logo_2023.svg/250px-R%C3%A1dio_Nacional_logo_2023.svg.png"
   stationuuid: 594546be-bd95-4eb4-9418-7a0767d37486
   changeuuid: 6e363948-f41e-46ad-8109-dc1706b0b612
   reviewedAt: 2026-04-30
@@ -15764,6 +15882,7 @@
   country: BR
   status: stream-only
 - id: br-mix-fm
+  favicon: "https://radiomixfm.com.br/wp-content/uploads/2017/06/logo-mix-pequeno.png"
   stationuuid: 61156199-ece3-413e-ac39-7b2483513ab2
   changeuuid: aa1cd035-a83a-4df9-b5b6-1d80954e1252
   reviewedAt: 2026-04-30
@@ -15782,6 +15901,7 @@
   country: BR
   status: stream-only
 - id: br-89-rock
+  favicon: "https://upload.wikimedia.org/wikipedia/commons/thumb/3/33/R%C3%A1dio_Rock_logo.svg/250px-R%C3%A1dio_Rock_logo.svg.png"
   stationuuid: 65908a60-3a4c-4d8c-b66c-d8eb96faefc6
   changeuuid: 91b5647a-c103-4568-8c51-90ed4c8b0a60
   reviewedAt: 2026-04-30
@@ -15799,6 +15919,7 @@
   country: BR
   status: stream-only
 - id: br-jb-fm
+  favicon: "https://jb.fm/static-images/logo-jb.png"
   stationuuid: 8cf1083b-a326-11e8-abb8-52543be04c81
   changeuuid: 27a0b9eb-325f-4624-bcfc-155d2fe09dab
   reviewedAt: 2026-04-30
@@ -15856,6 +15977,7 @@
   country: BR
   status: stream-only
 - id: br-bons-tempos
+  favicon: "https://cdn.onlineradiobox.com/img/l/5/41465.v12.png"
   stationuuid: 345cc08c-a5e3-43d9-9543-0626f2081177
   changeuuid: a3cb6c62-c9b2-43f0-8c3e-5bc82fff1389
   reviewedAt: 2026-04-30
@@ -15950,6 +16072,7 @@
   country: ZA
   status: stream-only
 - id: za-lekker-fm
+  favicon: "https://back.ww-cdn.com/superstatic/version/3848091/iphone/10/photo/sections_64541522_navBar_titleImage@2x.png?v=1721209190"
   stationuuid: 28b85cc9-696f-4175-966e-7459653c4811
   changeuuid: 0b4a8417-c5fa-46c3-bfd9-5cf42344bfc0
   reviewedAt: 2026-04-30
@@ -15967,6 +16090,7 @@
   country: ZA
   status: stream-only
 - id: za-ukhozi-fm
+  favicon: "https://www.ukhozifm.co.za/ukhozifm/wp-content/uploads/2024/10/cropped-cropped-cropped-ukhozi-tranparent-logo.png"
   stationuuid: ac81df15-039c-43df-b944-7462426b9db5
   changeuuid: 30cf7409-716d-46c4-8b5c-7a50288222df
   reviewedAt: 2026-04-30
@@ -16045,6 +16169,7 @@
   country: ZA
   status: stream-only
 - id: za-classic-fm-1027
+  favicon: "https://classicfm.co.za/images/logo.jpg"
   stationuuid: 5de8baec-2c0a-11e9-a35e-52543be04c81
   changeuuid: ce056e8f-8f53-4683-b7ca-a785e315fd5c
   reviewedAt: 2026-04-30
@@ -16083,6 +16208,7 @@
   country: ZA
   status: stream-only
 - id: za-amapiano-fm
+  favicon: "https://cdn.instant.audio/images/logos/radiosa-org/amapiano.png"
   stationuuid: bed37ad7-1542-4455-96ea-6b7608c7bc8f
   changeuuid: b9f7efb8-4c12-46a4-9dad-34741780a5e5
   reviewedAt: 2026-04-30
@@ -16101,6 +16227,7 @@
   country: ZA
   status: stream-only
 - id: za-joy-gospel
+  favicon: "https://public-rf-upload.minhawebradio.net/211254/logo/38f4273533cf449f295262eee24a7d02.png"
   stationuuid: 22a21e54-0c74-4c29-868c-8e8dd6ab8f22
   changeuuid: 01bf86b2-a06c-4b7a-b686-df64c10931e1
   reviewedAt: 2026-04-30
@@ -16119,6 +16246,7 @@
   country: ZA
   status: stream-only
 - id: ug-mutundwe
+  favicon: "https://mcfradio.co.ug/wp-content/uploads/2017/05/logo-MCF.png"
   stationuuid: 7f753b43-eb65-4638-bcea-8dbaaf620b0d
   changeuuid: 969af8ee-a304-4e6a-bd9e-e4a4cdb7cf81
   reviewedAt: 2026-04-30
@@ -16137,6 +16265,7 @@
   country: UG
   status: stream-only
 - id: ug-pearl-fm
+  favicon: "https://www.pearlfmuganda.com/pearlfmlogo.png"
   stationuuid: bf8d199f-e158-4205-bd1d-7cec0b8158aa
   changeuuid: 113507af-8c46-4bf6-a4e0-279e2c503cda
   reviewedAt: 2026-04-30
@@ -16155,6 +16284,7 @@
   country: UG
   status: stream-only
 - id: ug-radio-buddu
+  favicon: "https://cdn.onlineradiobox.com/img/l/8/131138.v1.png"
   stationuuid: e2d2f120-6771-4e92-8fff-7e5ba1052414
   changeuuid: cf8b038a-217b-40d7-868d-3351a8a468f7
   reviewedAt: 2026-04-30
@@ -16172,6 +16302,7 @@
   country: UG
   status: stream-only
 - id: ug-akaboozi-fm
+  favicon: "https://cdn.instant.audio/images/logos/radio-co-ug/akaboozi-fm.png"
   stationuuid: 9a8f7fb5-3159-11ea-afca-52543be04c81
   changeuuid: 8fbc0688-376c-4e44-aa85-10bed8ac86fb
   reviewedAt: 2026-04-30
@@ -16229,6 +16360,7 @@
   country: UG
   status: stream-only
 - id: id-elshinta
+  favicon: "https://upload.wikimedia.org/wikipedia/commons/thumb/5/59/Logoelshinta.png/250px-Logoelshinta.png"
   stationuuid: b2357cbe-d080-4099-8cae-770539945230
   changeuuid: 5294f04d-3720-4215-ac00-d5cca602abee
   reviewedAt: 2026-04-30
@@ -16264,6 +16396,7 @@
   country: ID
   status: stream-only
 - id: id-892-campursari
+  favicon: "https://campursarifm.com/images/logo-square.jpg"
   stationuuid: 1bdb7538-d6af-4c77-ab1e-d51185aa9384
   changeuuid: ae9037f7-8c38-402f-ac9d-e269ee06d31c
   reviewedAt: 2026-04-30
@@ -16282,6 +16415,7 @@
   country: ID
   status: stream-only
 - id: id-i-radio-jakarta
+  favicon: "https://assets-static.iswaranetwork.com/2025/02/ISWARA-LOGO-MAIN-01.png"
   stationuuid: 1c3b70d9-39d5-49d5-a81a-77833667a88b
   changeuuid: 6273d53a-c792-4e93-aa05-b7de5b73e3b7
   reviewedAt: 2026-04-30
@@ -16356,6 +16490,7 @@
   country: PH
   status: stream-only
 - id: ph-star-fm-manila
+  favicon: "https://upload.wikimedia.org/wikipedia/en/thumb/6/60/1027starfm.png/250px-1027starfm.png"
   stationuuid: 9c9368a3-8f90-4fc8-ba49-1127f9861d2f
   changeuuid: 5dbf4b3c-4190-4140-b96b-37d42ca82d65
   reviewedAt: 2026-04-30
@@ -16373,6 +16508,7 @@
   country: PH
   status: stream-only
 - id: ph-mor-entertainment
+  favicon: "https://upload.wikimedia.org/wikipedia/en/thumb/1/15/MOR_Entertainment_logo.png/250px-MOR_Entertainment_logo.png"
   stationuuid: 96d56356-354d-4a2e-97a7-25483f992be2
   changeuuid: d792640b-f543-4a26-8737-07cfdc9f6e82
   reviewedAt: 2026-04-30
@@ -16408,6 +16544,7 @@
   country: PH
   status: stream-only
 - id: ph-win-radio-manila
+  favicon: "https://winradioph.net/wp-content/uploads/Logo.png"
   stationuuid: 91d4bd6e-fc70-4d77-a563-99682073a7ba
   changeuuid: 5e8bb7b1-0d32-416d-b6f9-769eafc5a889
   reviewedAt: 2026-04-30
@@ -16425,6 +16562,7 @@
   country: PH
   status: stream-only
 - id: ph-love-radio-dagupan
+  favicon: "https://upload.wikimedia.org/wikipedia/en/thumb/3/32/Love_Radio_2021_logo.png/250px-Love_Radio_2021_logo.png"
   stationuuid: 247aa6ff-f402-4b81-8ebb-21fa00791ef5
   changeuuid: 0a41ee02-6527-4332-b838-5d659acec8b2
   reviewedAt: 2026-04-30
@@ -16442,6 +16580,7 @@
   country: PH
   status: stream-only
 - id: ph-radyo5
+  favicon: "https://upload.wikimedia.org/wikipedia/en/thumb/4/40/Radyo5truefmlogo.webp/250px-Radyo5truefmlogo.webp"
   stationuuid: 71623064-347c-4e85-8136-148115d350f2
   changeuuid: 846be421-9019-4bc2-8520-35731f17f062
   reviewedAt: 2026-04-30
@@ -16770,6 +16909,7 @@
   country: TR
   status: stream-only
 - id: tr-metro-fm
+  favicon: "https://upload.wikimedia.org/wikipedia/commons/5/5b/Logo_of_Metro_FM.png"
   stationuuid: 0012c08a-31e7-48c6-87a9-7f64736e0a38
   changeuuid: 9ebdc6a8-d475-4d7d-a82a-85cb425f35b1
   reviewedAt: 2026-04-30
@@ -16933,6 +17073,7 @@
   country: IN
   status: stream-only
 - id: in-air-fm-gold
+  favicon: "https://upload.wikimedia.org/wikipedia/en/thumb/7/7b/Akhashvani_logo.png/250px-Akhashvani_logo.png"
   stationuuid: a4ffabec-a162-4320-8cf2-049b8055b17a
   changeuuid: e9f1a388-6be5-46b4-8912-bcf92d8a5179
   reviewedAt: 2026-04-30
@@ -16951,6 +17092,7 @@
   country: IN
   status: stream-only
 - id: in-air-news
+  favicon: "https://upload.wikimedia.org/wikipedia/en/thumb/7/7b/Akhashvani_logo.png/250px-Akhashvani_logo.png"
   stationuuid: f5c095e7-6517-4175-9203-5b9e907fb821
   changeuuid: 56e851bc-7ed4-4149-a4ed-7700d5b6ddda
   reviewedAt: 2026-04-30
@@ -16988,6 +17130,7 @@
   country: IN
   status: stream-only
 - id: in-mirchi-top-20
+  favicon: "https://upload.wikimedia.org/wikipedia/en/thumb/a/a7/Radiomirchi.jpg/250px-Radiomirchi.jpg"
   stationuuid: 6b36ba4f-6d29-4272-b3c0-9aeeb64e61ec
   changeuuid: a09a15eb-95ac-4b84-a63b-c8be6238c9cd
   reviewedAt: 2026-04-30
@@ -17006,6 +17149,7 @@
   country: IN
   status: stream-only
 - id: in-mirchi-love
+  favicon: "https://upload.wikimedia.org/wikipedia/en/thumb/a/a7/Radiomirchi.jpg/250px-Radiomirchi.jpg"
   stationuuid: 0e5dfcc8-99e2-4fed-a232-7f4bf23ba3c3
   changeuuid: 8d3d55e6-9672-4fda-bd80-74df6a37693e
   reviewedAt: 2026-04-30
@@ -17235,6 +17379,7 @@
   country: CN
   status: stream-only
 - id: cn-cri-chinese
+  favicon: "https://upload.wikimedia.org/wikipedia/commons/thumb/5/54/Radio_China_International.svg/250px-Radio_China_International.svg.png"
   stationuuid: 28c73396-f7ea-49cf-a201-146bf29b2348
   changeuuid: d3ec1f93-d7d7-47d1-a394-14a53563079b
   reviewedAt: 2026-04-30
@@ -17254,6 +17399,7 @@
   country: CN
   status: stream-only
 - id: cn-cri-english
+  favicon: "https://upload.wikimedia.org/wikipedia/commons/thumb/5/54/Radio_China_International.svg/250px-Radio_China_International.svg.png"
   stationuuid: acf7c318-9031-4763-930a-00a4b5a032ec
   changeuuid: f1322cf3-91f0-4ea6-81cd-9c3a441476ff
   reviewedAt: 2026-04-30
@@ -17672,6 +17818,7 @@
   country: MX
   status: stream-only
 - id: mx-889-noticias
+  favicon: "https://upload.wikimedia.org/wikipedia/en/d/d9/XHM_88.9Noticias_logo.png"
   stationuuid: a0b40c3f-aede-46e9-b67f-38cd8b262936
   changeuuid: 96d58201-72d9-4bd7-bca8-3d2ca8ed9659
   reviewedAt: 2026-04-30
@@ -17690,6 +17837,7 @@
   country: MX
   status: stream-only
 - id: mx-amor-cdmx
+  favicon: "https://upload.wikimedia.org/wikipedia/commons/thumb/b/bf/XHSH-FM.png/250px-XHSH-FM.png"
   stationuuid: 11ee3ad5-ead9-47de-ab04-7e0d06789a15
   changeuuid: dda9afb5-aff4-430a-b877-1b7e0359039e
   reviewedAt: 2026-04-30
@@ -17708,6 +17856,7 @@
   country: MX
   status: stream-only
 - id: mx-la-ke-buena
+  favicon: "https://upload.wikimedia.org/wikipedia/commons/thumb/f/fb/Ke_Buena_Logo.png/250px-Ke_Buena_Logo.png"
   stationuuid: 427e7eda-148e-4da0-b63b-eb4bb9be92ab
   changeuuid: 96913214-b4ac-4902-be0f-6e96d1be11e1
   reviewedAt: 2026-04-30
@@ -17766,6 +17915,7 @@
   country: MX
   status: stream-only
 - id: mx-la-comadre
+  favicon: "https://upload.wikimedia.org/wikipedia/commons/thumb/7/75/La_Comadre_Logo.jpg/250px-La_Comadre_Logo.jpg"
   stationuuid: d6f68e4e-d46f-4702-aafe-710d8c9883ec
   changeuuid: 95cbe40f-fc82-485b-a0b1-ed8c711c3923
   reviewedAt: 2026-04-30
@@ -17784,6 +17934,7 @@
   country: MX
   status: stream-only
 - id: mx-mix-cdmx
+  favicon: "https://upload.wikimedia.org/wikipedia/en/thumb/7/7e/XHGV_106.5MIX_logo.png/250px-XHGV_106.5MIX_logo.png"
   stationuuid: 15a269a7-9f65-4deb-874a-4b4e6c65c358
   changeuuid: 3e29d724-001d-4440-bbe6-f628911b9381
   reviewedAt: 2026-04-30
@@ -17802,6 +17953,7 @@
   country: MX
   status: stream-only
 - id: mx-universal-cdmx
+  favicon: "https://cdn-profiles.tunein.com/s1171/images/logod.png?t=637908714790000000"
   stationuuid: daa9dfac-9b2a-41ff-b65e-3090a2b26cee
   changeuuid: f4361c39-aac0-429e-995f-06c1b5aef05d
   reviewedAt: 2026-04-30
@@ -17820,6 +17972,7 @@
   country: MX
   status: stream-only
 - id: mx-fonografo
+  favicon: "https://cdn-profiles.tunein.com/s47671/images/logod.jpg?t=637278363070000000"
   stationuuid: d95ad5e2-417c-4969-a533-c2d9c696d58c
   changeuuid: 8b43d228-dfbf-4891-9842-69bf82e82e12
   reviewedAt: 2026-04-30
@@ -17858,6 +18011,7 @@
   country: MX
   status: stream-only
 - id: mx-radio-felicidad
+  favicon: "https://upload.wikimedia.org/wikipedia/en/1/1d/XEFR_RadioFelicidad1180_logo.jpg"
   stationuuid: 177cc601-a536-41cc-bd67-7d10b1a5dee1
   changeuuid: a96a2740-5d25-4637-8e02-b857b57c55cb
   reviewedAt: 2026-04-30
@@ -17876,6 +18030,7 @@
   country: MX
   status: stream-only
 - id: mx-alfa
+  favicon: "https://upload.wikimedia.org/wikipedia/en/3/3e/Alfa_Radio_91.3fm.png"
   stationuuid: 5766fc5b-ce3e-4f46-a5b3-c274ea46d8e6
   changeuuid: 38781172-6f2f-4f15-a5a1-83c68ac829bf
   reviewedAt: 2026-04-30
@@ -17895,6 +18050,7 @@
   country: MX
   status: stream-only
 - id: mx-la-z
+  favicon: "https://grc-media.nyc3.cdn.digitaloceanspaces.com/uploads/sites/2/2025/10/logo_LaZ_400-edited.webp"
   stationuuid: 5355a4fe-be93-4f87-a172-0aa89638dcaa
   changeuuid: deebdffa-63cd-46b7-9279-5dbc59720c63
   reviewedAt: 2026-04-30
@@ -17913,6 +18069,7 @@
   country: MX
   status: stream-only
 - id: mx-banda-933
+  favicon: "https://upload.wikimedia.org/wikipedia/en/4/42/XHQQ_Banda93.3_logo.png"
   stationuuid: f94514ec-c316-4d21-bd27-b7f0e8e1944b
   changeuuid: 83876d3d-6a17-40f3-8b1d-715e8e86a3c9
   reviewedAt: 2026-04-30
@@ -18261,6 +18418,7 @@
   changeuuid: 973c6a32-2ac0-49ec-bd33-b4abce43d508
   reviewedAt: 2026-05-04
 - id: de-technolovers-bass-house
+  favicon: "https://technolovers.fm/assets/img/technolovers-dark.png"
   broadcaster: independent
   name: Technolovers - BASS HOUSE
   streamUrl: https://stream.technolovers.fm/bass-house?ref=radiobrowser
@@ -18338,6 +18496,7 @@
   changeuuid: 96402322-427f-49e4-bcc2-625b12738704
   reviewedAt: 2026-05-04
 - id: de-technolovers-handsup
+  favicon: "https://technolovers.fm/assets/img/technolovers-dark.png"
   broadcaster: independent
   name: Technolovers HANDSUP
   streamUrl: https://stream.technolovers.fm/handsup?ref=radiobrowser
@@ -18376,6 +18535,7 @@
   changeuuid: 77ab7d53-7b13-4688-93e4-65e46abab06c
   reviewedAt: 2026-05-04
 - id: de-romantic-piano-by-epic-piano
+  favicon: "https://epic-piano.com/assets/img/epicpiano-dark.png"
   broadcaster: independent
   name: ROMANTIC PIANO by Epic Piano
   streamUrl: https://stream.epic-piano.com/romantic-piano?ref=radiobrowser
@@ -18388,6 +18548,7 @@
   changeuuid: b05d8380-80f8-4b27-b859-b28bc092f3bd
   reviewedAt: 2026-05-04
 - id: de-technolovers-ibiza-house
+  favicon: "https://technolovers.fm/assets/img/technolovers-dark.png"
   broadcaster: independent
   name: Technolovers - IBIZA HOUSE
   streamUrl: https://stream.technolovers.fm/ibiza-house?ref=radiobrowser
@@ -18413,6 +18574,7 @@
   changeuuid: 69f52a47-87bd-4ff6-b1dc-2ac2ba8b3a08
   reviewedAt: 2026-05-04
 - id: de-epic-lounge-chillout-lounge
+  favicon: "https://cdn-profiles.tunein.com/s310364/images/logod.jpg?t=637815426870000000"
   broadcaster: independent
   name: Epic Lounge - CHILLOUT LOUNGE
   streamUrl: https://stream.epic-lounge.com/chillout-lounge?ref=radiobrowser
@@ -18451,6 +18613,7 @@
   changeuuid: 4ac85070-91c4-4363-b8b7-b07e3c61d35e
   reviewedAt: 2026-05-04
 - id: de-technolovers-uplifting-trance
+  favicon: "https://technolovers.fm/assets/img/technolovers-dark.png"
   broadcaster: independent
   name: Technolovers - UPLIFTING TRANCE
   streamUrl: https://stream.technolovers.fm/uplifting-trance?ref=radiobrowser
@@ -18476,6 +18639,7 @@
   changeuuid: 97fc1cf7-0ef3-4c71-a5d2-b1a3ede2b6fb
   reviewedAt: 2026-05-04
 - id: de-countryhits-fm-by-rautemusik-rm-fm
+  favicon: "https://cdn.onlineradiobox.com/img/l/6/34196.v9.png"
   broadcaster: independent
   name: __COUNTRYHITS.FM__ by rautemusik (rm.fm)
   streamUrl: https://country-high.rautemusik.fm/?ref=radiobrowser
@@ -18667,6 +18831,7 @@
   changeuuid: 51d371e5-d1a2-4c83-b952-853398a23433
   reviewedAt: 2026-05-04
 - id: de-chopin-by-epic-piano
+  favicon: "https://epic-piano.com/assets/img/epicpiano-dark.png"
   broadcaster: independent
   name: CHOPIN by Epic Piano
   streamUrl: https://stream.epic-piano.com/chopin?ref=radiobrowser
@@ -18795,6 +18960,7 @@
   changeuuid: e5ab8377-add7-423a-85e5-779039d86bca
   reviewedAt: 2026-05-04
 - id: de-technolovers-future-house
+  favicon: "https://technolovers.fm/assets/img/technolovers-dark.png"
   broadcaster: independent
   name: Technolovers FUTURE HOUSE
   streamUrl: https://stream.technolovers.fm/future-house?ref=radiobrowser
@@ -18909,6 +19075,7 @@
   changeuuid: c6ca9cd7-95b3-49d7-8f96-2f8426d7078b
   reviewedAt: 2026-05-04
 - id: de-technolovers-hardcore
+  favicon: "https://technolovers.fm/assets/img/technolovers-dark.png"
   broadcaster: independent
   name: Technolovers HARDCORE
   streamUrl: https://stream.technolovers.fm/hardcore?ref=radiobrowser
@@ -18958,6 +19125,7 @@
   changeuuid: 8b9d8130-2ee1-4fb3-83c2-4523a562a2af
   reviewedAt: 2026-05-04
 - id: de-epic-lounge-piano-jazz-bar
+  favicon: "https://cdn-profiles.tunein.com/s310369/images/logod.jpg?t=637815440490000000"
   broadcaster: independent
   name: Epic Lounge - PIANO & JAZZ BAR
   streamUrl: https://stream.epic-lounge.com/piano-jazz-bar?ref=radiobrowser
@@ -19033,6 +19201,7 @@
   changeuuid: b080b760-43f4-4f29-9d7e-186630ed3f8c
   reviewedAt: 2026-05-04
 - id: de-epic-classical-classical-piano
+  favicon: "https://cdn-profiles.tunein.com/s320513/images/logod.jpg?t=637931891670000000"
   broadcaster: independent
   name: EPIC CLASSICAL - Classical Piano
   streamUrl: https://stream.epic-classical.com/classical-piano
@@ -19084,6 +19253,7 @@
   changeuuid: 6dfe6c56-8704-43d7-b676-f7477c58508d
   reviewedAt: 2026-05-04
 - id: de-technolovers-electro
+  favicon: "https://technolovers.fm/assets/img/technolovers-dark.png"
   broadcaster: independent
   name: Technolovers  ELECTRO
   streamUrl: https://stream.technolovers.fm/electro?ref=radiobrowser
@@ -19122,6 +19292,7 @@
   changeuuid: a58ac7f1-8316-4b1b-bfda-5b850cefe63c
   reviewedAt: 2026-05-04
 - id: de-technolovers-hardstyle
+  favicon: "https://technolovers.fm/assets/img/technolovers-dark.png"
   broadcaster: independent
   name: Technolovers HARDSTYLE
   streamUrl: https://stream.technolovers.fm/hardstyle?ref=radiobrowser
@@ -19134,6 +19305,7 @@
   changeuuid: 72a825c2-12ab-4122-be84-287bfb168d70
   reviewedAt: 2026-05-04
 - id: de-epic-classical-classical-coffee-bar
+  favicon: "https://cdn-profiles.tunein.com/s320520/images/logod.jpg?t=637932432890000000"
   broadcaster: independent
   name: EPIC CLASSICAL - Classical Coffee Bar
   streamUrl: https://stream.epic-classical.com/classical-coffee-bar
@@ -19171,6 +19343,7 @@
   changeuuid: 02aee472-4176-499c-a7ec-575b4198188b
   reviewedAt: 2026-05-04
 - id: de-epic-classical-classical-meditation
+  favicon: "https://cdn-profiles.tunein.com/s320513/images/logod.jpg?t=637931891670000000"
   broadcaster: independent
   name: EPIC CLASSICAL - Classical Meditation
   streamUrl: https://stream.epic-classical.com/classical-meditation

--- a/public/stations.json
+++ b/public/stations.json
@@ -823,6 +823,7 @@
         "news",
         "switzerland"
       ],
+      "favicon": "https://shop.kontrafunk.radio/wp-content/themes/yootheme/cache/16/Kontrafunk_Logo_Shop-167778cd.jpeg",
       "bitrate": 192,
       "codec": "MP3",
       "metadata": "azuracast",
@@ -1035,6 +1036,7 @@
         "pop",
         "switzerland"
       ],
+      "favicon": "https://radio.streamitter.com/uploads/stations/radio-one-dance-ticino-wup9ke-migrated-42972-500.webp",
       "bitrate": 128,
       "codec": "AAC",
       "geo": [
@@ -1117,6 +1119,7 @@
         "oldies",
         "switzerland"
       ],
+      "favicon": "https://images.zeno.fm/oZMC-mGbvBMmhdx0Cc8V4SK29NmzGmoKhdpi2iAtfSU/rs:fill:288:288/g:ce:0:0/aHR0cHM6Ly9wcm94eS56ZW5vLmZtL2NvbnRlbnQvc3RhdGlvbnMvYWE5OGU1ZTYtNjNkMy00NDY5LWEwZjctZTI4NjhlZmQ5NmEwL2ltYWdlLz91PTE3MDE2OTg2ODIwMDA.webp",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -1174,6 +1177,7 @@
       "tags": [
         "switzerland"
       ],
+      "favicon": "https://bnj.blob.core.windows.net/assets/Htdocs/Images/Theme/rtn/logo-rtn.svg",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -1432,6 +1436,7 @@
       "tags": [
         "switzerland"
       ],
+      "favicon": "https://bnj.ch/img/logos/top/francophonie.svg",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -1568,6 +1573,7 @@
       "tags": [
         "switzerland"
       ],
+      "favicon": "https://bnj.blob.core.windows.net/assets/Htdocs/Images/Theme/rfj/logo-rfj.svg",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -1702,6 +1708,7 @@
         "rock",
         "switzerland"
       ],
+      "favicon": "https://radio-drachenblut.ch/radio-logo-footer.svg",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -1721,6 +1728,7 @@
         "latin",
         "switzerland"
       ],
+      "favicon": "https://images.zeno.fm/FgFUhWISvzVy9yXimBFjp_t6XXIKTNROD1ImcXF0LsI/rs:fill:288:288/g:ce:0:0/aHR0cHM6Ly9wcm94eS56ZW5vLmZtL2NvbnRlbnQvc3RhdGlvbnMvYWd4emZucGxibTh0YzNSaGRITnlNZ3NTQ2tGMWRHaERiR2xsYm5RWWdJQ0luYkxneXdrTUN4SU9VM1JoZEdsdmJsQnliMlpwYkdVWWdJREk1Smo0OVFrTW9nRUVlbVZ1YncvaW1hZ2UvP3U9MTc0NDY3Mjk5NDAwMA.webp",
       "codec": "MP3",
       "geo": [
         47.375,
@@ -2407,6 +2415,7 @@
       "tags": [
         "switzerland"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/1/2961.v4.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -2916,6 +2925,7 @@
         "gospel",
         "switzerland"
       ],
+      "favicon": "https://glaubesiegt.ch/wp-content/uploads/2026/02/Antenne-Jesus-Live-Logo-2-pp-effekt2.png",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -2954,6 +2964,7 @@
         "news",
         "switzerland"
       ],
+      "favicon": "https://www.radiofd.ch/images/radiofd_player.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -5839,6 +5850,7 @@
         "rock",
         "italy"
       ],
+      "favicon": "https://img-api.cloud.mediaset.net/api/images/rd/v1/ita/aHR0cHM6Ly93d3cudmlyZ2lucmFkaW8uaXQvd3AtY29udGVudC91cGxvYWRzLzIwMjUvMTEvV2VicmFkaW8tVmlyZ2luLTIwMjAtUm9jazcwLTE1ODgwNjI5MzA4OTlwbmctd2VicmFkaW9fdmlyZ2luX3JhZGlvX3JvY2tfXzcwLnBuZw/-/0/0?r=df74e68abb0949dd1d692d0c7e297095",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -6089,6 +6101,7 @@
         "classical",
         "italy"
       ],
+      "favicon": "https://www.veniceclassicradio.eu/logo/logo-vcr-white.svg",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -6110,7 +6123,7 @@
         "talk",
         "spain"
       ],
-      "favicon": "https://img2.rtve.es/a/3893534/square/?h=320",
+      "favicon": "https://img.rtve.es/css/style2011/i/PG_logo_RNE.png",
       "bitrate": 128,
       "codec": "AAC",
       "geo": [
@@ -6194,7 +6207,7 @@
         "talk",
         "spain"
       ],
-      "favicon": "https://cadenaser00.epimg.net/favicon.png",
+      "favicon": "https://cdn-profiles.tunein.com/s9031/images/logod.jpg",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -6259,7 +6272,7 @@
         "urban",
         "spain"
       ],
-      "favicon": "https://los40es00.epimg.net/iconos/v1.x/v1.0/promos/promo_og_los40.png",
+      "favicon": "https://los40es00.epimg.net/estaticos/recursosgraficos/html/img/l-los40-urban-hor.svg",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -6280,7 +6293,7 @@
         "electronic",
         "spain"
       ],
-      "favicon": "https://recursosweb.prisaradio.com/fotos/original/010002753887.png",
+      "favicon": "https://los40es00.epimg.net/estaticos/recursosgraficos/html/img/l-los40-dance-hor.svg",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -6301,7 +6314,7 @@
         "oldies",
         "spain"
       ],
-      "favicon": "https://los40es00.epimg.net/estaticos/recursosgraficos/v1/img/app/los40_192.png",
+      "favicon": "https://los40es00.epimg.net/estaticos/recursosgraficos/html/img/l-los40-classic-hor.svg",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -6926,7 +6939,7 @@
         "business",
         "netherlands"
       ],
-      "favicon": "https://www.bnr.nl/favicon.ico",
+      "favicon": "https://www.radiozenders.fm/media/images/stations-large/bnr-nieuwsradio.png",
       "bitrate": 96,
       "codec": "AAC",
       "geo": [
@@ -7078,7 +7091,7 @@
         "public radio",
         "germany"
       ],
-      "favicon": "http://www.inforadio.de/content/dam/rbb/rbb/logos/touch/inf-128.png",
+      "favicon": "https://www.inforadio.de/content/dam/rbb/inf/standardbilder/rbb24-inforadio_logo.svg.svg/img.svg",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -7165,7 +7178,7 @@
         "public radio",
         "germany"
       ],
-      "favicon": "http://www.kulturradio.de/content/dam/rbb/rbb/logos/touch/radio3-128.png",
+      "favicon": "https://www.radiodrei.de/content/dam/rbb/kul/layout/radio3.svg.svg/img.svg",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -7233,6 +7246,7 @@
         "ambient",
         "germany"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/fblogo/6/34466.v9.png",
       "bitrate": 128,
       "codec": "MP3",
       "metadata": "antenne",
@@ -7255,7 +7269,7 @@
         "rock",
         "germany"
       ],
-      "favicon": "http://www.antenne.de/logos/station-antenne-bayern/apple-touch-icon.png",
+      "favicon": "https://cdn.onlineradiobox.com/img/fblogo/6/34476.v7.png",
       "bitrate": 128,
       "codec": "MP3",
       "metadata": "antenne",
@@ -7278,7 +7292,7 @@
         "oldies",
         "germany"
       ],
-      "favicon": "http://www.antenne.de/logos/antenne-bayern/apple-touch-icon.png",
+      "favicon": "https://cdn.onlineradiobox.com/img/fblogo/9/34469.v8.png",
       "bitrate": 128,
       "codec": "MP3",
       "metadata": "antenne",
@@ -7301,6 +7315,7 @@
         "hits",
         "germany"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/fblogo/0/34470.v7.png",
       "bitrate": 128,
       "codec": "MP3",
       "metadata": "antenne",
@@ -7323,6 +7338,7 @@
         "oldies",
         "germany"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/fblogo/1/102891.v3.png",
       "bitrate": 128,
       "codec": "MP3",
       "metadata": "antenne",
@@ -7345,7 +7361,7 @@
         "ballads",
         "germany"
       ],
-      "favicon": "http://www.antenne.de/logos/station-antenne-bayern/apple-touch-icon.png",
+      "favicon": "https://cdn.onlineradiobox.com/img/fblogo/9/34479.v8.png",
       "bitrate": 128,
       "codec": "MP3",
       "metadata": "antenne",
@@ -7369,7 +7385,7 @@
         "charts",
         "germany"
       ],
-      "favicon": "http://www.antenne.de/logos/station-antenne-bayern/apple-touch-icon.png",
+      "favicon": "https://cdn.onlineradiobox.com/img/fblogo/3/34463.v9.png",
       "bitrate": 128,
       "codec": "MP3",
       "metadata": "antenne",
@@ -7936,7 +7952,7 @@
         "electronic",
         "germany"
       ],
-      "favicon": "https://www.rm.fm/favicon.ico",
+      "favicon": "https://images.zeno.fm/ZR8Ke7RjRKqi6YjTQbilYLcupY8OkX86cGLrkp6Hgyw/rs:fill:288:288/g:ce:0:0/aHR0cHM6Ly9wcm94eS56ZW5vLmZtL2NvbnRlbnQvc3RhdGlvbnMvOGYxZThhY2YtMmNlNi00NTQyLWE0MjMtYmMyOWVhNTE0ZTRhL2ltYWdlLz91PTE3NzAwNDMyNzkwMDA.webp",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -8069,6 +8085,7 @@
         "oldies",
         "germany"
       ],
+      "favicon": "https://static.ffh.de/fileadmin/_processed_/2/e/csm_ffh_80er_600x600_9d247e2c21.jpg",
       "bitrate": 128,
       "codec": "MP3",
       "metadata": "ffh",
@@ -8091,6 +8108,7 @@
         "hits",
         "germany"
       ],
+      "favicon": "https://static.ffh.de/fileadmin/_processed_/6/1/csm_ffh_90er_600x600_a417d2fdf9.jpg",
       "bitrate": 128,
       "codec": "MP3",
       "metadata": "ffh",
@@ -8113,6 +8131,7 @@
         "hits",
         "germany"
       ],
+      "favicon": "https://static.ffh.de/fileadmin/_processed_/d/6/csm_ffh2000er_600x600_7986e7cff4.jpg",
       "bitrate": 128,
       "codec": "MP3",
       "metadata": "ffh",
@@ -8136,6 +8155,7 @@
         "90s",
         "germany"
       ],
+      "favicon": "https://static.ffh.de/fileadmin/_processed_/c/b/csm_ffh_eurodance_600x600_d8e5d073f8.jpg",
       "bitrate": 128,
       "codec": "MP3",
       "metadata": "ffh",
@@ -8158,6 +8178,7 @@
         "chillout",
         "germany"
       ],
+      "favicon": "https://static.ffh.de/fileadmin/_processed_/7/a/csm_ffh_lounge_600x600_4f432dd4b1.jpg",
       "bitrate": 128,
       "codec": "MP3",
       "metadata": "ffh",
@@ -8180,7 +8201,7 @@
         "soft pop",
         "germany"
       ],
-      "favicon": "https://www.harmonyfm.de/android-icon.png",
+      "favicon": "https://static.ffh.de/fileadmin/_processed_/8/d/csm_harmony_simulcast_1400x1400_2424c1e327.jpg",
       "bitrate": 128,
       "codec": "MP3",
       "metadata": "ffh",
@@ -8486,6 +8507,7 @@
         "latin",
         "germany"
       ],
+      "favicon": "https://images.zeno.fm/brCD08_FGp-vj1byJ8-kyBM_wJZl6QarIrv19X94NI8/rs:fill:288:288/g:ce:0:0/aHR0cHM6Ly9wcm94eS56ZW5vLmZtL2NvbnRlbnQvc3RhdGlvbnMvZmE2OGViNjEtYzQ4Ni00ODBjLThjNmEtYWNhY2YyYTNiNDcxL2ltYWdlLz91PTE3MzM5MjcxMzQwMDA.webp",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -8589,6 +8611,7 @@
         "lounge",
         "germany"
       ],
+      "favicon": "https://images.zeno.fm/FqS92XriO2CCQJVQF8154WQh3bgn7DwGGr3nlUmfWrA/rs:fill:288:288/g:ce:0:0/aHR0cHM6Ly9wcm94eS56ZW5vLmZtL2NvbnRlbnQvc3RhdGlvbnMvMTY2NWFlNGMtNzRkYy00NGYwLWJkMGEtN2EwZDAyOTFhYThjL2ltYWdlLz91PTE3MDE2OTUyNjUwMDA.webp",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -8727,6 +8750,7 @@
         "lounge",
         "germany"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/6/120536.v3.png",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -8812,6 +8836,7 @@
         "electronic",
         "germany"
       ],
+      "favicon": "https://technolovers.fm/assets/img/streamlogos/eurodance.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -8831,6 +8856,7 @@
         "electronic",
         "germany"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s310358/images/logod.jpg?t=637815398970000000",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -8870,6 +8896,7 @@
         "electronic",
         "germany"
       ],
+      "favicon": "https://technolovers.fm/assets/img/streamlogos/vocal-trance.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -8991,6 +9018,7 @@
         "rock",
         "germany"
       ],
+      "favicon": "https://www.epicrockradio.com/images/ERR_Banner_Transparent_2024.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -9030,6 +9058,7 @@
         "electronic",
         "germany"
       ],
+      "favicon": "https://technolovers.fm/assets/img/streamlogos/drummnbass.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -9050,6 +9079,7 @@
         "lounge",
         "germany"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/4/147044.v1.png",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -9113,6 +9143,7 @@
         "lounge",
         "germany"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/1/120551.v4.png",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -9192,6 +9223,7 @@
         "electronic",
         "germany"
       ],
+      "favicon": "https://technolovers.fm/assets/img/technolovers-dark.png",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -9617,7 +9649,7 @@
         "french",
         "canada"
       ],
-      "favicon": "https://ici.radio-canada.ca/favicon.ico",
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/thumb/8/8d/ICI_Radio-Canada_Premi%C3%A8re.svg/960px-ICI_Radio-Canada_Premi%C3%A8re.svg.png",
       "bitrate": 128,
       "codec": "AAC",
       "geo": [
@@ -9639,7 +9671,7 @@
         "french",
         "canada"
       ],
-      "favicon": "https://ici.radio-canada.ca/favicon.ico",
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9f/Ici_Musique_logo.svg/960px-Ici_Musique_logo.svg.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -9978,7 +10010,7 @@
         "public radio",
         "australia"
       ],
-      "favicon": "https://www.sbs.com.au/_next/static/img/language/app-icon_128x128-18ef105.png",
+      "favicon": "https://assets.sbs.com.au/55/8c/c3735cb8469d862c1522c86db678/chill-white-blue.svg?imwidth=256",
       "bitrate": 97,
       "codec": "AAC",
       "geo": [
@@ -10299,6 +10331,7 @@
         "easy listening",
         "poland"
       ],
+      "favicon": "https://www.rmfclassic.pl/dist-v2021/images/logo-rmf-classic-2022.png",
       "bitrate": 48,
       "codec": "AAC+",
       "geo": [
@@ -10926,7 +10959,7 @@
         "rnb",
         "usa"
       ],
-      "favicon": "https://i.iheart.com/v3/re/assets.brands/595542fc52e033394f67a9eb?ops=new(),flood(%22white%22),swap(),merge(%22over%22),gravity(%22center%22),contain(167,167),quality(80),format(%22png%22)",
+      "favicon": "https://upload.wikimedia.org/wikipedia/en/thumb/f/f4/Power1051newyork.png/250px-Power1051newyork.png",
       "codec": "AAC",
       "geo": [
         40.713,
@@ -11160,7 +11193,7 @@
         "hits",
         "denmark"
       ],
-      "favicon": "https://assets.planetradio.co.uk/img/ConfigWebListenBarLogoImageUrl/174.jpg?ver=1490690222",
+      "favicon": "https://impro.usercontent.one/appid/oneComWsb/domain/nova.dk/media/nova.dk/onewebmedia/Nova%20logo%2017-02%20gr%C3%B8nnere.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -11202,7 +11235,7 @@
         "alternative",
         "denmark"
       ],
-      "favicon": "https://radioplay.dk/tesla/static/favicons/radioplay-dk/apple-touch-icon.png",
+      "favicon": "https://assets.planetradio.co.uk/img/ConfigWebHeaderLogoSVGImageUrl/176.svg?ver=1490690852",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -11223,7 +11256,7 @@
         "soft rock",
         "denmark"
       ],
-      "favicon": "https://listenapi.s3.amazonaws.com/img/ConfigWebListenBarLogoImageUrl/212.jpg?ver=1490197142",
+      "favicon": "https://assets.planetradio.co.uk/img/ConfigWebHeaderLogoSVGImageUrl/212.svg?ver=1490689918",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -11437,7 +11470,7 @@
         "alternative",
         "sweden"
       ],
-      "favicon": "https://cdn.khz.se/images/161x80/63808dd23f61e6193a9007a927189e13.png",
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/thumb/4/49/Logo_Bandit_Rock.svg/960px-Logo_Bandit_Rock.svg.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -11500,6 +11533,7 @@
         "classic hits",
         "sweden"
       ],
+      "favicon": "https://media.bauerradio.com/image/upload/c_crop,g_custom/v1588755869/brand_manager/stations/t9dopkx2fxswjvppxbiw.svg",
       "bitrate": 96,
       "codec": "AAC+",
       "geo": [
@@ -12164,7 +12198,7 @@
         "hits",
         "portugal"
       ],
-      "favicon": "https://static2.mytuner.mobi/media/tvos_radios/drkZNBUn6W.png",
+      "favicon": "https://radiocomercial.pt/images/svg/logoRC_white.svg?v=0.1",
       "bitrate": 128,
       "codec": "AAC",
       "geo": [
@@ -12185,6 +12219,7 @@
         "classic hits",
         "portugal"
       ],
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b0/M80_Radio_2025.svg/250px-M80_Radio_2025.svg.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -12247,7 +12282,7 @@
         "talk",
         "portugal"
       ],
-      "favicon": "https://rrsite-images.azureedge.net/favicon/apple-touch-icon.png",
+      "favicon": "https://rr.pt/img/logoRR-n.svg",
       "bitrate": 64,
       "codec": "MP3",
       "geo": [
@@ -12270,7 +12305,7 @@
         "dutch",
         "belgium"
       ],
-      "favicon": "https://upload.wikimedia.org/wikipedia/commons/0/08/VRT_Radio_1_logo.svg",
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/08/VRT_Radio_1_logo.svg/960px-VRT_Radio_1_logo.svg.png",
       "codec": "MP3",
       "geo": [
         50.851,
@@ -12292,7 +12327,7 @@
         "dutch",
         "belgium"
       ],
-      "favicon": "http://www.radio2.be/resources/favicon-radio2/apple-touch-icon-76x76.png",
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/thumb/6/6f/VRT_Radio_2_2025.svg/960px-VRT_Radio_2_2025.svg.png",
       "codec": "MP3",
       "geo": [
         51.219,
@@ -12336,7 +12371,7 @@
         "dutch",
         "belgium"
       ],
-      "favicon": "https://upload.wikimedia.org/wikipedia/commons/thumb/c/c9/Klara_Logo_Black_Screen.jpg/150px-Klara_Logo_Black_Screen.jpg",
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/VRT_Klara_2020.svg/960px-VRT_Klara_2020.svg.png",
       "codec": "MP3",
       "geo": [
         50.851,
@@ -12357,7 +12392,7 @@
         "dutch",
         "belgium"
       ],
-      "favicon": "https://www.vrt.be/content/dam/vrtvideo/branding/logos/klara-continuo/v2/color.svg",
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/VRT_Klara_2020.svg/960px-VRT_Klara_2020.svg.png",
       "codec": "MP3",
       "geo": [
         50.851,
@@ -12641,7 +12676,7 @@
         "dutch",
         "belgium"
       ],
-      "favicon": "https://qmusic.be/assets/favicon/default-67977c4f518d45d3a639958e1c6c072532dd2e05cbef9e42cb9f8ecde1964c97.ico",
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/thumb/7/70/Qmusic_logo.svg/330px-Qmusic_logo.svg.png",
       "bitrate": 96,
       "codec": "AAC+",
       "geo": [
@@ -13666,7 +13701,7 @@
         "talk",
         "romanian"
       ],
-      "favicon": "https://radiorfm.ro/wp-content/uploads/2023/05/favicon.png",
+      "favicon": "https://radiorfm.ro/wp-content/uploads/logo-radio.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -13984,6 +14019,7 @@
         "oldies",
         "slovak"
       ],
+      "favicon": "https://www.radiomelody.sk/wp-content/themes/melody/assets/logo.svg",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -14091,7 +14127,7 @@
         "pop",
         "bulgarian"
       ],
-      "favicon": "https://www.radioplay.bg/assets/logos/bgestrada.png",
+      "favicon": "https://media.metacast.eu/pictures/01_2021/DWbGdwO2ntMCels09JiL-63902.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -14238,7 +14274,7 @@
         "hits",
         "ukrainian"
       ],
-      "favicon": "https://lux.fm/assets/img/browser-icons/apple-touch-icon-120x120.png",
+      "favicon": "https://lux.fm/assets/img/common/logo-lux.svg",
       "bitrate": 128,
       "codec": "AAC",
       "geo": [
@@ -14341,7 +14377,7 @@
         "pop",
         "ukrainian"
       ],
-      "favicon": "https://maximum.fm/assets/images/favicons/favicon-96x96.png?v=53",
+      "favicon": "https://maximum.fm/assets/images/logo.svg",
       "bitrate": 128,
       "codec": "AAC",
       "geo": [
@@ -14553,7 +14589,7 @@
         "oldies",
         "serbian"
       ],
-      "favicon": "https://www.radioinbeograd.rs/favicon.ico",
+      "favicon": "https://radioin.co.rs/wp-content/uploads/2019/02/logo.png",
       "bitrate": 64,
       "codec": "MP3",
       "geo": [
@@ -14655,6 +14691,7 @@
         "public",
         "bosnian"
       ],
+      "favicon": "https://upload.wikimedia.org/wikipedia/en/thumb/c/c3/Federalni_radio_logo.png/250px-Federalni_radio_logo.png",
       "bitrate": 128,
       "codec": "AAC",
       "geo": [
@@ -14741,6 +14778,7 @@
         "croatian",
         "bosnian"
       ],
+      "favicon": "https://radio-medjugorje.com/wp-content/uploads/2020/04/mir-logo-90-border.png",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -14827,7 +14865,7 @@
         "j-pop",
         "japanese"
       ],
-      "favicon": "https://assets.radioapi.me/radios/01J65CR99GVHS3A7CT7D53C415.jpg",
+      "favicon": "https://r2.streamafrica.net/radios/01J65CR99GVHS3A7CT7D53C415.jpg",
       "codec": "MP3",
       "geo": [
         35.6762,
@@ -14909,6 +14947,7 @@
         "asian",
         "japanese"
       ],
+      "favicon": "https://asiadreamradio.torontocast.stream/stations/images/jazzsakuraplayer/JazzSakuraLogo512jp.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -14929,6 +14968,7 @@
         "j-pop",
         "japanese"
       ],
+      "favicon": "https://mmo.aiircdn.com/387/5ff1f48287927.jpg",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -14949,6 +14989,7 @@
         "hits",
         "japanese"
       ],
+      "favicon": "https://mmo.aiircdn.com/387/5ff1f49652efd.jpg",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -14969,7 +15010,7 @@
         "regional",
         "japanese"
       ],
-      "favicon": "https://www.beachfm.co.jp/favicon.ico",
+      "favicon": "https://www.beachfm.co.jp/wp-content/themes/welcart_basic-voll-beachfm/img/common/logo.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -15013,7 +15054,7 @@
         "video game",
         "japanese"
       ],
-      "favicon": "https://gensokyoradio.net/favicon.ico",
+      "favicon": "https://gensokyoradio.net/images/gr8_logo.png",
       "bitrate": 256,
       "codec": "MP3",
       "geo": [
@@ -15075,6 +15116,7 @@
         "talk",
         "japanese"
       ],
+      "favicon": "https://www.fred.fm/wp-content/uploads/2014/12/Fred-Logo_trasp_-copia.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -15118,6 +15160,7 @@
         "mandarin",
         "taiwanese"
       ],
+      "favicon": "https://www.rti.org.tw/Static/tw/image/classifyLogo.png",
       "codec": "AAC",
       "geo": [
         25.033,
@@ -15139,6 +15182,7 @@
         "mandarin",
         "taiwanese"
       ],
+      "favicon": "https://www.rti.org.tw/Static/tw/image/classifyLogo.png",
       "codec": "AAC",
       "geo": [
         25.033,
@@ -15224,6 +15268,7 @@
         "mandarin",
         "taiwanese"
       ],
+      "favicon": "https://cdn.instant.audio/images/logos/radios-tw/good-news-fm.png",
       "bitrate": 65,
       "codec": "AAC",
       "geo": [
@@ -15244,6 +15289,7 @@
         "mandarin",
         "taiwanese"
       ],
+      "favicon": "https://cdn.instant.audio/images/logos/radios-tw/good-news-fm.png",
       "bitrate": 65,
       "codec": "AAC",
       "geo": [
@@ -15471,7 +15517,7 @@
         "israeli",
         "military"
       ],
-      "favicon": "https://static-media.streema.com/media/cache/34/ee/34ee4ed52c07ad09122cbe047a7c0bfd.jpg",
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/thumb/e/e2/GLGLZ.svg/250px-GLGLZ.svg.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -15494,6 +15540,7 @@
         "israeli",
         "military"
       ],
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/thumb/3/30/GaltzLogo.svg/120px-GaltzLogo.svg.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -15557,7 +15604,7 @@
         "hebrew",
         "israeli"
       ],
-      "favicon": "https://digital.100fm.co.il/logo192.png",
+      "favicon": "https://d20x387xvo6jlt.cloudfront.net/wp-content/uploads/2020/12/SmallLogo.png",
       "bitrate": 128,
       "codec": "AAC",
       "geo": [
@@ -15578,7 +15625,7 @@
         "talk",
         "israeli"
       ],
-      "favicon": "https://s.ashams.com/static/css/images/logo-header.png",
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/thumb/2/22/Ashams_radio.png/250px-Ashams_radio.png",
       "bitrate": 64,
       "codec": "AAC",
       "geo": [
@@ -15599,6 +15646,7 @@
         "hebrew",
         "israeli"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/4/118774.v1.png",
       "bitrate": 128,
       "codec": "AAC",
       "geo": [
@@ -15620,6 +15668,7 @@
         "spanish",
         "venezuelan"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/6/31866.v6.png",
       "bitrate": 64,
       "codec": "MP3",
       "geo": [
@@ -15685,7 +15734,7 @@
         "spanish",
         "venezuelan"
       ],
-      "favicon": "https://plugmedia.co/play/wp-content/uploads/2021/01/Logo_Guayana.png",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/8/29838.v14.png",
       "bitrate": 32,
       "codec": "MP3",
       "geo": [
@@ -15838,6 +15887,7 @@
         "spanish",
         "uruguayan"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/0/80340.v9.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -15881,7 +15931,7 @@
         "spanish",
         "uruguayan"
       ],
-      "favicon": "https://espectador.com/public/img/favicon/apple-touch-icon.png",
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b4/Elespectadoram850.png/250px-Elespectadoram850.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -15968,6 +16018,7 @@
         "spanish",
         "uruguayan"
       ],
+      "favicon": "https://radiocolonia.com/wp-content/uploads/2021/02/Logo-color.png",
       "bitrate": 128,
       "codec": "AAC",
       "geo": [
@@ -15989,6 +16040,7 @@
         "spanish",
         "ecuadorian"
       ],
+      "favicon": "https://web.canelaradio.com/wp-content/uploads/2021/02/LOGO-CANELA_Mesa-de-trabajo-1-min.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -16010,6 +16062,7 @@
         "spanish",
         "ecuadorian"
       ],
+      "favicon": "https://web.canelaradio.com/wp-content/uploads/2021/02/LOGO-CANELA_Mesa-de-trabajo-1-min.png",
       "bitrate": 64,
       "codec": "MP3",
       "geo": [
@@ -16031,6 +16084,7 @@
         "spanish",
         "ecuadorian"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/1/30721.v15.png",
       "bitrate": 112,
       "codec": "MP3",
       "geo": [
@@ -16052,6 +16106,7 @@
         "spanish",
         "ecuadorian"
       ],
+      "favicon": "https://www.americaestereo.com/wp-content/uploads/2023/10/NuevoLogo2024.png",
       "bitrate": 40,
       "codec": "MP3",
       "geo": [
@@ -16073,6 +16128,7 @@
         "spanish",
         "ecuadorian"
       ],
+      "favicon": "https://radioondapositiva.com/wp-content/uploads/2019/07/logo-radio-onda-positiva.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -16094,6 +16150,7 @@
         "spanish",
         "ecuadorian"
       ],
+      "favicon": "https://hcjb.org/wp-content/uploads/2025/01/cropped-cropped-cropped-HCJB-Logo-Official-1.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -16136,6 +16193,7 @@
         "spanish",
         "ecuadorian"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/8/29348.v10.png",
       "bitrate": 32,
       "codec": "MP3",
       "geo": [
@@ -16157,6 +16215,7 @@
         "spanish",
         "ecuadorian"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/2/29852.v23.png",
       "bitrate": 48,
       "codec": "MP3",
       "geo": [
@@ -16178,6 +16237,7 @@
         "spanish",
         "ecuadorian"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/4/128484.v1.png",
       "bitrate": 48,
       "codec": "AAC",
       "geo": [
@@ -16263,7 +16323,7 @@
         "spanish",
         "peruvian"
       ],
-      "favicon": "https://upload.wikimedia.org/wikipedia/commons/thumb/b/be/Logostudio92.png/225px-Logostudio92.png",
+      "favicon": "https://sstudio92.radio-grpp.io/static/img/logo_studio92.svg",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -16285,7 +16345,7 @@
         "spanish",
         "peruvian"
       ],
-      "favicon": "https://eaudioplayer.radio-grpp.io/static/dist/img/favicons/apple-touch-icon.png?v=2016063020297",
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/thumb/8/8a/Logo_corazon2024.svg/250px-Logo_corazon2024.svg.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -16307,6 +16367,7 @@
         "spanish",
         "peruvian"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/0/26640.v8.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -16328,6 +16389,7 @@
         "spanish",
         "peruvian"
       ],
+      "favicon": "https://sstudio92.radio-grpp.io/static/img/logos/la_zona.svg",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -16349,7 +16411,7 @@
         "spanish",
         "peruvian"
       ],
-      "favicon": "https://static.wikia.nocookie.net/tvpedia-peru/images/2/2a/Radio_Panamericana_Retro_Rock.jpg/revision/latest?cb=20240315103233&path-prefix=es",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/0/133620.v4.png",
       "bitrate": 127,
       "codec": "MP3",
       "geo": [
@@ -16699,7 +16761,7 @@
         "spanish",
         "argentinian"
       ],
-      "favicon": "https://fmrockandpop.com/pwa/ios_192x192.png",
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/thumb/3/37/Radio_rockpop.png/250px-Radio_rockpop.png",
       "bitrate": 64,
       "codec": "AAC",
       "geo": [
@@ -16743,6 +16805,7 @@
         "spanish",
         "argentinian"
       ],
+      "favicon": "https://bluefm.com.ar/wp-content/themes/bluefmtheme/img/logo_blue.png",
       "bitrate": 64,
       "codec": "AAC",
       "geo": [
@@ -16830,6 +16893,7 @@
         "spanish",
         "argentinian"
       ],
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/thumb/6/64/Radio_La_Red_AM_910.png/250px-Radio_La_Red_AM_910.png",
       "bitrate": 64,
       "codec": "AAC",
       "geo": [
@@ -16939,7 +17003,7 @@
         "spanish",
         "colombian"
       ],
-      "favicon": "https://www.tropicanafm.com/wp-content/uploads/2021/02/cropped-favicon_tropicana-180x180.png",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/7/21737.v22.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -16983,6 +17047,7 @@
         "spanish",
         "colombian"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/3/22093.v9.png",
       "bitrate": 48,
       "codec": "AAC",
       "geo": [
@@ -17070,7 +17135,7 @@
         "spanish",
         "colombian"
       ],
-      "favicon": "https://mixradio.co/icon?b8748d2f62517688",
+      "favicon": "https://strapi-aws-s3-images-mix-bucket.s3.us-east-1.amazonaws.com/mix_light_mode_07df7ce987.webp",
       "bitrate": 64,
       "codec": "AAC",
       "geo": [
@@ -17116,7 +17181,7 @@
         "portuguese",
         "brazilian"
       ],
-      "favicon": "https://public.ebc.com.br/templates/logos/v3/logo-ebc.svg",
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/thumb/2/24/R%C3%A1dio_MEC_logo_2023.svg/250px-R%C3%A1dio_MEC_logo_2023.svg.png",
       "codec": "AAC",
       "geo": [
         -22.9068,
@@ -17138,7 +17203,7 @@
         "portuguese",
         "brazilian"
       ],
-      "favicon": "https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fimages.seeklogo.com%2Flogo-png%2F49%2F1%2Fradio-mec-logo-png_seeklogo-494149.png&f=1&nofb=1&ipt=27ab00eb7c162df6795eb22aa64d4ce46646ba94477f562bb2907be4ba990d63",
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/thumb/2/24/R%C3%A1dio_MEC_logo_2023.svg/250px-R%C3%A1dio_MEC_logo_2023.svg.png",
       "bitrate": 307,
       "codec": "AAC",
       "geo": [
@@ -17160,7 +17225,7 @@
         "portuguese",
         "brazilian"
       ],
-      "favicon": "https://yt3.googleusercontent.com/9M9Ulf03D2Ms6haBGOclxqov778KbJdPgh7HlLjMrJOlvaQ4wf_3kqFb6armS5M1kn4ZvLdJmeE=s900-c-k-c0x00ffffff-no-rj",
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/thumb/5/5a/R%C3%A1dio_Nacional_logo_2023.svg/250px-R%C3%A1dio_Nacional_logo_2023.svg.png",
       "bitrate": 235,
       "codec": "AAC",
       "geo": [
@@ -17183,7 +17248,7 @@
         "portuguese",
         "brazilian"
       ],
-      "favicon": "https://yt3.googleusercontent.com/9M9Ulf03D2Ms6haBGOclxqov778KbJdPgh7HlLjMrJOlvaQ4wf_3kqFb6armS5M1kn4ZvLdJmeE=s900-c-k-c0x00ffffff-no-rj",
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/thumb/5/5a/R%C3%A1dio_Nacional_logo_2023.svg/250px-R%C3%A1dio_Nacional_logo_2023.svg.png",
       "bitrate": 235,
       "codec": "AAC",
       "geo": [
@@ -17294,6 +17359,7 @@
         "portuguese",
         "brazilian"
       ],
+      "favicon": "https://radiomixfm.com.br/wp-content/uploads/2017/06/logo-mix-pequeno.png",
       "bitrate": 64,
       "codec": "AAC",
       "geo": [
@@ -17314,6 +17380,7 @@
         "portuguese",
         "brazilian"
       ],
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/thumb/3/33/R%C3%A1dio_Rock_logo.svg/250px-R%C3%A1dio_Rock_logo.svg.png",
       "bitrate": 128,
       "codec": "AAC",
       "geo": [
@@ -17335,6 +17402,7 @@
         "portuguese",
         "brazilian"
       ],
+      "favicon": "https://jb.fm/static-images/logo-jb.png",
       "bitrate": 48,
       "codec": "AAC",
       "geo": [
@@ -17398,7 +17466,7 @@
         "oldies",
         "brazilian"
       ],
-      "favicon": "https://static.radios.com.br/img/apple-touch-icon.png",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/5/41465.v12.png",
       "bitrate": 48,
       "codec": "MP3",
       "geo": [
@@ -17508,7 +17576,7 @@
         "schlager",
         "south african"
       ],
-      "favicon": "https://www.lekkerfm.com/favicon.ico",
+      "favicon": "https://back.ww-cdn.com/superstatic/version/3848091/iphone/10/photo/sections_64541522_navBar_titleImage@2x.png?v=1721209190",
       "bitrate": 64,
       "codec": "MP3",
       "geo": [
@@ -17530,7 +17598,7 @@
         "talk",
         "south african"
       ],
-      "favicon": "https://www.ukhozifm.co.za/wp-content/uploads/2023/07/cropped-ukhozi-tranparent-logo.png",
+      "favicon": "https://www.ukhozifm.co.za/ukhozifm/wp-content/uploads/2024/10/cropped-cropped-cropped-ukhozi-tranparent-logo.png",
       "bitrate": 48,
       "codec": "AAC",
       "geo": [
@@ -17618,7 +17686,7 @@
         "english",
         "south african"
       ],
-      "favicon": "https://www.classic1027.co.za/assets/images/apple-touch-icon.png",
+      "favicon": "https://classicfm.co.za/images/logo.jpg",
       "codec": "AAC",
       "geo": [
         -26.2041,
@@ -17659,7 +17727,7 @@
         "electronic",
         "south african"
       ],
-      "favicon": "https://cdn.webrad.io/images/logos/radiosa-org/amapiano.png",
+      "favicon": "https://cdn.instant.audio/images/logos/radiosa-org/amapiano.png",
       "codec": "MP3",
       "geo": [
         -26.2041,
@@ -17680,7 +17748,7 @@
         "english",
         "south african"
       ],
-      "favicon": "https://www.google.com/search?q=joy+gospel+radio+group&client=ms-android-mobicell&prmd=nmiv&sxsrf=APq-WBvKOVGQbCq5i6NX0F8KleM7OsyOlg:1647248530624&source=lnms&tbm=isch&sa=X&ved=2ahUKEwig6pj8nsX2AhWCYsAKHbWfBZQQ_AUoA3oECAIQAw&biw=377&bih=627&dpr=1.27#imgrc=seUxB2JYeu2ZVM",
+      "favicon": "https://public-rf-upload.minhawebradio.net/211254/logo/38f4273533cf449f295262eee24a7d02.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -17702,6 +17770,7 @@
         "english",
         "ugandan"
       ],
+      "favicon": "https://mcfradio.co.ug/wp-content/uploads/2017/05/logo-MCF.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -17723,6 +17792,7 @@
         "english",
         "ugandan"
       ],
+      "favicon": "https://www.pearlfmuganda.com/pearlfmlogo.png",
       "bitrate": 96,
       "codec": "MP3",
       "geo": [
@@ -17743,6 +17813,7 @@
         "regional",
         "ugandan"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/8/131138.v1.png",
       "bitrate": 64,
       "codec": "MP3",
       "geo": [
@@ -17763,7 +17834,7 @@
         "talk",
         "ugandan"
       ],
-      "favicon": "https://akaboozi.com/wp-content/uploads/2022/03/cropped-site-logo-180x180.png",
+      "favicon": "https://cdn.instant.audio/images/logos/radio-co-ug/akaboozi-fm.png",
       "bitrate": 64,
       "codec": "MP3",
       "geo": [
@@ -17828,6 +17899,7 @@
         "talk",
         "indonesian"
       ],
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/thumb/5/59/Logoelshinta.png/250px-Logoelshinta.png",
       "bitrate": 256,
       "codec": "AAC",
       "geo": [
@@ -17870,6 +17942,7 @@
         "traditional",
         "indonesian"
       ],
+      "favicon": "https://campursarifm.com/images/logo-square.jpg",
       "bitrate": 48,
       "codec": "AAC",
       "geo": [
@@ -17890,6 +17963,7 @@
         "hits",
         "indonesian"
       ],
+      "favicon": "https://assets-static.iswaranetwork.com/2025/02/ISWARA-LOGO-MAIN-01.png",
       "codec": "AAC",
       "geo": [
         -6.2088,
@@ -17971,7 +18045,7 @@
         "hits",
         "filipino"
       ],
-      "favicon": "https://upload.wikimedia.org/wikipedia/en/6/60/1027starfm.png",
+      "favicon": "https://upload.wikimedia.org/wikipedia/en/thumb/6/60/1027starfm.png/250px-1027starfm.png",
       "codec": "MP3",
       "geo": [
         14.5995,
@@ -17991,7 +18065,7 @@
         "opm",
         "filipino"
       ],
-      "favicon": "https://azuretv2devewu00sca63.blob.core.windows.net/abscbnimages/icon.png",
+      "favicon": "https://upload.wikimedia.org/wikipedia/en/thumb/1/15/MOR_Entertainment_logo.png/250px-MOR_Entertainment_logo.png",
       "codec": "MP3",
       "geo": [
         14.5995,
@@ -18031,6 +18105,7 @@
         "opm",
         "filipino"
       ],
+      "favicon": "https://winradioph.net/wp-content/uploads/Logo.png",
       "codec": "MP3",
       "geo": [
         14.5995,
@@ -18050,7 +18125,7 @@
         "opm",
         "filipino"
       ],
-      "favicon": "https://www.loveradio.com.ph/apple-touch-icon.png",
+      "favicon": "https://upload.wikimedia.org/wikipedia/en/thumb/3/32/Love_Radio_2021_logo.png/250px-Love_Radio_2021_logo.png",
       "bitrate": 64,
       "codec": "MP3",
       "geo": [
@@ -18071,7 +18146,7 @@
         "talk",
         "filipino"
       ],
-      "favicon": "https://upload.wikimedia.org/wikipedia/en/thumb/4/40/Radyo5truefmlogo.webp/440px-Radyo5truefmlogo.webp.png",
+      "favicon": "https://upload.wikimedia.org/wikipedia/en/thumb/4/40/Radyo5truefmlogo.webp/250px-Radyo5truefmlogo.webp",
       "bitrate": 463,
       "codec": "AAC",
       "geo": [
@@ -18449,7 +18524,7 @@
         "hits",
         "turkish"
       ],
-      "favicon": "https://metrofm.com.tr/favicon.ico",
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/5/5b/Logo_of_Metro_FM.png",
       "bitrate": 64,
       "codec": "AAC",
       "geo": [
@@ -18639,7 +18714,7 @@
         "hindi",
         "indian"
       ],
-      "favicon": "https://liveradios.in/wp-content/uploads/output-onlinepngtools-1-150x150.png",
+      "favicon": "https://upload.wikimedia.org/wikipedia/en/thumb/7/7b/Akhashvani_logo.png/250px-Akhashvani_logo.png",
       "codec": "AAC",
       "geo": [
         28.6139,
@@ -18661,7 +18736,7 @@
         "hindi",
         "indian"
       ],
-      "favicon": "https://liveradios.in/wp-content/uploads/output-onlinepngtools-1-150x150.png",
+      "favicon": "https://upload.wikimedia.org/wikipedia/en/thumb/7/7b/Akhashvani_logo.png/250px-Akhashvani_logo.png",
       "codec": "AAC",
       "geo": [
         28.6139,
@@ -18703,7 +18778,7 @@
         "hindi",
         "indian"
       ],
-      "favicon": "http://mirchi.in/favicon-196x196.png",
+      "favicon": "https://upload.wikimedia.org/wikipedia/en/thumb/a/a7/Radiomirchi.jpg/250px-Radiomirchi.jpg",
       "codec": "AAC",
       "geo": [
         19.076,
@@ -18724,7 +18799,7 @@
         "hindi",
         "indian"
       ],
-      "favicon": "http://mirchi.in/favicon-196x196.png",
+      "favicon": "https://upload.wikimedia.org/wikipedia/en/thumb/a/a7/Radiomirchi.jpg/250px-Radiomirchi.jpg",
       "codec": "AAC",
       "geo": [
         19.076,
@@ -18978,6 +19053,7 @@
         "mandarin",
         "chinese"
       ],
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/thumb/5/54/Radio_China_International.svg/250px-Radio_China_International.svg.png",
       "codec": "AAC",
       "geo": [
         39.9042,
@@ -18998,6 +19074,7 @@
         "english",
         "chinese"
       ],
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/thumb/5/54/Radio_China_International.svg/250px-Radio_China_International.svg.png",
       "codec": "AAC",
       "geo": [
         39.9042,
@@ -19457,7 +19534,7 @@
         "spanish",
         "mexican"
       ],
-      "favicon": "https://i.iheart.com/v3/re/new_assets/ce6ef23e-2cdd-44a2-b139-c2b08f9365e3?ops=fit(240%2C240)",
+      "favicon": "https://upload.wikimedia.org/wikipedia/en/d/d9/XHM_88.9Noticias_logo.png",
       "bitrate": 48,
       "codec": "AAC",
       "geo": [
@@ -19479,7 +19556,7 @@
         "spanish",
         "mexican"
       ],
-      "favicon": "https://i.iheart.com/v3/re/new_assets/5bce06169803f27603c24988?ops=fit(240%2C240)",
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/thumb/b/bf/XHSH-FM.png/250px-XHSH-FM.png",
       "bitrate": 48,
       "codec": "AAC",
       "geo": [
@@ -19501,7 +19578,7 @@
         "spanish",
         "mexican"
       ],
-      "favicon": "https://recursosweb.prisaradio.com/fotos/original/010002851440.jpg",
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/thumb/f/fb/Ke_Buena_Logo.png/250px-Ke_Buena_Logo.png",
       "bitrate": 56,
       "codec": "AAC",
       "geo": [
@@ -19567,7 +19644,7 @@
         "spanish",
         "mexican"
       ],
-      "favicon": "https://www.iheart.com/favicon.ico",
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/thumb/7/75/La_Comadre_Logo.jpg/250px-La_Comadre_Logo.jpg",
       "bitrate": 48,
       "codec": "AAC",
       "geo": [
@@ -19589,7 +19666,7 @@
         "spanish",
         "mexican"
       ],
-      "favicon": "https://i.iheart.com/v3/re/new_assets/77b18faf-00b4-483d-bb24-377cdd4b4998?ops=fit(240%2C240)",
+      "favicon": "https://upload.wikimedia.org/wikipedia/en/thumb/7/7e/XHGV_106.5MIX_logo.png/250px-XHGV_106.5MIX_logo.png",
       "bitrate": 48,
       "codec": "AAC",
       "geo": [
@@ -19611,7 +19688,7 @@
         "spanish",
         "mexican"
       ],
-      "favicon": "https://i.iheart.com/v3/re/new_assets/5ef0b2287ec97a064f3322c7",
+      "favicon": "https://cdn-profiles.tunein.com/s1171/images/logod.png?t=637908714790000000",
       "bitrate": 32,
       "codec": "AAC",
       "geo": [
@@ -19633,6 +19710,7 @@
         "spanish",
         "mexican"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s47671/images/logod.jpg?t=637278363070000000",
       "bitrate": 48,
       "codec": "AAC",
       "geo": [
@@ -19699,7 +19777,7 @@
         "spanish",
         "mexican"
       ],
-      "favicon": "https://i.iheart.com/v3/re/new_assets/5ef0ca067ec97a064f3322c9",
+      "favicon": "https://upload.wikimedia.org/wikipedia/en/3/3e/Alfa_Radio_91.3fm.png",
       "bitrate": 32,
       "codec": "AAC",
       "geo": [
@@ -19721,7 +19799,7 @@
         "spanish",
         "mexican"
       ],
-      "favicon": "https://i.iheart.com/v3/re/new_assets/5ef0ca937ec97a064f3322cd",
+      "favicon": "https://grc-media.nyc3.cdn.digitaloceanspaces.com/uploads/sites/2/2025/10/logo_LaZ_400-edited.webp",
       "bitrate": 32,
       "codec": "AAC",
       "geo": [
@@ -19743,6 +19821,7 @@
         "spanish",
         "mexican"
       ],
+      "favicon": "https://upload.wikimedia.org/wikipedia/en/4/42/XHQQ_Banda93.3_logo.png",
       "bitrate": 32,
       "codec": "AAC",
       "geo": [
@@ -20203,6 +20282,7 @@
         "electronic",
         "elektro"
       ],
+      "favicon": "https://technolovers.fm/assets/img/technolovers-dark.png",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -20325,6 +20405,7 @@
         "hands up",
         "handsup"
       ],
+      "favicon": "https://technolovers.fm/assets/img/technolovers-dark.png",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -20392,6 +20473,7 @@
         "classics",
         "instrumental"
       ],
+      "favicon": "https://epic-piano.com/assets/img/epicpiano-dark.png",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -20415,6 +20497,7 @@
         "house",
         "ibiza"
       ],
+      "favicon": "https://technolovers.fm/assets/img/technolovers-dark.png",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -20451,6 +20534,7 @@
         "chillout+lounge",
         "lounge"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s310364/images/logod.jpg?t=637815426870000000",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -20506,6 +20590,7 @@
         "uplifting",
         "uplifting trance"
       ],
+      "favicon": "https://technolovers.fm/assets/img/technolovers-dark.png",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -20549,6 +20634,7 @@
         "classic rock",
         "country"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/6/34196.v9.png",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -20815,6 +20901,7 @@
         "instrumental",
         "piano"
       ],
+      "favicon": "https://epic-piano.com/assets/img/epicpiano-dark.png",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -21011,6 +21098,7 @@
         "elektro",
         "elektronik"
       ],
+      "favicon": "https://technolovers.fm/assets/img/technolovers-dark.png",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -21176,6 +21264,7 @@
         "happy hardcore",
         "hardcore"
       ],
+      "favicon": "https://technolovers.fm/assets/img/technolovers-dark.png",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -21256,6 +21345,7 @@
         "piano",
         "piano jazz"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s310369/images/logod.jpg?t=637815440490000000",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -21361,6 +21451,7 @@
         "classic",
         "classical"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s320513/images/logod.jpg?t=637931891670000000",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -21441,6 +21532,7 @@
         "electro house",
         "electronic"
       ],
+      "favicon": "https://technolovers.fm/assets/img/technolovers-dark.png",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -21501,6 +21593,7 @@
         "hardcore",
         "hardstyle"
       ],
+      "favicon": "https://technolovers.fm/assets/img/technolovers-dark.png",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -21524,6 +21617,7 @@
         "classic",
         "classical"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s320520/images/logod.jpg?t=637932432890000000",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -21578,6 +21672,7 @@
         "classical",
         "klassik"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s320513/images/logod.jpg?t=637931891670000000",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"

--- a/tools/apply-logos.mjs
+++ b/tools/apply-logos.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+/**
+ * Apply Sonnet-agent-discovered logo URLs from `internal/logos/all.json`
+ * into `data/stations.yaml`. Mirrors the surgical-insert pattern in
+ * `wire-metadata.mjs` / `scrape-logos.mjs` / `wiki-logos.mjs` so the
+ * existing hand-formatted YAML structure stays intact.
+ *
+ *   node tools/apply-logos.mjs                   # apply all
+ *   node tools/apply-logos.mjs --dry-run         # don't mutate yaml
+ *   node tools/apply-logos.mjs --in <path>       # default internal/logos/all.json
+ *
+ * Insert path only — agents only ran on stations with no current
+ * favicon, so there's nothing to replace. If a row already has a
+ * `favicon:` line (race against another tool), the entry is skipped
+ * and reported.
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, '..');
+
+const argv = process.argv.slice(2);
+const argFlag = (n) => argv.includes(n);
+const argVal = (n, fb) => {
+  const i = argv.indexOf(n);
+  return i >= 0 && argv[i + 1] ? argv[i + 1] : fb;
+};
+const DRY_RUN = argFlag('--dry-run');
+const inputPath = join(root, argVal('--in', 'internal/logos/all.json'));
+
+const stationsPath = join(root, 'data/stations.yaml');
+let text = readFileSync(stationsPath, 'utf8');
+const all = JSON.parse(readFileSync(inputPath, 'utf8'));
+
+const ok = all.filter((r) => r.id && r.url);
+console.log(`apply-logos: ${ok.length} url(s) to apply (of ${all.length} entries)`);
+
+let inserted = 0;
+let skippedAlreadyHas = 0;
+let skippedMissing = 0;
+
+for (const w of ok) {
+  const idLine = `- id: ${w.id}\n`;
+  const idIdx = text.indexOf(idLine);
+  if (idIdx === -1) {
+    skippedMissing++;
+    console.warn(`  ! couldn't locate id line for ${w.id}`);
+    continue;
+  }
+
+  // Bail if row already has a favicon line (race protection — could
+  // happen if another tool ran between when the agent generated the
+  // candidate and when this writer applies it).
+  const insertAt = idIdx + idLine.length;
+  let hasFav = false;
+  let p = insertAt;
+  while (p < text.length) {
+    const lineEnd = text.indexOf('\n', p);
+    const line = text.slice(p, lineEnd === -1 ? text.length : lineEnd);
+    if (line.startsWith('- id:')) break;
+    if (line.startsWith('  favicon:')) { hasFav = true; break; }
+    if (lineEnd === -1) break;
+    p = lineEnd + 1;
+  }
+  if (hasFav) {
+    skippedAlreadyHas++;
+    continue;
+  }
+
+  const quoted = /[:#&*!|>'"%@`,\[\]{}]/.test(w.url) ? JSON.stringify(w.url) : w.url;
+  text = text.slice(0, insertAt) + `  favicon: ${quoted}\n` + text.slice(insertAt);
+  inserted++;
+}
+
+if (DRY_RUN) {
+  console.log(
+    `apply-logos --dry-run: would insert ${inserted}, skip-already-has ${skippedAlreadyHas}, miss ${skippedMissing}`,
+  );
+  process.exit(0);
+}
+
+writeFileSync(stationsPath, text);
+console.log(
+  `apply-logos: inserted ${inserted}, skipped-already-has ${skippedAlreadyHas}, missing-id ${skippedMissing}`,
+);


### PR DESCRIPTION
## What

Validation round for LLM-agent logo lookup, the third tier in the cascade after homepage scrape (#178, +3,575 logos) and Wikipedia (#182, +309 logos).

| | |
|---|---:|
| Candidates | 200 |
| Logo URLs found | **173** |
| Hit rate | **86.5%** |
| Tokens (Sonnet) | ~528k |
| Wall clock per agent | 23–30 min |

## Workflow

The big change vs earlier sweeps: **agents don't write YAML.** They write per-batch JSON. After all agents finish, one deterministic Node pass inserts into YAML. This keeps LLM non-determinism out of the catalog pipeline and avoids the YAML merge-train problems we hit during country curation.

```
internal/logos/in-batch{1..4}.json     ← input split (50 stations each)
       ↓ Sonnet agents in parallel
internal/logos/out-batch{1..4}.json    ← {id, url, source} per station
       ↓ aggregate
internal/logos/all.json
       ↓ tools/apply-logos.mjs (deterministic surgical insert)
data/stations.yaml
```

## Per-agent precision rules

- HTTPS only (mixed-content rule)
- Direct image URL (`.png/.jpg/.svg/.webp`)
- Filename has "logo" OR matches station name
- HEAD-verified `image/*` before committing
- Skip on doubt: stock photos, expiring social-media URLs, TV logos for radio stations, generic favicons
- 2 web searches + 3 HEAD checks max per station — time-box, precision over recall

## Source distribution (173 hits)

| Source | Count |
|---|---:|
| broadcaster-site | 84 |
| wikipedia/commons | 43 |
| onlineradiobox CDN | 14 |
| radio-aggregator | 13 |
| press-kit | 8 |
| broadcaster-distributor | 5 |
| radio-directory | 4 |
| tunein-cdn | 2 |

## Skipped (27 nulls)

Unreachable broadcaster sites, no public logo asset, defunct stations, HTTP-only or stock-photo-only results, GIF-only formats. These stay in the long-tail residue.

## Gates

- [x] \`npm run catalog\` → 15,608/15,608 published
- [x] \`npm run check-catalog\` clean
- [x] \`npm run check-duplicates\` → 0 collisions
- [x] \`npm test -- --run\` → 311/311

## Followup

If production review looks good, scale to the remaining ~1,920 candidates: ~38 more agents at this hit rate would yield ~1,660 more logos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)