### PR TITLE
chore: agent-discovered station logos wave 2 (298 stations)

### DIFF
--- a/data/stations.yaml
+++ b/data/stations.yaml
@@ -1297,6 +1297,7 @@
   country: CH
   status: stream-only
 - id: ch-radio-rocket
+  favicon: "https://cdn-radiotime-logos.tunein.com/s264064d.png"
   stationuuid: 7e0a8594-c455-4e7a-be89-efe7e955944c
   changeuuid: f2580886-fed3-4065-9a7f-a04aa5a15a44
   reviewedAt: 2026-05-04
@@ -1759,6 +1760,7 @@
   country: CH
   status: stream-only
 - id: ch-christmas-radio-fm
+  favicon: "https://cdn-radiotime-logos.tunein.com/s117510d.png"
   stationuuid: 3f92bfe7-33a4-4246-ae2d-0333a50c7961
   changeuuid: ea62e8fe-e3d4-41e5-aa00-e1750f36f5dd
   reviewedAt: 2026-05-04
@@ -9362,6 +9364,7 @@
   country: AU
   status: stream-only
 - id: au-smooth-fm-953
+  favicon: "https://cdn-profiles.tunein.com/s98004/images/logod.jpg"
   stationuuid: 964fb9c9-0601-11e8-ae97-52543be04c81
   changeuuid: 2a0e9f33-31a9-466d-b237-577c6104f168
   reviewedAt: 2026-04-29
@@ -9575,6 +9578,7 @@
   country: PL
   status: stream-only
 - id: pl-rmf-przeboje
+  favicon: "https://cdn.onlineradiobox.com/img/l/7/1497.v10.png"
   stationuuid: 960f824a-0601-11e8-ae97-52543be04c81
   changeuuid: e0055c66-04d8-4d0d-a79e-bd4ba9b70427
   reviewedAt: 2026-04-29
@@ -9593,6 +9597,7 @@
   country: PL
   status: stream-only
 - id: pl-rmf-dance
+  favicon: "https://cdn.onlineradiobox.com/img/l/1/1481.v7.png"
   stationuuid: 960f7041-0601-11e8-ae97-52543be04c81
   changeuuid: 568d057f-3d32-461a-b2a6-55a1ec2de85e
   reviewedAt: 2026-04-29
@@ -10368,6 +10373,7 @@
   country: DK
   status: stream-only
 - id: dk-the-voice
+  favicon: "https://cdn.onlineradiobox.com/img/l/2/11832.v2.png"
   stationuuid: 632fe760-a124-4385-9061-6acb4bd14d0f
   changeuuid: 69ce43a4-6de3-4fe4-b684-590bed5aeb4a
   reviewedAt: 2026-04-30
@@ -12084,6 +12090,7 @@
   country: CZ
   status: stream-only
 - id: cz-kiss-98
+  favicon: "https://cdn.onlineradiobox.com/img/l/8/46858.v9.png"
   stationuuid: 960ed37d-0601-11e8-ae97-52543be04c81
   changeuuid: c695e7d1-c886-46b9-a120-52162f9a100b
   reviewedAt: 2026-04-30
@@ -12487,6 +12494,7 @@
   country: HR
   status: stream-only
 - id: hr-banovina-turbo
+  favicon: "https://cdn.onlineradiobox.com/img/l/3/75503.v8.png"
   stationuuid: 16b39855-7723-4bec-b2cb-c439ea3f90af
   changeuuid: c40aaa53-8cdd-4aa6-9dd7-35367be8dd6f
   reviewedAt: 2026-05-02
@@ -13084,6 +13092,7 @@
   country: BG
   status: stream-only
 - id: bg-bad-rock
+  favicon: "https://cdn.onlineradiobox.com/img/l/2/135012.v1.png"
   stationuuid: 2091bc8a-ced6-43cd-8f38-5b05d62ce3c5
   changeuuid: 75f964a4-daed-43be-a4fe-e1ec08575cd5
   reviewedAt: 2026-04-30
@@ -13494,6 +13503,7 @@
   country: RS
   status: stream-only
 - id: rs-rock-radio-beograd
+  favicon: "https://cdn.onlineradiobox.com/img/l/4/66594.v14.png"
   stationuuid: db4feb1f-93ad-418d-8124-2896035429d3
   changeuuid: 73e11424-18be-48a8-bca9-2d6cec4fb24d
   reviewedAt: 2026-04-30
@@ -13660,6 +13670,7 @@
   country: JP
   status: stream-only
 - id: jp-anime-para-ti
+  favicon: "https://cdn.onlineradiobox.com/img/l/8/104068.v2.png"
   stationuuid: 1adf1539-e647-44c3-85d8-b437b768fb8c
   changeuuid: 0e26c2fc-4e3b-4c75-bd4b-5122c5efc129
   reviewedAt: 2026-04-30
@@ -13715,6 +13726,7 @@
   country: JP
   status: stream-only
 - id: jp-free-fm-tokyo
+  favicon: "https://cdn.onlineradiobox.com/img/l/5/79635.v9.png"
   stationuuid: af566e6b-3d2b-4b96-92ca-a9cb183e6fd8
   changeuuid: 07f78037-cdcf-432d-8059-090e9c67f7b5
   reviewedAt: 2026-04-30
@@ -14644,6 +14656,7 @@
   country: UY
   status: stream-only
 - id: uy-concierto-fm-95
+  favicon: "https://cdn-profiles.tunein.com/s149403/images/logod.jpg"
   stationuuid: 42edf7a6-ed2d-4c02-ae9d-bca6f6809648
   changeuuid: db62407f-116c-44b0-ac0b-62c54a455574
   reviewedAt: 2026-04-30
@@ -16452,6 +16465,7 @@
   country: ID
   status: stream-only
 - id: id-hardrock-876
+  favicon: "https://assets-static.therockinlife.com/wp-content/uploads/2024/12/TRL-LOGO-2024-01.png"
   stationuuid: c77a82b2-ff5c-4010-a1bb-d2e767865e58
   changeuuid: 4ca366cc-5ac2-47f7-a540-ba45f5621b6e
   reviewedAt: 2026-04-30
@@ -16598,6 +16612,7 @@
   country: PH
   status: stream-only
 - id: ph-90s-pinoy-alt
+  favicon: "https://cdn.onlineradiobox.com/img/l/5/113125.v16.png"
   stationuuid: dae9feeb-8565-4c50-b2d1-5781081fccb8
   changeuuid: 417c2135-e2b8-409b-b5af-7c0307fab4f7
   reviewedAt: 2026-04-30
@@ -16837,6 +16852,7 @@
   country: TR
   status: stream-only
 - id: tr-damar-turk-fm
+  favicon: "https://cdn.onlineradiobox.com/img/l/2/68492.v23.png"
   stationuuid: f3dfbec0-8ddb-457c-94cd-368631337c0f
   changeuuid: 66241db9-9721-4041-a0c7-ffc5404c1a28
   reviewedAt: 2026-04-30
@@ -16965,6 +16981,7 @@
   country: AE
   status: stream-only
 - id: ae-quran-sharjah
+  favicon: "https://cdn.onlineradiobox.com/img/l/6/87476.v2.png"
   stationuuid: 7cca8bd6-a173-4fca-9a74-ca1e15a631e5
   changeuuid: c034a5f9-1ea9-4c02-92f0-7c3743f0fab4
   reviewedAt: 2026-04-30
@@ -16983,6 +17000,7 @@
   country: AE
   status: stream-only
 - id: ae-radio-mirchi-dubai
+  favicon: "https://cdn.onlineradiobox.com/img/l/4/18894.v9.png"
   stationuuid: 619478a1-fb89-4864-bf88-80e9ba7382ce
   changeuuid: f0465206-f59f-4a4b-9feb-f8fe6fa444a1
   reviewedAt: 2026-04-30
@@ -17019,6 +17037,7 @@
   country: AE
   status: stream-only
 - id: ae-classical-mozart
+  favicon: "https://cdn.onlineradiobox.com/img/l/8/112318.v3.png"
   stationuuid: 1dc6efa7-139b-4314-a990-dc954f55ed67
   changeuuid: c08dab33-4e62-4471-9cb4-f7759d6368c8
   reviewedAt: 2026-04-30
@@ -17037,6 +17056,7 @@
   country: AE
   status: stream-only
 - id: ae-exclusively-pink-floyd
+  favicon: "https://cdn.onlineradiobox.com/img/l/8/91208.v6.png"
   stationuuid: 501e4f18-fd92-441e-b4c6-4bd4a8435672
   changeuuid: 8d0fbca5-36f9-45b9-8c82-7122a30f0f05
   reviewedAt: 2026-04-30
@@ -17055,6 +17075,7 @@
   country: AE
   status: stream-only
 - id: in-vividh-bharati
+  favicon: "https://cdn.onlineradiobox.com/img/l/8/83448.v5.png"
   stationuuid: 902ea231-d537-4dc8-8708-6819418086d0
   changeuuid: 69266897-e8ae-4df4-aa56-d358e3d43e5f
   reviewedAt: 2026-04-30
@@ -18986,6 +19007,7 @@
   changeuuid: 45801c78-ed40-42e2-a5d5-5a657592c7a7
   reviewedAt: 2026-05-04
 - id: de-juka-radio-kpop
+  favicon: "https://cdn.onlineradiobox.com/img/l/4/82014.v6.png"
   broadcaster: independent
   name: juka radio kpop
   streamUrl: https://juka-kpop.stream.laut.fm/juka-kpop?t302=2021-04-01_09-03-35&uuid=6aa06ca0-9a01-407d-91af-155d24c5c405
@@ -19356,6 +19378,7 @@
   changeuuid: cfce2086-40c8-4e8b-abca-b8668da5870b
   reviewedAt: 2026-05-04
 - id: de-technolovers-afro-house
+  favicon: "https://cdn-profiles.tunein.com/s310360/images/logod.jpg"
   broadcaster: independent
   name: Technolovers - AFRO HOUSE
   streamUrl: https://stream.technolovers.fm/afro-house?ref=radiobrowser
@@ -19394,6 +19417,7 @@
   changeuuid: 8eae1bec-69c2-4c0f-9526-980f1536dc26
   reviewedAt: 2026-05-04
 - id: de-epic-lounge-nature-sounds
+  favicon: "https://cdn.onlineradiobox.com/img/l/7/120537.v4.png"
   broadcaster: independent
   name: Epic Lounge - NATURE SOUNDS
   streamUrl: https://stream.epic-lounge.com/nature-sounds?ref=radiobrowser
@@ -19458,6 +19482,7 @@
   changeuuid: 6271a1bf-7ea3-4501-9ffc-78f3643f9e20
   reviewedAt: 2026-05-04
 - id: de-epic-classical-classical-guitar
+  favicon: "https://cdn.onlineradiobox.com/img/l/3/118003.v2.png"
   broadcaster: independent
   name: EPIC CLASSICAL - Classical Guitar
   streamUrl: https://stream.epic-classical.com/classical-guitar
@@ -19470,6 +19495,7 @@
   changeuuid: 36ec73be-bac3-48fd-ad61-df9b10bec9f5
   reviewedAt: 2026-05-04
 - id: de-0nlineradio-80s-rock
+  favicon: "https://cdn.onlineradiobox.com/img/l/0/122680.v3.png"
   broadcaster: independent
   name: 0nlineradio 80s ROCK
   streamUrl: https://stream.0nlineradio.com/80s-rock?ref=radiobrowser
@@ -19507,6 +19533,7 @@
   changeuuid: 2b22ee00-c1c4-4a91-80dc-00079ccfdc44
   reviewedAt: 2026-05-04
 - id: de-technolovers-techhouse
+  favicon: "https://cdn-profiles.tunein.com/s310359/images/logod.jpg"
   broadcaster: independent
   name: Technolovers - TECHHOUSE
   streamUrl: https://stream.technolovers.fm/techhouse?ref=radiobrowser
@@ -19711,6 +19738,7 @@
   changeuuid: 9bcc32bc-0cc3-49e8-9682-9ca1191542af
   reviewedAt: 2026-05-04
 - id: de-epic-lounge-soft-house-lounge
+  favicon: "https://cdn.onlineradiobox.com/img/l/2/120522.v11.png"
   broadcaster: independent
   name: Epic Lounge - SOFT HOUSE LOUNGE
   streamUrl: https://stream.epic-lounge.com/soft-house-lounge?ref=radiobrowser
@@ -19736,6 +19764,7 @@
   changeuuid: c3b061eb-421d-4603-b192-19ee8fa21e36
   reviewedAt: 2026-05-04
 - id: de-0nlineradio-mozart
+  favicon: "https://cdn-profiles.tunein.com/s309936/images/logod.jpg"
   broadcaster: independent
   name: 0nlineradio MOZART
   streamUrl: https://stream.0nlineradio.com/mozart?ref=radiobrowser
@@ -19748,6 +19777,7 @@
   changeuuid: 9b763916-ae72-4ce5-a7ee-cfa0e692d750
   reviewedAt: 2026-05-04
 - id: de-technolovers-gabber
+  favicon: "https://cdn-profiles.tunein.com/s310344/images/logod.jpg"
   broadcaster: independent
   name: Technolovers - GABBER
   streamUrl: https://stream.technolovers.fm/gabber?ref=radiobrowser
@@ -19903,6 +19933,7 @@
   changeuuid: c6d92654-81a2-4e8b-ad7b-0f468c0e20e2
   reviewedAt: 2026-05-04
 - id: de-0nlineradio-50s
+  favicon: "https://cdn.onlineradiobox.com/img/l/6/122676.v3.png"
   broadcaster: independent
   name: 0nlineradio 50s
   streamUrl: https://stream.0nlineradio.com/50s?ref=radiobrowser
@@ -19979,6 +20010,7 @@
   changeuuid: fdf867a7-6bb3-4d18-b723-0160dbaefdc9
   reviewedAt: 2026-05-04
 - id: de-solo-piano-by-epic-piano
+  favicon: "https://epic-piano.com/assets/img/epicpiano-dark.png"
   broadcaster: independent
   name: SOLO PIANO by Epic Piano
   streamUrl: https://stream.epic-piano.com/solo-piano?ref=radiobrowser
@@ -20056,6 +20088,7 @@
   changeuuid: b0d09c3f-86ef-40fc-8ff0-a4fec12e6df9
   reviewedAt: 2026-05-04
 - id: de-0nlineradio-60s
+  favicon: "https://cdn.onlineradiobox.com/img/l/7/122677.v3.png"
   broadcaster: independent
   name: 0nlineradio 60s
   streamUrl: https://stream.0nlineradio.com/60s?ref=radiobrowser
@@ -20146,6 +20179,7 @@
   changeuuid: 19c7b62b-c195-4ed9-baad-3b11ee70aadf
   reviewedAt: 2026-05-04
 - id: de-0nlineradio-70s
+  favicon: "https://cdn.onlineradiobox.com/img/l/8/122678.v3.png"
   broadcaster: independent
   name: 0nlineradio 70s
   streamUrl: https://stream.0nlineradio.com/70s?ref=radiobrowser
@@ -20236,6 +20270,7 @@
   changeuuid: 73a36450-e56a-4f0d-9278-c14cd5cad309
   reviewedAt: 2026-05-04
 - id: de-0nlineradio-metal
+  favicon: "https://cdn.onlineradiobox.com/img/l/7/122707.v3.png"
   broadcaster: independent
   name: 0nlineradio METAL
   streamUrl: https://stream.0nlineradio.com/metal?ref=radiobrowser
@@ -20248,6 +20283,7 @@
   changeuuid: e4472734-def8-41d1-bc45-3d77d10e65d5
   reviewedAt: 2026-05-04
 - id: de-technolovers-tropical-house
+  favicon: "https://cdn-profiles.tunein.com/s310158/images/logod.jpg"
   broadcaster: independent
   name: Technolovers TROPICAL HOUSE
   streamUrl: https://stream.technolovers.fm/tropical-house?ref=radiobrowser
@@ -20260,6 +20296,7 @@
   changeuuid: 8c306648-0f8e-4190-bd09-91bda301dc9a
   reviewedAt: 2026-05-04
 - id: de-epic-lounge-coffee-bar-lounge
+  favicon: "https://cdn.onlineradiobox.com/img/l/3/120523.v3.png"
   broadcaster: independent
   name: Epic Lounge - COFFEE BAR LOUNGE
   streamUrl: https://stream.epic-lounge.com/coffee-bar-lounge?ref=radiobrowser
@@ -20272,6 +20309,7 @@
   changeuuid: f7597b64-d18a-4538-8547-e482aff0b24a
   reviewedAt: 2026-05-04
 - id: de-hirschmilch-radio
+  favicon: "https://hirschmilch.de/logo.png"
   broadcaster: independent
   name: Hirschmilch Radio
   streamUrl: https://hirschmilch.de:7001/chillout.mp3
@@ -20297,6 +20335,7 @@
   changeuuid: 19c1a796-a98e-4ff0-9b6e-4bac4ad19d32
   reviewedAt: 2026-05-04
 - id: de-0nlineradio-greatest-hits
+  favicon: "https://cdn-profiles.tunein.com/s309751/images/logod.jpg"
   broadcaster: independent
   name: 0nlineradio GREATEST HITS
   streamUrl: https://stream.0nlineradio.com/greatest-hits?ref=radiobrowser
@@ -20309,6 +20348,7 @@
   changeuuid: 020c0e61-7759-4b20-91db-85107f0e3506
   reviewedAt: 2026-05-04
 - id: de-epic-classical-classical-relax
+  favicon: "https://cdn.onlineradiobox.com/img/l/0/118000.v2.png"
   broadcaster: independent
   name: EPIC CLASSICAL - Classical Relax
   streamUrl: https://stream.epic-classical.com/classical-relax
@@ -20503,6 +20543,7 @@
   changeuuid: 5a37ac65-2478-4f20-8ac6-51c10e7c6122
   reviewedAt: 2026-05-04
 - id: de-0nlineradio-90s
+  favicon: "https://cdn.onlineradiobox.com/img/l/1/122681.v3.png"
   broadcaster: independent
   name: 0nlineradio 90s
   streamUrl: https://stream.0nlineradio.com/90s?ref=radiobrowser
@@ -20528,6 +20569,7 @@
   changeuuid: 427887d5-d13b-479e-8ef7-810a80120176
   reviewedAt: 2026-05-04
 - id: de-0nlineradio-80s
+  favicon: "https://cdn.onlineradiobox.com/img/l/9/122679.v3.png"
   broadcaster: independent
   name: 0nlineradio 80s
   streamUrl: https://stream.0nlineradio.com/80s?ref=radiobrowser
@@ -20540,6 +20582,7 @@
   changeuuid: 46b6dcea-2bd9-457e-a24d-a3b21eb13789
   reviewedAt: 2026-05-04
 - id: de-0nlineradio-beethoven
+  favicon: "https://cdn-profiles.tunein.com/s309932/images/logod.jpg"
   broadcaster: independent
   name: 0nlineradio BEETHOVEN
   streamUrl: https://stream.0nlineradio.com/beethoven?ref=radiobrowser
@@ -20552,6 +20595,7 @@
   changeuuid: 5a0b60bf-48ff-4445-baaf-d767be047693
   reviewedAt: 2026-05-04
 - id: de-epic-lounge-french-cafe-lounge
+  favicon: "https://cdn.onlineradiobox.com/img/l/2/120532.v4.png"
   broadcaster: independent
   name: Epic Lounge - FRENCH CAFÉ LOUNGE
   streamUrl: https://0nlineradio.stream42.radiohost.de/lounge-french-cafe-lounge?ref=radiobrowser&upd-meta&upd-scheme=https&_art=dD0xNzY4NDQ1MTE3JmQ9ODA5N2Q3ZjM4NTY5ZGM3NzdlNTM
@@ -20642,6 +20686,7 @@
   changeuuid: f08f86be-941c-4b50-b851-d027aad05bc8
   reviewedAt: 2026-05-04
 - id: de-technolovers-melbourne-bounce
+  favicon: "https://cdn-profiles.tunein.com/s310148/images/logod.jpg"
   broadcaster: independent
   name: Technolovers MELBOURNE BOUNCE
   streamUrl: https://stream.technolovers.fm/melbourne-bounce?ref=radiobrowser
@@ -20667,6 +20712,7 @@
   changeuuid: 1c4b20b7-453a-4047-8f91-edcd777d5e96
   reviewedAt: 2026-05-04
 - id: de-0nlineradio-house
+  favicon: "https://cdn-profiles.tunein.com/s309752/images/logod.jpg"
   broadcaster: independent
   name: 0nlineradio HOUSE
   streamUrl: https://stream.0nlineradio.com/house?ref=radiobrowser
@@ -20679,6 +20725,7 @@
   changeuuid: ce3ef314-3dd1-42c4-822c-e836ee401141
   reviewedAt: 2026-05-04
 - id: de-technolovers-frenchcore
+  favicon: "https://cdn-profiles.tunein.com/s310350/images/logod.jpg"
   broadcaster: independent
   name: Technolovers - FRENCHCORE
   streamUrl: https://stream.technolovers.fm/frenchcore?ref=radiobrowser
@@ -20717,6 +20764,7 @@
   changeuuid: d9f53f10-6949-46de-9652-4df837b8dd6c
   reviewedAt: 2026-05-04
 - id: de-technolovers-house
+  favicon: "https://cdn-profiles.tunein.com/s310144/images/logod.jpg"
   broadcaster: independent
   name: Technolovers HOUSE
   streamUrl: https://stream.technolovers.fm/house?ref=radiobrowser
@@ -20742,6 +20790,7 @@
   changeuuid: 3a425865-5094-4639-804d-cf478a9b7c04
   reviewedAt: 2026-05-04
 - id: de-rbb-24-inforadio
+  favicon: "https://upload.wikimedia.org/wikipedia/commons/6/62/Rbb24_Inforadio_Logo_2022.svg"
   broadcaster: independent
   name: RBB 24 Inforadio
   streamUrl: https://f121.rndfnk.com/ard/rbb/inforadio/live/mp3/128/stream.mp3?cid=01FC1WYDPN76K6HSCD8QCR9D3S&sid=2QcLzffN32wHfW1lVCzlxHze7qi&token=pGWtFx8DdsdTygJQfppoygwrmQAJ9neXn-Oapylzh_E&tvf=RIPifb2zZBdmMTIxLnJuZGZuay5jb20
@@ -20754,6 +20803,7 @@
   changeuuid: 9dbd0b80-760b-486d-8c34-b08321e05055
   reviewedAt: 2026-05-04
 - id: de-epic-classical-classical-chillout
+  favicon: "https://cdn-profiles.tunein.com/s320517/images/logod.jpg"
   broadcaster: independent
   name: EPIC CLASSICAL - Classical Chillout
   streamUrl: https://stream.epic-classical.com/classical-chillout?ref=liveradio
@@ -20830,6 +20880,7 @@
   changeuuid: 4c32e997-4df2-48f0-b98c-b3f0fc83a12b
   reviewedAt: 2026-05-04
 - id: de-piano-coverhits-by-epic-piano
+  favicon: "https://cdn-profiles.tunein.com/s310028/images/logod.jpg"
   broadcaster: independent
   name: PIANO COVERHITS by Epic Piano
   streamUrl: https://stream.epic-piano.com/piano-coverhits?ref=radiobrowser
@@ -20855,6 +20906,7 @@
   changeuuid: e5d598f7-4017-4e86-b77c-8611626c8793
   reviewedAt: 2026-05-04
 - id: de-technolovers-trance
+  favicon: "https://cdn-profiles.tunein.com/s310163/images/logod.jpg"
   broadcaster: independent
   name: Technolovers TRANCE
   streamUrl: https://stream.technolovers.fm/trance?ref=radiobrowser
@@ -20867,6 +20919,7 @@
   changeuuid: 7e5e4be7-3a62-491c-bbbc-5d492b05870e
   reviewedAt: 2026-05-04
 - id: de-0nlineradio-2000er
+  favicon: "https://cdn-profiles.tunein.com/s309736/images/logod.jpg"
   broadcaster: independent
   name: 0nlineradio 2000er
   streamUrl: https://stream.0nlineradio.com/2000er?ref=radiobrowser
@@ -20943,6 +20996,7 @@
   changeuuid: cf3f8db6-d84c-4185-91e5-52623faf316d
   reviewedAt: 2026-05-04
 - id: de-epic-classical-classical-romance
+  favicon: "https://cdn-profiles.tunein.com/s320508/images/logod.jpg"
   broadcaster: independent
   name: EPIC CLASSICAL - Classical Romance
   streamUrl: https://stream.epic-classical.com/classical-romance
@@ -20993,6 +21047,7 @@
   changeuuid: fbfdc04e-76d6-4aa0-b2d2-b07518561f17
   reviewedAt: 2026-05-04
 - id: de-christmas-piano-by-epic-piano
+  favicon: "https://cdn-profiles.tunein.com/s310036/images/logod.jpg"
   broadcaster: independent
   name: CHRISTMAS PIANO by Epic Piano
   streamUrl: https://stream.epic-piano.com/christmas-piano?ref=radiobrowser
@@ -21031,6 +21086,7 @@
   changeuuid: 5ea2928e-7293-47c0-b170-1b76de1f1f68
   reviewedAt: 2026-05-04
 - id: de-epic-lounge-new-york-lounge
