### PR TITLE
chore: agent-discovered station logos wave 4 — partial (84 stations)

### DIFF
--- a/data/stations.yaml
+++ b/data/stations.yaml
@@ -34484,6 +34484,7 @@
   changeuuid: 778cf418-9ff8-4e7b-be6d-46f04f33f976
   reviewedAt: 2026-05-04
 - id: de-crazy4live
+  favicon: "https://cdn.onlineradiobox.com/img/l/1/51591.v9.png"
   broadcaster: independent
   name: Crazy4live
   streamUrl: https://crazy4live.stream.laut.fm/crazy4live?t302=2026-01-15_04-28-40&uuid=8a91d74c-5e3e-4ece-a78b-db70aa05f513
@@ -45210,6 +45211,7 @@
   changeuuid: 49aea8af-35de-4656-8a8a-ecb51fa8c2f5
   reviewedAt: 2026-05-04
 - id: us-sanctuary-radio-dark-electro-channel
+  favicon: "https://cdn.onlineradiobox.com/img/l/5/33675.v5.png"
   broadcaster: independent
   name: Sanctuary Radio (Dark Electro Channel)
   streamUrl: https://patmos.cdnstream.com/proxy/sanctua1?mp=/stream
@@ -45930,6 +45932,7 @@
   changeuuid: 583831f7-058c-432e-bbaa-c144cccf250b
   reviewedAt: 2026-05-04
 - id: us-kissin-99-3
+  favicon: "https://cdn.onlineradiobox.com/img/l/5/40555.v8.png"
   broadcaster: independent
   name: Kissin' 99.3
   streamUrl: https://ice66.securenetsystems.net/WKCNFM
@@ -45967,6 +45970,7 @@
   changeuuid: 454ffc06-7306-41fe-88a2-5ff7c4d17f72
   reviewedAt: 2026-05-04
 - id: us-new-wave-radio
+  favicon: "https://newwave.radio/wp-content/uploads/2020/06/NewWave-Radio-Logo-2.png"
   broadcaster: independent
   name: New Wave Radio
   streamUrl: https://digitalaudiobroadcasting.net:1085/stream
@@ -46510,6 +46514,7 @@
   changeuuid: 1cac0da2-5f81-4306-91f1-64745695c0a9
   reviewedAt: 2026-05-04
 - id: us-kiss-98-3
+  favicon: "https://cdn-profiles.tunein.com/s24081/images/logod.jpg?t=638493952960000000"
   broadcaster: independent
   name: Kiss 98.3
   streamUrl: https://ice64.securenetsystems.net/WKEMLP
@@ -46799,6 +46804,7 @@
   changeuuid: 5bc9cda0-fbe8-40ae-9131-ff6d9d3671da
   reviewedAt: 2026-05-04
 - id: us-pure-country-89-3
+  favicon: "https://cdn.onlineradiobox.com/img/l/4/18774.v8.png"
   broadcaster: independent
   name: Pure Country 89.3
   streamUrl: https://ice23.securenetsystems.net/QXFM
@@ -47135,6 +47141,7 @@
   changeuuid: 40c6eb6c-c941-4536-afaf-56644975bb28
   reviewedAt: 2026-05-04
 - id: us-ancient-faith-ministries-english-language-music
+  favicon: "https://www.ancientfaith.com/media/images/AFLogo_radio_midnight.width-750.png"
   broadcaster: independent
   name: Ancient Faith Ministries English language Music
   streamUrl: https://ancientfaith.streamguys1.com/ancientfaith3
@@ -61278,6 +61285,7 @@
   changeuuid: 12af8907-568a-4d11-af3b-e7ac21a662a1
   reviewedAt: 2026-05-04
 - id: us-radio-rumba-vacilon
+  favicon: "https://radiorumbavacilon.com/gallery_gen/dacac9541056aa61bb33d4dbb08bc9a3.png"
   broadcaster: independent
   name: Radio Rumba Vacilon
   streamUrl: https://sonic.globalstreaming.net/8120/;
@@ -61943,6 +61951,7 @@
   changeuuid: 6efb54f4-4561-473e-921c-246db8e3ab35
   reviewedAt: 2026-05-04
 - id: us-98-9-the-bridge
+  favicon: "https://images.zeno.fm/0WtbLuTFjJPjJCA4PYz1gxVX2Gt_viuCmy2HYBlA8FM/rs:fill:288:288/g:ce:0:0/aHR0cHM6Ly9wcm94eS56ZW5vLmZtL2NvbnRlbnQvc3RhdGlvbnMvYzdiZGY2NjgtNzc2Ny00NWZlLWExM2EtZWVlMjUyMjdlYWU5L2ltYWdlLz91PTE3MTM5Mzc3MDkwMDA.webp"
   broadcaster: independent
   name: 98.9 The Bridge
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/WKIMFMAAC.aac
@@ -64376,6 +64385,7 @@
   changeuuid: fc7391d3-a14e-4f0e-8a7e-6de91dacd80f
   reviewedAt: 2026-05-04
 - id: us-kwvh-wimberley-valley-radio
+  favicon: "https://static.wixstatic.com/media/939db4_850205ab600b4f6688405a3ac87bcbc1~mv2.png"
   broadcaster: independent
   name: KWVH - Wimberley Valley Radio
   streamUrl: https://ice41.securenetsystems.net/KWVH
@@ -65437,6 +65447,7 @@
   changeuuid: 4db7f5cc-4b9a-4f96-9c45-6f4dad247e1e
   reviewedAt: 2026-05-04
 - id: us-indiehq-radio
+  favicon: "https://indiehq.net/graphics/hqlogo.png"
   broadcaster: independent
   name: IndieHQ Radio
   streamUrl: https://davidgmedia.us:8020/radio.mp3
@@ -67095,6 +67106,7 @@
   changeuuid: 561b037c-73d5-48ce-9c67-ba6b6d773db6
   reviewedAt: 2026-05-04
 - id: us-kzps-lone-star-92-5
+  favicon: "https://i.iheart.com/v3/re/assets.brands/60bf9ce39a9c93cf48d16a2f?ops=gravity(%22center%22),contain(180,60)&quality=80"
   broadcaster: independent
   name: KZPS - Lone Star 92.5
   streamUrl: https://stream.revma.ihrhls.com/zc3379
@@ -69485,6 +69497,7 @@
   changeuuid: c61a3d08-7686-4c79-985a-4976fd5c8e5a
   reviewedAt: 2026-05-04
 - id: us-ktna-fm-88-9-talkeetna-ak
+  favicon: "https://ktna.org/wp-content/uploads/2018/04/logo-for-web-200x200.png"
   broadcaster: independent
   name: KTNA-FM 88.9 Talkeetna, AK
   streamUrl: https://ktna.broadcasttool.stream/play
@@ -76278,6 +76291,7 @@
   changeuuid: d83021b4-9ed4-4a85-a5c8-050f524819b0
   reviewedAt: 2026-05-04
 - id: us-krcu-public-radio-for-southeast-missouri
+  favicon: "https://npr.brightspotcdn.com/dims4/default/5cae731/2147483647/strip/true/crop/4167x1221+0+0/resize/267x78!/quality/90/?url=http%3A%2F%2Fnpr-brightspot.s3.amazonaws.com%2F5d%2F62%2F0042cacf4f4886925b051d96b2e9%2Fkrcu-50years-logo-white-rgb.png"
   broadcaster: independent
   name: KRCU Public Radio for Southeast Missouri
   streamUrl: https://krculive.semo.edu:8443/128k
@@ -83704,6 +83718,7 @@
   changeuuid: da1349e8-0fa2-44f2-96a3-e12c4871180a
   reviewedAt: 2026-05-04
 - id: gb-hearme-60s-rock
