### PR TITLE
chore: agent-discovered station logos wave 3 (234 stations)

### DIFF
--- a/data/stations.yaml
+++ b/data/stations.yaml
@@ -34548,6 +34548,7 @@
   changeuuid: ade845eb-c04b-4236-92c0-525c54cd76c9
   reviewedAt: 2026-05-04
 - id: de-museumradio
+  favicon: "https://www.plattenkiste.radio/index_htm_files/70.jpg"
   broadcaster: independent
   name: Museumradio
   streamUrl: https://museum.streamserver24.com:8080/stream
@@ -36079,6 +36080,7 @@
   changeuuid: d3de2616-a7dc-4dca-aacb-2f30fce3dc0d
   reviewedAt: 2026-05-04
 - id: de-xanadu-44
+  favicon: "https://www.radio.de/300/lautfm-xanadu.png?version=304163ede0e6010cc1c531240687f2050a0a4fb9"
   broadcaster: independent
   name: XANADU 44
   streamUrl: https://stream.laut.fm/xanadu
@@ -44181,6 +44183,7 @@
   changeuuid: 4b8f55b0-2067-4032-a21c-8756bb5f751c
   reviewedAt: 2026-05-04
 - id: us-96-9-bob-fm
+  favicon: "https://bobfm969.com/wp-content/uploads/sites/16/bob-fm-400px-373x500.jpg"
   broadcaster: independent
   name: 96.9 BOB FM
   streamUrl: https://ais-sa1.streamon.fm/7215_48k.aac
@@ -44193,6 +44196,7 @@
   changeuuid: d2f4d7b6-570a-4201-bd7b-9d5236e51f5c
   reviewedAt: 2026-05-04
 - id: us-no-agenda-show-stream-pls
+  favicon: "https://www.noagendashow.net/build/images/website-logo.c3d48c92.svg"
   broadcaster: independent
   name: No Agenda Show Stream (pls)
   streamUrl: https://listen.noagendastream.com/noagenda
@@ -44456,6 +44460,7 @@
   changeuuid: d2cb097f-316c-49e5-9902-b607aafd82f1
   reviewedAt: 2026-05-04
 - id: us-93-7-the-ticket
+  favicon: "https://theticketfm.com/wp-content/uploads/sites/4/The-Ticket-Logo-glow-400px.png"
   broadcaster: independent
   name: 93.7 The Ticket
   streamUrl: https://ice8.securenetsystems.net/KNTK
@@ -44699,6 +44704,7 @@
   changeuuid: 73c5d4c2-f24c-45e7-b567-c4600d6c4e94
   reviewedAt: 2026-05-04
 - id: us-radio-jan-usa
+  favicon: "https://www.radiojan.com/wp-content/uploads/2021/01/logowhite.svg"
   broadcaster: independent
   name: Radio Jan USA
   streamUrl: https://s4.voscast.com:8865/stream
@@ -44774,6 +44780,7 @@
   changeuuid: aae8407e-3490-4bb3-a125-d95eae7c5aa7
   reviewedAt: 2026-05-04
 - id: us-cbs-sports-radio-lynchburg
+  favicon: "https://cdnrf.securenetsystems.net/file_radio/stations_large/WVGM/v5/logo.png"
   broadcaster: independent
   name: CBS SPORTS Radio Lynchburg
   streamUrl: https://ice66.securenetsystems.net/WVGM
@@ -44873,6 +44880,7 @@
   changeuuid: ccfa1b90-b0dd-4cd1-b69b-549ae2c4a0fb
   reviewedAt: 2026-05-04
 - id: us-lofi-girl
+  favicon: "https://upload.wikimedia.org/wikipedia/commons/0/0f/Lofi_Girl_logo_%282024%29.svg"
   broadcaster: independent
   name: lofi girl
   streamUrl: https://play.streamafrica.net/lofiradio
@@ -46350,6 +46358,7 @@
   changeuuid: c3cd4ed3-9da9-4853-aae1-b856a0d4b19a
   reviewedAt: 2026-05-04
 - id: us-power-101-1-fm
+  favicon: "https://cdn.onlineradiobox.com/img/l/0/94790.v4.png"
   broadcaster: independent
   name: Power 101.1 FM
   streamUrl: https://ice3.securenetsystems.net/WHJA2
@@ -47745,6 +47754,7 @@
   changeuuid: fa124f0f-92c2-4e8c-b297-55db04fb97ba
   reviewedAt: 2026-05-04
 - id: us-jib-on-the-web
+  favicon: "https://cdn.onlineradiobox.com/img/l/4/75034.v11.png"
   broadcaster: independent
   name: JIB On The WEB
   streamUrl: https://ais-sa2.cdnstream1.com/2379_128.mp3
@@ -48315,6 +48325,7 @@
   changeuuid: 11d07c6d-6d6e-4cf1-88a8-97fdb9d24683
   reviewedAt: 2026-05-04
 - id: us-emocore
+  favicon: "https://cdn-profiles.tunein.com/s310932/images/logod.png?t=639137857510000000"
   broadcaster: independent
   name: Emocore
   streamUrl: https://emocore.stream.laut.fm/emocore?ref=radiode&t302=2021-07-31_22-18-20&uuid=9eeacdd0-1f90-4987-a064-69fca03ded3c
@@ -60923,6 +60934,7 @@
   changeuuid: 7578e0b0-7fd4-45fb-97d6-e4481ac584c8
   reviewedAt: 2026-05-04
 - id: us-supertalk-jackson
+  favicon: "https://www.supertalk.fm/wp-content/uploads/2024/06/sp_logo-e1718744468259.png"
   broadcaster: independent
   name: Supertalk Jackson
   streamUrl: https://live.amperwave.net/manifest/telesouth-wfmnfmaac-imc1
@@ -61228,6 +61240,7 @@
   changeuuid: 946acf18-677a-4998-89ae-38fbd48e2c43
   reviewedAt: 2026-05-04
 - id: us-myfm-101-3
+  favicon: "https://cdn.logfm.com/i/18/18321s300.webp?d=1691301294"
   broadcaster: independent
   name: MyFM 101.3
   streamUrl: https://ice64.securenetsystems.net/WMRC
@@ -61445,6 +61458,7 @@
   changeuuid: 9ec4480b-119d-4bc5-b998-1132195cadff
   reviewedAt: 2026-05-04
 - id: us-wysu-88-5-all-classical
+  favicon: "https://npr.brightspotcdn.com/dims4/default/38e1783/2147483647/strip/true/crop/422x171+0+0/resize/267x108!/quality/90/?url=http%3A%2F%2Fnpr-brightspot.s3.amazonaws.com%2F16%2Fea%2Ffeeebd2041858826ac1b747ddc26%2Fwysu-header-logo.png"
   broadcaster: independent
   name: WYSU 88.5 All Classical
   streamUrl: https://live.streamguys1.com:3181/hd2
@@ -62980,6 +62994,7 @@
   changeuuid: 34b7d3cc-1050-419b-b5cd-d4443c0d9181
   reviewedAt: 2026-05-04
 - id: us-our-generation-radio
+  favicon: "https://cdn.onlineradiobox.com/img/l/0/16240.v5.png"
   broadcaster: independent
   name: Our Generation Radio
   streamUrl: https://streaming.live365.com/a84571
@@ -63556,6 +63571,7 @@
   changeuuid: 882c6fdf-c95b-48e4-b314-a79ec2f411c1
   reviewedAt: 2026-05-04
 - id: us-kusc
+  favicon: "https://images.ctfassets.net/8usdt07j8s00/64q2oGq1OA3zTQGGX45pli/7e2f77b2c3ad958b0f00521ade288c9c/CC_Logo_Hor_Tag__1_.webp"
   broadcaster: independent
   name: KUSC
   streamUrl: https://18233.live.streamtheworld.com/KUSCMP96_SC
@@ -63800,6 +63816,7 @@
   changeuuid: cec1a22a-1ac0-4e80-ae20-aa7870909f71
   reviewedAt: 2026-05-04
 - id: us-unsung-80s-radio
+  favicon: "https://static2.mytuner.mobi/media/tvos_radios/fggzxucdvjl3.png"
   broadcaster: independent
   name: Unsung 80s Radio
   streamUrl: https://unsung80s.out.airtime.pro:8000/unsung80s_a
@@ -64371,6 +64388,7 @@
   changeuuid: 221c0ab9-23ea-43ae-9acb-6bcbe8ecf485
   reviewedAt: 2026-05-04
 - id: us-lobo-97-7
+  favicon: "https://cdn.onlineradiobox.com/img/l/4/28404.v4.png"
   broadcaster: independent
   name: Lobo 97.7
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/KBBXFMAAC.aac
@@ -65534,6 +65552,7 @@
   changeuuid: 7ed7e155-9fe5-46dc-9bfc-a37b06811df2
   reviewedAt: 2026-05-04
 - id: us-ktke-101-5-fm
+  favicon: "https://www.truckeetahoeradio.com/wp-content/uploads/2023/08/1015_Lake_Logo_WhiteHoriz.png"
   broadcaster: independent
   name: KTKE 101.5 FM
   streamUrl: https://ice9.securenetsystems.net/KTKE?playSessionID=2005F8CA-935A-763F-40B1A9507ADD7C3D
@@ -65953,6 +65972,7 @@
   changeuuid: 0886a103-1c85-48c8-ba49-caaadb7fe02a
   reviewedAt: 2026-05-04
 - id: us-1050-am-ktbl
+  favicon: "https://cdn.onlineradiobox.com/img/l/3/24153.v5.png"
   broadcaster: independent
   name: 1050 AM KTBL
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/KTBLAMAAC.aac
@@ -67729,6 +67749,7 @@
   changeuuid: e29d9b12-4722-4c47-a450-2304a88e53e0
   reviewedAt: 2026-05-04
 - id: us-fm-flashback
+  favicon: "https://cdn.onlineradiobox.com/img/l/0/120850.v5.png"
   broadcaster: independent
   name: FM Flashback
   streamUrl: https://ice.wbjb.net/FMF-MP3
@@ -70418,6 +70439,7 @@
   changeuuid: 578dc2df-0f86-40d4-9626-c600e63de6fe
   reviewedAt: 2026-05-04
 - id: us-tropical-105-7
+  favicon: "https://tropical1057.us/attachments/Logo/tropical.png"
   broadcaster: independent
   name: Tropical 105.7
   streamUrl: https://radioserver11.profesionalhosting.com/proxy/djqjfpwc?mp=/stream
@@ -70660,6 +70682,7 @@
   changeuuid: fdd361d3-0f37-40a7-acc1-0e07f68b678f
   reviewedAt: 2026-05-04
 - id: us-wuwf-classical
+  favicon: "https://npr.brightspotcdn.com/dims4/default/2ce244e/2147483647/strip/true/crop/1547x383+0+0/resize/267x66!/quality/90/?url=http%3A%2F%2Fnpr-brightspot.s3.amazonaws.com%2F2c%2Fcb%2F7e3870fa4319b2e047f33c0478fa%2Fwuwf-new-color.png"
   broadcaster: independent
   name: WUWF Classical
   streamUrl: https://wuwf.streamguys1.com/WUWFHD2.mp3
@@ -71015,6 +71038,7 @@
   changeuuid: f9f72db1-dbd1-480c-857b-d9199c7cdaef
   reviewedAt: 2026-05-04
 - id: us-kpig-fm
+  favicon: "https://site.kpig.com/wp-content/uploads/2021/09/170x220xlogo.png.pagespeed.ic_.PBXnkKbKM2.png"
   broadcaster: independent
   name: KPIG-FM
   streamUrl: https://stream.kpig.com/listen/877hg4r8-3642-8abb-258c-86147627ab14-64.aac
@@ -71079,6 +71103,7 @@
   changeuuid: 1135338b-7207-423d-9d33-7601574ef618
   reviewedAt: 2026-05-04
 - id: us-kzyn
+  favicon: "https://cdn-profiles.tunein.com/s306990/images/logod.jpg?t=637564431900000000"
   broadcaster: independent
   name: KZYN
   streamUrl: https://ice24.securenetsystems.net/KZYN
@@ -71130,6 +71155,7 @@
   changeuuid: 82e75402-4085-4076-80b6-237ab5b1b262
   reviewedAt: 2026-05-04
 - id: us-merf-radio-wmrf
+  favicon: "https://cdn.onlineradiobox.com/img/l/6/17586.v6.png"
   broadcaster: independent
   name: Merf Radio (WMRF)
   streamUrl: https://ice41.securenetsystems.net/WMRF
@@ -72097,6 +72123,7 @@
   changeuuid: c8d57a7e-d137-4a33-a26e-984c4ee2e9c5
   reviewedAt: 2026-05-04
 - id: us-insomniac-radio-one
+  favicon: "https://cdn.onlineradiobox.com/img/l/0/88360.v10.png"
   broadcaster: independent
   name: Insomniac Radio One
   streamUrl: https://stream.aiir.com/hoy4lohjjgiuv.mp3
@@ -73472,6 +73499,7 @@
   changeuuid: 86e4790a-5cd3-45d1-b618-981f8c71a80a
   reviewedAt: 2026-05-04
 - id: us-koko-lp-radio
+  favicon: "https://www.kokolp.org/KOKO-Skill-icon.png"
   broadcaster: independent
   name: KOKO LP Radio
   streamUrl: https://s2.yesstreaming.net:17031/stream
@@ -73920,6 +73948,7 @@
   changeuuid: 067514f0-3887-4b31-b782-d1e8d4381a6b
   reviewedAt: 2026-05-04
 - id: us-wgft-94-7
+  favicon: "https://espn947.com/wp-content/uploads/2025/05/ESPN_Radio_big-logo-scaled.png"
   broadcaster: independent
   name: WGFT 94.7
   streamUrl: https://ice23.securenetsystems.net/WGFTAM
@@ -73932,6 +73961,7 @@
   changeuuid: d0567ebd-afba-4392-af5d-9c6b3ba0dabb
   reviewedAt: 2026-05-04
 - id: us-whqr
+  favicon: "https://npr.brightspotcdn.com/dims4/default/065fc86/2147483647/strip/true/crop/450x201+0+0/resize/267x119!/quality/90/?url=http%3A%2F%2Fnpr-brightspot.s3.amazonaws.com%2F3d%2F19%2F3f5fd2264917b435d7724d211edb%2Fwhqr-logo-newq-no-tag-450x201.jpg"
   broadcaster: independent
   name: WHQR
   streamUrl: https://whqr.streamguys1.com/whqr_hd1
@@ -74394,6 +74424,7 @@
   changeuuid: d2dca17f-e86f-48d6-9eab-8f320c7b84f4
   reviewedAt: 2026-05-04
 - id: us-celestia-radio
+  favicon: "https://celestiaradio.com/index_files/CR_Test_Icon_2-01.png"
   broadcaster: independent
   name: Celestia Radio
   streamUrl: https://celestia.aiverse.org:8000/radio.mp3?type=.mp3
@@ -75203,6 +75234,7 @@
   changeuuid: b2fc9241-d308-4959-9059-52d1f5b71872
   reviewedAt: 2026-05-04
 - id: us-seven-rock-radio
+  favicon: "https://cdn.onlineradiobox.com/img/l/4/107544.v4.png"
   broadcaster: independent
   name: SEVEN ROCK RADIO
   streamUrl: https://c30.radioboss.fm:8569/stream
@@ -75825,6 +75857,7 @@
   changeuuid: 3967ef83-72db-41ea-8d43-653dfceff1ea
   reviewedAt: 2026-05-04
 - id: us-caddo-country
+  favicon: "https://caddocountry.com/wp-content/uploads/2026/01/cropped-cropped-Caddo-Country-Header-2.png"
   broadcaster: independent
   name: Caddo Country
   streamUrl: https://streaming.live365.com/a01456
@@ -76156,6 +76189,7 @@
   changeuuid: 4e0b5c55-c094-45dc-831e-ee7c7f98ec04
   reviewedAt: 2026-05-04
 - id: us-kfok
+  favicon: "https://kfok.org/wp-content/uploads/2019/09/KFOKORG_logo-300x300.png"
   broadcaster: independent
   name: KFOK
   streamUrl: https://kfok.streamguys1.com/live-mp3
@@ -76898,6 +76932,7 @@
   changeuuid: de7dcf33-6671-402e-9aca-da534b915a54
   reviewedAt: 2026-05-04
 - id: us-wixe-1190
+  favicon: "https://cdn.onlineradiobox.com/img/l/4/23974.v3.png"
   broadcaster: independent
   name: WIXE-1190
   streamUrl: https://streams.radiomast.io/0153a705-0f05-4ed1-ab0d-638a513370db
@@ -77118,6 +77153,7 @@
   changeuuid: 7d656e21-b37e-4705-83e6-ff6649a8dc9b
   reviewedAt: 2026-05-04
 - id: us-2020-the-beacon
+  favicon: "https://www.2020thebeacon.com/logo.png"
   broadcaster: independent
   name: 2020 the beacon
   streamUrl: https://listen.2020thebeacon.com:8000/radio.mp3
@@ -77195,6 +77231,7 @@
   changeuuid: 186e3b84-078b-4bc6-83a3-30949a22b794
   reviewedAt: 2026-05-04
 - id: us-99-3-kdrm
+  favicon: "https://jacobsradiollc.com/wp-content/uploads/2024/01/mix-99-logo.jpg"
   broadcaster: independent
   name: 99.3 KDRM
   streamUrl: https://us9.maindigitalstream.com/ssl/KDRM
@@ -77536,6 +77573,7 @@
   changeuuid: 42bf9c56-30cd-4216-9329-a83912b66d2c
   reviewedAt: 2026-05-04
 - id: us-indy-dancers
+  favicon: "https://www.indydancers.com/logos-Dance/IdlogoHR-neg-default.jpg"
   broadcaster: independent
   name: Indy Dancers
   streamUrl: https://play.radioking.io/indy-dancers-dancecast/345331
@@ -79732,6 +79770,7 @@
   changeuuid: 3c3b2758-6535-4d39-b63a-458aca39f5c5
   reviewedAt: 2026-05-04
 - id: us-khbl-96-9fm
+  favicon: "https://www.khbl.com/images/KHBL.png"
   broadcaster: independent
   name: KHBL 96.9FM
   streamUrl: https://streams.radiomast.io/fdb61263-8591-4fc7-b10b-e3d9c0911506
@@ -82099,6 +82138,7 @@
   changeuuid: ce8a2465-59c6-452a-9d76-a02e36713682
   reviewedAt: 2026-05-04
 - id: gb-tonic-ska-radio
+  favicon: "https://cdn.onlineradiobox.com/img/l/9/86049.v20.png"
   broadcaster: independent
   name: Tonic Ska Radio
   streamUrl: https://eu10.fastcast4u.com/tonicska
@@ -82274,6 +82314,7 @@
   changeuuid: 3f636f54-d44f-42ae-82be-96ea75a6ecf4
   reviewedAt: 2026-05-04
 - id: gb-the-voice-of-doom
+  favicon: "https://thevoiceofdoom.com/images/vod_logo_skull_326x160_i.jpg"
   broadcaster: independent
   name: The Voice Of Doom
   streamUrl: https://streaming.galaxywebsolutions.com:9046/stream