+  favicon: "https://cdn-profiles.tunein.com/s320534/images/logod.jpg"
   broadcaster: independent
   name: Epic Lounge - NEW YORK LOUNGE
   streamUrl: https://stream.epic-lounge.com/new-york-lounge
@@ -21043,6 +21099,7 @@
   changeuuid: 1ead6a4e-f423-453d-b5f7-684c7b1db9a0
   reviewedAt: 2026-05-04
 - id: de-technolovers-trap
+  favicon: "https://cdn-profiles.tunein.com/s310154/images/logod.jpg"
   broadcaster: independent
   name: Technolovers TRAP
   streamUrl: https://stream.technolovers.fm/trap?ref=radiobrowser
@@ -21055,6 +21112,7 @@
   changeuuid: c08c3fbd-1194-45e9-841b-89258c1735b0
   reviewedAt: 2026-05-04
 - id: de-epic-classical-classical-study
+  favicon: "https://cdn-profiles.tunein.com/s320510/images/logod.jpg"
   broadcaster: independent
   name: EPIC CLASSICAL - Classical Study
   streamUrl: https://stream.epic-classical.com/classical-study
@@ -21080,6 +21138,7 @@
   changeuuid: a881ce29-ecba-43ec-afb4-f3ef3520fd0b
   reviewedAt: 2026-05-04
 - id: de-technolovers-dirty-house
+  favicon: "https://cdn-profiles.tunein.com/s310160/images/logod.jpg"
   broadcaster: independent
   name: Technolovers DIRTY HOUSE
   streamUrl: https://stream.technolovers.fm/dirty-house?ref=radiobrowser
@@ -21234,6 +21293,7 @@
   changeuuid: 1c27f1f2-325a-49e9-8243-167b6712d8ba
   reviewedAt: 2026-05-04
 - id: de-epic-classical-classical-orchestral
+  favicon: "https://cdn-profiles.tunein.com/s320525/images/logod.jpg"
   broadcaster: independent
   name: EPIC CLASSICAL - Classical Orchestral
   streamUrl: https://stream.epic-classical.com/classical-orchestral?ref=liveradio
@@ -21246,6 +21306,7 @@
   changeuuid: 2cf3e2d1-195a-4397-a802-35f7d3b43bc0
   reviewedAt: 2026-05-04
 - id: de-0nlineradio-gospel
+  favicon: "https://cdn-profiles.tunein.com/s309749/images/logod.jpg"
   broadcaster: independent
   name: 0nlineradio GOSPEL
   streamUrl: https://stream.0nlineradio.com/gospel?ref=radiobrowser
@@ -21258,6 +21319,7 @@
   changeuuid: a024a580-8a9e-46a8-a433-13fbb738fefd
   reviewedAt: 2026-05-04
 - id: de-epic-lounge-beach-club-lounge
+  favicon: "https://cdn-profiles.tunein.com/s310481/images/logod.jpg"
   broadcaster: independent
   name: Epic Lounge - BEACH CLUB LOUNGE
   streamUrl: https://stream.epic-lounge.com/beach-club-lounge?ref=radiobrowser
@@ -21270,6 +21332,7 @@
   changeuuid: 9b700ca5-8417-45a6-8d60-3d22feeb9570
   reviewedAt: 2026-05-04
 - id: de-epic-lounge-spa-lounge
+  favicon: "https://cdn-profiles.tunein.com/s310368/images/logod.jpg"
   broadcaster: independent
   name: Epic Lounge - SPA LOUNGE
   streamUrl: https://stream.epic-lounge.com/spa-lounge?ref=radiobrowser
@@ -21438,6 +21501,7 @@
   changeuuid: 9ff467b3-041e-4010-800d-0d3df0fe6726
   reviewedAt: 2026-05-04
 - id: de-80s-90s
+  favicon: "https://cdn-profiles.tunein.com/s311284/images/logod.png"
   broadcaster: independent
   name: 80s-90s
   streamUrl: https://stream.laut.fm/80s-90s
@@ -21540,6 +21604,7 @@
   changeuuid: 8c28cca1-5bba-41e8-8234-05b266d9902a
   reviewedAt: 2026-05-04
 - id: de-0nlineradio-neue-deutsche-welle
+  favicon: "https://cdn-profiles.tunein.com/s309762/images/logod.jpg"
   broadcaster: independent
   name: 0nlineradio NEUE DEUTSCHE WELLE
   streamUrl: https://stream.0nlineradio.com/neuedeutschewelle?ref=radiobrowser
@@ -21578,6 +21643,7 @@
   changeuuid: 603d8449-bd0b-41d6-a0ed-8d5b810747f8
   reviewedAt: 2026-05-04
 - id: de-epic-lounge-lounge-covers
+  favicon: "https://cdn-profiles.tunein.com/s310370/images/logod.jpg"
   broadcaster: independent
   name: Epic Lounge - LOUNGE COVERS
   streamUrl: https://stream.epic-lounge.com/lounge-covers?ref=radiobrowser
@@ -21590,6 +21656,7 @@
   changeuuid: 377e52a4-a8e9-4ec9-9bbc-84da38fc16dd
   reviewedAt: 2026-05-04
 - id: de-great-piano-concerts-by-epic-piano
+  favicon: "https://cdn-profiles.tunein.com/s310029/images/logod.jpg"
   broadcaster: independent
   name: GREAT PIANO CONCERTS by Epic Piano
   streamUrl: https://stream.epic-piano.com/great-piano-concerts?ref=radiobrowser
@@ -21666,6 +21733,7 @@
   changeuuid: 1ffc517c-6ec2-4405-b3eb-7aa61aebe7eb
   reviewedAt: 2026-05-04
 - id: de-0nlineradio-schlager
+  favicon: "https://cdn-profiles.tunein.com/s309768/images/logod.jpg"
   broadcaster: independent
   name: 0nlineradio SCHLAGER
   streamUrl: https://stream.0nlineradio.com/schlager?ref=radiobrowser
@@ -21769,6 +21837,7 @@
   changeuuid: 06349ce0-b275-46bc-8272-3ba9b0d12c23
   reviewedAt: 2026-05-04
 - id: de-0nlineradio-schlager-evergreens
+  favicon: "https://cdn-profiles.tunein.com/s309769/images/logod.jpg"
   broadcaster: independent
   name: 0nlineradio SCHLAGER EVERGREENS
   streamUrl: https://stream.0nlineradio.com/schlager-evergreens?ref=radiobrowser
@@ -21846,6 +21915,7 @@
   changeuuid: 95e22c4f-e13b-422c-97b0-5c498628b0d3
   reviewedAt: 2026-05-04
 - id: de-epic-classical-classical-hotel-lounge
+  favicon: "https://cdn-profiles.tunein.com/s320507/images/logod.jpg"
   broadcaster: independent
   name: EPIC CLASSICAL - Classical Hotel Lounge
   streamUrl: https://stream.epic-classical.com/classical-hotel-lounge
@@ -21894,6 +21964,7 @@
   changeuuid: e9f49e23-a9d1-4f69-bde5-55c120ba6651
   reviewedAt: 2026-05-04
 - id: de-0nlineradio-schubert
+  favicon: "https://cdn-profiles.tunein.com/s309933/images/logod.jpg"
   broadcaster: independent
   name: 0nlineradio SCHUBERT
   streamUrl: https://stream.0nlineradio.com/schubert?ref=radiobrowser
@@ -21906,6 +21977,7 @@
   changeuuid: b0ed6dbd-453a-44b6-bb8d-f041207e4530
   reviewedAt: 2026-05-04
 - id: de-i-love-dance-first
+  favicon: "https://cdn-profiles.tunein.com/s306646/images/logod.png"
   broadcaster: independent
   name: I Love - Dance first!
   streamUrl: https://ilm.stream35.radiohost.de/ilm_ilovedancefirst_mp3-192?upd-meta&upd-scheme=https&_art=dD0xNzY4NDU2NzE2JmQ9OGJiYTc3MmNmYjNjMWZkMjkxZGY
@@ -21957,6 +22029,7 @@
   changeuuid: fa75234b-e452-4dbb-8335-5bbe7be48193
   reviewedAt: 2026-05-04
 - id: de-0nlineradio-schlager-oldies
+  favicon: "https://cdn-profiles.tunein.com/s309770/images/logod.jpg"
   broadcaster: independent
   name: 0nlineradio SCHLAGER OLDIES
   streamUrl: https://stream.0nlineradio.com/schlager-oldies?ref=radiobrowser
@@ -21982,6 +22055,7 @@
   changeuuid: ccb4e08e-076c-475a-a7aa-0a3725af6326
   reviewedAt: 2026-05-04
 - id: de-wdr3-256
+  favicon: "https://upload.wikimedia.org/wikipedia/commons/e/e6/WDR_3_logo.svg"
   broadcaster: independent
   name: wdr3 256
   streamUrl: https://wdr-wdr3-live.icecastssl.wdr.de/wdr/wdr3/live/mp3/256/stream.mp3
@@ -22201,6 +22275,7 @@
   changeuuid: 68c65030-d0ef-457b-9114-9688731fe3b3
   reviewedAt: 2026-05-04
 - id: de-0nlineradio-classic-rock
+  favicon: "https://cdn-profiles.tunein.com/s309742/images/logod.jpg"
   broadcaster: independent
   name: 0nlineradio CLASSIC ROCK
   streamUrl: https://stream.0nlineradio.com/classic-rock?ref=radiobrowser
@@ -22278,6 +22353,7 @@
   changeuuid: fd5dd67c-cf8b-439d-b71e-2bdb2adf0dee
   reviewedAt: 2026-05-04
 - id: de-epic-lounge-hotel-lounge
+  favicon: "https://cdn-profiles.tunein.com/s310366/images/logod.jpg"
   broadcaster: independent
   name: Epic Lounge - HOTEL LOUNGE
   streamUrl: https://stream.epic-lounge.com/hotel-lounge?ref=radiobrowser
@@ -22316,6 +22392,7 @@
   changeuuid: 6f5686fd-702b-4c7c-926d-00e3330e1f6b
   reviewedAt: 2026-05-04
 - id: de-epic-lounge-restaurant-lounge
+  favicon: "https://cdn-profiles.tunein.com/s310483/images/logod.jpg"
   broadcaster: independent
   name: Epic Lounge - RESTAURANT LOUNGE
   streamUrl: https://stream.epic-lounge.com/restaurant-lounge?ref=radiobrowser
@@ -22328,6 +22405,7 @@
   changeuuid: 6d22afb2-0b8e-45fc-a838-63c386be992e
   reviewedAt: 2026-05-04
 - id: de-radiomonster-fm-evergreens
+  favicon: "https://cdn-profiles.tunein.com/s233214/images/logod.png"
   broadcaster: independent
   name: Radiomonster.FM - Evergreens
   streamUrl: https://ic.radiomonster.fm/evergreens.ultra
@@ -22378,6 +22456,7 @@
   changeuuid: ec815505-8357-4d17-9159-68feaa89a91c
   reviewedAt: 2026-05-04
 - id: de-100-5-das-hitradio-alemannia-livestream
+  favicon: "https://upload.wikimedia.org/wikipedia/commons/3/39/100%2C5_Das_Hitradio_Logo.png"
   broadcaster: independent
   name: 100,5 DAS HITRADIO Alemannia-Livestream
   streamUrl: https://stream.dashitradio.de/alemannia/mp3-128/stream.mp3
@@ -22468,6 +22547,7 @@
   changeuuid: 81223dfb-8d37-4d01-8685-915303dd9e3c
   reviewedAt: 2026-05-04
 - id: de-epic-classical-classical-love-music
+  favicon: "https://cdn-profiles.tunein.com/s320519/images/logod.jpg"
   broadcaster: independent
   name: EPIC CLASSICAL - Classical Love Music
   streamUrl: https://stream.epic-classical.com/classical-love-music
@@ -22493,6 +22573,7 @@
   changeuuid: b4b2a96a-fc95-4799-a2f7-282cc8d471fc
   reviewedAt: 2026-05-04
 - id: de-liszt-by-epic-piano
+  favicon: "https://cdn-profiles.tunein.com/s310033/images/logod.jpg"
   broadcaster: independent
   name: LISZT by Epic Piano
   streamUrl: https://stream.epic-piano.com/liszt?ref=radiobrowser
@@ -22647,6 +22728,7 @@
   changeuuid: 2d4c883b-d076-444a-a3b5-885d44ce0485
   reviewedAt: 2026-05-04
 - id: de-technolovers-latin-house
+  favicon: "https://cdn-profiles.tunein.com/s310147/images/logod.jpg"
   broadcaster: independent
   name: Technolovers LATIN HOUSE
   streamUrl: https://stream.technolovers.fm/latinhouse?ref=radiobrowser
@@ -22749,6 +22831,7 @@
   changeuuid: eea70cf5-cb8b-4abd-9972-c131b2536054
   reviewedAt: 2026-05-04
 - id: de-epic-classical-classical-restaurant-music
+  favicon: "https://cdn-profiles.tunein.com/s320511/images/logod.jpg"
   broadcaster: independent
   name: EPIC CLASSICAL - Classical Restaurant Music
   streamUrl: https://stream.epic-classical.com/classical-restaurant-music
@@ -22787,6 +22870,7 @@
   changeuuid: a9238f3f-d55a-49b9-8b46-f02ac2792168
   reviewedAt: 2026-05-04
 - id: de-epic-classical-classical-lounge
+  favicon: "https://cdn-profiles.tunein.com/s320527/images/logod.jpg"
   broadcaster: independent
   name: EPIC CLASSICAL - Classical Lounge
   streamUrl: https://stream.epic-classical.com/classical-lounge
@@ -22888,6 +22972,7 @@
   changeuuid: 1bc2d87a-02c1-4635-a6a9-57b5de524b4c
   reviewedAt: 2026-05-04
 - id: de-gamernetfm
+  favicon: "https://cdn-profiles.tunein.com/s317224/images/logod.png"
   broadcaster: independent
   name: GamerNETfm
   streamUrl: https://gamernetfm.stream.laut.fm/gamernetfm
@@ -22912,6 +22997,7 @@
   changeuuid: afeb7da2-d9a5-4769-9e73-c41efb19d027
   reviewedAt: 2026-05-04
 - id: de-0nlineradio-2010er
+  favicon: "https://cdn-profiles.tunein.com/s309737/images/logod.jpg"
   broadcaster: independent
   name: 0nlineradio 2010er
   streamUrl: https://stream.0nlineradio.com/2010er?ref=radiobrowser
@@ -22924,6 +23010,7 @@
   changeuuid: 3940a2b3-b395-41a1-ae13-8bd8d8a17a1d
   reviewedAt: 2026-05-04
 - id: de-epic-lounge-summer-lounge
+  favicon: "https://cdn-profiles.tunein.com/s320532/images/logod.jpg"
   broadcaster: independent
   name: Epic Lounge - SUMMER LOUNGE
   streamUrl: https://stream.epic-lounge.com/summer-lounge
@@ -22948,6 +23035,7 @@
   changeuuid: 9cb2125c-9530-4e3b-8adc-08734b7122da
   reviewedAt: 2026-05-04
 - id: de-epic-lounge-soul-lounge
+  favicon: "https://cdn-profiles.tunein.com/s310486/images/logod.jpg"
   broadcaster: independent
   name: Epic Lounge - SOUL LOUNGE
   streamUrl: https://stream.epic-lounge.com/soul-lounge?ref=radiobrowser
@@ -22973,6 +23061,7 @@
   changeuuid: 6daf39f1-1f89-4b19-9e2b-d2c7405e7763
   reviewedAt: 2026-05-04
 - id: de-alpenweihnacht
+  favicon: "https://alpenweihnacht.de/AW.jpg"
   broadcaster: independent
   name: Alpenweihnacht
   streamUrl: https://stream.laut.fm/alpenweihnacht
@@ -23049,6 +23138,7 @@
   changeuuid: d1ffb3fa-d373-4d8e-912d-c64daad80fa0
   reviewedAt: 2026-05-04
 - id: de-0nlineradio-deutschrock
+  favicon: "https://cdn.onlineradiobox.com/img/l/0/122690.v4.png"
   broadcaster: independent
   name: 0nlineradio DEUTSCHROCK
   streamUrl: https://stream.0nlineradio.com/deutschrock?ref=radiobrowser
@@ -23074,6 +23164,7 @@
   changeuuid: 13013d13-9c50-4692-b7dc-624d6d9d3e27
   reviewedAt: 2026-05-04
 - id: de-epic-lounge-cocktail-lounge
+  favicon: "https://cdn-profiles.tunein.com/s310482/images/logod.jpg"
   broadcaster: independent
   name: Epic Lounge - COCKTAIL LOUNGE
   streamUrl: https://stream.epic-lounge.com/cocktail-lounge?ref=radiobrowser
@@ -23086,6 +23177,7 @@
   changeuuid: f904e772-592e-4a33-8a83-93e8fba73ae2
   reviewedAt: 2026-05-04
 - id: de-grieg-by-epic-piano
+  favicon: "https://cdn-profiles.tunein.com/s310031/images/logod.jpg"
   broadcaster: independent
   name: GRIEG by Epic Piano
   streamUrl: https://stream.epic-piano.com/grieg?ref=radiobrowser
@@ -23111,6 +23203,7 @@
   changeuuid: bc5a125d-fe12-4e60-bb06-9e3b3002879e
   reviewedAt: 2026-05-04
 - id: de-epic-lounge-massage-lounge
+  favicon: "https://cdn-profiles.tunein.com/s322192/images/logod.jpg"
   broadcaster: independent
   name: Epic Lounge - Massage Lounge
   streamUrl: https://stream.epic-lounge.com/massage-lounge
@@ -23123,6 +23216,7 @@
   changeuuid: 1462e0a3-857d-460d-a5ef-183e7a3c7bb3
   reviewedAt: 2026-05-04
 - id: de-epic-classical-classical-oldies
+  favicon: "https://cdn-profiles.tunein.com/s320529/images/logod.jpg"
   broadcaster: independent
   name: EPIC CLASSICAL - Classical Oldies
   streamUrl: https://stream.epic-classical.com/classical-oldies
@@ -23160,6 +23254,7 @@
   changeuuid: aa7462bc-c917-42e2-8288-73da039eacba
   reviewedAt: 2026-05-04
 - id: de-0nlineradio-volksmusik
+  favicon: "https://cdn-profiles.tunein.com/s309774/images/logod.jpg?t=637562689640000000"
   broadcaster: independent
   name: 0nlineradio VOLKSMUSIK
   streamUrl: https://stream.0nlineradio.com/volksmusik?ref=radiobrowser
@@ -23172,6 +23267,7 @@
   changeuuid: 1a220cca-217e-41c0-999a-5d6a93a927c3
   reviewedAt: 2026-05-04
 - id: de-epic-classical-classical-christmas
+  favicon: "https://cdn.onlineradiobox.com/img/l/0/118010.v2.png"
   broadcaster: independent
   name: EPIC CLASSICAL - Classical Christmas
   streamUrl: https://stream.epic-classical.com/classical-christmas
@@ -23184,6 +23280,7 @@
   changeuuid: e27e545b-ebb3-4985-a8e4-5b671356e76d
   reviewedAt: 2026-05-04
 - id: de-technolovers-lounge
+  favicon: "https://technolovers.fm/assets/img/technolovers-dark.png"
   broadcaster: independent
   name: Technolovers - LOUNGE
   streamUrl: https://stream.technolovers.fm/lounge?ref=radiobrowser
@@ -23232,6 +23329,7 @@
   changeuuid: 5df097c3-e51c-450b-ba7c-2369e690a364
   reviewedAt: 2026-05-04
 - id: de-0nlineradio-party
+  favicon: "https://cdn.onlineradiobox.com/img/l/9/122709.v3.png"
   broadcaster: independent
   name: 0nlineradio PARTY
   streamUrl: https://stream.0nlineradio.com/party?ref=radiobrowser
@@ -23426,6 +23524,7 @@
   changeuuid: 109620e2-5995-4cc4-9efa-4c05f8b2877e
   reviewedAt: 2026-05-04
 - id: de-epic-lounge-workday-lounge
+  favicon: "https://cdn.onlineradiobox.com/img/l/4/120554.v3.png"
   broadcaster: independent
   name: Epic Lounge - WORKDAY LOUNGE
   streamUrl: https://stream.epic-lounge.com/workday-lounge?ref=radiobrowser
@@ -23537,6 +23636,7 @@
   changeuuid: 58444288-4aeb-44be-ba82-d71f3b7108a0
   reviewedAt: 2026-05-04
 - id: de-radio-cafe-zimmermann
+  favicon: "https://www.radio-cafezimmermann.de/typo3conf/ext/sn_config_ra31/Resources/Public/Images/logo_rcz.png"
   broadcaster: independent
   name: Radio Cafe Zimmermann
   streamUrl: https://stream.radio-cafezimmermann.de/klassik/mp3-192/
@@ -23627,6 +23727,7 @@
   changeuuid: 53a99cfb-6953-4797-994f-08688ab1ef16
   reviewedAt: 2026-05-04
 - id: de-epic-lounge-shisha-lounge
+  favicon: "https://cdn.onlineradiobox.com/img/l/5/120535.v3.png"
   broadcaster: independent
   name: Epic Lounge - SHISHA LOUNGE
   streamUrl: https://stream.epic-lounge.com/shisha-lounge?ref=radiobrowser
@@ -23691,6 +23792,7 @@
   changeuuid: 464a9a20-a269-4665-ac88-6529f12d8a8d
   reviewedAt: 2026-05-04
 - id: de-epic-classical-classical-pop
+  favicon: "https://cdn.onlineradiobox.com/img/l/5/117995.v2.png"
   broadcaster: independent
   name: EPIC CLASSICAL - Classical Pop
   streamUrl: https://stream.epic-classical.com/classical-pop
@@ -23753,6 +23855,7 @@
   changeuuid: 1f36b6bd-0fb5-4aaf-8241-4529593d5c4d
   reviewedAt: 2026-05-04
 - id: de-0nlineradio-latin
+  favicon: "https://cdn.onlineradiobox.com/img/l/4/122704.v3.png"
   broadcaster: independent
   name: 0nlineradio LATIN
   streamUrl: https://stream.0nlineradio.com/latin?ref=radiobrowser
@@ -23765,6 +23868,7 @@
   changeuuid: ba7a4f25-5eeb-43d9-89f7-d56ae314da90
   reviewedAt: 2026-05-04
 - id: de-epic-lounge-poolside-lounge
+  favicon: "https://cdn.onlineradiobox.com/img/l/3/120533.v3.png"
   broadcaster: independent
   name: Epic Lounge - POOLSIDE LOUNGE
   streamUrl: https://stream.epic-lounge.com/poolside-lounge?ref=streema
@@ -23855,6 +23959,7 @@
   changeuuid: 0f114c38-f877-48d0-9fe6-cdbb152c767f
   reviewedAt: 2026-05-04
 - id: de-epic-classical-classical-sunrise
+  favicon: "https://cdn.onlineradiobox.com/img/l/9/118009.v2.png"
   broadcaster: independent
   name: EPIC CLASSICAL - Classical Sunrise
   streamUrl: https://stream.epic-classical.com/classical-sunrise
@@ -23880,6 +23985,7 @@
   changeuuid: 942c3813-ea15-4bb8-bbc9-4c1458c6afe5
   reviewedAt: 2026-05-04
 - id: de-0nlineradio-american-christmas
+  favicon: "https://cdn-profiles.tunein.com/s310167/images/logod.jpg?t=637739882620000000"
   broadcaster: independent
   name: 0nlineradio AMERICAN CHRISTMAS
   streamUrl: https://stream.0nlineradio.com/us-christmas?ref=radiobrowser
@@ -23981,6 +24087,7 @@
   changeuuid: 4f10bdfc-9858-4d95-a143-44a61b37e5c6
   reviewedAt: 2026-05-04
 - id: de-epic-classical-classical-nighttime
+  favicon: "https://cdn.onlineradiobox.com/img/l/7/118007.v2.png"
   broadcaster: independent
   name: EPIC CLASSICAL - Classical Nighttime
   streamUrl: https://stream.epic-classical.com/classical-nighttime
@@ -24044,6 +24151,7 @@
   changeuuid: 571cbbe3-2a2f-4d0f-bd4c-75ea317582a5
   reviewedAt: 2026-05-04
 - id: de-chillout-ibiza-fm
+  favicon: "https://static2.mytuner.mobi/media/tvos_radios/915/chillout-ibiza-fm.0d76f6fb.png"
   broadcaster: independent
   name: Chillout Ibiza FM
   streamUrl: https://edge3.peta.live365.net/b05055_128mp3
@@ -24056,6 +24164,7 @@
   changeuuid: a8a3079b-2c29-40a1-924c-bb04bf1b7628
   reviewedAt: 2026-05-04
 - id: de-epic-classical-classical-dinner
+  favicon: "https://cdn.onlineradiobox.com/img/l/6/117996.v2.png"
   broadcaster: independent
   name: EPIC CLASSICAL - Classical Dinner
   streamUrl: https://stream.epic-classical.com/classical-dinner
