### PR TITLE
feat(genre): canonical taxonomy + richer chip set (Phase 2)

### DIFF
--- a/index.html
+++ b/index.html
@@ -259,13 +259,10 @@
               <svg class="filter-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/></svg>
               <select class="filter-select" id="genre" aria-label="Filter by genre">
                 <option value="all">All genres</option>
-                <option value="jazz">Jazz</option>
-                <option value="ambient">Ambient</option>
-                <option value="classical">Classical</option>
-                <option value="electronic">Electronic</option>
-                <option value="indie">Indie</option>
-                <option value="rock">Rock</option>
-                <option value="eclectic">Eclectic</option>
+                <!-- Options populated at boot from src/genre-taxonomy.ts so
+                     the canonical chip list is the single source of truth.
+                     If JS hasn't run yet, only "All genres" is selectable —
+                     the page is still usable. -->
               </select>
               <svg class="filter-caret" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9 6 6 6-6"/></svg>
             </label>

--- a/src/genre-taxonomy.test.ts
+++ b/src/genre-taxonomy.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import { GENRES, findGenre, stationMatchesGenre } from './genre-taxonomy';
+
+const byId = new Map(GENRES.map((g) => [g.id, g]));
+
+describe('GENRES', () => {
+  it('has unique ids and non-empty labels/rbTag/match', () => {
+    const ids = new Set<string>();
+    for (const g of GENRES) {
+      expect(g.id).toMatch(/^[a-z][a-z0-9-]*$/);
+      expect(ids.has(g.id)).toBe(false);
+      ids.add(g.id);
+      expect(g.label.length).toBeGreaterThan(0);
+      expect(g.rbTag.length).toBeGreaterThan(0);
+      expect(g.match.length).toBeGreaterThan(0);
+      for (const m of g.match) expect(m).toBe(m.toLowerCase());
+    }
+  });
+});
+
+describe('findGenre', () => {
+  it('returns undefined for "all" / null / unknown', () => {
+    expect(findGenre('all')).toBeUndefined();
+    expect(findGenre(null)).toBeUndefined();
+    expect(findGenre(undefined)).toBeUndefined();
+    expect(findGenre('not-a-genre')).toBeUndefined();
+  });
+  it('returns the canonical record for a known id', () => {
+    expect(findGenre('rock')?.label).toBe('Rock');
+    expect(findGenre('hiphop')?.rbTag).toBe('hip hop');
+  });
+});
+
+describe('stationMatchesGenre', () => {
+  const rock = byId.get('rock')!;
+  const hiphop = byId.get('hiphop')!;
+  const oldies = byId.get('oldies')!;
+  const latin = byId.get('latin')!;
+  const ambient = byId.get('ambient')!;
+
+  it('matches simple cases', () => {
+    expect(stationMatchesGenre({ tags: ['rock'] }, rock)).toBe(true);
+    expect(stationMatchesGenre({ tags: ['pop', 'hits'] }, rock)).toBe(false);
+  });
+
+  it('matches via substring (classic rock → rock)', () => {
+    expect(stationMatchesGenre({ tags: ['classic rock'] }, rock)).toBe(true);
+    expect(stationMatchesGenre({ tags: ['punk rock'] }, rock)).toBe(true);
+    expect(stationMatchesGenre({ tags: ['alternative rock'] }, rock)).toBe(true);
+  });
+
+  it('matches synonyms via the match[] list', () => {
+    // "hip hop" tag, "hip-hop" tag, "rap" tag — all map to the hiphop chip
+    expect(stationMatchesGenre({ tags: ['hip hop'] }, hiphop)).toBe(true);
+    expect(stationMatchesGenre({ tags: ['hip-hop'] }, hiphop)).toBe(true);
+    expect(stationMatchesGenre({ tags: ['hiphop'] }, hiphop)).toBe(true);
+    expect(stationMatchesGenre({ tags: ['rap'] }, hiphop)).toBe(true);
+  });
+
+  it('decade tags fold into oldies', () => {
+    expect(stationMatchesGenre({ tags: ['80s'] }, oldies)).toBe(true);
+    expect(stationMatchesGenre({ tags: ['oldies'] }, oldies)).toBe(true);
+    expect(stationMatchesGenre({ tags: ['classic hits'] }, oldies)).toBe(true);
+    expect(stationMatchesGenre({ tags: ['schlager'] }, oldies)).toBe(true);
+  });
+
+  it('latin family folds together', () => {
+    expect(stationMatchesGenre({ tags: ['banda'] }, latin)).toBe(true);
+    expect(stationMatchesGenre({ tags: ['grupera'] }, latin)).toBe(true);
+    expect(stationMatchesGenre({ tags: ['reggaeton'] }, latin)).toBe(true);
+    expect(stationMatchesGenre({ tags: ['mexican'] }, latin)).toBe(true);
+    // Bare "noticias" (Spanish for "news") is also tagged latin since
+    // RB uses it almost exclusively for Latin American stations.
+    expect(stationMatchesGenre({ tags: ['noticias'] }, latin)).toBe(true);
+  });
+
+  it('matches case-insensitively', () => {
+    expect(stationMatchesGenre({ tags: ['ROCK'] }, rock)).toBe(true);
+    expect(stationMatchesGenre({ tags: ['Classic Rock'] }, rock)).toBe(true);
+  });
+
+  it('returns false for empty/missing tags', () => {
+    expect(stationMatchesGenre({}, rock)).toBe(false);
+    expect(stationMatchesGenre({ tags: [] }, rock)).toBe(false);
+    expect(stationMatchesGenre({ tags: null }, rock)).toBe(false);
+  });
+
+  it('chillout and lounge fold into ambient', () => {
+    expect(stationMatchesGenre({ tags: ['chillout'] }, ambient)).toBe(true);
+    expect(stationMatchesGenre({ tags: ['lounge'] }, ambient)).toBe(true);
+    expect(stationMatchesGenre({ tags: ['easy listening'] }, ambient)).toBe(true);
+  });
+});