@@ -82633,6 +82674,7 @@
   changeuuid: 48b6d05a-82cb-4cb3-8f92-b30b0bcede12
   reviewedAt: 2026-05-04
 - id: gb-netil-radio
+  favicon: "https://netilradio.com/images/logo.svg"
   broadcaster: independent
   name: Netil Radio
   streamUrl: https://netilradio.out.airtime.pro/netilradio_a
@@ -83293,6 +83335,7 @@
   changeuuid: b3331de2-4b47-4ef5-9ba2-c5290ec6807b
   reviewedAt: 2026-05-04
 - id: gb-asian-star-radio
+  favicon: "https://asianstarradio.co.uk/wp-content/uploads/2025/01/AS_1200x800-e1746383159267.png"
   broadcaster: independent
   name: Asian Star Radio
   streamUrl: https://radio.canstream.co.uk:9067/live.mp3
@@ -84273,6 +84316,7 @@
   changeuuid: 53e9781f-e877-4698-a8ec-72b44a85acb1
   reviewedAt: 2026-05-04
 - id: gb-noods-radio
+  favicon: "https://noodsradio.com/_nuxt/noods-logo.CgUioM5-.svg"
   broadcaster: independent
   name: "Noods Radio "
   streamUrl: https://noods-radio.radiocult.fm/stream
@@ -85090,6 +85134,7 @@
   changeuuid: a3966273-8248-410e-921b-27abcd1a7425
   reviewedAt: 2026-05-04
 - id: gb-bluesradio-uk
+  favicon: "http://www.bluesradio.co.uk/bruk_banner.png"
   broadcaster: independent
   name: BluesRadio UK
   streamUrl: https://streaming06.liveboxstream.uk/proxy/david125/stream
@@ -85539,6 +85584,7 @@
   changeuuid: 5de1ff37-452d-452e-8e37-17706452f8d7
   reviewedAt: 2026-05-04
 - id: gb-teamsport-radio
+  favicon: "https://cdn.instant.audio/images/logos/internetradiouk-com/in-store-radio-teamsport.png"
   broadcaster: independent
   name: Teamsport Radio
   streamUrl: https://uksouth1.juiceboxradio.com/tsradionational
@@ -85693,6 +85739,7 @@
   changeuuid: 9947a32e-28d6-4479-be0b-56f1927e2917
   reviewedAt: 2026-05-04
 - id: gb-hearme-2020s-pop-music
+  favicon: "https://hearme.fm/wp-content/uploads/2024/06/2024-Redrafted-Transparent-Box-No-Text-1-1024x1024.png"
   broadcaster: independent
   name: HearMe - 2020s Pop Music
   streamUrl: https://radio.hearme.fm:8000/stream
@@ -88651,6 +88698,7 @@
   changeuuid: a7af9736-1af2-4075-b402-809de4555cbb
   reviewedAt: 2026-05-04
 - id: gb-lofi-hiphop-chillsky
+  favicon: "https://chillsky.com/logo.png"
   broadcaster: independent
   name: Lofi hiphop - chillsky
   streamUrl: https://chill.radioca.st/stream
@@ -88727,6 +88775,7 @@
   changeuuid: c9454048-614d-459a-80cb-0c9961420ad9
   reviewedAt: 2026-05-04
 - id: gb-radio-grapevine
+  favicon: "https://www.radiograpevine.com/images/Headers/roundel.gif"
   broadcaster: independent
   name: Radio Grapevine
   streamUrl: https://streaming06.liveboxstream.uk/proxy/radiogra?mp=/stream
@@ -89907,6 +89956,7 @@
   changeuuid: 581364a4-a352-40ae-8c8c-cb5bcb0045e4
   reviewedAt: 2026-05-04
 - id: gb-green-radio
+  favicon: "https://cdn-radiotime-logos.tunein.com/s291453d.png"
   broadcaster: independent
   name: Green Radio
   streamUrl: https://gains.reviveradio.net/proxy/greenradio?mp=/stream
@@ -91296,6 +91346,7 @@
   changeuuid: 2ff12e1b-b6e9-4f22-8aa2-11aaf9eb0e84
   reviewedAt: 2026-05-04
 - id: gb-nitro-fm
+  favicon: "https://static2.mytuner.mobi/media/tvos_radios/paycr8nhlthu.png"
   broadcaster: independent
   name: nitro-FM
   streamUrl: https://radio.nitro-server.uk/listen/nitrohost/radio.mp3
@@ -92757,6 +92808,7 @@
   changeuuid: 2db93005-2418-4b10-bb92-bbfce6c07e06
   reviewedAt: 2026-05-04
 - id: fr-bide-et-musique
+  favicon: "https://www.bide-et-musique.com/images/logo.png"
   broadcaster: independent
   name: Bide et Musique
   streamUrl: https://relay2.bide-et-musique.com:9143/
@@ -92808,6 +92860,7 @@
   changeuuid: 3fcd4be0-5a8f-4a1a-991c-25a9b3e0569e
   reviewedAt: 2026-05-04
 - id: fr-classic-fm-france
+  favicon: "https://www.classicfm.fr/media/cover.jpg"
   broadcaster: independent
   name: Classic FM France
   streamUrl: https://classicfm.ice.infomaniak.ch/classic-fm.mp3
@@ -92897,6 +92950,7 @@
   changeuuid: 932baa18-a325-460f-b944-53060a6d0494
   reviewedAt: 2026-05-04
 - id: fr-rfm-slow
+  favicon: "https://cdn-profiles.tunein.com/s309249/images/logod.jpg?t=638677209640000000"
   broadcaster: independent
   name: RFM Slow
   streamUrl: https://stream.rfm.fr/rfm-wr13.aac
@@ -93000,6 +93054,7 @@
   changeuuid: 72dee637-880d-4933-8ccf-6a60a4942207
   reviewedAt: 2026-05-04
 - id: fr-kohina
+  favicon: "https://cdn.onlineradiobox.com/img/l/0/71600.v5.png"
   broadcaster: independent
   name: Kohina
   streamUrl: https://kohina.duckdns.org/icecast/stream.ogg
@@ -94500,6 +94555,7 @@
   changeuuid: 69d988a6-25a0-4a11-8c0c-9614fc6b0df0
   reviewedAt: 2026-05-04
 - id: fr-sunset-jazz-radio
+  favicon: "https://www.vip-radios.fm/wp-content/uploads/Sunset-Jazz-logo2.jpg"
   broadcaster: independent
   name: SUNSET JAZZ RADIO
   streamUrl: https://radio2.vip-radios.fm:18077/stream-mp3-SunsetJazz
@@ -95513,6 +95569,7 @@
   changeuuid: 1fdcd2a8-1068-4a4c-be33-4c3fa963bfba
   reviewedAt: 2026-05-04
 - id: fr-irulegiko-irratia
+  favicon: "https://irulegikoirratia.eus/img/irulegiko-irratia.png"
   broadcaster: independent
   name: Irulegiko Irratia
   streamUrl: https://hosting.studioradiomedia.fr:1365/stream
@@ -96069,6 +96126,7 @@
   changeuuid: 7b16cc97-11c6-4294-a0aa-fef6fea519d5
   reviewedAt: 2026-05-04
 - id: fr-lfm-radio
+  favicon: "https://cdn.onlineradiobox.com/img/l/2/7392.v5.png"
   broadcaster: independent
   name: LFM Radio
   streamUrl: https://www.radioking.com/play/passionauto974/63343
@@ -96094,6 +96152,7 @@
   changeuuid: 21c38edc-95c1-471b-a0f3-6044be3a1f00
   reviewedAt: 2026-05-04
 - id: fr-allzic-radio-kitch
+  favicon: "https://www.allzicradio.com/media/radios/allzic-radio-kitch.png"
   broadcaster: independent
   name: Allzic Radio Kitch
   streamUrl: https://allzic59.ice.infomaniak.ch/allzic59.aac
@@ -96501,6 +96560,7 @@
   changeuuid: ab55f5f7-4584-4e66-81e0-86ba2c5260c4
   reviewedAt: 2026-05-04
 - id: fr-allzic-radio-jazz
+  favicon: "https://www.allzicradio.com/media/radios/allzic-jazz_600px-carre.png"
   broadcaster: independent
   name: Allzic Radio Jazz
   streamUrl: https://allzic40.ice.infomaniak.ch/allzic40.aac
@@ -96642,6 +96702,7 @@
   changeuuid: 00b676f9-04d8-418c-aebd-ae03a08b6850
   reviewedAt: 2026-05-04
 - id: fr-radio-rencontre-dunkerque
+  favicon: "https://www.meetfm.fr/upload/design/61f6f288916554.63169499.png"
   broadcaster: independent
   name: Radio Rencontre Dunkerque
   streamUrl: https://listen.radioking.com/radio/153745/stream/194338
@@ -97265,6 +97326,7 @@
   changeuuid: 66a341ad-674a-4e3a-afc6-664f2ab50e32
   reviewedAt: 2026-05-04
 - id: fr-radio-arpitania
+  favicon: "https://radioarpitania.eu/wp-content/uploads/2022/10/radio-arpitania.png"
   broadcaster: independent
   name: Radio Arpitania
   streamUrl: https://listen.radioking.com/radio/28783/stream/64720
@@ -97600,6 +97662,7 @@
   changeuuid: 95386067-3551-4d66-a41d-586c08394b8e
   reviewedAt: 2026-05-04
 - id: fr-allzic-radio-live-gold
+  favicon: "https://www.allzicradio.com/media/radios/allzic-live-gold_600px-carre.png"
   broadcaster: independent
   name: Allzic Radio Live GOLD
   streamUrl: https://allzic45.ice.infomaniak.ch/allzic45.aac
@@ -97832,6 +97895,7 @@
   changeuuid: efdff5c4-387c-40d3-89f0-60766bd82ef7
   reviewedAt: 2026-05-04
 - id: fr-rvr
+  favicon: "https://www.rvrradio.fr/images/logorvr.png"
   broadcaster: independent
   name: RVR
   streamUrl: https://live.aurafm.org:7443/rvr-tarareplata
@@ -99347,6 +99411,7 @@
   changeuuid: b1ae8e2d-f0ba-4d8a-b90c-f441c3e2c593
   reviewedAt: 2026-05-04
 - id: fr-terre-marine-fm
+  favicon: "https://cdn-radiotime-logos.tunein.com/s50265d.png"
   broadcaster: independent
   name: Terre Marine FM
   streamUrl: https://radio3.pro-fhi.net:19045/stream
@@ -100022,6 +100087,7 @@
   changeuuid: 81020c72-ff07-4196-b9eb-2bb00bec9449
   reviewedAt: 2026-05-04
 - id: fr-franceinfo-aac-lofi
+  favicon: "https://media.info/l/o/6/6818.1503522375.png"
   broadcaster: independent
   name: franceinfo aac lofi
   streamUrl: https://icecast.radiofrance.fr/franceinfo-lofi.aac
@@ -101683,6 +101749,7 @@
   changeuuid: 51332e51-6767-4e28-a7d0-49da44f48771
   reviewedAt: 2026-05-04
 - id: fr-rayvox
+  favicon: "https://www.rayvox.org/images/logo-RAYV01.png"
   broadcaster: independent
   name: Rayvox
   streamUrl: https://www.rayvox.org:8443/flux
@@ -101887,6 +101954,7 @@
   changeuuid: eb5a8592-5fd8-4713-8af7-df985884c412
   reviewedAt: 2026-05-04
 - id: it-virgin-radio-rockstar-rolling-stones
+  favicon: "https://static2.mytuner.mobi/media/tvos_radios/188/virgin-radio-music-star-rolling-stones.ec0de946.png"
   broadcaster: independent
   name: "Virgin Radio Rockstar: Rolling Stones"
   streamUrl: https://icy.unitedradio.it/VirginSpecialEvent.mp3
@@ -101951,6 +102019,7 @@
   changeuuid: 6efa5faf-c55b-441b-bd2c-d19722e54f31
   reviewedAt: 2026-05-04
 - id: it-radio-romanista
+  favicon: "https://cdn.onlineradiobox.com/img/l/6/122996.v2.png"
   broadcaster: independent
   name: Radio Romanista
   streamUrl: https://romanista.newradio.it/stream
@@ -102154,6 +102223,7 @@
   changeuuid: 4fa9bc5b-9fe0-4025-a3c2-0c0e610c488d
   reviewedAt: 2026-05-04
 - id: it-virgin-radio-rockstar-queen
+  favicon: "https://www.virginradio.it/wp-content/uploads/2025/03/cropped-logo_colored.png"
   broadcaster: independent
   name: "Virgin Radio Rockstar: Queen"
   streamUrl: https://icy.unitedradio.it/Virgin_05.mp3
@@ -104231,6 +104301,7 @@
   changeuuid: d185cf1b-f4eb-469d-8f71-b691556f72d5
   reviewedAt: 2026-05-04
 - id: it-radio-news
+  favicon: "https://www.italianews24.news/wp-content/uploads/2025/10/cropped-italia-news-24-orizz-white.png"
   broadcaster: independent
   name: Radio News
   streamUrl: https://stream5.xdevel.com/audio5s975889-479/stream/icecast.audio
@@ -104903,6 +104974,7 @@
   changeuuid: 2d8236b9-d27e-4734-9f30-14d5d5097913
   reviewedAt: 2026-05-04
 - id: it-megamix80
+  favicon: "https://cdn.onlineradiobox.com/img/l/3/138023.v4.png"
   broadcaster: independent
   name: megamix80
   streamUrl: https://centova.ipstream.it/proxy/megamix80/stream
@@ -105906,6 +105978,7 @@
   changeuuid: 925c024d-c273-4797-a903-8f2e36c3d48f
   reviewedAt: 2026-05-04
 - id: it-nation-70s
+  favicon: "https://mmo.aiircdn.com/677/69cd28992b074.png"
   broadcaster: independent
   name: Nation 70s
   streamUrl: https://listen-nation.sharp-stream.com/nationradio70s.mp3
@@ -106145,6 +106218,7 @@
   changeuuid: aa95dbe0-9543-4b78-bd3b-520fa81ab8f6
   reviewedAt: 2026-05-04
 - id: it-zak-radio-sicilia
+  favicon: "https://zakradio.net/radio-tp/wp-content/uploads/2026/01/LOGO-2025.png"
   broadcaster: independent
   name: Zak Radio Sicilia
   streamUrl: https://zakradiosicilia.radioca.st/stream#.mp3
@@ -106411,6 +106485,7 @@
   changeuuid: 12e6d04e-db56-4c00-8ef8-5920892eb670
   reviewedAt: 2026-05-04
 - id: it-radio-omega-sound
+  favicon: "https://www.radioomega.it/images/Logo_ROS.jpg"
   broadcaster: independent
   name: Radio Omega Sound
   streamUrl: https://nr9.newradio.it/proxy/radioome?mp=/stream
@@ -106510,6 +106585,7 @@
   changeuuid: fcf6a3b8-50cb-44a9-a21d-d777586b513d
   reviewedAt: 2026-05-04
 - id: it-radio-gattopardo
+  favicon: "https://cdn.onlineradiobox.com/img/logo/5/132725.png"
   broadcaster: independent
   name: RADIO GATTOPARDO
   streamUrl: https://sr11.inmystream.it/proxy/radiogattopardo?mp=/stream&1700931042510
@@ -107230,6 +107306,7 @@
   changeuuid: 8b7f7475-75d9-4048-94a6-cb41e03a10ff
   reviewedAt: 2026-05-04
 - id: es-costa-del-mar-smooth-jazz
+  favicon: "https://www.cdm-radio.com/wp-content/uploads/Logo-Chillout.png"
   broadcaster: independent
   name: Costa Del Mar Smooth Jazz
   streamUrl: https://radio4.cdm-radio.com:18024/stream-mp3-Smooth
@@ -107421,6 +107498,7 @@
   changeuuid: b92bfcf7-3194-4dcc-bc2f-41e02deb3a96
   reviewedAt: 2026-05-04
 - id: es-mix80radio
+  favicon: "https://i0.wp.com/tunerplay.com/wp-content/uploads/2023/12/MIX80Radio.png?fit=1024%2C1024&ssl=1"
   broadcaster: independent
   name: Mix80Radio
   streamUrl: https://stream.tunerplay.com/radio/8040/radio.mp3
@@ -108480,6 +108558,7 @@
   changeuuid: 34dddb51-0b43-4eab-a0ca-cf43f4b9a994
   reviewedAt: 2026-05-04
 - id: es-cadena-ser-sevilla
+  favicon: "https://upload.wikimedia.org/wikipedia/commons/b/b1/Cadena_Ser_logo-2.svg"
   broadcaster: independent
   name: Cadena SER Sevilla
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/SER_SEVILLA.mp3
@@ -109747,6 +109826,7 @@
   changeuuid: bed51bf8-2742-40b7-b289-f0beafc66ccf
   reviewedAt: 2026-05-04
 - id: es-cadena-ser-cadiz
+  favicon: "https://upload.wikimedia.org/wikipedia/commons/2/28/Cadena_Ser_logo.svg"
   broadcaster: independent
   name: Cadena Ser + Cadiz
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/SER_MAS_CADIZ.mp3
@@ -109811,6 +109891,7 @@
   changeuuid: 4f66df69-29fd-4abb-b481-709be26dffdb
   reviewedAt: 2026-05-04
 - id: es-radio-la-granja
+  favicon: "https://radiolagranjazaragoza.wordpress.com/wp-content/uploads/2021/07/cropped-radiolagranjaramone.png"
   broadcaster: independent
   name: Radio La Granja
   streamUrl: https://radiobot.radioslibres.info/listen/radio_la_granja/rlg.mp3
@@ -110313,6 +110394,7 @@
   changeuuid: 570ab194-d3fa-4c65-8b17-fb2a74048b45
   reviewedAt: 2026-05-04
 - id: es-la-diez-capital-radio
+  favicon: "https://www.ladiez.es/images/logo-la10-capitalradio.png"
   broadcaster: independent
   name: La Diez Capital Radio
   streamUrl: https://panel5.soydigital.fm/8030/stream
@@ -111375,6 +111457,7 @@
   changeuuid: be1d9aed-afa2-4584-81dc-ea4dac4f137a
   reviewedAt: 2026-05-04
 - id: es-mortal-fm
+  favicon: "https://www.mortalfm.es/wp-content/uploads/2025/08/cropped-logo-2-scaled-1.png"
   broadcaster: independent
   name: Mortal FM
   streamUrl: https://server10.emitironline.com:8044/;
@@ -112796,6 +112879,7 @@
   changeuuid: bfaacb93-d6d9-4a6a-be65-f4b9b3b0e2a3
   reviewedAt: 2026-05-04
 - id: es-yumbo-fm
+  favicon: "https://cdn.onlineradiobox.com/img/l/3/4533.v5.png"
   broadcaster: independent
   name: Yumbo FM
   streamUrl: https://panel.amediastream.eu:8600/yumbofm
@@ -113639,6 +113723,7 @@
   changeuuid: c81c376c-3717-4aa0-9f7e-29c8f101678b
   reviewedAt: 2026-05-04
 - id: es-color-estereo-103-7-fm
+  favicon: "https://colorestereo.com/colorestereo_logo.jpg"
   broadcaster: independent
   name: Color Estéreo 103.7 FM
   streamUrl: https://azura5.emisiononline.es/listen/colorestereo/radio.mp3