@@ -24220,6 +24329,7 @@
   changeuuid: e8da4357-0f6e-4d5e-8f83-829a512dd1fc
   reviewedAt: 2026-05-04
 - id: de-radio2day
+  favicon: "https://cdn.onlineradiobox.com/img/l/1/661.v2.png"
   broadcaster: independent
   name: Radio2day
   streamUrl: https://radio2day.ip-streaming.net/radio2day
@@ -24245,6 +24355,7 @@
   changeuuid: 91820a41-d88e-49d3-aa46-7cb0580b6377
   reviewedAt: 2026-05-04
 - id: de-0nlineradio-lo-fi
+  favicon: "https://cdn.onlineradiobox.com/img/l/5/122705.v3.png"
   broadcaster: independent
   name: 0nlineradio LO-FI
   streamUrl: https://stream.0nlineradio.com/lo-fi?ref=radiobrowser
@@ -24283,6 +24394,7 @@
   changeuuid: 8b70b099-27ad-4015-b2e2-3b6aaf834811
   reviewedAt: 2026-05-04
 - id: de-epic-classical-classical-fairy-tales
+  favicon: "https://cdn-profiles.tunein.com/s320526/images/logod.jpg?t=637932456640000000"
   broadcaster: independent
   name: EPIC CLASSICAL - Classical Fairy Tales
   streamUrl: https://stream.epic-classical.com/classical-fairy-tales
@@ -24334,6 +24446,7 @@
   changeuuid: 5eab5be4-454f-4a6c-bfc8-b2a88d554daf
   reviewedAt: 2026-05-04
 - id: de-0nlineradio-urban
+  favicon: "https://cdn.onlineradiobox.com/img/l/9/122719.v3.png"
   broadcaster: independent
   name: 0nlineradio URBAN
   streamUrl: https://stream.0nlineradio.com/urban?ref=radiobrowser
@@ -24424,6 +24537,7 @@
   changeuuid: 72454673-b28a-4c87-83e5-09a3b8bc6040
   reviewedAt: 2026-05-04
 - id: de-0nlineradio-chillout
+  favicon: "https://cdn.onlineradiobox.com/img/l/5/122685.v3.png"
   broadcaster: independent
   name: 0nlineradio CHILLOUT
   streamUrl: https://stream.0nlineradio.com/chillout?ref=radiobrowser
@@ -24538,6 +24652,7 @@
   changeuuid: f5be21dc-55ec-42cb-9cee-bc0f8ec4806c
   reviewedAt: 2026-05-04
 - id: de-0nlineradio-schumann
+  favicon: "https://cdn-profiles.tunein.com/s309934/images/logod.jpg?t=637630166770000000"
   broadcaster: independent
   name: 0nlineradio SCHUMANN
   streamUrl: https://stream.0nlineradio.com/schumann?ref=radiobrowser
@@ -24563,6 +24678,7 @@
   changeuuid: 21df0db3-91a7-4249-aa8a-713a56b499f6
   reviewedAt: 2026-05-04
 - id: de-epic-lounge-christmas-lounge
+  favicon: "https://cdn.onlineradiobox.com/img/l/4/120534.v4.png"
   broadcaster: independent
   name: Epic Lounge - CHRISTMAS LOUNGE
   streamUrl: https://stream.epic-lounge.com/christmas-lounge?ref=radiobrowser
@@ -24716,6 +24832,7 @@
   changeuuid: 6b5d4011-dcd0-4af8-ad74-64a61aa53744
   reviewedAt: 2026-05-04
 - id: de-oldie-welle-ingolstadt
+  favicon: "https://cdn.onlineradiobox.com/img/l/3/103213.v3.png"
   broadcaster: independent
   name: oldie-welle-Ingolstadt
   streamUrl: https://funkhaus-ingolstadt.stream24.net/oldie-welle-ingolstadt.mp3
@@ -24793,6 +24910,7 @@
   changeuuid: f381211a-5e5b-491e-9f53-eb1f0debe136
   reviewedAt: 2026-05-04
 - id: de-0nlineradio-lovehits
+  favicon: "https://cdn.onlineradiobox.com/img/l/6/122706.v3.png"
   broadcaster: independent
   name: 0nlineradio LOVEHITS
   streamUrl: https://stream.0nlineradio.com/lovehits?ref=radiobrowser
@@ -24946,6 +25064,7 @@
   changeuuid: dd40ca54-0a96-4165-bc41-866e0bbcef65
   reviewedAt: 2026-05-04
 - id: de-yourtime-fm
+  favicon: "https://cdn-profiles.tunein.com/s245283/images/logod.png?t=639137857450000000"
   broadcaster: independent
   name: YourTime-FM
   streamUrl: https://stream.laut.fm/yourtime-fm
@@ -24958,6 +25077,7 @@
   changeuuid: 842fc0ca-01a5-4a8d-baad-47c7fed879b7
   reviewedAt: 2026-05-04
 - id: de-0nlineradio
+  favicon: "https://cdn.onlineradiobox.com/img/l/7/122697.v3.png"
   broadcaster: independent
   name: 0nlineradio
   streamUrl: https://stream.0nlineradio.com/jazz?ref=radiobrowser
@@ -24970,6 +25090,7 @@
   changeuuid: d88f651d-a7be-472f-a90e-4dddf7a93f3b
   reviewedAt: 2026-05-04
 - id: de-dwg-pur
+  favicon: "https://cdn.onlineradiobox.com/img/l/0/92050.v3.png"
   broadcaster: independent
   name: DWG Pur
   streamUrl: https://server25531.streamplus.de/stream.mp3
@@ -24995,6 +25116,7 @@
   changeuuid: 0bcdf921-e5a4-4f99-92cc-bb1d4da4198a
   reviewedAt: 2026-05-04
 - id: de-0nlineradio-trending-charts
+  favicon: "https://images.zeno.fm/QGOChNr_0sGoNcZ_hQq6Fwl6_75TH8fQnXFbUvNRvjI/rs:fill:288:288/g:ce:0:0/aHR0cHM6Ly9wcm94eS56ZW5vLmZtL2NvbnRlbnQvc3RhdGlvbnMvMDgyMzJjMGEtYjRlNS00NjNhLWFjNDItYjE4YjZhMDE1YmE0L2ltYWdlLz91PTE3MTM4NzMyMzcwMDA.webp"
   broadcaster: independent
   name: 0nlineradio - TRENDING CHARTS
   streamUrl: https://stream.0nlineradio.com/trending-charts
@@ -25007,6 +25129,7 @@
   changeuuid: ca673d3a-9cf9-45d1-bc37-34875ad57ea8
   reviewedAt: 2026-05-04
 - id: de-radio-endstation
+  favicon: "https://cdn.onlineradiobox.com/img/l/9/102199.v8.png"
   broadcaster: independent
   name: Radio Endstation
   streamUrl: https://funkturm.radio-endstation.de/hls/radio-endstation/live.m3u8
@@ -25045,6 +25168,7 @@
   changeuuid: 4ffc436b-ca26-4d1c-95ce-3c11a2011465
   reviewedAt: 2026-05-04
 - id: de-50s-60s-radio
+  favicon: "https://cdn-profiles.tunein.com/s312514/images/logod.png?t=639137858110000000"
   broadcaster: independent
   name: 50s 60s Radio
   streamUrl: https://50s60s-radio.stream.laut.fm/50s60s-radio?
@@ -25183,6 +25307,7 @@
   changeuuid: fbb9212a-a24d-4fe8-b5da-91c1340a112a
   reviewedAt: 2026-05-04
 - id: de-0nlineradio-christmas
+  favicon: "https://cdn.onlineradiobox.com/img/l/6/122686.v3.png"
   broadcaster: independent
   name: 0nlineradio CHRISTMAS
   streamUrl: https://stream.0nlineradio.com/christmas?ref=radiobrowser
@@ -25426,6 +25551,7 @@
   changeuuid: 1f32a752-709a-4270-b6e2-c2e15e4445ea
   reviewedAt: 2026-05-04
 - id: de-90er-revival
+  favicon: "https://cdn.onlineradiobox.com/img/l/1/49641.v3.png"
   broadcaster: independent
   name: 90er-Revival
   streamUrl: https://stream.laut.fm/90er-revival
@@ -25537,6 +25663,7 @@
   changeuuid: b2b12140-b032-4403-8b97-03da25d1da7d
   reviewedAt: 2026-05-04
 - id: de-htd-radio-hit-the-dark
+  favicon: "https://www.htd-radio.de/wp-content/uploads/2021/11/logo1.png"
   broadcaster: independent
   name: HTD Radio - Hit the Dark
   streamUrl: https://htd-radio.stream.laut.fm/htd-radio?pl=pls&t302=2026-01-15_07-45-57&uuid=f054998e-93c0-400a-911a-92895c0501f8
@@ -25574,6 +25701,7 @@
   changeuuid: 4650a1e8-8bba-49e4-9bb2-2c16533f4a77
   reviewedAt: 2026-05-04
 - id: de-0nlineradio-rock
+  favicon: "https://cdn.onlineradiobox.com/img/l/3/122713.v3.png"
   broadcaster: independent
   name: 0nlineradio ROCK
   streamUrl: https://stream.0nlineradio.com/rock?ref=radiobrowser
@@ -25806,6 +25934,7 @@
   changeuuid: b4899ac2-e74a-4e36-93ee-626a9b63ffc2
   reviewedAt: 2026-05-04
 - id: de-0nlineradio-deutschrap
+  favicon: "https://cdn.onlineradiobox.com/img/l/3/122693.v3.png"
   broadcaster: independent
   name: 0nlineradio DEUTSCHRAP
   streamUrl: https://stream.0nlineradio.com/deutschrap?ref=radiobrowser
@@ -26026,6 +26155,7 @@
   changeuuid: 148c3ccb-623f-4a5a-ae36-50f6cbf2d2e9
   reviewedAt: 2026-05-04
 - id: de-0nlineradio-top40
+  favicon: "https://cdn.onlineradiobox.com/img/l/8/122718.v3.png"
   broadcaster: independent
   name: 0nlineradio TOP40
   streamUrl: https://stream.0nlineradio.com/top40?ref=radiobrowser
@@ -26038,6 +26168,7 @@
   changeuuid: c849a2bb-9de2-4b5c-865f-9515d17e6940
   reviewedAt: 2026-05-04
 - id: de-epic-lounge-gaming-lounge
+  favicon: "https://cdn.onlineradiobox.com/img/l/0/120550.v4.png"
   broadcaster: independent
   name: Epic Lounge - GAMING LOUNGE
   streamUrl: https://stream.epic-lounge.com/gaming-lounge?ref=radiobrowser
@@ -26076,6 +26207,7 @@
   changeuuid: 252f6289-eb7d-4e12-9b27-bab57a549848
   reviewedAt: 2026-05-04
 - id: de-soundsindie
+  favicon: "https://cdn-profiles.tunein.com/s235046/images/logod.png?t=639137857310000000"
   broadcaster: independent
   name: Soundsindie
   streamUrl: https://soundsindie.stream.laut.fm/soundsindie?t302=2026-01-15_00-39-17&uuid=b964e14b-acde-48cc-9208-0a783f2e7667
@@ -26503,6 +26635,7 @@
   changeuuid: 886b030a-bcf5-4fae-875a-a1fd06871c02
   reviewedAt: 2026-05-04
 - id: de-shredded-by-rautemusik-rm-fm
+  favicon: "https://cdn.onlineradiobox.com/img/l/7/137117.v2.png"
   broadcaster: independent
   name: __SHREDDED__ by RauteMusik (rm.fm)
   streamUrl: https://streams.rautemusik.fm/shredded/mp3-192/stream.mp3
@@ -26515,6 +26648,7 @@
   changeuuid: 25367034-93a0-48cc-a22b-56d048b2434c
   reviewedAt: 2026-05-04
 - id: de-dwg-lyra
+  favicon: "https://cdn.onlineradiobox.com/img/l/9/92049.v5.png"
   broadcaster: independent
   name: DWG Lyra
   streamUrl: https://server34599.streamplus.de/stream.mp3
@@ -26565,6 +26699,7 @@
   changeuuid: 90b955e6-eabe-41ab-8664-52522c2889db
   reviewedAt: 2026-05-04
 - id: de-castlefm
+  favicon: "https://cdn.onlineradiobox.com/img/l/5/99845.v2.png"
   broadcaster: independent
   name: CastleFM
   streamUrl: https://stream.laut.fm/castlefm
@@ -26808,6 +26943,7 @@
   changeuuid: feb5f53c-4dcb-4d32-ab2e-afdd591c49ac
   reviewedAt: 2026-05-04
 - id: de-mdf1-hd-regionalfernsehen-magdeburg
+  favicon: "https://www.mdf1.de/img/logo_mdf1.png"
   broadcaster: independent
   name: MDF1 HD - Regionalfernsehen Magdeburg
   streamUrl: https://h056.video-stream-hosting.de/medienasa-live/_definst_/mp4:mdf1_high/playlist.m3u8
@@ -26885,6 +27021,7 @@
   changeuuid: e6891cd0-93e0-44f5-9862-367dddc9df8a
   reviewedAt: 2026-05-04
 - id: de-nightride-fm-rektory
+  favicon: "https://nightride.fm/blog/content/images/2020/10/nr_full_600_pale-2.png"
   broadcaster: independent
   name: Nightride FM - Rektory
   streamUrl: https://stream.nightride.fm/rektory.mp3
@@ -26949,6 +27086,7 @@
   changeuuid: beccd3bb-3577-494b-9185-e19278f67d9a
   reviewedAt: 2026-05-04
 - id: de-0nlineradio-queer
+  favicon: "https://cdn.onlineradiobox.com/img/l/1/122711.v3.png"
   broadcaster: independent
   name: 0nlineradio QUEER
   streamUrl: https://stream.0nlineradio.com/queer?ref=radiobrowser
@@ -27102,6 +27240,7 @@
   changeuuid: cbb49a5e-efa0-4894-ab2e-ab59eea15113
   reviewedAt: 2026-05-04
 - id: de-m1-fm-kuschelschlager
+  favicon: "https://static2.mytuner.mobi/media/tvos_radios/637/m1fm-kuschel-schlager.2e877d23.jpg"
   broadcaster: independent
   name: M1.FM - Kuschelschlager
   streamUrl: https://tuner.m1.fm/kuschelschlager.mp3
@@ -27218,6 +27357,7 @@
   changeuuid: 57be3612-80dc-46ba-b197-3779fa7ca604
   reviewedAt: 2026-05-04
 - id: de-blackspot
+  favicon: "https://cdn.onlineradiobox.com/img/l/3/44503.v2.png"
   broadcaster: independent
   name: Blackspot
   streamUrl: https://blackspot.stream.laut.fm/blackspot
@@ -27346,6 +27486,7 @@
   changeuuid: cb14c1b5-a4f1-483f-aff5-70978caec528
   reviewedAt: 2026-05-04
 - id: de-radio-bielefeld-80er
+  favicon: "https://cdn.onlineradiobox.com/img/l/1/129401.v2.png"
   broadcaster: independent
   name: Radio Bielefeld 80er
   streamUrl: https://addrad.io/4455rqg
@@ -27384,6 +27525,7 @@
   changeuuid: 326ac12b-fe57-46a9-82d4-2bd7762d702f
   reviewedAt: 2026-05-04
 - id: de-rattlesnake-radio
+  favicon: "https://cdn.onlineradiobox.com/img/l/7/42837.v2.png"
   broadcaster: independent
   name: "Rattlesnake Radio "
   streamUrl: https://server3755.streamplus.de/stream.mp3
@@ -27933,6 +28075,7 @@
   changeuuid: 5bb0cf8f-552c-403b-aa12-fb87e70b8c13
   reviewedAt: 2026-05-04
 - id: de-dancefloor-fm
+  favicon: "https://cdn-profiles.tunein.com/s329239/images/logod.png?t=639136128180000000"
   broadcaster: independent
   name: Dancefloor FM
   streamUrl: https://dancefloor-fm.stream.laut.fm/dancefloor-fm?t302=2025-03-03_21-41-17&uuid=ebadfaf0-8781-4c90-bb05-6652467979a2
@@ -28186,6 +28329,7 @@
   changeuuid: f38168e4-b693-493d-bed5-07f7d6f5a8bc
   reviewedAt: 2026-05-04
 - id: de-radio-landau
+  favicon: "https://www.radio.de/175/lautfm-radiolandau.png?version=23c91c529b1b921620f1dd1dbe2ac5983d5aa6cf"
   broadcaster: independent
   name: Radio Landau
   streamUrl: https://radiolandau.stream.laut.fm/radiolandau?autoplay=1&t302=2026-01-15_04-32-23&uuid=e7434870-47a3-40c8-b36b-28961178b681
@@ -28428,6 +28572,7 @@
   changeuuid: 6708735d-8dbe-4137-9d39-78496bd04069
   reviewedAt: 2026-05-04
 - id: de-0nlineradio-gran-prix
+  favicon: "https://cdn-profiles.tunein.com/s309750/images/logod.jpg?t=637562633390000000"
   broadcaster: independent
   name: 0nlineradio GRAN PRIX
   streamUrl: https://stream.0nlineradio.com/grandprix?ref=radiobrowser
@@ -28505,6 +28650,7 @@
   changeuuid: 6ab6711c-f197-4137-99af-edd089e6f279
   reviewedAt: 2026-05-04
 - id: de-jesus-deine-hoffnung-radio
+  favicon: "https://cdn-profiles.tunein.com/s320235/images/logod.png?t=639137859150000000"
   broadcaster: independent
   name: jesus-deine-hoffnung-radio
   streamUrl: https://jesus-deine-hoffnung-radio.stream.laut.fm/jesus-deine-hoffnung-radio
@@ -28932,6 +29078,7 @@
   changeuuid: 01ec10b6-6f85-44ed-87ad-f84c84ffd4ad
   reviewedAt: 2026-05-04
 - id: de-94-3-rs2
+  favicon: "https://cdn-profiles.tunein.com/s25221/images/logod.png?t=638295792520000000"
   broadcaster: independent
   name: 94.3 rs2
   streamUrl: https://stream.rs2.de/rs2/mp3-128/playlist
@@ -29100,6 +29247,7 @@
   changeuuid: 83a0f44c-3a59-4c06-8314-8898f87d48c3
   reviewedAt: 2026-05-04
 - id: de-odinsmetalrockclub
+  favicon: "https://www.radio.de/175/lautfm-odinsmetalrockclub.png?version=db804fed59899a5364e3fb650421838f88da3e6c"
   broadcaster: independent
   name: ODINSMETALROCKCLUB
   streamUrl: https://odinsmetalrockclub.stream.laut.fm/odinsmetalrockclub?pl=m3u&t302=2026-01-15_06-47-08&uuid=a3f143a2-3f6a-450e-ab7a-0c9f463704ff
@@ -29229,6 +29377,7 @@
   changeuuid: 4d82f63f-af9a-402c-b474-13a20ce1f381
   reviewedAt: 2026-05-04
 - id: de-jazz-christmas
+  favicon: "https://cdn-profiles.tunein.com/s321354/images/logod.png?t=639137859070000000"
   broadcaster: independent
   name: Jazz Christmas
   streamUrl: https://jazzchristmas.stream.laut.fm/jazzchristmas?t302=2023-12-19_08-05-17&uuid=43cac575-4695-4eca-baf1-5d2f18f5897b
@@ -29589,6 +29738,7 @@
   changeuuid: bbe5bb51-5d03-444c-a528-cfb02f86945d
   reviewedAt: 2026-05-04
 - id: de-exogaming
+  favicon: "https://cdn-profiles.tunein.com/s317326/images/logod.png?t=639137858760000000"
   broadcaster: independent
   name: EXOGAMING
   streamUrl: https://exogaming.stream.laut.fm/exogaming?pl=m3u&t302=2026-01-15_04-32-19&uuid=26045880-323b-46fa-86ae-1edc8318dc7d
@@ -29704,6 +29854,7 @@
   changeuuid: c15ebb16-16ab-40df-8231-a3ef08987d7b
   reviewedAt: 2026-05-04
 - id: de-0nlineradio-deutsch
+  favicon: "https://cdn-profiles.tunein.com/s309746/images/logod.jpg?t=637562632390000000"
   broadcaster: independent
   name: 0nlineradio DEUTSCH
   streamUrl: https://stream.0nlineradio.com/deutsch?ref=radiobrowser
@@ -29817,6 +29968,7 @@
   changeuuid: c7d1a299-4488-4174-b554-6dd05eb3ec23
   reviewedAt: 2026-05-04
 - id: de-radio-diefflen
+  favicon: "https://www.radio.de/175/lautfm-radiodiefflen.png?version=dd5920242b8247c18f6da13f21ec573cc9e5ef95"
   broadcaster: independent
   name: Radio Diefflen
   streamUrl: https://radiodiefflen.stream.laut.fm/radiodiefflen?pl=m3u&t302=2026-01-15_06-03-50&uuid=9a3fd861-dd28-4228-b902-e69eda1b80e4
@@ -29881,6 +30033,7 @@
   changeuuid: ac9ffe24-bccf-4eb5-98d7-8af703b7b0ff
   reviewedAt: 2026-05-04
 - id: de-917xfm
+  favicon: "https://upload.wikimedia.org/wikipedia/commons/f/f0/917xfm-Logo.svg"
   broadcaster: independent
   name: 917xfm
   streamUrl: https://rockantenne-hh-stream07.radiohost.de/917xfm_mp3-192?
@@ -29906,6 +30059,7 @@
   changeuuid: 63b62596-d218-41b0-90a1-4da4e87de992
   reviewedAt: 2026-05-04
 - id: de-classic-progrock-saar
+  favicon: "https://cdn-profiles.tunein.com/s319565/images/logod.png?t=639137858950000000"
   broadcaster: independent
   name: Classic Progrock Saar
   streamUrl: https://classic-progrock-fm.stream.laut.fm/classic-progrock-fm?t302=2025-03-10_17-34-10&uuid=8e6c3b96-2d13-44bc-a51b-386795198f38
@@ -30008,6 +30162,7 @@
   changeuuid: aa63d3b1-2a64-490c-854f-3b40c79feeb5
   reviewedAt: 2026-05-04
 - id: de-max-dance
+  favicon: "https://cdn.onlineradiobox.com/img/l/6/106146.v27.png"
   broadcaster: independent
   name: MAX.DANCE
   streamUrl: https://maxdance.stream.laut.fm/maxdance
@@ -30072,6 +30227,7 @@
   changeuuid: 207533ab-31c1-4f48-af1a-eba012136160
   reviewedAt: 2026-05-04
 - id: de-sg-radio
+  favicon: "https://www.sgradio.eu/img/logosmall.png"
   broadcaster: independent
   name: SG Radio
   streamUrl: https://synthesizergreatest.stream.laut.fm/synthesizergreatest
@@ -30173,6 +30329,7 @@
   changeuuid: f12add78-718b-44e6-b75a-8ceba2b3eed5
   reviewedAt: 2026-05-04
 - id: de-iceradio-germany
+  favicon: "https://www.iceradio.net/_img/logo.png"
   broadcaster: independent
   name: Iceradio Germany
   streamUrl: https://www.iceradio.net/listen
@@ -30273,6 +30430,7 @@
   changeuuid: 87901d3e-72f5-4678-b8a3-14ab0a6af09c
   reviewedAt: 2026-05-04
 - id: de-yesterday-fm
+  favicon: "https://cdn-radiotime-logos.tunein.com/s261866d.png"
   broadcaster: independent
   name: Yesterday.FM
   streamUrl: https://yesterdayfm.schlagerparadies.de/yesterdayfm
@@ -30414,6 +30572,7 @@
   changeuuid: d694f9b5-111d-4fed-9583-85ac1974d8a1
   reviewedAt: 2026-05-04
 - id: de-lightyeartraxx2
+  favicon: "https://cdn-profiles.tunein.com/s312149/images/logod.png?t=639137858000000000"
   broadcaster: independent
   name: Lightyeartraxx2
   streamUrl: https://stream.laut.fm/lightyeartraxx
@@ -30616,6 +30775,7 @@
   changeuuid: ac344ca4-6cb7-4d1c-8b3e-a306133dbd2c
   reviewedAt: 2026-05-04
 - id: de-sudstadt-radio
+  favicon: "https://static-media.streema.com/media/cache/39/62/396249a75485b8456dae30e4388adfc9.png"
   broadcaster: independent
   name: Südstadt Radio
   streamUrl: https://listen.radioking.com/radio/253861/stream/298342
@@ -30770,6 +30930,7 @@
   changeuuid: f5b3a171-b227-4cf0-bae6-d89e66405b05
   reviewedAt: 2026-05-04
 - id: de-goa-world
+  favicon: "https://luzifer.us/wp-content/uploads/2026/02/cropped-Luzifer-us-united-network-goa-marius-251x251.png"
   broadcaster: independent
   name: GoA World
   streamUrl: https://a11.asurahosting.com:8350/radio.mp3
@@ -30782,6 +30943,7 @@
   changeuuid: c2edfdc5-597d-4069-8e9c-15e4aebcd0e5
   reviewedAt: 2026-05-04
 - id: de-hit-radiotom
+  favicon: "https://cdn.onlineradiobox.com/img/l/5/104895.v2.png"
   broadcaster: independent
   name: Hit-RADIOTOM
   streamUrl: https://stream.laut.fm/hitradiotom