--- a/src/genre-taxonomy.ts
+++ b/src/genre-taxonomy.ts
@@ -1,0 +1,87 @@
+/**
+ * Canonical genre taxonomy for the catalog browse filter.
+ *
+ * Radio Browser's per-station `tags` are free-form (volunteer-tagged,
+ * multi-language, ~6,000 distinct strings across our 15k catalog).
+ * The previous 8-option dropdown matched those raw tags by substring,
+ * which left 97% of stations un-bucketable through the chip set.
+ *
+ * This module collapses the long tail to ~22 chips a user can reason
+ * about, and gives each chip:
+ *
+ *   · `match[]`  — list of tag forms that should be treated as this
+ *                  genre (case-insensitive, substring match per term).
+ *                  Used for the local-catalog filter.
+ *   · `rbTag`    — the single string we send to Radio Browser's
+ *                  `tag` query parameter when the user picks this
+ *                  chip on the long-tail RB browse view. RB's tag
+ *                  search is itself a substring match server-side, so
+ *                  we send the most-common form.
+ *
+ * Order in `GENRES` is the order chips/options render in the UI. It
+ * roughly mirrors station-count popularity in the catalog so the most
+ * common genres come first.
+ */
+
+export interface Genre {
+  /** Stable id used in URLs, telemetry, and the <select> value. */
+  id: string;
+  /** Display label for the chip / dropdown option. */
+  label: string;
+  /** Tag forms that count as this genre. Case-insensitive. Substring
+   *  match — "rock" also matches "classic rock", "punk rock", … */
+  match: string[];
+  /** Tag string sent to Radio Browser when this chip is active on the
+   *  long-tail browse view. */
+  rbTag: string;
+}
+
+export const GENRES: Genre[] = [
+  { id: 'pop',          label: 'Pop',          match: ['pop'],                                                                                                                                                                                                              rbTag: 'pop' },
+  { id: 'rock',         label: 'Rock',         match: ['rock'],                                                                                                                                                                                                             rbTag: 'rock' },
+  { id: 'oldies',       label: 'Oldies',       match: ['oldies', 'classic hits', '60s', '70s', '80s', '90s', 'schlager'],                                                                                                                                                    rbTag: 'oldies' },
+  { id: 'latin',        label: 'Latin',        match: ['latino', 'latin', 'banda', 'grupera', 'salsa', 'mariachi', 'bachata', 'merengue', 'cumbia', 'reggaeton', 'spanish', 'mexican', 'brazilian', 'sertanejo', 'español', 'tejano', 'norteño', 'romantica', 'noticias'],   rbTag: 'latino' },
+  { id: 'news',         label: 'News',         match: ['news', 'noticias'],                                                                                                                                                                                                  rbTag: 'news' },
+  { id: 'talk',         label: 'Talk',         match: ['talk'],                                                                                                                                                                                                              rbTag: 'talk' },
+  { id: 'public',       label: 'Public',       match: ['public radio', 'community radio', 'public', 'community'],                                                                                                                                                            rbTag: 'public radio' },
+  { id: 'dance',        label: 'Dance',        match: ['dance', 'edm', 'club'],                                                                                                                                                                                              rbTag: 'dance' },
+  { id: 'electronic',   label: 'Electronic',   match: ['electronic', 'electronica', 'techno', 'trance', 'electro'],                                                                                                                                                          rbTag: 'electronic' },
+  { id: 'house',        label: 'House',        match: ['house'],                                                                                                                                                                                                             rbTag: 'house' },
+  { id: 'christian',    label: 'Christian',    match: ['christian', 'gospel', 'religious', 'worship'],                                                                                                                                                                       rbTag: 'christian' },
+  { id: 'indie',        label: 'Indie/alt',    match: ['indie', 'alternative', 'alt'],                                                                                                                                                                                       rbTag: 'alternative' },
+  { id: 'jazz',         label: 'Jazz',         match: ['jazz'],                                                                                                                                                                                                              rbTag: 'jazz' },
+  { id: 'classical',    label: 'Classical',    match: ['classical', 'orchestral'],                                                                                                                                                                                           rbTag: 'classical' },
+  { id: 'ambient',      label: 'Chill',        match: ['ambient', 'chillout', 'chill', 'lounge', 'easy listening', 'downtempo', 'meditation', 'relax'],                                                                                                                      rbTag: 'ambient' },
+  { id: 'country',      label: 'Country',      match: ['country'],                                                                                                                                                                                                           rbTag: 'country' },
+  { id: 'hiphop',       label: 'Hip hop',      match: ['hip hop', 'hip-hop', 'hiphop', 'rap', 'r&b'],                                                                                                                                                                        rbTag: 'hip hop' },
+  { id: 'sports',       label: 'Sports',       match: ['sports', 'sport'],                                                                                                                                                                                                   rbTag: 'sports' },
+  { id: 'folk',         label: 'Folk',         match: ['folk'],                                                                                                                                                                                                              rbTag: 'folk' },
+  { id: 'reggae',       label: 'Reggae',       match: ['reggae', 'ska', 'dancehall'],                                                                                                                                                                                        rbTag: 'reggae' },
+  { id: 'soul',         label: 'Soul/R&B',     match: ['soul', 'rnb', 'rhythm and blues', 'funk'],                                                                                                                                                                           rbTag: 'soul' },
+  { id: 'metal',        label: 'Metal',        match: ['metal'],                                                                                                                                                                                                             rbTag: 'metal' },
+];
+
+const BY_ID = new Map(GENRES.map((g) => [g.id, g]));
+
+export function findGenre(id: string | null | undefined): Genre | undefined {
+  if (!id || id === 'all') return undefined;
+  return BY_ID.get(id);
+}
+
+/** Does the station's tag list match this genre? Case-insensitive
+ *  substring against any of the genre's `match` terms. Empty/missing
+ *  tag list → no match. */
+export function stationMatchesGenre(
+  station: { tags?: string[] | null },
+  genre: Genre,
+): boolean {
+  const tags = station.tags;
+  if (!tags || tags.length === 0) return false;
+  for (const t of tags) {
+    const tl = String(t).toLowerCase();
+    for (const m of genre.match) {
+      if (tl.includes(m)) return true;
+    }
+  }
+  return false;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,7 @@ import { AudioPlayer } from './player';
 import { track } from './telemetry';
 import { pseudoFrequency } from './radioBrowser';
 import { composeBrowseFilter, PAGE_SIZE, fetchStations, searchStations } from './stations';
+import { GENRES, findGenre, stationMatchesGenre } from './genre-taxonomy';
 import {
   addCustom,
   getCustom,
@@ -174,6 +175,16 @@ const $wordmark = document.getElementById('wordmark') as HTMLButtonElement;
 const $search = document.getElementById('search') as HTMLInputElement;
 const $searchClear = document.getElementById('search-clear') as HTMLButtonElement;
 const $genre = document.getElementById('genre') as HTMLSelectElement;
+// Populate genre dropdown from the taxonomy. Boot-time so it's
+// available before the first render. The "All genres" option is
+// already in the static markup as the default; we just append the
+// canonical chip list after it.
+for (const g of GENRES) {
+  const opt = document.createElement('option');
+  opt.value = g.id;
+  opt.textContent = g.label;
+  $genre.appendChild(opt);
+}
 const $country = document.getElementById('country') as HTMLSelectElement;
 const $modePlayed = document.getElementById('mode-played') as HTMLButtonElement;
 const $mapToggle = document.getElementById('map-toggle') as HTMLButtonElement;
@@ -1497,10 +1508,14 @@ function renderContent(): void {
 
   if (activeTab === 'browse') {
     const query = $search.value.trim();
-    const genreTag = activeTag === 'all' ? undefined : activeTag;
+    const activeGenre = findGenre(activeTag);
     const countryFilter = activeCountry === 'all' ? undefined : activeCountry.toUpperCase();
-    const noFilter = !query && !genreTag && !countryFilter;
-    const tagFilter = browseMode === 'news' ? 'news' : genreTag;
+    const noFilter = !query && !activeGenre && !countryFilter;
+    // News mode is a special case that pretends the "news" chip is
+    // active even when the dropdown says "all". Resolve it through the
+    // taxonomy so synonyms (noticias / local news) fold in.
+    const newsGenre = browseMode === 'news' ? findGenre('news') : undefined;
+    const effectiveGenre = newsGenre ?? activeGenre;
     // Map view only renders inside the home view (no genre/country/search);
     // disable the toggle visually when it'd be a no-op.
     $mapToggle.disabled = !noFilter;
@@ -1572,7 +1587,7 @@ function renderContent(): void {
     // Filtered view (search / genre / country): built-ins + custom
     // matches first ("My stations"), then Radio Browser long-tail.
     const tagMatch = (s: Station): boolean =>
-      !tagFilter || (s.tags ?? []).some((t) => t.toLowerCase().includes(tagFilter));
+      !effectiveGenre || stationMatchesGenre(s, effectiveGenre);
     const countryMatch = (s: Station): boolean =>
       !countryFilter || (s.country ?? '').toUpperCase() === countryFilter;
     const mySource = [...BUILTIN_STATIONS, ...getCustom()];
@@ -1586,7 +1601,7 @@ function renderContent(): void {
       if (remainingMy > 0) $content.append(homeShowMoreButton(remainingMy));
     }
     if (lastBrowseStations.length > 0) {
-      const label = query ? 'Results' : tagFilter ?? 'Results';
+      const label = query ? 'Results' : effectiveGenre?.label ?? 'Results';
       $content.append(sectionLabel(label, lastBrowseStations.length));
       $content.append(renderRows(lastBrowseStations));
       if (browseHasMore) $content.append(loadMoreButton());

--- a/src/stations.ts
+++ b/src/stations.ts
@@ -1,4 +1,5 @@
 import { BUILTIN_STATIONS } from './builtins';
+import { findGenre } from './genre-taxonomy';
 import { normalizeStreamUrl, radioBrowser } from './radioBrowser';
 import type { Station } from './types';
 
@@ -102,17 +103,23 @@ export interface BrowseInputs {
 
 /** Build the StationFilter and hasAnyFilter signal that the Browse
  *  page sends to RB. Pure — every read happens in one place, so
- *  runQuery and loadMore can never drift out of sync. */
+ *  runQuery and loadMore can never drift out of sync.
+ *
+ *  The genre id (e.g. `hiphop`) maps to a single RB tag string
+ *  (e.g. `hip hop`) via the taxonomy. RB does substring matching
+ *  server-side, so picking the most-common form of the tag also
+ *  catches the synonyms (`hip-hop`, `hiphop`). */
 export function composeBrowseFilter(
   inputs: BrowseInputs,
   opts: { offset?: number } = {},
 ): { filter: StationFilter; hasAnyFilter: boolean } {
   const query = inputs.query.trim();
-  const genreTag = inputs.activeTag === 'all' ? undefined : inputs.activeTag;
+  // News mode replaces any user-picked genre with `news` — same
+  // precedence runQuery used before extraction.
+  const genreId = inputs.browseMode === 'news' ? 'news' : inputs.activeTag;
+  const genre = findGenre(genreId);
+  const tag = genre?.rbTag;
   const countryCode = inputs.activeCountry === 'all' ? undefined : inputs.activeCountry;
-  // News mode replaces any user-picked genre with the literal `news`
-  // tag — same precedence runQuery used before extraction.
-  const tag = inputs.browseMode === 'news' ? 'news' : genreTag;
   return {
     filter: {
       query: query || undefined,


### PR DESCRIPTION
## What

22-option canonical genre taxonomy replacing the old 8-option dropdown, plus tag-synonym matching. Builds on #187 (which got tag coverage from 6% → 69%).

## The taxonomy

22 chips, each with a `match[]` list of synonym tag forms and an `rbTag` for the Radio Browser long-tail search:

| | | | |
|---|---|---|---|
| Pop | Rock | Oldies | Latin |
| News | Talk | Public | Dance |
| Electronic | House | Christian | Indie/alt |
| Jazz | Classical | Chill | Country |
| Hip hop | Sports | Folk | Reggae |
| Soul/R&B | Metal | | |

Synonym examples (the magic):

- **Hip hop** folds `hip hop` / `hip-hop` / `hiphop` / `rap` / `r&b`
- **Latin** folds `banda` / `grupera` / `salsa` / `mariachi` / `bachata` / `merengue` / `cumbia` / `reggaeton` / `mexican` / `brazilian` / `sertanejo` / `español` / `noticias`
- **Oldies** folds `60s` / `70s` / `80s` / `90s` / `classic hits` / `schlager`
- **Chill** folds `ambient` / `chillout` / `lounge` / `easy listening` / `downtempo`
- **News** folds `news` / `noticias` / `local news`
- **Reggae** folds `ska` / `dancehall`

## Coverage check

Each new chip now buckets hundreds-to-thousands of stations across the 10,807 tagged catalog rows:

\`\`\`
pop          1,950   classic     400
rock         1,294   ambient     431
latin        1,335   indie/alt   433
news         1,140   electronic  473
oldies       1,087   christian   497
talk           667   country     275
public         622   house       271
dance          579   hiphop      299
jazz           429   sports      222
soul           220   reggae      157
metal          131   folk        185
\`\`\`

## How

- `src/genre-taxonomy.ts` — single source of truth. \`Genre[]\` definition + \`findGenre(id)\` + \`stationMatchesGenre(station, genre)\`.
- `index.html` — dropdown options removed from static markup; "All genres" is the only static option. JS populates the rest at boot from \`GENRES\`.
- `src/main.ts` — local filter routes through \`stationMatchesGenre\`. News mode resolves through the same taxonomy so "noticias" / "local news" fold in.
- `src/stations.ts` — \`composeBrowseFilter\` sends \`genre.rbTag\` to Radio Browser instead of the raw chip id. RB does substring tag search, so the most-common form catches the synonym variants server-side.

## Tests

11 new vitest cases on the taxonomy itself: synonym folding, decade → oldies, Latin family, case-insensitivity, missing/empty tags, the tricky "rock vs classic rock" substring case.

Total suite: 311 → 322.

## Gates

- [x] \`tsc --noEmit\` clean
- [x] \`vitest run\` 322/322
- [x] \`npm run build\` clean

## Out of scope (follow-up ideas)

- Chip-row UI (horizontal scrollable strip instead of dropdown)
- Multi-select (filter by 2+ genres)
- Separate **language** facet — RB has the field, we still drop it; same backfill pattern as #187 would unlock it

🤖 Generated with [Claude Code](https://claude.com/claude-code)