@@ -114463,6 +114548,7 @@
   changeuuid: bfd774af-8fdb-4a6e-b300-738cd5c7d615
   reviewedAt: 2026-05-04
 - id: es-monte-olivete
+  favicon: "https://monteolivete.org/wp-content/uploads/2016/09/M.png"
   broadcaster: independent
   name: Monte Olivete
   streamUrl: https://online.monteolivete.org:8005/stream
@@ -114579,6 +114665,7 @@
   changeuuid: 018e9b77-cb5b-4f55-84a7-273132f7b1cf
   reviewedAt: 2026-05-04
 - id: es-radio-tordera
+  favicon: "https://radiotordera.cat/radio/wp-content/uploads/2021/07/firma-logo-RT-.jpg"
   broadcaster: independent
   name: Radio Tordera
   streamUrl: https://relay.stream.enacast-cloud.com:40295/radiotorderaHD.mp3
@@ -115441,6 +115528,7 @@
   changeuuid: c6186d69-2591-4078-9e5b-0b7a53d7e6ae
   reviewedAt: 2026-05-04
 - id: nl-lx-classics
+  favicon: "https://www.lxclassics.com/img/logo_lxclassics.jpg"
   broadcaster: independent
   name: LX Classics
   streamUrl: https://mcp-1.streampanel.nl:8020/lxclassics_mp3
@@ -116747,6 +116835,7 @@
   changeuuid: 270afd95-2b1c-41d2-8e26-0b94075a411b
   reviewedAt: 2026-05-04
 - id: nl-razo-amsterdam
+  favicon: "https://www.salto.nl/wp-content/themes/musiks-salto/assets/images/razo.png"
   broadcaster: independent
   name: RaZO Amsterdam
   streamUrl: https://s42.myradiostream.com/33512/listen.mp3
@@ -117284,6 +117373,7 @@
   changeuuid: 08222036-4385-4eda-9ae4-f4e3a521530b
   reviewedAt: 2026-05-04
 - id: nl-armin-van-buuren
+  favicon: "https://upload.wikimedia.org/wikipedia/commons/c/c9/A_State_Of_Trance_Radio.jpg"
   broadcaster: independent
   name: Armin van Buuren
   streamUrl: https://stream01.pcradio.ru/Armin_van_buuren-med
@@ -118602,6 +118692,7 @@
   changeuuid: 7078d2d0-9017-4e90-9f41-6459f780699c
   reviewedAt: 2026-05-04
 - id: nl-rivierenland-radio
+  favicon: "https://www.rivierenland-radio.nl/uploads/rivierenland-radio.nl/1640410917-Simple%20logo2.2%20on%20white%20350x124.png"
   broadcaster: independent
   name: Rivierenland Radio
   streamUrl: https://rivierenlandradio.stream-server.nl/stream
@@ -119045,6 +119136,7 @@
   changeuuid: e67f4b71-ef05-485e-b9ea-814b921328b5
   reviewedAt: 2026-05-04
 - id: nl-sinterklaas-radio
+  favicon: "https://sintfm.nl/media/logo3.png"
   broadcaster: independent
   name: Sinterklaas Radio
   streamUrl: https://stream.tbmp.nl:8000/sinterklaasradiohigh.mp3
@@ -119133,6 +119225,7 @@
   changeuuid: 6861332e-a9b3-4450-b010-f8e0318e0e68
   reviewedAt: 2026-05-04
 - id: nl-island-92
+  favicon: "https://www.island92.com/wp-content/uploads/2016/02/i92logo.png"
   broadcaster: independent
   name: Island 92
   streamUrl: https://ais-sa1.streamon.fm/7338_48k.aac
@@ -119260,6 +119353,7 @@
   changeuuid: 4f3ba7e9-e86b-4ec5-b897-8faa35e62da8
   reviewedAt: 2026-05-04
 - id: nl-traxxradio
+  favicon: "https://www.traxxradio.nl/traxxlogosimple.jpg"
   broadcaster: independent
   name: TraxxRadio
   streamUrl: https://server-28.stream-server.nl:8896/stream
@@ -119464,6 +119558,7 @@
   changeuuid: a42aa680-b963-49b0-86d3-44170e1af9a8
   reviewedAt: 2026-05-04
 - id: nl-radio-0511
+  favicon: "https://radio0511.com/img/logo_radio0511.png"
   broadcaster: independent
   name: Radio 0511
   streamUrl: https://443-1.autopo.st/191/stream
@@ -121025,6 +121120,7 @@
   changeuuid: bd9ef7e8-7104-47e7-b882-ea7fdebe446f
   reviewedAt: 2026-05-04
 - id: nl-hitgolfradio-nl
+  favicon: "https://hitgolfradio.nl/wp-content/uploads/2025/06/hitgolfradio.png"
   broadcaster: independent
   name: Hitgolfradio.nl
   streamUrl: https://ex52.voordeligstreamen.nl/8072/stream
@@ -121062,6 +121158,7 @@
   changeuuid: 043ef077-327f-477f-bcab-bd0684891476
   reviewedAt: 2026-05-04
 - id: nl-kromhout-radio
+  favicon: "https://cdn.onlineradiobox.com/img/l/0/108360.v6.png"
   broadcaster: independent
   name: Kromhout Radio
   streamUrl: https://server-67.stream-server.nl:8784/stream
@@ -124681,6 +124778,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: pl-radio-kech-nowogard
+  favicon: "https://static.wixstatic.com/media/fec211_a76d8b62a4fb414b86923c978538af9e~mv2.png/v1/fill/w_197,h_123,al_c,q_85,usm_0.66_1.00_0.01,enc_avif,quality_auto/fec211_a76d8b62a4fb414b86923c978538af9e~mv2.png"
   broadcaster: independent
   name: Radio KECh Nowogard
   streamUrl: https://s3.slotex.pl/shoutcast/7016/stream
@@ -125325,6 +125423,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: pl-slonskie-radio-hitmix
+  favicon: "https://cdn.onlineradiobox.com/img/l/6/1466.v1.png"
   broadcaster: independent
   name: Slonskie Radio Hitmix
   streamUrl: https://s1.slotex.pl:7294/stream/1/
@@ -127975,6 +128074,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: ar-radio-utn-bahia-blanca-fm-93-5
+  favicon: "https://ceut.frbb.utn.edu.ar/web/img/logoUTNheader.png"
   broadcaster: independent
   name: Radio UTN Bahia Blanca - FM 93.5
   streamUrl: https://sonic.cloudstreaming.eu:10986/;
@@ -127989,6 +128089,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: ar-radio-verdad-villa-dolores
+  favicon: "https://radioverdadvd.com.ar/img/logo_1722895386.png"
   broadcaster: independent
   name: Radio Verdad (Villa Dolores)
   streamUrl: https://streaming1.locucionar.com/proxy/radioverdad?mp=/stream
@@ -128048,6 +128149,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: ar-somos-radio-am-530-radio-de-las-madres-de-plaza-
+  favicon: "https://am530somosradio.com/wp-content/uploads/2023/12/logo3.png"
   broadcaster: independent
   name: Somos Radio - AM 530 (Radio de las Madres de Plaza de Mayo)
   streamUrl: https://cdn.instream.audio:9288/stream
@@ -128535,6 +128637,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: ar-cuarteto-en-la-web
+  favicon: "https://cuartetoenlaweb.com.ar/js/logo.png"
   broadcaster: independent
   name: cuarteto en la web
   streamUrl: https://masservidor.net/8616/stream
@@ -128578,6 +128681,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: ar-fm-90-saladillo-fm-90-7
+  favicon: "https://fm90saladillo.com.ar/wp-content/uploads/2023/09/logo-fm90-150x150.jpeg"
   broadcaster: independent
   name: FM 90 Saladillo FM 90.7
   streamUrl: https://chino.republicahosting.com:2316/live
@@ -128956,6 +129060,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: ar-tmb-the-musical-box
+  favicon: "https://www.themusicalbox.com.ar/imagenes/logos/tmbescudo.png"
   broadcaster: independent
   name: TMB The Musical Box
   streamUrl: https://tmbradio.radioca.st/stream
@@ -130245,6 +130350,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: ar-planet-music-pinamar-99-5
+  favicon: "https://www.planetmusic.fm/img/Planet_logo.png"
   broadcaster: independent
   name: Planet Music Pinamar 99.5
   streamUrl: https://strcdn.klm99.com:10984/planetpinamar
@@ -132581,6 +132687,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: ar-signos-fm-allen
+  favicon: "https://signos.fm/wp-content/uploads/2025/12/signos-logo-acoado-horiz-v4-scaled-e1765907786719.png"
   broadcaster: independent
   name: Signos FM Allen
   streamUrl: https://radios.streamingdha.com.ar/8046/;/stream
@@ -134426,6 +134533,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: au-imc-country-radio
+  favicon: "https://cdn.onlineradiobox.com/img/l/7/124357.v2.png"
   broadcaster: independent
   name: IMC Country Radio
   streamUrl: https://servidor36.brlogic.com:7050/live
@@ -134781,6 +134889,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: au-gem-fm-91-5mhz-bowen-gem-of-the-coral-coast
+  favicon: "https://www.951gemfm.org/wp-content/uploads/2024/05/size-adjusted-logo-4-7394e432f810.png"
   broadcaster: independent
   name: Gem FM 91.5MHz Bowen - Gem of the Coral Coast
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/4GEMAAC.aac
@@ -136674,6 +136783,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: au-98-9-tyga-fm-new-norfolk
+  favicon: "https://cdn.onlineradiobox.com/img/l/4/27094.v14.png"
   broadcaster: independent
   name: "98.9 TYGA FM New Norfolk"
   streamUrl: https://radio12.shoutcast.net.au:2020/stream/8012
@@ -137552,6 +137662,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: au-trax-fm-port-pirie
+  favicon: "https://traxfm.org.au/wp-content/uploads/2023/09/TraxLogoWeb.jpg"
   broadcaster: independent
   name: Trax FM Port Pirie
   streamUrl: https://stream01.sigile.net/traxfm-64-aac
@@ -137655,6 +137766,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: au-hobart-fm
+  favicon: "https://hobartfm.org.au/wp-content/uploads/2021/02/Hobart-FM-Logo-nocallsign.png"
   broadcaster: independent
   name: Hobart FM
   streamUrl: https://radio12.shoutcast.net.au:8032/;
@@ -138423,6 +138535,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: tr-joy-turk-turkey
+  favicon: "https://cdn-profiles.tunein.com/s14281/images/logod.jpg?t=636442872385700000"
   broadcaster: independent
   name: JOY TÜRK TURKEY
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/JOY_TURK_SC?/
@@ -139019,6 +139132,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: tr-turkuvaz-musiki
+  favicon: "https://i.tmgrup.com.tr/rt/site/v2/c/i/radio/turkuvaz-musiki.png"
   broadcaster: independent
   name: Turkuvaz Musiki
   streamUrl: https://trkvz-radyolar.ercdn.net/turkuvazmusiki/playlist.m3u8
@@ -139047,6 +139161,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: tr-danceland-turkey
+  favicon: "https://cdn.onlineradiobox.com/img/l/4/16504.v10.png"
   broadcaster: independent
   name: Danceland turkey
   streamUrl: https://moondigitaledge.radyotvonline.net/danceland/playlist.m3u8
@@ -139104,6 +139219,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: tr-lalegul-fm
+  favicon: "https://cdn.onlineradiobox.com/img/l/1/68601.v9.png"
   broadcaster: independent
   name: LALEGÜL FM
   streamUrl: https://icecast.netmedya.net/lalegulfm
@@ -139147,6 +139263,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: tr-radyo-spor
+  favicon: "https://cdn.onlineradiobox.com/img/l/8/14208.v8.png"
   broadcaster: independent
   name: Radyo Spor
   streamUrl: https://moondigitaledge.radyotvonline.net/radyospor/playlist.m3u8
@@ -139464,6 +139581,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: tr-radyo-yalova
+  favicon: "https://cdn.onlineradiobox.com/img/logo/6/92726.png"
   broadcaster: independent
   name: "Radyo Yalova "
   streamUrl: https://studio25.radiolize.com/radio/8200/radio.mp3
@@ -139737,6 +139855,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: tr-standart-fm
+  favicon: "https://cdn.onlineradiobox.com/img/l/5/68565.v2.png"
   broadcaster: independent
   name: Standart.fm
   streamUrl: https://moondigitaledge.radyotvonline.net/standartfm/playlist.m3u8
@@ -139892,6 +140011,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: tr-fenomen-akustik
+  favicon: "https://cdn.radyofenomen.com/artwork/logo20.png"
   broadcaster: independent
   name: FENOMEN AKUSTIK
   streamUrl: https://live.radyofenomen.com/fenomenakustik/abr/fenomenakustik/128/chunks.m3u8
@@ -139919,6 +140039,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: tr-lig-radyo
+  favicon: "https://cdn.onlineradiobox.com/img/l/7/68567.v9.png"
   broadcaster: independent
   name: Lig Radyo
   streamUrl: https://ligradyo.radyotvonline.net/ligradyo
@@ -140472,6 +140593,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: tr-easyland
+  favicon: "https://cdn.onlineradiobox.com/img/l/4/16494.v7.png"
   broadcaster: independent
   name: Easyland
   streamUrl: https://moondigitaledge.radyotvonline.net/easyland/playlist.m3u8
@@ -141003,6 +141125,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: tr-beyaz-tv
+  favicon: "https://www.beyaztv.com.tr/images/logo.png"
   broadcaster: independent
   name: "Beyaz TV "
   streamUrl: https://beyaztv-live.daioncdn.net/beyaztv/beyaztv_1080p.m3u8
@@ -141133,6 +141256,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: tr-radyo-34
+  favicon: "https://cdn.onlineradiobox.com/img/l/0/16250.v8.png"
   broadcaster: independent
   name: RADYO 34
   streamUrl: https://radyo34.radyotvonline.net/radyo34
@@ -141625,6 +141749,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: tr-dream-turk
+  favicon: "https://cdn.onlineradiobox.com/img/l/3/80363.v10.png"
   broadcaster: independent
   name: DREAM TÜRK
   streamUrl: https://radyo.duhnet.tv/dreamturk
@@ -141652,6 +141777,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: tr-gurbetci-fm
+  favicon: "https://cdn.onlineradiobox.com/img/l/2/17242.v6.png"
   broadcaster: independent
   name: GURBETCİ FM
   streamUrl: https://sssx.radyosfer.com/gurbetcifm/
@@ -142146,6 +142272,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: tr-cesme-viking-radyo
+  favicon: "https://cdn.onlineradiobox.com/img/l/1/97701.v4.png"
   broadcaster: independent
   name: ÇEŞME VİKİNG RADYO
   streamUrl: https://ip169.ozelip.com/8432/stream
@@ -142389,6 +142516,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: tr-garaj-radyo
+  favicon: "https://cdn.onlineradiobox.com/img/l/9/76059.v7.png"
   broadcaster: independent
   name: GARAJ RADYO
   streamUrl: https://moondigitaledge.radyotvonline.net/garajradyo/playlist.m3u8
@@ -142588,6 +142716,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: tr-number-1-turk-rap
+  favicon: "https://www.numberone.com.tr/wp-content/uploads/2021/10/yeni-logonr1.png"
   broadcaster: independent
   name: Number 1 Türk Rap
   streamUrl: https://dijimedya.radyotvonline.net/turkrap
@@ -142861,6 +142990,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: tr-radyo-baska
+  favicon: "https://cdn.onlineradiobox.com/img/l/2/75052.v8.png"
   broadcaster: independent
   name: RADYO BAŞKA
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/BASKA.mp3
@@ -142890,6 +143020,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: tr-radyo-caglar
+  favicon: "https://cdn.onlineradiobox.com/img/l/5/16915.v7.png"
   broadcaster: independent
   name: RADYO ÇAĞLAR
   streamUrl: https://sssx.radyosfer.com/radyocaglar/stream
@@ -142934,6 +143065,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: tr-radyo-energy
+  favicon: "https://cdn.onlineradiobox.com/img/l/0/68450.v8.png"
   broadcaster: independent
   name: RADYO ENERGY
   streamUrl: https://trkvz-radyolar.ercdn.net/radyoenergy/playlist.m3u8
@@ -143178,6 +143310,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: tr-radyo-pause
+  favicon: "https://radyopause.com.tr/wp-content/uploads/2025/07/Adsiz-276-x-58-piksel.png"
   broadcaster: independent
   name: RADYO PAUSE
   streamUrl: https://radyopause.ozelip.com.tr:8040/
@@ -143393,6 +143526,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: tr-tiryaki-fm
+  favicon: "https://cdn.onlineradiobox.com/img/l/5/69345.v7.png"
   broadcaster: independent
   name: TİRYAKİ FM
   streamUrl: https://yayin.turkhosted.com:6056/mp3
@@ -144385,6 +144519,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: id-sun-fm-103-5mhz-banjarmasin
+  favicon: "https://sunfm.co.id/images/logo/logo.png"
   broadcaster: independent
   name: SUN FM 103.5MHZ Banjarmasin
   streamUrl: https://a1.siar.us/listen/sunfm/radio.mp3
@@ -144754,6 +144889,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: id-rri-channel-5
+  favicon: "https://rri.co.id/assets_frontend/images/logo/only_logo_blue_bg_white.png"
   broadcaster: independent
   name: RRI Channel 5
   streamUrl: https://stream-node1.rri.co.id/streaming/41/8941/chlima.mp3
@@ -145340,6 +145476,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: id-lppl-radio-kota-batik-fm
+  favicon: "https://rkb.pekalongankota.go.id/template/website/images/logo.png"
   broadcaster: independent
   name: LPPL RADIO KOTA BATIK FM
   streamUrl: https://studio1.indostreamers.com:8010/stream/1/
@@ -147123,6 +147260,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: co-alr-jazz-radio
+  favicon: "https://cdn.jsdelivr.net/gh/JulioRBM2/ALR-Jazz-Radio@f67b3b832937c9e34ffe6ad9a56ee08baf5701a9/nuevologo20251200x400.svg"
   broadcaster: independent
   name: ALR Jazz Radio
   streamUrl: https://radio30.virtualtronics.com/proxy/abaco?mp=/stream/
@@ -147152,6 +147290,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: co-zonasalsa-radio
+  favicon: "https://cdn.onlineradiobox.com/img/l/8/62798.v10.png"
   broadcaster: independent
   name: ZonaSalsa Radio
   streamUrl: https://cast6.asurahosting.com/proxy/salsafou/stream
@@ -148617,6 +148756,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: co-antena-de-los-andes-1520-am
+  favicon: "https://antenadelosandes.com/player/adla_logo.png"
   broadcaster: independent
   name: Antena de los Andes 1520 AM
   streamUrl: https://radiolatina.live/9374/stream
@@ -150133,6 +150273,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: co-javeriana-estereo-91-9
+  favicon: "https://javerianaestereo.com/documents/4772835/4785241/Logo-Menu-javeriana-estereo.png/2e4574e5-524c-4cfd-63be-75d57104a3eb?t=1646427893310"
   broadcaster: independent
   name: "Javeriana Estéreo 91,9"
   streamUrl: https://radio06.cehis.net/proxy/javerian?mp=%2Fstream