@@ -30794,6 +30956,7 @@
   changeuuid: 9ff93f18-bea9-42f8-a0d1-267dbb611c8b
   reviewedAt: 2026-05-04
 - id: de-karnevalsmusik
+  favicon: "https://www.radio.de/175/lautfm-karnevalsmusik.png?version=1ea1efe10a15aca93341a735fc13c9077124a5b4"
   broadcaster: independent
   name: Karnevalsmusik
   streamUrl: https://karnevalsmusik.stream.laut.fm/karnevalsmusik?
@@ -30831,6 +30994,7 @@
   changeuuid: b2653bc7-3e7b-472a-b097-14ad2afb4762
   reviewedAt: 2026-05-04
 - id: de-radio-zwiebel
+  favicon: "https://cdn-profiles.tunein.com/s108537/images/logod.jpg?t=637588530550000000"
   broadcaster: independent
   name: Radio Zwiebel
   streamUrl: https://server7.streamserver24.com:8080/proxy/radiozwiebel?mp=/stream
@@ -30920,6 +31084,7 @@
   changeuuid: 10bdc5de-02ea-418d-b2eb-01fdbdb918bb
   reviewedAt: 2026-05-04
 - id: de-deutrockosterreich
+  favicon: "https://www.radio.de/175/lautfm-deutrockosterreich.png?version=4162b251323bbd06b7b01efa09fda7a88e6f0397"
   broadcaster: independent
   name: deutrockösterreich
   streamUrl: https://stream.laut.fm/deutrockosterreich
@@ -30971,6 +31136,7 @@
   changeuuid: 128bc764-091e-4778-80a9-944f43c6d48c
   reviewedAt: 2026-05-04
 - id: de-knixx-fm-dein-webradio
+  favicon: "https://cdn.onlineradiobox.com/img/l/7/51107.v5.png"
   broadcaster: independent
   name: knixx.fm - Dein Webradio
   streamUrl: https://s1.knixx.fm/dein_webradio_64.aac
@@ -31177,6 +31343,7 @@
   changeuuid: a4d47b4e-44dd-4e3e-96d6-44d4c7a4207b
   reviewedAt: 2026-05-04
 - id: de-radio-marzahn
+  favicon: "https://d371i8ihhgym7w.cloudfront.net/38314.png"
   broadcaster: independent
   name: Radio Marzahn
   streamUrl: https://stream.laut.fm/radio-marzahn
@@ -31395,6 +31562,7 @@
   changeuuid: 0b39e4c4-4ccd-4ba5-ad94-1c9b1e26ac02
   reviewedAt: 2026-05-04
 - id: de-alles-volksmusik
+  favicon: "https://www.radio.de/175/lautfm-alles-volksmusik.png?version=95b496d353602539b556808ff88f80690d50cb59"
   broadcaster: independent
   name: "Alles Volksmusik "
   streamUrl: https://stream.laut.fm/alles-volksmusik
@@ -31614,6 +31782,7 @@
   changeuuid: 97d387ef-97ea-4d64-9a35-6c1b35073450
   reviewedAt: 2026-05-04
 - id: de-just-80-maximal
+  favicon: "https://cdn-profiles.tunein.com/s101681/images/logod.png?t=639137857080000000"
   broadcaster: independent
   name: "Just 80 Maximal "
   streamUrl: https://stream.laut.fm/just80s_maximal
@@ -31626,6 +31795,7 @@
   changeuuid: 1ba3510e-1dab-4b8e-9297-991041870b52
   reviewedAt: 2026-05-04
 - id: de-laut-fm-post-rock-web
+  favicon: "https://www.radio.de/175/lautfm-post-rock.png?version=91db28ddab006c1d3941022454686564fc7f7928"
   broadcaster: independent
   name: Laut.fm Post-Rock web
   streamUrl: https://stream.laut.fm/post-rock
@@ -31715,6 +31885,7 @@
   changeuuid: dc32da84-5850-4aa0-8b6f-cadac27f6243
   reviewedAt: 2026-05-04
 - id: de-rockpalast-revival-radio-saar
+  favicon: "https://www.phonostar.de/images/auto_created/lautfm_rockpalast-revival-radio184x184.png"
   broadcaster: independent
   name: Rockpalast Revival Radio Saar
   streamUrl: https://rockpalast-revival-radio.stream.laut.fm/rockpalast-revival-radio?t302=2025-03-10_17-35-46&uuid=c2fb9df2-862c-4a7d-bc4e-03b06d147dff
@@ -31727,6 +31898,7 @@
   changeuuid: d745b067-75c3-4146-bb49-142ba1adaf38
   reviewedAt: 2026-05-04
 - id: de-rockstellar
+  favicon: "https://www.radio.de/175/lautfm-rockstellar.png?version=9ccecb175de97781d63638f71b641dea95b66725"
   broadcaster: independent
   name: Rockstellar
   streamUrl: https://stream.laut.fm/rockstellar
@@ -31829,6 +32001,7 @@
   changeuuid: 1dd37ed5-3c7a-4591-b765-70b3c9539074
   reviewedAt: 2026-05-04
 - id: de-form3l-eins-retro-radio-saar
+  favicon: "https://www.phonostar.de/images/auto_created/lautfm_formel-eins-retro-hitradio184x184.png"
   broadcaster: independent
   name: Form3l Eins Retro Radio Saar
   streamUrl: https://formel-eins-retro-hitradio.stream.laut.fm/formel-eins-retro-hitradio?t302=2025-03-10_17-37-07&uuid=e594fcf2-c9e2-40c2-9ef6-16a52b59b4dc
@@ -32163,6 +32336,7 @@
   changeuuid: 1f46086e-387c-48b4-8c1f-82743641c8af
   reviewedAt: 2026-05-04
 - id: de-karls-erlebnis-radio
+  favicon: "https://d2absclsvmaf7v.cloudfront.net/eyJidWNrZXQiOiJyZWRha3Rpb24ua2FybHMiLCJrZXkiOiJiaWxkZXIvMzRkZWViMDQtNmM5Ny0xMWVkLWJhYjYtMDAwMDAwMDAwMDAwL2VybGVibmlzX3JhZGlvX2xvZ28ucG5nIiwiZWRpdHMiOnsidG9Gb3JtYXQiOiJ3ZWJwIiwid2VicCI6eyJsb3NzbGVzcyI6ZmFsc2V9LCJyZXNpemUiOnsiaGVpZ2h0IjoxMTAwLCJ3aWR0aCI6bnVsbCwiZml0IjoiaW5zaWRlIiwicG9zaXRpb24iOiJlbnRyb3B5IiwiYmFja2dyb3VuZCI6IiNlYmQ4YmYifX19"
   broadcaster: independent
   name: Karls Erlebnis-Radio
   streamUrl: https://radio.karls.de/karls-erlebnisradio/mp3-192
@@ -32277,6 +32451,7 @@
   changeuuid: 0f1cb73a-0678-4886-af71-1f7edc2a7944
   reviewedAt: 2026-05-04
 - id: de-volksmusik
+  favicon: "https://www.radio.de/175/lautfm-weissblauerstammtisch.png?version=641bf5029ca8c53c7575f94daa8ea3ce254749c6"
   broadcaster: independent
   name: "Volksmusik "
   streamUrl: https://weissblauerstammtisch.stream.laut.fm/weissblauerstammtisch?t302=2026-01-15_06-06-11&uuid=24628a67-3741-4ee3-a806-6e0926549abc
@@ -32392,6 +32567,7 @@
   changeuuid: 27be4bc6-7949-4570-aa08-57f460d60f9f
   reviewedAt: 2026-05-04
 - id: de-hrvatski-radio-frankfurt
+  favicon: "https://cdn-radiotime-logos.tunein.com/s198968d.png"
   broadcaster: independent
   name: Hrvatski Radio Frankfurt
   streamUrl: https://a9.asurahosting.com:7110/radio.mp3
@@ -32456,6 +32632,7 @@
   changeuuid: 8f99bcbd-450e-41ea-91e6-464e8a90c2a8
   reviewedAt: 2026-05-04
 - id: de-musikladen-revival-radio-saar
+  favicon: "https://www.phonostar.de/images/auto_created/lautfm_musikladen-revival-radio184x184.png"
   broadcaster: independent
   name: Musikladen Revival Radio Saar
   streamUrl: https://musikladen-revival-radio.stream.laut.fm/musikladen-revival-radio?t302=2025-03-10_17-38-08&uuid=1766b96d-ba02-413f-8745-c66f62db6891
@@ -32558,6 +32735,7 @@
   changeuuid: 613aafa6-aac4-4d55-a262-da81ae0bd5ab
   reviewedAt: 2026-05-04
 - id: de-soundpool
+  favicon: "https://www.radio.de/175/lautfm-soundpool.png?version=d667dcd82ef0213f59141f6bad1747210201ca07"
   broadcaster: independent
   name: Soundpool
   streamUrl: https://stream.laut.fm/soundpool
@@ -32899,6 +33077,7 @@
   changeuuid: 576eabfc-5b05-4c0c-843b-565578811a06
   reviewedAt: 2026-05-04
 - id: de-bravo-hits-saar
+  favicon: "https://www.phonostar.de/images/auto_created/lautfm_bravo-hit-revival-radio184x184.png"
   broadcaster: independent
   name: Bravo Hits Saar
   streamUrl: https://stream.laut.fm/bravo-hit-revival-radio
@@ -33255,6 +33434,7 @@
   changeuuid: a4b00c9e-d3cc-4a98-b4f5-3b6e12d55955
   reviewedAt: 2026-05-04
 - id: de-kb-rock
+  favicon: "https://www.radio.de/175/lautfm-kbrock.png?version=ba9ba8f6f3ccd54b0c1f8bac6e3a72a74fba23db"
   broadcaster: independent
   name: KB ROCK
   streamUrl: https://kbrock.stream.laut.fm/kbrock?pl=pls&t302=2020-08-07_21-11-15&uuid=bdc97b0d-5aef-4607-b0f2-e8fa10984eaa
@@ -33358,6 +33538,7 @@
   changeuuid: 4b3e750c-e114-4d14-a91a-32fe07c2e318
   reviewedAt: 2026-05-04
 - id: de-neu-jerusalem
+  favicon: "https://cdn.onlineradiobox.com/img/l/1/131201.v6.png"
   broadcaster: independent
   name: neu-jerusalem
   streamUrl: https://audio.bild-und-ton.stream:16162/neu-jerusalem-de
@@ -33383,6 +33564,7 @@
   changeuuid: abf8014f-90e7-4fd7-9079-3ea3d29c418a
   reviewedAt: 2026-05-04
 - id: de-radio-kevelaer
+  favicon: "https://www.radio.de/175/lautfm-radio-kevelaer.png?version=69b45d3ef6f704a9d6df0e51c78919c8051535c5"
   broadcaster: independent
   name: Radio Kevelaer
   streamUrl: https://radio-kevelaer.stream.laut.fm/radio-kevelaer?t302=2026-01-15_06-06-43&uuid=0e175da8-04d0-4fca-8202-9295dd635bee
@@ -33395,6 +33577,7 @@
   changeuuid: d6a3ee87-c47d-497c-a0c7-c54c3b073de1
   reviewedAt: 2026-05-04
 - id: de-radio-okj
+  favicon: "https://cdn-profiles.tunein.com/s121501/images/logod.jpg?t=638102603460000000"
   broadcaster: independent
   name: Radio OKJ
   streamUrl: https://stream.radio-okj.de:8443/okj
@@ -33407,6 +33590,7 @@
   changeuuid: e4d36a75-7cb8-4423-89be-81812b599a76
   reviewedAt: 2026-05-04
 - id: de-radio-santec
+  favicon: "https://radio-santec.com/wp-content/uploads/2019/05/RadioSantecLogo_klein.png"
   broadcaster: independent
   name: Radio Santec
   streamUrl: https://onairport.live/radioul-de
@@ -33482,6 +33666,7 @@
   changeuuid: 9f602b54-97a9-4f67-80a7-eff4ac45357c
   reviewedAt: 2026-05-04
 - id: de-bluewolf-radio
+  favicon: "https://cdn-radiotime-logos.tunein.com/s274554d.png"
   broadcaster: independent
   name: Bluewolf Radio
   streamUrl: https://bluewolf-radio.stream.laut.fm/bluewolf-radio?t302=2026-01-15_05-34-50&uuid=a21a7566-3bd5-4b51-8041-0f87da546120
@@ -33991,6 +34176,7 @@
   changeuuid: fb65c0c8-9e84-4297-89ad-9149531c8d05
   reviewedAt: 2026-05-04
 - id: de-mtc-fm
+  favicon: "https://www.radio.de/175/lautfm-mtc-fm.png?version=5565ba32a0f32cdbab98c3e24425005ef6a6f938"
   broadcaster: independent
   name: mtc-fm
   streamUrl: https://stream.laut.fm/mtc-fm
@@ -34872,6 +35058,7 @@
   changeuuid: c371aa93-fbcb-40b5-b669-89ab85335f04
   reviewedAt: 2026-05-04
 - id: de-modern-piano-by-epic-piano
+  favicon: "https://epic-piano.com/assets/img/streamlogos/modern-piano.jpg"
   broadcaster: independent
   name: MODERN PIANO by Epic Piano
   streamUrl: https://stream.epic-piano.com/modern-piano
@@ -35208,6 +35395,7 @@
   changeuuid: 0de4039d-368f-4a66-8bea-dcf923143cdb
   reviewedAt: 2026-05-04
 - id: de-antenne-unna-dein-80er-radio
+  favicon: "https://logos-der-nrwlokalradios.s3.eu-central-1.amazonaws.com/01ba-36-13.png"
   broadcaster: independent
   name: Antenne Unna – Dein 80er Radio
   streamUrl: https://stream.lokalradio.nrw/445dyj5
@@ -35220,6 +35408,7 @@
   changeuuid: 7087bd34-7cbf-41c9-8d54-37a45f607b4c
   reviewedAt: 2026-05-04
 - id: de-antenne-unna-dein-lounge-radio
+  favicon: "https://logos-der-nrwlokalradios.s3.eu-central-1.amazonaws.com/01ba-36-13.png"
   broadcaster: independent
   name: Antenne Unna – Dein Lounge Radio
   streamUrl: https://stream.lokalradio.nrw/445dzn7
@@ -35232,6 +35421,7 @@
   changeuuid: aaa162d5-b55b-485b-9f05-88348983496e
   reviewedAt: 2026-05-04
 - id: de-antenne-unna-dein-new-country-radio
+  favicon: "https://logos-der-nrwlokalradios.s3.eu-central-1.amazonaws.com/01ba-36-13.png"
   broadcaster: independent
   name: Antenne Unna – Dein New Country Radio
   streamUrl: https://stream.lokalradio.nrw/445829b
@@ -35333,6 +35523,7 @@
   changeuuid: fea0a524-e18c-44c0-a5a6-a5721a607cae
   reviewedAt: 2026-05-04
 - id: de-ct-das-radio-campus-radio-bochum
+  favicon: "https://cdn.onlineradiobox.com/img/l/5/685.v3.png"
   broadcaster: independent
   name: CT das radio Campus Radio Bochum
   streamUrl: https://live.ctdasradio.de/live
@@ -35602,6 +35793,7 @@
   changeuuid: 152ecfff-a7b5-456e-b889-3a6a7b35a7a7
   reviewedAt: 2026-05-04
 - id: de-radio-andreo
+  favicon: "https://cdn-profiles.tunein.com/s312104/images/logod.png?t=639137858040000000"
   broadcaster: independent
   name: radio andreo
   streamUrl: https://stream.laut.fm/radio_andreo
@@ -36355,6 +36547,7 @@
   changeuuid: 442457b3-2381-42dd-919b-b4008708dfcf
   reviewedAt: 2026-05-04
 - id: de-lumaxit-radio
+  favicon: "https://cdn.ltscloud.de/img/lumaxit/website/main/logo.png"
   broadcaster: independent
   name: Lumaxit Radio
   streamUrl: https://stream.laut.fm/lumaxit
@@ -36818,6 +37011,7 @@
   changeuuid: 327d93b5-ad02-4dc0-97ed-8912c9b030ef
   reviewedAt: 2026-05-04
 - id: de-dunkler-welle-das-schwarzeste-radio-im-netz
+  favicon: "https://dunklewelle.eu/wp-content/uploads/cropped-RDW_Header_Anniversary.png"
   broadcaster: independent
   name: Dunkler Welle - Das Schwärzeste Radio Im Netz
   streamUrl: https://dunklewelle.spcast.eu/dj03
@@ -36970,6 +37164,7 @@
   changeuuid: f2ab140b-402a-47ee-aceb-efc963d0a246
   reviewedAt: 2026-05-04
 - id: de-central-fm-radio-saarschleifenland
+  favicon: "https://cdn-radiotime-logos.tunein.com/s266799d.png"
   broadcaster: independent
   name: Central FM Radio Saarschleifenland
   streamUrl: https://mobil.antennepulheim.de/radiorslaacp.aac
@@ -36982,6 +37177,7 @@
   changeuuid: 3a5ff7a6-8e32-44a9-b0a1-239d0122a297
   reviewedAt: 2026-05-04
 - id: de-corax-lokalfunk-halle
+  favicon: "https://cdn-radiotime-logos.tunein.com/s84587d.png"
   broadcaster: independent
   name: CORAX – Lokalfunk Halle
   streamUrl: https://stream1.datenkollektiv.net/corax_256.mp3
@@ -37242,6 +37438,7 @@
   changeuuid: e97ca2ff-448e-45cb-bfd6-38c6ea3403e8
   reviewedAt: 2026-05-04
 - id: de-radio-freundes-dienst
+  favicon: "https://www.radiofd.org/images/radiofd_player.png"
   broadcaster: independent
   name: Radio Freundes-Dienst
   streamUrl: https://stream.radiofd.org/radiofd/mp3_128/radiobrowser
@@ -37254,6 +37451,7 @@
   changeuuid: e55782ad-f0e0-4e5d-92d8-ca691e287787
   reviewedAt: 2026-05-04
 - id: de-radio-frieden
+  favicon: "https://www.radiofrieden.com/wp-content/themes/Divi/images/logo.png"
   broadcaster: independent
   name: Radio Frieden
   streamUrl: https://server33307.streamplus.de/stream.mp3
@@ -37680,6 +37878,7 @@
   changeuuid: 8f09cf4a-1381-4901-8471-3f9aaf6fb9fc
   reviewedAt: 2026-05-04
 - id: ch-kontrafunk-mobil
+  favicon: "https://cdn-profiles.tunein.com/s351779/images/logod.png?t=639046279360000000"
   broadcaster: independent
   name: Kontrafunk (Mobil)
   streamUrl: https://icecast.multhielemedia.de/listen/kontrafunk/mobil
@@ -37705,6 +37904,7 @@
   changeuuid: 0f39d171-fb07-4af3-9415-fc690f8a3ae8
   reviewedAt: 2026-05-04
 - id: ch-my105-x-mas-radio-aac
+  favicon: "https://cdn-profiles.tunein.com/s257861/images/logod.jpg?t=638058393970000000"
   broadcaster: independent
   name: my105 X-MAS Radio (AAC)
   streamUrl: https://stream01.my105.ch/my105xmas-aac.mp3
@@ -37780,6 +37980,7 @@
   changeuuid: 4fbed920-bab8-4e53-8e47-b6c7dd992476
   reviewedAt: 2026-05-04
 - id: at-mountain-reggae-radio
+  favicon: "https://cdn-radiotime-logos.tunein.com/s276382d.png"
   broadcaster: independent
   name: Mountain Reggae Radio
   streamUrl: https://mountainreggaeradio.stream.laut.fm/mountainreggaeradio
@@ -37906,6 +38107,7 @@
   changeuuid: 5139a8ce-6fee-44cd-9c52-fab18525240c
   reviewedAt: 2026-05-04
 - id: at-antenne-austro-hits
+  favicon: "https://upload.wikimedia.org/wikipedia/commons/thumb/e/e9/Antenne_Steiermark_logo_%282024%29.svg/250px-Antenne_Steiermark_logo_%282024%29.svg.png"
   broadcaster: independent
   name: Antenne Austro Hits
   streamUrl: https://live.antenne.at/auh
@@ -37944,6 +38146,7 @@
   changeuuid: 7a0c20f2-bf1d-4aa7-9a18-de8580b05e90
   reviewedAt: 2026-05-04
 - id: at-radio-steiermark-80er-pop
+  favicon: "https://upload.wikimedia.org/wikipedia/commons/thumb/e/e9/Antenne_Steiermark_logo_%282024%29.svg/250px-Antenne_Steiermark_logo_%282024%29.svg.png"
   broadcaster: independent
   name: Radio Steiermark 80er POP
   streamUrl: https://live.antenne.at/80s
@@ -38185,6 +38388,7 @@
   changeuuid: c2de3230-9ae3-413f-853b-76a8eb5ddf02
   reviewedAt: 2026-05-04
 - id: at-technikum-city
+  favicon: "https://www.radiotechnikum.at/img/rtg_logo_klein.png"
   broadcaster: independent
   name: Technikum City
   streamUrl: https://stream.radiotechnikum.at/TECHCITY
@@ -38236,6 +38440,7 @@
   changeuuid: 6da00e9d-8a45-4daa-b1ff-7796f2daa969
   reviewedAt: 2026-05-04
 - id: at-styrialounge
+  favicon: "https://cdn.onlineradiobox.com/img/l/3/69503.v3.png"
   broadcaster: independent
   name: Styrialounge
   streamUrl: https://styrialounge.out.airtime.pro/styrialounge_a
@@ -38261,6 +38466,7 @@
   changeuuid: 361b76f9-55e1-41f4-b664-832a29942b02
   reviewedAt: 2026-05-04
 - id: at-yeshua-at-radio
+  favicon: "https://yeshua.at/server/img/YeshuaBanner.240.150.jpg"
   broadcaster: independent
   name: Yeshua.at Radio
   streamUrl: https://yeshua.at:8443/stream
@@ -38285,6 +38491,7 @@
   changeuuid: 8cdbdaba-46ef-4b4d-b242-4478c716ffd8
   reviewedAt: 2026-05-04
 - id: at-petersplattentek
+  favicon: "https://www.radio.at/175/petersplattenthek.png?version=c6cae17fc98e049390c2f5ec3e9e038468d31d37"
   broadcaster: independent
   name: PetersPlattentek
   streamUrl: https://server7524.streamplus.de/stream.mp3
@@ -38475,6 +38682,7 @@
   changeuuid: 4fe5e4e0-4afb-482f-ae44-8edd583cd2b0
   reviewedAt: 2026-05-04
 - id: at-radio-studio-enns
+  favicon: "https://cdn.onlineradiobox.com/img/l/3/2343.v17.png"
   broadcaster: independent
   name: Radio Studio Enns
   streamUrl: https://server4.streamserver24.com:61414/
@@ -39378,6 +39586,7 @@
   changeuuid: 38e1d207-20df-4d60-9bd1-78657bc24223
   reviewedAt: 2026-05-04
 - id: us-station
+  favicon: "https://upload.wikimedia.org/wikipedia/commons/thumb/0/07/Voice_of_America_Logo.svg/250px-Voice_of_America_Logo.svg.png"
   broadcaster: independent
   name: 美国之音
   streamUrl: https://voa-ingest.akamaized.net/hls/live/2035206/151_124L/playlist.m3u8
@@ -39403,6 +39612,7 @@
   changeuuid: 9a75949d-8887-4a02-a87f-5a4ea96e0174
   reviewedAt: 2026-05-04
 - id: us-classic-rock-109
+  favicon: "https://www.classicrock109.com/images/logo.png"
   broadcaster: independent
   name: Classic Rock 109
   streamUrl: https://jenny.torontocast.com:2000/stream/ClassicRock109
@@ -39467,6 +39677,7 @@
   changeuuid: a171b663-ebfc-4485-97ee-fe65be8f4191
   reviewedAt: 2026-05-04
 - id: us-christian-life-radio
+  favicon: "https://cdn-radiotime-logos.tunein.com/s112984d.png"
   broadcaster: independent
   name: Christian Life Radio
   streamUrl: https://ice64.securenetsystems.net/CLR1MP3
@@ -39634,6 +39845,7 @@
   changeuuid: 87181b60-8964-4c5d-9d81-ba32da4dcce1
   reviewedAt: 2026-05-04
 - id: us-the-independent-fm
+  favicon: "https://cdn.onlineradiobox.com/img/l/3/16043.v6.png"
   broadcaster: independent
   name: The Independent FM
   streamUrl: https://listen.radioking.com/radio/293701/stream/340084
@@ -39915,6 +40127,7 @@
   changeuuid: 2099054c-bd08-4788-a9bb-18a16c41b13c
   reviewedAt: 2026-05-04
 - id: us-cbs-news
+  favicon: "https://upload.wikimedia.org/wikipedia/commons/thumb/0/02/CBS_News_Radio_Logo_%282021%29.svg/960px-CBS_News_Radio_Logo_%282021%29.svg.png"
   broadcaster: independent
   name: CBS News
   streamUrl: https://cbsn-us.cbsnstream.cbsnews.com/out/v1/55a8648e8f134e82a470f83d562deeca/master.m3u8