+  favicon: "https://hearme.fm/wp-content/uploads/2024/06/2024-Redrafted-Transparent-Box-No-Text-1-1024x1024.png"
   broadcaster: independent
   name: HearMe - 60s Rock
   streamUrl: https://radio.hearme.fm:8230/stream
@@ -84368,6 +84383,7 @@
   changeuuid: fbeca935-ad75-4af9-b027-c8e27743622f
   reviewedAt: 2026-05-04
 - id: gb-hereme-2000s-pop
+  favicon: "https://hearme.fm/wp-content/uploads/2024/06/8002-2000s-pop-music.webp"
   broadcaster: independent
   name: Hereme 2000s pop
   streamUrl: https://radio.hearme.fm:8040/stream
@@ -86095,6 +86111,7 @@
   changeuuid: 9c9902cd-f144-41f5-ba00-4fbaf7162506
   reviewedAt: 2026-05-04
 - id: gb-gamingnow-radio
+  favicon: "https://test.gamingnow.net/wp-content/uploads/2020/05/Logo-Black.png"
   broadcaster: independent
   name: GamingNow Radio
   streamUrl: https://media01.gamingnow.net:8010/
@@ -86247,6 +86264,7 @@
   changeuuid: 58ac4297-cc98-4794-a00b-6d82775953f6
   reviewedAt: 2026-05-04
 - id: gb-hearme-2010s-pop-music
+  favicon: "https://hearme.fm/wp-content/uploads/2024/06/2024-Redrafted-Transparent-Box-No-Text-1-1024x1024.png"
   broadcaster: independent
   name: HearMe 2010s pop music
   streamUrl: https://radio.hearme.fm:8030/stream
@@ -89272,6 +89290,7 @@
   changeuuid: 7a32eafb-85dc-418a-a8c6-26d1a4ee25d4
   reviewedAt: 2026-05-04
 - id: gb-soundart-radio
+  favicon: "https://soundartradio.org.uk/uploads/soundartradio/img/soundart_radio_logo.png"
   broadcaster: independent
   name: Soundart Radio
   streamUrl: https://radio.canstream.co.uk:8134/live.mp3
@@ -90568,6 +90587,7 @@
   changeuuid: c084e011-0ea9-4203-a898-3a5a654478b0
   reviewedAt: 2026-05-04
 - id: gb-frisky-radio-classics
+  favicon: "https://cdn.onlineradiobox.com/img/l/0/30450.v2.png"
   broadcaster: independent
   name: Frisky Radio Classics
   streamUrl: https://stream.classics.friskyradio.com/
@@ -90580,6 +90600,7 @@
   changeuuid: 796bec5c-3266-4aec-bd01-80eb76d04063
   reviewedAt: 2026-05-04
 - id: gb-genesis-radio-birmingham
+  favicon: "https://www.genesisradiobirmingham.com/wp-content/uploads/2021/01/grb-170x170.png"
   broadcaster: independent
   name: Genesis Radio Birmingham
   streamUrl: https://cast5.my-control-panel.com/proxy/grb/stream
@@ -93234,6 +93255,7 @@
   changeuuid: 82838675-166e-441c-8dad-1026c9475c66
   reviewedAt: 2026-05-04
 - id: fr-radiogospel
+  favicon: "https://radiogospel.fr/wp-content/uploads/2023/03/rglogo.png"
   broadcaster: independent
   name: RadioGospel
   streamUrl: https://d3m456gauclwb5.cloudfront.net/radiogospel_high
@@ -96778,6 +96800,7 @@
   changeuuid: f387a5ad-4bfb-4206-8fc8-cbcf6b5f4f3f
   reviewedAt: 2026-05-04
 - id: fr-allzic-radio-road-66
+  favicon: "https://www.radio.fr/300/allzicroad66.png?version=8eccfdcfb3166a176ac08b94857f45d1f498fa89"
   broadcaster: independent
   name: Allzic Radio Road 66
   streamUrl: https://allzic37.ice.infomaniak.ch/allzic37.aac
@@ -98479,6 +98502,7 @@
   changeuuid: 788904f8-ddab-41d1-b46c-f3ad6061f477
   reviewedAt: 2026-05-04
 - id: fr-le-village-pop
+  favicon: "https://cdn.onlineradiobox.com/img/l/6/81096.v6.png"
   broadcaster: independent
   name: Le village pop
   streamUrl: https://listen.radioking.com/radio/200437/stream/243028
@@ -99833,6 +99857,7 @@
   changeuuid: c3dded75-8d3d-4933-bd7a-061a625dab9e
   reviewedAt: 2026-05-04
 - id: fr-radio-fatx
+  favicon: "https://www.fatx.fr/static/logo_fatx_blanc_280x162.png"
   broadcaster: independent
   name: Radio FATX
   streamUrl: https://radio.fatx.fr/radio_fatx
@@ -103030,6 +103055,7 @@
   changeuuid: 5dbdb25d-9dbc-401d-adfa-b5e5ad4c4ee1
   reviewedAt: 2026-05-04
 - id: it-radio-rouge-italy
+  favicon: "https://cdn-profiles.tunein.com/s135784/images/logod.jpg?t=638245695440000000"
   broadcaster: independent
   name: " Radio Rouge Italy"
   streamUrl: https://nl1.streamingpulse.com/ssl/radiorougeitaly
@@ -103456,6 +103482,7 @@
   changeuuid: f6de7241-f3d1-4be9-80e8-08dae0f56bfd
   reviewedAt: 2026-05-04
 - id: it-italia-news-24
+  favicon: "https://www.italianews24.news/wp-content/uploads/2025/10/cropped-italia-news-24-orizz-white.png"
   broadcaster: independent
   name: Italia News 24
   streamUrl: https://stream6.xdevel.com/audio6s975889-649/stream/icecast.audio
@@ -103759,6 +103786,7 @@
   changeuuid: 18cee22f-2aca-49f8-a835-8cff1667813f
   reviewedAt: 2026-05-04
 - id: it-radio-precisa-i-piu-trasmessi-dal-1975-ad-oggi
+  favicon: "https://cdn.onlineradiobox.com/img/l/6/101776.v4.png"
   broadcaster: independent
   name: RADIO PRECISA I più trasmessi dal 1975 ad oggi
   streamUrl: https://rprecisa.radioca.st/radioprecisa
@@ -104214,6 +104242,7 @@
   changeuuid: 091866c4-8f72-4c61-b2e0-1e3f81a78784
   reviewedAt: 2026-05-04
 - id: it-rmc-radio-bau-co
+  favicon: "https://www.radiomontecarlo.net/wp-content/uploads/2025/05/cropped-cropped-transparent-logo_white.png"
   broadcaster: independent
   name: RMC Radio Bau & Co
   streamUrl: https://icy.unitedradio.it/RadioBAU.mp3
@@ -105065,6 +105094,7 @@
   changeuuid: aa696c3e-a048-4f83-93c0-6f39fca7a52f
   reviewedAt: 2026-05-04
 - id: it-radio-rouge-fm
+  favicon: "https://cdn-profiles.tunein.com/s135784/images/logod.jpg?t=638245695440000000"
   broadcaster: independent
   name: Radio Rouge FM
   streamUrl: https://nl1.streamingpulse.com/ssl/radiorouge993
@@ -108166,6 +108196,7 @@
   changeuuid: 3f9116f3-3602-4b48-ad78-0276b63d52c5
   reviewedAt: 2026-05-04
 - id: es-europa-fm-guipuzcoa