@@ -151266,6 +151407,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: co-buenisima-radio-tv
+  favicon: "https://cdn.onlineradiobox.com/img/l/7/103897.v3.png"
   broadcaster: independent
   name: buenísima radio tv
   streamUrl: https://radiohd.streaminghd.co:7319/stream
@@ -153198,6 +153340,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: ph-kaibigan-radio
+  favicon: "https://cdn-profiles.tunein.com/s350808/images/logod.png?t=639025615830000000"
   broadcaster: independent
   name: Kaibigan Radio
   streamUrl: https://stream.rcast.net/66925
@@ -155420,6 +155563,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: ro-radio-dor-romania
+  favicon: "https://radiodor.net/templates/default/img/logo.png"
   broadcaster: independent
   name: Radio DOR Romania
   streamUrl: https://live7digi.antenaplay.ro/radiodor/radiodor-48000.m3u8
@@ -155878,6 +156022,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: ro-gorebel
+  favicon: "https://gofm.ro/gorebel/wp-content/uploads/2024/04/go-thumbnail.png"
   broadcaster: independent
   name: goREBEL
   streamUrl: https://live.gofm.ro:2000/stream/goREBEL/stream.mp3
@@ -156887,6 +157032,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: ro-dux-radio
+  favicon: "https://duxradio.ro/wp-content/uploads/2026/03/Untitled-500-x-500-px.png"
   broadcaster: independent
   name: Dux Radio
   streamUrl: https://radio.duxradio.ro:8002/stream
@@ -157340,6 +157486,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: ro-radio-1-pitesti
+  favicon: "https://cdn.instant.audio/images/logos/radio-org-ro/pitesti-1.png"
   broadcaster: independent
   name: "radio 1 pitesti "
   streamUrl: https://ssl.radios.show/8050/stream
@@ -157459,6 +157606,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: ro-marlene-radio
+  favicon: "https://cdn.onlineradiobox.com/img/l/7/117817.v6.png"
   broadcaster: independent
   name: Marlene Radio
   streamUrl: https://live.gofm.ro:2000/stream/MARLENERADIO/stream.mp3
@@ -161129,6 +161277,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: rs-radio-diskos
+  favicon: "https://cdn.onlineradiobox.com/img/l/0/67340.v8.png"
   broadcaster: independent
   name: Radio Diskos
   streamUrl: https://eu8.fastcast4u.com/proxy/znedel032?mp=/1
@@ -162744,6 +162893,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: pt-m80-radio-aac
+  favicon: "https://m80.pt/images/makeover/logo-m80.svg"
   broadcaster: independent
   name: M80 Rádio (AAC)
   streamUrl: https://stream-icy.bauermedia.pt/m80.aac
@@ -163110,6 +163260,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: pt-radio-maria-portugal
+  favicon: "https://static-media.streema.com/media/cache/4d/63/4d63dc2f45c231e071fa00a548dd2f22.png"
   broadcaster: independent
   name: Radio Maria Portugal
   streamUrl: https://dreamsiteradiocp5.com/proxy/rmportugal1?mp=/stream
@@ -163393,6 +163544,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: pt-posto-emissor-do-funchal-om
+  favicon: "https://www.pef.pt/images/202506261149361.png"
   broadcaster: independent
   name: Posto Emissor do Funchal OM
   streamUrl: https://centova.radio.com.pt/proxy/422?mp=/stream;
@@ -163993,6 +164145,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: pt-rtp-antena-3-madeira
+  favicon: "https://media.rtp.pt/empresa/wp-content/uploads/sites/31/2015/07/Institutional_RTPAntena3_Horizontal_PositivoCor_web-1.png"
   broadcaster: independent
   name: RTP Antena 3 Madeira
   streamUrl: https://radiocast.rtp.pt/antena3madeira80a.mp3
@@ -164006,6 +164159,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: pt-radio-comercial-natal
+  favicon: "https://radiocomercial.pt/images/logos/logo-rc-subfooter.png"
   broadcaster: independent
   name: Rádio Comercial Natal
   streamUrl: https://stream-icy.bauermedia.pt/rcxmas.aac
@@ -164080,6 +164234,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: pt-radio-metal-on-the-heavy
+  favicon: "https://cdn.onlineradiobox.com/img/l/8/19798.v9.png"
   broadcaster: independent
   name: "Radio Metal On: The Heavy"
   streamUrl: https://radiometalon.com/listen/radio_metal_on_the_heavy/radio.mp3
@@ -164710,6 +164865,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: nz-the-edge
+  favicon: "https://images.ctfassets.net/r65x6q43xsmv/1pzJ3Zc5e180plaXxUnkyT/ea87b3f87de6e573b250506c9ac2779d/edge_purple_web_station_logo.svg"
   broadcaster: independent
   name: The Edge
   streamUrl: https://digitalstreams.mediaworks.nz/edge_net/playlist.m3u8
@@ -164945,6 +165101,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: nz-one-christian-radio
+  favicon: "https://cdn.instant.audio/images/logos/radio-org-nz/one-christian.png"
   broadcaster: independent
   name: One Christian Radio
   streamUrl: https://radio.wanderingsheep.net:33001/onechristianradio
@@ -165449,6 +165606,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: nz-mpr-manawatu-people-s-radio
+  favicon: "https://cdn3.firecrestsystems.com/FC_Access/Images/MPR-reverse_main.png"
   broadcaster: independent
   name: "MPR Manawatu People's Radio"
   streamUrl: https://live.accessmedia.nz/MPR.stream/playlist.m3u8
@@ -165597,6 +165755,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: nz-rdu
+  favicon: "https://cdn.onlineradiobox.com/img/l/7/1177.v9.png"
   broadcaster: independent
   name: RDU
   streamUrl: https://rdu985fm-gecko.radioca.st/stream
@@ -167408,6 +167567,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: ie-scariff-bay-community-radio
+  favicon: "https://deow9bq0xqvbj.cloudfront.net/image-logo/4688176/SBCR_NEW_LOGO_DEC_218rqcp.jpg"
   broadcaster: independent
   name: Scariff Bay Community Radio
   streamUrl: https://s4.radio.co/s87ac5cf5a/listen
@@ -167747,6 +167907,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-ban-ban
+  favicon: "https://www.banban.jp/radio/images/common/logo.svg"
   broadcaster: independent
   name: BAN-BANラジオ
   streamUrl: https://mtist.as.smartstream.ne.jp/30078/livestream/playlist.m3u8
@@ -167934,6 +168095,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-fm-2
+  favicon: "https://fm-maple.com/wp-content/uploads/2026/01/cropped-IMG_9551.jpeg"
   broadcaster: independent
   name: FMメイプル
   streamUrl: https://mtist.as.smartstream.ne.jp/30015/livestream/playlist.m3u8
@@ -167976,6 +168138,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-775-fm
+  favicon: "https://775fm.co.jp/wp/wp-content/themes/775fm/images/logo.png?20220406"
   broadcaster: independent
   name: "775ライブリーFM"
   streamUrl: https://mtist.as.smartstream.ne.jp/30026/livestream/playlist.m3u8
@@ -168004,6 +168167,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-j-club-powerplay-hiphop-asia-dream-radio
+  favicon: "https://cdn.onlineradiobox.com/img/l/1/13121.v6.png"
   broadcaster: independent
   name: J-Club Powerplay HipHop(Asia DREAM Radio)
   streamUrl: https://kathy.torontocast.com:3350/;?shoutcast
@@ -168059,6 +168223,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-fm78-1
+  favicon: "https://radiokaros.com/wp/wp-content/themes/radiokaros/assets/images/logo.png"
   broadcaster: independent
   name: ラジオカロスサッポロ FM78.1
   streamUrl: https://mtist.as.smartstream.ne.jp/30034/livestream/playlist.m3u8
@@ -168200,6 +168365,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-city
+  favicon: "https://maeradi.net/assets/images/common/logo.svg"
   broadcaster: independent
   name: まえばしCITYエフエム
   streamUrl: https://mtist.as.smartstream.ne.jp/30043/livestream/playlist.m3u8
@@ -168411,6 +168577,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-otaku-music-radio
+  favicon: "https://cdn-radiotime-logos.tunein.com/s169598d.png"
   broadcaster: independent
   name: Otaku Music Radio
   streamUrl: https://kathy.torontocast.com:2880/;?type=http&nocache=1606748882
@@ -168453,6 +168620,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-fm-17
+  favicon: "https://cdn.instant.audio/images/logos/jpradio-jp/harbor-station.png"
   broadcaster: independent
   name: 敦賀FM
   streamUrl: https://mtist.as.smartstream.ne.jp/30012/livestream/playlist.m3u8
@@ -168524,6 +168692,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-fm-18
+  favicon: "https://fmyanbaru.co.jp/wp-content/themes/Fmyambaru/assets/images/logo-header.png"
   broadcaster: independent
   name: FMやんばる
   streamUrl: https://mtist.as.smartstream.ne.jp/30095/livestream/playlist.m3u8
@@ -168553,6 +168722,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-befm
+  favicon: "https://www.befm.co.jp/fm/wp-content/uploads/2020/11/bunnerB.png"
   broadcaster: independent
   name: BeFM
   streamUrl: https://mtist.as.smartstream.ne.jp/30079/livestream/playlist.m3u8
@@ -168623,6 +168793,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp--8
+  favicon: "https://fm767.com/wp/wp-content/uploads/digipress/magjam/title/header_logo.png"
   broadcaster: independent
   name: フラワーラジオ
   streamUrl: https://mtist.as.smartstream.ne.jp/30002/livestream/playlist.m3u8
@@ -168766,6 +168937,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-fm-24
+  favicon: "https://static.mytuner.mobi/media/tvos_radios/uwqtqhbsahhe.png"
   broadcaster: independent
   name: FMぎのわん
   streamUrl: https://mtist.as.smartstream.ne.jp/30093/livestream/playlist.m3u8
@@ -168849,6 +169021,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp--13
+  favicon: "https://zenkokunews.sakura.ne.jp/radiosweet/wp-content/uploads/2025/05/815%E3%83%AD%E3%82%B4-1-3-scaled.png"
   broadcaster: independent
   name: ラジオスイート
   streamUrl: https://mtist.as.smartstream.ne.jp/30061/livestream/playlist.m3u8
@@ -168892,6 +169065,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp--14
+  favicon: "https://static2.mytuner.mobi/media/tvos_radios/ZbadTqaXkc.png"
   broadcaster: independent
   name: ラジオ石巻
   streamUrl: https://mtist.as.smartstream.ne.jp/30037/livestream/playlist.m3u8
@@ -169022,6 +169196,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-asia-dream-radio-japan-hits
+  favicon: "https://cdn.onlineradiobox.com/img/l/0/64360.v11.png"
   broadcaster: independent
   name: asia DREAM radio - Japan Hits
   streamUrl: https://quincy.torontocast.com:2020/stream.mp3
@@ -169213,6 +169388,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: za-jakaranda-fm
+  favicon: "https://turntable.kagiso.io/images/Jac_Logo.max-140x140.png"
   broadcaster: independent
   name: Jakaranda FM
   streamUrl: https://edge.iono.fm/xice/jacarandafm_live_high.mp3
@@ -169827,6 +170003,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: za-perron-fm
+  favicon: "https://perronfm.co.za/radio/wp-content/uploads/2022/08/headerlogo.webp"
   broadcaster: independent
   name: Perron FM
   streamUrl: https://zas7.ndx.co.za:8044/stream?1694973588521
@@ -169959,6 +170136,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: za-gospelbluesradio
+  favicon: "https://gospelbluesradio.com/wp-content/uploads/2023/08/gospel-blues-radio-com-1.jpg"
   broadcaster: independent
   name: GospelBluesRadio
   streamUrl: https://gospelblues365.com/listen/gospelbluesradio/radio
@@ -171327,6 +171505,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: pe-radio-girasol
+  favicon: "https://radiogirasol.com/girasol_logo.png"
   broadcaster: independent
   name: Radio Girasol
   streamUrl: https://miradioperu.com/8008/stream
@@ -171398,6 +171577,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: pe-radio-ondas-del-huallaga
+  favicon: "https://www.radioondasdelhuallaga.com/img/logo.png"
   broadcaster: independent
   name: Radio Ondas del Huallaga
   streamUrl: https://cloud9.ldwebstudios.net:7005/;
@@ -171628,6 +171808,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: pe-radio-studio-97
+  favicon: "https://studio97.com.pe/logo/97.png"
   broadcaster: independent
   name: Radio Studio 97
   streamUrl: https://sechin.grupocentroserver.com/radio/8140/radio.mp3
@@ -172532,6 +172713,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: br-radio-mgt-sertanejo
+  favicon: "https://static-media.streema.com/media/cache/3b/15/3b15fe866594b8ee8d7c2aa08a0114fc.jpg"
   broadcaster: independent
   name: Rádio MGT Sertanejo
   streamUrl: https://cast.mgtradio.net/radio/8000/aac
@@ -173830,6 +174012,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: br-radio-liberdade-92-9-belo-horizonte-mg
+  favicon: "https://radioliberdade.com.br/imagens/upload/config/full-logotopo-1735211535.png"
   broadcaster: independent
   name: Radio Liberdade 92.9 (Belo Horizonte - MG)
   streamUrl: https://8335.brasilstream.com.br/stream
@@ -175001,6 +175184,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: br-musical-fm-2
+  favicon: "https://fmmusical.com.br/forbesradio.png"
   broadcaster: independent
   name: musical fm 2
   streamUrl: https://9176.brasilstream.com.br/stream
@@ -175443,6 +175627,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: br-radio-cidade-87-5-fm
+  favicon: "https://static2.mytuner.mobi/media/tvos_radios/199/radio-cidade-itanhae.fad80905.png"
   broadcaster: independent
   name: Radio Cidade 87.5 FM
   streamUrl: https://srv2.braudio.com.br/sc/7344/;?1708352992585
@@ -175707,6 +175892,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: br-boa-fm-aracaju-sergipe
+  favicon: "https://cdn.onlineradiobox.com/img/l/3/111983.v1.png"
   broadcaster: independent
   name: Boa Fm - Aracaju Sergipe
   streamUrl: https://s07.maxcast.com.br:8074/live
@@ -176637,6 +176823,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: br-brahma-fm
+  favicon: "https://cdn.onlineradiobox.com/img/l/0/125480.v3.png"
   broadcaster: independent
   name: Brahma FM
   streamUrl: https://casthttps1.suaradionanet.net/13385/stream
@@ -177300,6 +177487,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: br-cultura-fm-95-1-mhz-uberlandia-mg-zyc697
+  favicon: "https://radioculturafm.com.br/wp-content/themes/culturafm/img/logo.png"
   broadcaster: independent
   name: Cultura FM 95.1 Mhz (Uberlândia - MG) (ZYC697)
   streamUrl: https://8040.brasilstream.com.br/stream
@@ -177982,6 +178170,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: br-voz-do-esporte-3
+  favicon: "https://vozdoesporte.com.br/radio/wp-content/uploads/2023/08/logo-2.png"
   broadcaster: independent
   name: voz do esporte 3
   streamUrl: https://paineldj.com.br:20172/stream
@@ -177996,6 +178185,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: br-87-fm
+  favicon: "https://www.fm87.com.br/v4/images/logoatz.png"
   broadcaster: independent
   name: 87 FM
   streamUrl: https://exodo.ddns.seg.br:20011/;?1705778463505=
@@ -180185,6 +180375,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: br-voz-do-esporte-4
+  favicon: "https://vozdoesporte.com.br/radio/wp-content/uploads/2023/08/logo-2.png"
   broadcaster: independent
   name: voz do esporte 4
   streamUrl: https://paineldj.com.br:20193/stream
@@ -180570,6 +180761,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: br-radio-jauense
+  favicon: "https://www.radiojauense.com.br/radio-aovivo-files/radio-2018.png"
   broadcaster: independent
   name: Radio Jauense
   streamUrl: https://s38.maxcast.com.br:8091/live
@@ -186038,6 +186230,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-canal-58-guadalajara-580-am-xeav-am-radio-canon-
+  favicon: "https://www.canal58.net/wp-content/uploads/2022/04/cropped-logo.jpg"
   broadcaster: independent
   name: "Canal 58 (Guadalajara) - 580 AM - XEAV-AM - Radio Cañón / NTR Medios de Comunicación - Guadalajara, JC"
   streamUrl: https://streaming.servicioswebmx.com/8266/stream
@@ -186831,6 +187024,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-buenisiima-acapulco-103-9-fm-xhpo-fm-grupo-audio
+  favicon: "https://cdn.onlineradiobox.com/img/l/5/49665.v12.png"
   broadcaster: independent
   name: "Buenisiima (Acapulco) - 103.9 FM - XHPO-FM - Grupo Audiorama Comunicaciones - Acapulco, GR"
   streamUrl: https://ss1.audiorama.com.mx:6606/
@@ -187127,6 +187321,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-radio-formula-tampico-103-9-fm-tampico-tamaulipa
+  favicon: "https://cdn.onlineradiobox.com/img/l/5/107765.v10.png"
   broadcaster: independent
   name: "Radio fórmula (Tampico) - 103.9 FM [Tampico, Tamaulipas]"
   streamUrl: https://stream.radiojar.com/ympb8vef3p8uv
@@ -187155,6 +187350,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-radio-formula-la-paz-97-5-fm-la-paz-baja-califor
+  favicon: "https://static2.mytuner.mobi/media/tvos_radios/119/radio-formula-la-paz.819aa51a.png"
   broadcaster: independent
   name: "Radio fórmula (La Paz) - 97.5 FM [La Paz, Baja California Sur]"
   streamUrl: https://stream.radiojar.com/n9nz7y4n3p8uv
@@ -187357,6 +187553,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-radio-ranchito-calvillo-99-7-fm-xhplvi-fm-grupo-
+  favicon: "https://cdn.onlineradiobox.com/img/l/9/151569.v3.png"
   broadcaster: independent
   name: "Radio Ranchito (Calvillo) - 99.7 FM - XHPLVI-FM - Grupo ULTRA - Calvillo, Aguascalientes"
   streamUrl: https://streamingcwsradio30.com:7006/stream.mp3
@@ -187705,6 +187902,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-buenisiima-mexicali-850-am-xezf-am-grupo-audiora
+  favicon: "https://backend-audiorama-media.s3.amazonaws.com/2024/10/Buenisiima_Mexicali.png"
   broadcaster: independent
   name: "Buenisiima (Mexicali) - 850 AM - XEZF-AM - Grupo Audiorama Comunicaciones - Mexicali, BC"
   streamUrl: https://ss1.audiorama.com.mx:6594/
@@ -188022,6 +188220,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-super-chilpancingo-102-7-fm-680-am-xhchg-fm-xech
+  favicon: "https://backend-audiorama-media.s3.amazonaws.com/2024/10/Super_Chilpancingo.png"
   broadcaster: independent
   name: "SUPER (Chilpancingo) - 102.7 FM / 680 AM - XHCHG-FM / XECHG-AM - Grupo Audiorama Comunicaciones - Chilpancingo, GR"
   streamUrl: https://ss1.audiorama.com.mx:6616/
@@ -188957,6 +189156,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-mexiquense-radio-metepec-91-7-fm-xhgem-fm-sistem
+  favicon: "https://cdn.onlineradiobox.com/img/l/8/49968.v11.png"
   broadcaster: independent
   name: "Mexiquense Radio (Metepec) - 91.7 FM - XHGEM-FM - Sistema Mexiquense de Medios Públicos - Metepec, EM"
   streamUrl: https://streamingcwsradio30.com:7019/;