@@ -40206,6 +40419,7 @@
   changeuuid: bd2f38e8-66c5-47e0-8b3c-682cd9287301
   reviewedAt: 2026-05-04
 - id: us-american-tamil-radio
+  favicon: "https://www.americantamilradio.com/assets/img/radiologo.png"
   broadcaster: independent
   name: American Tamil Radio
   streamUrl: https://cp11.serverse.com/proxy/hgsmgluv?mp=/stream
@@ -41718,6 +41932,7 @@
   changeuuid: bd92cd56-43e2-4221-a2ee-c5d0731ecb9f
   reviewedAt: 2026-05-04
 - id: us-cape-christian-radio
+  favicon: "https://cdn-radiotime-logos.tunein.com/s54344d.png"
   broadcaster: independent
   name: Cape Christian Radio
   streamUrl: https://ice64.securenetsystems.net/CCR1MP3
@@ -48226,6 +48441,7 @@
   changeuuid: 332117f2-f3e5-4bd6-9d25-4ca8217dbff9
   reviewedAt: 2026-05-04
 - id: us-new-country-101-five
+  favicon: "https://cdn.onlineradiobox.com/img/l/0/41160.v10.png"
   broadcaster: independent
   name: New Country 101 FIVE
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/WKHXFMAAC.aac
@@ -48667,6 +48883,7 @@
   changeuuid: 2d01fb9c-e759-46f6-82fc-e5ebe18719e4
   reviewedAt: 2026-05-04
 - id: us-chabad-org-jewish-music
+  favicon: "https://cdn-profiles.tunein.com/s305576/images/logod.png?t=636567072334970000"
   broadcaster: independent
   name: Chabad.org Jewish Music
   streamUrl: https://stream.radio.co/sdfd68a101/listen
@@ -48883,6 +49100,7 @@
   changeuuid: e207773b-b800-48a0-84df-7ec400383025
   reviewedAt: 2026-05-04
 - id: us-wabc-oldies-time-machine
+  favicon: "https://cdn-profiles.tunein.com/s251480/images/logod.jpg?t=638218628910000000"
   broadcaster: independent
   name: WABC Oldies Time Machine
   streamUrl: https://sonic-ca.instainternet.com/8144/stream
@@ -49157,6 +49375,7 @@
   changeuuid: 9700a95b-7da1-499e-b507-b225c36c7ae5
   reviewedAt: 2026-05-04
 - id: us-la-suavecita-106-9-107-1fm
+  favicon: "https://cdn.onlineradiobox.com/img/l/8/27608.v7.png"
   broadcaster: independent
   name: La Suavecita 106.9/107.1FM
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/KVVAFMAAC.aac
@@ -49232,6 +49451,7 @@
   changeuuid: 3109341a-50dd-4a7a-8fad-711ec523b9f5
   reviewedAt: 2026-05-04
 - id: us-100-hitradio
+  favicon: "https://cdn-profiles.tunein.com/s131838/images/logod.png?t=637898859630000000"
   broadcaster: independent
   name: 100 Hitradio
   streamUrl: https://radio1.streamserver.link/radio/8010/100hit-aac
@@ -49306,6 +49526,7 @@
   changeuuid: 927f1f89-4c31-47ae-a54e-66240e8336d8
   reviewedAt: 2026-05-04
 - id: us-folk-alley-fresh-cuts
+  favicon: "https://folkalley.com/wp-content/themes/folkalley/dist/images/logo.png"
   broadcaster: independent
   name: Folk Alley Fresh Cuts
   streamUrl: https://freshgrass.streamguys1.com/freshcuts-128mp3
@@ -49444,6 +49665,7 @@
   changeuuid: 9d22764c-9ea4-4021-bca2-3d8b773b3433
   reviewedAt: 2026-05-04
 - id: us-viva-radio
+  favicon: "https://cdn.onlineradiobox.com/img/l/0/106420.v8.png"
   broadcaster: independent
   name: Viva Radio
   streamUrl: https://ice66.securenetsystems.net/WRYM
@@ -49546,6 +49768,7 @@
   changeuuid: 5937081f-6572-4a8f-ae97-7d9313047220
   reviewedAt: 2026-05-04
 - id: us-ancient-faith-ministrie-talk-english
+  favicon: "https://www.ancientfaith.com/assets/images/afm-text-white.png"
   broadcaster: independent
   name: Ancient Faith Ministrie Talk English
   streamUrl: https://ancientfaith.streamguys1.com/talk
@@ -49660,6 +49883,7 @@
   changeuuid: c47f7ebc-ddbc-4fff-99d6-5ff9d067b6c7
   reviewedAt: 2026-05-04
 - id: us-104-9-funasia
+  favicon: "https://www.funasia.net/logo.webp"
   broadcaster: independent
   name: 104.9 FunAsiA
   streamUrl: https://funasia.streamguys1.com/live-1
@@ -49723,6 +49947,7 @@
   changeuuid: e789589d-9d35-4bc7-8286-b25761bbe8d1
   reviewedAt: 2026-05-04
 - id: us-kwem-radio
+  favicon: "https://static2.mytuner.mobi/media/tvos_radios/736/kwem-lp-933-fm.119c3585.png"
   broadcaster: independent
   name: KWEM Radio
   streamUrl: https://ice6.securenetsystems.net/KWEM
@@ -49886,6 +50111,7 @@
   changeuuid: bf714003-ab45-4af1-8057-8c45fdd8ef00
   reviewedAt: 2026-05-04
 - id: us-biblischer-horfunk-german
+  favicon: "https://bbn1.bbnradio.org/german/wp-content/uploads/sites/9/2017/10/Germanbbnlogo-green.png"
   broadcaster: independent
   name: Biblischer Hörfunk German
   streamUrl: https://streams.radiomast.io/79ce8dd0-c0e9-4443-b887-0fdc1617f8bc
@@ -49975,6 +50201,7 @@
   changeuuid: 280e4137-3459-43f6-ad51-14424ad4b6f3
   reviewedAt: 2026-05-04
 - id: us-the-rock-hd
+  favicon: "https://therockhd.com/img/R_logo.png"
   broadcaster: independent
   name: The Rock HD
   streamUrl: https://ice.zradio.org/r/high.mp3
@@ -50000,6 +50227,7 @@
   changeuuid: 3ebd5237-6823-452f-95da-e9358abf26d2
   reviewedAt: 2026-05-04
 - id: us-wrbz-95-5
+  favicon: "https://cdn.onlineradiobox.com/img/l/3/81533.v4.png"
   broadcaster: independent
   name: WRBZ 95.5
   streamUrl: https://ice10.securenetsystems.net/WRBZ955
@@ -50077,6 +50305,7 @@
   changeuuid: 000585f7-ba78-4307-96bd-9587ea8a0564
   reviewedAt: 2026-05-04
 - id: us-la-suavecita-92-1
+  favicon: "https://cdn.onlineradiobox.com/img/l/4/32994.v11.png"
   broadcaster: independent
   name: La Suavecita 92.1
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/KJMNFMAAC.aac
@@ -50306,6 +50535,7 @@
   changeuuid: a6d086be-f529-4276-b9c3-704b8b6fe5ef
   reviewedAt: 2026-05-04
 - id: us-freedom-95
+  favicon: "https://dehayf5mhw1h7.cloudfront.net/wp-content/uploads/sites/728/2016/10/03152123/Freedom-95-Logo.png"
   broadcaster: independent
   name: Freedom 95
   streamUrl: https://ice24.securenetsystems.net/WFDM
@@ -50331,6 +50561,7 @@
   changeuuid: 137f2c2e-b5cc-4a35-a356-3e61c47ba426
   reviewedAt: 2026-05-04
 - id: us-living-worship-radio
+  favicon: "https://livingworship.radio/wp-content/uploads/2025/09/LivingWorship.png"
   broadcaster: independent
   name: Living Worship .Radio
   streamUrl: https://ice.zradio.org/w/high.aac
@@ -50543,6 +50774,7 @@
   changeuuid: 5dd47927-a9f1-4593-be7c-f7441d4a35f6
   reviewedAt: 2026-05-04
 - id: us-kbmw-1450-am
+  favicon: "https://cdn.onlineradiobox.com/img/l/8/22548.v4.png"
   broadcaster: independent
   name: KBMW 1450 AM
   streamUrl: https://ice6.securenetsystems.net/KBMWAM
@@ -50643,6 +50875,7 @@
   changeuuid: 532f5a7c-534f-4cfb-90a6-1500fc8b12f7
   reviewedAt: 2026-05-04
 - id: us-jesus-radio-us
+  favicon: "https://jesusradio.fm/wp-content/themes/jesusradio_theme/assets/img/logo-dark.png"
   broadcaster: independent
   name: Jesus Radio US
   streamUrl: https://streaming.radio.co/s1dc8ab02e/listen
@@ -50806,6 +51039,7 @@
   changeuuid: b91fc063-5b8b-4bea-8e1c-9fca5222ddad
   reviewedAt: 2026-05-04
 - id: us-sanctuary-radio-live-club-mix-channel
+  favicon: "https://cdn-radiotime-logos.tunein.com/s121324d.png"
   broadcaster: independent
   name: Sanctuary Radio (Live Club Mix Channel)
   streamUrl: https://thassos.cdnstream.com/proxy/rob?mp=/stream
@@ -51010,6 +51244,7 @@
   changeuuid: 304e79ab-cd00-4943-957e-5813f36e7d0d
   reviewedAt: 2026-05-04
 - id: us-kpbs-radio-reading-service
+  favicon: "https://cdn.onlineradiobox.com/img/l/9/8479.v4.png"
   broadcaster: independent
   name: KPBS Radio Reading Service
   streamUrl: https://kpbs-rrs.streamguys1.com/kpbs-rrs
@@ -51085,6 +51320,7 @@
   changeuuid: d3c7b695-7334-4055-9b12-e51d8d28bd1c
   reviewedAt: 2026-05-04
 - id: us-la-jefa-99-3
+  favicon: "https://cdn.onlineradiobox.com/img/l/4/14914.v14.png"
   broadcaster: independent
   name: La Jefa 99.3
   streamUrl: https://ice6.securenetsystems.net/WGUE?type=.mp3%27
@@ -51392,6 +51628,7 @@
   changeuuid: 76aa991b-8d00-4b25-a2d5-d8b36db0e16c
   reviewedAt: 2026-05-04
 - id: us-95-the-met
+  favicon: "https://cdn-profiles.tunein.com/s21940/images/logod.png?t=637018144020000000"
   broadcaster: independent
   name: 95 the Met
   streamUrl: https://ice66.securenetsystems.net/WMTT
@@ -51468,6 +51705,7 @@
   changeuuid: 017104e7-468e-4cd9-a9fc-c4ac198d6d80
   reviewedAt: 2026-05-04
 - id: us-sacrameto-capradio-news
+  favicon: "https://cdn.onlineradiobox.com/img/l/6/5356.v1.png"
   broadcaster: independent
   name: Sacrameto CapRadio News
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/KXJZ.mp3
@@ -51480,6 +51718,7 @@
   changeuuid: 95c9bc38-92d0-44a8-8faa-1e4233061e87
   reviewedAt: 2026-05-04
 - id: us-sounds-of-broadway
+  favicon: "https://cdn.onlineradiobox.com/img/l/5/87155.v2.png"
   broadcaster: independent
   name: Sounds of Broadway
   streamUrl: https://streamer.radio.co/s5cd7204e5/listen
@@ -51667,6 +51906,7 @@
   changeuuid: 30c75c74-9544-4414-90fa-b22c4b0d6de7
   reviewedAt: 2026-05-04
 - id: us-radio-singham
+  favicon: "https://cdn.onlineradiobox.com/img/l/3/105113.v5.png"
   broadcaster: independent
   name: "Radio Singham "
   streamUrl: https://stream.zeno.fm/2vhb00mhky8uv
@@ -51716,6 +51956,7 @@
   changeuuid: c59bd44f-c537-4de1-9d66-51f290632464
   reviewedAt: 2026-05-04
 - id: us-wbob-jacksonville
+  favicon: "https://wbob.com/wp-content/uploads/sites/2/WBOB-Logo.svg"
   broadcaster: independent
   name: WBOB Jacksonville
   streamUrl: https://ice41.securenetsystems.net/WBOB
@@ -51842,6 +52083,7 @@
   changeuuid: 8d39fb11-c26f-4404-ad75-a76835002213
   reviewedAt: 2026-05-04
 - id: us-the-ridge
+  favicon: "https://media.live365.com/download/48c6b077-fd67-4df6-bc66-fe319f2276c8.jpg"
   broadcaster: independent
   name: The Ridge
   streamUrl: https://streaming.live365.com/a91300
@@ -51995,6 +52237,7 @@
   changeuuid: 1dcadcb9-4d86-4243-8139-778948207b16
   reviewedAt: 2026-05-04
 - id: us-pure-oldies-107-5
+  favicon: "https://cdn.onlineradiobox.com/img/l/7/125577.v7.png"
   broadcaster: independent
   name: Pure Oldies 107.5
   streamUrl: https://live.amperwave.net/direct/saga-wdbrhd3aac-imc
@@ -52046,6 +52289,7 @@
   changeuuid: 5087a0b5-011b-4688-a2d4-e74adaac2a44
   reviewedAt: 2026-05-04
 - id: us-america-old-time-radio
+  favicon: "https://cdn-radiotime-logos.tunein.com/s189712d.png"
   broadcaster: independent
   name: America OLD time Radio
   streamUrl: https://kea.cdnstream.com/1893_128
@@ -52186,6 +52430,7 @@
   changeuuid: c3d086e8-bebc-48fa-abf3-2d91d3e4af65
   reviewedAt: 2026-05-04
 - id: us-kuaf-hd3-jazz-stream-fayetteville-ar
+  favicon: "https://npr.brightspotcdn.com/dims4/default/2fe2307/2147483647/strip/true/crop/3537x1681+0+0/resize/252x120!/quality/90/?url=http%3A%2F%2Fnpr-brightspot.s3.amazonaws.com%2F8c%2F6d%2Fc5e7cb4e475aa5a25568b8e3586c%2Fkuaf-mustache.png"
   broadcaster: independent
   name: KUAF-HD3 Jazz Stream - Fayetteville, AR
   streamUrl: https://war.streamguys1.com:7031/kuaf3
@@ -52468,6 +52713,7 @@
   changeuuid: 235e2867-aff2-4b05-83ee-1fde57ea1cfe
   reviewedAt: 2026-05-04
 - id: us-bigfoot-country-legends
+  favicon: "https://cdn.onlineradiobox.com/img/l/1/113631.v4.png"
   broadcaster: independent
   name: Bigfoot Country Legends
   streamUrl: https://ice24.securenetsystems.net/WLEJ
@@ -52506,6 +52752,7 @@
   changeuuid: 6de411a9-3339-4ab4-8da6-d141552e9622
   reviewedAt: 2026-05-04
 - id: us-holy-culture
+  favicon: "https://play-lh.googleusercontent.com/uvZWPGlOECO3ie0ha3sfctKpOc2Cv1HSliBD6vWAr47aJIyrFlxkVVWBGwbfSVd2XA4=w240-h480"
   broadcaster: independent
   name: Holy Culture
   streamUrl: https://stream.radio.co/s09849366f/listen
@@ -52596,6 +52843,7 @@
   changeuuid: 44803049-d4c1-4576-8813-ea239aaee4d0
   reviewedAt: 2026-05-04
 - id: us-89-3-wzrd-the-wizard-freeform-radio
+  favicon: "https://cdn-profiles.tunein.com/s24421/images/logod.png?t=637496908310000000"
   broadcaster: independent
   name: 89.3 - WZRD “The Wizard” Freeform Radio
   streamUrl: https://wzrd.streamguys1.com/live
@@ -52748,6 +52996,7 @@
   changeuuid: 2a3a0382-2394-4831-b31e-c42bafa892b4
   reviewedAt: 2026-05-04
 - id: us-sunny-radio
+  favicon: "https://cdn-profiles.tunein.com/s297540/images/logod.jpg?t=636409137619000000"
   broadcaster: independent
   name: Sunny Radio
   streamUrl: https://stream.revma.ihrhls.com/zc5014
@@ -52759,6 +53008,7 @@
   changeuuid: 4df0d1a4-0c2d-4673-bee4-3cf2b11888f2
   reviewedAt: 2026-05-04
 - id: us-wsmr-classical
+  favicon: "https://cdn-profiles.tunein.com/s47518/images/logod.png?t=636355859113600000"
   broadcaster: independent
   name: WSMR Classical
   streamUrl: https://streaming.floridaclassicalstation.fm/wsmr
@@ -52911,6 +53161,7 @@
   changeuuid: 7f1288dd-8de5-4c77-a960-415e38599875
   reviewedAt: 2026-05-04
 - id: us-kpac-88-3-fm-tpr-classical
+  favicon: "https://cdn-radiotime-logos.tunein.com/s34616d.png"
   broadcaster: independent
   name: KPAC 88.3 FM TPR Classical
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/KPACFMAAC.aac
@@ -52987,6 +53238,7 @@
   changeuuid: e6567efd-b67d-4aee-aafd-224cb0cf0a67
   reviewedAt: 2026-05-04
 - id: us-4u-motown
+  favicon: "https://www.4uradios.com/images/4umotown.jpg"
   broadcaster: independent
   name: 4U Motown
   streamUrl: https://str4uice.streamakaci.com/4umotown.mp3
@@ -53064,6 +53316,7 @@
   changeuuid: 1b732463-15b5-45a7-b7f6-3fc45aa7326d
   reviewedAt: 2026-05-04
 - id: us-joy-fm-florida
+  favicon: "https://cdn-profiles.tunein.com/s29850/images/logod.jpg?t=1"
   broadcaster: independent
   name: JOY FM FLORIDA
   streamUrl: https://rtn.cdnstream1.com/2580_96.aac
@@ -53127,6 +53380,7 @@
   changeuuid: cac60bd1-cbe2-49ba-8e91-62fb463385a0
   reviewedAt: 2026-05-04
 - id: us-kik-country
+  favicon: "https://static-media.streema.com/media/cache/e3/64/e3640ca5d64d3e2b867c763373e35aed.png"
   broadcaster: independent
   name: KIK Country
   streamUrl: https://ice5.securenetsystems.net/KICKFM
@@ -53164,6 +53418,7 @@
   changeuuid: 04aa0c66-398e-4117-b15d-37d3b326f7a2
   reviewedAt: 2026-05-04
 - id: us-radio-africa-1804
+  favicon: "https://cdn-profiles.tunein.com/s245638/images/logod.png?t=636626976301100000"
   broadcaster: independent
   name: Radio Africa 1804
   streamUrl: https://radioafrica1804.radioca.st/stream?fbclid=IwZXh0bgNhZW0CMTEAAR3p98dzdsZrwtqWOVDYxmh47DPWz5zJPwesnrlulZrOzEg2smZ_DvXeoaE_aem_52V7iXQ5XljK
@@ -53329,6 +53584,7 @@
   changeuuid: b67b7814-c78d-44ef-88d0-b1fe9f6a754c
   reviewedAt: 2026-05-04
 - id: us-tattoo-metal
+  favicon: "https://cdn-profiles.tunein.com/s284539/images/logod.png?t=636391904259000000"
   broadcaster: independent
   name: Tattoo metal
   streamUrl: https://usa14.fastcast4u.com/proxy/tattoometal?mp=/1
@@ -53522,6 +53778,7 @@
   changeuuid: 156ba7e8-2154-4d79-aeaf-32a7fd441152
   reviewedAt: 2026-05-04
 - id: us-waza-107-7-fm
+  favicon: "https://cdn.onlineradiobox.com/img/l/5/30105.v3.png"
   broadcaster: independent
   name: WAZA 107.7 FM
   streamUrl: https://ice5.securenetsystems.net/WAZA
@@ -53661,6 +53918,7 @@
   changeuuid: 00650cff-2a8d-4a24-b313-a6f42538c9a3
   reviewedAt: 2026-05-04
 - id: us-praise-96-5
+  favicon: "https://cdn.onlineradiobox.com/img/l/2/99082.v3.png"
   broadcaster: independent
   name: Praise 96.5
   streamUrl: https://ice64.securenetsystems.net/WMRKHD3
@@ -53839,6 +54097,7 @@
   changeuuid: 5bb88fd0-578b-4bac-b990-724d017893b1
   reviewedAt: 2026-05-04
 - id: us-big-r-radio-80s-punk-rock
+  favicon: "https://cdn.onlineradiobox.com/img/l/3/31673.v2.png"
   broadcaster: independent
   name: Big R Radio - 80s Punk Rock
   streamUrl: https://bigrradio.cdnstream1.com/5218_128
@@ -54071,6 +54330,7 @@
   changeuuid: 54f26e2b-993b-4169-b143-5f941f37e7c4
   reviewedAt: 2026-05-04
 - id: us-k-kountry-95
+  favicon: "https://cdn.onlineradiobox.com/img/l/7/32527.v3.png"
   broadcaster: independent
   name: K-Kountry 95
   streamUrl: https://crystalout.surfernetwork.com:8001/KAMS_MP3
@@ -54107,6 +54367,7 @@
   changeuuid: 613a6bfb-54b8-4134-9383-dd8eb91307ba
   reviewedAt: 2026-05-04
 - id: us-la-suavecita-93-9
+  favicon: "https://cdn.onlineradiobox.com/img/l/7/18387.v6.png"
   broadcaster: independent
   name: La Suavecita 93.9
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/KINTFM.mp3
@@ -54669,6 +54930,7 @@
   changeuuid: fa3cd87c-1262-440b-8f95-fb28a3abc642
   reviewedAt: 2026-05-04
 - id: us-radio-oncemore
+  favicon: "https://cdn-profiles.tunein.com/s126354/images/logod.jpg?t=636334906075200000"
   broadcaster: independent
   name: Radio OnceMore
   streamUrl: https://ice66.securenetsystems.net/ROM
@@ -54808,6 +55070,7 @@
   changeuuid: 60e86a16-ad90-4de1-b248-0ed212d647f8
   reviewedAt: 2026-05-04
 - id: us-kajun-107-1
+  favicon: "https://cdn.onlineradiobox.com/img/l/1/34561.v3.png"
   broadcaster: independent
   name: Kajun 107.1
   streamUrl: https://ice8.securenetsystems.net/WHMD
@@ -55025,6 +55288,7 @@
   changeuuid: d1dc6220-b4fc-4723-b257-fa0d1622aabf
   reviewedAt: 2026-05-04
 - id: us-intense-102-9-fm
+  favicon: "https://cdn-profiles.tunein.com/s141461/images/logod.png?t=637776082850000000"
   broadcaster: independent
   name: Intense 102.9 fm
   streamUrl: https://ice6.securenetsystems.net/INTRADIO
@@ -55089,6 +55353,7 @@
   changeuuid: 59f27b6e-8eb0-4181-8bf1-a9e8c42f999b
   reviewedAt: 2026-05-04
 - id: us-la-tricolor-94-7
+  favicon: "https://static2.mytuner.mobi/media/tvos_radios/819/la-tricolor-947-fm-kyse.863f8b44.png"
   broadcaster: independent
   name: La Tricolor 94.7
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/KYSEFMAAC.aac
@@ -55126,6 +55391,7 @@
   changeuuid: 57b10c24-1799-4e84-9514-cb80a0b47b4a
   reviewedAt: 2026-05-04
 - id: us-rock-100-5
+  favicon: "https://cdn-profiles.tunein.com/s23895/images/logod.png?t=638096511020000000"
   broadcaster: independent
   name: Rock 100.5
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/WNNXFMAAC.aac
@@ -55253,6 +55519,7 @@
   changeuuid: a28dbf00-9539-4227-b483-98e9f9eeede6
   reviewedAt: 2026-05-04
 - id: us-gumbo-94-9
+  favicon: "https://cdn.onlineradiobox.com/img/l/7/4367.v7.png"
   broadcaster: independent
   name: Gumbo 94.9
   streamUrl: https://ice42.securenetsystems.net/WGUO
@@ -55365,6 +55632,7 @@
   changeuuid: 43b88ab8-83b7-4839-9449-2f5550b5cb54
   reviewedAt: 2026-05-04
 - id: us-q107-3
+  favicon: "https://cdn-radiotime-logos.tunein.com/s27830d.png"
   broadcaster: independent
   name: Q107.3
   streamUrl: https://ice66.securenetsystems.net/WCGQFM
@@ -55377,6 +55645,7 @@
   changeuuid: ec0763d3-7c5e-42d1-a44b-2ff6a9726f4e
   reviewedAt: 2026-05-04
 - id: us-radiohits-us
+  favicon: "https://cdn-profiles.tunein.com/s156347/images/logod.jpg?t=638181864600000000"
   broadcaster: independent
   name: RadioHits.us
   streamUrl: https://streaming.live365.com/a30884
@@ -55439,6 +55708,7 @@
   changeuuid: 1c22250b-8bb6-415c-a42d-4c2412ac29dc
   reviewedAt: 2026-05-04
 - id: us-wiod