+  favicon: "https://upload.wikimedia.org/wikipedia/commons/6/6d/EuropaFM_logo.svg"
   broadcaster: independent
   name: Europa FM Guipuzcoa
   streamUrl: https://stream.zeno.fm/se76qau1hc9uv
@@ -108583,6 +108614,7 @@
   changeuuid: add2d4ca-849f-4a43-a9c1-9a3f1083b37b
   reviewedAt: 2026-05-04
 - id: es-aragon-radio
+  favicon: "https://www.cartv.es/theme/cartv-2017/images/radio/mainheader/logo-aragonradio.png"
   broadcaster: independent
   name: Aragón Radio
   streamUrl: https://cartv.streaming.aranova.es/hls/live/aragonradio_huesca.m3u8
@@ -110612,6 +110644,7 @@
   changeuuid: 29e6d118-18f1-4cd0-b23a-1531cc25ff7a
   reviewedAt: 2026-05-04
 - id: es-montserrat-radio
+  favicon: "https://enacast.com/media/cache/01/9a/019a11732ea06382330ac5247a929ade.png"
   broadcaster: independent
   name: Montserrat Ràdio
   streamUrl: https://enacast.com/radioabadiademontserrat/streams/HD
@@ -112625,6 +112658,7 @@
   changeuuid: c811c7f4-ea0e-4e4f-838b-5ab5133cac6d
   reviewedAt: 2026-05-04
 - id: es-radio-ponts
+  favicon: "https://ik.imagekit.io/7ftrkrun31/enacast/logos/2017/05/31/logo_fora_progamacio.jpg?tr=h-300,fo-auto"
   broadcaster: independent
   name: Ràdio Ponts
   streamUrl: https://enacast.com/radioponts/streams/HD
@@ -117080,6 +117114,7 @@
   changeuuid: f6e5624b-effc-4aea-bab7-0f26449e96bb
   reviewedAt: 2026-05-04
 - id: nl-slam-40
+  favicon: "https://upload.wikimedia.org/wikipedia/commons/2/28/Slam%21FM-logo.png"
   broadcaster: independent
   name: Slam! 40
   streamUrl: https://22673.live.streamtheworld.com/WEB14_MP3_SC
@@ -128209,6 +128244,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: ar-radio-21-fm-90-1-caleta-olivia
+  favicon: "https://static-media.streema.com/media/cache/4f/54/4f54e276f175304bdc2595acf2c5ec62.png"
   broadcaster: independent
   name: Radio 21 FM 90.1 - Caleta Olivia
   streamUrl: https://cdn.instream.audio/:9135/stream
@@ -134698,6 +134734,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: au-rebel-fm
+  favicon: "https://upload.wikimedia.org/wikipedia/en/1/10/Rebel_FM_logo_2015.png"
   broadcaster: independent
   name: rebel fm
   streamUrl: https://s8.yesstreaming.net:17099/RblLgn
@@ -135576,6 +135613,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: au-thelight-christmas
+  favicon: "https://cdn.onlineradiobox.com/img/l/4/112044.v8.png"
   broadcaster: independent
   name: TheLight Christmas
   streamUrl: https://stream.thelight.com.au:8150/;stream/1
@@ -137809,6 +137847,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: au-paw-media-yuendumu
+  favicon: "https://images.squarespace-cdn.com/content/v1/698569480d6a892f8d5efc19/12286a4e-dc60-4d53-bffd-6134fd9cc8a9/PAW_LOGO_Image_alpha.png?format=1500w"
   broadcaster: independent
   name: PAW Media Yuendumu
   streamUrl: https://firstnationsmedia.stream/8016/stream
@@ -139020,6 +139059,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: tr-fenomen-turk
+  favicon: "https://cdn.onlineradiobox.com/img/l/0/16590.v12.png"
   broadcaster: independent
   name: FENOMEN TÜRK
   streamUrl: https://live.radyofenomen.com/fenomenturk/abr/fenomenturk/256/chunks.m3u8
@@ -139366,6 +139406,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: tr-radyo-fenomen-2010-lar
+  favicon: "https://cdn.radyofenomen.com/artwork/logo20.png"
   broadcaster: independent
   name: RADYO FENOMEN 2010 LAR
   streamUrl: https://live.radyofenomen.com/fenomen2010/abr/playlist.m3u8
@@ -139997,6 +140038,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: tr-discoland
+  favicon: "https://cdn.onlineradiobox.com/img/l/3/16513.v7.png"
   broadcaster: independent
   name: Discoland
   streamUrl: https://moondigitaledge.radyotvonline.net/discoland/playlist.m3u8
@@ -141792,6 +141834,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: tr-kiss-gold-turk
+  favicon: "https://static-media.streema.com/media/cache/1e/0c/1e0cc754937d83eb51baaacb80db38ac.jpg"
   broadcaster: independent
   name: KİSS GOLD TÜRK
   streamUrl: https://dijimedya.radyotvonline.net/goldturk
@@ -142461,6 +142504,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: tr-evrensel-fm
+  favicon: "https://cdn.onlineradiobox.com/img/l/8/69688.v7.png"
   broadcaster: independent
   name: EVRENSEL FM
   streamUrl: https://ssl16.ozelip.com/asistan/stream/914fcb8228b91c6fe05b3bd0fa85299c
@@ -143195,6 +143239,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: tr-radyo-lojik
+  favicon: "https://cdn.onlineradiobox.com/img/l/9/13789.v7.png"
   broadcaster: independent
   name: RADYO LOJİK
   streamUrl: https://ip20.ozelip.com:9710/
@@ -151364,6 +151409,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: co-arjona-stereo-93-5
+  favicon: "https://cdn.onlineradiobox.com/img/l/1/98191.v19.png"
   broadcaster: independent
   name: arjona stereo 93.5
   streamUrl: https://accplus.tecnohost.ec/8160/stream
@@ -152117,6 +152163,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: ph-radio-maria-philippines
+  favicon: "https://cdn.instant.audio/images/logos/radio-org-ph/maria.png"
   broadcaster: independent
   name: "Radio Maria Philippines "
   streamUrl: https://dreamsiteradiocp2.com/proxy/rmphilippine?mp=/stream?ver=748140
@@ -156289,6 +156336,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: ro-gojazz
+  favicon: "https://cdn.onlineradiobox.com/img/l/0/90780.v5.png"
   broadcaster: independent
   name: goJAZZ
   streamUrl: https://live.gofm.ro:2020/stream/goJAZZ
@@ -157221,6 +157269,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: ro-radio-aquila
+  favicon: "https://radio-aquila.ro/wp-content/uploads/2021/02/logo_RA_alb876x780-150x150.png"
   broadcaster: independent
   name: Radio Aquila
   streamUrl: https://s10.webradio-hosting.com/proxy/schrteam/stream
@@ -160300,6 +160349,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: rs-moj-radio
+  favicon: "https://www.mojradio.net/wp-content/uploads/2024/04/MOJRadio-Logo-300x184.png"
   broadcaster: independent
   name: Moj Radio
   streamUrl: https://eu4.fastcast4u.com/proxy/svidakov?mp=/1
@@ -160502,6 +160552,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: rs-laguna
+  favicon: "https://cdn.onlineradiobox.com/img/l/0/13260.v14.png"
   broadcaster: independent
   name: Laguna
   streamUrl: https://live.radiolaguna.rs/laguna
@@ -163038,6 +163089,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: pt-radio-vizela
+  favicon: "https://www.radiovizela.pt/images/logo.png"
   broadcaster: independent
   name: Rádio Vizela
   streamUrl: https://proxy-audio.ptisp.com:8100/stream