@@ -189765,6 +189965,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-radiante-91-1-fm-la-paz-baja-california-sur
+  favicon: "https://radiante.fm/img/radiante-fm-horizontal-color.svg"
   broadcaster: independent
   name: "Radiante - 91.1 FM [La Paz, Baja California Sur]"
   streamUrl: https://streamingcwsradio30.com:7035/;
@@ -190270,6 +190471,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-z-ciudad-juarez-103-5-fm-720-am-xhem-fm-xejcc
+  favicon: "https://cdn.onlineradiobox.com/img/l/0/9570.v14.png"
   broadcaster: independent
   name: "La Z Ciudad Juárez - 103.5 FM / 720 AM - XHEM-FM / XEJCC-AM - Grupo Audiorama Comunicaciones - Ciudad Juárez, Chihuahua"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XHEM_FMAAC.aac
@@ -190776,6 +190978,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-love-fm-tepic-96-1-fm-xheoo-fm-grupo-audiorama-c
+  favicon: "https://backend-audiorama-media.s3.amazonaws.com/2024/10/Love_Tepic.png"
   broadcaster: independent
   name: "Love FM (Tepic) - 96.1 FM - XHEOO-FM - Grupo Audiorama Comunicaciones - Tepic, Nayarit"
   streamUrl: https://ss1.audiorama.com.mx:6684/stream
@@ -191518,6 +191721,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-radio-uadeo-los-mochis-89-3-fm-xhudo-fm-universi
+  favicon: "https://cdn.onlineradiobox.com/img/l/4/116814.v2.png"
   broadcaster: independent
   name: "Radio UAdeO (Los Mochis) - 89.3 FM - XHUDO-FM - Universidad Autónoma de Occidente - Los Mochis, Sinaloa"
   streamUrl: https://xhudo-megacaster.radioca.st/stream
@@ -191794,6 +191998,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-vida-piedras-negras-99-9-fm-xhsg-fm-grupo-audior
+  favicon: "https://backend-audiorama-media.s3.amazonaws.com/2024/10/2-logo-vida.webp"
   broadcaster: independent
   name: "Vida (Piedras Negras) - 99.9 FM - XHSG-FM - Grupo Audiorama Comunicaciones - Piedras Negras, Coahuila"
   streamUrl: https://ss1.audiorama.com.mx:6670/stream/
@@ -198304,6 +198509,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: ua-radiorelax-instrumental-hd
+  favicon: "https://www.radiorelax.ua/static/img/about_logo/relax_logo_slogan.png"
   broadcaster: independent
   name: RadioRelax_Instrumental_HD
   streamUrl: https://online.radiorelax.ua/RadioRelax_Instrumental_HD
@@ -198408,6 +198614,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: ua-informator-fm
+  favicon: "https://static2.mytuner.mobi/media/tvos_radios/CYVEfT3JUP.jpg"
   broadcaster: independent
   name: Informator FM
   streamUrl: https://main.inf.fm:8101/;?type=http&nocache=221893
@@ -200246,6 +200453,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: cz-radio-humor-2
+  favicon: "https://cdn.onlineradiobox.com/img/l/0/18000.v10.png"
   broadcaster: independent
   name: Rádio humor 2
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/RADIO_HUMOR.aac
@@ -200377,6 +200585,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: cz-cesky-rozhlas-brno
+  favicon: "https://upload.wikimedia.org/wikipedia/commons/4/43/CRo_Brno_logo.png"
   broadcaster: independent
   name: Český rozhlas Brno
   streamUrl: https://rozhlas.stream/brno.mp3
@@ -203672,6 +203881,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: be-joe-easy
+  favicon: "https://cdn.onlineradiobox.com/img/l/8/84238.v6.png"
   broadcaster: independent
   name: joe easy
   streamUrl: https://streams.radio.dpgmedia.cloud/redirect/joe_easy/mp3
@@ -203731,6 +203941,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: be-radio-campus-bxl-92-1-ogg-hq
+  favicon: "https://cdn.onlineradiobox.com/img/l/6/13136.v4.png"
   broadcaster: independent
   name: "Radio Campus BXL 92.1 [Ogg HQ]"
   streamUrl: https://www.radiocampus.be/stream/stream_hi.ogg
@@ -203773,6 +203984,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: be-impact-fm
+  favicon: "https://www.impactradio.be/upload/design/667d242eb7cc06.83738740.png"
   broadcaster: independent
   name: Impact FM
   streamUrl: https://impactfm.ice.infomaniak.ch/impactfm-64.aac
@@ -203862,6 +204074,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: be-zoe-fm
+  favicon: "https://cdn.onlineradiobox.com/img/l/5/12785.v3.png"
   broadcaster: independent
   name: Zoe FM
   streamUrl: https://icecast.movemedia.be/zoe128
@@ -203979,6 +204192,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: be-joe-top-2000
+  favicon: "https://cdn.onlineradiobox.com/img/l/4/84234.v8.png"
   broadcaster: independent
   name: Joe - Top 2000
   streamUrl: https://streams.radio.dpgmedia.cloud/redirect/top2000/mp3
@@ -204139,6 +204353,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: be-versuz
+  favicon: "https://cdn.onlineradiobox.com/img/l/8/13648.v5.png"
   broadcaster: independent
   name: Versuz
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/TOPVERSUZ.mp3
@@ -204549,6 +204764,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: be-radyo-gar
+  favicon: "https://radyogar.com/img/icon.png"
   broadcaster: independent
   name: Radyo Gar
   streamUrl: https://gargara.net/listen/zana/radio.mp3
@@ -206825,6 +207041,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: hr-radio-ritam-sibenik
+  favicon: "https://radioritam.hr/wp-content/uploads/2022/12/Radio-Ritam-SQUARE-LOGO-RED-PNG-BEZ-RUBA-2-FINAL.png"
   broadcaster: independent
   name: Radio Ritam Šibenik
   streamUrl: https://ec2s.crolive.com.hr:8455/stream
@@ -207108,6 +207325,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: hr-057-radio-zadar-croatia
+  favicon: "https://cdn.onlineradiobox.com/img/l/3/23853.v6.png"
   broadcaster: independent
   name: "057 radio, Zadar, Croatia"
   streamUrl: https://audio.alter-media.hr/9052/stream
@@ -207462,6 +207680,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: hr-banovina-light
+  favicon: "https://cdn.onlineradiobox.com/img/l/4/75504.v8.png"
   broadcaster: independent
   name: Banovina Light
   streamUrl: https://audio.radio-banovina.hr:7008/stream
@@ -207754,6 +207973,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: ca-70-80-90-italia-d-autore
+  favicon: "https://radiosuitenetwork.torontocast.stream/wp-content/uploads/2021/09/600.png"
   broadcaster: independent
   name: "70 80 90 ITALIA D'AUTORE"
   streamUrl: https://maggie.torontocast.com:2020/stream/708090italiadautore
@@ -209755,6 +209975,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: ca-cjrp-fm-alive-fm-saint-john-canada
+  favicon: "https://alivefm.ca/wp-content/uploads/2026/03/AliveLogo_NoFrew.png"
   broadcaster: independent
   name: CJRP-FM - Alive FM Saint John Canada
   streamUrl: https://us9.streamingpulse.com/ssl/NewsongFM
@@ -210685,6 +210906,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: ca-cfbu-103-7-brock-university-st-catharines-on
+  favicon: "https://cdn.onlineradiobox.com/img/l/5/20945.v5.png"
   broadcaster: independent
   name: "CFBU 103.7 Brock University, St. Catharines, ON"
   streamUrl: https://stream2.statsradio.com:8160/stream
@@ -211027,6 +211249,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: ca-la-bonita-x101
+  favicon: "https://cdn.onlineradiobox.com/img/l/5/93105.v44.png"
   broadcaster: independent
   name: La Bonita X101
   streamUrl: https://listen.labonita.torontocast.stream/
@@ -211663,6 +211886,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: ca-choc-88-7
+  favicon: "https://cdn.onlineradiobox.com/img/l/0/104320.v4.png"
   broadcaster: independent
   name: CHOC 88.7
   streamUrl: https://stream2.statsradio.com:8110/stream
@@ -212402,6 +212626,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: ca-radio-canada-ici-premiere-colombie-britannique-y
+  favicon: "https://ici.radio-canada.ca/Content/premiere/_images/logo/logo-ici-premiere.svg"
   broadcaster: independent
   name: "Radio Canada Ici Première (Colombie-Britannique-Yukon, Grand Nord) Vancouver, BC"
   streamUrl: https://rcavliveaudio.akamaized.net/hls/live/2006975/P-2BVAN0_VAN/master.m3u8
@@ -212848,6 +213073,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: ca-cfai-fm-101-1-edmundston-105-1-grand-sault-nb
+  favicon: "https://cfai.fm/wp-content/themes/cfai/assets/img/cfai-logo.png"
   broadcaster: independent
   name: "CFAI-FM 101.1 Edmundston &105.1 Grand Sault, NB"
   streamUrl: https://stream2.statsradio.com:8028/stream
@@ -213930,6 +214156,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: ca-easy-music-plus
+  favicon: "https://www.easymusicplus.com/images/ezmplogo.png"
   broadcaster: independent
   name: Easy Music Plus
   streamUrl: https://cheetah.streemlion.com:3545/stream
@@ -214331,6 +214558,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: ca-cftx-fm-96-5-bpm-sports-gatineau-qc
+  favicon: "https://upload.wikimedia.org/wikipedia/commons/thumb/0/06/BPM_SPORTS_logo.svg/250px-BPM_SPORTS_logo.svg.png"
   broadcaster: independent
   name: "CFTX-FM 96.5 \"BPM Sports\" Gatineau, QC"
   streamUrl: https://stream0.bpmsports.ca/cftx.aac
@@ -214434,6 +214662,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: ca-cimg-fm-the-eagle-94-1-swift-current-sk
+  favicon: "https://golden-west-broadcasting-ltd-corporate-account-v1775663884.websitepro-cdn.com/wp-content/uploads/2023/11/Country94-RGB-Logo-Colour.svg"
   broadcaster: independent
   name: "CIMG-FM \"The Eagle 94.1\" Swift Current, SK"
   streamUrl: https://lax-live2-ais-relay1.leanstream.co/goldenwest/CIMGFM.stream/playlist.m3u8
@@ -214656,6 +214885,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: ca-ritmo-x99
+  favicon: "https://cdn.onlineradiobox.com/img/l/1/131741.v4.png"
   broadcaster: independent
   name: Ritmo X99
   streamUrl: https://listen.ritmo.torontocast.stream/
@@ -215948,6 +216178,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: ca-civh-95-9-fm-the-goat-vanderhoof-bc
+  favicon: "https://www.vistaradio.ca/wp-content/uploads/2014/09/thegoat-600X403.png"
   broadcaster: independent
   name: "CIVH \"95.9 FM The Goat\" Vanderhoof, BC"
   streamUrl: https://vistaradio.streamb.live/SB00076
@@ -216007,6 +216238,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: ca-cjci-97-3-country-97-prince-george-bc
+  favicon: "https://upload.wikimedia.org/wikipedia/en/thumb/4/4a/CJCI_country97_logo.png/250px-CJCI_country97_logo.png"
   broadcaster: independent
   name: "CJCI 97.3 \"Country 97\" Prince George, BC"
   streamUrl: https://vistaradio.streamb.live/SB00040
@@ -216051,6 +216283,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: ca-cjpg-fm-mix-96-5-portage-la-prairie-mb
+  favicon: "https://golden-west-broadcasting-ltd-corporate-account-v1775663884.websitepro-cdn.com/wp-content/uploads/2023/08/mix965.svg"
   broadcaster: independent
   name: "CJPG-FM \"Mix 96.5\" Portage la Prairie, MB"
   streamUrl: https://goldenwest.leanstream.co/CJPGFM
@@ -217890,6 +218123,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: ca-mtsn-the-mammoth
+  favicon: "https://cdn.onlineradiobox.com/img/l/1/156271.v1.png"
   broadcaster: independent
   name: MTSN - The Mammoth
   streamUrl: https://radio.mammothradio.com/radio/8000/radio.mp3

--- a/public/stations.json
+++ b/public/stations.json
@@ -41882,6 +41882,7 @@
       "streamUrl": "https://museum.streamserver24.com:8080/stream",
       "homepage": "http://www.plattenkiste.radio/",
       "country": "DE",
+      "favicon": "https://www.plattenkiste.radio/index_htm_files/70.jpg",
       "bitrate": 256,
       "codec": "MP3",
       "status": "stream-only"
@@ -43831,6 +43832,7 @@
       "streamUrl": "https://stream.laut.fm/xanadu",
       "homepage": "http://www.xanadu44.com/",
       "country": "DE",
+      "favicon": "https://www.radio.de/300/lautfm-xanadu.png?version=304163ede0e6010cc1c531240687f2050a0a4fb9",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -54465,6 +54467,7 @@
       "streamUrl": "https://ais-sa1.streamon.fm/7215_48k.aac",
       "homepage": "https://www.bobfm969.com/",
       "country": "US",
+      "favicon": "https://bobfm969.com/wp-content/uploads/sites/16/bob-fm-400px-373x500.jpg",
       "bitrate": 96,
       "codec": "AAC",
       "status": "stream-only"
@@ -54484,6 +54487,7 @@
         "curry",
         "dvorak"
       ],
+      "favicon": "https://www.noagendashow.net/build/images/website-logo.c3d48c92.svg",
       "codec": "MP3",
       "status": "stream-only"
     },
@@ -54802,6 +54806,7 @@
       "tags": [
         "sports"
       ],
+      "favicon": "https://theticketfm.com/wp-content/uploads/sites/4/The-Ticket-Logo-glow-400px.png",
       "bitrate": 32,
       "codec": "AAC+",
       "status": "stream-only"
@@ -55102,6 +55107,7 @@
       "tags": [
         "armenian"
       ],
+      "favicon": "https://www.radiojan.com/wp-content/uploads/2021/01/logowhite.svg",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -55207,6 +55213,7 @@
         "sports",
         "wvgm"
       ],
+      "favicon": "https://cdnrf.securenetsystems.net/file_radio/stations_large/WVGM/v5/logo.png",
       "bitrate": 32,
       "codec": "AAC+",
       "status": "stream-only"
@@ -55335,6 +55342,7 @@
       "streamUrl": "https://play.streamafrica.net/lofiradio",
       "homepage": "https://play.streamafrica.net/lofiradio",
       "country": "US",
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/0/0f/Lofi_Girl_logo_%282024%29.svg",
       "codec": "MP3",
       "status": "stream-only"
     },
@@ -57221,6 +57229,7 @@
       "tags": [
         "hip hop"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/0/94790.v4.png",
       "bitrate": 32,
       "codec": "AAC+",
       "status": "stream-only"
@@ -58997,6 +59006,7 @@
         "beautiful music",
         "easy listening"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/4/75034.v11.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -59689,6 +59699,7 @@
       "streamUrl": "https://emocore.stream.laut.fm/emocore?ref=radiode&t302=2021-07-31_22-18-20&uuid=9eeacdd0-1f90-4987-a064-69fca03ded3c",
       "homepage": "https://emocore.stream.laut.fm/",
       "country": "US",
+      "favicon": "https://cdn-profiles.tunein.com/s310932/images/logod.png?t=639137857510000000",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -75253,6 +75264,7 @@
       "streamUrl": "https://live.amperwave.net/manifest/telesouth-wfmnfmaac-imc1",
       "homepage": "https://www.google.com/url?sa=t&source=web&rct=j&opi=89978449&url=https://www.supertalk.fm/stations/jackson-97-3/&ved=2ahUKEwjS8JfknoGCAxXYxjgGHX0wBcoQFnoECBYQAQ&usg=AOvVaw2BcCSsHLm3BlqbvH2S0-qY",
       "country": "US",
+      "favicon": "https://www.supertalk.fm/wp-content/uploads/2024/06/sp_logo-e1718744468259.png",
       "bitrate": 64,
       "codec": "AAC+",
       "status": "stream-only"
@@ -75643,6 +75655,7 @@
         "sports",
         "talk"
       ],
+      "favicon": "https://cdn.logfm.com/i/18/18321s300.webp?d=1691301294",
       "bitrate": 32,
       "codec": "AAC+",
       "status": "stream-only"
@@ -75908,6 +75921,7 @@
       "tags": [
         "classical"
       ],
+      "favicon": "https://npr.brightspotcdn.com/dims4/default/38e1783/2147483647/strip/true/crop/422x171+0+0/resize/267x108!/quality/90/?url=http%3A%2F%2Fnpr-brightspot.s3.amazonaws.com%2F16%2Fea%2Ffeeebd2041858826ac1b747ddc26%2Fwysu-header-logo.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -77896,6 +77910,7 @@
       "streamUrl": "https://streaming.live365.com/a84571",
       "homepage": "http://www.ourgenerationradio.com/",
       "country": "US",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/0/16240.v5.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -78606,6 +78621,7 @@
       "tags": [
         "classical"
       ],
+      "favicon": "https://images.ctfassets.net/8usdt07j8s00/64q2oGq1OA3zTQGGX45pli/7e2f77b2c3ad958b0f00521ade288c9c/CC_Logo_Hor_Tag__1_.webp",
       "bitrate": 96,
       "codec": "MP3",
       "status": "stream-only"
@@ -78901,6 +78917,7 @@
         "classic hits",
         "oldies"
       ],
+      "favicon": "https://static2.mytuner.mobi/media/tvos_radios/fggzxucdvjl3.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -79638,6 +79655,7 @@
       "tags": [
         "regional mexican"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/4/28404.v4.png",
       "bitrate": 64,
       "codec": "AAC+",
       "status": "stream-only"
@@ -81099,6 +81117,7 @@
         "community radio",
         "rock"
       ],
+      "favicon": "https://www.truckeetahoeradio.com/wp-content/uploads/2023/08/1015_Lake_Logo_WhiteHoriz.png",
       "bitrate": 32,
       "codec": "AAC+",
       "status": "stream-only"
@@ -81612,6 +81631,7 @@
         "news",
         "talk"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/3/24153.v5.png",
       "bitrate": 48,
       "codec": "AAC+",
       "status": "stream-only"
@@ -83792,6 +83812,7 @@
       "streamUrl": "https://ice.wbjb.net/FMF-MP3",
       "homepage": "http://fmflashback.org/",
       "country": "US",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/0/120850.v5.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -87040,6 +87061,7 @@
       "streamUrl": "https://radioserver11.profesionalhosting.com/proxy/djqjfpwc?mp=/stream",
       "homepage": "https://tropical1057.us/",
       "country": "US",
+      "favicon": "https://tropical1057.us/attachments/Logo/tropical.png",
       "codec": "MP3",
       "status": "stream-only"
     },
@@ -87336,6 +87358,7 @@
         "classical",
         "classical music"
       ],