+  favicon: "https://cdn-profiles.tunein.com/s29627/images/logod.jpg?t=638088213350000000"
   broadcaster: independent
   name: Wiod
   streamUrl: https://stream.revma.ihrhls.com/zc569/hls.m3u8
@@ -55653,6 +55923,7 @@
   changeuuid: 1b6956db-3680-4970-81ab-3fddb1d41a57
   reviewedAt: 2026-05-04
 - id: us-106-9-the-q
+  favicon: "https://cdn-radiotime-logos.tunein.com/s101953d.png"
   broadcaster: independent
   name: 106.9 The Q
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/KVGQFMAAC.aac
@@ -56293,6 +56564,7 @@
   changeuuid: 34568445-c472-4ed5-88a2-fe49ff6f5fc1
   reviewedAt: 2026-05-04
 - id: us-us1-radio
+  favicon: "https://cdn-radiotime-logos.tunein.com/s23879d.png"
   broadcaster: independent
   name: US1 Radio
   streamUrl: https://ice42.securenetsystems.net/WWUS
@@ -56419,6 +56691,7 @@
   changeuuid: 1de2fd21-c9e7-4d3d-99cf-6cf8dec83983
   reviewedAt: 2026-05-04
 - id: us-88-5-wjie
+  favicon: "https://cdn-radiotime-logos.tunein.com/s29842d.png"
   broadcaster: independent
   name: 88.5 WJIE
   streamUrl: https://ice7.securenetsystems.net/WJIE
@@ -56444,6 +56717,7 @@
   changeuuid: 082c2a6e-65d1-4049-b58f-c84f3495f5b2
   reviewedAt: 2026-05-04
 - id: us-allfunkradio
+  favicon: "https://cdn-profiles.tunein.com/s306478/images/logod.png?t=639137857500000000"
   broadcaster: independent
   name: AllFunkRadio
   streamUrl: https://stream.laut.fm/54-funk-soul-dance
@@ -56533,6 +56807,7 @@
   changeuuid: e8930c83-13bb-402b-8f28-b73d23df8205
   reviewedAt: 2026-05-04
 - id: us-lite-rock-105
+  favicon: "https://cdn-profiles.tunein.com/s23795/images/logod.png?t=637450243020000000"
   broadcaster: independent
   name: Lite Rock 105
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/WWLIFMAAC.aac
@@ -56712,6 +56987,7 @@
   changeuuid: e7bd6510-a1ca-48d9-b9a2-5ede233db4a2
   reviewedAt: 2026-05-04
 - id: us-altrok-radio-wbjb-nj
+  favicon: "https://cdn-radiotime-logos.tunein.com/s55282d.png"
   broadcaster: independent
   name: Altrok Radio WBJB, NJ
   streamUrl: https://ice.wbjb.net/ALT-MP3-High
@@ -56749,6 +57025,7 @@
   changeuuid: 1e8734c7-c313-46f8-8bc6-5645c068e2ba
   reviewedAt: 2026-05-04
 - id: us-heaven-88-7
+  favicon: "https://cdn-radiotime-logos.tunein.com/s32590d.png"
   broadcaster: independent
   name: Heaven 88.7
   streamUrl: https://ice7.securenetsystems.net/KFBN887
@@ -56825,6 +57102,7 @@
   changeuuid: 8809fc78-7737-4b2b-9a61-37eb88490aca
   reviewedAt: 2026-05-04
 - id: us-la-classica
+  favicon: "https://cdn-profiles.tunein.com/s244379/images/logod.jpg?t=639000204920000000"
   broadcaster: independent
   name: La Classica
   streamUrl: https://stream.laclassica.be:18023/stream2
@@ -57002,6 +57280,7 @@
   changeuuid: 27ec3370-b54b-4c53-a808-4e586e26f3b6
   reviewedAt: 2026-05-04
 - id: us-big-froggy-101
+  favicon: "https://cdn-profiles.tunein.com/s29079/images/logod.jpg?t=637324168590000000"
   broadcaster: independent
   name: Big Froggy 101
   streamUrl: https://ice25.securenetsystems.net/WFGE
@@ -57089,6 +57368,7 @@
   changeuuid: 1961ee3a-a0b2-4f4d-bbc5-7c2e327f414e
   reviewedAt: 2026-05-04
 - id: us-krko-1380am-95-3fm
+  favicon: "https://cdn-profiles.tunein.com/s35018/images/logod.png?t=638313527230000000"
   broadcaster: independent
   name: KRKO 1380AM 95.3FM
   streamUrl: https://www.ophanim.net:8444/s/9400
@@ -57327,6 +57607,7 @@
   changeuuid: acac0aaf-32e6-4236-a002-418733a20b91
   reviewedAt: 2026-05-04
 - id: us-am-790
+  favicon: "https://cdn-profiles.tunein.com/s22836/images/logod.png?t=636664762814900000"
   broadcaster: independent
   name: AM 790
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/WPRVAMAAC.aac
@@ -57403,6 +57684,7 @@
   changeuuid: 64a4143c-65d7-42ef-bbea-700fa3f799f5
   reviewedAt: 2026-05-04
 - id: us-gd-radio
+  favicon: "https://cdn-radiotime-logos.tunein.com/s54607d.png"
   broadcaster: independent
   name: GD Radio
   streamUrl: https://ssl.rockhost.com/proxy/gdradiov2?mp=/stream
@@ -57452,6 +57734,7 @@
   changeuuid: 3a942994-0629-4c2d-b1d8-459fa9df41a8
   reviewedAt: 2026-05-04
 - id: us-kbbi-890-homer-ak
+  favicon: "https://cdn-profiles.tunein.com/s31632/images/logod.jpg?t=637885828450000000"
   broadcaster: independent
   name: KBBI 890 Homer, AK
   streamUrl: https://kbbi.streamguys1.com/xstream
@@ -57708,6 +57991,7 @@
   changeuuid: d8ab22ef-2007-4b1f-84d6-404017eddff3
   reviewedAt: 2026-05-04
 - id: us-hot-99-5
+  favicon: "https://cdn-profiles.tunein.com/s29553/images/logod.jpg?t=638493951420000000"
   broadcaster: independent
   name: HOT 99.5
   streamUrl: https://stream.revma.ihrhls.com/zc2509/hls.m3u8
@@ -57733,6 +58017,7 @@
   changeuuid: 3e1c367b-19ad-4541-b308-787832a29293
   reviewedAt: 2026-05-04
 - id: us-kbrw-680-am
+  favicon: "https://cdn-radiotime-logos.tunein.com/s31846d.png"
   broadcaster: independent
   name: KBRW  680 AM
   streamUrl: https://tektite.streamguys1.com:5345/live
@@ -57809,6 +58094,7 @@
   changeuuid: c53dff9e-5471-48f3-bf25-986768ed4c85
   reviewedAt: 2026-05-04
 - id: us-radio-naya-andaz
+  favicon: "https://static2.mytuner.mobi/media/tvos_radios/701/radio-naya-andaz.49231c6b.png"
   broadcaster: independent
   name: Radio Naya Andaz
   streamUrl: https://radionayaandaz.out.airtime.pro/radionayaandaz_a
@@ -58065,6 +58351,7 @@
   changeuuid: 4b908ecf-c5cc-4f47-a68d-5b82417e458d
   reviewedAt: 2026-05-04
 - id: us-ktlr-community-talk-am-890
+  favicon: "https://cdn-radiotime-logos.tunein.com/s35690d.png"
   broadcaster: independent
   name: KTLR Community Talk AM 890
   streamUrl: https://crystalout.surfernetwork.com:8001/KTLR_MP3
@@ -58202,6 +58489,7 @@
   changeuuid: c9f14950-7f97-42c6-8edb-fc20112958d4
   reviewedAt: 2026-05-04
 - id: us-wsou
+  favicon: "https://cdn-profiles.tunein.com/s22916/images/logod.jpg?t=638971731730000000"
   broadcaster: independent
   name: WSOU
   streamUrl: https://d3byg0ij92yqk6.cloudfront.net/streamWSOU1.m3u8
@@ -58404,6 +58692,7 @@
   changeuuid: 0fb65d91-8ae1-4a1a-b70e-535674a9de94
   reviewedAt: 2026-05-04
 - id: us-sun-radio
+  favicon: "https://cdn-profiles.tunein.com/s32699/images/logod.png"
   broadcaster: independent
   name: Sun Radio
   streamUrl: https://ice10.securenetsystems.net/SUNRADIO
@@ -58620,6 +58909,7 @@
   changeuuid: a1853b54-580c-432c-b7b9-7239693cde46
   reviewedAt: 2026-05-04
 - id: us-kmbi-moody-radio-northwest
+  favicon: "https://cdn-radiotime-logos.tunein.com/s33968d.png"
   broadcaster: independent
   name: KMBI - Moody Radio Northwest
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/KMBIFM.mp3
@@ -58952,6 +59242,7 @@
   changeuuid: 269e1af4-3214-496c-97b1-304fd54ca0e5
   reviewedAt: 2026-05-04
 - id: us-kmhd2-adaptive-aac
+  favicon: "https://cdn-profiles.tunein.com/s121776/images/logod.jpg?t=637073598750000000"
   broadcaster: independent
   name: KMHD2 Adaptive AAC
   streamUrl: https://live.amperwave.net/manifest/mhcc-kmhchd2aac-hlsc1.m3u8
@@ -59218,6 +59509,7 @@
   changeuuid: a567957c-8b85-47f1-9d41-e85d42289fdc
   reviewedAt: 2026-05-04
 - id: us-88-5-chuck-fm
+  favicon: "https://cdn-profiles.tunein.com/s42211/images/logod.png?t=636467840514000000"
   broadcaster: independent
   name: 88.5 Chuck FM
   streamUrl: https://ice23.securenetsystems.net/CHUCKFM
@@ -59509,6 +59801,7 @@
   changeuuid: 2d7f1c31-e170-4e63-b281-67e40f8e1650
   reviewedAt: 2026-05-04
 - id: us-star-107-9-america-s-first-80s-station
+  favicon: "https://cdn-profiles.tunein.com/s7365/images/logod.png?t=637039015280000000"
   broadcaster: independent
   name: STAR 107.9 - America's First 80s Station
   streamUrl: https://streaming.live365.com/a51314
@@ -59685,6 +59978,7 @@
   changeuuid: ba8602dc-ecc8-4b72-8bd0-cb8d0797ec03
   reviewedAt: 2026-05-04
 - id: us-keys-for-kids-radio
+  favicon: "https://cdn-radiotime-logos.tunein.com/s18666d.png"
   broadcaster: independent
   name: Keys for Kids Radio
   streamUrl: https://streaming.live365.com/a78246_2
@@ -59851,6 +60145,7 @@
   changeuuid: a773fda2-b74e-4e3d-963f-83ee46ac8000
   reviewedAt: 2026-05-04
 - id: us-xtra-106-3
+  favicon: "https://cdn-profiles.tunein.com/s28830/images/logod.jpg?t=637557521030000000"
   broadcaster: independent
   name: Xtra 106.3
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/WFOMAM.mp3
@@ -60004,6 +60299,7 @@
   changeuuid: 0b9aaea5-6b57-4bbe-8f63-cfcb6524611b
   reviewedAt: 2026-05-04
 - id: us-friends-of-csb-tuner-feed-of-89-3-fm
+  favicon: "https://cdn-profiles.tunein.com/s28036/images/logod.png?t=636603604151500000"
   broadcaster: independent
   name: Friends of 'CSB (Tuner feed of 89.3 FM)
   streamUrl: https://s20.myradiostream.com:18792/listen.mp3
@@ -60131,6 +60427,7 @@
   changeuuid: cf83edd5-8593-44f2-84f7-c1919a75f10a
   reviewedAt: 2026-05-04
 - id: us-radio-epic
+  favicon: "https://cdn-profiles.tunein.com/s340024/images/logod.png?t=638754978530000000"
   broadcaster: independent
   name: Radio Epic
   streamUrl: https://broadcast.miami/proxy/epic?mp=/stream/;
@@ -60180,6 +60477,7 @@
   changeuuid: ee278356-4e32-4b55-a1ea-41d026238776
   reviewedAt: 2026-05-04
 - id: us-stereo-rey
+  favicon: "https://cdn-profiles.tunein.com/s273680/images/logod.jpg?t=638015808470000000"
   broadcaster: independent
   name: STEREO REY
   streamUrl: https://server.radiogs.net/8174/stream

--- a/public/stations.json
+++ b/public/stations.json
@@ -1379,6 +1379,7 @@
         "rock",
         "switzerland"
       ],
+      "favicon": "https://cdn-radiotime-logos.tunein.com/s264064d.png",
       "bitrate": 320,
       "codec": "MP3",
       "geo": [
@@ -1865,6 +1866,7 @@
       "tags": [
         "switzerland"
       ],
+      "favicon": "https://cdn-radiotime-logos.tunein.com/s117510d.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -10116,7 +10118,7 @@
         "adult contemporary",
         "australia"
       ],
-      "favicon": "https://d2nzqyyfd6k6c7.cloudfront.net/favicon_2.ico",
+      "favicon": "https://cdn-profiles.tunein.com/s98004/images/logod.jpg",
       "bitrate": 48,
       "codec": "AAC+",
       "geo": [
@@ -10352,7 +10354,7 @@
         "classic hits",
         "poland"
       ],
-      "favicon": "http://www.rmfon.pl/assets/images/favicon/apple-touch-icon.png",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/7/1497.v10.png",
       "bitrate": 64,
       "codec": "MP3",
       "geo": [
@@ -10373,7 +10375,7 @@
         "electronic",
         "poland"
       ],
-      "favicon": "http://www.rmfon.pl/assets/images/favicon/apple-touch-icon.png",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/1/1481.v7.png",
       "bitrate": 64,
       "codec": "MP3",
       "geo": [
@@ -11214,7 +11216,7 @@
         "hits",
         "denmark"
       ],
-      "favicon": "https://assets.planetradio.co.uk/img/ConfigWebListenBarLogoImageUrl/173.jpg",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/2/11832.v2.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -13080,6 +13082,7 @@
         "hits",
         "czech"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/8/46858.v9.png",
       "bitrate": 128,
       "codec": "AAC",
       "geo": [
@@ -13525,7 +13528,7 @@
         "hits",
         "croatian"
       ],
-      "favicon": "https://www.radio-banovina.hr/turbo/tmp/images/logo.1642614175.png",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/3/75503.v8.png",
       "bitrate": 96,
       "codec": "MP3",
       "geo": [
@@ -14190,7 +14193,7 @@
         "metal",
         "bulgarian"
       ],
-      "favicon": "https://www.badrockradio.net/wp-content/uploads/2024/06/960x0-100x100.webp",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/2/135012.v1.png",
       "bitrate": 320,
       "codec": "MP3",
       "geo": [
@@ -14650,6 +14653,7 @@
         "rock",
         "serbian"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/4/66594.v14.png",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -14844,7 +14848,7 @@
         "spanish",
         "japanese"
       ],
-      "favicon": "https://images.zeno.fm/TrBD3tEtOJbMAdKu3XR64pWUT2XTjBhzgn2n2w_lFnE/rs:fit:500:500/g:ce:0:0/aHR0cHM6Ly9zdHJlYW0tdG9vbHMuemVub21lZGlhLmNvbS9jb250ZW50L3N0YXRpb25zL2FneHpmbnBsYm04dGMzUmhkSE55TWdzU0NrRjFkR2hEYkdsbGJuUVlnSUNBeF92bDF3b01DeElPVTNSaGRHbHZibEJ5YjJacGJHVVlnSUNBZ0lEeWlBb01vZ0VFZW1WdWJ3L2ltYWdlLz9yZXNpemU9NTAweDUwMCZ1cGRhdGVkPTE2NjI3NzM0MjEwMDA.webp",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/8/104068.v2.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -14906,6 +14910,7 @@
         "community",
         "japanese"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/5/79635.v9.png",
       "bitrate": 320,
       "codec": "MP3",
       "geo": [
@@ -15953,6 +15958,7 @@
         "spanish",
         "uruguayan"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s149403/images/logod.jpg",
       "bitrate": 256,
       "codec": "MP3",
       "geo": [
@@ -18003,7 +18009,7 @@
         "hits",
         "indonesian"
       ],
-      "favicon": "https://hardrockfm.com/favicon.ico",
+      "favicon": "https://assets-static.therockinlife.com/wp-content/uploads/2024/12/TRL-LOGO-2024-01.png",
       "codec": "AAC",
       "geo": [
         -6.2088,
@@ -18168,7 +18174,7 @@
         "90s",
         "filipino"
       ],
-      "favicon": "https://img1.wsimg.com/isteam/ip/2bffade2-3155-4bd7-8193-8155e093f550/9PA%20Small%20Logo.png/:/rs=w:200,h:200,cg:true,m/cr=w:200,h:200/qt=q:95",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/5/113125.v16.png",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -18440,7 +18446,7 @@
         "folk",
         "turkish"
       ],
-      "favicon": "https://www.damarturkfm.com/favicon.ico",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/2/68492.v23.png",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -18589,6 +18595,7 @@
         "arabic",
         "emirati"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/6/87476.v2.png",
       "bitrate": 56,
       "codec": "AAC",
       "geo": [
@@ -18610,6 +18617,7 @@
         "indian",
         "emirati"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/4/18894.v9.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -18652,7 +18660,7 @@
         "english",
         "emirati"
       ],
-      "favicon": "https://cdn.audioaddict.com/classicalradio.com/assets/apple-touch-icon-120x120-7922555f3bb73e6e492c46abda410434ea8ca2dd3349ce116a1511dde6f4f584.png",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/8/112318.v3.png",
       "codec": "AAC",
       "geo": [
         25.2048,
@@ -18673,6 +18681,7 @@
         "english",
         "emirati"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/8/91208.v6.png",
       "codec": "AAC",
       "geo": [
         25.2048,
@@ -18693,6 +18702,7 @@
         "hindi",
         "indian"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/8/83448.v5.png",
       "bitrate": 94,
       "codec": "AAC",
       "geo": [
@@ -21130,6 +21140,7 @@
         "k-pop",
         "kpop"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/4/82014.v6.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -21692,6 +21703,7 @@
         "house",
         "soulful house"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s310360/images/logod.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -21752,6 +21764,7 @@
         "relaxing",
         "sounds of nature"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/7/120537.v4.png",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -21847,6 +21860,7 @@
         "guitar",
         "klassik"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/3/118003.v2.png",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -21866,6 +21880,7 @@
         "classic rock",
         "classic rock oldies"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/0/122680.v3.png",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -21923,6 +21938,7 @@
         "tech house",
         "techno"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s310359/images/logod.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -22216,6 +22232,7 @@
         "lounge",
         "lounge music"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/2/120522.v11.png",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -22251,6 +22268,7 @@
       "streamUrl": "https://stream.0nlineradio.com/mozart?ref=radiobrowser",
       "homepage": "https://0nlineradio.com/",
       "country": "DE",
+      "favicon": "https://cdn-profiles.tunein.com/s309936/images/logod.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -22269,6 +22287,7 @@
         "gabber",
         "gabberdisco"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s310344/images/logod.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -22483,6 +22502,7 @@
         "golden oldies",
         "goldies"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/6/122676.v3.png",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -22598,6 +22618,7 @@
         "instrumental",
         "new age piano"
       ],
+      "favicon": "https://epic-piano.com/assets/img/epicpiano-dark.png",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -22708,6 +22729,7 @@
       "streamUrl": "https://stream.0nlineradio.com/60s?ref=radiobrowser",
       "homepage": "https://0nlineradio.com/",
       "country": "DE",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/7/122677.v3.png",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -22842,6 +22864,7 @@
         "oldies",
         "oldies 50's/60's"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/8/122678.v3.png",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -22983,6 +23006,7 @@
         "nu metal",
         "rock"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/7/122707.v3.png",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -23002,6 +23026,7 @@
         "tropical",
         "tropical house"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s310158/images/logod.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -23025,6 +23050,7 @@
         "relax",
         "relaxation"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/3/120523.v3.png",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -23041,6 +23067,7 @@
         "chillout",
         "relax"
       ],
+      "favicon": "https://hirschmilch.de/logo.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -23075,6 +23102,7 @@
         "90er",
         "90s"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s309751/images/logod.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -23098,6 +23126,7 @@
         "classical",
         "klassik"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/0/118000.v2.png",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -23410,6 +23439,7 @@
         "discofox oldies",
         "goldies"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/1/122681.v3.png",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -23452,6 +23482,7 @@
         "goldies",
         "oldies"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/9/122679.v3.png",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -23475,6 +23506,7 @@
         "classical",
         "symphonic"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s309932/images/logod.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -23498,6 +23530,7 @@
         "lounge",
         "lounge music"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/2/120532.v4.png",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -23636,6 +23669,7 @@
         "dutch",
         "electro"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s310148/images/logod.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -23683,6 +23717,7 @@
         "electronic",
         "house"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s309752/images/logod.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -23706,6 +23741,7 @@
         "hardstyle",
         "uptempo hardcore"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s310350/images/logod.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -23766,6 +23802,7 @@
         "electronic",
         "electronic dance music"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s310144/images/logod.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -23805,6 +23842,7 @@
         "local news",
         "news"
       ],
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/6/62/Rbb24_Inforadio_Logo_2022.svg",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -23824,6 +23862,7 @@
         "chillout+lounge",
         "classic"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s320517/images/logod.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -23939,6 +23978,7 @@
         "hits",
         "piano"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s310028/images/logod.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -23972,6 +24012,7 @@
         "trance",
         "trance uplifting"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s310163/images/logod.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -23995,6 +24036,7 @@
         "pop",
         "rnb"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s309736/images/logod.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -24114,6 +24156,7 @@
         "jazz",
         "klassik"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s320508/images/logod.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -24200,6 +24243,7 @@
         "classics",
         "instrumental"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s310036/images/logod.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -24263,6 +24307,7 @@
         "chillout+lounge",
         "lounge"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s320534/images/logod.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -24282,6 +24327,7 @@
         "post dubstep",
         "trap"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s310154/images/logod.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -24305,6 +24351,7 @@
         "classical",
         "jazz"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s320510/images/logod.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -24340,6 +24387,7 @@
         "house",
         "houseparty"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s310160/images/logod.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -24558,6 +24606,7 @@
         "orchestra",
         "orchestral"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s320525/images/logod.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -24576,6 +24625,7 @@
         "gospel pop",
         "southern gospel"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s309749/images/logod.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -24599,6 +24649,7 @@
         "chillout+lounge",
         "lounge"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s310481/images/logod.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -24622,6 +24673,7 @@
         "chillout",
         "lounge"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s310368/images/logod.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -24852,6 +24904,7 @@
       "streamUrl": "https://stream.laut.fm/80s-90s",
       "homepage": "https://stream.laut.fm/80s-90s",
       "country": "DE",
+      "favicon": "https://cdn-profiles.tunein.com/s311284/images/logod.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -24995,6 +25048,7 @@
         "ndw",
         "neue deutsche härte"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s309762/images/logod.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -25058,6 +25112,7 @@
         "jazz",
         "lounge"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s310370/images/logod.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -25076,6 +25131,7 @@
         "classics",
         "piano"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s310029/images/logod.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -25194,6 +25250,7 @@
         "discofox+schlager",
         "schlager"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s309768/images/logod.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -25335,6 +25392,7 @@
         "oldies",
         "schlager"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s309769/images/logod.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -25445,6 +25503,7 @@
         "classical",
         "classical music"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s320507/images/logod.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -25524,6 +25583,7 @@
         "symphonic",
         "symphony"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s309933/images/logod.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -25544,6 +25604,7 @@
         "i love dance first!",
         "ilove dance first!"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s306646/images/logod.png",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -25609,6 +25670,7 @@
         "discofox",
         "discofox+schlager"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s309770/images/logod.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -25647,6 +25709,7 @@
       "tags": [
         "klassik"
       ],
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/e/e6/WDR_3_logo.svg",
       "bitrate": 256,
       "codec": "MP3",
       "status": "stream-only"
@@ -25943,6 +26006,7 @@
         "rock",
         "rock'n'roll"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s309742/images/logod.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -26055,6 +26119,7 @@
         "lounge",
         "lounge music"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s310366/images/logod.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -26109,6 +26174,7 @@
         "chillout+lounge",
         "lounge"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s310483/images/logod.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -26128,6 +26194,7 @@
         "evergreens",
         "radiomonster"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s233214/images/logod.png",
       "bitrate": 320,
       "codec": "MP3",
       "status": "stream-only"
@@ -26193,6 +26260,7 @@
       "streamUrl": "https://stream.dashitradio.de/alemannia/mp3-128/stream.mp3",
       "homepage": "https://stream.dashitradio.de/alemannia/mp3-128/stream.mp3",
       "country": "DE",
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/3/39/100%2C5_Das_Hitradio_Logo.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -26306,6 +26374,7 @@
         "love",
         "love songs"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s320519/images/logod.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -26342,6 +26411,7 @@
         "classics",
         "klassik"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s310033/images/logod.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -26578,6 +26648,7 @@
       "streamUrl": "https://stream.technolovers.fm/latinhouse?ref=radiobrowser",
       "homepage": "https://technolovers.fm/",
       "country": "DE",