@@ -163661,6 +163713,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: pt-radio-popular-de-source
+  favicon: "https://radiosoure.pt/wp-content/uploads/2017/04/headerbannertest2.png"
   broadcaster: independent
   name: Rádio Popular de Source
   streamUrl: https://nl.digitalrm.pt:8072/stream?1671016403075=
@@ -164940,6 +164993,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: nz-the-generator
+  favicon: "https://cdn.instant.audio/images/logos/radio-org-nz/the-generator.png"
   broadcaster: independent
   name: The Generator
   streamUrl: https://s1.myradiostream.com/:14268/;?type=http&nocache=1608640718?0.7458407789862892
@@ -165043,6 +165097,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: nz-george-fm
+  favicon: "https://upload.wikimedia.org/wikipedia/en/c/c0/George-FM.png"
   broadcaster: independent
   name: George FM
   streamUrl: https://digitalstreams.mediaworks.nz/george_net/playlist.m3u8
@@ -165057,6 +165112,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: nz-radio-sangeet-masti
+  favicon: "https://public-rf-upload.minhawebradio.net/207467/logo/9abfa0e4a21358f5083a79a22b587580.jpg"
   broadcaster: independent
   name: Radio Sangeet Masti
   streamUrl: https://servidor19-4.brlogic.com:7304/live?source=website
@@ -165457,6 +165513,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: nz-coast-access-radio
+  favicon: "https://cdn.instant.audio/images/logos/radio-org-nz/coast-access.png"
   broadcaster: independent
   name: Coast Access Radio
   streamUrl: https://live.accessmedia.nz/Coast.stream_aac/playlist.m3u8
@@ -167952,6 +168009,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-j-rock-powerplay-asia-dream-radio
+  favicon: "https://cdn.onlineradiobox.com/img/l/3/64373.v11.png"
   broadcaster: independent
   name: J-Rock Powerplay(Asia DREAM Radio)
   streamUrl: https://kathy.torontocast.com:3340/;?shoutcast
@@ -167994,6 +168052,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-tokyo-star-radio-fm
+  favicon: "https://static.mytuner.mobi/media/tvos_radios/nkdjrxrksehq.png"
   broadcaster: independent
   name: Tokyo Star Radio(八王子FM)
   streamUrl: https://mtist.as.smartstream.ne.jp/30081/livestream/playlist.m3u8
@@ -168563,6 +168622,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-fm-15
+  favicon: "https://www.fukaya-fm.com/cms/wp-content/themes/fm/common/images/logo.svg"
   broadcaster: independent
   name: FMふっかちゃん
   streamUrl: https://mtist.as.smartstream.ne.jp/30047/livestream/playlist.m3u8
@@ -168980,6 +169040,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp--12
+  favicon: "https://fmyokote.sakura.ne.jp/home/wp-content/uploads/2020/08/logo.png"
   broadcaster: independent
   name: 横手かまくらエフエム
   streamUrl: https://mtist.as.smartstream.ne.jp/30076/livestream/playlist.m3u8
@@ -169152,6 +169213,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-gotanno-fm-89-2
+  favicon: "https://images.zeno.fm/aByE803sTCFZKR-fDK7uBTm7qFmTs1dKssySc3IDTk4/rs:fill:288:288/g:ce:0:0/aHR0cHM6Ly9wcm94eS56ZW5vLmZtL2NvbnRlbnQvc3RhdGlvbnMvZmRmZmMyN2YtYTA5Ni00YmU4LWIzYmYtMmM1MWE5NDNhMWQxL2ltYWdlLz91PTE3NzAwNDUwMzUwMDA.webp"
   broadcaster: independent
   name: Gotanno FM 89.2
   streamUrl: https://radio.gotanno.love/;
@@ -169545,6 +169607,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: za-smile-90-4-fm
+  favicon: "https://cdn.onlineradiobox.com/img/l/4/864.v12.png"
   broadcaster: independent
   name: Smile 90.4 FM
   streamUrl: https://edge.iono.fm/xice/212_medium.aac
@@ -174717,6 +174780,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: br-alpha-fm-102-1-mhz-goiania-go
+  favicon: "https://cdn.onlineradiobox.com/img/l/5/68225.v25.png"
   broadcaster: independent
   name: Alpha FM 102.1 MHz (Goiânia - GO)
   streamUrl: https://ice.fabricahost.com.br/alphafm1021
@@ -174954,6 +175018,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: br-itapema-102-3-fm
+  favicon: "https://upload.wikimedia.org/wikipedia/pt/b/b9/Logotipo_da_Itapema_FM.png"
   broadcaster: independent
   name: Itapema 102.3 FM
   streamUrl: https://liverd102fm.rbsdirect.com.br/primary/ita_poa.sdp/chunklist_0ac85862-caaa-446f-93bf-3e12816c36a0.m3u8
@@ -176218,6 +176283,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: br-radio-nova-fm-anapolis
+  favicon: "https://radionovafmanapolis.com.br/images/logo-rodape.png"
   broadcaster: independent
   name: Rádio Nova FM Anápolis
   streamUrl: https://player.g2play.com.br/proxy/27362
@@ -178524,6 +178590,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: br-radio-ilustrada-fm-102-3
+  favicon: "https://www.ilustradafm.com.br/wp-content/themes/ilustradafm/images/logo-2022.png"
   broadcaster: independent
   name: Radio Ilustrada FM 102.3
   streamUrl: https://ice.fabricahost.com.br/ilustradafm
@@ -185023,6 +185090,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-crystal-valle-de-mexico-103-7-fm-xhcme-fm-grupo-
+  favicon: "https://cdn.onlineradiobox.com/img/l/5/14465.v13.png"
   broadcaster: independent
   name: "Crystal (Valle de México) - 103.7 FM - XHCME-FM - Grupo Siete - Coacalco / Melchor Ocampo, EM"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XHCMEFMAAC.aac
@@ -189289,6 +189357,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-comadre-merida-98-5-fm-xhmt-fm-grupo-sipse-ra
+  favicon: "https://sipseplay.com/wp-content/uploads/2024/03/LA-COMADRE-MER.png"
   broadcaster: independent
   name: "La Comadre (Mérida) - 98.5 FM - XHMT-FM - Grupo SIPSE Radio - Mérida, Yucatán"
   streamUrl: https://cast4.my-control-panel.com/proxy/televiso/comadremid
@@ -190067,6 +190136,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-los40-puerto-vallarta-91-1-fm-xhptoj-fm-radiopol
+  favicon: "https://cdn.onlineradiobox.com/img/l/3/82813.v7.png"
   broadcaster: independent
   name: "LOS40 Puerto Vallarta - 91.1 FM - XHPTOJ-FM - Radiópolis - Puerto Vallarta, JC"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/LOS40_VALLARTA.mp3
@@ -194368,6 +194438,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-adictiva-radio-ensenada-100-3-fm-xhdx-fm-esquina
+  favicon: "https://upload.wikimedia.org/wikipedia/commons/d/d7/Adictiva_1003.png"
   broadcaster: independent
   name: "Adictiva Radio (Ensenada) - 100.3 FM - XHDX-FM - Esquina 32 - Ensenada, Baja California"
   streamUrl: https://cast2.my-control-panel.com/proxy/smashco1/stream
@@ -194456,6 +194527,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-primera-ojinaga-101-7-fm-xhog-fm-grupo-bm-rad
+  favicon: "https://cdn.onlineradiobox.com/img/l/1/8921.v14.png"
   broadcaster: independent
   name: "La Primera (Ojinaga) - 101.7 FM - XHOG-FM - Grupo BM Radio - Ojinaga, Chihuahua"
   streamUrl: https://stream.zeno.fm/g0fffb5ub84tv