+      "favicon": "https://npr.brightspotcdn.com/dims4/default/2ce244e/2147483647/strip/true/crop/1547x383+0+0/resize/267x66!/quality/90/?url=http%3A%2F%2Fnpr-brightspot.s3.amazonaws.com%2F2c%2Fcb%2F7e3870fa4319b2e047f33c0478fa%2Fwuwf-new-color.png",
       "bitrate": 96,
       "codec": "MP3",
       "geo": [
@@ -87820,6 +87843,7 @@
       "tags": [
         "ricj"
       ],
+      "favicon": "https://site.kpig.com/wp-content/uploads/2021/09/170x220xlogo.png.pagespeed.ic_.PBXnkKbKM2.png",
       "bitrate": 64,
       "codec": "AAC+",
       "geo": [
@@ -87883,6 +87907,7 @@
       "streamUrl": "https://ice24.securenetsystems.net/KZYN",
       "homepage": "http://redrock.fm/zion-1041",
       "country": "US",
+      "favicon": "https://cdn-profiles.tunein.com/s306990/images/logod.jpg?t=637564431900000000",
       "bitrate": 64,
       "codec": "AAC+",
       "geo": [
@@ -87951,6 +87976,7 @@
         "90s",
         "adult contemporary"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/6/17586.v6.png",
       "bitrate": 32,
       "codec": "AAC",
       "geo": [
@@ -89135,6 +89161,7 @@
       "streamUrl": "https://stream.aiir.com/hoy4lohjjgiuv.mp3",
       "homepage": "https://stream.aiir.com/hoy4lohjjgiuv.mp3",
       "country": "US",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/0/88360.v10.png",
       "codec": "MP3",
       "status": "stream-only"
     },
@@ -90738,6 +90765,7 @@
       "streamUrl": "https://s2.yesstreaming.net:17031/stream",
       "homepage": "https://www.kokolp.org/",
       "country": "US",
+      "favicon": "https://www.kokolp.org/KOKO-Skill-icon.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -91259,6 +91287,7 @@
       "tags": [
         "r&b music"
       ],
+      "favicon": "https://espn947.com/wp-content/uploads/2025/05/ESPN_Radio_big-logo-scaled.png",
       "bitrate": 32,
       "codec": "AAC+",
       "status": "stream-only"
@@ -91273,6 +91302,7 @@
       "tags": [
         "public radio"
       ],
+      "favicon": "https://npr.brightspotcdn.com/dims4/default/065fc86/2147483647/strip/true/crop/450x201+0+0/resize/267x119!/quality/90/?url=http%3A%2F%2Fnpr-brightspot.s3.amazonaws.com%2F3d%2F19%2F3f5fd2264917b435d7724d211edb%2Fwhqr-logo-newq-no-tag-450x201.jpg",
       "bitrate": 96,
       "codec": "MP3",
       "geo": [
@@ -91821,6 +91851,7 @@
         "fan music",
         "mlp"
       ],
+      "favicon": "https://celestiaradio.com/index_files/CR_Test_Icon_2-01.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -92752,6 +92783,7 @@
       "streamUrl": "https://c30.radioboss.fm:8569/stream",
       "homepage": "https://sevenrockradio.com/",
       "country": "US",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/4/107544.v4.png",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -93472,6 +93504,7 @@
       "streamUrl": "https://streaming.live365.com/a01456",
       "homepage": "https://www.caddocountry.com/",
       "country": "US",
+      "favicon": "https://caddocountry.com/wp-content/uploads/2026/01/cropped-cropped-Caddo-Country-Header-2.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -93898,6 +93931,7 @@
       "streamUrl": "https://kfok.streamguys1.com/live-mp3",
       "homepage": "https://kfok.org/",
       "country": "US",
+      "favicon": "https://kfok.org/wp-content/uploads/2019/09/KFOKORG_logo-300x300.png",
       "bitrate": 110,
       "codec": "MP3",
       "status": "stream-only"
@@ -94753,6 +94787,7 @@
       "streamUrl": "https://streams.radiomast.io/0153a705-0f05-4ed1-ab0d-638a513370db",
       "homepage": "http://wixe.com/",
       "country": "US",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/4/23974.v3.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -95047,6 +95082,7 @@
         "classic rock",
         "country"
       ],
+      "favicon": "https://www.2020thebeacon.com/logo.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -95145,6 +95181,7 @@
         "90s",
         "pop"
       ],
+      "favicon": "https://jacobsradiollc.com/wp-content/uploads/2024/01/mix-99-logo.jpg",
       "bitrate": 140,
       "codec": "MP3",
       "geo": [
@@ -95527,6 +95564,7 @@
       "streamUrl": "https://play.radioking.io/indy-dancers-dancecast/345331",
       "homepage": "https://www.indydancers.com/",
       "country": "US",
+      "favicon": "https://www.indydancers.com/logos-Dance/IdlogoHR-neg-default.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -98101,6 +98139,7 @@
       "streamUrl": "https://streams.radiomast.io/fdb61263-8591-4fc7-b10b-e3d9c0911506",
       "homepage": "https://www.khbl.com/",
       "country": "US",
+      "favicon": "https://www.khbl.com/images/KHBL.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -100980,6 +101019,7 @@
       "tags": [
         "ska"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/9/86049.v20.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -101228,6 +101268,7 @@
         "metal",
         "symphonic metal"
       ],
+      "favicon": "https://thevoiceofdoom.com/images/vod_logo_skull_326x160_i.jpg",
       "bitrate": 320,
       "codec": "AAC",
       "status": "stream-only"
@@ -101682,6 +101723,7 @@
         "electro",
         "electronic"
       ],
+      "favicon": "https://netilradio.com/images/logo.svg",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -102539,6 +102581,7 @@
       "tags": [
         "music"
       ],
+      "favicon": "https://asianstarradio.co.uk/wp-content/uploads/2025/01/AS_1200x800-e1746383159267.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -103756,6 +103799,7 @@
       "streamUrl": "https://noods-radio.radiocult.fm/stream",
       "homepage": "http://www.noodsradio.com/",
       "country": "GB",
+      "favicon": "https://noodsradio.com/_nuxt/noods-logo.CgUioM5-.svg",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -104778,6 +104822,7 @@
       "tags": [
         "blues"
       ],
+      "favicon": "http://www.bluesradio.co.uk/bruk_banner.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -105327,6 +105372,7 @@
       "streamUrl": "https://uksouth1.juiceboxradio.com/tsradionational",
       "homepage": "http://teamsportradio.com/",
       "country": "GB",
+      "favicon": "https://cdn.instant.audio/images/logos/internetradiouk-com/in-store-radio-teamsport.png",
       "bitrate": 96,
       "codec": "AAC+",
       "status": "stream-only"
@@ -105508,6 +105554,7 @@
       "tags": [
         "2020s pop music"
       ],
+      "favicon": "https://hearme.fm/wp-content/uploads/2024/06/2024-Redrafted-Transparent-Box-No-Text-1-1024x1024.png",
       "codec": "MP3",
       "geo": [
         53.1204,
@@ -108958,6 +109005,7 @@
         "chillout",
         "lofi hip hop"
       ],
+      "favicon": "https://chillsky.com/logo.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -109057,6 +109105,7 @@
       "streamUrl": "https://streaming06.liveboxstream.uk/proxy/radiogra?mp=/stream",
       "homepage": "https://www.radiograpevine.com/",
       "country": "GB",
+      "favicon": "https://www.radiograpevine.com/images/Headers/roundel.gif",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -110382,6 +110431,7 @@
       "streamUrl": "https://gains.reviveradio.net/proxy/greenradio?mp=/stream",
       "homepage": "https://greenradiolive.com/",
       "country": "GB",
+      "favicon": "https://cdn-radiotime-logos.tunein.com/s291453d.png",
       "bitrate": 256,
       "codec": "MP3",
       "status": "stream-only"
@@ -112030,6 +112080,7 @@
       "streamUrl": "https://radio.nitro-server.uk/listen/nitrohost/radio.mp3",
       "homepage": "https://radio.nitro-server.uk/listen/nitrohost/",
       "country": "GB",
+      "favicon": "https://static2.mytuner.mobi/media/tvos_radios/paycr8nhlthu.png",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -113776,6 +113827,7 @@
       "tags": [
         "oldies"
       ],
+      "favicon": "https://www.bide-et-musique.com/images/logo.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -113845,6 +113897,7 @@
       "streamUrl": "https://classicfm.ice.infomaniak.ch/classic-fm.mp3",
       "homepage": "https://www.classicfm.fr/",
       "country": "FR",
+      "favicon": "https://www.classicfm.fr/media/cover.jpg",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -113959,6 +114012,7 @@
       "streamUrl": "https://stream.rfm.fr/rfm-wr13.aac",
       "homepage": "https://stream.rfm.fr/rfm-wr13.aac",
       "country": "FR",
+      "favicon": "https://cdn-profiles.tunein.com/s309249/images/logod.jpg?t=638677209640000000",
       "bitrate": 128,
       "codec": "AAC+",
       "status": "stream-only"
@@ -114078,6 +114132,7 @@
         "chiptunes",
         "retro games"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/0/71600.v5.png",
       "codec": "OGG",
       "status": "stream-only"
     },
@@ -115930,6 +115985,7 @@
       "tags": [
         "soft jazz – 100% vocal"
       ],
+      "favicon": "https://www.vip-radios.fm/wp-content/uploads/Sunset-Jazz-logo2.jpg",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -117249,6 +117305,7 @@
         "local music",
         "local news"
       ],
+      "favicon": "https://irulegikoirratia.eus/img/irulegiko-irratia.png",
       "bitrate": 320,
       "codec": "MP3",
       "geo": [
@@ -117960,6 +118017,7 @@
       "tags": [
         "outre-mer"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/2/7392.v5.png",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -117987,6 +118045,7 @@
         "kitch",
         "music"
       ],
+      "favicon": "https://www.allzicradio.com/media/radios/allzic-radio-kitch.png",
       "bitrate": 64,
       "codec": "AAC+",
       "status": "stream-only"
@@ -118474,6 +118533,7 @@
         "jazz",
         "music"
       ],
+      "favicon": "https://www.allzicradio.com/media/radios/allzic-jazz_600px-carre.png",
       "bitrate": 64,
       "codec": "AAC+",
       "status": "stream-only"
@@ -118650,6 +118710,7 @@
         "accordéon",
         "musique de vieux"
       ],
+      "favicon": "https://www.meetfm.fr/upload/design/61f6f288916554.63169499.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -119403,6 +119464,7 @@
       "streamUrl": "https://listen.radioking.com/radio/28783/stream/64720",
       "homepage": "http://www.oarp.eu/",
       "country": "FR",
+      "favicon": "https://radioarpitania.eu/wp-content/uploads/2022/10/radio-arpitania.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -119803,6 +119865,7 @@
       "tags": [
         "music"
       ],
+      "favicon": "https://www.allzicradio.com/media/radios/allzic-live-gold_600px-carre.png",
       "bitrate": 64,
       "codec": "AAC+",
       "status": "stream-only"
@@ -120100,6 +120163,7 @@
       "tags": [
         "talk & speech"
       ],
+      "favicon": "https://www.rvrradio.fr/images/logorvr.png",
       "bitrate": 160,
       "codec": "AAC",
       "status": "stream-only"
@@ -121946,6 +122010,7 @@
       "streamUrl": "https://radio3.pro-fhi.net:19045/stream",
       "homepage": "https://www.terremarinefm.com/",
       "country": "FR",
+      "favicon": "https://cdn-radiotime-logos.tunein.com/s50265d.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -122781,6 +122846,7 @@
       "tags": [
         "news"
       ],
+      "favicon": "https://media.info/l/o/6/6818.1503522375.png",
       "bitrate": 32,
       "codec": "AAC",
       "status": "stream-only"
@@ -124730,6 +124796,7 @@
         "culture",
         "music"
       ],
+      "favicon": "https://www.rayvox.org/images/logo-RAYV01.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -125000,6 +125067,7 @@
         "rock and roll",
         "rolling stones"
       ],
+      "favicon": "https://static2.mytuner.mobi/media/tvos_radios/188/virgin-radio-music-star-rolling-stones.ec0de946.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -125086,6 +125154,7 @@
         "sport",
         "talk"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/6/122996.v2.png",
       "bitrate": 64,
       "codec": "AAC+",
       "status": "stream-only"
@@ -125344,6 +125413,7 @@
         "pop rock",
         "queen"
       ],
+      "favicon": "https://www.virginradio.it/wp-content/uploads/2025/03/cropped-logo_colored.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -127929,6 +127999,7 @@
         "news",
         "talk"
       ],
+      "favicon": "https://www.italianews24.news/wp-content/uploads/2025/10/cropped-italia-news-24-orizz-white.png",
       "codec": "MP3",
       "status": "stream-only"
     },
@@ -128777,6 +128848,7 @@
       "streamUrl": "https://centova.ipstream.it/proxy/megamix80/stream",
       "homepage": "http://ntova.ipstream.it/",
       "country": "IT",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/3/138023.v4.png",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -129948,6 +130020,7 @@
       "streamUrl": "https://listen-nation.sharp-stream.com/nationradio70s.mp3",
       "homepage": "https://listen-nation.sharp-stream.com/nationradio70s.mp3",
       "country": "IT",
+      "favicon": "https://mmo.aiircdn.com/677/69cd28992b074.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -130225,6 +130298,7 @@
         "mixed music",
         "mixed programming"
       ],
+      "favicon": "https://zakradio.net/radio-tp/wp-content/uploads/2026/01/LOGO-2025.png",
       "bitrate": 96,
       "codec": "MP3",
       "geo": [
@@ -130556,6 +130630,7 @@
         "anzio",
         "world music"
       ],
+      "favicon": "https://www.radioomega.it/images/Logo_ROS.jpg",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -130659,6 +130734,7 @@
       "streamUrl": "https://sr11.inmystream.it/proxy/radiogattopardo?mp=/stream&1700931042510",
       "homepage": "https://www.radiogattopardo.it/",
       "country": "IT",
+      "favicon": "https://cdn.onlineradiobox.com/img/logo/5/132725.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -131523,6 +131599,7 @@
         "smooth jazz",
         "smooth lounge"
       ],
+      "favicon": "https://www.cdm-radio.com/wp-content/uploads/Logo-Chillout.png",
       "bitrate": 96,
       "codec": "MP3",
       "status": "stream-only"
@@ -131777,6 +131854,7 @@
       "streamUrl": "https://stream.tunerplay.com/radio/8040/radio.mp3",
       "homepage": "https://www.tunerplay.live/mix80radio",
       "country": "ES",
+      "favicon": "https://i0.wp.com/tunerplay.com/wp-content/uploads/2023/12/MIX80Radio.png?fit=1024%2C1024&ssl=1",
       "bitrate": 256,
       "codec": "MP3",
       "geo": [
@@ -133128,6 +133206,7 @@
         "news talk",
         "news talk music"
       ],
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/b/b1/Cadena_Ser_logo-2.svg",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -134780,6 +134859,7 @@
         "debates y deportes",
         "noticias"
       ],
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/2/28/Cadena_Ser_logo.svg",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -134860,6 +134940,7 @@
         "music",
         "spoken word"
       ],
+      "favicon": "https://radiolagranjazaragoza.wordpress.com/wp-content/uploads/2021/07/cropped-radiolagranjaramone.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -135560,6 +135641,7 @@
         "magazines",
         "noticias locales"
       ],
+      "favicon": "https://www.ladiez.es/images/logo-la10-capitalradio.png",
       "bitrate": 96,
       "codec": "AAC",
       "geo": [
@@ -136888,6 +136970,7 @@
       "streamUrl": "https://server10.emitironline.com:8044/;",
       "homepage": "https://mortalfm.es/",
       "country": "ES",
+      "favicon": "https://www.mortalfm.es/wp-content/uploads/2025/08/cropped-logo-2-scaled-1.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -138697,6 +138780,7 @@
       "tags": [
         "dance"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/3/4533.v5.png",
       "bitrate": 160,
       "codec": "MP3",
       "status": "stream-only"
@@ -139771,6 +139855,7 @@
         "salsa",
         "tropical"
       ],
+      "favicon": "https://colorestereo.com/colorestereo_logo.jpg",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -140785,6 +140870,7 @@
       "streamUrl": "https://online.monteolivete.org:8005/stream",
       "homepage": "http://monteolivete.org/",
       "country": "ES",
+      "favicon": "https://monteolivete.org/wp-content/uploads/2016/09/M.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -140924,6 +141010,7 @@
       "streamUrl": "https://relay.stream.enacast-cloud.com:40295/radiotorderaHD.mp3",
       "homepage": "https://radiotordera.cat/radio/",
       "country": "ES",
+      "favicon": "https://radiotordera.cat/radio/wp-content/uploads/2021/07/firma-logo-RT-.jpg",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -142020,6 +142107,7 @@
       "streamUrl": "https://mcp-1.streampanel.nl:8020/lxclassics_mp3",
       "homepage": "http://www.lxclassics.com/",
       "country": "NL",
+      "favicon": "https://www.lxclassics.com/img/logo_lxclassics.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -143637,6 +143725,7 @@
       "streamUrl": "https://s42.myradiostream.com/33512/listen.mp3",
       "homepage": "https://www.razoamsterdam.nl/",
       "country": "NL",
+      "favicon": "https://www.salto.nl/wp-content/themes/musiks-salto/assets/images/razo.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -144300,6 +144389,7 @@
       "tags": [
         "music dj"
       ],
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/c/c9/A_State_Of_Trance_Radio.jpg",
       "codec": "AAC",
       "status": "stream-only"
     },
@@ -145973,6 +146063,7 @@
       "streamUrl": "https://rivierenlandradio.stream-server.nl/stream",
       "homepage": "https://www.rivierenlandradio.nl/",
       "country": "NL",
+      "favicon": "https://www.rivierenland-radio.nl/uploads/rivierenland-radio.nl/1640410917-Simple%20logo2.2%20on%20white%20350x124.png",
       "bitrate": 320,
       "codec": "MP3",
       "status": "stream-only"
@@ -146556,6 +146647,7 @@
         "kids",
         "seasonal/holiday"
       ],
+      "favicon": "https://sintfm.nl/media/logo3.png",
       "bitrate": 320,
       "codec": "MP3",
       "geo": [
@@ -146669,6 +146761,7 @@
       "streamUrl": "https://ais-sa1.streamon.fm/7338_48k.aac",
       "homepage": "https://island92.com/",
       "country": "NL",
+      "favicon": "https://www.island92.com/wp-content/uploads/2016/02/i92logo.png",
       "bitrate": 48,
       "codec": "AAC+",
       "status": "stream-only"
@@ -146837,6 +146930,7 @@
         "hits",
         "internet radio"
       ],
+      "favicon": "https://www.traxxradio.nl/traxxlogosimple.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -147102,6 +147196,7 @@
       "tags": [
         "various"
       ],
+      "favicon": "https://radio0511.com/img/logo_radio0511.png",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -149133,6 +149228,7 @@
         "piratenhits",
         "piratenmuziek"
       ],
+      "favicon": "https://hitgolfradio.nl/wp-content/uploads/2025/06/hitgolfradio.png",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -149175,6 +149271,7 @@
         "dutch music",
         "various"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/0/108360.v6.png",
       "bitrate": 192,
       "codec": "AAC",
       "status": "stream-only"
@@ -152986,6 +153083,7 @@
         "christian",
         "christian music"
       ],