+      "favicon": "https://cdn-profiles.tunein.com/s310147/images/logod.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -26737,6 +26808,7 @@
         "classical music",
         "instrumental"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s320511/images/logod.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -26799,6 +26871,7 @@
         "chillout+lounge",
         "classical"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s320527/images/logod.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -26929,6 +27002,7 @@
         "remix",
         "remixes"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s317224/images/logod.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -26963,6 +27037,7 @@
         "edm",
         "electro"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s309737/images/logod.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -26986,6 +27061,7 @@
         "relax",
         "relaxation music"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s320532/images/logod.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -27020,6 +27096,7 @@
         "classic soul",
         "lounge"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s310486/images/logod.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -27055,6 +27132,7 @@
         "volksmusik",
         "weihnachten"
       ],
+      "favicon": "https://alpenweihnacht.de/AW.jpg",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -27177,6 +27255,7 @@
         "deutschrock",
         "german"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/0/122690.v4.png",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -27216,6 +27295,7 @@
         "lounge",
         "lounge music"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s310482/images/logod.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -27239,6 +27319,7 @@
         "instrumental",
         "klassik"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s310031/images/logod.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -27274,6 +27355,7 @@
         "easy listening",
         "lounge"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s322192/images/logod.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -27297,6 +27379,7 @@
         "jazz",
         "klassik"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s320529/images/logod.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -27339,6 +27422,7 @@
         "schlager",
         "volksmusik"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s309774/images/logod.jpg?t=637562689640000000",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -27358,6 +27442,7 @@
         "klassik",
         "klassik weihnachten christmas"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/0/118010.v2.png",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -27377,6 +27462,7 @@
         "house",
         "lounge"
       ],
+      "favicon": "https://technolovers.fm/assets/img/technolovers-dark.png",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -27447,6 +27533,7 @@
         "discofox+schlager",
         "edm"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/9/122709.v3.png",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -27751,6 +27838,7 @@
         "lofi",
         "lounge"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/4/120554.v3.png",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -27902,6 +27990,7 @@
       "tags": [
         "classical"
       ],
+      "favicon": "https://www.radio-cafezimmermann.de/typo3conf/ext/sn_config_ra31/Resources/Public/Images/logo_rcz.png",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -28023,6 +28112,7 @@
         "oriental",
         "rap hiphop rnb"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/5/120535.v3.png",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -28111,6 +28201,7 @@
         "música pop",
         "piano"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/5/117995.v2.png",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -28206,6 +28297,7 @@
         "moombahton",
         "musica latina"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/4/122704.v3.png",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -28229,6 +28321,7 @@
         "lounge music",
         "relax"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/3/120533.v3.png",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -28352,6 +28445,7 @@
         "classical",
         "klassik"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/9/118009.v2.png",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -28387,6 +28481,7 @@
         "christian music",
         "christmas"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s310167/images/logod.jpg?t=637739882620000000",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -28537,6 +28632,7 @@
         "classical",
         "nightlife"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/7/118007.v2.png",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -28619,6 +28715,7 @@
       "tags": [
         "lounge"
       ],
+      "favicon": "https://static2.mytuner.mobi/media/tvos_radios/915/chillout-ibiza-fm.0d76f6fb.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -28638,6 +28735,7 @@
         "jazz",
         "klassik"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/6/117996.v2.png",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -28853,6 +28951,7 @@
         "80s",
         "90s"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/1/661.v2.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -28887,6 +28986,7 @@
         "relax",
         "relaxing"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/5/122705.v3.png",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -28942,6 +29042,7 @@
         "fairytales",
         "klassik"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s320526/images/logod.jpg?t=637932456640000000",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -29025,6 +29126,7 @@
         "rap hiphop rnb",
         "rnb"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/9/122719.v3.png",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -29135,6 +29237,7 @@
         "relax",
         "relaxing"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/5/122685.v3.png",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -29290,6 +29393,7 @@
         "symphonic",
         "symphony"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s309934/images/logod.jpg?t=637630166770000000",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -29317,6 +29421,7 @@
       "streamUrl": "https://stream.epic-lounge.com/christmas-lounge?ref=radiobrowser",
       "homepage": "https://epic-lounge.com/",
       "country": "DE",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/4/120534.v4.png",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -29538,6 +29643,7 @@
         "local news",
         "oldies"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/3/103213.v3.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -29648,6 +29754,7 @@
         "love songs",
         "lovesongs"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/6/122706.v3.png",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -29832,6 +29939,7 @@
         "top100",
         "young adults"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s245283/images/logod.png?t=639137857450000000",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -29851,6 +29959,7 @@
         "smooth jazz",
         "vocal jazz"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/7/122697.v3.png",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -29869,6 +29978,7 @@
       "tags": [
         "christian"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/0/92050.v3.png",
       "bitrate": 64,
       "codec": "MP3",
       "status": "stream-only"
@@ -29910,6 +30020,7 @@
         "electronic",
         "hits"
       ],
+      "favicon": "https://images.zeno.fm/QGOChNr_0sGoNcZ_hQq6Fwl6_75TH8fQnXFbUvNRvjI/rs:fill:288:288/g:ce:0:0/aHR0cHM6Ly9wcm94eS56ZW5vLmZtL2NvbnRlbnQvc3RhdGlvbnMvMDgyMzJjMGEtYjRlNS00NjNhLWFjNDItYjE4YjZhMDE1YmE0L2ltYWdlLz91PTE3MTM4NzMyMzcwMDA.webp",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -29933,6 +30044,7 @@
         "ska",
         "skin"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/9/102199.v8.png",
       "bitrate": 52,
       "codec": "AAC",
       "status": "stream-only"
@@ -29975,6 +30087,7 @@
       "tags": [
         "oldies"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s312514/images/logod.png?t=639137858110000000",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -30154,6 +30267,7 @@
         "christmas music",
         "weihnachten"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/6/122686.v3.png",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -30481,6 +30595,7 @@
         "pop",
         "techno"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/1/49641.v3.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -30626,6 +30741,7 @@
         "electropop",
         "synth-pop"
       ],
+      "favicon": "https://www.htd-radio.de/wp-content/uploads/2021/11/logo1.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -30671,6 +30787,7 @@
         "pop rock",
         "progressive rock"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/3/122713.v3.png",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -30968,6 +31085,7 @@
         "german",
         "hiphop"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/3/122693.v3.png",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -31280,6 +31398,7 @@
         "rap",
         "rock"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/8/122718.v3.png",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -31299,6 +31418,7 @@
         "chillout+lounge",
         "classic hip hop"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/0/120550.v4.png",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -31342,6 +31462,7 @@
       "streamUrl": "https://soundsindie.stream.laut.fm/soundsindie?t302=2026-01-15_00-39-17&uuid=b964e14b-acde-48cc-9208-0a783f2e7667",
       "homepage": "https://stream.laut.fm/soundsindie",
       "country": "DE",
+      "favicon": "https://cdn-profiles.tunein.com/s235046/images/logod.png?t=639137857310000000",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -31895,6 +32016,7 @@
         "heavy metal",
         "metal"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/7/137117.v2.png",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -31906,6 +32028,7 @@
       "streamUrl": "https://server34599.streamplus.de/stream.mp3",
       "homepage": "https://radio.dwgradio.net/de/radio-pur-lyra/",
       "country": "DE",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/9/92049.v5.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -31973,6 +32096,7 @@
         "dance",
         "pop"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/5/99845.v2.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -32291,6 +32415,7 @@
         "regionalfernsehen",
         "tv halle"
       ],
+      "favicon": "https://www.mdf1.de/img/logo_mdf1.png",
       "bitrate": 2468,
       "codec": "AAC",
       "status": "stream-only"
@@ -32383,6 +32508,7 @@
       "streamUrl": "https://stream.nightride.fm/rektory.mp3",
       "homepage": "https://stream.nightride.fm/rektory.mp3",
       "country": "DE",
+      "favicon": "https://nightride.fm/blog/content/images/2020/10/nr_full_600_pale-2.png",
       "bitrate": 320,
       "codec": "MP3",
       "status": "stream-only"
@@ -32470,6 +32596,7 @@
         "gay",
         "german"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/1/122711.v3.png",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -32683,6 +32810,7 @@
       "tags": [
         "schlager"
       ],
+      "favicon": "https://static2.mytuner.mobi/media/tvos_radios/637/m1fm-kuschel-schlager.2e877d23.jpg",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -32841,6 +32969,7 @@
         "industrial",
         "synthpop"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/3/44503.v2.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -33012,6 +33141,7 @@
         "80s",
         "80s radio"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/1/129401.v2.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -33060,6 +33190,7 @@
       "tags": [
         "country"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/7/42837.v2.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -33766,6 +33897,7 @@
       "streamUrl": "https://dancefloor-fm.stream.laut.fm/dancefloor-fm?t302=2025-03-03_21-41-17&uuid=ebadfaf0-8781-4c90-bb05-6652467979a2",
       "homepage": "http://www.saarlandsender.de/Startseite/",
       "country": "DE",
+      "favicon": "https://cdn-profiles.tunein.com/s329239/images/logod.png?t=639136128180000000",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -34092,6 +34224,7 @@
       "streamUrl": "https://radiolandau.stream.laut.fm/radiolandau?autoplay=1&t302=2026-01-15_04-32-23&uuid=e7434870-47a3-40c8-b36b-28961178b681",
       "homepage": "https://www.radiolandau.com/",
       "country": "DE",
+      "favicon": "https://www.radio.de/175/lautfm-radiolandau.png?version=23c91c529b1b921620f1dd1dbe2ac5983d5aa6cf",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -34417,6 +34550,7 @@
         "european",
         "european music"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s309750/images/logod.jpg?t=637562633390000000",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -34524,6 +34658,7 @@
         "christian",
         "predigten"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s320235/images/logod.png?t=639137859150000000",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -35083,6 +35218,7 @@
       "streamUrl": "https://stream.rs2.de/rs2/mp3-128/playlist",
       "homepage": "https://webradio.rs2de/livestream.m3u",
       "country": "DE",
+      "favicon": "https://cdn-profiles.tunein.com/s25221/images/logod.png?t=638295792520000000",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -35309,6 +35445,7 @@
         "mittelalter",
         "rock"
       ],
+      "favicon": "https://www.radio.de/175/lautfm-odinsmetalrockclub.png?version=db804fed59899a5364e3fb650421838f88da3e6c",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -35451,6 +35588,7 @@
       "streamUrl": "https://jazzchristmas.stream.laut.fm/jazzchristmas?t302=2023-12-19_08-05-17&uuid=43cac575-4695-4eca-baf1-5d2f18f5897b",
       "homepage": "https://jazzchristmas.stream.laut.fm/jazzchristmas?t302=2023-12-19_08-05-17&uuid=43cac575-4695-4eca-baf1-5d2f18f5897b",
       "country": "DE",
+      "favicon": "https://cdn-profiles.tunein.com/s321354/images/logod.png?t=639137859070000000",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -35865,6 +36003,7 @@
       "streamUrl": "https://exogaming.stream.laut.fm/exogaming?pl=m3u&t302=2026-01-15_04-32-19&uuid=26045880-323b-46fa-86ae-1edc8318dc7d",
       "homepage": "https://exogaming.stream.laut.fm/",
       "country": "DE",
+      "favicon": "https://cdn-profiles.tunein.com/s317326/images/logod.png?t=639137858760000000",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -36003,6 +36142,7 @@
       "streamUrl": "https://stream.0nlineradio.com/deutsch?ref=radiobrowser",
       "homepage": "https://0nlineradio.com/",
       "country": "DE",
+      "favicon": "https://cdn-profiles.tunein.com/s309746/images/logod.jpg?t=637562632390000000",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -36150,6 +36290,7 @@
         "pop",
         "rock"
       ],
+      "favicon": "https://www.radio.de/175/lautfm-radiodiefflen.png?version=dd5920242b8247c18f6da13f21ec573cc9e5ef95",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -36240,6 +36381,7 @@
       "tags": [
         "indie"
       ],
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/f/f0/917xfm-Logo.svg",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -36263,6 +36405,7 @@
       "streamUrl": "https://classic-progrock-fm.stream.laut.fm/classic-progrock-fm?t302=2025-03-10_17-34-10&uuid=8e6c3b96-2d13-44bc-a51b-386795198f38",
       "homepage": "https://classic-progrock-fm.stream.laut.fm/classic-progrock-fm?t302=2025-03-10_17-34-10&uuid=8e6c3b96-2d13-44bc-a51b-386795198f38",
       "country": "DE",
+      "favicon": "https://cdn-profiles.tunein.com/s319565/images/logod.png?t=639137858950000000",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -36405,6 +36548,7 @@
         "latin house",
         "tribal house"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/6/106146.v27.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -36483,6 +36627,7 @@
       "streamUrl": "https://synthesizergreatest.stream.laut.fm/synthesizergreatest",
       "homepage": "https://www.sgradio.eu/",
       "country": "DE",
+      "favicon": "https://www.sgradio.eu/img/logosmall.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -36613,6 +36758,7 @@
       "tags": [
         "electro industrial darkwave ebm futurepop synthpop goth"
       ],
+      "favicon": "https://www.iceradio.net/_img/logo.png",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -36753,6 +36899,7 @@
       "streamUrl": "https://yesterdayfm.schlagerparadies.de/yesterdayfm",
       "homepage": "http://www.rockhausradio.de/",
       "country": "DE",
+      "favicon": "https://cdn-radiotime-logos.tunein.com/s261866d.png",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -36933,6 +37080,7 @@
       "streamUrl": "https://stream.laut.fm/lightyeartraxx",
       "homepage": "https://stream.laut.fm/lightyeartraxx",
       "country": "DE",
+      "favicon": "https://cdn-profiles.tunein.com/s312149/images/logod.png?t=639137858000000000",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -37198,6 +37346,7 @@
         "local radio",
         "pop"
       ],
+      "favicon": "https://static-media.streema.com/media/cache/39/62/396249a75485b8456dae30e4388adfc9.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -37392,6 +37541,7 @@
         "lovesongs",
         "metal"
       ],
+      "favicon": "https://luzifer.us/wp-content/uploads/2026/02/cropped-Luzifer-us-united-network-goa-marius-251x251.png",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -37414,6 +37564,7 @@
         "pop",
         "pop rock"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/5/104895.v2.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -37425,6 +37576,7 @@
       "streamUrl": "https://karnevalsmusik.stream.laut.fm/karnevalsmusik?",
       "homepage": "https://karnevalsmusik.stream.laut.fm/",
       "country": "DE",
+      "favicon": "https://www.radio.de/175/lautfm-karnevalsmusik.png?version=1ea1efe10a15aca93341a735fc13c9077124a5b4",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -37474,6 +37626,7 @@
         "indie",
         "pop"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s108537/images/logod.jpg?t=637588530550000000",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -37570,6 +37723,7 @@
       "tags": [
         "deutschrock"
       ],
+      "favicon": "https://www.radio.de/175/lautfm-deutrockosterreich.png?version=4162b251323bbd06b7b01efa09fda7a88e6f0397",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -37642,6 +37796,7 @@
         "pop",
         "rock"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/7/51107.v5.png",
       "bitrate": 64,
       "codec": "AAC+",
       "status": "stream-only"
@@ -37924,6 +38079,7 @@
         "pop",
         "sir.robo media"
       ],
+      "favicon": "https://d371i8ihhgym7w.cloudfront.net/38314.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -38191,6 +38347,7 @@
       "tags": [
         "volksmusik"
       ],
+      "favicon": "https://www.radio.de/175/lautfm-alles-volksmusik.png?version=95b496d353602539b556808ff88f80690d50cb59",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -38449,6 +38606,7 @@
       "tags": [
         "pop und rock"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s101681/images/logod.png?t=639137857080000000",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -38463,6 +38621,7 @@
       "tags": [
         "post rock"
       ],
+      "favicon": "https://www.radio.de/175/lautfm-post-rock.png?version=91db28ddab006c1d3941022454686564fc7f7928",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -38569,6 +38728,7 @@
       "streamUrl": "https://rockpalast-revival-radio.stream.laut.fm/rockpalast-revival-radio?t302=2025-03-10_17-35-46&uuid=c2fb9df2-862c-4a7d-bc4e-03b06d147dff",
       "homepage": "https://rockpalast-revival-radio.stream.laut.fm/rockpalast-revival-radio?t302=2025-03-10_17-35-46&uuid=c2fb9df2-862c-4a7d-bc4e-03b06d147dff",
       "country": "DE",
+      "favicon": "https://www.phonostar.de/images/auto_created/lautfm_rockpalast-revival-radio184x184.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -38580,6 +38740,7 @@
       "streamUrl": "https://stream.laut.fm/rockstellar",
       "homepage": "https://stream.laut.fm/rockstellar",
       "country": "DE",
+      "favicon": "https://www.radio.de/175/lautfm-rockstellar.png?version=9ccecb175de97781d63638f71b641dea95b66725",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -38691,6 +38852,7 @@
       "streamUrl": "https://formel-eins-retro-hitradio.stream.laut.fm/formel-eins-retro-hitradio?t302=2025-03-10_17-37-07&uuid=e594fcf2-c9e2-40c2-9ef6-16a52b59b4dc",
       "homepage": "https://formel-eins-retro-hitradio.stream.laut.fm/formel-eins-retro-hitradio?t302=2025-03-10_17-37-07&uuid=e594fcf2-c9e2-40c2-9ef6-16a52b59b4dc",
       "country": "DE",
+      "favicon": "https://www.phonostar.de/images/auto_created/lautfm_formel-eins-retro-hitradio184x184.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -39093,6 +39255,7 @@
         "family",
         "pop"
       ],
+      "favicon": "https://d2absclsvmaf7v.cloudfront.net/eyJidWNrZXQiOiJyZWRha3Rpb24ua2FybHMiLCJrZXkiOiJiaWxkZXIvMzRkZWViMDQtNmM5Ny0xMWVkLWJhYjYtMDAwMDAwMDAwMDAwL2VybGVibmlzX3JhZGlvX2xvZ28ucG5nIiwiZWRpdHMiOnsidG9Gb3JtYXQiOiJ3ZWJwIiwid2VicCI6eyJsb3NzbGVzcyI6ZmFsc2V9LCJyZXNpemUiOnsiaGVpZ2h0IjoxMTAwLCJ3aWR0aCI6bnVsbCwiZml0IjoiaW5zaWRlIiwicG9zaXRpb24iOiJlbnRyb3B5IiwiYmFja2dyb3VuZCI6IiNlYmQ4YmYifX19",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -39241,6 +39404,7 @@
       "tags": [
         "schlager"
       ],
+      "favicon": "https://www.radio.de/175/lautfm-weissblauerstammtisch.png?version=641bf5029ca8c53c7575f94daa8ea3ce254749c6",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -39386,6 +39550,7 @@
         "folk",
         "pop"
       ],
+      "favicon": "https://cdn-radiotime-logos.tunein.com/s198968d.png",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -39457,6 +39622,7 @@
       "streamUrl": "https://musikladen-revival-radio.stream.laut.fm/musikladen-revival-radio?t302=2025-03-10_17-38-08&uuid=1766b96d-ba02-413f-8745-c66f62db6891",
       "homepage": "https://musikladen-revival-radio.stream.laut.fm/musikladen-revival-radio?t302=2025-03-10_17-38-08&uuid=1766b96d-ba02-413f-8745-c66f62db6891",
       "country": "DE",
+      "favicon": "https://www.phonostar.de/images/auto_created/lautfm_musikladen-revival-radio184x184.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -39566,6 +39732,7 @@
       "streamUrl": "https://stream.laut.fm/soundpool",
       "homepage": "https://stream.laut.fm/soundpool",
       "country": "DE",
+      "favicon": "https://www.radio.de/175/lautfm-soundpool.png?version=d667dcd82ef0213f59141f6bad1747210201ca07",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -39993,6 +40160,7 @@
       "streamUrl": "https://stream.laut.fm/bravo-hit-revival-radio",
       "homepage": "https://stream.laut.fm/bravo-hit-revival-radio",
       "country": "DE",
+      "favicon": "https://www.phonostar.de/images/auto_created/lautfm_bravo-hit-revival-radio184x184.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -40414,6 +40582,7 @@
       "streamUrl": "https://kbrock.stream.laut.fm/kbrock?pl=pls&t302=2020-08-07_21-11-15&uuid=bdc97b0d-5aef-4607-b0f2-e8fa10984eaa",
       "homepage": "https://kbrock.stream.laut.fm/",
       "country": "DE",
+      "favicon": "https://www.radio.de/175/lautfm-kbrock.png?version=ba9ba8f6f3ccd54b0c1f8bac6e3a72a74fba23db",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -40542,6 +40711,7 @@
       "tags": [
         "religious"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/1/131201.v6.png",
       "bitrate": 95,
       "codec": "AAC+",
       "status": "stream-only"
@@ -40573,6 +40743,7 @@
       "streamUrl": "https://radio-kevelaer.stream.laut.fm/radio-kevelaer?t302=2026-01-15_06-06-43&uuid=0e175da8-04d0-4fca-8202-9295dd635bee",
       "homepage": "https://radio-kevelaer.de/",
       "country": "DE",
+      "favicon": "https://www.radio.de/175/lautfm-radio-kevelaer.png?version=69b45d3ef6f704a9d6df0e51c78919c8051535c5",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -40592,6 +40763,7 @@
         "nichtkommerzielles lokalradio",
         "noncommercial"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s121501/images/logod.jpg?t=638102603460000000",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -40610,6 +40782,7 @@
       "tags": [
         "religious"
       ],
+      "favicon": "https://radio-santec.com/wp-content/uploads/2019/05/RadioSantecLogo_klein.png",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -40699,6 +40872,7 @@
         "classic hits",
         "oldies"
       ],
+      "favicon": "https://cdn-radiotime-logos.tunein.com/s274554d.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -41264,6 +41438,7 @@
       "streamUrl": "https://stream.laut.fm/mtc-fm",
       "homepage": "https://stream.laut.fm/mtc-fm",
       "country": "DE",
+      "favicon": "https://www.radio.de/175/lautfm-mtc-fm.png?version=5565ba32a0f32cdbab98c3e24425005ef6a6f938",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -42351,6 +42526,7 @@
         "easy listening",
         "piano"
       ],
+      "favicon": "https://epic-piano.com/assets/img/streamlogos/modern-piano.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -42764,6 +42940,7 @@
       "tags": [
         "80s"
       ],
+      "favicon": "https://logos-der-nrwlokalradios.s3.eu-central-1.amazonaws.com/01ba-36-13.png",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -42782,6 +42959,7 @@
       "tags": [
         "lounge"
       ],
+      "favicon": "https://logos-der-nrwlokalradios.s3.eu-central-1.amazonaws.com/01ba-36-13.png",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -42800,6 +42978,7 @@
       "tags": [
         "new country"
       ],
+      "favicon": "https://logos-der-nrwlokalradios.s3.eu-central-1.amazonaws.com/01ba-36-13.png",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -42942,6 +43121,7 @@
       "streamUrl": "https://live.ctdasradio.de/live",
       "homepage": "https://live.ctdasradio.de/",
       "country": "DE",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/5/685.v3.png",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -43304,6 +43484,7 @@
       "streamUrl": "https://stream.laut.fm/radio_andreo",
       "homepage": "https://radioandreo.de/",
       "country": "DE",
+      "favicon": "https://cdn-profiles.tunein.com/s312104/images/logod.png?t=639137858040000000",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -44265,6 +44446,7 @@
       "streamUrl": "https://stream.laut.fm/lumaxit",
       "homepage": "https://radio.lumaxit.de/",
       "country": "DE",
+      "favicon": "https://cdn.ltscloud.de/img/lumaxit/website/main/logo.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -44863,6 +45045,7 @@
       "tags": [
         "eclectic"
       ],
+      "favicon": "https://dunklewelle.eu/wp-content/uploads/cropped-RDW_Header_Anniversary.png",
       "bitrate": 320,
       "codec": "MP3",
       "geo": [
@@ -45023,6 +45206,7 @@
       "streamUrl": "https://mobil.antennepulheim.de/radiorslaacp.aac",
       "homepage": "http://www.centralfm.de/",
       "country": "DE",
+      "favicon": "https://cdn-radiotime-logos.tunein.com/s266799d.png",
       "bitrate": 64,
       "codec": "AAC+",
       "status": "stream-only"
@@ -45034,6 +45218,7 @@
       "streamUrl": "https://stream1.datenkollektiv.net/corax_256.mp3",
       "homepage": "http://radiocorax.de/",
       "country": "DE",
+      "favicon": "https://cdn-radiotime-logos.tunein.com/s84587d.png",
       "bitrate": 152,
       "codec": "MP3",
       "status": "stream-only"
@@ -45407,6 +45592,7 @@
         "christmas music",
         "news"
       ],
+      "favicon": "https://www.radiofd.org/images/radiofd_player.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -45421,6 +45607,7 @@
       "tags": [
         "christian"
       ],