@@ -194734,6 +194806,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-ke-buena-93-9-iguala
+  favicon: "https://grupo-rc.mx/wp-content/uploads/2023/04/14_XHIGA_LKB_93.9_iguala.png"
   broadcaster: independent
   name: La Ke Buena 93.9 Iguala
   streamUrl: https://streaming.servicioswebmx.com/8292/stream
@@ -202000,6 +202073,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: hu-mixradioretro
+  favicon: "https://cdn.onlineradiobox.com/img/l/3/73103.v10.png"
   broadcaster: independent
   name: MixradioRetro
   streamUrl: https://stream.phost.hu:8004/retro
@@ -203200,6 +203274,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: hu-best-fm-szekesfehervar
+  favicon: "https://www.bestfm.hu/best_fm_logo.png"
   broadcaster: independent
   name: Best FM Székesfehérvár
   streamUrl: https://icast.connectmedia.hu/5113/live.mp3
@@ -204104,6 +204179,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: be-radio-emotion-belgique
+  favicon: "https://www.radio.fr/300/radioemotionbe.png?version=ada38834e96d67af856203df43e80ced7092a581"
   broadcaster: independent
   name: Radio Emotion Belgique
   streamUrl: https://stream1.dgnet.be/1
@@ -207740,6 +207816,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: hr-radio-daruvar
+  favicon: "https://www.radio-daruvar.hr/wp-content/uploads/2024/10/logo-web-368x250px.png"
   broadcaster: independent
   name: Radio Daruvar
   streamUrl: https://mcp1.mydataknox.com:8020/live.mp3
@@ -207754,6 +207831,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: hr-radio-zupanja
+  favicon: "https://radiozupanja.hr/wp-content/uploads/2024/01/145802-1.png"
   broadcaster: independent
   name: Radio Županja
   streamUrl: https://audio.alter-media.hr:7019/stream
@@ -215002,6 +215080,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: ca-cfta-107-9-tantramar-fm-amherst-ns
+  favicon: "https://upload.wikimedia.org/wikipedia/commons/7/71/CFTA_FM_LOGO.png"
   broadcaster: independent
   name: "CFTA 107.9 Tantramar FM Amherst, NS"
   streamUrl: https://s15.myradiostream.com/:14808/stream.mp3?_=1
@@ -215677,6 +215756,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: ca-cfcp-98-9-jet-fm-courtenay-bc
+  favicon: "https://cdn-profiles.tunein.com/s11917/images/logod.png?t=637082229260000000"
   broadcaster: independent
   name: "CFCP 98.9 \"Jet FM\" Courtenay, BC"
   streamUrl: https://vistaradio.streamb.live/SB00079
@@ -215750,6 +215830,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: ca-chwy-fm-106-7-big-106-weyburn-sk
+  favicon: "https://upload.wikimedia.org/wikipedia/commons/e/e3/Big_106_FM_Logo.png"
   broadcaster: independent
   name: "CHWY-FM 106.7 \"Big 106\" Weyburn, SK"
   streamUrl: https://hel-ais-relay1.leanstream.co/goldenwest/CHWYFM.stream/playlist.m3u8
@@ -216327,6 +216408,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: ca-cklp-103-3-moose-fm-parry-sound-on
+  favicon: "https://cdn-radiotime-logos.tunein.com/s12326d.png"
   broadcaster: independent
   name: "CKLP 103.3 \"Moose FM\" Parry Sound, ON"
   streamUrl: https://vistaradio.streamb.live/SB00114
@@ -216519,6 +216601,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: ca-cfbg-99-5-moose-fm-bracebridge-on
+  favicon: "https://cdn.onlineradiobox.com/img/l/8/14858.v5.png"
   broadcaster: independent
   name: "CFBG 99.5 \"Moose FM\" Bracebridge, ON"
   streamUrl: https://vistaradio.streamb.live/SB00115
@@ -216875,6 +216958,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: ca-radio-stonata
+  favicon: "https://static-media.streema.com/media/cache/b8/07/b8072753cc2cef37b6668350345bc40b.jpg"
   broadcaster: independent
   name: Radio Stonata
   streamUrl: https://quincy.torontocast.com:1745/stream

--- a/public/stations.json
+++ b/public/stations.json
@@ -41812,6 +41812,7 @@
       "streamUrl": "https://crazy4live.stream.laut.fm/crazy4live?t302=2026-01-15_04-28-40&uuid=8a91d74c-5e3e-4ece-a78b-db70aa05f513",
       "homepage": "https://crazy4live.com/",
       "country": "DE",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/1/51591.v9.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -55773,6 +55774,7 @@
       "streamUrl": "https://patmos.cdnstream.com/proxy/sanctua1?mp=/stream",
       "homepage": "https://www.sanctuaryradio.com/",
       "country": "US",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/5/33675.v5.png",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -56675,6 +56677,7 @@
       "tags": [
         "country"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/5/40555.v8.png",
       "bitrate": 32,
       "codec": "AAC+",
       "status": "stream-only"
@@ -56723,6 +56726,7 @@
       "tags": [
         "new wave"
       ],
+      "favicon": "https://newwave.radio/wp-content/uploads/2020/06/NewWave-Radio-Logo-2.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -57433,6 +57437,7 @@
       "tags": [
         "oldies"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s24081/images/logod.jpg?t=638493952960000000",
       "bitrate": 32,
       "codec": "AAC+",
       "status": "stream-only"
@@ -57791,6 +57796,7 @@
       "streamUrl": "https://ice23.securenetsystems.net/QXFM",
       "homepage": "https://qxfm.com/",
       "country": "US",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/4/18774.v8.png",
       "bitrate": 64,
       "codec": "AAC+",
       "status": "stream-only"
@@ -58212,6 +58218,7 @@
       "tags": [
         "christian"
       ],
+      "favicon": "https://www.ancientfaith.com/media/images/AFLogo_radio_midnight.width-750.png",
       "bitrate": 96,
       "codec": "AAC+",
       "status": "stream-only"
@@ -75697,6 +75704,7 @@
       "streamUrl": "https://sonic.globalstreaming.net/8120/;",
       "homepage": "https://radiorumbavacilon.com/",
       "country": "US",
+      "favicon": "https://radiorumbavacilon.com/gallery_gen/dacac9541056aa61bb33d4dbb08bc9a3.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -76559,6 +76567,7 @@
       "tags": [
         "urban contemporary"
       ],
+      "favicon": "https://images.zeno.fm/0WtbLuTFjJPjJCA4PYz1gxVX2Gt_viuCmy2HYBlA8FM/rs:fill:288:288/g:ce:0:0/aHR0cHM6Ly9wcm94eS56ZW5vLmZtL2NvbnRlbnQvc3RhdGlvbnMvYzdiZGY2NjgtNzc2Ny00NWZlLWExM2EtZWVlMjUyMjdlYWU5L2ltYWdlLz91PTE3MTM5Mzc3MDkwMDA.webp",
       "bitrate": 48,
       "codec": "AAC+",
       "status": "stream-only"
@@ -79641,6 +79650,7 @@
         "texas",
         "wimberley valley radio"
       ],
+      "favicon": "https://static.wixstatic.com/media/939db4_850205ab600b4f6688405a3ac87bcbc1~mv2.png",
       "bitrate": 64,
       "codec": "AAC+",
       "status": "stream-only"
@@ -80979,6 +80989,7 @@
         "indie music",
         "indie pop"
       ],