+      "favicon": "https://static.wixstatic.com/media/fec211_a76d8b62a4fb414b86923c978538af9e~mv2.png/v1/fill/w_197,h_123,al_c,q_85,usm_0.66_1.00_0.01,enc_avif,quality_auto/fec211_a76d8b62a4fb414b86923c978538af9e~mv2.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -153647,6 +153745,7 @@
       "streamUrl": "https://s1.slotex.pl:7294/stream/1/",
       "homepage": "http://www.slonskieradiohitmix.eu/#",
       "country": "PL",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/6/1466.v1.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -156578,6 +156677,7 @@
         "universidad tecnologica nacional",
         "utn"
       ],
+      "favicon": "https://ceut.frbb.utn.edu.ar/web/img/logoUTNheader.png",
       "bitrate": 48,
       "codec": "AAC+",
       "status": "stream-only"
@@ -156595,6 +156695,7 @@
         "politics",
         "sports"
       ],
+      "favicon": "https://radioverdadvd.com.ar/img/logo_1722895386.png",
       "bitrate": 32,
       "codec": "AAC+",
       "geo": [
@@ -156664,6 +156765,7 @@
       "streamUrl": "https://cdn.instream.audio:9288/stream",
       "homepage": "https://am530somosradio.com/",
       "country": "AR",
+      "favicon": "https://am530somosradio.com/wp-content/uploads/2023/12/logo3.png",
       "bitrate": 48,
       "codec": "AAC+",
       "geo": [
@@ -157224,6 +157326,7 @@
       "streamUrl": "https://masservidor.net/8616/stream",
       "homepage": "https://cuartetoenlaweb.com.ar/",
       "country": "AR",
+      "favicon": "https://cuartetoenlaweb.com.ar/js/logo.png",
       "bitrate": 32,
       "codec": "AAC+",
       "status": "stream-only"
@@ -157268,6 +157371,7 @@
       "tags": [
         "news talk music"
       ],
+      "favicon": "https://fm90saladillo.com.ar/wp-content/uploads/2023/09/logo-fm90-150x150.jpeg",
       "bitrate": 32,
       "codec": "AAC",
       "geo": [
@@ -157680,6 +157784,7 @@
       "streamUrl": "https://tmbradio.radioca.st/stream",
       "homepage": "https://www.themusicalbox.com.ar/tmbradio.htm",
       "country": "AR",
+      "favicon": "https://www.themusicalbox.com.ar/imagenes/logos/tmbescudo.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -159138,6 +159243,7 @@
       "tags": [
         "talk. music"
       ],
+      "favicon": "https://www.planetmusic.fm/img/Planet_logo.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -161767,6 +161873,7 @@
         "music",
         "noticias locales"
       ],
+      "favicon": "https://signos.fm/wp-content/uploads/2025/12/signos-logo-acoado-horiz-v4-scaled-e1765907786719.png",
       "bitrate": 64,
       "codec": "AAC+",
       "geo": [
@@ -163901,6 +164008,7 @@
       "streamUrl": "https://servidor36.brlogic.com:7050/live",
       "homepage": "https://www.imccountryradio.com/",
       "country": "AU",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/7/124357.v2.png",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -164333,6 +164441,7 @@
         "information",
         "news"
       ],
+      "favicon": "https://www.951gemfm.org/wp-content/uploads/2024/05/size-adjusted-logo-4-7394e432f810.png",
       "bitrate": 128,
       "codec": "AAC+",
       "geo": [
@@ -166330,6 +166439,7 @@
       "tags": [
         "community"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/4/27094.v14.png",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -167189,6 +167299,7 @@
       "tags": [
         "community"
       ],
+      "favicon": "https://traxfm.org.au/wp-content/uploads/2023/09/TraxLogoWeb.jpg",
       "bitrate": 64,
       "codec": "AAC",
       "status": "stream-only"
@@ -167287,6 +167398,7 @@
       "tags": [
         "community"
       ],
+      "favicon": "https://hobartfm.org.au/wp-content/uploads/2021/02/Hobart-FM-Logo-nocallsign.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -168044,6 +168156,7 @@
       "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/JOY_TURK_SC?/",
       "homepage": "https://playerservices.streamtheworld.com/api/livestream-redirect/JOY_TURK_SC?/",
       "country": "TR",
+      "favicon": "https://cdn-profiles.tunein.com/s14281/images/logod.jpg?t=636442872385700000",
       "bitrate": 64,
       "codec": "MP3",
       "status": "stream-only"
@@ -168601,6 +168714,7 @@
       "streamUrl": "https://trkvz-radyolar.ercdn.net/turkuvazmusiki/playlist.m3u8",
       "homepage": "https://www.canliradyodinle.fm/turkuvaz-musiki-dinle.html",
       "country": "TR",
+      "favicon": "https://i.tmgrup.com.tr/rt/site/v2/c/i/radio/turkuvaz-musiki.png",
       "bitrate": 64,
       "codec": "AAC",
       "status": "stream-only"
@@ -168623,6 +168737,7 @@
       "streamUrl": "https://moondigitaledge.radyotvonline.net/danceland/playlist.m3u8",
       "homepage": "https://moondigitaledge.radyotvonline.net/danceland/playlist.m3u8",
       "country": "TR",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/4/16504.v10.png",
       "bitrate": 128,
       "codec": "AAC+",
       "status": "stream-only"
@@ -168672,6 +168787,7 @@
       "streamUrl": "https://icecast.netmedya.net/lalegulfm",
       "homepage": "https://icecast.netmedya.net/lalegulfm",
       "country": "TR",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/1/68601.v9.png",
       "bitrate": 128,
       "codec": "AAC+",
       "status": "stream-only"
@@ -168709,6 +168825,7 @@
       "tags": [
         "classical"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/8/14208.v8.png",
       "bitrate": 63,
       "codec": "AAC+",
       "status": "stream-only"
@@ -169003,6 +169120,7 @@
       "tags": [
         "folk"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/logo/6/92726.png",
       "bitrate": 48,
       "codec": "AAC",
       "status": "stream-only"
@@ -169249,6 +169367,7 @@
       "streamUrl": "https://moondigitaledge.radyotvonline.net/standartfm/playlist.m3u8",
       "homepage": "http://www.standart.fm/",
       "country": "TR",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/5/68565.v2.png",
       "bitrate": 128,
       "codec": "AAC+",
       "geo": [
@@ -169398,6 +169517,7 @@
       "streamUrl": "https://live.radyofenomen.com/fenomenakustik/abr/fenomenakustik/128/chunks.m3u8",
       "homepage": "https://live.radyofenomen.com/fenomenakustik/abr/fenomenakustik/128/chunks.m3u8",
       "country": "TR",
+      "favicon": "https://cdn.radyofenomen.com/artwork/logo20.png",
       "codec": "UNKNOWN",
       "status": "stream-only"
     },
@@ -169422,6 +169542,7 @@
       "tags": [
         "classical"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/7/68567.v9.png",
       "bitrate": 125,
       "codec": "AAC+",
       "status": "stream-only"
@@ -169934,6 +170055,7 @@
       "streamUrl": "https://moondigitaledge.radyotvonline.net/easyland/playlist.m3u8",
       "homepage": "https://moondigitaledge.radyotvonline.net/easyland/playlist.m3u8",
       "country": "TR",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/4/16494.v7.png",
       "bitrate": 128,
       "codec": "AAC+",
       "status": "stream-only"
@@ -170485,6 +170607,7 @@
       "streamUrl": "https://beyaztv-live.daioncdn.net/beyaztv/beyaztv_1080p.m3u8",
       "homepage": "http://beyaztv.com.tr/",
       "country": "TR",
+      "favicon": "https://www.beyaztv.com.tr/images/logo.png",
       "codec": "UNKNOWN",
       "status": "stream-only"
     },
@@ -170594,6 +170717,7 @@
       "streamUrl": "https://radyo34.radyotvonline.net/radyo34",
       "homepage": "https://radyo34.radyotvonline.net/radyo34",
       "country": "TR",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/0/16250.v8.png",
       "bitrate": 160,
       "codec": "AAC+",
       "status": "stream-only"
@@ -171035,6 +171159,7 @@
       "streamUrl": "https://radyo.duhnet.tv/dreamturk",
       "homepage": "https://radyo.duhnet.tv/dreamturk",
       "country": "TR",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/3/80363.v10.png",
       "codec": "AAC",
       "status": "stream-only"
     },
@@ -171056,6 +171181,7 @@
       "streamUrl": "https://sssx.radyosfer.com/gurbetcifm/",
       "homepage": "https://sssx.radyosfer.com/gurbetcifm/",
       "country": "TR",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/2/17242.v6.png",
       "bitrate": 96,
       "codec": "MP3",
       "status": "stream-only"
@@ -171473,6 +171599,7 @@
       "streamUrl": "https://ip169.ozelip.com/8432/stream",
       "homepage": "https://ip169.ozelip.com/8432/stream",
       "country": "TR",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/1/97701.v4.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -171669,6 +171796,7 @@
       "streamUrl": "https://moondigitaledge.radyotvonline.net/garajradyo/playlist.m3u8",
       "homepage": "https://moondigitaledge.radyotvonline.net/garajradyo/playlist.m3u8",
       "country": "TR",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/9/76059.v7.png",
       "bitrate": 127,
       "codec": "AAC+",
       "status": "stream-only"
@@ -171826,6 +171954,7 @@
       "streamUrl": "https://dijimedya.radyotvonline.net/turkrap",
       "homepage": "https://dijimedya.radyotvonline.net/turkrap",
       "country": "TR",
+      "favicon": "https://www.numberone.com.tr/wp-content/uploads/2021/10/yeni-logonr1.png",
       "bitrate": 128,
       "codec": "AAC+",
       "status": "stream-only"
@@ -172042,6 +172171,7 @@
       "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/BASKA.mp3",
       "homepage": "https://playerservices.streamtheworld.com/api/livestream-redirect/BASKA.mp3",
       "country": "TR",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/2/75052.v8.png",
       "bitrate": 64,
       "codec": "MP3",
       "status": "stream-only"
@@ -172065,6 +172195,7 @@
       "streamUrl": "https://sssx.radyosfer.com/radyocaglar/stream",
       "homepage": "https://sssx.radyosfer.com/radyocaglar/stream",
       "country": "TR",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/5/16915.v7.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -172100,6 +172231,7 @@
       "streamUrl": "https://trkvz-radyolar.ercdn.net/radyoenergy/playlist.m3u8",
       "homepage": "https://trkvz-radyolar.ercdn.net/radyoenergy/playlist.m3u8",
       "country": "TR",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/0/68450.v8.png",
       "bitrate": 64,
       "codec": "AAC",
       "status": "stream-only"
@@ -172293,6 +172425,7 @@
       "streamUrl": "https://radyopause.ozelip.com.tr:8040/",
       "homepage": "https://radyopause.com.tr/",
       "country": "TR",
+      "favicon": "https://radyopause.com.tr/wp-content/uploads/2025/07/Adsiz-276-x-58-piksel.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -172481,6 +172614,7 @@
       "streamUrl": "https://yayin.turkhosted.com:6056/mp3",
       "homepage": "https://yayin.turkhosted.com:6056/mp3",
       "country": "TR",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/5/69345.v7.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -173522,6 +173656,7 @@
       "tags": [
         "pop"
       ],
+      "favicon": "https://sunfm.co.id/images/logo/logo.png",
       "codec": "MP3",
       "status": "stream-only"
     },
@@ -173895,6 +174030,7 @@
         "80s",
         "90s"
       ],
+      "favicon": "https://rri.co.id/assets_frontend/images/logo/only_logo_blue_bg_white.png",
       "bitrate": 96,
       "codec": "AAC+",
       "status": "stream-only"
@@ -174461,6 +174597,7 @@
       "streamUrl": "https://studio1.indostreamers.com:8010/stream/1/",
       "homepage": "http://rkb.pekalongankota.go.id/",
       "country": "ID",
+      "favicon": "https://rkb.pekalongankota.go.id/template/website/images/logo.png",
       "bitrate": 24,
       "codec": "AAC+",
       "status": "stream-only"
@@ -176251,6 +176388,7 @@
       "tags": [
         "jazz"
       ],
+      "favicon": "https://cdn.jsdelivr.net/gh/JulioRBM2/ALR-Jazz-Radio@f67b3b832937c9e34ffe6ad9a56ee08baf5701a9/nuevologo20251200x400.svg",
       "bitrate": 32,
       "codec": "AAC+",
       "geo": [
@@ -176281,6 +176419,7 @@
       "streamUrl": "https://cast6.asurahosting.com/proxy/salsafou/stream",
       "homepage": "http://zonsalsaradio.com/",
       "country": "CO",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/8/62798.v10.png",
       "bitrate": 96,
       "codec": "AAC+",
       "geo": [
@@ -178105,6 +178244,7 @@
         "radio hablada",
         "variety"
       ],
+      "favicon": "https://antenadelosandes.com/player/adla_logo.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -179959,6 +180099,7 @@
       "streamUrl": "https://radio06.cehis.net/proxy/javerian?mp=%2Fstream",
       "homepage": "https://javerianaestereo.com/player-javeriana-estereo",
       "country": "CO",
+      "favicon": "https://javerianaestereo.com/documents/4772835/4785241/Logo-Menu-javeriana-estereo.png/2e4574e5-524c-4cfd-63be-75d57104a3eb?t=1646427893310",
       "bitrate": 96,
       "codec": "MP3",
       "status": "stream-only"
@@ -181206,6 +181347,7 @@
       "streamUrl": "https://radiohd.streaminghd.co:7319/stream",
       "homepage": "https://radiohd.streaminghd.co:7319/stream",
       "country": "CO",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/7/103897.v3.png",
       "bitrate": 64,
       "codec": "AAC",
       "status": "stream-only"
@@ -182908,6 +183050,7 @@
       "streamUrl": "https://stream.rcast.net/66925",
       "homepage": "http://kaibiganradio.ph/player/",
       "country": "PH",
+      "favicon": "https://cdn-profiles.tunein.com/s350808/images/logod.png?t=639025615830000000",
       "bitrate": 64,
       "codec": "AAC+",
       "status": "stream-only"
@@ -184831,6 +184974,7 @@
       "streamUrl": "https://live7digi.antenaplay.ro/radiodor/radiodor-48000.m3u8",
       "homepage": "http://radiodor.net/",
       "country": "RO",
+      "favicon": "https://radiodor.net/templates/default/img/logo.png",
       "codec": "UNKNOWN",
       "status": "stream-only"
     },
@@ -185354,6 +185498,7 @@
         "independent",
         "indie"
       ],
+      "favicon": "https://gofm.ro/gorebel/wp-content/uploads/2024/04/go-thumbnail.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -186486,6 +186631,7 @@
         "indie",
         "oldies"
       ],
+      "favicon": "https://duxradio.ro/wp-content/uploads/2026/03/Untitled-500-x-500-px.png",
       "bitrate": 320,
       "codec": "MP3",
       "status": "stream-only"
@@ -186987,6 +187133,7 @@
       "tags": [
         "petrecere"
       ],
+      "favicon": "https://cdn.instant.audio/images/logos/radio-org-ro/pitesti-1.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -187128,6 +187275,7 @@
         "pop",
         "romantic"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/7/117817.v6.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -191473,6 +191621,7 @@
       "tags": [
         "narodna"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/0/67340.v8.png",
       "bitrate": 48,
       "codec": "AAC+",
       "status": "stream-only"
@@ -193214,6 +193363,7 @@
         "90's",
         "portugal"
       ],
+      "favicon": "https://m80.pt/images/makeover/logo-m80.svg",
       "bitrate": 127,
       "codec": "AAC",
       "status": "stream-only"
@@ -193628,6 +193778,7 @@
         "radio maria",
         "religious"
       ],
+      "favicon": "https://static-media.streema.com/media/cache/4d/63/4d63dc2f45c231e071fa00a548dd2f22.png",
       "bitrate": 64,
       "codec": "AAC+",
       "geo": [
@@ -193935,6 +194086,7 @@
       "streamUrl": "https://centova.radio.com.pt/proxy/422?mp=/stream;",
       "homepage": "http://pef.pt/sitepef/category/canal-1/",
       "country": "PT",
+      "favicon": "https://www.pef.pt/images/202506261149361.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -194549,6 +194701,7 @@
         "newcomer",
         "pop"
       ],
+      "favicon": "https://media.rtp.pt/empresa/wp-content/uploads/sites/31/2015/07/Institutional_RTPAntena3_Horizontal_PositivoCor_web-1.png",
       "codec": "MP3",
       "status": "stream-only"
     },
@@ -194559,6 +194712,7 @@
       "streamUrl": "https://stream-icy.bauermedia.pt/rcxmas.aac",
       "homepage": "https://bauermedia.pt/radiocomercial/rc-natal",
       "country": "PT",
+      "favicon": "https://radiocomercial.pt/images/logos/logo-rc-subfooter.png",
       "bitrate": 127,
       "codec": "AAC",
       "status": "stream-only"
@@ -194630,6 +194784,7 @@
       "streamUrl": "https://radiometalon.com/listen/radio_metal_on_the_heavy/radio.mp3",
       "homepage": "https://metalon.org/",
       "country": "PT",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/8/19798.v9.png",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -195265,6 +195420,7 @@
       "streamUrl": "https://digitalstreams.mediaworks.nz/edge_net/playlist.m3u8",
       "homepage": "https://www.theedge.co.nz/home.html",
       "country": "NZ",
+      "favicon": "https://images.ctfassets.net/r65x6q43xsmv/1pzJ3Zc5e180plaXxUnkyT/ea87b3f87de6e573b250506c9ac2779d/edge_purple_web_station_logo.svg",
       "bitrate": 130,
       "codec": "AAC",
       "geo": [
@@ -195533,6 +195689,7 @@
         "hymn",
         "praise"
       ],
+      "favicon": "https://cdn.instant.audio/images/logos/radio-org-nz/one-christian.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -196101,6 +196258,7 @@
         "local",
         "music"
       ],
+      "favicon": "https://cdn3.firecrestsystems.com/FC_Access/Images/MPR-reverse_main.png",
       "bitrate": 134,
       "codec": "MP3",
       "status": "stream-only"
@@ -196252,6 +196410,7 @@
       "tags": [
         "alternative"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/7/1177.v9.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -198165,6 +198324,7 @@
       "streamUrl": "https://s4.radio.co/s87ac5cf5a/listen",
       "homepage": "http://www.scariffbayradio.com/",
       "country": "IE",
+      "favicon": "https://deow9bq0xqvbj.cloudfront.net/image-logo/4688176/SBCR_NEW_LOGO_DEC_218rqcp.jpg",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -198516,6 +198676,7 @@
         "86.9",
         "加古川市"
       ],
+      "favicon": "https://www.banban.jp/radio/images/common/logo.svg",
       "bitrate": 179,
       "codec": "AAC",
       "status": "stream-only"
@@ -198710,6 +198871,7 @@
       "streamUrl": "https://mtist.as.smartstream.ne.jp/30015/livestream/playlist.m3u8",
       "homepage": "https://superradio.cc/",
       "country": "JP",
+      "favicon": "https://fm-maple.com/wp-content/uploads/2026/01/cropped-IMG_9551.jpeg",
       "bitrate": 207,
       "codec": "AAC",
       "status": "stream-only"
@@ -198755,6 +198917,7 @@
         "77.5",
         "朝霞"
       ],