+      "favicon": "https://www.radiofrieden.com/wp-content/themes/Divi/images/logo.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -45874,6 +46061,7 @@
         "opinion",
         "talk"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s351779/images/logod.png?t=639046279360000000",
       "bitrate": 64,
       "codec": "AAC",
       "geo": [
@@ -45908,6 +46096,7 @@
       "streamUrl": "https://stream01.my105.ch/my105xmas-aac.mp3",
       "homepage": "https://www.my105.ch/xmas",
       "country": "CH",
+      "favicon": "https://cdn-profiles.tunein.com/s257861/images/logod.jpg?t=638058393970000000",
       "bitrate": 96,
       "codec": "AAC+",
       "status": "stream-only"
@@ -46006,6 +46195,7 @@
         "hip-hop",
         "reggae"
       ],
+      "favicon": "https://cdn-radiotime-logos.tunein.com/s276382d.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -46187,6 +46377,7 @@
         "austrohits",
         "austropop"
       ],
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/thumb/e/e9/Antenne_Steiermark_logo_%282024%29.svg/250px-Antenne_Steiermark_logo_%282024%29.svg.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -46241,6 +46432,7 @@
       "streamUrl": "https://live.antenne.at/80s",
       "homepage": "http://www.antenne.at/",
       "country": "AT",
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/thumb/e/e9/Antenne_Steiermark_logo_%282024%29.svg/250px-Antenne_Steiermark_logo_%282024%29.svg.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -46563,6 +46755,7 @@
         "dab+",
         "easy listening"
       ],
+      "favicon": "https://www.radiotechnikum.at/img/rtg_logo_klein.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -46635,6 +46828,7 @@
       "tags": [
         "jazz"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/3/69503.v3.png",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -46665,6 +46859,7 @@
       "tags": [
         "christian"
       ],
+      "favicon": "https://yeshua.at/server/img/YeshuaBanner.240.150.jpg",
       "codec": "OGG",
       "status": "stream-only"
     },
@@ -46696,6 +46891,7 @@
       "streamUrl": "https://server7524.streamplus.de/stream.mp3",
       "homepage": "http://www.petersplattenthek.at/",
       "country": "AT",
+      "favicon": "https://www.radio.at/175/petersplattenthek.png?version=c6cae17fc98e049390c2f5ec3e9e038468d31d37",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -46944,6 +47140,7 @@
       "streamUrl": "https://server4.streamserver24.com:61414/",
       "homepage": "https://www.studioenns.eu/",
       "country": "AT",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/3/2343.v17.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -48105,6 +48302,7 @@
       "tags": [
         "新闻"
       ],
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/07/Voice_of_America_Logo.svg/250px-Voice_of_America_Logo.svg.png",
       "bitrate": 140,
       "codec": "AAC",
       "status": "stream-only"
@@ -48140,6 +48338,7 @@
       "streamUrl": "https://jenny.torontocast.com:2000/stream/ClassicRock109",
       "homepage": "http://www.classicrock109.com/site/index.html",
       "country": "US",
+      "favicon": "https://www.classicrock109.com/images/logo.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -48237,6 +48436,7 @@
       "tags": [
         "christian"
       ],
+      "favicon": "https://cdn-radiotime-logos.tunein.com/s112984d.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -48492,6 +48692,7 @@
         "indie music",
         "indie rock"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/3/16043.v6.png",
       "bitrate": 320,
       "codec": "MP3",
       "status": "stream-only"
@@ -48928,6 +49129,7 @@
         "新闻",
         "综合"
       ],
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/02/CBS_News_Radio_Logo_%282021%29.svg/960px-CBS_News_Radio_Logo_%282021%29.svg.png",
       "bitrate": 273,
       "codec": "AAC",
       "status": "stream-only"
@@ -49303,6 +49505,7 @@
       "tags": [
         "tamil cinema music"
       ],
+      "favicon": "https://www.americantamilradio.com/assets/img/radiologo.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -51339,6 +51542,7 @@
       "tags": [
         "christian"
       ],
+      "favicon": "https://cdn-radiotime-logos.tunein.com/s54344d.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -59631,6 +59835,7 @@
       "tags": [
         "country"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/0/41160.v10.png",
       "bitrate": 48,
       "codec": "AAC+",
       "status": "stream-only"
@@ -60199,6 +60404,7 @@
         "jewish",
         "judaism"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s305576/images/logod.png?t=636567072334970000",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -60469,6 +60675,7 @@
         "70s",
         "oldies"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s251480/images/logod.jpg?t=638218628910000000",
       "bitrate": 64,
       "codec": "MP3",
       "status": "stream-only"
@@ -60823,6 +61030,7 @@
       "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/KVVAFMAAC.aac",
       "homepage": "https://www.radiolasuavecita.com/phoenix",
       "country": "US",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/8/27608.v7.png",
       "bitrate": 64,
       "codec": "AAC+",
       "status": "stream-only"
@@ -60907,6 +61115,7 @@
       "streamUrl": "https://radio1.streamserver.link/radio/8010/100hit-aac",
       "homepage": "https://100hitradio.net/",
       "country": "US",
+      "favicon": "https://cdn-profiles.tunein.com/s131838/images/logod.png?t=637898859630000000",
       "bitrate": 64,
       "codec": "AAC",
       "status": "stream-only"
@@ -60993,6 +61202,7 @@
       "tags": [
         "folk"
       ],
+      "favicon": "https://folkalley.com/wp-content/themes/folkalley/dist/images/logo.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -61153,6 +61363,7 @@
       "tags": [
         "tropical"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/0/106420.v8.png",
       "bitrate": 48,
       "codec": "AAC+",
       "status": "stream-only"
@@ -61281,6 +61492,7 @@
       "tags": [
         "christian"
       ],
+      "favicon": "https://www.ancientfaith.com/assets/images/afm-text-white.png",
       "bitrate": 96,
       "codec": "AAC+",
       "status": "stream-only"
@@ -61442,6 +61654,7 @@
       "tags": [
         "asian"
       ],
+      "favicon": "https://www.funasia.net/logo.webp",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -61517,6 +61730,7 @@
       "tags": [
         "oldies"
       ],
+      "favicon": "https://static2.mytuner.mobi/media/tvos_radios/736/kwem-lp-933-fm.119c3585.png",
       "bitrate": 32,
       "codec": "AAC+",
       "status": "stream-only"
@@ -61726,6 +61940,7 @@
         "bible",
         "christian"
       ],
+      "favicon": "https://bbn1.bbnradio.org/german/wp-content/uploads/sites/9/2017/10/Germanbbnlogo-green.png",
       "bitrate": 56,
       "codec": "AAC",
       "status": "stream-only"
@@ -61828,6 +62043,7 @@
       "tags": [
         "christian rock"
       ],
+      "favicon": "https://therockhd.com/img/R_logo.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -61858,6 +62074,7 @@
       "tags": [
         "classic hits"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/3/81533.v4.png",
       "bitrate": 64,
       "codec": "AAC+",
       "status": "stream-only"
@@ -61950,6 +62167,7 @@
       "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/KJMNFMAAC.aac",
       "homepage": "https://www.radiolasuavecita.com/",
       "country": "US",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/4/32994.v11.png",
       "bitrate": 64,
       "codec": "AAC+",
       "status": "stream-only"
@@ -62223,6 +62441,7 @@
       "tags": [
         "talk"
       ],
+      "favicon": "https://dehayf5mhw1h7.cloudfront.net/wp-content/uploads/sites/728/2016/10/03152123/Freedom-95-Logo.png",
       "bitrate": 32,
       "codec": "AAC+",
       "status": "stream-only"
@@ -62253,6 +62472,7 @@
       "tags": [
         "christian"
       ],
+      "favicon": "https://livingworship.radio/wp-content/uploads/2025/09/LivingWorship.png",
       "bitrate": 128,
       "codec": "AAC+",
       "geo": [
@@ -62514,6 +62734,7 @@
       "tags": [
         "country"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/8/22548.v4.png",
       "bitrate": 32,
       "codec": "AAC+",
       "status": "stream-only"
@@ -62637,6 +62858,7 @@
       "tags": [
         "christian"
       ],
+      "favicon": "https://jesusradio.fm/wp-content/themes/jesusradio_theme/assets/img/logo-dark.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -62831,6 +63053,7 @@
         "industrial",
         "remixes"
       ],
+      "favicon": "https://cdn-radiotime-logos.tunein.com/s121324d.png",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -63083,6 +63306,7 @@
         "newspapers",
         "reading"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/9/8479.v4.png",
       "bitrate": 75,
       "codec": "MP3",
       "status": "stream-only"
@@ -63173,6 +63397,7 @@
         "música",
         "talk"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/4/14914.v14.png",
       "bitrate": 64,
       "codec": "AAC+",
       "status": "stream-only"
@@ -63550,6 +63775,7 @@
       "tags": [
         "classic rock"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s21940/images/logod.png?t=637018144020000000",
       "bitrate": 32,
       "codec": "AAC+",
       "status": "stream-only"
@@ -63638,6 +63864,7 @@
       "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/KXJZ.mp3",
       "homepage": "https://player.capradio.org/about",
       "country": "US",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/6/5356.v1.png",
       "bitrate": 96,
       "codec": "MP3",
       "status": "stream-only"
@@ -63657,6 +63884,7 @@
         "soundtrack",
         "theater"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/5/87155.v2.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -63892,6 +64120,7 @@
       "tags": [
         "music"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/3/105113.v5.png",
       "codec": "MP3",
       "status": "stream-only"
     },
@@ -63947,6 +64176,7 @@
       "tags": [
         "talk"
       ],
+      "favicon": "https://wbob.com/wp-content/uploads/sites/2/WBOB-Logo.svg",
       "bitrate": 64,
       "codec": "AAC+",
       "status": "stream-only"
@@ -64112,6 +64342,7 @@
         "dodgeville",
         "radio"
       ],
+      "favicon": "https://media.live365.com/download/48c6b077-fd67-4df6-bc66-fe319f2276c8.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -64303,6 +64534,7 @@
       "streamUrl": "https://live.amperwave.net/direct/saga-wdbrhd3aac-imc",
       "homepage": "https://pureoldies1075.com/",
       "country": "US",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/7/125577.v7.png",
       "bitrate": 32,
       "codec": "AAC+",
       "status": "stream-only"
@@ -64373,6 +64605,7 @@
         "old time radio",
         "otr"
       ],
+      "favicon": "https://cdn-radiotime-logos.tunein.com/s189712d.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -64567,6 +64800,7 @@
         "jazz",
         "public radio"
       ],
+      "favicon": "https://npr.brightspotcdn.com/dims4/default/2fe2307/2147483647/strip/true/crop/3537x1681+0+0/resize/252x120!/quality/90/?url=http%3A%2F%2Fnpr-brightspot.s3.amazonaws.com%2F8c%2F6d%2Fc5e7cb4e475aa5a25568b8e3586c%2Fkuaf-mustache.png",
       "bitrate": 96,
       "codec": "MP3",
       "status": "stream-only"
@@ -64899,6 +65133,7 @@
       "tags": [
         "classic country"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/1/113631.v4.png",
       "bitrate": 32,
       "codec": "AAC+",
       "status": "stream-only"
@@ -64949,6 +65184,7 @@
         "hip-hop",
         "rap"
       ],
+      "favicon": "https://play-lh.googleusercontent.com/uvZWPGlOECO3ie0ha3sfctKpOc2Cv1HSliBD6vWAr47aJIyrFlxkVVWBGwbfSVd2XA4=w240-h480",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -65056,6 +65292,7 @@
       "streamUrl": "https://wzrd.streamguys1.com/live",
       "homepage": "https://wzrdchicago.com/",
       "country": "US",
+      "favicon": "https://cdn-profiles.tunein.com/s24421/images/logod.png?t=637496908310000000",
       "bitrate": 96,
       "codec": "AAC",
       "status": "stream-only"
@@ -65238,6 +65475,7 @@
         "classic rock",
         "oldies"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s297540/images/logod.jpg?t=636409137619000000",
       "codec": "AAC",
       "status": "stream-only"
     },
@@ -65248,6 +65486,7 @@
       "streamUrl": "https://streaming.floridaclassicalstation.fm/wsmr",
       "homepage": "https://wusfnews.wusf.usf.edu/classical",
       "country": "US",
+      "favicon": "https://cdn-profiles.tunein.com/s47518/images/logod.png?t=636355859113600000",
       "bitrate": 192,
       "codec": "AAC",
       "status": "stream-only"
@@ -65441,6 +65680,7 @@
       "tags": [
         "classical"
       ],
+      "favicon": "https://cdn-radiotime-logos.tunein.com/s34616d.png",
       "bitrate": 64,
       "codec": "AAC+",
       "status": "stream-only"
@@ -65535,6 +65775,7 @@
         "r&b",
         "soul"
       ],
+      "favicon": "https://www.4uradios.com/images/4umotown.jpg",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -65639,6 +65880,7 @@
       "streamUrl": "https://rtn.cdnstream1.com/2580_96.aac",
       "homepage": "https://florida.thejoyfm.com/",
       "country": "US",
+      "favicon": "https://cdn-profiles.tunein.com/s29850/images/logod.jpg?t=1",
       "bitrate": 96,
       "codec": "AAC+",
       "status": "stream-only"
@@ -65714,6 +65956,7 @@
       "tags": [
         "country"
       ],
+      "favicon": "https://static-media.streema.com/media/cache/e3/64/e3640ca5d64d3e2b867c763373e35aed.png",
       "bitrate": 32,
       "codec": "AAC+",
       "status": "stream-only"
@@ -65757,6 +66000,7 @@
       "streamUrl": "https://radioafrica1804.radioca.st/stream?fbclid=IwZXh0bgNhZW0CMTEAAR3p98dzdsZrwtqWOVDYxmh47DPWz5zJPwesnrlulZrOzEg2smZ_DvXeoaE_aem_52V7iXQ5XljK",
       "homepage": "https://radioafrica1804.radioca.st/stream?fbclid=IwZXh0bgNhZW0CMTEAAR3p98dzdsZrwtqWOVDYxmh47DPWz5zJPwesnrlulZrOzEg2smZ_DvXeoaE_aem_52V7iXQ5XljK",
       "country": "US",
+      "favicon": "https://cdn-profiles.tunein.com/s245638/images/logod.png?t=636626976301100000",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -65971,6 +66215,7 @@
       "tags": [
         "heavy metal"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s284539/images/logod.png?t=636391904259000000",
       "bitrate": 320,
       "codec": "MP3",
       "status": "stream-only"
@@ -66207,6 +66452,7 @@
       "tags": [
         "urban contemporary"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/5/30105.v3.png",
       "bitrate": 64,
       "codec": "AAC+",
       "status": "stream-only"
@@ -66377,6 +66623,7 @@
       "tags": [
         "gospel"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/2/99082.v3.png",
       "bitrate": 32,
       "codec": "AAC+",
       "status": "stream-only"
@@ -66613,6 +66860,7 @@
         "80's",
         "punk rock"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/3/31673.v2.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -66913,6 +67161,7 @@
       "tags": [
         "country"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/7/32527.v3.png",
       "codec": "MP3",
       "status": "stream-only"
     },
@@ -66953,6 +67202,7 @@
       "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/KINTFM.mp3",
       "homepage": "https://www.radiolasuavecita.com/el-paso",
       "country": "US",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/7/18387.v6.png",
       "bitrate": 96,
       "codec": "MP3",
       "status": "stream-only"
@@ -67638,6 +67888,7 @@
         "old time radio",
         "otr"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s126354/images/logod.jpg?t=636334906075200000",
       "bitrate": 64,
       "codec": "AAC+",
       "status": "stream-only"
@@ -67809,6 +68060,7 @@
       "tags": [
         "country"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/1/34561.v3.png",
       "bitrate": 32,
       "codec": "AAC+",
       "status": "stream-only"
@@ -68087,6 +68339,7 @@
       "tags": [
         "music"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s141461/images/logod.png?t=637776082850000000",
       "bitrate": 32,
       "codec": "AAC+",
       "status": "stream-only"
@@ -68173,6 +68426,7 @@
       "tags": [
         "regional mexican"
       ],
+      "favicon": "https://static2.mytuner.mobi/media/tvos_radios/819/la-tricolor-947-fm-kyse.863f8b44.png",
       "bitrate": 64,
       "codec": "AAC+",
       "status": "stream-only"
@@ -68222,6 +68476,7 @@
       "tags": [
         "classic rock"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s23895/images/logod.png?t=638096511020000000",
       "bitrate": 48,
       "codec": "AAC+",
       "status": "stream-only"
@@ -68367,6 +68622,7 @@
       "streamUrl": "https://ice42.securenetsystems.net/WGUO",
       "homepage": "https://gumbo949.com/",
       "country": "US",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/7/4367.v7.png",
       "bitrate": 32,
       "codec": "AAC+",
       "status": "stream-only"
@@ -68506,6 +68762,7 @@
         "pop",
         "top 40"
       ],
+      "favicon": "https://cdn-radiotime-logos.tunein.com/s27830d.png",
       "bitrate": 32,
       "codec": "AAC+",
       "status": "stream-only"
@@ -68520,6 +68777,7 @@
       "tags": [
         "radio music rock pop"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s156347/images/logod.jpg?t=638181864600000000",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -68597,6 +68855,7 @@
       "streamUrl": "https://stream.revma.ihrhls.com/zc569/hls.m3u8",
       "homepage": "https://stream.revma.ihrhls.com/zc569/hls.m3u8",
       "country": "US",
+      "favicon": "https://cdn-profiles.tunein.com/s29627/images/logod.jpg?t=638088213350000000",
       "bitrate": 24,
       "codec": "AAC",
       "status": "stream-only"
@@ -68856,6 +69115,7 @@
         "pop",
         "top 40"
       ],
+      "favicon": "https://cdn-radiotime-logos.tunein.com/s101953d.png",
       "bitrate": 64,
       "codec": "AAC+",
       "status": "stream-only"
@@ -69649,6 +69909,7 @@
       "tags": [
         "classic hits"
       ],
+      "favicon": "https://cdn-radiotime-logos.tunein.com/s23879d.png",
       "bitrate": 64,
       "codec": "AAC+",
       "status": "stream-only"
@@ -69811,6 +70072,7 @@
       "tags": [
         "christian contemporary"
       ],
+      "favicon": "https://cdn-radiotime-logos.tunein.com/s29842d.png",
       "bitrate": 32,
       "codec": "AAC+",
       "status": "stream-only"
@@ -69837,6 +70099,7 @@
       "tags": [
         "funk"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s306478/images/logod.png?t=639137857500000000",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -69943,6 +70206,7 @@
       "tags": [
         "adult contemporary"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s23795/images/logod.png?t=637450243020000000",
       "bitrate": 48,
       "codec": "AAC+",
       "status": "stream-only"
@@ -70154,6 +70418,7 @@
       "streamUrl": "https://ice.wbjb.net/ALT-MP3-High",
       "homepage": "http://www.altrok.com/",
       "country": "US",
+      "favicon": "https://cdn-radiotime-logos.tunein.com/s55282d.png",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -70198,6 +70463,7 @@
       "tags": [
         "gospel"
       ],
+      "favicon": "https://cdn-radiotime-logos.tunein.com/s32590d.png",
       "bitrate": 32,
       "codec": "AAC+",
       "status": "stream-only"
@@ -70291,6 +70557,7 @@
       "tags": [
         "classical"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s244379/images/logod.jpg?t=639000204920000000",
       "bitrate": 64,
       "codec": "AAC+",
       "status": "stream-only"
@@ -70509,6 +70776,7 @@
       "tags": [
         "country"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s29079/images/logod.jpg?t=637324168590000000",
       "bitrate": 64,
       "codec": "AAC+",
       "status": "stream-only"
@@ -70618,6 +70886,7 @@
         "music",
         "rock"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s35018/images/logod.png?t=638313527230000000",
       "bitrate": 96,
       "codec": "MP3",
       "status": "stream-only"
@@ -70926,6 +71195,7 @@
       "tags": [
         "business news"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s22836/images/logod.png?t=636664762814900000",
       "bitrate": 48,
       "codec": "AAC+",
       "status": "stream-only"
@@ -71021,6 +71291,7 @@
         "live music",
         "sixties"
       ],
+      "favicon": "https://cdn-radiotime-logos.tunein.com/s54607d.png",
       "bitrate": 96,
       "codec": "MP3",
       "geo": [
@@ -71079,6 +71350,7 @@
         "npr",
         "public radio"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s31632/images/logod.jpg?t=637885828450000000",
       "bitrate": 64,
       "codec": "AAC+",
       "status": "stream-only"
@@ -71374,6 +71646,7 @@
         "top 40",
         "wiht"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s29553/images/logod.jpg?t=638493951420000000",
       "bitrate": 24,
       "codec": "AAC",
       "status": "stream-only"
@@ -71405,6 +71678,7 @@
       "tags": [
         "public radio"
       ],
+      "favicon": "https://cdn-radiotime-logos.tunein.com/s31846d.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -71491,6 +71765,7 @@
       "tags": [
         "music"
       ],
+      "favicon": "https://static2.mytuner.mobi/media/tvos_radios/701/radio-naya-andaz.49231c6b.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -71812,6 +72087,7 @@
       "tags": [
         "talk"
       ],
+      "favicon": "https://cdn-radiotime-logos.tunein.com/s35690d.png",
       "codec": "MP3",
       "status": "stream-only"
     },
@@ -71973,6 +72249,7 @@
         "heavy metal",
         "metal"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s22916/images/logod.jpg?t=638971731730000000",
       "codec": "UNKNOWN",
       "status": "stream-only"
     },
@@ -72235,6 +72512,7 @@
       "tags": [
         "rock"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s32699/images/logod.png",
       "bitrate": 32,
       "codec": "AAC+",
       "status": "stream-only"
@@ -72491,6 +72769,7 @@
         "praise",
         "worship"
       ],
+      "favicon": "https://cdn-radiotime-logos.tunein.com/s33968d.png",
       "bitrate": 96,
       "codec": "MP3",
       "geo": [
@@ -72900,6 +73179,7 @@
         "alternative rock",
         "college radio"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s121776/images/logod.jpg?t=637073598750000000",
       "bitrate": 64,
       "codec": "AAC",
       "geo": [
@@ -73248,6 +73528,7 @@
       "tags": [
         "adult hits"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s42211/images/logod.png?t=636467840514000000",
       "bitrate": 64,
       "codec": "AAC+",
       "status": "stream-only"
@@ -73596,6 +73877,7 @@
       "streamUrl": "https://streaming.live365.com/a51314",
       "homepage": "http://star1079.com/",
       "country": "US",
+      "favicon": "https://cdn-profiles.tunein.com/s7365/images/logod.png?t=637039015280000000",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -73800,6 +74082,7 @@
       "streamUrl": "https://streaming.live365.com/a78246_2",
       "homepage": "https://radio.keysforkids.org/",
       "country": "US",
+      "favicon": "https://cdn-radiotime-logos.tunein.com/s18666d.png",
       "bitrate": 128,
       "codec": "AAC+",
       "status": "stream-only"
@@ -73995,6 +74278,7 @@
       "tags": [
         "sports"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s28830/images/logod.jpg?t=637557521030000000",
       "bitrate": 48,
       "codec": "MP3",
       "status": "stream-only"
@@ -74195,6 +74479,7 @@
         "experimental",
         "folk"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s28036/images/logod.png?t=636603604151500000",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -74368,6 +74653,7 @@
         "funk",
         "soul"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s340024/images/logod.png?t=638754978530000000",
       "bitrate": 320,
       "codec": "MP3",
       "geo": [
@@ -74436,6 +74722,7 @@
       "tags": [
         "international"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s273680/images/logod.jpg?t=638015808470000000",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"


### PR DESCRIPTION
## What

Wave 2 of the LLM-agent logo cascade, on top of #178 / #182 / #183.

| | |
|---|---:|
| Candidates | 400 (8 batches × 50) |
| Batches completed | **7 of 8** |
| Logo URLs found | **298** |
| Hit rate (over completed) | **85.1%** (in line with wave 1's 86.5%) |
| Tokens (Sonnet, rough) | ~830k |

**Batch 6 stalled twice** — watchdog killed the agent after 600s of no progress on the same 50 US/long-tail entries. After two failed attempts I cut losses rather than burn more tokens. Those 50 stations defer to a future wave.

## Source distribution (298 hits)

| Source | Hits |
|---|---:|
| TuneIn CDN | 132 |
| OnlineRadioBox | 98 |
| Broadcaster site | 51 |
| Wikipedia / Commons | 8 |
| myTuner | 5 |
| Other (Zeno, Live365, Google Play, Streema) | 4 |

TuneIn dominated this wave because the residue contained many internet-radio sub-channel families (0nlineradio, Technolovers, Epic-*). TuneIn maintains per-channel logos for those.

## Architecture (same as #183)

Agents write JSON only. \`tools/apply-logos.mjs\` does the surgical YAML insert deterministically. Keeps LLM output out of the catalog pipeline.

## Gates

- [x] \`npm run catalog\` → 15,608/15,608 published
- [x] \`npm run check-catalog\` clean
- [x] \`npm run check-duplicates\` → 0 collisions
- [x] \`npm test -- --run\` → 311/311

## Stragglers

- 52 nulls from this wave (defunct, unreachable, HTTP-only, no-good-match — agent correctly preferred null over wrong)
- 50 stations from the stalled batch 6
- ~1,360 unprocessed candidates remain in the no-favicon-with-homepage residue

A wave 3 (8–10 more agents) would mop up most of the remaining candidates. The defunct/unreachable population is the asymptote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)