+      "favicon": "https://indiehq.net/graphics/hqlogo.png",
       "bitrate": 192,
       "codec": "MP3",
       "geo": [
@@ -83017,6 +83028,7 @@
       "streamUrl": "https://stream.revma.ihrhls.com/zc3379",
       "homepage": "https://stream.revma.ihrhls.com/zc3379",
       "country": "US",
+      "favicon": "https://i.iheart.com/v3/re/assets.brands/60bf9ce39a9c93cf48d16a2f?ops=gravity(%22center%22),contain(180,60)&quality=80",
       "codec": "AAC",
       "status": "stream-only"
     },
@@ -85918,6 +85930,7 @@
         "npr",
         "public radio"
       ],
+      "favicon": "https://ktna.org/wp-content/uploads/2018/04/logo-for-web-200x200.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -94029,6 +94042,7 @@
         "classical",
         "public radio"
       ],
+      "favicon": "https://npr.brightspotcdn.com/dims4/default/5cae731/2147483647/strip/true/crop/4167x1221+0+0/resize/267x78!/quality/90/?url=http%3A%2F%2Fnpr-brightspot.s3.amazonaws.com%2F5d%2F62%2F0042cacf4f4886925b051d96b2e9%2Fkrcu-50years-logo-white-rgb.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -103051,6 +103065,7 @@
         "60s rock",
         "60’s rock"
       ],
+      "favicon": "https://hearme.fm/wp-content/uploads/2024/06/2024-Redrafted-Transparent-Box-No-Text-1-1024x1024.png",
       "codec": "MP3",
       "geo": [
         54.3678,
@@ -103870,6 +103885,7 @@
         "pop",
         "pop music"
       ],
+      "favicon": "https://hearme.fm/wp-content/uploads/2024/06/8002-2000s-pop-music.webp",
       "codec": "MP3",
       "geo": [
         52.6964,
@@ -105997,6 +106013,7 @@
       "streamUrl": "https://media01.gamingnow.net:8010/",
       "homepage": "https://gamingnow.net/radio/",
       "country": "GB",
+      "favicon": "https://test.gamingnow.net/wp-content/uploads/2020/05/Logo-Black.png",
       "bitrate": 256,
       "codec": "MP3",
       "status": "stream-only"
@@ -106163,6 +106180,7 @@
       "streamUrl": "https://radio.hearme.fm:8030/stream",
       "homepage": "https://hearme.fm/",
       "country": "GB",
+      "favicon": "https://hearme.fm/wp-content/uploads/2024/06/2024-Redrafted-Transparent-Box-No-Text-1-1024x1024.png",
       "codec": "MP3",
       "geo": [
         52.6964,
@@ -109677,6 +109695,7 @@
         "field recordings",
         "soundart"
       ],
+      "favicon": "https://soundartradio.org.uk/uploads/soundartradio/img/soundart_radio_logo.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -111146,6 +111165,7 @@
       "streamUrl": "https://stream.classics.friskyradio.com/",
       "homepage": "http://friskyradio.com/",
       "country": "GB",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/0/30450.v2.png",
       "bitrate": 96,
       "codec": "MP3",
       "status": "stream-only"
@@ -111157,6 +111177,7 @@
       "streamUrl": "https://cast5.my-control-panel.com/proxy/grb/stream",
       "homepage": "https://genesisradiobirmingham.com/",
       "country": "GB",
+      "favicon": "https://www.genesisradiobirmingham.com/wp-content/uploads/2021/01/grb-170x170.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -114343,6 +114364,7 @@
       "tags": [
         "gospel"
       ],
+      "favicon": "https://radiogospel.fr/wp-content/uploads/2023/03/rglogo.png",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -118802,6 +118824,7 @@
       "tags": [
         "music"
       ],
+      "favicon": "https://www.radio.fr/300/allzicroad66.png?version=8eccfdcfb3166a176ac08b94857f45d1f498fa89",
       "bitrate": 64,
       "codec": "AAC+",
       "status": "stream-only"
@@ -120861,6 +120884,7 @@
         "pop rock",
         "rock"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/6/81096.v6.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -122534,6 +122558,7 @@
         "80s",
         "90s"
       ],
+      "favicon": "https://www.fatx.fr/static/logo_fatx_blanc_280x162.png",
       "bitrate": 320,
       "codec": "MP3",
       "status": "stream-only"
@@ -126408,6 +126433,7 @@
       "streamUrl": "https://nl1.streamingpulse.com/ssl/radiorougeitaly",
       "homepage": "https://radiorouge.com/",
       "country": "IT",
+      "favicon": "https://cdn-profiles.tunein.com/s135784/images/logod.jpg?t=638245695440000000",
       "bitrate": 320,
       "codec": "MP3",
       "geo": [
@@ -126939,6 +126965,7 @@
         "news",
         "talk"
       ],
+      "favicon": "https://www.italianews24.news/wp-content/uploads/2025/10/cropped-italia-news-24-orizz-white.png",
       "codec": "MP3",
       "status": "stream-only"
     },
@@ -127317,6 +127344,7 @@
         "90s",
         "adult classic pop"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/6/101776.v4.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -127896,6 +127924,7 @@
         "animals",
         "pop"
       ],
+      "favicon": "https://www.radiomontecarlo.net/wp-content/uploads/2025/05/cropped-cropped-transparent-logo_white.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -128962,6 +128991,7 @@
       "tags": [
         "adult contemporary"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s135784/images/logod.jpg?t=638245695440000000",
       "bitrate": 320,
       "codec": "MP3",
       "status": "stream-only"
@@ -132693,6 +132723,7 @@
       "streamUrl": "https://stream.zeno.fm/se76qau1hc9uv",
       "homepage": "https://stream.zeno.fm/se76qau1hc9uv",
       "country": "ES",
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/6/6d/EuropaFM_logo.svg",
       "codec": "AAC",
       "geo": [
         43.3214,
@@ -133240,6 +133271,7 @@
       "tags": [
         "aragon"
       ],
+      "favicon": "https://www.cartv.es/theme/cartv-2017/images/radio/mainheader/logo-aragonradio.png",
       "bitrate": 96,
       "codec": "AAC",
       "status": "stream-only"
@@ -135910,6 +135942,7 @@
         "christian",
         "montserrat"
       ],
+      "favicon": "https://enacast.com/media/cache/01/9a/019a11732ea06382330ac5247a929ade.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -138476,6 +138509,7 @@
       "tags": [
         "ponts"
       ],
+      "favicon": "https://ik.imagekit.io/7ftrkrun31/enacast/logos/2017/05/31/logo_fora_progamacio.jpg?tr=h-300,fo-auto",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -144020,6 +144054,7 @@
       "streamUrl": "https://22673.live.streamtheworld.com/WEB14_MP3_SC",
       "homepage": "https://radiocorp.nl/slam/",
       "country": "NL",
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/2/28/Slam%21FM-logo.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -156842,6 +156877,7 @@
       "tags": [
         "caleta olivia"
       ],
+      "favicon": "https://static-media.streema.com/media/cache/4f/54/4f54e276f175304bdc2595acf2c5ec62.png",
       "bitrate": 96,
       "codec": "AAC+",
       "status": "stream-only"
@@ -164214,6 +164250,7 @@
       "streamUrl": "https://s8.yesstreaming.net:17099/RblLgn",
       "homepage": "https://rebelfm.com.au/logan/",
       "country": "AU",
+      "favicon": "https://upload.wikimedia.org/wikipedia/en/1/10/Rebel_FM_logo_2015.png",
       "bitrate": 64,
       "codec": "AAC",
       "status": "stream-only"
@@ -165196,6 +165233,7 @@
       "streamUrl": "https://stream.thelight.com.au:8150/;stream/1",
       "homepage": "https://thelightchristmas.com.au/",
       "country": "AU",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/4/112044.v8.png",
       "bitrate": 64,
       "codec": "AAC+",
       "status": "stream-only"
@@ -167442,6 +167480,7 @@
         "community",
         "indigenous"
       ],