+      "favicon": "https://775fm.co.jp/wp/wp-content/themes/775fm/images/logo.png?20220406",
       "bitrate": 180,
       "codec": "AAC",
       "status": "stream-only"
@@ -198784,6 +198947,7 @@
       "tags": [
         "pop"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/1/13121.v6.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -198838,6 +199002,7 @@
       "tags": [
         "コミュニティfm"
       ],
+      "favicon": "https://radiokaros.com/wp/wp-content/themes/radiokaros/assets/images/logo.png",
       "bitrate": 174,
       "codec": "AAC",
       "status": "stream-only"
@@ -198984,6 +199149,7 @@
         "84.5",
         "前橋"
       ],
+      "favicon": "https://maeradi.net/assets/images/common/logo.svg",
       "bitrate": 178,
       "codec": "AAC",
       "status": "stream-only"
@@ -199198,6 +199364,7 @@
       "streamUrl": "https://kathy.torontocast.com:2880/;?type=http&nocache=1606748882",
       "homepage": "https://www.otakumusicradio.com/",
       "country": "JP",
+      "favicon": "https://cdn-radiotime-logos.tunein.com/s169598d.png",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -199243,6 +199410,7 @@
         "77.9",
         "敦賀市"
       ],
+      "favicon": "https://cdn.instant.audio/images/logos/jpradio-jp/harbor-station.png",
       "bitrate": 125,
       "codec": "AAC",
       "status": "stream-only"
@@ -199315,6 +199483,7 @@
         "87.7",
         "名護市"
       ],
+      "favicon": "https://fmyanbaru.co.jp/wp-content/themes/Fmyambaru/assets/images/logo-header.png",
       "bitrate": 242,
       "codec": "AAC",
       "status": "stream-only"
@@ -199342,6 +199511,7 @@
         "76.5",
         "八戸市"
       ],
+      "favicon": "https://www.befm.co.jp/fm/wp-content/uploads/2020/11/bunnerB.png",
       "bitrate": 182,
       "codec": "AAC",
       "status": "stream-only"
@@ -199416,6 +199586,7 @@
         "76.7",
         "鴻巣"
       ],
+      "favicon": "https://fm767.com/wp/wp-content/uploads/digipress/magjam/title/header_logo.png",
       "bitrate": 203,
       "codec": "AAC",
       "status": "stream-only"
@@ -199565,6 +199736,7 @@
         "79.7",
         "宜野湾市"
       ],
+      "favicon": "https://static.mytuner.mobi/media/tvos_radios/uwqtqhbsahhe.png",
       "bitrate": 203,
       "codec": "AAC",
       "status": "stream-only"
@@ -199654,6 +199826,7 @@
         "81.5",
         "東近江市"
       ],
+      "favicon": "https://zenkokunews.sakura.ne.jp/radiosweet/wp-content/uploads/2025/05/815%E3%83%AD%E3%82%B4-1-3-scaled.png",
       "bitrate": 203,
       "codec": "AAC",
       "status": "stream-only"
@@ -199697,6 +199870,7 @@
         "76",
         "石巻"
       ],
+      "favicon": "https://static2.mytuner.mobi/media/tvos_radios/ZbadTqaXkc.png",
       "bitrate": 136,
       "codec": "AAC",
       "status": "stream-only"
@@ -199840,6 +200014,7 @@
         "jpop",
         "pop"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/0/64360.v11.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -200030,6 +200205,7 @@
       "tags": [
         "80s"
       ],
+      "favicon": "https://turntable.kagiso.io/images/Jac_Logo.max-140x140.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -200679,6 +200855,7 @@
       "tags": [
         "pop"
       ],
+      "favicon": "https://perronfm.co.za/radio/wp-content/uploads/2022/08/headerlogo.webp",
       "bitrate": 48,
       "codec": "AAC+",
       "status": "stream-only"
@@ -200801,6 +200978,7 @@
       "streamUrl": "https://gospelblues365.com/listen/gospelbluesradio/radio",
       "homepage": "https://gospelbluesradio.com/",
       "country": "ZA",
+      "favicon": "https://gospelbluesradio.com/wp-content/uploads/2023/08/gospel-blues-radio-com-1.jpg",
       "bitrate": 64,
       "codec": "MP3",
       "status": "stream-only"
@@ -202157,6 +202335,7 @@
       "tags": [
         "local radio"
       ],
+      "favicon": "https://radiogirasol.com/girasol_logo.png",
       "bitrate": 48,
       "codec": "AAC+",
       "status": "stream-only"
@@ -202232,6 +202411,7 @@
       "tags": [
         "variado"
       ],
+      "favicon": "https://www.radioondasdelhuallaga.com/img/logo.png",
       "bitrate": 32,
       "codec": "AAC+",
       "status": "stream-only"
@@ -202457,6 +202637,7 @@
       "streamUrl": "https://sechin.grupocentroserver.com/radio/8140/radio.mp3",
       "homepage": "http://www.studio97.com.pe/",
       "country": "PE",
+      "favicon": "https://studio97.com.pe/logo/97.png",
       "bitrate": 96,
       "codec": "MP3",
       "status": "stream-only"
@@ -203483,6 +203664,7 @@
       "tags": [
         "misc"
       ],
+      "favicon": "https://static-media.streema.com/media/cache/3b/15/3b15fe866594b8ee8d7c2aa08a0114fc.jpg",
       "bitrate": 64,
       "codec": "AAC+",
       "status": "stream-only"
@@ -204948,6 +205130,7 @@
       "tags": [
         "sertanejo"
       ],
+      "favicon": "https://radioliberdade.com.br/imagens/upload/config/full-logotopo-1735211535.png",
       "bitrate": 96,
       "codec": "AAC",
       "geo": [
@@ -206228,6 +206411,7 @@
       "tags": [
         "gospel"
       ],
+      "favicon": "https://fmmusical.com.br/forbesradio.png",
       "bitrate": 64,
       "codec": "AAC+",
       "status": "stream-only"
@@ -206697,6 +206881,7 @@
       "streamUrl": "https://srv2.braudio.com.br/sc/7344/;?1708352992585",
       "homepage": "https://www.radiocidadeitafm.com.br/",
       "country": "BR",
+      "favicon": "https://static2.mytuner.mobi/media/tvos_radios/199/radio-cidade-itanhae.fad80905.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -206983,6 +207168,7 @@
       "streamUrl": "https://s07.maxcast.com.br:8074/live",
       "homepage": "http://boafm-aracaju.com/",
       "country": "BR",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/3/111983.v1.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -208011,6 +208197,7 @@
       "tags": [
         "sertanejo"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/0/125480.v3.png",
       "bitrate": 128,
       "codec": "AAC",
       "status": "stream-only"
@@ -208707,6 +208894,7 @@
         "miscellaneous",
         "popular music"
       ],
+      "favicon": "https://radioculturafm.com.br/wp-content/themes/culturafm/img/logo.png",
       "bitrate": 84,
       "codec": "AAC+",
       "geo": [
@@ -209442,6 +209630,7 @@
         "esportes",
         "esportes futebol"
       ],
+      "favicon": "https://vozdoesporte.com.br/radio/wp-content/uploads/2023/08/logo-2.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -209459,6 +209648,7 @@
         "music",
         "news"
       ],
+      "favicon": "https://www.fm87.com.br/v4/images/logoatz.png",
       "bitrate": 32,
       "codec": "AAC+",
       "geo": [
@@ -211749,6 +211939,7 @@
       "streamUrl": "https://paineldj.com.br:20193/stream",
       "homepage": "https://vozdoesporte.com.br/",
       "country": "BR",
+      "favicon": "https://vozdoesporte.com.br/radio/wp-content/uploads/2023/08/logo-2.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -212170,6 +212361,7 @@
         "local news",
         "news"
       ],
+      "favicon": "https://www.radiojauense.com.br/radio-aovivo-files/radio-2018.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -219507,6 +219699,7 @@
         "estación",
         "gdl"
       ],
+      "favicon": "https://www.canal58.net/wp-content/uploads/2022/04/cropped-logo.jpg",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -220689,6 +220882,7 @@
         "entretenimiento",
         "estación"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/5/49665.v12.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -221132,6 +221326,7 @@
         "news",
         "talk & speech"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/5/107765.v10.png",
       "codec": "AAC",
       "status": "stream-only"
     },
@@ -221171,6 +221366,7 @@
         "news",
         "talk & speech"
       ],
+      "favicon": "https://static2.mytuner.mobi/media/tvos_radios/119/radio-formula-la-paz.819aa51a.png",
       "codec": "AAC",
       "status": "stream-only"
     },
@@ -221474,6 +221670,7 @@
         "español",
         "estación"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/9/151569.v3.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -222012,6 +222209,7 @@
         "baja california",
         "buenisiima"
       ],
+      "favicon": "https://backend-audiorama-media.s3.amazonaws.com/2024/10/Buenisiima_Mexicali.png",
       "bitrate": 64,
       "codec": "MP3",
       "geo": [
@@ -222507,6 +222705,7 @@
         "estación",
         "fm"
       ],
+      "favicon": "https://backend-audiorama-media.s3.amazonaws.com/2024/10/Super_Chilpancingo.png",
       "bitrate": 64,
       "codec": "MP3",
       "geo": [
@@ -223914,6 +224113,7 @@
         "estado de méxico",
         "fm"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/8/49968.v11.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -225148,6 +225348,7 @@
         "news",
         "talk & speech"
       ],
+      "favicon": "https://radiante.fm/img/radiante-fm-horizontal-color.svg",
       "bitrate": 320,
       "codec": "MP3",
       "status": "stream-only"
@@ -225886,6 +226087,7 @@
         "banda",
         "chihuahua"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/0/9570.v14.png",
       "bitrate": 32,
       "codec": "AAC+",
       "geo": [
@@ -226681,6 +226883,7 @@
         "entretenimiento",
         "español"
       ],
+      "favicon": "https://backend-audiorama-media.s3.amazonaws.com/2024/10/Love_Tepic.png",
       "bitrate": 48,
       "codec": "MP3",
       "geo": [
@@ -227765,6 +227968,7 @@
         "estación",
         "fm"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/4/116814.v2.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -228182,6 +228386,7 @@
         "español",
         "estación"
       ],
+      "favicon": "https://backend-audiorama-media.s3.amazonaws.com/2024/10/2-logo-vida.webp",
       "bitrate": 64,
       "codec": "MP3",
       "geo": [
@@ -237418,6 +237623,7 @@
       "streamUrl": "https://online.radiorelax.ua/RadioRelax_Instrumental_HD",
       "homepage": "https://online.radiorelax.ua/",
       "country": "UA",
+      "favicon": "https://www.radiorelax.ua/static/img/about_logo/relax_logo_slogan.png",
       "bitrate": 320,
       "codec": "MP3",
       "status": "stream-only"
@@ -237534,6 +237740,7 @@
       "streamUrl": "https://main.inf.fm:8101/;?type=http&nocache=221893",
       "homepage": "https://informator.fm/",
       "country": "UA",
+      "favicon": "https://static2.mytuner.mobi/media/tvos_radios/CYVEfT3JUP.jpg",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -239720,6 +239927,7 @@
       "tags": [
         "humor"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/0/18000.v10.png",
       "bitrate": 128,
       "codec": "AAC+",
       "status": "stream-only"
@@ -239868,6 +240076,7 @@
       "tags": [
         "local"
       ],
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/4/43/CRo_Brno_logo.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -243357,6 +243566,7 @@
       "tags": [
         "smoothest songs"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/8/84238.v6.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -243424,6 +243634,7 @@
         "folk",
         "hip hop"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/6/13136.v4.png",
       "codec": "OGG",
       "status": "stream-only"
     },
@@ -243468,6 +243679,7 @@
       "streamUrl": "https://impactfm.ice.infomaniak.ch/impactfm-64.aac",
       "homepage": "http://www.impact-fm.be/fr/impact.htm",
       "country": "BE",
+      "favicon": "https://www.impactradio.be/upload/design/667d242eb7cc06.83738740.png",
       "bitrate": 64,
       "codec": "AAC+",
       "status": "stream-only"
@@ -243561,6 +243773,7 @@
         "goldies",
         "oldies"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/5/12785.v3.png",
       "bitrate": 128,
       "codec": "AAC+",
       "status": "stream-only"
@@ -243687,6 +243900,7 @@
       "streamUrl": "https://streams.radio.dpgmedia.cloud/redirect/top2000/mp3",
       "homepage": "https://streams.radio.dpgmedia.cloud/redirect/top2000/mp3",
       "country": "BE",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/4/84234.v8.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -243866,6 +244080,7 @@
       "streamUrl": "https://playerservices.streamtheworld.com/api/livestream-redirect/TOPVERSUZ.mp3",
       "homepage": "https://www.versuzradio.com/",
       "country": "BE",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/8/13648.v5.png",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -244275,6 +244490,7 @@
       "streamUrl": "https://gargara.net/listen/zana/radio.mp3",
       "homepage": "https://radyogar.com/",
       "country": "BE",
+      "favicon": "https://radyogar.com/img/icon.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -246877,6 +247093,7 @@
         "regional",
         "šibenik"
       ],
+      "favicon": "https://radioritam.hr/wp-content/uploads/2022/12/Radio-Ritam-SQUARE-LOGO-RED-PNG-BEZ-RUBA-2-FINAL.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -247165,6 +247382,7 @@
       "streamUrl": "https://audio.alter-media.hr/9052/stream",
       "homepage": "https://www.057info.hr/",
       "country": "HR",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/3/23853.v6.png",
       "bitrate": 320,
       "codec": "MP3",
       "geo": [
@@ -247579,6 +247797,7 @@
       "streamUrl": "https://audio.radio-banovina.hr:7008/stream",
       "homepage": "https://www.radio-banovina.hr/light/",
       "country": "HR",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/4/75504.v8.png",
       "bitrate": 96,
       "codec": "MP3",
       "status": "stream-only"
@@ -247946,6 +248165,7 @@
         "italian pop",
         "musica italiana"
       ],
+      "favicon": "https://radiosuitenetwork.torontocast.stream/wp-content/uploads/2021/09/600.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -250302,6 +250522,7 @@
         "music",
         "talk"
       ],
+      "favicon": "https://alivefm.ca/wp-content/uploads/2026/03/AliveLogo_NoFrew.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -251365,6 +251586,7 @@
         "st. catharines",
         "university radio"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/5/20945.v5.png",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -251782,6 +252004,7 @@
         "exitos",
         "latin"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/5/93105.v44.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -252553,6 +252776,7 @@
         "pop rock",
         "rock"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/0/104320.v4.png",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -253473,6 +253697,7 @@
       "tags": [
         "radio publique"
       ],
+      "favicon": "https://ici.radio-canada.ca/Content/premiere/_images/logo/logo-ici-premiere.svg",
       "bitrate": 48,
       "codec": "AAC",
       "geo": [
@@ -254026,6 +254251,7 @@
         "active rock",
         "community radio"
       ],
+      "favicon": "https://cfai.fm/wp-content/themes/cfai/assets/img/cfai-logo.png",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -255388,6 +255614,7 @@
       "streamUrl": "https://cheetah.streemlion.com:3545/stream",
       "homepage": "https://easymusicplus.com/",
       "country": "CA",
+      "favicon": "https://www.easymusicplus.com/images/ezmplogo.png",
       "bitrate": 320,
       "codec": "MP3",
       "status": "stream-only"
@@ -255875,6 +256102,7 @@
         "bpm sports",
         "sports"
       ],
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/thumb/0/06/BPM_SPORTS_logo.svg/250px-BPM_SPORTS_logo.svg.png",
       "bitrate": 48,
       "codec": "AAC",
       "geo": [
@@ -256002,6 +256230,7 @@
       "tags": [
         "classic hits"
       ],
+      "favicon": "https://golden-west-broadcasting-ltd-corporate-account-v1775663884.websitepro-cdn.com/wp-content/uploads/2023/11/Country94-RGB-Logo-Colour.svg",
       "bitrate": 63,
       "codec": "AAC+",
       "geo": [
@@ -256276,6 +256505,7 @@
         "reggaeton",
         "spanish contemporary hits"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/1/131741.v4.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -257839,6 +258069,7 @@
       "tags": [
         "active rock"
       ],
+      "favicon": "https://www.vistaradio.ca/wp-content/uploads/2014/09/thegoat-600X403.png",
       "bitrate": 32,
       "codec": "AAC+",
       "geo": [
@@ -257913,6 +258144,7 @@
       "tags": [
         "country"
       ],
+      "favicon": "https://upload.wikimedia.org/wikipedia/en/thumb/4/4a/CJCI_country97_logo.png/250px-CJCI_country97_logo.png",
       "bitrate": 57,
       "codec": "AAC+",
       "geo": [
@@ -257969,6 +258201,7 @@
       "tags": [
         "hot adult cont"
       ],
+      "favicon": "https://golden-west-broadcasting-ltd-corporate-account-v1775663884.websitepro-cdn.com/wp-content/uploads/2023/08/mix965.svg",
       "bitrate": 63,
       "codec": "AAC+",
       "geo": [
@@ -260005,6 +260238,7 @@
       "tags": [
         "classic rock  50's 60's 70's 80's 90's"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/1/156271.v1.png",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [


### PR DESCRIPTION
## What

Wave 3 of the agent logo cascade. Hit rate drops to 52% from waves 1–2's ~86% — we're now in the long-tail residue: small local FM, niche internet-radio, stream-URL-as-homepage entries.

| | |
|---|---:|
| Candidates | 500 (10 batches × 50, shuffled to avoid cluster stalls) |
| Batches saved usable output | 9 of 10 |
| Logo URLs found | **234** |
| Hit rate (over 450 saved) | **52%** |
| Tokens (Sonnet, rough) | ~1.1M |

**Batch 4 stalled** with nothing saved (watchdog killed agent at 600s of no progress). Random shuffle reduced but didn't eliminate the stall risk — 1 of 10 this round vs 1 of 8 last round. Same call as before: cut losses, don't burn tokens on a third retry.

## Source distribution (234 hits)

| Source | Hits |
|---|---:|
| Broadcaster site | 134 |
| OnlineRadioBox | 66 |
| TuneIn CDN | 8 |
| myTuner / myTuner-CDN | 8 |
| Wikipedia / Commons | 7 |
| Streema | 2 |
| Other (long tail) | 9 |

Different shape from wave 2: broadcaster-site dominates here because the long-tail isn't well-indexed by TuneIn or OnlineRadioBox. Agents had to dig into individual broadcaster sites.

## Cumulative session totals (logo project)

| Phase | Logos |
|---|---:|
| Homepage scrape (#178) | 3,575 |
| Wikipedia direct (#182) | 309 |
| Agent wave 1 (#183) | 173 |
| Agent wave 2 (#184) | 298 |
| Agent wave 3 (this PR) | **234** |
| **Total** | **4,589 stations** |

## Gates

- [x] catalog 15,608/15,608 published
- [x] check-catalog clean
- [x] check-duplicates 0 collisions
- [x] vitest 311/311

## Stragglers

- 216 nulls from this wave (legitimate "no good logo exists")
- 50 stations from stalled batch 4
- ~970 unprocessed candidates remain in the no-favicon residue

The remaining residue is heavy on stations that genuinely have no logo (defunct, stream-only, etc.) — wave 4 hit rate would likely be even lower. Could keep going but diminishing returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)