+      "favicon": "https://images.squarespace-cdn.com/content/v1/698569480d6a892f8d5efc19/12286a4e-dc60-4d53-bffd-6134fd9cc8a9/PAW_LOGO_Image_alpha.png?format=1500w",
       "bitrate": 96,
       "codec": "MP3",
       "status": "stream-only"
@@ -168613,6 +168652,7 @@
       "streamUrl": "https://live.radyofenomen.com/fenomenturk/abr/fenomenturk/256/chunks.m3u8",
       "homepage": "https://live.radyofenomen.com/fenomenturk/abr/fenomenturk/256/chunks.m3u8",
       "country": "TR",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/0/16590.v12.png",
       "codec": "UNKNOWN",
       "status": "stream-only"
     },
@@ -168910,6 +168950,7 @@
       "streamUrl": "https://live.radyofenomen.com/fenomen2010/abr/playlist.m3u8",
       "homepage": "https://live.radyofenomen.com/fenomen2010/abr/playlist.m3u8",
       "country": "TR",
+      "favicon": "https://cdn.radyofenomen.com/artwork/logo20.png",
       "bitrate": 149,
       "codec": "AAC",
       "status": "stream-only"
@@ -169506,6 +169547,7 @@
       "streamUrl": "https://moondigitaledge.radyotvonline.net/discoland/playlist.m3u8",
       "homepage": "https://moondigitaledge.radyotvonline.net/discoland/playlist.m3u8",
       "country": "TR",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/3/16513.v7.png",
       "bitrate": 127,
       "codec": "AAC+",
       "status": "stream-only"
@@ -171193,6 +171235,7 @@
       "streamUrl": "https://dijimedya.radyotvonline.net/goldturk",
       "homepage": "https://dijimedya.radyotvonline.net/goldturk",
       "country": "TR",
+      "favicon": "https://static-media.streema.com/media/cache/1e/0c/1e0cc754937d83eb51baaacb80db38ac.jpg",
       "bitrate": 128,
       "codec": "AAC+",
       "status": "stream-only"
@@ -171753,6 +171796,7 @@
       "streamUrl": "https://ssl16.ozelip.com/asistan/stream/914fcb8228b91c6fe05b3bd0fa85299c",
       "homepage": "https://ssl16.ozelip.com/asistan/stream/914fcb8228b91c6fe05b3bd0fa85299c",
       "country": "TR",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/8/69688.v7.png",
       "codec": "MP3",
       "status": "stream-only"
     },
@@ -172334,6 +172378,7 @@
       "streamUrl": "https://ip20.ozelip.com:9710/",
       "homepage": "https://radyolojik.com/",
       "country": "TR",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/9/13789.v7.png",
       "bitrate": 128,
       "codec": "AAC+",
       "status": "stream-only"
@@ -181302,6 +181347,7 @@
       "streamUrl": "https://accplus.tecnohost.ec/8160/stream",
       "homepage": "https://accplus.tecnohost.ec/8160/stream",
       "country": "CO",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/1/98191.v19.png",
       "bitrate": 96,
       "codec": "MP3",
       "status": "stream-only"
@@ -182001,6 +182047,7 @@
       "tags": [
         "catholic radio"
       ],
+      "favicon": "https://cdn.instant.audio/images/logos/radio-org-ph/maria.png",
       "bitrate": 32,
       "codec": "MP3",
       "status": "stream-only"
@@ -185782,6 +185829,7 @@
         "jazz",
         "smooth jazz"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/0/90780.v5.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -186832,6 +186880,7 @@
         "new music",
         "oldies"
       ],
+      "favicon": "https://radio-aquila.ro/wp-content/uploads/2021/02/logo_RA_alb876x780-150x150.png",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -190696,6 +190745,7 @@
       "streamUrl": "https://eu4.fastcast4u.com/proxy/svidakov?mp=/1",
       "homepage": "https://www.mojradio.net/",
       "country": "RS",
+      "favicon": "https://www.mojradio.net/wp-content/uploads/2024/04/MOJRadio-Logo-300x184.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -190877,6 +190927,7 @@
       "tags": [
         "undefined"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/0/13260.v14.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -193529,6 +193580,7 @@
         "hits",
         "local news"
       ],
+      "favicon": "https://www.radiovizela.pt/images/logo.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -194203,6 +194255,7 @@
         "local radio",
         "pop"
       ],
+      "favicon": "https://radiosoure.pt/wp-content/uploads/2017/04/headerbannertest2.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -195510,6 +195563,7 @@
         "heavy metal",
         "rock"
       ],
+      "favicon": "https://cdn.instant.audio/images/logos/radio-org-nz/the-generator.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -195622,6 +195676,7 @@
       "streamUrl": "https://digitalstreams.mediaworks.nz/george_net/playlist.m3u8",
       "homepage": "https://www.georgefm.co.nz/home.html",
       "country": "NZ",
+      "favicon": "https://upload.wikimedia.org/wikipedia/en/c/c0/George-FM.png",
       "bitrate": 130,
       "codec": "AAC",
       "status": "stream-only"
@@ -195636,6 +195691,7 @@
       "tags": [
         "music"
       ],
+      "favicon": "https://public-rf-upload.minhawebradio.net/207467/logo/9abfa0e4a21358f5083a79a22b587580.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -196086,6 +196142,7 @@
       "tags": [
         "community radio"
       ],
+      "favicon": "https://cdn.instant.audio/images/logos/radio-org-nz/coast-access.png",
       "bitrate": 150,
       "codec": "AAC",
       "status": "stream-only"
@@ -198719,6 +198776,7 @@
         "music",
         "pop"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/3/64373.v11.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -198764,6 +198822,7 @@
         "77.5",
         "八王子"
       ],
+      "favicon": "https://static.mytuner.mobi/media/tvos_radios/nkdjrxrksehq.png",
       "bitrate": 117,
       "codec": "AAC",
       "status": "stream-only"
@@ -199353,6 +199412,7 @@
         "88.5",
         "深谷"
       ],
+      "favicon": "https://www.fukaya-fm.com/cms/wp-content/themes/fm/common/images/logo.svg",
       "bitrate": 178,
       "codec": "AAC",
       "status": "stream-only"
@@ -199782,6 +199842,7 @@
         "77.4",
         "横手"
       ],
+      "favicon": "https://fmyokote.sakura.ne.jp/home/wp-content/uploads/2020/08/logo.png",
       "bitrate": 208,
       "codec": "AAC",
       "status": "stream-only"
@@ -199960,6 +200021,7 @@
         "indie pop",
         "jpop"
       ],
+      "favicon": "https://images.zeno.fm/aByE803sTCFZKR-fDK7uBTm7qFmTs1dKssySc3IDTk4/rs:fill:288:288/g:ce:0:0/aHR0cHM6Ly9wcm94eS56ZW5vLmZtL2NvbnRlbnQvc3RhdGlvbnMvZmRmZmMyN2YtYTA5Ni00YmU4LWIzYmYtMmM1MWE5NDNhMWQxL2ltYWdlLz91PTE3NzAwNDUwMzUwMDA.webp",
       "bitrate": 96,
       "codec": "MP3",
       "geo": [
@@ -200362,6 +200424,7 @@
       "streamUrl": "https://edge.iono.fm/xice/212_medium.aac",
       "homepage": "https://smile904.fm/",
       "country": "ZA",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/4/864.v12.png",
       "codec": "AAC",
       "status": "stream-only"
     },
@@ -205909,6 +205972,7 @@
       "tags": [
         "misc"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/5/68225.v25.png",
       "bitrate": 128,
       "codec": "AAC+",
       "geo": [
@@ -206170,6 +206234,7 @@
         "rock",
         "soft rock"
       ],
+      "favicon": "https://upload.wikimedia.org/wikipedia/pt/b/b9/Logotipo_da_Itapema_FM.png",
       "codec": "UNKNOWN",
       "geo": [
         -30.0486,
@@ -207527,6 +207592,7 @@
       "streamUrl": "https://player.g2play.com.br/proxy/27362",
       "homepage": "https://radionovafmanapolis.com/",
       "country": "BR",
+      "favicon": "https://radionovafmanapolis.com.br/images/logo-rodape.png",
       "bitrate": 128,
       "codec": "AAC+",
       "status": "stream-only"
@@ -210022,6 +210088,7 @@
       "tags": [
         "misc"
       ],
+      "favicon": "https://www.ilustradafm.com.br/wp-content/themes/ilustradafm/images/logo-2022.png",
       "bitrate": 48,
       "codec": "AAC",
       "status": "stream-only"
@@ -217879,6 +217946,7 @@
         "ciudad de méxico",
         "ciudad mexico"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/5/14465.v13.png",
       "bitrate": 64,
       "codec": "AAC+",
       "geo": [
@@ -224323,6 +224391,7 @@
         "entretenimiento",
         "español"
       ],
+      "favicon": "https://sipseplay.com/wp-content/uploads/2024/03/LA-COMADRE-MER.png",
       "bitrate": 128,
       "codec": "AAC",
       "geo": [
@@ -225492,6 +225561,7 @@
         "fm",
         "juvenil"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/3/82813.v7.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -231692,6 +231762,7 @@
         "ensenada",
         "entretenimiento"
       ],
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/d/d7/Adictiva_1003.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -231812,6 +231883,7 @@
         "español",
         "estación"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/1/8921.v14.png",
       "codec": "MP3",
       "geo": [
         29.5661,
@@ -232204,6 +232276,7 @@
         "grupera",
         "grupo radio cañón"
       ],
+      "favicon": "https://grupo-rc.mx/wp-content/uploads/2023/04/14_XHIGA_LKB_93.9_iguala.png",
       "bitrate": 128,
       "codec": "MP3",
       "status": "stream-only"
@@ -241539,6 +241612,7 @@
       "streamUrl": "https://stream.phost.hu:8004/retro",
       "homepage": "https://stream.phost.hu:8004/retro",
       "country": "HU",
+      "favicon": "https://cdn.onlineradiobox.com/img/l/3/73103.v10.png",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -242817,6 +242891,7 @@
       "streamUrl": "https://icast.connectmedia.hu/5113/live.mp3",
       "homepage": "https://www.bestfm.hu/",
       "country": "HU",
+      "favicon": "https://www.bestfm.hu/best_fm_logo.png",
       "codec": "MP3",
       "geo": [
         47.1515,
@@ -243797,6 +243872,7 @@
       "streamUrl": "https://stream1.dgnet.be/1",
       "homepage": "https://www.radioemotion.be/",
       "country": "BE",
+      "favicon": "https://www.radio.fr/300/radioemotionbe.png?version=ada38834e96d67af856203df43e80ced7092a581",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"
@@ -247845,6 +247921,7 @@
       "streamUrl": "https://mcp1.mydataknox.com:8020/live.mp3",
       "homepage": "https://www.radio-daruvar.hr/",
       "country": "HR",
+      "favicon": "https://www.radio-daruvar.hr/wp-content/uploads/2024/10/logo-web-368x250px.png",
       "bitrate": 256,
       "codec": "AAC",
       "status": "stream-only"
@@ -247856,6 +247933,7 @@
       "streamUrl": "https://audio.alter-media.hr:7019/stream",
       "homepage": "https://radiozupanja.hr/",
       "country": "HR",
+      "favicon": "https://radiozupanja.hr/wp-content/uploads/2024/01/145802-1.png",
       "bitrate": 320,
       "codec": "MP3",
       "status": "stream-only"
@@ -256644,6 +256722,7 @@
       "tags": [
         "community radio"
       ],
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/7/71/CFTA_FM_LOGO.png",
       "bitrate": 128,
       "codec": "MP3",
       "geo": [
@@ -257463,6 +257542,7 @@
       "tags": [
         "active rock"
       ],
+      "favicon": "https://cdn-profiles.tunein.com/s11917/images/logod.png?t=637082229260000000",
       "bitrate": 57,
       "codec": "AAC+",
       "geo": [
@@ -257556,6 +257636,7 @@
       "tags": [
         "adult hits"
       ],
+      "favicon": "https://upload.wikimedia.org/wikipedia/commons/e/e3/Big_106_FM_Logo.png",
       "bitrate": 64,
       "codec": "AAC+",
       "geo": [
@@ -258259,6 +258340,7 @@
       "tags": [
         "adult hits"
       ],
+      "favicon": "https://cdn-radiotime-logos.tunein.com/s12326d.png",
       "bitrate": 57,
       "codec": "AAC+",
       "geo": [
@@ -258466,6 +258548,7 @@
       "tags": [
         "hot adult contemporary"
       ],
+      "favicon": "https://cdn.onlineradiobox.com/img/l/8/14858.v5.png",
       "bitrate": 57,
       "codec": "AAC+",
       "geo": [
@@ -258867,6 +258950,7 @@
       "streamUrl": "https://quincy.torontocast.com:1745/stream",
       "homepage": "https://www.radiostonata.com/",
       "country": "CA",
+      "favicon": "https://static-media.streema.com/media/cache/b8/07/b8072753cc2cef37b6668350345bc40b.jpg",
       "bitrate": 192,
       "codec": "MP3",
       "status": "stream-only"


### PR DESCRIPTION
## What

Wave 4 of the agent logo cascade — **cut short by the Sonnet usage cap** (resets 6:40pm Zurich). 9 of 10 agents reported \"out of extra usage\" mid-run.

| | |
|---|---:|
| Candidates | 500 |
| Batches with any saved output | 8 of 10 |
| Logo URLs found | **84** |
| Hit rate (over 271 saved entries) | **31%** |

Two batches (2 and 4) saved nothing before the cap fired. The other 8 had varying degrees of completion.

## Why the hit rate is dropping

This slice is the deepest long tail. Lots of stream-only homepages, expired-cert sites, defunct entries — many stations genuinely have no public logo. Agents correctly returned null when they couldn't find a real match. Source distribution skews harder toward broadcaster-site and OnlineRadioBox aggregator (TuneIn / Wikipedia coverage thins out at this depth).

## Cumulative session totals

| Phase | Logos |
|---|---:|
| Homepage scrape (#178) | 3,575 |
| Wikipedia direct (#182) | 309 |
| Agent wave 1 (#183) | 173 |
| Agent wave 2 (#184) | 298 |
| Agent wave 3 (#185) | 234 |
| Agent wave 4 (this PR) | **84** |
| **Total stations touched** | **4,673** |

## Gates

- [x] catalog 15,608/15,608 published
- [x] check-catalog clean
- [x] check-duplicates 0 collisions
- [x] vitest 311/311

## Stragglers

- 187 saved-but-null entries from this wave (genuinely no good logo)
- 100 stations from batches 2 and 4 (cap fired before save)
- ~780 unprocessed candidates remain

The cap-affected stations could be re-attempted after the quota resets if we want one more pass — at this depth, hit rates of ~30% mean each wave produces ~150 logos for ~10 agents, so the logo-per-token ratio keeps dropping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)