### PR TITLE
fix(catalog): quote numeric/reserved tag scalars (was breaking search)

### DIFF
--- a/data/stations.yaml
+++ b/data/stations.yaml
@@ -18796,7 +18796,7 @@
   changeuuid: 9595f6c9-9e1c-49e5-9dba-0de025c20f9e
   reviewedAt: 2026-05-04
 - id: de-partyhits-dein-musikmix-aus-ballermann-apres-ski
-  tags: ["\"bob\"", "#", 0, 11.11, abriss, abrissparty, apresski, ballermann]
+  tags: ["\"bob\"", "#", "0", "11.11", abriss, abrissparty, apresski, ballermann]
   broadcaster: independent
   name: "# PartyHits - Dein Musikmix aus Ballermann, Apres Ski, Wiesn, Karneval, Silvesterparty, TOP 100 Party, Malle, Nonstop, DJ LIVE, Abriss, Feier, Bass, Feiermusik, Partymusik, Apres ski Party, Fussball Hits"
   streamUrl: https://partyhits-high.rautemusik.fm/?ref=radio-browser-ph2
@@ -21026,7 +21026,7 @@
   changeuuid: 8a06b33a-8583-417d-af79-f2420dc7b939
   reviewedAt: 2026-05-04
 - id: de-70-s-80-s-90-s-riw-vintage-channel
-  tags: [128 kbit/s, 128 kbps, 1970s, "1980's", 1990s, 70, 70 80 hits, "70's"]
+  tags: [128 kbit/s, 128 kbps, 1970s, "1980's", 1990s, "70", 70 80 hits, "70's"]
   broadcaster: independent
   name: 70's 80's 90's Riw Vintage Channel
   streamUrl: https://stream.laut.fm/70s-80s-90s-riw-vintage-channel
@@ -21247,7 +21247,7 @@
   changeuuid: 0c782b45-5957-4b3b-b3d0-6470b01e3137
   reviewedAt: 2026-05-04
 - id: de-80s-by-rautemusik-rm-fm
-  tags: [1980s, 80, "80's", 80er, 80s, golden oldies, goldies, oldies]
+  tags: [1980s, "80", "80's", 80er, 80s, golden oldies, goldies, oldies]
   broadcaster: independent
   name: __80S__ by rautemusik (rm.fm)
   streamUrl: https://80s-high.rautemusik.fm/?ref=radiobrowser
@@ -28434,7 +28434,7 @@
   changeuuid: 7a7a550d-930a-4805-a3a6-bf2759ecca76
   reviewedAt: 2026-05-04
 - id: de-70s-oldies-70er-disco-funk-soul-classic-pop-retr
-  tags: [1970s, 70, 70 80 hits, "70's", 70er, 70s, 70s disco, classic hits 60s 70a 80s]
+  tags: [1970s, "70", 70 80 hits, "70's", 70er, 70s, 70s disco, classic hits 60s 70a 80s]
   broadcaster: independent
   name: "* 70s || Oldies, 70er, Disco, Funk, Soul, Classic Pop, Retro, Kultsongs, Evergreens, Vinyl Vibes, Groovy, Feel Good, Nostalgie, Zeitlos, Charts"
   streamUrl: https://0nlineradio.radioho.st/0r-70s?ref=rb26
@@ -36852,7 +36852,7 @@
   changeuuid: c233c6c5-6b42-460e-a24d-ea85ed623920
   reviewedAt: 2026-05-04
 - id: de-radio-grammo-das-schellack-radio
-  tags: [78, schellack]
+  tags: ["78", schellack]
   favicon: "https://www.radiogrammo.de/wp-content/uploads/2026/03/cropped-Logo-Grammo-schwarz-180x180.png"
   broadcaster: independent
   name: Radio Grammo - Das Schellack-Radio
@@ -40402,7 +40402,7 @@
   changeuuid: ee6f62b6-cc71-4f97-86ec-6e62e23cdb96
   reviewedAt: 2026-05-04
 - id: us-classic-vinyl-hd
-  tags: [1930, 1940, 1950, 1960, beautiful music, big band, classic hits, crooners]
+  tags: ["1930", "1940", "1950", "1960", beautiful music, big band, classic hits, crooners]
   broadcaster: independent
   name: Classic Vinyl HD
   streamUrl: https://icecast.walmradio.com:8443/classic
@@ -40430,7 +40430,7 @@
   changeuuid: e9b63fe9-41fb-4f1f-9905-e4821d073da6
   reviewedAt: 2026-05-04
 - id: us-walm-old-time-radio
-  tags: [78, 78-rpm, 78rpm, classic, comedy, drama, easy listening, musical]
+  tags: ["78", 78-rpm, 78rpm, classic, comedy, drama, easy listening, musical]
   broadcaster: independent
   name: WALM - Old Time Radio
   streamUrl: https://icecast.walmradio.com:8443/otr
@@ -40444,7 +40444,7 @@
   changeuuid: d661b7a4-aa8b-43b3-b36d-da7372c82e62
   reviewedAt: 2026-05-04
 - id: us-classic-hits-radio-70-80-discofunk-modernsoul-bo
-  tags: [1970s, 1980s, "70's", 70s, 70s disco, 80, "80's", 80s]
+  tags: [1970s, 1980s, "70's", 70s, 70s disco, "80", "80's", 80s]
   favicon: "https://classichits.radio/wp-content/uploads/2022/10/classichitsit-370x370.png"
   broadcaster: independent
   name: CLASSIC HITS RADIO 70 80 DiscoFunk ModernSoul Boogie
@@ -40554,7 +40554,7 @@
   changeuuid: e88f4ee7-6d65-430f-9d93-4c6289363f73
   reviewedAt: 2026-05-04
 - id: us-70s-80s-disco-funk-modernsoul-boogie
-  tags: [1970s, 1980s, "70's", 70er, 70s, 70s disco, 80, "80's"]
+  tags: [1970s, 1980s, "70's", 70er, 70s, 70s disco, "80", "80's"]
   favicon: "https://funky.radio/wp-content/uploads/2020/10/funkyradio-LOGO512-300x300.jpg"
   broadcaster: independent
   name: 70s 80s Disco Funk ModernSoul Boogie
@@ -42715,7 +42715,7 @@
   changeuuid: 18d01e8a-174e-4f00-91dc-a693934854b5
   reviewedAt: 2026-05-04
 - id: us-a-strangely-isolated-place-9128
-  tags: [9128, a strangely isolated place, asip]
+  tags: ["9128", a strangely isolated place, asip]
   broadcaster: independent
   name: A Strangely Isolated Place / 9128
   streamUrl: https://streams.radio.co/s0aa1e6f4a/listen
@@ -63836,7 +63836,7 @@
   changeuuid: 946acf18-677a-4998-89ae-38fbd48e2c43
   reviewedAt: 2026-05-04
 - id: us-myfm-101-3
-  tags: [101.3, local news, morning show, music, sports, talk]
+  tags: ["101.3", local news, morning show, music, sports, talk]
   favicon: "https://cdn.logfm.com/i/18/18321s300.webp?d=1691301294"
   broadcaster: independent
   name: MyFM 101.3
@@ -65998,7 +65998,7 @@
   changeuuid: ab7499c1-095b-48db-9ad7-8dc948c0ddf1
   reviewedAt: 2026-05-04
 - id: us-97x
-  tags: [97.1, 97.1 fm, 97x, 97x.fm, 97xfm, christian, christian hip hop, christian rock]
+  tags: ["97.1", 97.1 fm, 97x, 97x.fm, 97xfm, christian, christian hip hop, christian rock]
   broadcaster: independent
   name: 97X
   streamUrl: https://streaming.live365.com/a10801
@@ -81543,7 +81543,7 @@
   changeuuid: 8bdc6319-dfe8-417c-9216-477de8223d78
   reviewedAt: 2026-05-04
 - id: us-pac-98-7
-  tags: [98.7, classical, music, wpac]
+  tags: ["98.7", classical, music, wpac]
   broadcaster: independent
   name: PAC 98.7
   streamUrl: https://ice42.securenetsystems.net/WPAC
@@ -87966,7 +87966,7 @@
   changeuuid: f8191e12-58f1-4315-9208-90311bdb9ec0
   reviewedAt: 2026-05-04
 - id: gb-107-8-black-diamond-fm
-  tags: [107.8, 107.8 fm, country, music, regge, reggeton, rock]
+  tags: ["107.8", 107.8 fm, country, music, regge, reggeton, rock]
   broadcaster: independent
   name: 107.8 Black Diamond FM
   streamUrl: https://icecast-s.bdfm.radio/blackdiamondfm?icecast
@@ -96654,7 +96654,7 @@
   changeuuid: 8d442ca8-4e27-49fb-a6b6-b8aef7a47203
   reviewedAt: 2026-05-04
 - id: fr-oui-fm-rock-2000
-  tags: [2000, rock]
+  tags: ["2000", rock]
   favicon: "https://medias.lesindesradios.fr/t:app(web)/t:r(unknown)/filters:format(jpeg)/medias/Vsj0LZpM34/image/ouifm_fm_home1753971855995.jpg"
   broadcaster: independent
   name: OUI FM ROCK 2000
@@ -103747,7 +103747,7 @@
   changeuuid: 403c6464-f721-4c16-b572-9ce935daf853
   reviewedAt: 2026-05-04
 - id: fr-toulouse-fm
-  tags: ["2000's", 2000s, 2010, "2010's", 2010s, 2020, 2020s, french]
+  tags: ["2000's", 2000s, "2010", "2010's", 2010s, "2020", 2020s, french]
   broadcaster: independent
   name: Toulouse FM
   streamUrl: https://n32a-eu.rcs.revma.com/1x41712gy7uvv
@@ -106240,7 +106240,7 @@
   changeuuid: 30506ba5-50a0-4d28-8f33-176521aba3ca
   reviewedAt: 2026-05-04
 - id: it-70-80-hits-hq
-  tags: [320 kbps, 70, 70 80 hits, 70 80 hits hq, 70 music, 70-80, 70-80 hits, 80]
+  tags: [320 kbps, "70", 70 80 hits, 70 80 hits hq, 70 music, 70-80, 70-80 hits, "80"]
   favicon: "https://www.70-80.it/wp-content/uploads/2020/03/logo-70-80-300x300.jpg"
   broadcaster: independent
   name: 70 80 Hits HQ
@@ -106254,7 +106254,7 @@
   changeuuid: d2a49aeb-c641-4ad3-9beb-28b30e1f9268
   reviewedAt: 2026-05-04
 - id: it-classic-hits-radio-italia
-  tags: [1970s, 1980s, "70's", 70s, 70s disco, 80, "80's", 80s]
+  tags: [1970s, 1980s, "70's", 70s, 70s disco, "80", "80's", 80s]
   favicon: "https://classichits.radio/wp-content/uploads/2022/10/classichitsit-370x370.png"
   broadcaster: independent
   name: CLASSIC HITS RADIO Italia
@@ -106405,7 +106405,7 @@
   changeuuid: 6e979322-3b33-4af4-8a37-e09b34a19268
   reviewedAt: 2026-05-04
 - id: it-70-80-disco-funk-modernsoul-e-boogie
-  tags: [1970s, 1980s, "70's", 70er, 70s, 70s disco, 80, "80's"]
+  tags: [1970s, 1980s, "70's", 70er, 70s, 70s disco, "80", "80's"]
   favicon: "https://funky.radio/wp-content/uploads/2020/10/funkyradio-LOGO512-300x300.jpg"
   broadcaster: independent
   name: 70 80 Disco Funk ModernSoul e Boogie
@@ -107779,7 +107779,7 @@
   changeuuid: 027670fd-9985-4690-b38e-a4eb3f743d4b
   reviewedAt: 2026-05-04
 - id: it-nbc-milano
-  tags: [70, 70 80 hits, 70 hits, 80, 80 hits, greatest hits, hq, milano]
+  tags: ["70", 70 80 hits, 70 hits, "80", 80 hits, greatest hits, hq, milano]
   broadcaster: independent
   name: NBC Milano
   streamUrl: https://nr7.newradio.it:19350/stream
@@ -121181,7 +121181,7 @@
   changeuuid: 10b31b64-f5b1-4f45-99bd-1f8d59c2f5ca
   reviewedAt: 2026-05-04
 - id: nl-radio-gelderland
-  tags: [103.5, news, public radio]
+  tags: ["103.5", news, public radio]
   broadcaster: independent
   name: Radio Gelderland
   streamUrl: https://d2od87akyl46nm.cloudfront.net/icecast/omroepgelderland/radiogelderland
@@ -127796,7 +127796,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: pl-radio-disco-dance
-  tags: [70, 70s, 80, 80s, 90, 90s, disco, disco polo]
+  tags: ["70", 70s, "80", 80s, "90", 90s, disco, disco polo]
   broadcaster: independent
   name: Radio Disco-Dance
   streamUrl: https://radiodd.cloud/radio/8000/radio.mp3
@@ -129392,7 +129392,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: pl-radio-zet-128-kbps
-  tags: [95.6, hits]
+  tags: ["95.6", hits]
   broadcaster: independent
   name: Radio ZET 128 Kbps
   streamUrl: https://zt02.cdn.eurozet.pl/zet-old.mp3
@@ -132664,7 +132664,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: ar-metro-95-1
-  tags: [95.1, 95.1 fm, argentina, buenos aires, ciudad de buenos aires, dance, electronic, entertainment]
+  tags: ["95.1", 95.1 fm, argentina, buenos aires, ciudad de buenos aires, dance, electronic, entertainment]
   broadcaster: independent
   name: Metro 95.1
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/METRO.mp3
@@ -147156,7 +147156,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: tr-radyo-9
-  tags: [9, 99.9, 99.9 fm, ankara, aydin, aydın, bölgesel, dokuz]
+  tags: ["9", "99.9", 99.9 fm, ankara, aydin, aydın, bölgesel, dokuz]
   broadcaster: independent
   name: Radyo 9
   streamUrl: https://radyo.yayin.com.tr:4010/
@@ -152242,7 +152242,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: id-kinozal-tv
-  tags: [2024, adult conterporary, best, club, club house, dance, dance pop, deep house]
+  tags: ["2024", adult conterporary, best, club, club house, dance, dance pop, deep house]
   favicon: "https://kinozal.tv/pic/favicon.ico"
   broadcaster: independent
   name: Kinozal.TV
@@ -175193,7 +175193,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-ban-ban
-  tags: [86.9, 加古川市]
+  tags: ["86.9", 加古川市]
   favicon: "https://www.banban.jp/radio/images/common/logo.svg"
   broadcaster: independent
   name: BAN-BANラジオ
@@ -175285,7 +175285,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-tokyo-star-radio-fm
-  tags: [77.5, 八王子]
+  tags: ["77.5", 八王子]
   favicon: "https://static.mytuner.mobi/media/tvos_radios/nkdjrxrksehq.png"
   broadcaster: independent
   name: Tokyo Star Radio(八王子FM)
@@ -175316,7 +175316,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-fm
-  tags: [83.4, full service, music]
+  tags: ["83.4", full service, music]
   broadcaster: independent
   name: FM世田谷
   streamUrl: https://fmsetagaya834.out.airtime.pro/fmsetagaya834_a
@@ -175332,7 +175332,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-
-  tags: [79.6, 秋田]
+  tags: ["79.6", 秋田]
   broadcaster: independent
   name: エフエム椿台
   streamUrl: https://mtist.as.smartstream.ne.jp/30014/livestream/playlist.m3u8
@@ -175347,7 +175347,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp--2
-  tags: [79.7, 京都市]
+  tags: ["79.7", 京都市]
   broadcaster: independent
   name: 京都三条ラジオカフェ
   streamUrl: https://mtist.as.smartstream.ne.jp/30082/livestream/playlist.m3u8
@@ -175409,7 +175409,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-fm-radio3-3
-  tags: [76.2, 仙台]
+  tags: ["76.2", 仙台]
   broadcaster: independent
   name: FM RADIO3 (ラジオ3)
   streamUrl: https://mtist.as.smartstream.ne.jp/30007/livestream/playlist.m3u8
@@ -175424,7 +175424,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-fm-3
-  tags: [83.8, 調布]
+  tags: ["83.8", 調布]
   broadcaster: independent
   name: 調布FM
   streamUrl: https://mtist.as.smartstream.ne.jp/30039/livestream/playlist.m3u8
@@ -175439,7 +175439,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-775-fm
-  tags: [77.5, 朝霞]
+  tags: ["77.5", 朝霞]
   favicon: "https://775fm.co.jp/wp/wp-content/themes/775fm/images/logo.png?20220406"
   broadcaster: independent
   name: "775ライブリーFM"
@@ -175455,7 +175455,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-fm-4
-  tags: [79.7, 仙台]
+  tags: ["79.7", 仙台]
   broadcaster: independent
   name: fmいずみ
   streamUrl: https://mtist.as.smartstream.ne.jp/30018/livestream/playlist.m3u8
@@ -175499,7 +175499,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-fm-kawaguchi-856-studio-fm
-  tags: [85.6, 川口]
+  tags: ["85.6", 川口]
   broadcaster: independent
   name: FM Kawaguchi 856 studio (FM川口)
   streamUrl: https://mtist.as.smartstream.ne.jp/30035/livestream/playlist.m3u8
@@ -175514,7 +175514,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-fm-5
-  tags: [82.2, 日立]
+  tags: ["82.2", 日立]
   broadcaster: independent
   name: FMひたち
   streamUrl: https://mtist.as.smartstream.ne.jp/30023/livestream/playlist.m3u8
@@ -175560,7 +175560,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-radio-mix-kyoto-fm87-0
-  tags: [87.0, 京都府]
+  tags: ["87.0", 京都府]
   broadcaster: independent
   name: Radio Mix Kyoto FM87.0
   streamUrl: https://mtist.as.smartstream.ne.jp/30071/livestream/playlist.m3u8
@@ -175575,7 +175575,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-fm-6
-  tags: [88.5, 江東]
+  tags: ["88.5", 江東]
   broadcaster: independent
   name: レインボータウンFM
   streamUrl: https://mtist.as.smartstream.ne.jp/30036/livestream/playlist.m3u8
@@ -175605,7 +175605,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-bay-wave
-  tags: [78.1, 塩竈]
+  tags: ["78.1", 塩竈]
   broadcaster: independent
   name: BAY WAVE 塩竈のラジオ
   streamUrl: https://mtist.as.smartstream.ne.jp/30056/livestream/playlist.m3u8
@@ -175620,7 +175620,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-fm-7
-  tags: [84.4, 立川]
+  tags: ["84.4", 立川]
   broadcaster: independent
   name: FMたちかわ
   streamUrl: https://mtist.as.smartstream.ne.jp/30033/livestream/playlist.m3u8
@@ -175649,7 +175649,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-air-station-hibiki
-  tags: [88.2, 北九州市]
+  tags: ["88.2", 北九州市]
   broadcaster: independent
   name: AIR STATION HIBIKI
   streamUrl: https://mtist.as.smartstream.ne.jp/30052/livestream/playlist.m3u8
@@ -175678,7 +175678,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-city
-  tags: [84.5, 前橋]
+  tags: ["84.5", 前橋]
   favicon: "https://maeradi.net/assets/images/common/logo.svg"
   broadcaster: independent
   name: まえばしCITYエフエム
@@ -175694,7 +175694,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp--4
-  tags: [78.9, 大島郡]
+  tags: ["78.9", 大島郡]
   broadcaster: independent
   name: エフエムたつごう
   streamUrl: https://mtist.as.smartstream.ne.jp/30072/livestream/playlist.m3u8
@@ -175709,7 +175709,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-fm-9
-  tags: [86.2, 長岡京市]
+  tags: ["86.2", 長岡京市]
   broadcaster: independent
   name: FMおとくに
   streamUrl: https://mtist.as.smartstream.ne.jp/30063/livestream/playlist.m3u8
@@ -175753,7 +175753,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-801
-  tags: [80.1, 名取]
+  tags: ["80.1", 名取]
   broadcaster: independent
   name: なとらじ801
   streamUrl: https://mtist.as.smartstream.ne.jp/30092/livestream/playlist.m3u8
@@ -175768,7 +175768,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-daraz-fm
-  tags: [79.8, 米子市]
+  tags: ["79.8", 米子市]
   broadcaster: independent
   name: DARAZ FM
   streamUrl: https://mtist.as.smartstream.ne.jp/30053/livestream/playlist.m3u8
@@ -175783,7 +175783,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-fm-11
-  tags: [81.8, 宜野湾市]
+  tags: ["81.8", 宜野湾市]
   broadcaster: independent
   name: ぎのわんシティFM
   streamUrl: https://mtist.as.smartstream.ne.jp/30098/livestream/playlist.m3u8
@@ -175798,7 +175798,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp--5
-  tags: [86.8, 越谷]
+  tags: ["86.8", 越谷]
   broadcaster: independent
   name: ハローハッピー・こしがやエフエム
   streamUrl: https://mtist.as.smartstream.ne.jp/30096/livestream/playlist.m3u8
@@ -175813,7 +175813,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-fm-12
-  tags: [76.1, 石垣市]
+  tags: ["76.1", 石垣市]
   broadcaster: independent
   name: FMいしがきサンサンラジオ
   streamUrl: https://mtist.as.smartstream.ne.jp/30069/livestream/playlist.m3u8
@@ -175828,7 +175828,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-koco
-  tags: [79.1, 郡山]
+  tags: ["79.1", 郡山]
   broadcaster: independent
   name: KOCOラジ
   streamUrl: https://mtist.as.smartstream.ne.jp/30020/livestream/playlist.m3u8
@@ -175843,7 +175843,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-fm-n1
-  tags: [76.3, 野々市]
+  tags: ["76.3", 野々市]
   broadcaster: independent
   name: FM N1
   streamUrl: https://mtist.as.smartstream.ne.jp/30001/livestream/playlist.m3u8
@@ -175858,7 +175858,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-fm-13
-  tags: [79.4, 京丹後市]
+  tags: ["79.4", 京丹後市]
   broadcaster: independent
   name: FMたんご
   streamUrl: https://mtist.as.smartstream.ne.jp/30073/livestream/playlist.m3u8
@@ -175873,7 +175873,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-fm-14
-  tags: [83.2, 豊見城市]
+  tags: ["83.2", 豊見城市]
   broadcaster: independent
   name: FMとよみ
   streamUrl: https://mtist.as.smartstream.ne.jp/30083/livestream/playlist.m3u8
@@ -175888,7 +175888,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-fm-15
-  tags: [88.5, 深谷]
+  tags: ["88.5", 深谷]
   favicon: "https://www.fukaya-fm.com/cms/wp-content/themes/fm/common/images/logo.svg"
   broadcaster: independent
   name: FMふっかちゃん
@@ -175919,7 +175919,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-fm-16
-  tags: [76.2, いわき市]
+  tags: ["76.2", いわき市]
   broadcaster: independent
   name: FMいわき
   streamUrl: https://mtist.as.smartstream.ne.jp/30009/livestream/playlist.m3u8
@@ -175934,7 +175934,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp--6
-  tags: [77.7, 奄美市]
+  tags: ["77.7", 奄美市]
   broadcaster: independent
   name: あまみエフエム
   streamUrl: https://mtist.as.smartstream.ne.jp/30054/livestream/playlist.m3u8
@@ -175949,7 +175949,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-fm-17
-  tags: [77.9, 敦賀市]
+  tags: ["77.9", 敦賀市]
   favicon: "https://cdn.instant.audio/images/logos/jpradio-jp/harbor-station.png"
   broadcaster: independent
   name: 敦賀FM
@@ -175965,7 +175965,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-fm-mot-com
-  tags: [77.7, 本宮]
+  tags: ["77.7", 本宮]
   broadcaster: independent
   name: FM Mot.com
   streamUrl: https://mtist.as.smartstream.ne.jp/30019/livestream/playlist.m3u8
@@ -175995,7 +175995,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp--7
-  tags: [86.1, 直方市]
+  tags: ["86.1", 直方市]
   broadcaster: independent
   name: チョクラジ
   streamUrl: https://mtist.as.smartstream.ne.jp/30085/livestream/playlist.m3u8
@@ -176010,7 +176010,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-fm76-9
-  tags: [76.9, 盛岡]
+  tags: ["76.9", 盛岡]
   broadcaster: independent
   name: ラヂオもりおか FM76.9
   streamUrl: https://mtist.as.smartstream.ne.jp/30017/livestream/playlist.m3u8
@@ -176025,7 +176025,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-fm-18
-  tags: [87.7, 名護市]
+  tags: ["87.7", 名護市]
   favicon: "https://fmyanbaru.co.jp/wp-content/themes/Fmyambaru/assets/images/logo-header.png"
   broadcaster: independent
   name: FMやんばる
@@ -176056,7 +176056,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-befm
-  tags: [76.5, 八戸市]
+  tags: ["76.5", 八戸市]
   favicon: "https://www.befm.co.jp/fm/wp-content/uploads/2020/11/bunnerB.png"
   broadcaster: independent
   name: BeFM
@@ -176072,7 +176072,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-fm-19
-  tags: [77.9, 二戸]
+  tags: ["77.9", 二戸]
   broadcaster: independent
   name: カシオペアFM
   streamUrl: https://mtist.as.smartstream.ne.jp/30050/livestream/playlist.m3u8
@@ -176087,7 +176087,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-wi-radio
-  tags: [77.6]
+  tags: ["77.6"]
   broadcaster: independent
   name: wi-radio
   streamUrl: https://mtist.as.smartstream.ne.jp/30087/livestream/playlist.m3u8
@@ -176102,7 +176102,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-fm-20
-  tags: [79.1, 鹿角]
+  tags: ["79.1", 鹿角]
   broadcaster: independent
   name: 鹿角きりたんぽFM
   streamUrl: https://mtist.as.smartstream.ne.jp/30089/livestream/playlist.m3u8
@@ -176117,7 +176117,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-reds-wave
-  tags: [87.3, さいたま市]
+  tags: ["87.3", さいたま市]
   broadcaster: independent
   name: REDS WAVE
   streamUrl: https://mtist.as.smartstream.ne.jp/30008/livestream/playlist.m3u8
@@ -176132,7 +176132,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp--8
-  tags: [76.7, 鴻巣]
+  tags: ["76.7", 鴻巣]
   favicon: "https://fm767.com/wp/wp-content/uploads/digipress/magjam/title/header_logo.png"
   broadcaster: independent
   name: フラワーラジオ
@@ -176148,7 +176148,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp--9
-  tags: [82.6, 宮古]
+  tags: ["82.6", 宮古]
   broadcaster: independent
   name: みやこハーバーラジオ
   streamUrl: https://mtist.as.smartstream.ne.jp/30097/livestream/playlist.m3u8
@@ -176178,7 +176178,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-b-fm791
-  tags: [79.1, 徳島市]
+  tags: ["79.1", 徳島市]
   broadcaster: independent
   name: B･FM791
   streamUrl: https://mtist.as.smartstream.ne.jp/30010/livestream/playlist.m3u8
@@ -176193,7 +176193,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-fm-21
-  tags: [76.2, 水戸]
+  tags: ["76.2", 水戸]
   broadcaster: independent
   name: FMぱるるん
   streamUrl: https://mtist.as.smartstream.ne.jp/30022/livestream/playlist.m3u8
@@ -176208,7 +176208,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-egao
-  tags: [76.3, 岡崎]
+  tags: ["76.3", 岡崎]
   broadcaster: independent
   name: エフエムEGAO
   streamUrl: https://mtist.as.smartstream.ne.jp/30040/livestream/playlist.m3u8
@@ -176254,7 +176254,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-fm-22
-  tags: [88.6, 延岡市]
+  tags: ["88.6", 延岡市]
   broadcaster: independent
   name: FMのべおか
   streamUrl: https://mtist.as.smartstream.ne.jp/30088/livestream/playlist.m3u8
@@ -176269,7 +176269,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-fm-23
-  tags: [76.3, 湯沢]
+  tags: ["76.3", 湯沢]
   broadcaster: independent
   name: FMゆーとぴあ
   streamUrl: https://mtist.as.smartstream.ne.jp/30030/livestream/playlist.m3u8
@@ -176284,7 +176284,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-fm-24
-  tags: [79.7, 宜野湾市]
+  tags: ["79.7", 宜野湾市]
   favicon: "https://static.mytuner.mobi/media/tvos_radios/uwqtqhbsahhe.png"
   broadcaster: independent
   name: FMぎのわん
@@ -176300,7 +176300,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp--10
-  tags: [76.1, 黒部市]
+  tags: ["76.1", 黒部市]
   broadcaster: independent
   name: ラジオ・ミュー
   streamUrl: https://mtist.as.smartstream.ne.jp/30006/livestream/playlist.m3u8
@@ -176315,7 +176315,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp--11
-  tags: [77.5, 気仙沼]
+  tags: ["77.5", 気仙沼]
   broadcaster: independent
   name: ラヂオ気仙沼
   streamUrl: https://mtist.as.smartstream.ne.jp/30094/livestream/playlist.m3u8
@@ -176330,7 +176330,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp--12
-  tags: [77.4, 横手]
+  tags: ["77.4", 横手]
   favicon: "https://fmyokote.sakura.ne.jp/home/wp-content/uploads/2020/08/logo.png"
   broadcaster: independent
   name: 横手かまくらエフエム
@@ -176346,7 +176346,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-fm-25
-  tags: [76.4, 豊岡市]
+  tags: ["76.4", 豊岡市]
   broadcaster: independent
   name: FM ジャングル
   streamUrl: https://mtist.as.smartstream.ne.jp/30013/livestream/playlist.m3u8
@@ -176375,7 +176375,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp--13
-  tags: [81.5, 東近江市]
+  tags: ["81.5", 東近江市]
   favicon: "https://zenkokunews.sakura.ne.jp/radiosweet/wp-content/uploads/2025/05/815%E3%83%AD%E3%82%B4-1-3-scaled.png"
   broadcaster: independent
   name: ラジオスイート
@@ -176391,7 +176391,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-fm-26
-  tags: [85.4, 牛久]
+  tags: ["85.4", 牛久]
   broadcaster: independent
   name: FMうしくうれしく放送
   streamUrl: https://mtist.as.smartstream.ne.jp/30021/livestream/playlist.m3u8
@@ -176421,7 +176421,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp--14
-  tags: [4, 76, 石巻]
+  tags: ["4", "76", 石巻]
   favicon: "https://static2.mytuner.mobi/media/tvos_radios/ZbadTqaXkc.png"
   broadcaster: independent
   name: ラジオ石巻
@@ -176437,7 +176437,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: jp-fm-27
-  tags: [84.2, 海老名]
+  tags: ["84.2", 海老名]
   broadcaster: independent
   name: ＦＭカオン
   streamUrl: https://mtist.as.smartstream.ne.jp/30057/livestream/playlist.m3u8
@@ -180046,7 +180046,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: pe-max-radio-station
-  tags: [90, variada]
+  tags: ["90", variada]
   favicon: "https://player.rdp.com.pe/img/core-img/favicon.png"
   broadcaster: independent
   name: MAX RADIO STATION
@@ -180991,7 +180991,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: br-gold-web-32kb
-  tags: [70s, 80, 90, adult, oldies]
+  tags: [70s, "80", "90", adult, oldies]
   broadcaster: independent
   name: Gold Web 32kb
   streamUrl: https://centova.svdns.com.br:19418/stream1
@@ -187275,7 +187275,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: br-radio-lembranca
-  tags: [80, 90 e 2.000, anos 70]
+  tags: ["80", 90 e 2.000, anos 70]
   favicon: "https://www.toligado.net.br/favicon.ico"
   broadcaster: independent
   name: Rádio Lembrança
@@ -191341,7 +191341,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-sabrosita-ciudad-de-mexico-590-am-xeph-am-nrm-co
-  tags: [590, 590 am, am, ciudad de mexico, ciudad de méxico, ciudad mexico, estación, latin  salsa kumbia  merenge  reggaeton]
+  tags: ["590", 590 am, am, ciudad de mexico, ciudad de méxico, ciudad mexico, estación, latin  salsa kumbia  merenge  reggaeton]
   broadcaster: independent
   name: SABROSITA Ciudad de México - 590 AM - XEPH-AM - NRM Comunicaciones - Ciudad de México
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XEPHAMAAC.aac
@@ -191357,7 +191357,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-radio-felicidad-ciudad-de-mexico-1180-am-xefr-am
-  tags: [1180, 1180 am, 60s, 70s, 80s, acir, am, balada]
+  tags: ["1180", 1180 am, 60s, 70s, 80s, acir, am, balada]
   broadcaster: independent
   name: Radio Felicidad Ciudad de México - 1180 AM - XEFR-AM - Grupo ACIR - Ciudad de México
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XEFRAMAAC_SC.aac
@@ -191405,7 +191405,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-mejor-ciudad-de-mexico-97-7-fm-xerc-fm-mvs-ra
-  tags: [97.7, 97.7 fm, aquí nomás, banda, cdmx, ciudad de méxico, estación, fm]
+  tags: ["97.7", 97.7 fm, aquí nomás, banda, cdmx, ciudad de méxico, estación, fm]
   broadcaster: independent
   name: La Mejor Ciudad de México - 97.7 FM - XERC-FM - MVS Radio - Ciudad de México
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XERCFM_SC
@@ -191421,7 +191421,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-radio-formula-104-1-fm-xerfr-fm-grupo-formula-ci
-  tags: [104.1, 104.1 fm, acustic, cdmx, ciudad de mexico, ciudad de méxico, ciudad mexico, entretenimiento]
+  tags: ["104.1", 104.1 fm, acustic, cdmx, ciudad de mexico, ciudad de méxico, ciudad mexico, entretenimiento]
   broadcaster: independent
   name: Radio Fórmula - 104.1 FM - XERFR-FM - Grupo Fórmula - Ciudad de México
   streamUrl: https://mdstrm.com/audio/61e1dfd2658baf082814e25d/live.m3u8
@@ -191453,7 +191453,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-joya-93-7-fm-xejp-fm-grupo-radio-centro-ciudad-d
-  tags: [93.7, 93.7 fm, cdmx, ciudad de mexico, ciudad de méxico, estación, fm, grupo radio centro]
+  tags: ["93.7", 93.7 fm, cdmx, ciudad de mexico, ciudad de méxico, estación, fm, grupo radio centro]
   favicon: "https://upload.wikimedia.org/wikipedia/commons/8/82/XEJP_Joya93.7_logo.jpg"
   broadcaster: independent
   name: JOYA - 93.7 FM - XEJP-FM - Grupo Radio Centro - Ciudad de México
@@ -191469,7 +191469,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-el-fonografo-690-am-xen-am-grupo-radio-centro-ci
-  tags: [690, 690 am, am, ciudad de mexico, ciudad de méxico, ciudad mexico, el fonógrafo, español]
+  tags: ["690", 690 am, am, ciudad de mexico, ciudad de méxico, ciudad mexico, el fonógrafo, español]
   favicon: "https://upload.wikimedia.org/wikipedia/commons/a/a8/Logo_Radio_Centro.png"
   broadcaster: independent
   name: El Fonógrafo - 690 AM - XEN-AM - Grupo Radio Centro - Ciudad de México
@@ -191485,7 +191485,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-w-radio-ciudad-de-mexico-96-9-fm-900-am-xew-fm-x
-  tags: [900, 900 am, 96.9, 96.9 fm, am, cdmx, ciudad de mexico, ciudad de méxico]
+  tags: ["900", 900 am, "96.9", 96.9 fm, am, cdmx, ciudad de mexico, ciudad de méxico]
   favicon: "https://www.wradio.com.mx/pf/resources/wradiomx/touch-icon-iphone-retina.png?d=256&amp;mxId=00000000"
   broadcaster: independent
   name: W Radio Ciudad de México - 96.9 FM / 900 AM - XEW-FM / XEW-AM - Radiópolis - Ciudad de México
@@ -191517,7 +191517,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-grupera-puebla-89-3-fm-xhnp-fm-cinco-radio-pu
-  tags: [89.3, 89.3 fm, cinco radio, entretenimiento, estación, fm, grupera, grupero]
+  tags: ["89.3", 89.3 fm, cinco radio, entretenimiento, estación, fm, grupera, grupero]
   favicon: "https://i0.wp.com/cincoradio.com.mx/wp-content/uploads/2026/01/favicon-01.png?fit=97%2C180&#038;ssl=1"
   broadcaster: independent
   name: "La Grupera (Puebla) - 89.3 FM - XHNP-FM - Cinco Radio - Puebla, PU"
@@ -191564,7 +191564,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-mvs-noticias-102-5-fm-xhmvs-fm-mvs-radio-ciudad-
-  tags: [102.5, 102.5 fm, auto y más, baladas en ingles, clasicos en ingles, deporte, deportes, estación]
+  tags: ["102.5", 102.5 fm, auto y más, baladas en ingles, clasicos en ingles, deporte, deportes, estación]
   broadcaster: independent
   name: MVS Noticias - 102.5 FM - XHMVS-FM - MVS Radio - Ciudad de México
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XHMVSFM_SC
@@ -191596,7 +191596,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-beat-100-9-fm-xhson-fm-nrm-comunicaciones-ciudad
-  tags: [100.9, 100.9 fm, 100.9fm, beat, beats, cdmx, ciudad de mexico, ciudad de méxico]
+  tags: ["100.9", 100.9 fm, 100.9fm, beat, beats, cdmx, ciudad de mexico, ciudad de méxico]
   broadcaster: independent
   name: BEAT 100.9 FM - XHSON-FM - NRM Comunicaciones - Ciudad de México
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XHSONFMAAC.aac
@@ -191611,7 +191611,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-stereo-cien-100-1-fm-xhmm-fm-nrm-comunicaciones-
-  tags: ["00's", 00s, 100.1, 100.1 fm, 1000, 1000 am, "1980's", 1980s]
+  tags: ["00's", 00s, "100.1", 100.1 fm, "1000", 1000 am, "1980's", 1980s]
   broadcaster: independent
   name: Stereo Cien - 100.1 FM - XHMM-FM - NRM Comunicaciones - Ciudad de México
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XHMMFMAAC.aac
@@ -191627,7 +191627,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-w-deportes-ciudad-de-mexico-730-am-xex-am-radiop
-  tags: [730, 730 am, am, cdmx, ciudad de mexico, ciudad de méxico, ciudad mexico, deporte]
+  tags: ["730", 730 am, am, cdmx, ciudad de mexico, ciudad de méxico, ciudad mexico, deporte]
   broadcaster: independent
   name: W Deportes (Ciudad de México) - 730 AM - XEX-AM - Radiópolis - Ciudad de México
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/TDW730AMAAC.aac
@@ -191738,7 +191738,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-los40-ciudad-de-mexico-101-7-fm-xex-fm-radiopoli
-  tags: [101.7, 101.7 fm, cdmx, ciudad de méxico, entretenimiento, estación, fm, los40]
+  tags: ["101.7", 101.7 fm, cdmx, ciudad de méxico, entretenimiento, estación, fm, los40]
   broadcaster: independent
   name: LOS40 Ciudad de México - 101.7 FM - XEX-FM - Radiópolis - Ciudad de México
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/LOS40_MEXICOAAC.aac
@@ -191754,7 +191754,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-sabrosita-monterrey-95-7-fm-xhrk-fm-grupo-rad
-  tags: [95.7, 95.7 fm, banda, banda norteña, banda tradicional, estación, fm, grupera]
+  tags: ["95.7", 95.7 fm, banda, banda norteña, banda tradicional, estación, fm, grupera]
   broadcaster: independent
   name: "La Sabrosita (Monterrey) - 95.7 FM - XHRK-FM - Grupo Radio Alegría - Monterrey, NL"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/LASABROSITA_957FMAAC.aac
@@ -191770,7 +191770,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-match-ciudad-de-mexico-99-3-fm-xhpop-fm-grupo-ac
-  tags: [99.3, 99.3 fm, acir, cdmx, ciudad de méxico, estación, fm, grupo acir]
+  tags: ["99.3", 99.3 fm, acir, cdmx, ciudad de méxico, estación, fm, grupo acir]
   broadcaster: independent
   name: Match Ciudad de México - 99.3 FM - XHPOP-FM - Grupo ACIR - Ciudad de México
   streamUrl: https://16603.live.streamtheworld.com:443/XHPOPFMAAC.aac
@@ -191802,7 +191802,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-formula-melodica-guadalajara-97-9-fm-xetia-fm-gr
-  tags: [97.9, 97.9 fm, balada, balada en español, balada pop, baladas, baladas en español, estación]
+  tags: ["97.9", 97.9 fm, balada, balada en español, balada pop, baladas, baladas en español, estación]
   broadcaster: independent
   name: "Fórmula Melódica (Guadalajara) - 97.9 FM - XETIA-FM - Grupo Unidifusión - Guadalajara, JC"
   streamUrl: https://s2.yesstreaming.net:9085/stream
@@ -191882,7 +191882,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-radio-formula-103-3-fm-xerfr-fm-grupo-formula-ci
-  tags: [103.3, 103.3 fm, ciudad de mexico, ciudad de méxico, ciudad mexico, entretenimiento, estación, fm]
+  tags: ["103.3", 103.3 fm, ciudad de mexico, ciudad de méxico, ciudad mexico, entretenimiento, estación, fm]
   broadcaster: independent
   name: Radio Fórmula - 103.3 FM - XERFR-FM - Grupo Fórmula - Ciudad de México
   streamUrl: https://mdstrm.com/audio/6102ce7ef33d0b0830ec3adc/live.m3u8
@@ -191914,7 +191914,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-mejor-monterrey-92-5-fm-xhsro-fm-mvs-radio-mo
-  tags: [92.5, 92.5 fm, banda, banda norteña, banda tradicional, estación, fm, grupera]
+  tags: ["92.5", 92.5 fm, banda, banda norteña, banda tradicional, estación, fm, grupera]
   broadcaster: independent
   name: "La Mejor Monterrey - 92.5 FM - XHSRO-FM - MVS Radio - Monterrey, NL"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XHSROFM_SC
@@ -191978,7 +191978,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-w-radio-san-luis-potosi-100-1-fm-xhpm-fm-globalm
-  tags: [100.1, 100.1 fm, estación, fm, globalmedia, mex, mexico, mx]
+  tags: ["100.1", 100.1 fm, estación, fm, globalmedia, mex, mexico, mx]
   favicon: "https://www.globalmedia.mx/assets/favicon/apple-touch-icon-e3be40001a772e7d3c8486aedd7b55cf7211916d6fc9ce7fac6ed6efe8b7688d.png"
   broadcaster: independent
   name: "W Radio San Luis Potosí - 100.1 FM - XHPM-FM - GlobalMedia - San Luis Potosí, SL"
@@ -192230,7 +192230,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-bestia-grupera-ciudad-de-mexico-540-am-xewf-a
-  tags: [540, 540 am, am, banda, banda norteña, banda tradicional, cdmx, ciudad de mexico]
+  tags: ["540", 540 am, am, banda, banda norteña, banda tradicional, cdmx, ciudad de mexico]
   broadcaster: independent
   name: "La Bestia Grupera (Ciudad de México) - 540 AM - XEWF-AM - Radiorama - Tlalmanalco, EM"
   streamUrl: https://ss1.audiorama.com.mx:6584/
@@ -192260,7 +192260,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-octava-ciudad-de-mexico-88-1-fm-xhred-fm-grup
-  tags: [88.1, 88.1 fm, adult contemporary, cdmx, ciudad de mexico, ciudad de méxico, clasicos, clasicos en ingles]
+  tags: ["88.1", 88.1 fm, adult contemporary, cdmx, ciudad de mexico, ciudad de méxico, clasicos, clasicos en ingles]
   favicon: "https://editorial.laoctava.com/wp-content/uploads/2020/12/logo-laoctava-2-2x-2.png"
   broadcaster: independent
   name: LA OCTAVA (Ciudad de México) - 88.1 FM - XHRED-FM - Grupo Radio Centro - Ciudad de México
@@ -192276,7 +192276,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-ranchera-aguascalientes-106-1-fm-xhltz-fm-gru
-  tags: [106.1, 106.1 fm, aguascalientes, entretenimiento, español, estación, fm, grupera]
+  tags: ["106.1", 106.1 fm, aguascalientes, entretenimiento, español, estación, fm, grupera]
   favicon: "https://grupozer.mx/images/favicon.png"
   broadcaster: independent
   name: "La Ranchera (Aguascalientes) - 106.1 FM - XHLTZ-FM - Grupo Radiofónico ZER - Aguascalientes, AG"
@@ -192292,7 +192292,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-amor-puebla-103-3-fm-xhrh-fm-grupo-acir-puebla-p
-  tags: [103.3, 103.3 fm, acir, amor, amor sólo música romántica, balada, balada en español, baladas]
+  tags: ["103.3", 103.3 fm, acir, amor, amor sólo música romántica, balada, balada en español, baladas]
   broadcaster: independent
   name: "Amor Puebla - 103.3 FM - XHRH-FM - Grupo ACIR - Puebla, PU"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XHRHFMAAC.aac
@@ -192308,7 +192308,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-abc-deportes-monterrey-92-1-fm-660-am-xhgbo-fm-x
-  tags: [92.1, 92.1 fm, abc deportes, deporte, deportes, estación, fm, general escobedo]
+  tags: ["92.1", 92.1 fm, abc deportes, deporte, deportes, estación, fm, general escobedo]
   broadcaster: independent
   name: "ABC Deportes (Monterrey) - 92.1 FM / 660 AM - XHGBO-FM / XEFZ-AM - Grupo Radio Alegría - General Bravo / Monterrey, NL"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/ABC_NOTICIAS_660AM.mp3
@@ -192356,7 +192356,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-radio-centro-y-el-fonografo-690-am-xen-am-grupo-
-  tags: [690, 690 am, am, ciudad de mexico, ciudad de méxico, ciudad mexico, el fonógrafo, español]
+  tags: ["690", 690 am, am, ciudad de mexico, ciudad de méxico, ciudad mexico, el fonógrafo, español]
   favicon: "https://upload.wikimedia.org/wikipedia/commons/a/a8/Logo_Radio_Centro.png"
   broadcaster: independent
   name: Radio Centro y El Fonógrafo - 690 AM - XEN-AM - Grupo Radio Centro - Ciudad de México
@@ -192387,7 +192387,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-radio-ranchito-morelia-102-5-fm-xhrpa-fm-grupo-u
-  tags: [102.5, 102.5 fm, entretenimiento, estación, fm, grupo ultra, latino américa, latinoamerica]
+  tags: ["102.5", 102.5 fm, entretenimiento, estación, fm, grupo ultra, latino américa, latinoamerica]
   broadcaster: independent
   name: "Radio Ranchito (Morelia) - 102.5 FM - XHRPA-FM - Grupo ULTRA - Morelia, MI"
   streamUrl: https://ranchito.b-cdn.net/stream
@@ -192403,7 +192403,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-radio-formula-970-am-xerfr-am-grupo-formula-ciud
-  tags: [970, 970 am, am, cdmx, ciudad de mexico, ciudad de méxico, ciudad mexico, entretenimiento]
+  tags: ["970", 970 am, am, cdmx, ciudad de mexico, ciudad de méxico, ciudad mexico, entretenimiento]
   broadcaster: independent
   name: Radio Fórmula - 970 AM - XERFR-AM - Grupo Fórmula - Ciudad de México
   streamUrl: https://mdstrm.com/audio/61e1e0125e404b0836c1e402/live.m3u8
@@ -192435,7 +192435,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-radio-formula-1470-am-xeai-am-grupo-formula-ciud
-  tags: [1470, 1470 am, am, ciudad de mexico, ciudad de méxico, ciudad mexico, entretenimiento, estación]
+  tags: ["1470", 1470 am, am, ciudad de mexico, ciudad de méxico, ciudad mexico, entretenimiento, estación]
   broadcaster: independent
   name: Radio Fórmula - 1470 AM - XEAI-AM - Grupo Fórmula - Ciudad de México
   streamUrl: https://mdstrm.com/audio/602196cd0607850695f31cd8/live.m3u8
@@ -192481,7 +192481,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-mejor-guadalajara-95-5-fm-xhro-fm-mvs-radio-g
-  tags: [95.5, 95.5 fm, aquí nomás, banda, banda norteña, banda tradicional, estación, fm]
+  tags: ["95.5", 95.5 fm, aquí nomás, banda, banda norteña, banda tradicional, estación, fm]
   broadcaster: independent
   name: "La Mejor Guadalajara - 95.5 FM - XHRO-FM - MVS Radio - Guadalajara, JC"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XHRO_SC
@@ -192497,7 +192497,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-buena-onda-guadalajara-101-9-fm-xead-fm-grupo
-  tags: [101.9, 101.9 fm, balada, balada en español, balada pop, baladas, baladas en español, estación]
+  tags: ["101.9", 101.9 fm, balada, balada en español, balada pop, baladas, baladas en español, estación]
   broadcaster: independent
   name: "La Buena Onda (Guadalajara) - 101.9 FM - XEAD-FM - Grupo Unidifusión - Guadalajara, JC"
   streamUrl: https://s2.yesstreaming.net:9094/stream
@@ -192513,7 +192513,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-inolvidable-perote-101-1-fm-xhper-fm-rradiotl
-  tags: [101.1, 101.1 fm, avanradio, balada, balada en español, balada pop, baladas, baladas en español]
+  tags: ["101.1", 101.1 fm, avanradio, balada, balada en español, balada pop, baladas, baladas en español]
   broadcaster: independent
   name: "La Inolvidable (Perote) - 101.1 FM - XHPER-FM - RRADIOTL, A.C. - Perote, VE"
   streamUrl: https://streaming.servicioswebmx.com/8078/stream
@@ -192529,7 +192529,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-exa-fm-ciudad-de-mexico-104-9-fm-xhexa-fm-mvs-ra
-  tags: [104.9, 104.9 fm, cdmx, ciudad de méxico, dresden, entretenimiento, exa, exa fm]
+  tags: ["104.9", 104.9 fm, cdmx, ciudad de méxico, dresden, entretenimiento, exa, exa fm]
   broadcaster: independent
   name: Exa FM Ciudad de México - 104.9 FM - XHEXA-FM - MVS Radio - Ciudad de México
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XHEXAAAC.aac
@@ -192545,7 +192545,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-fm-globo-mexicali-101-9-fm-xhpf-fm-mvs-radio-mex
-  tags: [101.9, 101.9 fm, baja california, balada, balada en español, balada pop, baladas, baladas en español]
+  tags: ["101.9", 101.9 fm, baja california, balada, balada en español, balada pop, baladas, baladas en español]
   broadcaster: independent
   name: "FM Globo Mexicali - 101.9 FM - XHPF-FM - MVS Radio - Mexicali, BC"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XHPFFMAAC.aac
@@ -192577,7 +192577,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-antologia-vallenata-xeh-14-20-monterrey-1420-am-
-  tags: [1420, 1420 am, am, colombia vallenata, cumbia, cumbias, estación, grupo radio centro]
+  tags: ["1420", 1420 am, am, colombia vallenata, cumbia, cumbias, estación, grupo radio centro]
   broadcaster: independent
   name: "Antología Vallenata, XEH 14-20 (Monterrey) - 1420 AM - XEH-AM - Grupo Radio Centro - Monterrey, NL"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XEH_AMAAC.aac
@@ -192592,7 +192592,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-abc-noticias-monterrey-570-am-xebjb-am-grupo-rad
-  tags: [570, 570 am, abc noticias, am, clasicos, clasicos en ingles, classic hits, classics]
+  tags: ["570", 570 am, abc noticias, am, clasicos, clasicos en ingles, classic hits, classics]
   broadcaster: independent
   name: "ABC Noticias (Monterrey) - 570 AM - XEBJB-AM - Grupo Radio Alegría - Monterrey, NL"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/REGIONAL_MEXICANA_570AM.mp3
@@ -192624,7 +192624,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-ke-buena-guadalajara-97-1-fm-xeba-fm-radiopol
-  tags: [97.1, 97.1 fm, banda, estación, fm, gdl, grupera, guadalajara]
+  tags: ["97.1", 97.1 fm, banda, estación, fm, gdl, grupera, guadalajara]
   broadcaster: independent
   name: "La Ke Buena Guadalajara - 97.1 FM - XEBA-FM - Radiópolis - Guadalajara, JC"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/KEBUENA_GDL_SC
@@ -192655,7 +192655,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-radio-unam-fm-ciudad-de-mexico-96-1-fm-xeun-fm-u
-  tags: [96.1, 96.1 fm, ciudad de méxico, college, college radio, cultura, cultural, cultural mexico]
+  tags: ["96.1", 96.1 fm, ciudad de méxico, college, college radio, cultura, cultural, cultural mexico]
   favicon: "https://www.radio.unam.mx/wp-content/uploads/2016/09/cropped-icono_RU-180x180.png"
   broadcaster: independent
   name: Radio UNAM FM (Ciudad de México) - 96.1 FM - XEUN-FM - UNAM (Universidad Autónoma de México) - Ciudad de México
@@ -192687,7 +192687,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-radio-disney-ciudad-de-mexico-92-1-fm-xhfo-fm-gr
-  tags: [92.1, 92.1 fm, ciudad de méxico, disney, entretenimiento, estación, familia, fm]
+  tags: ["92.1", 92.1 fm, ciudad de méxico, disney, entretenimiento, estación, familia, fm]
   favicon: "https://cdn-web.tunein.com/assets/img/apple-touch-icon-180.png"
   broadcaster: independent
   name: Radio Disney Ciudad de México - 92.1 FM - XHFO-FM - Grupo Siete - Ciudad de México
@@ -192703,7 +192703,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-jalisco-radio-fm-guadalajara-96-3-fm-xejb-fm-gob
-  tags: [107.1, 107.1 fm, 96.3, 96.3 fm, ciudad guzmán, cultura, cultural, cultural mexico]
+  tags: ["107.1", 107.1 fm, "96.3", 96.3 fm, ciudad guzmán, cultura, cultural, cultural mexico]
   favicon: "https://jaliscotv.com/wp-content/uploads/2025/09/favicon-300x300.webp"
   broadcaster: independent
   name: "Jalisco Radio (FM) (Guadalajara) - 96.3 FM - XEJB-FM - Gobierno del Estado de Jalisco - Guadalajara, JC"
@@ -192735,7 +192735,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-radio-formula-1500-am-xedf-am-grupo-formula-ciud
-  tags: [1500, 1500 am, am, ciudad de mexico, ciudad de méxico, ciudad mexico, entretenimiento, entrevistas]
+  tags: ["1500", 1500 am, am, ciudad de mexico, ciudad de méxico, ciudad mexico, entretenimiento, entrevistas]
   broadcaster: independent
   name: Radio Fórmula - 1500 AM - XEDF-AM - Grupo Fórmula - Ciudad de México
   streamUrl: https://mdstrm.com/audio/61e1e00417181d3a42851257/live.m3u8
@@ -192751,7 +192751,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-mejor-leon-99-9-fm-xhso-fm-mvs-radio-leon-gt
-  tags: [99.9, 99.9 fm, aquí nomás, banda, banda norteña, banda tradicional, estación, fm]
+  tags: ["99.9", 99.9 fm, aquí nomás, banda, banda norteña, banda tradicional, estación, fm]
   broadcaster: independent
   name: "La Mejor León - 99.9 FM - XHSO-FM - MVS Radio - León, GT"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XHSOFM_SC
@@ -192783,7 +192783,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-ke-buena-merida-90-9-fm-xhmqm-fm-cadena-rasa-
-  tags: [90.9, 90.9 fm, banda, banda norteña, banda tradicional, estación, fm, grupera]
+  tags: ["90.9", 90.9 fm, banda, banda norteña, banda tradicional, estación, fm, grupera]
   favicon: "https://cadenarasa.com/uploads/banners/596-portada-ke-buena-2023.png"
   broadcaster: independent
   name: "La Ke Buena Mérida - 90.9 FM - XHMQM-FM - Cadena RASA - Mérida, YU"
@@ -192829,7 +192829,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-mix-cancun-93-1-fm-xhyi-fm-grupo-acir-cancun-qr
-  tags: [2000s, 2010s, 580, 580 am, 80s, 90s, 90s y más, 93.1]
+  tags: [2000s, 2010s, "580", 580 am, 80s, 90s, 90s y más, "93.1"]
   broadcaster: independent
   name: "MIX Cancún - 93.1 FM - XHYI-FM - Grupo ACIR - Cancún, QR"
   streamUrl: https://18243.live.streamtheworld.com:443/XHYIFMAAC.aac
@@ -192845,7 +192845,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-premier-91-7-monterrey-91-7-fm-xhxl-fm-grupo-rad
-  tags: [91.7, 91.7 fm, balada en español, baladas en español, español, estación, fm, grupo radio alegría]
+  tags: ["91.7", 91.7 fm, balada en español, baladas en español, español, estación, fm, grupo radio alegría]
   favicon: "https://premier917.fm/wp-content/uploads/2021/11/cropped-Logo-PremierNuevo_Mesa-de-trabajo-1-180x180.png"
   broadcaster: independent
   name: "PREMIER 91.7 (Monterrey) - 91.7 FM - XHXL-FM - Grupo Radio Alegría - Monterrey, NL"
@@ -192892,7 +192892,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-exa-fm-mexicali-91-5-fm-xhjc-fm-mvs-radio-mexica
-  tags: [91.5, 91.5 fm, baja california, estación, exa, exa fm, fm, juvenil]
+  tags: ["91.5", 91.5 fm, baja california, estación, exa, exa fm, fm, juvenil]
   broadcaster: independent
   name: "Exa FM Mexicali - 91.5 FM - XHJC-FM - MVS Radio - Mexicali, BC"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XHJCFM_SC
@@ -192938,7 +192938,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-fm-globo-monterrey-88-1-fm-xhjm-fm-mvs-radio-mon
-  tags: [88.1, 88.1 fm, adult hits, estación, fm, fm globo, hits, latin pop]
+  tags: ["88.1", 88.1 fm, adult hits, estación, fm, fm globo, hits, latin pop]
   broadcaster: independent
   name: "FM Globo Monterrey - 88.1 FM - XHJM-FM - MVS Radio - Monterrey, NL"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XHJMFM_SC
@@ -192984,7 +192984,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-mejor-cuernavaca-97-3-fm-xhvz-fm-mvs-radio-cu
-  tags: [97.3, 97.3 fm, aquí nomás, banda, banda norteña, banda tradicional, cuernavaca, estación]
+  tags: ["97.3", 97.3 fm, aquí nomás, banda, banda norteña, banda tradicional, cuernavaca, estación]
   broadcaster: independent
   name: "La Mejor Cuernavaca - 97.3 FM - XHVZ-FM - MVS Radio - Cuernavaca, MO"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XHVZ_SC
@@ -193000,7 +193000,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-match-puebla-90-1-fm-xhrs-fm-grupo-acir-puebla-p
-  tags: [90.1, 90.1 fm, acir, estación, fm, grupo acir, iheart, iheart radio]
+  tags: ["90.1", 90.1 fm, acir, estación, fm, grupo acir, iheart, iheart radio]
   broadcaster: independent
   name: "Match Puebla - 90.1 FM - XHRS-FM - Grupo ACIR - Puebla, PU"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XHRSFMAAC.aac
@@ -193016,7 +193016,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-bestia-grupera-cuautla-104-5-fm-xhcu-fm-grupo
-  tags: [104.5, 104.5 fm, banda, banda norteña, banda tradicional, cuautla, estación, fm]
+  tags: ["104.5", 104.5 fm, banda, banda norteña, banda tradicional, cuautla, estación, fm]
   broadcaster: independent
   name: "La Bestia Grupera (Cuautla) - 104.5 FM - XHCU-FM - Grupo Audiorama Comunicaciones - Cuautla, MO"
   streamUrl: https://ss1.audiorama.com.mx:6624/
@@ -193032,7 +193032,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-mejor-veracruz-100-5-fm-xhve-fm-mvs-radio-ver
-  tags: [100.5, 100.5 fm, aquí nomás, banda, boca del río, estación, fm, grupera]
+  tags: ["100.5", 100.5 fm, aquí nomás, banda, boca del río, estación, fm, grupera]
   broadcaster: independent
   name: "La Mejor Veracruz - 100.5 FM - XHVE-FM - MVS Radio - Veracruz, VE"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XHVEFMAAC.aac
@@ -193064,7 +193064,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-fiera-veracruz-94-1-fm-xhhv-fm-grupo-pazos-ve
-  tags: [94.1, 94.1 fm, boca del río, estación, fm, grupera, grupo pazos, la fiera]
+  tags: ["94.1", 94.1 fm, boca del río, estación, fm, grupera, grupo pazos, la fiera]
   favicon: "https://www.lafiera.mx/img/imgplayerfacebook.jpg"
   broadcaster: independent
   name: "La Fiera Veracruz - 94.1 FM - XHHV-FM - Grupo Pazos - Veracruz, VE"
@@ -193080,7 +193080,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-exitos-matamoros-91-3-fm-xhmls-fm-grupo-radio-av
-  tags: [91.3, 91.3 fm, brownsville, entretenimiento, estación, fm, juvenil, latinoamérica]
+  tags: ["91.3", 91.3 fm, brownsville, entretenimiento, estación, fm, juvenil, latinoamérica]
   broadcaster: independent
   name: "Éxitos (Matamoros) - 91.3 FM - XHMLS-FM - Grupo Radio Avanzado - Matamoros, Tamaulipas"
   streamUrl: https://ice8.securenetsystems.net/EXITO913
@@ -193096,7 +193096,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-crystal-valle-de-mexico-103-7-fm-xhcme-fm-grupo-
-  tags: [103.7, 103.7 fm, cdmx, ciudad de mexico, ciudad de méxico, ciudad mexico, coacalco, crystal]
+  tags: ["103.7", 103.7 fm, cdmx, ciudad de mexico, ciudad de méxico, ciudad mexico, coacalco, crystal]
   favicon: "https://cdn.onlineradiobox.com/img/l/5/14465.v13.png"
   broadcaster: independent
   name: "Crystal (Valle de México) - 103.7 FM - XHCME-FM - Grupo Siete - Coacalco / Melchor Ocampo, EM"
@@ -193112,7 +193112,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-mix-toluca-90-1-fm-xheno-fm-grupo-acir-toluca-em
-  tags: [2000s, 2010s, 80s, 90.1, 90.1 fm, 90.1 mix, 90s, acir]
+  tags: [2000s, 2010s, 80s, "90.1", 90.1 fm, 90.1 mix, 90s, acir]
   broadcaster: independent
   name: "MIX Toluca - 90.1 FM - XHENO-FM Grupo ACIR - Toluca, EM"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XHENOFMAAC.aac
@@ -193128,7 +193128,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-tremenda-durango-96-5-fm-xhdng-fm-grupo-garza
-  tags: [96.5, 96.5 fm, durango, estación, fm, grupera, grupero, grupo garza limón]
+  tags: ["96.5", 96.5 fm, durango, estación, fm, grupera, grupero, grupo garza limón]
   broadcaster: independent
   name: "La Tremenda (Durango) - 96.5 FM - XHDNG-FM - Grupo Garza Limón - Durango, DG"
   streamUrl: https://radio.latremenda.com.mx/Durango
@@ -193207,7 +193207,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-fm-globo-guadalajara-98-7-fm-xhlc-fm-mvs-radio-g
-  tags: [98.7, 98.7 fm, balada, balada en español, balada pop, baladas, baladas en español, classics]
+  tags: ["98.7", 98.7 fm, balada, balada en español, balada pop, baladas, baladas en español, classics]
   broadcaster: independent
   name: "FM Globo Guadalajara - 98.7 FM - XHLC-FM - MVS Radio - Guadalajara, JC"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XHLCFM_SC
@@ -193223,7 +193223,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-los40-queretaro-90-1-fm-xhpsji-fm-globalmedia-sa
-  tags: [90.1, 90.1 fm, entretenimiento, español, estación, fm, globalmedia, guanajuato]
+  tags: ["90.1", 90.1 fm, entretenimiento, español, estación, fm, globalmedia, guanajuato]
   broadcaster: independent
   name: "LOS40 Querétaro - 90.1 FM - XHPSJI-FM - GlobalMedia - San José Iturbide, GT"
   streamUrl: https://playradio.mx/proxy/los40jose?mp=/stream
@@ -193239,7 +193239,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-zeta-navojoa-88-9-fm-xhens-fm-uniradio-navojo
-  tags: ["1980's", 1980s, 1990s, 2000-2021, 2000er, 2000s, 70 80 hits, 80]
+  tags: ["1980's", 1980s, 1990s, 2000-2021, 2000er, 2000s, 70 80 hits, "80"]
   broadcaster: independent
   name: "La Zeta (Navojoa) - 88.9 FM - XHENS-FM - Uniradio - Navojoa, SO"
   streamUrl: https://streamingcwsradio30.com:7032/stream
@@ -193287,7 +193287,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-amor-toluca-92-5-fm-xhrj-fm-grupo-acir-toluca-em
-  tags: [92.5, 92.5 fm, acir, amor, amor sólo música romántica, balada, balada en español, baladas]
+  tags: ["92.5", 92.5 fm, acir, amor, amor sólo música romántica, balada, balada en español, baladas]
   broadcaster: independent
   name: "Amor Toluca - 92.5 FM - XHRJ-FM - Grupo ACIR - Toluca, EM"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XHRJFMAAC.aac
@@ -193303,7 +193303,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-gigante-piedras-negras-ver-95-3-fm-xhgn-fm-pi
-  tags: [95.3, 95.3 fm, estación, fm, grupera, grupero, la gigante, mex]
+  tags: ["95.3", 95.3 fm, estación, fm, grupera, grupero, la gigante, mex]
   broadcaster: independent
   name: "La Gigante (Piedras Negras, Ver.) - 95.3 FM - XHGN-FM - Piedras Negras, VE"
   streamUrl: https://s2.yesstreaming.net:17103/stream
@@ -193318,7 +193318,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-comadre-puebla-105-5-fm-xhhit-fm-grupo-acir-p
-  tags: [105.5, 105.5 fm, acir, banda, estación, fm, grupera, grupo acir]
+  tags: ["105.5", 105.5 fm, acir, banda, estación, fm, grupera, grupo acir]
   broadcaster: independent
   name: "La Comadre Puebla - 105.5 FM - XHHIT-FM - Grupo ACIR - Puebla, PU"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XEHIT_SC.aac
@@ -193334,7 +193334,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-mix-puebla-91-7-fm-xhrc-fm-grupo-acir-puebla-pu
-  tags: [2000s, 2010s, 80s, 90s, 91.7, 91.7 fm, acir, estación]
+  tags: [2000s, 2010s, 80s, 90s, "91.7", 91.7 fm, acir, estación]
   broadcaster: independent
   name: "MIX Puebla - 91.7 FM - XHRC-FM - Grupo ACIR - Puebla, PU"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XHRCFMAAC.aac
@@ -193350,7 +193350,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-oye-89-7-89-7-fm-xeoye-fm-nrm-comunicaciones-ciu
-  tags: [89.7, 89.7 fm, cdmx, ciudad de mexico, ciudad de méxico, entretenimiento, estación, fm]
+  tags: ["89.7", 89.7 fm, cdmx, ciudad de mexico, ciudad de méxico, entretenimiento, estación, fm]
   broadcaster: independent
   name: OYE 89.7 - 89.7 FM - XEOYE-FM - NRM Comunicaciones - Ciudad de México
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XEOYEFMAAC.aac
@@ -193428,7 +193428,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-radio-unam-am-ciudad-de-mexico-860-am-xeun-am-un
-  tags: [860, 860 am, am, ciudad de méxico, college, college radio, cultura, cultural]
+  tags: ["860", 860 am, am, ciudad de méxico, college, college radio, cultura, cultural]
   favicon: "https://www.radio.unam.mx/wp-content/uploads/2016/09/cropped-icono_RU-180x180.png"
   broadcaster: independent
   name: Radio UNAM AM (Ciudad de México) - 860 AM - XEUN-AM - UNAM (Universidad Autónoma de México) - Ciudad de México
@@ -193459,7 +193459,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-super-mexicali-89-9-fm-xhsol-fm-grupo-audiorama-
-  tags: [89.9, 89.9 fm, baja california, entretenimiento, estación, fm, grupo audiorama comunicaciones, juvenil]
+  tags: ["89.9", 89.9 fm, baja california, entretenimiento, estación, fm, grupo audiorama comunicaciones, juvenil]
   broadcaster: independent
   name: "SUPER (Mexicali) - 89.9 FM - XHSOL-FM - Grupo Audiorama Comunicaciones - Mexicali, BC"
   streamUrl: https://ss1.audiorama.com.mx:6590/super
@@ -193474,7 +193474,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-ke-buena-acayucan-93-9-fm-xhevz-fm-acayucan-v
-  tags: [93.9, 93.9 fm, acayucan, banda, estación, fm, grupera, la ke buena]
+  tags: ["93.9", 93.9 fm, acayucan, banda, estación, fm, grupera, la ke buena]
   broadcaster: independent
   name: "La Ke Buena Acayucan - 93.9 FM - XHEVZ-FM - Acayucan, VE"
   streamUrl: https://secure.radiorama.mx:2170/
@@ -193490,7 +193490,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-w-radio-queretaro-1310-am-xeqrmd-am-globalmedia-
-  tags: [1310, 1310 am, "1980's", 1980s, 1990s, 70 80 hits, 80, "80's"]
+  tags: ["1310", 1310 am, "1980's", 1980s, 1990s, 70 80 hits, "80", "80's"]
   favicon: "https://www.globalmedia.mx/assets/favicon/apple-touch-icon-e3be40001a772e7d3c8486aedd7b55cf7211916d6fc9ce7fac6ed6efe8b7688d.png"
   broadcaster: independent
   name: "W Radio Querétaro - 1310 AM - XEQRMD-AM - GlobalMedia - Querétaro, QT"
@@ -193553,7 +193553,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-comadre-pachuca-104-5-fm-xhrd-fm-grupo-acir-p
-  tags: [104.5, 104.5 fm, acir, banda, estación, fm, grupera, grupo acir]
+  tags: ["104.5", 104.5 fm, acir, banda, estación, fm, grupera, grupo acir]
   broadcaster: independent
   name: "La Comadre Pachuca - 104.5 FM - XHRD-FM - Grupo ACIR - Pachuca, HG"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XHRDAAC.aac
@@ -193569,7 +193569,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-exa-fm-veracruz-93-3-fm-xhps-fm-mvs-radio-veracr
-  tags: [93.3, 93.3 fm, boca del río, en todas partes, exa, exa fm, fm, juvenil]
+  tags: ["93.3", 93.3 fm, boca del río, en todas partes, exa, exa fm, fm, juvenil]
   broadcaster: independent
   name: "Exa FM Veracruz - 93.3 FM - XHPS-FM - MVS Radio - Veracruz, VE"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XHPSFM_SC.aac
@@ -193633,7 +193633,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-fusion-veracruz-90-1-fm-xhll-fm-grupo-pazos-vera
-  tags: [90.1, 90.1 fm, boca del río, fm, grupo pazos, mex, mexico, mx]
+  tags: ["90.1", 90.1 fm, boca del río, fm, grupo pazos, mex, mexico, mx]
   broadcaster: independent
   name: "Fusión Veracruz - 90.1 FM - XHLL-FM - Grupo Pazos - Veracruz, VE"
   streamUrl: https://sgaudio.centrocibernetico.com/fusion
@@ -193649,7 +193649,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-mejor-hermosillo-98-5-fm-xhbh-fm-mvs-radio-he
-  tags: [98.5, 98.5 fm, aquí nomás, banda, banda norteña, banda tradicional, estación, fm]
+  tags: ["98.5", 98.5 fm, aquí nomás, banda, banda norteña, banda tradicional, estación, fm]
   broadcaster: independent
   name: "La Mejor Hermosillo - 98.5 FM - XHBH-FM - MVS Radio - Hermosillo, SO"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XHBH_SC
@@ -193664,7 +193664,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-exa-fm-san-juan-del-rio-99-1-fm-xhvi-fm-san-juan
-  tags: [99.1, 99.1 fm, balada pop, estación, exa, exa fm, fm, juvenil]
+  tags: ["99.1", 99.1 fm, balada pop, estación, exa, exa fm, fm, juvenil]
   broadcaster: independent
   name: "Exa FM San Juan del Río - 99.1 FM - XHVI-FM - San Juan del Río, Querétaro"
   streamUrl: https://tv.radiohosting.online:8352/stream
@@ -193680,7 +193680,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-exa-fm-guadalajara-101-1-fm-xhma-fm-mvs-radio-gu
-  tags: [101.1, 101.1 fm, entretenimiento, estación, exa, exa fm, fm, guadalajara]
+  tags: ["101.1", 101.1 fm, entretenimiento, estación, exa, exa fm, fm, guadalajara]
   broadcaster: independent
   name: "Exa FM Guadalajara - 101.1 FM - XHMA-FM - MVS Radio - Guadalajara, JC"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XHMAAAC.aac
@@ -193696,7 +193696,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-xeu-la-u-de-veracruz-98-1-fm-xhu-fm-grupo-pazos-
-  tags: [98.1, 98.1 fm, boca del río, deporte, deportes, entretenimiento, estación, fm]
+  tags: ["98.1", 98.1 fm, boca del río, deporte, deportes, entretenimiento, estación, fm]
   favicon: "https://xeu.mx/imgcontenido/logo-xeu-new.jpg"
   broadcaster: independent
   name: "XEU La \"U\" de Veracruz - 98.1 FM - XHU-FM - Grupo Pazos - Veracruz, VE"
@@ -193711,7 +193711,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-ke-buena-san-luis-potosi-105-7-fm-xhbm-fm-glo
-  tags: [105.7, 105.7 fm, banda, fm, globalmedia, grupera, la ke buena, mex]
+  tags: ["105.7", 105.7 fm, banda, fm, globalmedia, grupera, la ke buena, mex]
   favicon: "https://www.globalmedia.mx/assets/favicon/apple-touch-icon-e3be40001a772e7d3c8486aedd7b55cf7211916d6fc9ce7fac6ed6efe8b7688d.png"
   broadcaster: independent
   name: "La Ke Buena San Luis Potosí - 105.7 FM - XHBM-FM - GlobalMedia - San Luis Potosí, SL"
@@ -193727,7 +193727,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-mejor-puerto-vallarta-99-9-fm-xhcjx-fm-mvs-ra
-  tags: [99.9, 99.9 fm, aquí nomás, banda, banda norteña, banda tradicional, entretenimiento, español]
+  tags: ["99.9", 99.9 fm, aquí nomás, banda, banda norteña, banda tradicional, entretenimiento, español]
   broadcaster: independent
   name: "La Mejor Puerto Vallarta - 99.9 FM - XHCJX-FM - MVS Radio - Puerto Vallarta, JC"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XHCJX_SC
@@ -193789,7 +193789,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-mix-puerto-vallarta-92-7-fm-xhvay-fm-grupo-acir-
-  tags: [2000s, 2010s, 80s, 90s, 90s y más, 92.7, 92.7 fm, acir]
+  tags: [2000s, 2010s, 80s, 90s, 90s y más, "92.7", 92.7 fm, acir]
   broadcaster: independent
   name: "MIX Puerto Vallarta - 92.7 FM - XHVAY-FM - Grupo ACIR - Puerto Vallarta, JC"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XHVAYFMAAC.aac
@@ -193821,7 +193821,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-bestia-grupera-leon-90-3-fm-xhml-f-20cf3116
-  tags: [90.3, 90.3 fm, banda, banda norteña, banda tradicional, estación, fm, grupera]
+  tags: ["90.3", 90.3 fm, banda, banda norteña, banda tradicional, estación, fm, grupera]
   broadcaster: independent
   name: "La Bestia Grupera (León) - 90.3 FM - XHML-FM - Grupo Audiorama Comunicaciones - León, GT"
   streamUrl: https://ss1.audiorama.com.mx:6636/
@@ -193836,7 +193836,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-mix-morelia-101-7-fm-xhemm-fm-grupo-acir-morelia
-  tags: [101.7, 101.7 fm, acir, estación, fm, grupo acir, iheart, iheart radio]
+  tags: ["101.7", 101.7 fm, acir, estación, fm, grupo acir, iheart, iheart radio]
   broadcaster: independent
   name: "MIX Morelia - 101.7 FM - XHEMM-FM - Grupo ACIR - Morelia, MI"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XHEMMAAC.aac
@@ -193852,7 +193852,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-pasion-fm-puebla-104-3-fm-xhpue-fm-cinco-radio-p
-  tags: [104.3, 104.3 fm, balada, balada en español, balada pop, baladas, baladas en español, cinco radio]
+  tags: ["104.3", 104.3 fm, balada, balada en español, balada pop, baladas, baladas en español, cinco radio]
   broadcaster: independent
   name: "Pasión FM (Puebla) - 104.3 FM - XHPUE-FM - Cinco Radio - Puebla, PU"
   streamUrl: https://stream.zeno.fm/1qhuwrman5zuv
@@ -193883,7 +193883,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-octava-sports-107-3-hd2-xeqr-fm-grupo-radio-c
-  tags: [107.3, 107.3 fm, ciudad de mexico, ciudad de méxico, ciudad mexico, deporte, deportes, estación]
+  tags: ["107.3", 107.3 fm, ciudad de mexico, ciudad de méxico, ciudad mexico, deporte, deportes, estación]
   favicon: "https://editorial.laoctava.com/wp-content/uploads/2020/12/logo-laoctava-2-2x-2.png"
   broadcaster: independent
   name: LA OCTAVA SPORTS - 107.3 HD2 - XEQR-FM - Grupo Radio Centro - Ciudad de México
@@ -193899,7 +193899,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-bestia-grupera-mexicali-92-3-fm-xh-40653893
-  tags: [92.3, 92.3 fm, baja california, banda, banda norteña, banda tradicional, estación, fm]
+  tags: ["92.3", 92.3 fm, baja california, banda, banda norteña, banda tradicional, estación, fm]
   broadcaster: independent
   name: "La Bestia Grupera (Mexicali) - 92.3 FM - XHMMF-FM - Grupo Audiorama Comunicaciones - Mexicali, BC"
   streamUrl: https://ss1.audiorama.com.mx:6592/
@@ -193914,7 +193914,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-los40-guadalajara-102-7-fm-xehl-fm-radiopolis-gu
-  tags: [102.7, 102.7 fm, entretenimiento, estación, fm, guadalajara, jalisco, juvenil]
+  tags: ["102.7", 102.7 fm, entretenimiento, estación, fm, guadalajara, jalisco, juvenil]
   broadcaster: independent
   name: "LOS40 Guadalajara - 102.7 FM - XEHL-FM - Radiópolis - Guadalajara, JC"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/LOS40_GDLAAC.aac
@@ -193976,7 +193976,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-radio-lobo-san-jose-iturbide-88-3-fm-xhsji-fm-co
-  tags: [88.3, 88.3 fm, banda, banda norteña, banda tradicional, corporación bajío comunicaciones, estación, fm]
+  tags: ["88.3", 88.3 fm, banda, banda norteña, banda tradicional, corporación bajío comunicaciones, estación, fm]
   broadcaster: independent
   name: "Radio Lobo (San José Iturbide) - 88.3 FM - XHSJI-FM - Corporación Bajío Comunicaciones - San José Iturbide, GT"
   streamUrl: https://radios.radiohd.com.mx/8270/;
@@ -193992,7 +193992,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-amor-guadalajara-93-1-fm-xhpi-fm-grupo-acir-guad
-  tags: [93.1, 93.1 fm, acir, amor, amor sólo música romántica, balada, balada en español, baladas]
+  tags: ["93.1", 93.1 fm, acir, amor, amor sólo música romántica, balada, balada en español, baladas]
   favicon: "https://www.iheart.com/static/assets/apple-touch-icon.png"
   broadcaster: independent
   name: "Amor Guadalajara - 93.1 FM - XHPI-FM - Grupo ACIR - Guadalajara, JC"
@@ -194040,7 +194040,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-exa-fm-tijuana-91-7-fm-xhglx-fm-mvs-radio-tijuan
-  tags: [91.7, 91.7 fm, baja california, california, estación, exa, exa fm, fm]
+  tags: ["91.7", 91.7 fm, baja california, california, estación, exa, exa fm, fm]
   broadcaster: independent
   name: "Exa FM Tijuana - 91.7 FM - XHGLX-FM - MVS Radio - Tijuana, BC"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XHGLXAAC.aac
@@ -194056,7 +194056,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-digital-102-9-monterrey-102-9-fm-xhmg-fm-grupo-r
-  tags: [102.9, 102.9 fm, contemporary hits, estación, fm, hits, juvenil, latin music]
+  tags: ["102.9", 102.9 fm, contemporary hits, estación, fm, hits, juvenil, latin music]
   broadcaster: independent
   name: "Digital 102-9 (Monterrey) - 102.9 FM - XHMG-FM - Grupo Radio Alegría - Monterrey, NL"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/DIGITAL_1029FMAAC.aac
@@ -194072,7 +194072,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-comadre-culiacan-98-5-fm-xhcli-fm-grupo-acir-
-  tags: [98.5, 98.5 fm, acir, banda, culiacán, estación, fm, grupera]
+  tags: ["98.5", 98.5 fm, acir, banda, culiacán, estación, fm, grupera]
   favicon: "https://www.iheart.com/static/assets/apple-touch-icon.png"
   broadcaster: independent
   name: "La Comadre Culiacán - 98.5 FM - XHCLI-FM - Grupo ACIR - Culiacán, SI"
@@ -194088,7 +194088,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-ke-buena-puerto-vallarta-95-9-fm-xhcju-fm-glo
-  tags: [95.9, 95.9 fm, banda, estación, fm, globalmedia, grupera, la ke buena]
+  tags: ["95.9", 95.9 fm, banda, estación, fm, globalmedia, grupera, la ke buena]
   broadcaster: independent
   name: "La Ke Buena Puerto Vallarta - 95.9 FM - XHCJU-FM - GlobalMedia - Puerto Vallarta, JC"
   streamUrl: https://kebuenavalla.b-cdn.net/stream
@@ -194150,7 +194150,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-mix-san-luis-potosi-98-5-fm-xhqk-fm-grupo-acir-s
-  tags: [2000s, 2010s, 80s, 90s, 90s y más, 98.5, 98.5 fm, acir]
+  tags: [2000s, 2010s, 80s, 90s, 90s y más, "98.5", 98.5 fm, acir]
   broadcaster: independent
   name: "MIX San Luis Potosí - 98.5 FM - XHQK-FM - Grupo ACIR - San Luis Potosí, SL"
   streamUrl: https://14943.live.streamtheworld.com:443/XHQKFMAAC.aac
@@ -194166,7 +194166,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-radio-omega-ciudad-de-mexico-830-am-xeite-am-igl
-  tags: [830, 830 am, am, cdmx, ciudad de mexico, ciudad de méxico, ciudad mexico, cristian]
+  tags: ["830", 830 am, am, cdmx, ciudad de mexico, ciudad de méxico, ciudad mexico, cristian]
   broadcaster: independent
   name: Radio Omega (Ciudad de México) - 830 AM - XEITE-AM - Iglesia Universal del Reino de Dios - Ciudad de México
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XEITEAAC.aac
@@ -194182,7 +194182,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-lupe-zacatecas-93-3-fm-xhexz-fm-grupo-radiofonic
-  tags: [93.3, 93.3 fm, banda, banda norteña, banda tradicional, entretenimiento, español, estación]
+  tags: ["93.3", 93.3 fm, banda, banda norteña, banda tradicional, entretenimiento, español, estación]
   broadcaster: independent
   name: "Lupe (Zacatecas) - 93.3 FM - XHEXZ-FM - Grupo Radiofónico ZER - Guadalupe, ZA"
   streamUrl: https://cast.zuperdns.net/8010/stream/
@@ -194198,7 +194198,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-mundo-cuernavaca-96-5-fm-xhjmg-fm-grupo-mundo-co
-  tags: ["1980's", 1980s, "80's", 80s, 96.5, 96.5 fm, balada, balada en español]
+  tags: ["1980's", 1980s, "80's", 80s, "96.5", 96.5 fm, balada, balada en español]
   broadcaster: independent
   name: "Mundo (Cuernavaca) - 96.5 FM - XHJMG-FM - Grupo Mundo Comunicaciones - Cuernavaca, MO"
   streamUrl: https://tv.radiohosting.online:8556/stream
@@ -194229,7 +194229,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-lider-stereo-zer-zacatecas-96-5-fm-xhzer-fm-g
-  tags: [96.5, 96.5 fm, estación, fm, grupo radiofónico zer, la líder, la líder stereo zer, mex]
+  tags: ["96.5", 96.5 fm, estación, fm, grupo radiofónico zer, la líder, la líder stereo zer, mex]
   favicon: "https://grupozer.mx/images/favicon.png"
   broadcaster: independent
   name: "La Líder Stereo ZER (Zacatecas) - 96.5 FM - XHZER-FM - Grupo Radiofónico ZER - Zacatecas, ZA"
@@ -194260,7 +194260,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-mix-pachuca-92-5-fm-xhpk-fm-grupo-acir-pachuca-h
-  tags: [2000s, 2010s, 80s, 90s, 90s y más, 92.5, 92.5 fm, acir]
+  tags: [2000s, 2010s, 80s, 90s, 90s y más, "92.5", 92.5 fm, acir]
   broadcaster: independent
   name: "MIX Pachuca - 92.5 FM - XHPK-FM - Grupo ACIR - Pachuca, HG"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XHPKFMAAC.aac
@@ -194276,7 +194276,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-trion-san-luis-90-1-fm-xhsmr-fm-globalmedia-san-
-  tags: [90.1, 90.1 fm, alternative, alternative rock, estación, fm, grupo fórmula, indie]
+  tags: ["90.1", 90.1 fm, alternative, alternative rock, estación, fm, grupo fórmula, indie]
   broadcaster: independent
   name: "Trión San Luis - 90.1 FM - XHSMR-FM - GlobalMedia - San Luis Potosí, SL"
   streamUrl: https://trion.b-cdn.net/stream
@@ -194323,7 +194323,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-kaliente-aguascalientes-102-9-fm-xhey-fm-grup
-  tags: [102.9, 102.9 fm, aguascalientes, banda norteña, entretenimiento, español, estación, fm]
+  tags: ["102.9", 102.9 fm, aguascalientes, banda norteña, entretenimiento, español, estación, fm]
   favicon: "https://grupozer.mx/images/favicon.png"
   broadcaster: independent
   name: "La Kaliente (Aguascalientes) - 102.9 FM - XHEY-FM - Grupo Radiofónico ZER - Aguascalientes, AG"
@@ -194354,7 +194354,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-ke-buena-campeche-102-7-fm-xhac-fm-ncs-nucleo
-  tags: [102.7, 102.7 fm, banda, campeche, estación, fm, grupera, la ke buena]
+  tags: ["102.7", 102.7 fm, banda, campeche, estación, fm, grupera, la ke buena]
   broadcaster: independent
   name: "La Ke Buena Campeche - 102.7 FM - XHAC-FM - NCS (Núcleo Comunicación del Sureste) - Campeche, CM"
   streamUrl: https://sp2.servidorrprivado.com:10887/
@@ -194385,7 +194385,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-canal-58-guadalajara-580-am-xeav-am-radio-canon-
-  tags: [580, 580 am, abc radio, am, estación, gdl, grupo radio cañón, guadalajara]
+  tags: ["580", 580 am, abc radio, am, estación, gdl, grupo radio cañón, guadalajara]
   favicon: "https://www.canal58.net/wp-content/uploads/2022/04/cropped-logo.jpg"
   broadcaster: independent
   name: "Canal 58 (Guadalajara) - 580 AM - XEAV-AM - Radio Cañón / NTR Medios de Comunicación - Guadalajara, JC"
@@ -194448,7 +194448,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-mejor-merida-90-1-fm-xhqw-fm-mvs-radio-merida
-  tags: [90.1, 90.1 fm, aquí nomás, estación, fm, grupera, la mejor, la mejor aquí nomás]
+  tags: ["90.1", 90.1 fm, aquí nomás, estación, fm, grupera, la mejor, la mejor aquí nomás]
   broadcaster: independent
   name: "La Mejor Mérida - 90.1 FM - XHQW-FM - MVS Radio - Mérida, YU"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XHQW_SC
@@ -194464,7 +194464,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-mejor-torreon-estereo-gallito-97-1-fm-xhpe-fm
-  tags: [97.1, 97.1 fm, aquí nomás, banda, banda norteña, banda tradicional, coahuila, entretenimiento]
+  tags: ["97.1", 97.1 fm, aquí nomás, banda, banda norteña, banda tradicional, coahuila, entretenimiento]
   broadcaster: independent
   name: "La Mejor Torreón (Estéreo Gallito) - 97.1 FM - XHPE-FM - Grupo Radio Estéreo Mayran - Torreón, CO"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XHPE_SC
@@ -194479,7 +194479,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-mix-leon-103-1-fm-xhxf-fm-grupo-acir-leon-gt
-  tags: [103.1, 103.1 fm, 2000s, 2010s, 80s, 90s, 90s y más, acir]
+  tags: ["103.1", 103.1 fm, 2000s, 2010s, 80s, 90s, 90s y más, acir]
   broadcaster: independent
   name: "MIX León - 103.1 FM - XHXF-FM - Grupo ACIR - León, GT"
   streamUrl: https://14623.live.streamtheworld.com:443/XHXFAAC.aac
@@ -194589,7 +194589,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-vox-love-station-san-luis-potosi-96-9-fm-xhod-fm
-  tags: [96.9, 96.9 fm, entretenimiento, estación, fm, globalmedia, mex, mexico]
+  tags: ["96.9", 96.9 fm, entretenimiento, estación, fm, globalmedia, mex, mexico]
   favicon: "https://www.globalmedia.mx/assets/favicon/apple-touch-icon-e3be40001a772e7d3c8486aedd7b55cf7211916d6fc9ce7fac6ed6efe8b7688d.png"
   broadcaster: independent
   name: "VOX Love Station San Luis Potosí - 96.9 FM - XHOD-FM - GlobalMedia - San Luis Potosí, SL"
@@ -194653,7 +194653,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-poderosa-aguascalientes-107-7-fm-xhyz-fm-radi
-  tags: [107.7, 107.7 fm, aguascalientes, estación, fm, grupera, grupero, la poderosa]
+  tags: ["107.7", 107.7 fm, aguascalientes, estación, fm, grupera, grupero, la poderosa]
   broadcaster: independent
   name: "La Poderosa (Aguascalientes) - 107.7 FM - XHYZ-FM - Radiogrupo - Aguascalientes, AG"
   streamUrl: https://secure.radiorama.mx:2001/
@@ -194668,7 +194668,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-amor-queretaro-97-9-fm-xhqto-fm-grupo-acir-quere
-  tags: [97.9, 97.9 fm, acir, amor, amor sólo música romántica, balada, balada en español, baladas]
+  tags: ["97.9", 97.9 fm, acir, amor, amor sólo música romántica, balada, balada en español, baladas]
   broadcaster: independent
   name: "Amor Querétaro - 97.9 FM - XHQTO-FM - Grupo ACIR - Querétaro, QT"
   streamUrl: https://27163.live.streamtheworld.com:443/XHQTOAAC.aac
@@ -194714,7 +194714,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-1030-am-ciudad-de-mexico-1030-am-xeqr-am-grupo-r
-  tags: [1030, 1030 am, am, ciudad de mexico, ciudad de méxico, ciudad mexico, deporte, deportes]
+  tags: ["1030", 1030 am, am, ciudad de mexico, ciudad de méxico, ciudad mexico, deporte, deportes]
   favicon: "https://pwaimg.listenlive.co/XEQR_AM_1885301_config_station_logo_image_1692720039.png"
   broadcaster: independent
   name: 1030 AM (Ciudad de México) - 1030 AM - XEQR-AM - Grupo Radio Centro - Ciudad de México
@@ -194730,7 +194730,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-candela-san-luis-potosi-94-1-fm-xhrasa-fm-cadena
-  tags: [94.1, 94.1 fm, cadena rasa, candela, cumbia, cumbias, entretenimiento, estación]
+  tags: ["94.1", 94.1 fm, cadena rasa, candela, cumbia, cumbias, entretenimiento, estación]
   broadcaster: independent
   name: "Candela (San Luis Potosí) - 94.1 FM - XHRASA-FM - Cadena RASA - San Luis Potosí, SL"
   streamUrl: https://stream-156.zeno.fm/q8mt825e0chvv?zt=eyJhbGciOiJIUzI1NiJ9.eyJzdHJlYW0iOiJxOG10ODI1ZTBjaHZ2IiwiaG9zdCI6InN0cmVhbS0xNTYuemVuby5mbSIsInRtIjpmYWxzZSwicnR0bCI6NSwianRpIjoiOV9GMzBka0ZUNW0xZGctS2VUNkRLQSIsImlhdCI6MTc2ODQ1MzQ0OCwiZXhwIjoxNzY4NDUzNTA4fQ.1_kyyY7R2vxwxjgAEUYjh3iwRWSDoQKKILwwbJ5bbPc
@@ -194760,7 +194760,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-mejor-ciudad-obregon-103-3-fm-xhvjs-fm-radio-
-  tags: [103.3, 103.3 fm, aquí nomás, banda, banda norteña, banda tradicional, ciudad obregón, estación]
+  tags: ["103.3", 103.3 fm, aquí nomás, banda, banda norteña, banda tradicional, ciudad obregón, estación]
   broadcaster: independent
   name: "La Mejor Ciudad Obregón - 103.3 FM - XHVJS-FM - Radio Grupo García de León - Ciudad Obregón, SO"
   streamUrl: https://streamingcwsradio30.com:7058/;
@@ -194776,7 +194776,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-los40-mexicali-90-7-fm-xhmoe-fm-radiopolis-mexic
-  tags: [90.7, 90.7 fm, baja california, entretenimiento, estación, fm, juvenil, los40]
+  tags: ["90.7", 90.7 fm, baja california, entretenimiento, estación, fm, juvenil, los40]
   broadcaster: independent
   name: "LOS40 Mexicali - 90.7 FM - XHMOE-FM - Radiópolis - Mexicali, BC"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/LOS40_MEXICO2AAC.aac
@@ -194792,7 +194792,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-los40-san-luis-potosi-103-9-fm-xhewa-fm-globalme
-  tags: [103.9, 103.9 fm, entretenimiento, estación, fm, globalmedia, juvenil, los40]
+  tags: ["103.9", 103.9 fm, entretenimiento, estación, fm, globalmedia, juvenil, los40]
   broadcaster: independent
   name: "LOS40 San Luis Potosí - 103.9 FM - XHEWA-FM - GlobalMedia - San Luis Potosí, SL"
   streamUrl: https://los40.b-cdn.net/stream
@@ -194824,7 +194824,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-unica-fresnillo-103-3-fm-xhih-fm-torres-corpo
-  tags: [103.3, 103.3 fm, estación, fm, fresnillo, la única, mex, mexico]
+  tags: ["103.3", 103.3 fm, estación, fm, fresnillo, la única, mex, mexico]
   broadcaster: independent
   name: "La Única Fresnillo - 103.3 FM - XHIH-FM - Torres Corporativo - Fresnillo, ZA"
   streamUrl: https://radioforte.com/8006/stream
@@ -194872,7 +194872,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-uam-radio-ciudad-de-mexico-94-1-fm-xhuam-fm-uam-
-  tags: [94.9, 94.9 fm, ciudad de mexico, ciudad de méxico, ciudad mexico, college, college radio, estación]
+  tags: ["94.9", 94.9 fm, ciudad de mexico, ciudad de méxico, ciudad mexico, college, college radio, estación]
   favicon: "https://uamradio.uam.mx/wp-content/uploads/2023/10/cropped-Favicon2-180x180.jpeg"
   broadcaster: independent
   name: UAM Radio (Ciudad de México) - 94.1 FM - XHUAM-FM - UAM (Universidad Autónoma Metropolitana) - Ciudad de México
@@ -194904,7 +194904,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-radiomas-orizaba-105-5-fm-xhoba-fm-rtv-radio-tel
-  tags: [105.5, 105.5 fm, cordoba, córdoba, estación, fm, fortín de las flores, gobierno del estado de veracruz]
+  tags: ["105.5", 105.5 fm, cordoba, córdoba, estación, fm, fortín de las flores, gobierno del estado de veracruz]
   favicon: "https://www.radiomas.mx/wp-content/themes/radiomas_v4/favicon.png"
   broadcaster: independent
   name: "RadioMás (Orizaba) - 105.5 FM - XHOBA-FM - RTV (Radio Televisión de Veracruz) - La Perla / Orizaba, VE"
@@ -194936,7 +194936,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-mejor-culiacan-104-1-fm-xhecq-fm-gpm-grupo-pr
-  tags: [104.1, 104.1 fm, aquí nomás, banda, banda norteña, banda tradicional, estación, fm]
+  tags: ["104.1", 104.1 fm, aquí nomás, banda, banda norteña, banda tradicional, estación, fm]
   broadcaster: independent
   name: "La Mejor Culiacán - 104.1 FM - XHECQ-FM - GPM (Grupo Promomedios) - Culiacán, SI"
   streamUrl: https://icy.gvstream.live/gpm-cq.aac
@@ -194952,7 +194952,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-ola-tuxpan-91-5-fm-xhtl-fm-tuxpan-ve
-  tags: [91.5, 91.5 fm, balada pop, entretenimiento, español, estación, fm, juvenil]
+  tags: ["91.5", 91.5 fm, balada pop, entretenimiento, español, estación, fm, juvenil]
   broadcaster: independent
   name: "La Ola (Tuxpan) - 91.5 FM - XHTL-FM - Tuxpan, VE"
   streamUrl: https://sp3.servidorrprivado.com:10972/
@@ -195043,7 +195043,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-exa-fm-tampico-95-3-fm-xhox-fm-mvs-radio-tampico
-  tags: [95.3, 95.3 fm, entretenimiento, estación, exa, exa fm, fm, juvenil]
+  tags: ["95.3", 95.3 fm, entretenimiento, estación, exa, exa fm, fm, juvenil]
   broadcaster: independent
   name: "Exa FM Tampico - 95.3 FM - XHOX-FM - MVS Radio - Tampico, TM"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XHOXAAC.aac
@@ -195091,7 +195091,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-xeu-veracruz-98-1-fm-xhu-fm-grupo-pazos-radio-ve
-  tags: [98.1, 98.1 fm, boca del río, deporte, deportes, entretenimiento, estación, fm]
+  tags: ["98.1", 98.1 fm, boca del río, deporte, deportes, entretenimiento, estación, fm]
   favicon: "https://xeu.mx/imgcontenido/logo-xeu-new.jpg"
   broadcaster: independent
   name: "XEU (Veracruz) - 98.1 FM - XHU-FM - Grupo Pazos Radio - Veracruz, VE"
@@ -195123,7 +195123,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-mas-picuda-cuernavaca-94-9-fm-xhsw-fm-radiora
-  tags: [94.9, 94.9 fm, cuernavaca, estación, fm, grupera, grupero, la más picuda]
+  tags: ["94.9", 94.9 fm, cuernavaca, estación, fm, grupera, grupero, la más picuda]
   broadcaster: independent
   name: "La Más Picuda (Cuernavaca) - 94.9 FM - XHSW-FM - Radiorama - Cuernavaca, MO"
   streamUrl: https://server2.sit-mexico.com:2199/proxy/xhsw
@@ -195216,7 +195216,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-super-stereo-merida-105-9-fm-xhfcy-fm-grupo-radi
-  tags: [105.9, 105.9 fm, adult hits, contemporary hits, estación, exitos, fm, hits]
+  tags: ["105.9", 105.9 fm, adult hits, contemporary hits, estación, exitos, fm, hits]
   broadcaster: independent
   name: "Super Stereo (Mérida) - 105.9 FM - XHFCY-FM - Grupo Radio Digital - Mérida, YU"
   streamUrl: https://stream.zeno.fm/130pyk2xr98uv
@@ -195230,7 +195230,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-buenisiima-acapulco-103-9-fm-xhpo-fm-grupo-audio
-  tags: [103.9, 103.9 fm, acapulco, buenisiima, entretenimiento, estación, fm, guerrero]
+  tags: ["103.9", 103.9 fm, acapulco, buenisiima, entretenimiento, estación, fm, guerrero]
   favicon: "https://cdn.onlineradiobox.com/img/l/5/49665.v12.png"
   broadcaster: independent
   name: "Buenisiima (Acapulco) - 103.9 FM - XHPO-FM - Grupo Audiorama Comunicaciones - Acapulco, GR"
@@ -195246,7 +195246,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-mejor-puerto-escondido-94-1-fm-xhedo-fm-puert
-  tags: [94.1, 94.1 fm, aquí nomás, banda, banda norteña, banda tradicional, entretenimiento, español]
+  tags: ["94.1", 94.1 fm, aquí nomás, banda, banda norteña, banda tradicional, entretenimiento, español]
   broadcaster: independent
   name: "La Mejor Puerto Escondido - 94.1 FM - XHEDO-FM - Puerto Escondido, OA"
   streamUrl: https://stream9.mexiserver.com:7120/
@@ -195277,7 +195277,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-exa-fm-leon-104-1-fm-xhmd-fm-mvs-radio-leon-gt
-  tags: [104.1, 104.1 fm, entretenimiento, estación, exa, exa fm, fm, guanajuato]
+  tags: ["104.1", 104.1 fm, entretenimiento, estación, exa, exa fm, fm, guanajuato]
   broadcaster: independent
   name: "Exa FM León - 104.1 FM - XHMD-FM - MVS Radio - León, GT"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XHMDFM_SC
@@ -195309,7 +195309,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-radio-vital-guadalajara-1310-am-xetia-am-grupo-u
-  tags: [1310, 1310 am, am, entretenimiento, estación, gdl, grupo unidifusión, guadalajara]
+  tags: ["1310", 1310 am, am, entretenimiento, estación, gdl, grupo unidifusión, guadalajara]
   broadcaster: independent
   name: "Radio Vital (Guadalajara) - 1310 AM - XETIA-AM - Grupo Unidifusión - Tonalá / Guadalajara, JC"
   streamUrl: https://s2.yesstreaming.net:9097/stream
@@ -195325,7 +195325,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-exa-fm-el-paso-98-3-fm-xhpx-fm-mvs-radio-ciudad-
-  tags: [98.3, 98.3 fm, chihuahua, ciudad juárez, el paso, entretenimiento, estación, exa]
+  tags: ["98.3", 98.3 fm, chihuahua, ciudad juárez, el paso, entretenimiento, estación, exa]
   broadcaster: independent
   name: "Exa FM El Paso - 98.3 FM - XHPX-FM - MVS Radio - Ciudad Juárez, CH"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XHPX_SC
@@ -195341,7 +195341,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-mejor-acapulco-100-1-fm-xhse-fm-mvs-radio-aca
-  tags: [100.1, 100.1 fm, acapulco, aquí nomás, banda, banda norteña, banda tradicional, estación]
+  tags: ["100.1", 100.1 fm, acapulco, aquí nomás, banda, banda norteña, banda tradicional, estación]
   broadcaster: independent
   name: "La Mejor Acapulco - 100.1 FM - XHSE-FM - MVS Radio - Acapulco, GR"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XHSE_SC.aac
@@ -195373,7 +195373,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-los40-san-luis-potosi-540-am-xewa-am-globalmedia
-  tags: [103.9, 103.9 fm, 540, 540 am, adult top 40, entretenimiento, estación, fm]
+  tags: ["103.9", 103.9 fm, "540", 540 am, adult top 40, entretenimiento, estación, fm]
   broadcaster: independent
   name: "LOS40 San Luis Potosí - 540 AM - XEWA-AM - GlobalMedia - San Luis Potosí, SL"
   streamUrl: https://playradio.mx/proxy/los40?mp=/stream
@@ -195421,7 +195421,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-amor-es-aguascalientes-104-5-fm-xhdc-fm-grupo-ra
-  tags: [104.5, 104.5 fm, 80s en español, balada, balada en español, balada pop, baladas, baladas en español]
+  tags: ["104.5", 104.5 fm, 80s en español, balada, balada en español, balada pop, baladas, baladas en español]
   favicon: "https://grupozer.mx/images/favicon.png"
   broadcaster: independent
   name: "AMOR es (Aguascalientes) - 104.5 FM - XHDC-FM - Grupo Radiofónico ZER - Aguascalientes, AG"
@@ -195437,7 +195437,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-fm-globo-tijuana-99-3-fm-xhocl-fm-mvs-radio-tiju
-  tags: [99.3, 99.3 fm, baja california, balada, balada en español, baladas, baladas en español, fm]
+  tags: ["99.3", 99.3 fm, baja california, balada, balada en español, baladas, baladas en español, fm]
   broadcaster: independent
   name: "FM Globo Tijuana - 99.3 FM - XHOCL-FM - MVS Radio - Tijuana, BC"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XHOCLAAC.aac
@@ -195453,7 +195453,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-match-culiacan-100-1-fm-xhcna-fm-grupo-acir-culi
-  tags: [100.1, 100.1 fm, acir, culiacán, iheart, match, mex, mx]
+  tags: ["100.1", 100.1 fm, acir, culiacán, iheart, match, mex, mx]
   broadcaster: independent
   name: "Match Culiacán - 100.1 FM - XHCNA-FM - Grupo ACIR - Culiacán, SI"
   streamUrl: https://18423.live.streamtheworld.com:443/XHCNAFM_SC
@@ -195500,7 +195500,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-digital-106-5-zacatecas-106-5-fm-xhlk-fm-grupo-r
-  tags: [106.5, 106.5 fm, digital, entretenimiento, estación, fm, grupo radiofónico zer, grupo zer]
+  tags: ["106.5", 106.5 fm, digital, entretenimiento, estación, fm, grupo radiofónico zer, grupo zer]
   broadcaster: independent
   name: "Digital 106.5 (Zacatecas) - 106.5 FM - XHLK-FM - Grupo Radiofónico ZER - Zacatecas, ZA"
   streamUrl: https://cast.zuperdns.net/8020/stream/
@@ -195531,7 +195531,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-mejor-manzanillo-96-3-fm-xhecs-fm-manzanillo-
-  tags: [96.3, 96.3 fm, aquí nomás, banda, banda norteña, banda tradicional, colima, entretenimiento]
+  tags: ["96.3", 96.3 fm, aquí nomás, banda, banda norteña, banda tradicional, colima, entretenimiento]
   broadcaster: independent
   name: "La Mejor Manzanillo - 96.3 FM - XHECS-FM - Manzanillo, CL"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XHVGFM_SC
@@ -195562,7 +195562,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-amor-101-guaymas-101-3-fm-630-am-xhfx-fm-xefx-am
-  tags: [101.3, 101.3 fm, 630, 630 am, amor 101, combo, combos, entretenimiento]
+  tags: ["101.3", 101.3 fm, "630", 630 am, amor 101, combo, combos, entretenimiento]
   favicon: "https://amor101.com/wp-content/uploads/2024/01/cropped-cropped-favicon-1-180x180.png"
   broadcaster: independent
   name: "Amor 101 (Guaymas) - 101.3 FM / 630 AM - XHFX-FM / XEFX-AM - Grupo ASVA - Guaymas, SO"
@@ -195593,7 +195593,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-exa-fm-puebla-94-1-fm-xhje-fm-mvs-radio-puebla-p
-  tags: [94.1, 94.1 fm, entretenimiento, estación, exa, exa fm, fm, juvenil]
+  tags: ["94.1", 94.1 fm, entretenimiento, estación, exa, exa fm, fm, juvenil]
   broadcaster: independent
   name: "Exa FM Puebla - 94.1 FM - XHJE-FM - MVS Radio - Puebla, PU"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XHJEFMAAC.aac
@@ -195609,7 +195609,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-bestia-grupera-chihuahua-99-3-fm-xhrpc-fm-gru
-  tags: [99.3, 99.3 fm, banda, banda norteña, banda tradicional, chihuahua, estación, fm]
+  tags: ["99.3", 99.3 fm, banda, banda norteña, banda tradicional, chihuahua, estación, fm]
   broadcaster: independent
   name: "La Bestia Grupera (Chihuahua) - 99.3 FM - XHRPC-FM - Grupo Audiorama Comunicaciones - Chihuahua, CH"
   streamUrl: https://ss1.audiorama.com.mx:6646/
@@ -195655,7 +195655,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-los40-xalapa-104-1-fm-xhgr-fm-xalapa-ve
-  tags: [104.1, 104.1 fm, avanradio, estación, fm, juvenil, los40, mex]
+  tags: ["104.1", 104.1 fm, avanradio, estación, fm, juvenil, los40, mex]
   broadcaster: independent
   name: "LOS40 Xalapa - 104.1 FM - XHGR-FM - Xalapa, VE"
   streamUrl: https://streaming.servicioswebmx.com/8138/stream
@@ -195687,7 +195687,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-mejor-aguascalientes-93-7-fm-xhagt-fm-radio-u
-  tags: [93.7, 93.7 fm, aguascalientes, aquí nomás, banda, banda norteña, banda tradicional, estación]
+  tags: ["93.7", 93.7 fm, aguascalientes, aquí nomás, banda, banda norteña, banda tradicional, estación]
   favicon: "https://www.radiouniversal.mx/assets/images/apple-touch-icon-114x114.png"
   broadcaster: independent
   name: "La Mejor Aguascalientes - 93.7 FM - XHAGT-FM - Radio Universal - Aguascalienteas, AG"
@@ -195719,7 +195719,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-mejor-colima-92-5-fm-xhuu-fm-radio-colima-col
-  tags: [92.5, 92.5 fm, aquí nomás, banda, banda norteña, banda tradicional, colima, estación]
+  tags: ["92.5", 92.5 fm, aquí nomás, banda, banda norteña, banda tradicional, colima, estación]
   broadcaster: independent
   name: "La Mejor Colima - 92.5 FM - XHUU-FM - Radio Colima - Colima, CL"
   streamUrl: https://hls.gvstream.live/lamejor/colima925.stream/playlist.m3u8
@@ -195827,7 +195827,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-exa-fm-campeche-100-3-fm-xhmi-fm-ncs-nucleo-comu
-  tags: [100.3, 100.3 fm, campeche, estación, exa, exa fm, fm, juvenil]
+  tags: ["100.3", 100.3 fm, campeche, estación, exa, exa fm, fm, juvenil]
   broadcaster: independent
   name: "Exa FM Campeche - 100.3 FM - XHMI-FM - NCS (Núcleo Comunicación del Sureste) - Campeche, CM"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XHMI_SC
@@ -195859,7 +195859,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-match-leon-97-5-fm-xhpq-fm-grupo-acir-leon-gt
-  tags: [97.5, 97.5 fm, acir, estación, fm, grupo acir, guanajuato, iheart]
+  tags: ["97.5", 97.5 fm, acir, estación, fm, grupo acir, guanajuato, iheart]
   broadcaster: independent
   name: "Match León - 97.5 FM - XHPQ-FM - Grupo ACIR - León, GT"
   streamUrl: https://14623.live.streamtheworld.com:443/XHPQFMAAC.aac
@@ -195890,7 +195890,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-el-lobo-chihuahua-106-1-fm-xhsu-fm-sistema-radio
-  tags: [106.1, 106.1 fm, chihuahua, clasicos, clasicos en ingles, clásicos, el lobo, estación]
+  tags: ["106.1", 106.1 fm, chihuahua, clasicos, clasicos en ingles, clásicos, el lobo, estación]
   broadcaster: independent
   name: "El Lobo (Chihuahua) - 106.1 FM - XHSU-FM - Sistema Radio Lobo - Chihuahua, CH"
   streamUrl: https://streamingcwsradio30.com/8172/stream
@@ -195906,7 +195906,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-los40-merida-96-9-fm-xhul-fm-cadena-rasa-merida-
-  tags: [96.9, 96.9 fm, cadena rasa, entretenimiento, estación, fm, juvenil, latin pop]
+  tags: ["96.9", 96.9 fm, cadena rasa, entretenimiento, estación, fm, juvenil, latin pop]
   favicon: "https://cadenarasa.com/uploads/banners/706-portada-los-40-2025.png"
   broadcaster: independent
   name: "LOS40 Mérida - 96.9 FM - XHUL-FM - Cadena RASA - Mérida, YU"
@@ -195951,7 +195951,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-mejor-nogales-96-7-fm-xhngs-fm-mvs-radio-noga
-  tags: [96.7, 96.7 fm, aquí nomás, banda, banda norteña, banda tradicional, entretenimiento, español]
+  tags: ["96.7", 96.7 fm, aquí nomás, banda, banda norteña, banda tradicional, entretenimiento, español]
   broadcaster: independent
   name: "La Mejor Nogales - 96.7 FM - XHNGS-FM - MVS Radio - Nogales, SO"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XHNGS_SC
@@ -195967,7 +195967,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-bestia-grupera-chilpancingo-99-7-fm-xhepi-fm-
-  tags: [99.7, 99.7 fm, banda, banda norteña, banda tradicional, chilpancingo, estación, fm]
+  tags: ["99.7", 99.7 fm, banda, banda norteña, banda tradicional, chilpancingo, estación, fm]
   broadcaster: independent
   name: "La Bestia Grupera (Chilpancingo) - 99.7 FM - XHEPI-FM - Grupo Audiorama Comunicaciones - Chilpancingo, GR"
   streamUrl: https://ss1.audiorama.com.mx:6614/
@@ -196075,7 +196075,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-universal-guadalajara-700-am-xedkr-am-grupo-radi
-  tags: [700, 700 am, adult contemporary, am, clasicos, clasicos en ingles, classics, estación]
+  tags: ["700", 700 am, adult contemporary, am, clasicos, clasicos en ingles, classics, estación]
   broadcaster: independent
   name: "UNIVERSAL Guadalajara - 700 AM - XEDKR-AM - Grupo Radio Centro - Guadalajara, JC"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XEDKR_AMAAC.aac
@@ -196090,7 +196090,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-vibe-fm-guadalajara-107-5-fm-xhvoz-fm-grupo-audi
-  tags: [107.5, 107.5 fm, bailable, dance, dance music, edm, edm radioshows, electro]
+  tags: ["107.5", 107.5 fm, bailable, dance, dance music, edm, edm radioshows, electro]
   favicon: "https://www.audioramaguadalajara.mx/wp-content/uploads/2023/08/cropped-Favicon-MX3-180x180.png"
   broadcaster: independent
   name: "Vibe FM (Guadalajara) - 107.5 FM - XHVOZ-FM - Grupo Audiorama Comunicaciones - Guadalajara, JC"
@@ -196136,7 +196136,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-ele-fresnillo-95-1-fm-xhel-fm-torres-corporat
-  tags: [95.1, 95.1 fm, estación, fm, fresnillo, mex, mexico, music]
+  tags: ["95.1", 95.1 fm, estación, fm, fresnillo, mex, mexico, music]
   broadcaster: independent
   name: "La Ele (Fresnillo) - 95.1 FM - XHEL-FM - Torres Corporativo - Fresnillo, ZA"
   streamUrl: https://radioforte.com/8008/stream
@@ -196168,7 +196168,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-buenisiima-mexicali-850-am-xezf-am-grupo-audiora
-  tags: [850, 850 am, adult hits, am, baja california, buenisiima, classic hits, estación]
+  tags: ["850", 850 am, adult hits, am, baja california, buenisiima, classic hits, estación]
   favicon: "https://backend-audiorama-media.s3.amazonaws.com/2024/10/Buenisiima_Mexicali.png"
   broadcaster: independent
   name: "Buenisiima (Mexicali) - 850 AM - XEZF-AM - Grupo Audiorama Comunicaciones - Mexicali, BC"
@@ -196229,7 +196229,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-super-estelar-ciudad-acuna-92-9-fm-xhcdu-fm-grup
-  tags: [92.9, 92.9 fm, ciudad acuna, ciudad acuña, coahuila, grupera, grupero, grupo zócalo]
+  tags: ["92.9", 92.9 fm, ciudad acuna, ciudad acuña, coahuila, grupera, grupero, grupo zócalo]
   favicon: "https://pwaimg.listenlive.co/XHCDUFM_908351_config_station_logo_image_1396280675.png"
   broadcaster: independent
   name: "Super Estelar (Ciudad Acuña) - 92.9 FM - XHCDU-FM - Grupo Zócalo - Ciudad Acuña, CO"
@@ -196245,7 +196245,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-nueva-comitan-92-5-fm-xhfrt-fm-radio-canon-nt
-  tags: [92.5, 92.5 fm, abc radio, banda, banda norteña, banda tradicional, chiapas, comitán]
+  tags: ["92.5", 92.5 fm, abc radio, banda, banda norteña, banda tradicional, chiapas, comitán]
   broadcaster: independent
   name: "La Nueva (Comitán) - 92.5 FM - XHFRT-FM - Radio Cañón / NTR Medios de Comunicación - Comitán, CS"
   streamUrl: https://streaming.servicioswebmx.com/8240/stream
@@ -196260,7 +196260,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-love-fm-guanajuato-101-5-fm-xhvlo-fm-grupo-audio
-  tags: [101.5, 101.5 fm, estación, fm, grupo audiorama comunicaciones, guanajuato, love, love fm]
+  tags: ["101.5", 101.5 fm, estación, fm, grupo audiorama comunicaciones, guanajuato, love, love fm]
   broadcaster: independent
   name: "Love FM (Guanajuato) - 101.5 FM - XHVLO-FM - Grupo Audiorama Comunicaciones - Guanajuato, GT"
   streamUrl: https://ss1.audiorama.com.mx:6632/
@@ -196337,7 +196337,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-los40-veracruz-98-9-fm-xhwb-fm-radiopolis-veracr
-  tags: [98.9, 98.9 fm, entretenimiento, estación, fm, juvenil, los40, mex]
+  tags: ["98.9", 98.9 fm, entretenimiento, estación, fm, juvenil, los40, mex]
   broadcaster: independent
   name: "LOS40 Veracruz - 98.9 FM - XHWB-FM - Radiópolis - Veracruz, VE"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/LOS40_VERAAC.aac
@@ -196352,7 +196352,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-mexiquense-radio-valle-de-bravo-104-5-fm-xhval-f
-  tags: [104.5, 104.5 fm, estación, estado de mexico, estado de méxico, fm, gobierno del estado de méxico, mex]
+  tags: ["104.5", 104.5 fm, estación, estado de mexico, estado de méxico, fm, gobierno del estado de méxico, mex]
   broadcaster: independent
   name: "Mexiquense Radio (Valle de Bravo) - 104.5 FM - XHVAL-FM - Sistema Mexiquense de Medios Públicos - Valle de Bravo, EM"
   streamUrl: https://streamingcwsradio30.com:7048/;
@@ -196382,7 +196382,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-tremenda-fresnillo-98-5-fm-xhyq-fm-grupo-radi
-  tags: [98.5, 98.5 fm, entretenimiento, estación, fm, fresnillo, grupo radiofónico zer, grupo zer]
+  tags: ["98.5", 98.5 fm, entretenimiento, estación, fm, fresnillo, grupo radiofónico zer, grupo zer]
   favicon: "https://grupozer.mx/images/favicon.png"
   broadcaster: independent
   name: "La Tremenda (Fresnillo) - 98.5 FM - XHYQ-FM - Grupo Radiofónico ZER - Fresnillo, ZA"
@@ -196398,7 +196398,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-los40-leon-93-1-fm-xherz-fm-grupo-audiorama-comu
-  tags: [93.1, 93.1 fm, entretenimiento, estación, fm, grupo audiorama comunicaciones, guanajuato, juvenil]
+  tags: ["93.1", 93.1 fm, entretenimiento, estación, fm, grupo audiorama comunicaciones, guanajuato, juvenil]
   broadcaster: independent
   name: "LOS40 León - 93.1 FM - XHERZ-FM - Grupo Audiorama Comunicaciones - León, GT"
   streamUrl: https://ss1.audiorama.com.mx:6634/
@@ -196445,7 +196445,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-92-9-fm-xalapa-92-9-fm-xhjh-fm-radio-canon-ntr-m
-  tags: [92.9, 92.9 fm, abc radio, estación, fm, grupo radio cañón, informativo ntr, mex]
+  tags: ["92.9", 92.9 fm, abc radio, estación, fm, grupo radio cañón, informativo ntr, mex]
   broadcaster: independent
   name: "92.9 FM (Xalapa) - 92.9 FM - XHJH-FM - Radio Cañón / NTR Medios de Comunicación - Xalapa, VE"
   streamUrl: https://streaming.servicioswebmx.com/8294/stream
@@ -196476,7 +196476,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-imagen-san-luis-potosi-103-1-fm-xhepo-fm-globalm
-  tags: [103.1, 103.1 fm, business news, cultural news, deporte, deportes, economic news, estación]
+  tags: ["103.1", 103.1 fm, business news, cultural news, deporte, deportes, economic news, estación]
   broadcaster: independent
   name: "Imagen (San Luis Potosí) - 103.1 FM - XHEPO-FM - GlobalMedia - San Luis Potosí, SL"
   streamUrl: https://imagen.b-cdn.net/stream
@@ -196492,7 +196492,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-sensitiva-88-3-maravatio-88-3-fm-xhpvat-fm-grupo
-  tags: [88.3, 88.3 fm, banda, banda norteña, banda tradicional, fm, grupera, grupero]
+  tags: ["88.3", 88.3 fm, banda, banda norteña, banda tradicional, fm, grupera, grupero]
   broadcaster: independent
   name: "Sensitiva 88.3 (Maravatio) - 88.3 FM - XHPVAT-FM - Grupo LCL Comunicaciones - Maravatío, MI"
   streamUrl: https://server.multimediamb.com/9324/;
@@ -196507,7 +196507,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-super-chilpancingo-102-7-fm-680-am-xhchg-fm-xech
-  tags: [102.7, 102.7 fm, chilpancingo, entretenimiento, estación, fm, grupo audiorama comunicaciones, guerrero]
+  tags: ["102.7", 102.7 fm, chilpancingo, entretenimiento, estación, fm, grupo audiorama comunicaciones, guerrero]
   favicon: "https://backend-audiorama-media.s3.amazonaws.com/2024/10/Super_Chilpancingo.png"
   broadcaster: independent
   name: "SUPER (Chilpancingo) - 102.7 FM / 680 AM - XHCHG-FM / XECHG-AM - Grupo Audiorama Comunicaciones - Chilpancingo, GR"
@@ -196569,7 +196569,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-inolvidable-jerez-90-7-fm-xhjrz-fm-grupo-radiofo
-  tags: [90.7, 90.7 fm, balada, balada en español, baladas, baladas en español, español, estación]
+  tags: ["90.7", 90.7 fm, balada, balada en español, baladas, baladas en español, español, estación]
   favicon: "https://grupozer.mx/images/favicon.png"
   broadcaster: independent
   name: "Inolvidable (Jerez) - 90.7 FM - XHJRZ-FM - Grupo Radiofónico ZER - Jerez, ZA"
@@ -196585,7 +196585,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-grande-de-michoacan-zitacuaro-95-1-fm-xhlx-fm
-  tags: [95.1, 95.1 fm, estación, fm, la grande de michoacán, latinoamérica, michoacán, moi merino]
+  tags: ["95.1", 95.1 fm, estación, fm, la grande de michoacán, latinoamérica, michoacán, moi merino]
   broadcaster: independent
   name: "La Grande de Michoacán (Zitácuaro) - 95.1 FM - XHLX-FM - Zitácuaro, Michoacán"
   streamUrl: https://stream.zeno.fm/5xptpdq1sy8uv
@@ -196600,7 +196600,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-voz-radio-mexicali-101-3-fm-xhabca-fm-radio-c
-  tags: [101.3, 101.3 fm, abc radio, baja california, baladas en ingles, clasicos en ingles, estación, fm]
+  tags: ["101.3", 101.3 fm, abc radio, baja california, baladas en ingles, clasicos en ingles, estación, fm]
   broadcaster: independent
   name: "La Voz Radio (Mexicali) - 101.3 FM - XHABCA-FM - Radio Cañón / NTR Medios de Comunicación - Mexicali, BC"
   streamUrl: https://streaming.servicioswebmx.com/8286/stream
@@ -196678,7 +196678,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-exa-fm-comitan-95-7-fm-xhcts-fm-radio-canon-ntr-
-  tags: [95.7, 95.7 fm, adult top 40, chiapas, comitán, estación, exa, exa fm]
+  tags: ["95.7", 95.7 fm, adult top 40, chiapas, comitán, estación, exa, exa fm]
   broadcaster: independent
   name: "Exa FM Comitán - 95.7 FM - XHCTS-FM - Radio Cañón / NTR Medios de Comunicación - Comitán, CS"
   streamUrl: https://streaming.servicioswebmx.com/8242/stream
@@ -196753,7 +196753,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-radio-canon-mazatlan-98-7-fm-xhvox-fm-radio-cano
-  tags: [98.7, 98.7 fm, estación, fm, grupo radio cañón, mazatlán, mex, mexico]
+  tags: ["98.7", 98.7 fm, estación, fm, grupo radio cañón, mazatlán, mex, mexico]
   broadcaster: independent
   name: "Radio Cañón (Mazatlán) - 98.7 FM - XHVOX-FM - Radio Cañón / NTR Medios de Comunicación - Mazatlán, SI"
   streamUrl: https://streaming.servicioswebmx.com/8276/stream
@@ -196799,7 +196799,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-love-fm-leon-101-5-fm-xhvlo-fm-grupo-audiorama-c
-  tags: [101.5, 101.5 fm, balada, balada en español, balada pop, baladas, baladas en español, español]
+  tags: ["101.5", 101.5 fm, balada, balada en español, balada pop, baladas, baladas en español, español]
   favicon: "https://www.radiorama.mx/images/favicon.ico"
   broadcaster: independent
   name: "Love FM (León) - 101.5 FM - XHVLO-FM - Grupo Audiorama Comunicaciones - León, Guanajuato"
@@ -196815,7 +196815,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-w-radio-vallarta-90-3-fm-xhpva-fm-globalmedia-pu
-  tags: ["1980's", 1980s, 1990s, 70 80 hits, 80, "80's", 80s, 90]
+  tags: ["1980's", 1980s, 1990s, 70 80 hits, "80", "80's", 80s, "90"]
   favicon: "https://www.globalmedia.mx/assets/favicon/apple-touch-icon-e3be40001a772e7d3c8486aedd7b55cf7211916d6fc9ce7fac6ed6efe8b7688d.png"
   broadcaster: independent
   name: "W Radio Vallarta - 90.3 FM - XHPVA-FM - GlobalMedia - Puerto Vallarta, JC"
@@ -196846,7 +196846,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-amor-es-zacatecas-99-3-fm-xhzaz-fm-grupo-radiofo
-  tags: [80s en español, 99.3, 99.3 fm, balada, balada en español, balada pop, baladas, baladas en español]
+  tags: [80s en español, "99.3", 99.3 fm, balada, balada en español, balada pop, baladas, baladas en español]
   favicon: "https://grupozer.mx/images/favicon.png"
   broadcaster: independent
   name: "AMOR es (Zacatecas) - 99.3 FM - XHZAZ-FM - Grupo Radiofónico ZER - Zacatecas, ZA"
@@ -196909,7 +196909,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-mejor-piedras-negras-99-1-fm-xhsl-fm-xh-medio
-  tags: [99.1, 99.1 fm, aquí nomás, banda, banda norteña, banda tradicional, coahuila, entretenimiento]
+  tags: ["99.1", 99.1 fm, aquí nomás, banda, banda norteña, banda tradicional, coahuila, entretenimiento]
   broadcaster: independent
   name: "La Mejor Piedras Negras - 99.1 FM - XHSL-FM - XH Medios - Piedras Negras, CO"
   streamUrl: https://hls.gvstream.live/lamejor/piedrasnegras991.stream/playlist.m3u8
@@ -197003,7 +197003,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-exa-fm-tuxtepec-101-3-fm-xhptux-fm-grupo-rojaz-t
-  tags: [101.3, 101.3 fm, en todas partes, estación, exa, exa fm, fm, grupo rojaz]
+  tags: ["101.3", 101.3 fm, en todas partes, estación, exa, exa fm, fm, grupo rojaz]
   broadcaster: independent
   name: "Exa FM Tuxtepec - 101.3 FM - XHPTUX-FM - Grupo Rojaz - Tuxtepec, OA"
   streamUrl: https://stream5.mexiserver.com:1007/stream
@@ -197080,7 +197080,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-exa-fm-ciudad-obregon-99-3-fm-xhox-fm-radio-grup
-  tags: [99.3, 99.3 fm, ciudad obregón, entretenimiento, estación, exa, exa fm, juvenil]
+  tags: ["99.3", 99.3 fm, ciudad obregón, entretenimiento, estación, exa, exa fm, juvenil]
   broadcaster: independent
   name: "Exa FM Ciudad Obregón - 99.3 FM - XHOX-FM - Radio Grupo García de León - Ciudad Obregón, SO"
   streamUrl: https://streamingcwsradio30.com:7056/
@@ -197096,7 +197096,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-octava-guadalajara-700-am-xedkr-am-grupo-radi
-  tags: [700, 700 am, adult contemporary, am, clasicos, clasicos en ingles, classics, estación]
+  tags: ["700", 700 am, adult contemporary, am, clasicos, clasicos en ingles, classics, estación]
   favicon: "https://editorial.laoctava.com/wp-content/uploads/2020/12/logo-laoctava-2-2x-2.png"
   broadcaster: independent
   name: "LA OCTAVA (Guadalajara) - 700 AM - XEDKR-AM - Grupo Radio Centro - Guadalajara, JC"
@@ -197175,7 +197175,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-exa-fm-cuernavaca-95-7-fm-xhct-fm-mvs-radio-cuer
-  tags: [95.7, 95.7 fm, cuernavaca, entretenimiento, estación, exa, exa fm, fm]
+  tags: ["95.7", 95.7 fm, cuernavaca, entretenimiento, estación, exa, exa fm, fm]
   broadcaster: independent
   name: "Exa FM Cuernavaca - 95.7 FM - XHCT-FM - MVS Radio - Cuernavaca, MO"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XHCTAAC.aac
@@ -197223,7 +197223,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-voz-del-pitic-88-1-fm-xhrmo-fm-democracia-y-d
-  tags: [88.1, 88.1 fm, concesión social, cultura, cultural, estación, fm, hermosillo]
+  tags: ["88.1", 88.1 fm, concesión social, cultura, cultural, estación, fm, hermosillo]
   broadcaster: independent
   name: "La Voz del Pitic - 88.1 FM - XHRMO-FM - Democracia y Deliberación Desértica, A.C. - Hermosillo, SO"
   streamUrl: https://s5.mexside.net:8080/stream
@@ -197239,7 +197239,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-los40-zamora-88-1-fm-xhzn-fm-grupo-radio-zamora-
-  tags: [88.1, 88.1 fm, estación, fm, grupo radio zamora, juvenil, los40, mex]
+  tags: ["88.1", 88.1 fm, estación, fm, grupo radio zamora, juvenil, los40, mex]
   broadcaster: independent
   name: "LOS40 Zamora - 88.1 FM - XHZN-FM - Grupo Radio Zamora - Zamora, MI"
   streamUrl: https://stream.zeno.fm/071em957am8uv
@@ -197254,7 +197254,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-radio-canon-guadalajara-95-9-fm-xhabcj-fm-radio-
-  tags: [70s, 80s, 90s, 95.9, 95.9 fm, abc radio, clasicos en ingles, clásicos]
+  tags: [70s, 80s, 90s, "95.9", 95.9 fm, abc radio, clasicos en ingles, clásicos]
   broadcaster: independent
   name: "Radio Cañón (Guadalajara) - 95.9 FM - XHABCJ-FM - Radio Cañón / NTR Medios de Comunicación - Guadalajara, Jalisco"
   streamUrl: https://streaming.servicioswebmx.com/8272/stream
@@ -197285,7 +197285,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-radio-zacatecas-97-9-fm-xhzh-fm-sizart-sistema-z
-  tags: [97.9, 97.9 fm, cultura, cultural, educativa, estación, fm, mex]
+  tags: ["97.9", 97.9 fm, cultura, cultural, educativa, estación, fm, mex]
   broadcaster: independent
   name: "Radio Zacatecas - 97.9 FM - XHZH-FM - SIZART (Sistema Zacatecano de Radio y Televisión) - Zacatecas, ZA"
   streamUrl: https://streamingcwsradio30.com:7051/;
@@ -197301,7 +197301,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-sensitiva-maravatio-88-3-fm-xhpvat-fm-grupo-lcl-
-  tags: [88.3, 88.3 fm, banda, banda norteña, banda tradicional, fm, grupera, grupero]
+  tags: ["88.3", 88.3 fm, banda, banda norteña, banda tradicional, fm, grupera, grupero]
   broadcaster: independent
   name: "Sensitiva (Maravatio) - 88.3 FM - XHPVAT-FM - Grupo LCL Comunicaciones - Maravatío, MI"
   streamUrl: https://server.multimediamb.com/9324/sensitiva
@@ -197378,7 +197378,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-mexiquense-radio-metepec-1600-am-xege-6333ea9b
-  tags: [1600, 1600 am, am, estación, estado de mexico, estado de méxico, gobierno del estado de méxico, metepec]
+  tags: ["1600", 1600 am, am, estación, estado de mexico, estado de méxico, gobierno del estado de méxico, metepec]
   broadcaster: independent
   name: "Mexiquense Radio (Metepec) - 1600 AM - XEGEM-AM - Sistema Mexiquense de Medios Públicos - Metepec, EM"
   streamUrl: https://streamingcwsradio30.com:7046/;
@@ -197393,7 +197393,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-radio-imer-comitan-107-9-fm-540-am-xhemit-fm-xem
-  tags: [107.9, 107.9 fm, 540, 540 am, am, bachata, balada, balada en español]
+  tags: ["107.9", 107.9 fm, "540", 540 am, am, bachata, balada, balada en español]
   favicon: "https://www.imer.mx/radioimer/wp-content/uploads/sites/25/favicon_radio_imer2023_32.png"
   broadcaster: independent
   name: "Radio IMER (Comitán) - 107.9 FM / 540 AM - XHEMIT-FM / XEMIT-AM - IMER - Comitán, CS"
@@ -197441,7 +197441,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-exa-fm-torreon-95-5-fm-xhmp-fm-grupo-radio-ester
-  tags: [95.5, 95.5 fm, coahuila, en todas partes, entretenimiento, estación, exa, exa fm]
+  tags: ["95.5", 95.5 fm, coahuila, en todas partes, entretenimiento, estación, exa, exa fm]
   broadcaster: independent
   name: "Exa FM Torreón - 95.5 FM - XHMP-FM - Grupo Radio Estéreo Mayran - Torreón, CO"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XHMPAAC.aac
@@ -197456,7 +197456,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-acerera-monclova-88-1-fm-560-am-xhgik-fm-xegi
-  tags: [560, 560 am, 88.1, 88.1 fm, am, coahuila, entretenimiento, estación]
+  tags: ["560", 560 am, "88.1", 88.1 fm, am, coahuila, entretenimiento, estación]
   favicon: "https://lavoz.blob.core.windows.net/images/sitio.png"
   broadcaster: independent
   name: "La Acerera (Monclova) - 88.1 FM / 560 AM - XHGIK-FM / XEGIK-AM - Grupo Kamar - Monclova, CO"
@@ -197504,7 +197504,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-mexiquense-radio-metepec-91-7-fm-xhgem-fm-sistem
-  tags: [91.7, 91.7 fm, estación, estado de mexico, estado de méxico, fm, gobierno del estado de méxico, metepec]
+  tags: ["91.7", 91.7 fm, estación, estado de mexico, estado de méxico, fm, gobierno del estado de méxico, metepec]
   favicon: "https://cdn.onlineradiobox.com/img/l/8/49968.v11.png"
   broadcaster: independent
   name: "Mexiquense Radio (Metepec) - 91.7 FM - XHGEM-FM - Sistema Mexiquense de Medios Públicos - Metepec, EM"
@@ -197520,7 +197520,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-mexiquense-radio-zumpango-88-5-fm-xhzum-fm-siste
-  tags: [88.5, 88.5 fm, estación, estado de mexico, estado de méxico, fm, gobierno del estado de méxico, mex]
+  tags: ["88.5", 88.5 fm, estación, estado de mexico, estado de méxico, fm, gobierno del estado de méxico, mex]
   broadcaster: independent
   name: "Mexiquense Radio (Zumpango) - 88.5 FM - XHZUM-FM - Sistema Mexiquense de Medios Públicos - Zumpango, EM"
   streamUrl: https://streamingcwsradio30.com:7049/;
@@ -197551,7 +197551,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-vida-acapulco-89-7-fm-xhkj-fm-grupo-audiorama-co
-  tags: [89.7, 89.7 fm, acapulco, estación, fm, grupo audiorama comunicaciones, guerrero, latin]
+  tags: ["89.7", 89.7 fm, acapulco, estación, fm, grupo audiorama comunicaciones, guerrero, latin]
   broadcaster: independent
   name: "Vida (Acapulco) - 89.7 FM - XHKJ-FM - Grupo Audiorama Comunicaciones - Acapulco, GR"
   streamUrl: https://ss1.audiorama.com.mx:6610/
@@ -197566,7 +197566,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-exa-fm-merida-99-3-fm-xhmra-fm-mvs-radio-merida-
-  tags: [99.3, 99.3 fm, entretenimiento, estación, exa, exa fm, fm, juvenil]
+  tags: ["99.3", 99.3 fm, entretenimiento, estación, exa, exa fm, fm, juvenil]
   broadcaster: independent
   name: "Exa FM Mérida - 99.3 FM - XHMRA-FM - MVS Radio - Mérida, YU"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XHMRA_SC
@@ -197582,7 +197582,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-love-fm-chihuahua-90-1-fm-xhua-fm-grupo-audioram
-  tags: [90.1, 90.1 fm, balada, balada en español, balada pop, baladas, baladas en español, baladas en ingles]
+  tags: ["90.1", 90.1 fm, balada, balada en español, balada pop, baladas, baladas en español, baladas en ingles]
   broadcaster: independent
   name: "Love FM (Chihuahua) - 90.1 FM - XHUA-FM - Grupo Audiorama Comunicaciones - Chihuahua, CH"
   streamUrl: https://ss1.audiorama.com.mx:6650/
@@ -197803,7 +197803,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-mas-buena-mazatlan-104-3-fm-xhenx-fm-radio-ca
-  tags: [104.3, 104.3 fm, banda, banda norteña, banda tradicional, estación, fm, grupera]
+  tags: ["104.3", 104.3 fm, banda, banda norteña, banda tradicional, estación, fm, grupera]
   broadcaster: independent
   name: "La Más Buena (Mazatlán) - 104.3 FM - XHENX-FM - Radio Cañón / NTR Medios de Comunicación - Mazatlán, SI"
   streamUrl: https://streaming.servicioswebmx.com/8278/stream
@@ -197819,7 +197819,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-super-acapulco-94-5-fm-xhnu-fm-grupo-audiorama-c
-  tags: [94.5, 94.5 fm, acapulco, entretenimiento, estación, fm, grupo audiorama comunicaciones, guerrero]
+  tags: ["94.5", 94.5 fm, acapulco, entretenimiento, estación, fm, grupo audiorama comunicaciones, guerrero]
   broadcaster: independent
   name: "SUPER (Acapulco) - 94.5 FM - XHNU-FM - Grupo Audiorama Comunicaciones - Acapulco, GR"
   streamUrl: https://ss1.audiorama.com.mx:6608/
@@ -197834,7 +197834,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-voces-acapulco-92-1-fm-xhacd-fm-grupo-audiorama-
-  tags: [92.1, 92.1 fm, acapulco, entrevistas, estación, fm, grupo audiorama comunicaciones, guerrero]
+  tags: ["92.1", 92.1 fm, acapulco, entrevistas, estación, fm, grupo audiorama comunicaciones, guerrero]
   broadcaster: independent
   name: "Voces (Acapulco) - 92.1 FM - XHACD-FM - Grupo Audiorama Comunicaciones - Acapulco, GR"
   streamUrl: https://ss1.audiorama.com.mx:6612/
@@ -197879,7 +197879,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-sol-fm-manzanillo-89-7-fm-560-am-xhmza-fm-xemza-
-  tags: [560, 560 am, 89.7, 89.7 fm, am, cihuatlán, colima, entretenimiento]
+  tags: ["560", 560 am, "89.7", 89.7 fm, am, cihuatlán, colima, entretenimiento]
   favicon: "https://grupozer.mx/images/favicon.png"
   broadcaster: independent
   name: "Sol FM (Manzanillo) - 89.7 FM / 560 AM - XHMZA-FM / XEMZA-AM - Grupo Radiofónico ZER - Cihuatlán, JC / Manzanillo, CL"
@@ -198035,7 +198035,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-bestia-grupera-cordoba-96-1-fm-xhsic-fm-radio
-  tags: [96.1, 96.1 fm, banda, banda norteña, banda tradicional, córdoba, español, estación]
+  tags: ["96.1", 96.1 fm, banda, banda norteña, banda tradicional, córdoba, español, estación]
   favicon: "https://www.radiorama.mx/images/favicon.ico"
   broadcaster: independent
   name: "La Bestia Grupera (Córdoba) - 96.1 FM - XHSIC-FM - Radiorama - Córdoba, VE"
@@ -198067,7 +198067,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-grande-rio-grande-97-1-fm-xhzc-fm-rio-grande-
-  tags: [97.1, 97.1 fm, entretenimiento, estación, fm, latinoamerica, mex, mexico]
+  tags: ["97.1", 97.1 fm, entretenimiento, estación, fm, latinoamerica, mex, mexico]
   broadcaster: independent
   name: "La Grande (Río Grande) - 97.1 FM - XHZC-FM - Río Grande, ZA"
   streamUrl: https://radioforte.com/8004/stream
@@ -198083,7 +198083,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-los40-agua-prieta-99-9-fm-xhnno-fm-grupo-radiofo
-  tags: [99.9, 99.9 fm, agua prieta, estación, fm, grupo radiofónico zer, juvenil, latin pop]
+  tags: ["99.9", 99.9 fm, agua prieta, estación, fm, grupo radiofónico zer, juvenil, latin pop]
   favicon: "https://www.grupozer.mx/images/favicon.png"
   broadcaster: independent
   name: "LOS40 Agua Prieta - 99.9 FM - XHNNO-FM - Grupo Radiofónico ZER - Agua Prieta, SO"
@@ -198145,7 +198145,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-sonido-estrella-zacatecas-89-9-fm-xhepc-fm-zacat
-  tags: [89.9, 89.9 fm, estación, fm, méxico, noticias, noticias cortas, noticias en español]
+  tags: ["89.9", 89.9 fm, estación, fm, méxico, noticias, noticias cortas, noticias en español]
   broadcaster: independent
   name: "Sonido Estrella (Zacatecas) - 89.9 FM - XHEPC-FM - Zacatecas, ZA"
   streamUrl: https://radioforte.com/8010/sonidoestrella
@@ -198240,7 +198240,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-nuestra-navojoa-1270-am-xegl-am-642-media-nav
-  tags: [1270, 1270 am, 642 media, am, balada en español, baladas en español, español, estación]
+  tags: ["1270", 1270 am, 642 media, am, balada en español, baladas en español, español, estación]
   broadcaster: independent
   name: "La Nuestra (Navojoa) - 1270 AM - XEGL-AM - 642 Media - Navojoa, SO"
   streamUrl: https://s5.mexside.net:8018/stream
@@ -198336,7 +198336,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-jalisco-radio-fm-ciudad-guzman-107-1-fm-xhcgj-fm
-  tags: [107.1, 107.1 fm, 96.3, 96.3 fm, ciudad guzmán, cultura, cultural, cultural mexico]
+  tags: ["107.1", 107.1 fm, "96.3", 96.3 fm, ciudad guzmán, cultura, cultural, cultural mexico]
   favicon: "https://jaliscotv.com/wp-content/uploads/2025/09/favicon-300x300.webp"
   broadcaster: independent
   name: "Jalisco Radio (FM) (Ciudad Guzmán) - 107.1 FM - XHCGJ-FM - Gobierno del Estado de Jalisco - Ciudad Guzmán, JC"
@@ -198383,7 +198383,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-radio-activa-salina-cruz-89-1-fm-xhike-fm-ike-si
-  tags: [89.1, 89.1 fm, community, community news, community radio, comunitaria, comunitario, comunity]
+  tags: ["89.1", 89.1 fm, community, community news, community radio, comunitaria, comunitario, comunity]
   favicon: "https://radioxhikefm.com/paginaWP/wp-content/uploads/2020/05/cropped-IMG-20200527-WA0025-1-180x180.jpg"
   broadcaster: independent
   name: "Radio Activa (Salina Cruz) - 89.1 FM - XHIKE-FM - Ike Siidi Viaa, A.C. - Salina Cruz, OA"
@@ -198459,7 +198459,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-exa-fm-nogales-102-7-fm-xhqt-fm-mvs-radio-nogale
-  tags: [102.7, 102.7 fm, entretenimiento, estación, exa, exa fm, fm, juvenil]
+  tags: ["102.7", 102.7 fm, entretenimiento, estación, exa, exa fm, fm, juvenil]
   broadcaster: independent
   name: "Exa FM Nogales - 102.7 FM - XHQT-FM - MVS Radio - Nogales, SO"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XHQT_SC
@@ -198475,7 +198475,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-los40-puerto-vallarta-91-1-fm-xhptoj-fm-radiopol
-  tags: [91.1, 91.1 fm, entretenimiento, estación, fm, juvenil, latin music, latin pop]
+  tags: ["91.1", 91.1 fm, entretenimiento, estación, fm, juvenil, latin music, latin pop]
   favicon: "https://cdn.onlineradiobox.com/img/l/3/82813.v7.png"
   broadcaster: independent
   name: "LOS40 Puerto Vallarta - 91.1 FM - XHPTOJ-FM - Radiópolis - Puerto Vallarta, JC"
@@ -198582,7 +198582,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-tuxtepexa-fm-tuxtepec-101-3-fm-xhptux-fm-grupo-r
-  tags: [101.3, 101.3 fm, en todas partes, entretenimiento, estación, exa, exa fm, fm]
+  tags: ["101.3", 101.3 fm, en todas partes, entretenimiento, estación, exa, exa fm, fm]
   broadcaster: independent
   name: "tuxtepExa FM Tuxtepec - 101.3 FM - XHPTUX-FM - Grupo Rojaz - Tuxtepec, OA"
   streamUrl: https://stream5.mexiserver.com:1007/
@@ -198613,7 +198613,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-mas-buena-taxco-96-1-fm-xhxc-fm-ntr-medios-de
-  tags: [96.1, 96.1 fm, estación, fm, grupo radio cañón, guerrero, la más buena, mex]
+  tags: ["96.1", 96.1 fm, estación, fm, grupo radio cañón, guerrero, la más buena, mex]
   broadcaster: independent
   name: "La Más Buena (Taxco) - 96.1 FM - XHXC-FM - NTR Medios de Comunicación - Taxco, GR"
   streamUrl: https://streaming.servicioswebmx.com/8288/stream
@@ -198767,7 +198767,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-los40-ensenada-96-9-fm-xhpsen-fm-radiopolis-ense
-  tags: [96.9, 96.9 fm, baja california, ensenada, entretenimiento, estación, fm, juvenil]
+  tags: ["96.9", 96.9 fm, baja california, ensenada, entretenimiento, estación, fm, juvenil]
   broadcaster: independent
   name: "LOS40 Ensenada - 96.9 FM - XHPSEN-FM - Radiópolis - Ensenada, BC"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/LOS40_ENSENADAAAC.aac
@@ -198860,7 +198860,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-exa-fm-ensenada-104-1-fm-xhada-fm-mvs-radio-ense
-  tags: [104.1, 104.1 fm, baja california, ensenada, entretenimiento, estación, exa, exa fm]
+  tags: ["104.1", 104.1 fm, baja california, ensenada, entretenimiento, estación, exa, exa fm]
   broadcaster: independent
   name: "Exa FM Ensenada - 104.1 FM - XHADA-FM - MVS Radio - Ensenada, BC"
   streamUrl: https://playerservices.streamtheworld.com/api/livestream-redirect/XHADA_SC
@@ -199013,7 +199013,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-focus-radio-reynosa-1670-am-xefcr-am-reynosa-tm
-  tags: [1670, 1670 am, am, concesión social, entretenimiento, estación, focus radio, latino américa]
+  tags: ["1670", 1670 am, am, concesión social, entretenimiento, estación, focus radio, latino américa]
   broadcaster: independent
   name: "Focus Radio (Reynosa) - 1670 AM - XEFCR-AM - Reynosa, TM"
   streamUrl: https://stream9.mexiserver.com/8214/stream
@@ -199045,7 +199045,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-radio-jerez-jerez-89-1-fm-xhxm-fm-grupo-radiofon
-  tags: [89.1, 89.1 fm, entretenimiento, español, estación, fm, grupera, grupero]
+  tags: ["89.1", 89.1 fm, entretenimiento, español, estación, fm, grupera, grupero]
   broadcaster: independent
   name: "Radio Jerez (Jerez) - 89.1 FM - XHXM-FM - Grupo Radiofónico ZER - Jerez, ZA"
   streamUrl: https://cast.zuperdns.net/8016/stream/
@@ -199278,7 +199278,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-fm-celaya-99-5-fm-xhaf-fm-radiorama-celaya-gt
-  tags: [99.5, 99.5 fm, "@fm", "@fm te conecta", arroba fm, arroba fm te conecta, celaya, entretenimiento]
+  tags: ["99.5", 99.5 fm, "@fm", "@fm te conecta", arroba fm, arroba fm te conecta, celaya, entretenimiento]
   favicon: "https://www.arroba.fm/img/favicon.png"
   broadcaster: independent
   name: "@FM (Celaya) - 99.5 FM - XHAF-FM - Radiorama - Celaya, GT"
@@ -200907,7 +200907,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-kebuena-tuxtla-100-1-fm
-  tags: [100.1, la ke buena, radio núcleo, radiópolis]
+  tags: ["100.1", la ke buena, radio núcleo, radiópolis]
   broadcaster: independent
   name: La KeBuena Tuxtla 100.1 FM
   streamUrl: https://stream.freepi.io/8306/live
@@ -201850,7 +201850,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-ke-buena-acapulco-98-5-fm
-  tags: [98.5, grupera, radiópolis, regional mexicano]
+  tags: ["98.5", grupera, radiópolis, regional mexicano]
   broadcaster: independent
   name: La Ke Buena Acapulco 98.5 FM
   streamUrl: https://streaming.servicioswebmx.com/8252/stream
@@ -201866,7 +201866,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-kebuena-88-9-guasave
-  tags: [88.9, grupera, radiópolis, regional mexicano]
+  tags: ["88.9", grupera, radiópolis, regional mexicano]
   favicon: "https://lakebuenaguasave.com/img/LaKBfavicon.png"
   broadcaster: independent
   name: La KeBuena 88.9 Guasave
@@ -203131,7 +203131,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-grande-del-sureste-90-3
-  tags: [90.3, grupera, la tg, radio núcleo, sureste]
+  tags: ["90.3", grupera, la tg, radio núcleo, sureste]
   favicon: "https://i0.wp.com/radionucleo.com/wp-content/uploads/2023/11/cropped-cropped-cropped-favicon-radionucleo.png?fit=180%2C180&#038;ssl=1"
   broadcaster: independent
   name: La Grande del Sureste 90.3
@@ -203801,7 +203801,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-melyh-radio
-  tags: [2000-2021, 2000s, 2021, 2022, 2023, 2024, english, hip-hop]
+  tags: [2000-2021, 2000s, "2021", "2022", "2023", "2024", english, hip-hop]
   broadcaster: independent
   name: melyh radio
   streamUrl: https://stream.zeno.fm/e2gvuhrbvmavv
@@ -206942,7 +206942,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-coahuila-hoy-93-1-fm-xhcsba-monclova-coahuila
-  tags: [93.1, coahuila, fm, mexico, monclova, noticias, radio local]
+  tags: ["93.1", coahuila, fm, mexico, monclova, noticias, radio local]
   favicon: "https://www.grupomradio.mx/wp-content/uploads/2023/08/LOGO_APP.png"
   broadcaster: independent
   name: "Coahuila Hoy 93.1 FM - XHCSBA - Monclova, Coahuila"
@@ -207019,7 +207019,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-poderosa-94-7-fm-1480-am-xhxu-fm-xexu-am-fron
-  tags: [1480, 94.7, am, coahuila, fm, frontera, grupera, mexico]
+  tags: ["1480", "94.7", am, coahuila, fm, frontera, grupera, mexico]
   broadcaster: independent
   name: "La Poderosa 94.7 FM / 1480 AM - XHXU-FM / XEXU-AM - Frontera, Coahuila"
   streamUrl: https://stream.zeno.fm/am6mttdgsysuv
@@ -207095,7 +207095,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-la-super-estacion-103-1-fm-1330-am-xhwq-fm-xewq-
-  tags: [103.1, 1330, am, coahuila, fm, grupera, mexico, monclova]
+  tags: ["103.1", "1330", am, coahuila, fm, grupera, mexico, monclova]
   favicon: "https://static.xx.fbcdn.net/rsrc.php/y1/r/ay1hV6OlegS.ico"
   broadcaster: independent
   name: "La Super Estación 103.1 FM / 1330 AM - XHWQ-FM / XEWQ-AM - Monclova, Coahuila"
@@ -207204,7 +207204,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: mx-region-91-1-fm-capital-maxima-xhmzi-fm-monclova-
-  tags: [91.1, capital media, coahuila, fm, grupera, grupo region, mexico, monclova]
+  tags: ["91.1", capital media, coahuila, fm, grupera, grupo region, mexico, monclova]
   favicon: "https://pwaimg.listenlive.co/XHNZI_1361191_config_station_logo_image_1432854720.png"
   broadcaster: independent
   name: "Region 91.1 FM (Capital Maxima) - XHMZI-FM - Monclova, Coahuila"
@@ -217360,7 +217360,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: ca-fm-96-1
-  tags: [96.1, 96.1 fm, music, news, pop, talk]
+  tags: ["96.1", 96.1 fm, music, news, pop, talk]
   broadcaster: independent
   name: 加拿大中文电台FM.96.1
   streamUrl: https://5b2959fe11444.streamlock.net/radio/fm961.stream/playlist.m3u8
@@ -217375,7 +217375,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: ca-70-80-90-italia-d-autore
-  tags: [70, 80, 90, classic italian pop, italian pop, musica italiana]
+  tags: ["70", "80", "90", classic italian pop, italian pop, musica italiana]
   favicon: "https://radiosuitenetwork.torontocast.stream/wp-content/uploads/2021/09/600.png"
   broadcaster: independent
   name: "70 80 90 ITALIA D'AUTORE"
@@ -217422,7 +217422,7 @@
 
 # Auto-imported from Radio Browser (2026-05-04)
 - id: ca-rdmix-italo-disco-80s
-  tags: [1980, 1980s, 1980s hits, "80's", 80er, 80s, anni 80, classic hits]
+  tags: ["1980", 1980s, 1980s hits, "80's", 80er, 80s, anni 80, classic hits]
   broadcaster: independent
   name: "# RdMix Italo Disco 80s"
   streamUrl: https://cast1.torontocast.com:2130/stream

--- a/public/stations.json
+++ b/public/stations.json
@@ -20823,8 +20823,8 @@
       "tags": [
         "\"bob\"",
         "#",
-        0,
-        11.11,
+        "0",
+        "11.11",
         "abriss",
         "abrissparty",
         "apresski",
@@ -24068,7 +24068,7 @@
         "1970s",
         "1980's",
         "1990s",
-        70,
+        "70",
         "70 80 hits",
         "70's"
       ],
@@ -24412,7 +24412,7 @@
       "country": "DE",
       "tags": [
         "1980s",
-        80,
+        "80",
         "80's",
         "80er",
         "80s",
@@ -33917,7 +33917,7 @@
       "country": "DE",
       "tags": [
         "1970s",
-        70,
+        "70",
         "70 80 hits",
         "70's",
         "70er",
@@ -44003,7 +44003,7 @@
       "homepage": "https://www.radio-grammo.de/",
       "country": "DE",
       "tags": [
-        78,
+        "78",
         "schellack"
       ],
       "favicon": "https://www.radiogrammo.de/wp-content/uploads/2026/03/cropped-Logo-Grammo-schwarz-180x180.png",
@@ -48308,10 +48308,10 @@
       "homepage": "https://walmradio.com/classic",
       "country": "US",
       "tags": [
-        1930,
-        1940,
-        1950,
-        1960,
+        "1930",
+        "1940",
+        "1950",
+        "1960",
         "beautiful music",
         "big band",
         "classic hits",
@@ -48360,7 +48360,7 @@
       "homepage": "https://walmradio.com/otr",
       "country": "US",
       "tags": [
-        78,
+        "78",
         "78-rpm",
         "78rpm",
         "classic",
@@ -48391,7 +48391,7 @@
         "70's",
         "70s",
         "70s disco",
-        80,
+        "80",
         "80's",
         "80s"
       ],
@@ -48559,7 +48559,7 @@
         "70er",
         "70s",
         "70s disco",
-        80,
+        "80",
         "80's"
       ],
       "favicon": "https://funky.radio/wp-content/uploads/2020/10/funkyradio-LOGO512-300x300.jpg",
@@ -51377,7 +51377,7 @@
       "homepage": "https://9128.live/",
       "country": "US",
       "tags": [
-        9128,
+        "9128",
         "a strangely isolated place",
         "asip"
       ],
@@ -76339,7 +76339,7 @@
       "homepage": "https://superradio.cc/",
       "country": "US",
       "tags": [
-        101.3,
+        "101.3",
         "local news",
         "morning show",
         "music",
@@ -78976,7 +78976,7 @@
       "homepage": "https://97x.fm/",
       "country": "US",
       "tags": [
-        97.1,
+        "97.1",
         "97.1 fm",
         "97x",
         "97x.fm",
@@ -97058,7 +97058,7 @@
       "homepage": "https://superradio.cc/",
       "country": "US",
       "tags": [
-        98.7,
+        "98.7",
         "classical",
         "music",
         "wpac"
@@ -104585,7 +104585,7 @@
       "homepage": "https://www.blackdiamondfm.com/",
       "country": "GB",
       "tags": [
-        107.8,
+        "107.8",
         "107.8 fm",
         "country",
         "music",
@@ -114550,7 +114550,7 @@
       "homepage": "https://www.ouifm.fr/",
       "country": "FR",
       "tags": [
-        2000,
+        "2000",
         "rock"
       ],
       "favicon": "https://medias.lesindesradios.fr/t:app(web)/t:r(unknown)/filters:format(jpeg)/medias/Vsj0LZpM34/image/ouifm_fm_home1753971855995.jpg",
@@ -122967,10 +122967,10 @@
       "tags": [
         "2000's",
         "2000s",
-        2010,
+        "2010",
         "2010's",
         "2010s",
-        2020,
+        "2020",
         "2020s",
         "french"
       ],
@@ -125856,13 +125856,13 @@
       "country": "IT",
       "tags": [
         "320 kbps",
-        70,
+        "70",
         "70 80 hits",
         "70 80 hits hq",
         "70 music",
         "70-80",
         "70-80 hits",
-        80
+        "80"
       ],
       "favicon": "https://www.70-80.it/wp-content/uploads/2020/03/logo-70-80-300x300.jpg",
       "bitrate": 320,
@@ -125882,7 +125882,7 @@
         "70's",
         "70s",
         "70s disco",
-        80,
+        "80",
         "80's",
         "80s"
       ],
@@ -126064,7 +126064,7 @@
         "70er",
         "70s",
         "70s disco",
-        80,
+        "80",
         "80's"
       ],
       "favicon": "https://funky.radio/wp-content/uploads/2020/10/funkyradio-LOGO512-300x300.jpg",
@@ -127695,10 +127695,10 @@
       "homepage": "https://www.nbcmilano.it/",
       "country": "IT",
       "tags": [
-        70,
+        "70",
         "70 80 hits",
         "70 hits",
-        80,
+        "80",
         "80 hits",
         "greatest hits",
         "hq",
@@ -143766,7 +143766,7 @@
       "homepage": "https://www.gld.nl/radio/overzicht",
       "country": "NL",
       "tags": [
-        103.5,
+        "103.5",
         "news",
         "public radio"
       ],
@@ -151715,11 +151715,11 @@
       "homepage": "https://radiodd.eu/",
       "country": "PL",
       "tags": [
-        70,
+        "70",
         "70s",
-        80,
+        "80",
         "80s",
-        90,
+        "90",
         "90s",
         "disco",
         "disco polo"
@@ -153326,7 +153326,7 @@
       "homepage": "https://www.radiozet.pl/",
       "country": "PL",
       "tags": [
-        95.6,
+        "95.6",
         "hits"
       ],
       "favicon": "https://i.postimg.cc/G35rjL2K/radio-zet-8fe59cd4.jpg",
@@ -156621,7 +156621,7 @@
       "homepage": "https://www.metro951.com/",
       "country": "AR",
       "tags": [
-        95.1,
+        "95.1",
         "95.1 fm",
         "argentina",
         "buenos aires",
@@ -171590,8 +171590,8 @@
       "homepage": "https://www.radyo9.com/",
       "country": "TR",
       "tags": [
-        9,
-        99.9,
+        "9",
+        "99.9",
         "99.9 fm",
         "ankara",
         "aydin",
@@ -176204,7 +176204,7 @@
       "homepage": "https://kinozal.tv/radio.php",
       "country": "ID",
       "tags": [
-        2024,
+        "2024",
         "adult conterporary",
         "best",
         "club",
@@ -200140,7 +200140,7 @@
       "homepage": "https://global.superradio.cc/",
       "country": "JP",
       "tags": [
-        86.9,
+        "86.9",
         "加古川市"
       ],
       "favicon": "https://www.banban.jp/radio/images/common/logo.svg",
@@ -200229,7 +200229,7 @@
       "homepage": "https://global.superradio.cc/",
       "country": "JP",
       "tags": [
-        77.5,
+        "77.5",
         "八王子"
       ],
       "favicon": "https://static.mytuner.mobi/media/tvos_radios/nkdjrxrksehq.png",
@@ -200259,7 +200259,7 @@
       "homepage": "https://fmsetagaya.com/",
       "country": "JP",
       "tags": [
-        83.4,
+        "83.4",
         "full service",
         "music"
       ],
@@ -200276,7 +200276,7 @@
       "homepage": "https://global.superradio.cc/",
       "country": "JP",
       "tags": [
-        79.6,
+        "79.6",
         "秋田"
       ],
       "bitrate": 208,
@@ -200291,7 +200291,7 @@
       "homepage": "https://global.superradio.cc/",
       "country": "JP",
       "tags": [
-        79.7,
+        "79.7",
         "京都市"
       ],
       "bitrate": 175,
@@ -200353,7 +200353,7 @@
       "homepage": "https://superradio.cc/",
       "country": "JP",
       "tags": [
-        76.2,
+        "76.2",
         "仙台"
       ],
       "bitrate": 425,
@@ -200368,7 +200368,7 @@
       "homepage": "https://global.superradio.cc/",
       "country": "JP",
       "tags": [
-        83.8,
+        "83.8",
         "調布"
       ],
       "bitrate": 150,
@@ -200383,7 +200383,7 @@
       "homepage": "https://global.superradio.cc/",
       "country": "JP",
       "tags": [
-        77.5,
+        "77.5",
         "朝霞"
       ],
       "favicon": "https://775fm.co.jp/wp/wp-content/themes/775fm/images/logo.png?20220406",
@@ -200399,7 +200399,7 @@
       "homepage": "https://global.superradio.cc/",
       "country": "JP",
       "tags": [
-        79.7,
+        "79.7",
         "仙台"
       ],
       "bitrate": 174,
@@ -200439,7 +200439,7 @@
       "homepage": "https://global.superradio.cc/",
       "country": "JP",
       "tags": [
-        85.6,
+        "85.6",
         "川口"
       ],
       "bitrate": 148,
@@ -200454,7 +200454,7 @@
       "homepage": "https://global.superradio.cc/",
       "country": "JP",
       "tags": [
-        82.2,
+        "82.2",
         "日立"
       ],
       "bitrate": 275,
@@ -200506,7 +200506,7 @@
       "homepage": "https://global.superradio.cc/",
       "country": "JP",
       "tags": [
-        87,
+        "87.0",
         "京都府"
       ],
       "bitrate": 181,
@@ -200521,7 +200521,7 @@
       "homepage": "https://superradio.cc/",
       "country": "JP",
       "tags": [
-        88.5,
+        "88.5",
         "江東"
       ],
       "bitrate": 174,
@@ -200548,7 +200548,7 @@
       "homepage": "https://superradio.cc/",
       "country": "JP",
       "tags": [
-        78.1,
+        "78.1",
         "塩竈"
       ],
       "bitrate": 206,
@@ -200563,7 +200563,7 @@
       "homepage": "https://global.superradio.cc/",
       "country": "JP",
       "tags": [
-        84.4,
+        "84.4",
         "立川"
       ],
       "bitrate": 151,
@@ -200589,7 +200589,7 @@
       "homepage": "https://global.superradio.cc/",
       "country": "JP",
       "tags": [
-        88.2,
+        "88.2",
         "北九州市"
       ],
       "bitrate": 178,
@@ -200615,7 +200615,7 @@
       "homepage": "https://global.superradio.cc/",
       "country": "JP",
       "tags": [
-        84.5,
+        "84.5",
         "前橋"
       ],
       "favicon": "https://maeradi.net/assets/images/common/logo.svg",
@@ -200631,7 +200631,7 @@
       "homepage": "https://global.superradio.cc/",
       "country": "JP",
       "tags": [
-        78.9,
+        "78.9",
         "大島郡"
       ],
       "bitrate": 173,
@@ -200646,7 +200646,7 @@
       "homepage": "https://global.superradio.cc/",
       "country": "JP",
       "tags": [
-        86.2,
+        "86.2",
         "長岡京市"
       ],
       "bitrate": 179,
@@ -200684,7 +200684,7 @@
       "homepage": "https://global.superradio.cc/",
       "country": "JP",
       "tags": [
-        80.1,
+        "80.1",
         "名取"
       ],
       "bitrate": 203,
@@ -200699,7 +200699,7 @@
       "homepage": "https://global.superradio.cc/",
       "country": "JP",
       "tags": [
-        79.8,
+        "79.8",
         "米子市"
       ],
       "bitrate": 144,
@@ -200714,7 +200714,7 @@
       "homepage": "https://global.superradio.cc/",
       "country": "JP",
       "tags": [
-        81.8,
+        "81.8",
         "宜野湾市"
       ],
       "bitrate": 174,
@@ -200729,7 +200729,7 @@
       "homepage": "https://global.superradio.cc/",
       "country": "JP",
       "tags": [
-        86.8,
+        "86.8",
         "越谷"
       ],
       "bitrate": 152,
@@ -200744,7 +200744,7 @@
       "homepage": "https://global.superradio.cc/",
       "country": "JP",
       "tags": [
-        76.1,
+        "76.1",
         "石垣市"
       ],
       "bitrate": 154,
@@ -200759,7 +200759,7 @@
       "homepage": "https://global.superradio.cc/",
       "country": "JP",
       "tags": [
-        79.1,
+        "79.1",
         "郡山"
       ],
       "bitrate": 148,
@@ -200774,7 +200774,7 @@
       "homepage": "https://global.superradio.cc/",
       "country": "JP",
       "tags": [
-        76.3,
+        "76.3",
         "野々市"
       ],
       "bitrate": 171,
@@ -200789,7 +200789,7 @@
       "homepage": "https://global.superradio.cc/",
       "country": "JP",
       "tags": [
-        79.4,
+        "79.4",
         "京丹後市"
       ],
       "bitrate": 209,
@@ -200804,7 +200804,7 @@
       "homepage": "https://global.superradio.cc/",
       "country": "JP",
       "tags": [
-        83.2,
+        "83.2",
         "豊見城市"
       ],
       "bitrate": 146,
@@ -200819,7 +200819,7 @@
       "homepage": "https://global.superradio.cc/",
       "country": "JP",
       "tags": [
-        88.5,
+        "88.5",
         "深谷"
       ],
       "favicon": "https://www.fukaya-fm.com/cms/wp-content/themes/fm/common/images/logo.svg",
@@ -200847,7 +200847,7 @@
       "homepage": "https://global.superradio.cc/",
       "country": "JP",
       "tags": [
-        76.2,
+        "76.2",
         "いわき市"
       ],
       "bitrate": 174,
@@ -200862,7 +200862,7 @@
       "homepage": "https://global.superradio.cc/",
       "country": "JP",
       "tags": [
-        77.7,
+        "77.7",
         "奄美市"
       ],
       "bitrate": 208,
@@ -200877,7 +200877,7 @@
       "homepage": "https://global.superradio.cc/",
       "country": "JP",
       "tags": [
-        77.9,
+        "77.9",
         "敦賀市"
       ],
       "favicon": "https://cdn.instant.audio/images/logos/jpradio-jp/harbor-station.png",
@@ -200893,7 +200893,7 @@
       "homepage": "https://global.superradio.cc/",
       "country": "JP",
       "tags": [
-        77.7,
+        "77.7",
         "本宮"
       ],
       "bitrate": 152,
@@ -200920,7 +200920,7 @@
       "homepage": "https://global.superradio.cc/",
       "country": "JP",
       "tags": [
-        86.1,
+        "86.1",
         "直方市"
       ],
       "bitrate": 75,
@@ -200935,7 +200935,7 @@
       "homepage": "https://superradio.cc/",
       "country": "JP",
       "tags": [
-        76.9,
+        "76.9",
         "盛岡"
       ],
       "bitrate": 181,
@@ -200950,7 +200950,7 @@
       "homepage": "https://global.superradio.cc/",
       "country": "JP",
       "tags": [
-        87.7,
+        "87.7",
         "名護市"
       ],
       "favicon": "https://fmyanbaru.co.jp/wp-content/themes/Fmyambaru/assets/images/logo-header.png",
@@ -200978,7 +200978,7 @@
       "homepage": "https://superradio.cc/",
       "country": "JP",
       "tags": [
-        76.5,
+        "76.5",
         "八戸市"
       ],
       "favicon": "https://www.befm.co.jp/fm/wp-content/uploads/2020/11/bunnerB.png",
@@ -200994,7 +200994,7 @@
       "homepage": "https://superradio.cc/",
       "country": "JP",
       "tags": [
-        77.9,
+        "77.9",
         "二戸"
       ],
       "bitrate": 151,
@@ -201009,7 +201009,7 @@
       "homepage": "https://global.superradio.cc/",
       "country": "JP",
       "tags": [
-        77.6
+        "77.6"
       ],
       "bitrate": 181,
       "codec": "AAC",
@@ -201023,7 +201023,7 @@
       "homepage": "https://global.superradio.cc/",
       "country": "JP",
       "tags": [
-        79.1,
+        "79.1",
         "鹿角"
       ],
       "bitrate": 210,
@@ -201038,7 +201038,7 @@
       "homepage": "https://global.superradio.cc/",
       "country": "JP",
       "tags": [
-        87.3,
+        "87.3",
         "さいたま市"
       ],
       "bitrate": 174,
@@ -201053,7 +201053,7 @@
       "homepage": "https://global.superradio.cc/",
       "country": "JP",
       "tags": [
-        76.7,
+        "76.7",
         "鴻巣"
       ],
       "favicon": "https://fm767.com/wp/wp-content/uploads/digipress/magjam/title/header_logo.png",
@@ -201069,7 +201069,7 @@
       "homepage": "https://superradio.cc/",
       "country": "JP",
       "tags": [
-        82.6,
+        "82.6",
         "宮古"
       ],
       "bitrate": 145,
@@ -201096,7 +201096,7 @@
       "homepage": "https://global.superradio.cc/",
       "country": "JP",
       "tags": [
-        79.1,
+        "79.1",
         "徳島市"
       ],
       "bitrate": 116,
@@ -201111,7 +201111,7 @@
       "homepage": "https://global.superradio.cc/",
       "country": "JP",
       "tags": [
-        76.2,
+        "76.2",
         "水戸"
       ],
       "bitrate": 178,
@@ -201126,7 +201126,7 @@
       "homepage": "https://global.superradio.cc/",
       "country": "JP",
       "tags": [
-        76.3,
+        "76.3",
         "岡崎"
       ],
       "bitrate": 178,
@@ -201173,7 +201173,7 @@
       "homepage": "https://global.superradio.cc/",
       "country": "JP",
       "tags": [
-        88.6,
+        "88.6",
         "延岡市"
       ],
       "bitrate": 152,
@@ -201188,7 +201188,7 @@
       "homepage": "https://global.superradio.cc/",
       "country": "JP",
       "tags": [
-        76.3,
+        "76.3",
         "湯沢"
       ],
       "bitrate": 153,
@@ -201203,7 +201203,7 @@
       "homepage": "https://global.superradio.cc/",
       "country": "JP",
       "tags": [
-        79.7,
+        "79.7",
         "宜野湾市"
       ],
       "favicon": "https://static.mytuner.mobi/media/tvos_radios/uwqtqhbsahhe.png",
@@ -201219,7 +201219,7 @@
       "homepage": "https://global.superradio.cc/",
       "country": "JP",
       "tags": [
-        76.1,
+        "76.1",
         "黒部市"
       ],
       "bitrate": 133,
@@ -201234,7 +201234,7 @@
       "homepage": "https://superradio.cc/",
       "country": "JP",
       "tags": [
-        77.5,
+        "77.5",
         "気仙沼"
       ],
       "bitrate": 247,
@@ -201249,7 +201249,7 @@
       "homepage": "https://superradio.cc/",
       "country": "JP",
       "tags": [
-        77.4,
+        "77.4",
         "横手"
       ],
       "favicon": "https://fmyokote.sakura.ne.jp/home/wp-content/uploads/2020/08/logo.png",
@@ -201265,7 +201265,7 @@
       "homepage": "https://global.superradio.cc/",
       "country": "JP",
       "tags": [
-        76.4,
+        "76.4",
         "豊岡市"
       ],
       "bitrate": 178,
@@ -201294,7 +201294,7 @@
       "homepage": "https://global.superradio.cc/",
       "country": "JP",
       "tags": [
-        81.5,
+        "81.5",
         "東近江市"
       ],
       "favicon": "https://zenkokunews.sakura.ne.jp/radiosweet/wp-content/uploads/2025/05/815%E3%83%AD%E3%82%B4-1-3-scaled.png",
@@ -201310,7 +201310,7 @@
       "homepage": "https://global.superradio.cc/",
       "country": "JP",
       "tags": [
-        85.4,
+        "85.4",
         "牛久"
       ],
       "bitrate": 131,
@@ -201337,8 +201337,8 @@
       "homepage": "https://superradio.cc/",
       "country": "JP",
       "tags": [
-        4,
-        76,
+        "4",
+        "76",
         "石巻"
       ],
       "favicon": "https://static2.mytuner.mobi/media/tvos_radios/ZbadTqaXkc.png",
@@ -201354,7 +201354,7 @@
       "homepage": "https://global.superradio.cc/",
       "country": "JP",
       "tags": [
-        84.2,
+        "84.2",
         "海老名"
       ],
       "bitrate": 152,
@@ -204951,7 +204951,7 @@
       "homepage": "https://player.rdp.com.pe/maxplayer.php",
       "country": "PE",
       "tags": [
-        90,
+        "90",
         "variada"
       ],
       "favicon": "https://player.rdp.com.pe/img/core-img/favicon.png",
@@ -205967,8 +205967,8 @@
       "country": "BR",
       "tags": [
         "70s",
-        80,
-        90,
+        "80",
+        "90",
         "adult",
         "oldies"
       ],
@@ -212499,7 +212499,7 @@
       "homepage": "https://toligado.net.br/",
       "country": "BR",
       "tags": [
-        80,
+        "80",
         "90 e 2.000",
         "anos 70"
       ],
@@ -216895,7 +216895,7 @@
       "homepage": "https://www.sabrosita590am.com.mx/",
       "country": "MX",
       "tags": [
-        590,
+        "590",
         "590 am",
         "am",
         "ciudad de mexico",
@@ -216921,7 +216921,7 @@
       "homepage": "https://www.iheart.com/live/radio-felicidad-1180-6534/",
       "country": "MX",
       "tags": [
-        1180,
+        "1180",
         "1180 am",
         "60s",
         "70s",
@@ -216984,7 +216984,7 @@
       "homepage": "https://www.lamejor.com.mx/",
       "country": "MX",
       "tags": [
-        97.7,
+        "97.7",
         "97.7 fm",
         "aquí nomás",
         "banda",
@@ -217006,7 +217006,7 @@
       "homepage": "https://www.radioformula.com.mx/p/en-vivo/1041-fm.html",
       "country": "MX",
       "tags": [
-        104.1,
+        "104.1",
         "104.1 fm",
         "acustic",
         "cdmx",
@@ -217058,7 +217058,7 @@
       "homepage": "https://www.joya937.mx/",
       "country": "MX",
       "tags": [
-        93.7,
+        "93.7",
         "93.7 fm",
         "cdmx",
         "ciudad de mexico",
@@ -217080,7 +217080,7 @@
       "homepage": "https://www.radiocentroelfonografo.com/",
       "country": "MX",
       "tags": [
-        690,
+        "690",
         "690 am",
         "am",
         "ciudad de mexico",
@@ -217106,9 +217106,9 @@
       "homepage": "https://www.wradio.com.mx/",
       "country": "MX",
       "tags": [
-        900,
+        "900",
         "900 am",
-        96.9,
+        "96.9",
         "96.9 fm",
         "am",
         "cdmx",
@@ -217158,7 +217158,7 @@
       "homepage": "http://cincoradio.com.mx/",
       "country": "MX",
       "tags": [
-        89.3,
+        "89.3",
         "89.3 fm",
         "cinco radio",
         "entretenimiento",
@@ -217235,7 +217235,7 @@
       "homepage": "https://www.mvsnoticias.com/",
       "country": "MX",
       "tags": [
-        102.5,
+        "102.5",
         "102.5 fm",
         "auto y más",
         "baladas en ingles",
@@ -217287,7 +217287,7 @@
       "homepage": "https://www.beat1009.com.mx/",
       "country": "MX",
       "tags": [
-        100.9,
+        "100.9",
         "100.9 fm",
         "100.9fm",
         "beat",
@@ -217314,9 +217314,9 @@
       "tags": [
         "00's",
         "00s",
-        100.1,
+        "100.1",
         "100.1 fm",
-        1000,
+        "1000",
         "1000 am",
         "1980's",
         "1980s"
@@ -217338,7 +217338,7 @@
       "homepage": "https://www.wdeportes.com/",
       "country": "MX",
       "tags": [
-        730,
+        "730",
         "730 am",
         "am",
         "cdmx",
@@ -217505,7 +217505,7 @@
       "homepage": "https://www.los40.com.mx/",
       "country": "MX",
       "tags": [
-        101.7,
+        "101.7",
         "101.7 fm",
         "cdmx",
         "ciudad de méxico",
@@ -217527,7 +217527,7 @@
       "homepage": "https://www.lasabrosita.fm/",
       "country": "MX",
       "tags": [
-        95.7,
+        "95.7",
         "95.7 fm",
         "banda",
         "banda norteña",
@@ -217553,7 +217553,7 @@
       "homepage": "https://www.iheart.com/live/match-993-ciudad-de-mexico-6251/",
       "country": "MX",
       "tags": [
-        99.3,
+        "99.3",
         "99.3 fm",
         "acir",
         "cdmx",
@@ -217597,7 +217597,7 @@
       "homepage": "https://www.notisistema.com/formulamelodica/",
       "country": "MX",
       "tags": [
-        97.9,
+        "97.9",
         "97.9 fm",
         "balada",
         "balada en español",
@@ -217727,7 +217727,7 @@
       "homepage": "https://www.radioformula.com.mx/p/en-vivo/1033-fm.html",
       "country": "MX",
       "tags": [
-        103.3,
+        "103.3",
         "103.3 fm",
         "ciudad de mexico",
         "ciudad de méxico",
@@ -217775,7 +217775,7 @@
       "homepage": "https://www.lamejor.com.mx/monterrey/",
       "country": "MX",
       "tags": [
-        92.5,
+        "92.5",
         "92.5 fm",
         "banda",
         "banda norteña",
@@ -217879,7 +217879,7 @@
       "homepage": "https://www.globalmedia.mx/stations/WRadio",
       "country": "MX",
       "tags": [
-        100.1,
+        "100.1",
         "100.1 fm",
         "estación",
         "fm",
@@ -218262,7 +218262,7 @@
       "homepage": "http://www.radioramavm.mx/labestiagrupera/",
       "country": "MX",
       "tags": [
-        540,
+        "540",
         "540 am",
         "am",
         "banda",
@@ -218312,7 +218312,7 @@
       "homepage": "https://www.laoctava.com/",
       "country": "MX",
       "tags": [
-        88.1,
+        "88.1",
         "88.1 fm",
         "adult contemporary",
         "cdmx",
@@ -218338,7 +218338,7 @@
       "homepage": "https://grupozer.mx/portada.php?id=103",
       "country": "MX",
       "tags": [
-        106.1,
+        "106.1",
         "106.1 fm",
         "aguascalientes",
         "entretenimiento",
@@ -218364,7 +218364,7 @@
       "homepage": "https://www.iheart.com/live/amor-1033-6572/",
       "country": "MX",
       "tags": [
-        103.3,
+        "103.3",
         "103.3 fm",
         "acir",
         "amor",
@@ -218386,7 +218386,7 @@
       "homepage": "https://www.abcdeportes.mx/",
       "country": "MX",
       "tags": [
-        92.1,
+        "92.1",
         "92.1 fm",
         "abc deportes",
         "deporte",
@@ -218464,7 +218464,7 @@
       "homepage": "https://www.radiocentroelfonografo.com/",
       "country": "MX",
       "tags": [
-        690,
+        "690",
         "690 am",
         "am",
         "ciudad de mexico",
@@ -218502,7 +218502,7 @@
       "homepage": "https://tunein.com/radio/Radio-Ranchito-1025-s169172/",
       "country": "MX",
       "tags": [
-        102.5,
+        "102.5",
         "102.5 fm",
         "entretenimiento",
         "estación",
@@ -218528,7 +218528,7 @@
       "homepage": "https://www.radioformula.com.mx/p/en-vivo/970-am.html",
       "country": "MX",
       "tags": [
-        970,
+        "970",
         "970 am",
         "am",
         "cdmx",
@@ -218580,7 +218580,7 @@
       "homepage": "https://www.radioformula.com.mx/p/en-vivo/1470-am.html",
       "country": "MX",
       "tags": [
-        1470,
+        "1470",
         "1470 am",
         "am",
         "ciudad de mexico",
@@ -218643,7 +218643,7 @@
       "homepage": "https://www.lamejor.com.mx/guadalajara/",
       "country": "MX",
       "tags": [
-        95.5,
+        "95.5",
         "95.5 fm",
         "aquí nomás",
         "banda",
@@ -218669,7 +218669,7 @@
       "homepage": "https://www.notisistema.com/buenaonda/",
       "country": "MX",
       "tags": [
-        101.9,
+        "101.9",
         "101.9 fm",
         "balada",
         "balada en español",
@@ -218695,7 +218695,7 @@
       "homepage": "https://www.lainolvidabledeperote.com/",
       "country": "MX",
       "tags": [
-        101.1,
+        "101.1",
         "101.1 fm",
         "avanradio",
         "balada",
@@ -218721,7 +218721,7 @@
       "homepage": "https://www.exafm.com/",
       "country": "MX",
       "tags": [
-        104.9,
+        "104.9",
         "104.9 fm",
         "cdmx",
         "ciudad de méxico",
@@ -218743,7 +218743,7 @@
       "homepage": "https://www.fmglobo.com/mexicali/",
       "country": "MX",
       "tags": [
-        101.9,
+        "101.9",
         "101.9 fm",
         "baja california",
         "balada",
@@ -218795,7 +218795,7 @@
       "homepage": "https://www.radiocentro.com/",
       "country": "MX",
       "tags": [
-        1420,
+        "1420",
         "1420 am",
         "am",
         "colombia vallenata",
@@ -218820,7 +218820,7 @@
       "homepage": "http://abcnoticias.mx/",
       "country": "MX",
       "tags": [
-        570,
+        "570",
         "570 am",
         "abc noticias",
         "am",
@@ -218872,7 +218872,7 @@
       "homepage": "https://escucha.kebuena.com.mx/emisora/ke_buena_guadalajara/",
       "country": "MX",
       "tags": [
-        97.1,
+        "97.1",
         "97.1 fm",
         "banda",
         "estación",
@@ -218914,7 +218914,7 @@
       "homepage": "https://www.radio.unam.mx/",
       "country": "MX",
       "tags": [
-        96.1,
+        "96.1",
         "96.1 fm",
         "ciudad de méxico",
         "college",
@@ -218966,7 +218966,7 @@
       "homepage": "https://tunein.com/radio/Radio-Disney-Ciudad-de-Mxico-921-s88449/",
       "country": "MX",
       "tags": [
-        92.1,
+        "92.1",
         "92.1 fm",
         "ciudad de méxico",
         "disney",
@@ -218992,9 +218992,9 @@
       "homepage": "http://jaliscoradio.com/",
       "country": "MX",
       "tags": [
-        107.1,
+        "107.1",
         "107.1 fm",
-        96.3,
+        "96.3",
         "96.3 fm",
         "ciudad guzmán",
         "cultura",
@@ -219044,7 +219044,7 @@
       "homepage": "https://www.radioformula.com.mx/p/en-vivo/1500-am.html",
       "country": "MX",
       "tags": [
-        1500,
+        "1500",
         "1500 am",
         "am",
         "ciudad de mexico",
@@ -219070,7 +219070,7 @@
       "homepage": "https://www.lamejor.com.mx/leon/",
       "country": "MX",
       "tags": [
-        99.9,
+        "99.9",
         "99.9 fm",
         "aquí nomás",
         "banda",
@@ -219122,7 +219122,7 @@
       "homepage": "https://www.cadenarasa.com/kebuena",
       "country": "MX",
       "tags": [
-        90.9,
+        "90.9",
         "90.9 fm",
         "banda",
         "banda norteña",
@@ -219189,12 +219189,12 @@
       "tags": [
         "2000s",
         "2010s",
-        580,
+        "580",
         "580 am",
         "80s",
         "90s",
         "90s y más",
-        93.1
+        "93.1"
       ],
       "favicon": "https://i.iheart.com/v3/re/new_assets/c6d5e262-600f-457d-b681-b8b4da6f40d1?ops=fit(240%2C240)",
       "bitrate": 48,
@@ -219209,7 +219209,7 @@
       "homepage": "https://www.premier917.fm/",
       "country": "MX",
       "tags": [
-        91.7,
+        "91.7",
         "91.7 fm",
         "balada en español",
         "baladas en español",
@@ -219277,7 +219277,7 @@
       "homepage": "https://www.exafm.com/mexicali/",
       "country": "MX",
       "tags": [
-        91.5,
+        "91.5",
         "91.5 fm",
         "baja california",
         "estación",
@@ -219344,7 +219344,7 @@
       "homepage": "https://www.fmglobo.com/monterrey/",
       "country": "MX",
       "tags": [
-        88.1,
+        "88.1",
         "88.1 fm",
         "adult hits",
         "estación",
@@ -219420,7 +219420,7 @@
       "homepage": "https://www.lamejor.com.mx/cuernavaca/",
       "country": "MX",
       "tags": [
-        97.3,
+        "97.3",
         "97.3 fm",
         "aquí nomás",
         "banda",
@@ -219446,7 +219446,7 @@
       "homepage": "https://www.iheart.com/live/match-901-puebla-8041/",
       "country": "MX",
       "tags": [
-        90.1,
+        "90.1",
         "90.1 fm",
         "acir",
         "estación",
@@ -219468,7 +219468,7 @@
       "homepage": "http://www.audioramamorelos.mx/labestiagrupera/",
       "country": "MX",
       "tags": [
-        104.5,
+        "104.5",
         "104.5 fm",
         "banda",
         "banda norteña",
@@ -219494,7 +219494,7 @@
       "homepage": "https://www.lamejor.com.mx/veracruz/",
       "country": "MX",
       "tags": [
-        100.5,
+        "100.5",
         "100.5 fm",
         "aquí nomás",
         "banda",
@@ -219542,7 +219542,7 @@
       "homepage": "https://www.lafiera.mx/",
       "country": "MX",
       "tags": [
-        94.1,
+        "94.1",
         "94.1 fm",
         "boca del río",
         "estación",
@@ -219568,7 +219568,7 @@
       "homepage": "https://www.exitos913.com/",
       "country": "MX",
       "tags": [
-        91.3,
+        "91.3",
         "91.3 fm",
         "brownsville",
         "entretenimiento",
@@ -219594,7 +219594,7 @@
       "homepage": "https://www.crystal1037.mx/",
       "country": "MX",
       "tags": [
-        103.7,
+        "103.7",
         "103.7 fm",
         "cdmx",
         "ciudad de mexico",
@@ -219623,7 +219623,7 @@
         "2000s",
         "2010s",
         "80s",
-        90.1,
+        "90.1",
         "90.1 fm",
         "90.1 mix",
         "90s",
@@ -219642,7 +219642,7 @@
       "homepage": "https://durango.latremenda.com.mx/",
       "country": "MX",
       "tags": [
-        96.5,
+        "96.5",
         "96.5 fm",
         "durango",
         "estación",
@@ -219762,7 +219762,7 @@
       "homepage": "https://www.fmglobo.com/guadalajara/",
       "country": "MX",
       "tags": [
-        98.7,
+        "98.7",
         "98.7 fm",
         "balada",
         "balada en español",
@@ -219788,7 +219788,7 @@
       "homepage": "https://www.globalmedia.mx/LOS40QUERETARO",
       "country": "MX",
       "tags": [
-        90.1,
+        "90.1",
         "90.1 fm",
         "entretenimiento",
         "español",
@@ -219821,7 +219821,7 @@
         "2000er",
         "2000s",
         "70 80 hits",
-        80
+        "80"
       ],
       "favicon": "https://upload.wikimedia.org/wikipedia/en/9/98/XHENS_LaZETA88.9_logo.png",
       "bitrate": 128,
@@ -219892,7 +219892,7 @@
       "homepage": "https://www.iheart.com/live/amor-925-6573/",
       "country": "MX",
       "tags": [
-        92.5,
+        "92.5",
         "92.5 fm",
         "acir",
         "amor",
@@ -219914,7 +219914,7 @@
       "homepage": "http://www.lagigante953.net/",
       "country": "MX",
       "tags": [
-        95.3,
+        "95.3",
         "95.3 fm",
         "estación",
         "fm",
@@ -219939,7 +219939,7 @@
       "homepage": "https://www.iheart.com/live/la-comadre-1055-8746/",
       "country": "MX",
       "tags": [
-        105.5,
+        "105.5",
         "105.5 fm",
         "acir",
         "banda",
@@ -219965,7 +219965,7 @@
         "2010s",
         "80s",
         "90s",
-        91.7,
+        "91.7",
         "91.7 fm",
         "acir",
         "estación"
@@ -219983,7 +219983,7 @@
       "homepage": "https://www.oye897.com.mx/",
       "country": "MX",
       "tags": [
-        89.7,
+        "89.7",
         "89.7 fm",
         "cdmx",
         "ciudad de mexico",
@@ -220093,7 +220093,7 @@
       "homepage": "https://www.radio.unam.mx/",
       "country": "MX",
       "tags": [
-        860,
+        "860",
         "860 am",
         "am",
         "ciudad de méxico",
@@ -220144,7 +220144,7 @@
       "homepage": "https://www.audioramabc.com/supermexicali/",
       "country": "MX",
       "tags": [
-        89.9,
+        "89.9",
         "89.9 fm",
         "baja california",
         "entretenimiento",
@@ -220169,7 +220169,7 @@
       "homepage": "http://www.kebuenaacayucan.com.mx/",
       "country": "MX",
       "tags": [
-        93.9,
+        "93.9",
         "93.9 fm",
         "acayucan",
         "banda",
@@ -220195,13 +220195,13 @@
       "homepage": "https://www.globalmedia.mx/stations/WRADIOQUERETARO",
       "country": "MX",
       "tags": [
-        1310,
+        "1310",
         "1310 am",
         "1980's",
         "1980s",
         "1990s",
         "70 80 hits",
-        80,
+        "80",
         "80's"
       ],
       "favicon": "https://www.globalmedia.mx/assets/favicon/apple-touch-icon-e3be40001a772e7d3c8486aedd7b55cf7211916d6fc9ce7fac6ed6efe8b7688d.png",
@@ -220285,7 +220285,7 @@
       "homepage": "https://www.iheart.com/live/la-comadre-1045-8099/",
       "country": "MX",
       "tags": [
-        104.5,
+        "104.5",
         "104.5 fm",
         "acir",
         "banda",
@@ -220307,7 +220307,7 @@
       "homepage": "https://www.exafm.com/veracruz/",
       "country": "MX",
       "tags": [
-        93.3,
+        "93.3",
         "93.3 fm",
         "boca del río",
         "en todas partes",
@@ -220411,7 +220411,7 @@
       "homepage": "https://www.fusionradio.mx/",
       "country": "MX",
       "tags": [
-        90.1,
+        "90.1",
         "90.1 fm",
         "boca del río",
         "fm",
@@ -220437,7 +220437,7 @@
       "homepage": "https://www.lamejor.com.mx/hermosillo/",
       "country": "MX",
       "tags": [
-        98.5,
+        "98.5",
         "98.5 fm",
         "aquí nomás",
         "banda",
@@ -220462,7 +220462,7 @@
       "homepage": "https://exafm.com/sanjuandelrio/",
       "country": "MX",
       "tags": [
-        99.1,
+        "99.1",
         "99.1 fm",
         "balada pop",
         "estación",
@@ -220488,7 +220488,7 @@
       "homepage": "https://www.exafm.com/guadalajara/",
       "country": "MX",
       "tags": [
-        101.1,
+        "101.1",
         "101.1 fm",
         "entretenimiento",
         "estación",
@@ -220510,7 +220510,7 @@
       "homepage": "https://www.xeu.mx/",
       "country": "MX",
       "tags": [
-        98.1,
+        "98.1",
         "98.1 fm",
         "boca del río",
         "deporte",
@@ -220535,7 +220535,7 @@
       "homepage": "https://www.globalmedia.mx/kebuena",
       "country": "MX",
       "tags": [
-        105.7,
+        "105.7",
         "105.7 fm",
         "banda",
         "fm",
@@ -220557,7 +220557,7 @@
       "homepage": "http://lamejor.com.mx/puertovallarta",
       "country": "MX",
       "tags": [
-        99.9,
+        "99.9",
         "99.9 fm",
         "aquí nomás",
         "banda",
@@ -220655,7 +220655,7 @@
         "80s",
         "90s",
         "90s y más",
-        92.7,
+        "92.7",
         "92.7 fm",
         "acir"
       ],
@@ -220698,7 +220698,7 @@
       "homepage": "http://www.audioramabajio.mx/labestiagrupera/",
       "country": "MX",
       "tags": [
-        90.3,
+        "90.3",
         "90.3 fm",
         "banda",
         "banda norteña",
@@ -220723,7 +220723,7 @@
       "homepage": "https://www.iheart.com/live/mix-1017-8079/",
       "country": "MX",
       "tags": [
-        101.7,
+        "101.7",
         "101.7 fm",
         "acir",
         "estación",
@@ -220745,7 +220745,7 @@
       "homepage": "https://www.pasion.fm/",
       "country": "MX",
       "tags": [
-        104.3,
+        "104.3",
         "104.3 fm",
         "balada",
         "balada en español",
@@ -220796,7 +220796,7 @@
       "homepage": "https://www.laoctava.com/sports",
       "country": "MX",
       "tags": [
-        107.3,
+        "107.3",
         "107.3 fm",
         "ciudad de mexico",
         "ciudad de méxico",
@@ -220822,7 +220822,7 @@
       "homepage": "https://www.audioramabc.com/labestiamexicali/",
       "country": "MX",
       "tags": [
-        92.3,
+        "92.3",
         "92.3 fm",
         "baja california",
         "banda",
@@ -220847,7 +220847,7 @@
       "homepage": "https://escucha.los40.com.mx/emisora/40p_guadalajara/",
       "country": "MX",
       "tags": [
-        102.7,
+        "102.7",
         "102.7 fm",
         "entretenimiento",
         "estación",
@@ -220945,7 +220945,7 @@
       "homepage": "https://www.radiolobobajio.mx/",
       "country": "MX",
       "tags": [
-        88.3,
+        "88.3",
         "88.3 fm",
         "banda",
         "banda norteña",
@@ -220971,7 +220971,7 @@
       "homepage": "https://www.iheart.com/live/amor-931-6569/",
       "country": "MX",
       "tags": [
-        93.1,
+        "93.1",
         "93.1 fm",
         "acir",
         "amor",
@@ -221040,7 +221040,7 @@
       "homepage": "https://www.exafm.com/sdtj/",
       "country": "MX",
       "tags": [
-        91.7,
+        "91.7",
         "91.7 fm",
         "baja california",
         "california",
@@ -221066,7 +221066,7 @@
       "homepage": "https://www.digital1029.fm/",
       "country": "MX",
       "tags": [
-        102.9,
+        "102.9",
         "102.9 fm",
         "contemporary hits",
         "estación",
@@ -221092,7 +221092,7 @@
       "homepage": "https://www.iheart.com/live/la-comadre-985-culiacan-6574/",
       "country": "MX",
       "tags": [
-        98.5,
+        "98.5",
         "98.5 fm",
         "acir",
         "banda",
@@ -221114,7 +221114,7 @@
       "homepage": "https://www.globalmedia.mx/stations/KeBuenaVallarta",
       "country": "MX",
       "tags": [
-        95.9,
+        "95.9",
         "95.9 fm",
         "banda",
         "estación",
@@ -221221,7 +221221,7 @@
         "80s",
         "90s",
         "90s y más",
-        98.5,
+        "98.5",
         "98.5 fm",
         "acir"
       ],
@@ -221238,7 +221238,7 @@
       "homepage": "https://universal.org.mx/radio-omega/",
       "country": "MX",
       "tags": [
-        830,
+        "830",
         "830 am",
         "am",
         "cdmx",
@@ -221264,7 +221264,7 @@
       "homepage": "https://tunein.com/radio/Lupe-FM-933-s216068/",
       "country": "MX",
       "tags": [
-        93.3,
+        "93.3",
         "93.3 fm",
         "banda",
         "banda norteña",
@@ -221294,7 +221294,7 @@
         "1980s",
         "80's",
         "80s",
-        96.5,
+        "96.5",
         "96.5 fm",
         "balada",
         "balada en español"
@@ -221332,7 +221332,7 @@
       "homepage": "https://grupozer.mx/portada.php?id=800",
       "country": "MX",
       "tags": [
-        96.5,
+        "96.5",
         "96.5 fm",
         "estación",
         "fm",
@@ -221388,7 +221388,7 @@
         "80s",
         "90s",
         "90s y más",
-        92.5,
+        "92.5",
         "92.5 fm",
         "acir"
       ],
@@ -221405,7 +221405,7 @@
       "homepage": "https://www.globalmedia.mx/Tri%C3%B3n",
       "country": "MX",
       "tags": [
-        90.1,
+        "90.1",
         "90.1 fm",
         "alternative",
         "alternative rock",
@@ -221478,7 +221478,7 @@
       "homepage": "https://grupozer.mx/portada.php?id=102",
       "country": "MX",
       "tags": [
-        102.9,
+        "102.9",
         "102.9 fm",
         "aguascalientes",
         "banda norteña",
@@ -221520,7 +221520,7 @@
       "homepage": "http://www.ncscampeche.com/kebuena-campeche.html",
       "country": "MX",
       "tags": [
-        102.7,
+        "102.7",
         "102.7 fm",
         "banda",
         "campeche",
@@ -221562,7 +221562,7 @@
       "homepage": "https://radiocanion.com/xeav-am/",
       "country": "MX",
       "tags": [
-        580,
+        "580",
         "580 am",
         "abc radio",
         "am",
@@ -221665,7 +221665,7 @@
       "homepage": "https://www.lamejor.com.mx/merida/",
       "country": "MX",
       "tags": [
-        90.1,
+        "90.1",
         "90.1 fm",
         "aquí nomás",
         "estación",
@@ -221691,7 +221691,7 @@
       "homepage": "http://www.lamejor.gremradio.com.mx/",
       "country": "MX",
       "tags": [
-        97.1,
+        "97.1",
         "97.1 fm",
         "aquí nomás",
         "banda",
@@ -221716,7 +221716,7 @@
       "homepage": "https://www.iheart.com/live/mix-1031-8107/",
       "country": "MX",
       "tags": [
-        103.1,
+        "103.1",
         "103.1 fm",
         "2000s",
         "2010s",
@@ -221888,7 +221888,7 @@
       "homepage": "https://www.globalmedia.mx/stations/VOX969",
       "country": "MX",
       "tags": [
-        96.9,
+        "96.9",
         "96.9 fm",
         "entretenimiento",
         "estación",
@@ -221984,7 +221984,7 @@
       "homepage": "https://radiogrupo.com/lapoderosa107-7/",
       "country": "MX",
       "tags": [
-        107.7,
+        "107.7",
         "107.7 fm",
         "aguascalientes",
         "estación",
@@ -222009,7 +222009,7 @@
       "homepage": "https://www.iheart.com/live/amor-979-6570/",
       "country": "MX",
       "tags": [
-        97.9,
+        "97.9",
         "97.9 fm",
         "acir",
         "amor",
@@ -222064,7 +222064,7 @@
       "homepage": "http://player.listenlive.co/51851/es",
       "country": "MX",
       "tags": [
-        1030,
+        "1030",
         "1030 am",
         "am",
         "ciudad de mexico",
@@ -222090,7 +222090,7 @@
       "homepage": "https://cadenarasa.com/san-luis-potosi/san-luis-potosi/candela?fbclid=IwAR34MNUgZAFwiuQ1nWif9o2HxoEOaNikHujI8GVo5cS6NvKjdxu8-itSdO4",
       "country": "MX",
       "tags": [
-        94.1,
+        "94.1",
         "94.1 fm",
         "cadena rasa",
         "candela",
@@ -222131,7 +222131,7 @@
       "homepage": "https://www.lamejor.com.mx/cdobregon/",
       "country": "MX",
       "tags": [
-        103.3,
+        "103.3",
         "103.3 fm",
         "aquí nomás",
         "banda",
@@ -222157,7 +222157,7 @@
       "homepage": "https://escucha.los40.com.mx/emisora/los40_mexicali/",
       "country": "MX",
       "tags": [
-        90.7,
+        "90.7",
         "90.7 fm",
         "baja california",
         "entretenimiento",
@@ -222179,7 +222179,7 @@
       "homepage": "https://www.globalmedia.mx/Los40",
       "country": "MX",
       "tags": [
-        103.9,
+        "103.9",
         "103.9 fm",
         "entretenimiento",
         "estación",
@@ -222223,7 +222223,7 @@
       "homepage": "http://www.launica.fm/",
       "country": "MX",
       "tags": [
-        103.3,
+        "103.3",
         "103.3 fm",
         "estación",
         "fm",
@@ -222301,7 +222301,7 @@
       "homepage": "https://uamradio.uam.mx/",
       "country": "MX",
       "tags": [
-        94.9,
+        "94.9",
         "94.9 fm",
         "ciudad de mexico",
         "ciudad de méxico",
@@ -222349,7 +222349,7 @@
       "homepage": "http://radiomas.mx/",
       "country": "MX",
       "tags": [
-        105.5,
+        "105.5",
         "105.5 fm",
         "cordoba",
         "córdoba",
@@ -222401,7 +222401,7 @@
       "homepage": "https://lamejor.com.mx/culiacan/",
       "country": "MX",
       "tags": [
-        104.1,
+        "104.1",
         "104.1 fm",
         "aquí nomás",
         "banda",
@@ -222427,7 +222427,7 @@
       "homepage": "https://www.radioola.com.mx/",
       "country": "MX",
       "tags": [
-        91.5,
+        "91.5",
         "91.5 fm",
         "balada pop",
         "entretenimiento",
@@ -222547,7 +222547,7 @@
       "homepage": "https://www.exafm.com/tampico/",
       "country": "MX",
       "tags": [
-        95.3,
+        "95.3",
         "95.3 fm",
         "entretenimiento",
         "estación",
@@ -222621,7 +222621,7 @@
       "homepage": "https://www.xeu.mx/",
       "country": "MX",
       "tags": [
-        98.1,
+        "98.1",
         "98.1 fm",
         "boca del río",
         "deporte",
@@ -222673,7 +222673,7 @@
       "homepage": "https://www.radioramamorelos.com.mx/principal/la-mas-picuda-94-9-fm/",
       "country": "MX",
       "tags": [
-        94.9,
+        "94.9",
         "94.9 fm",
         "cuernavaca",
         "estación",
@@ -222817,7 +222817,7 @@
       "homepage": "https://www.superstereomerida.com/",
       "country": "MX",
       "tags": [
-        105.9,
+        "105.9",
         "105.9 fm",
         "adult hits",
         "contemporary hits",
@@ -222841,7 +222841,7 @@
       "homepage": "http://www.audioramaguerrero.mx/buenisima/",
       "country": "MX",
       "tags": [
-        103.9,
+        "103.9",
         "103.9 fm",
         "acapulco",
         "buenisiima",
@@ -222867,7 +222867,7 @@
       "homepage": "http://lamejor.com.mx/puertoescondido",
       "country": "MX",
       "tags": [
-        94.1,
+        "94.1",
         "94.1 fm",
         "aquí nomás",
         "banda",
@@ -222909,7 +222909,7 @@
       "homepage": "https://www.exafm.com/leon/",
       "country": "MX",
       "tags": [
-        104.1,
+        "104.1",
         "104.1 fm",
         "entretenimiento",
         "estación",
@@ -222957,7 +222957,7 @@
       "homepage": "https://www.notisistema.com/radiovital/",
       "country": "MX",
       "tags": [
-        1310,
+        "1310",
         "1310 am",
         "am",
         "entretenimiento",
@@ -222983,7 +222983,7 @@
       "homepage": "https://www.exafm.com/elpaso/",
       "country": "MX",
       "tags": [
-        98.3,
+        "98.3",
         "98.3 fm",
         "chihuahua",
         "ciudad juárez",
@@ -223005,7 +223005,7 @@
       "homepage": "https://www.lamejor.com.mx/acapulco/",
       "country": "MX",
       "tags": [
-        100.1,
+        "100.1",
         "100.1 fm",
         "acapulco",
         "aquí nomás",
@@ -223057,9 +223057,9 @@
       "homepage": "http://globalmedia.mx/Los40",
       "country": "MX",
       "tags": [
-        103.9,
+        "103.9",
         "103.9 fm",
-        540,
+        "540",
         "540 am",
         "adult top 40",
         "entretenimiento",
@@ -223135,7 +223135,7 @@
       "homepage": "https://grupozer.mx/portada.php?id=100",
       "country": "MX",
       "tags": [
-        104.5,
+        "104.5",
         "104.5 fm",
         "80s en español",
         "balada",
@@ -223161,7 +223161,7 @@
       "homepage": "https://www.fmglobo.com/tijuana/",
       "country": "MX",
       "tags": [
-        99.3,
+        "99.3",
         "99.3 fm",
         "baja california",
         "balada",
@@ -223183,7 +223183,7 @@
       "homepage": "https://www.iheart.com/live/match-1001-culiacan-8039/",
       "country": "MX",
       "tags": [
-        100.1,
+        "100.1",
         "100.1 fm",
         "acir",
         "culiacán",
@@ -223247,7 +223247,7 @@
       "homepage": "https://grupozer.mx/portada.php?id=801",
       "country": "MX",
       "tags": [
-        106.5,
+        "106.5",
         "106.5 fm",
         "digital",
         "entretenimiento",
@@ -223298,7 +223298,7 @@
       "homepage": "https://lamejor.com.mx/manzanillo/",
       "country": "MX",
       "tags": [
-        96.3,
+        "96.3",
         "96.3 fm",
         "aquí nomás",
         "banda",
@@ -223340,9 +223340,9 @@
       "homepage": "https://amor101.com/",
       "country": "MX",
       "tags": [
-        101.3,
+        "101.3",
         "101.3 fm",
-        630,
+        "630",
         "630 am",
         "amor 101",
         "combo",
@@ -223382,7 +223382,7 @@
       "homepage": "https://www.exafm.com/puebla/",
       "country": "MX",
       "tags": [
-        94.1,
+        "94.1",
         "94.1 fm",
         "entretenimiento",
         "estación",
@@ -223404,7 +223404,7 @@
       "homepage": "http://www.audioramachihuahua.mx/labestiagrupera/",
       "country": "MX",
       "tags": [
-        99.3,
+        "99.3",
         "99.3 fm",
         "banda",
         "banda norteña",
@@ -223480,7 +223480,7 @@
       "homepage": "https://www.los40xalapa.com/",
       "country": "MX",
       "tags": [
-        104.1,
+        "104.1",
         "104.1 fm",
         "avanradio",
         "estación",
@@ -223528,7 +223528,7 @@
       "homepage": "https://www.radiouniversal.mx/la-mejor.html",
       "country": "MX",
       "tags": [
-        93.7,
+        "93.7",
         "93.7 fm",
         "aguascalientes",
         "aquí nomás",
@@ -223572,7 +223572,7 @@
       "homepage": "http://www.lamejor.com.mx/colima",
       "country": "MX",
       "tags": [
-        92.5,
+        "92.5",
         "92.5 fm",
         "aquí nomás",
         "banda",
@@ -223737,7 +223737,7 @@
       "homepage": "https://www.exafm.com/campeche/",
       "country": "MX",
       "tags": [
-        100.3,
+        "100.3",
         "100.3 fm",
         "campeche",
         "estación",
@@ -223785,7 +223785,7 @@
       "homepage": "https://www.iheart.com/live/match-975-leon-8097/",
       "country": "MX",
       "tags": [
-        97.5,
+        "97.5",
         "97.5 fm",
         "acir",
         "estación",
@@ -223828,7 +223828,7 @@
       "homepage": "https://www.ellobo106.com/",
       "country": "MX",
       "tags": [
-        106.1,
+        "106.1",
         "106.1 fm",
         "chihuahua",
         "clasicos",
@@ -223854,7 +223854,7 @@
       "homepage": "https://www.cadenarasa.com/los40",
       "country": "MX",
       "tags": [
-        96.9,
+        "96.9",
         "96.9 fm",
         "cadena rasa",
         "entretenimiento",
@@ -223925,7 +223925,7 @@
       "homepage": "https://lamejor.com.mx/nogales/",
       "country": "MX",
       "tags": [
-        96.7,
+        "96.7",
         "96.7 fm",
         "aquí nomás",
         "banda",
@@ -223951,7 +223951,7 @@
       "homepage": "http://www.audioramaguerrero.mx/labestiagrupera997/",
       "country": "MX",
       "tags": [
-        99.7,
+        "99.7",
         "99.7 fm",
         "banda",
         "banda norteña",
@@ -224129,7 +224129,7 @@
       "homepage": "https://www.universal881.com/",
       "country": "MX",
       "tags": [
-        700,
+        "700",
         "700 am",
         "adult contemporary",
         "am",
@@ -224154,7 +224154,7 @@
       "homepage": "http://www.audioramaguadalajara.mx/Vibe/",
       "country": "MX",
       "tags": [
-        107.5,
+        "107.5",
         "107.5 fm",
         "bailable",
         "dance",
@@ -224222,7 +224222,7 @@
       "homepage": "http://www.laele.fm/",
       "country": "MX",
       "tags": [
-        95.1,
+        "95.1",
         "95.1 fm",
         "estación",
         "fm",
@@ -224274,7 +224274,7 @@
       "homepage": "https://www.audioramabc.com/buenisimamexicali/",
       "country": "MX",
       "tags": [
-        850,
+        "850",
         "850 am",
         "adult hits",
         "am",
@@ -224362,7 +224362,7 @@
       "homepage": "http://player.listenlive.co/29701/",
       "country": "MX",
       "tags": [
-        92.9,
+        "92.9",
         "92.9 fm",
         "ciudad acuna",
         "ciudad acuña",
@@ -224388,7 +224388,7 @@
       "homepage": "https://www.radiocanion.com/xhfrt/",
       "country": "MX",
       "tags": [
-        92.5,
+        "92.5",
         "92.5 fm",
         "abc radio",
         "banda",
@@ -224413,7 +224413,7 @@
       "homepage": "http://www.audioramabajio.mx/love/",
       "country": "MX",
       "tags": [
-        101.5,
+        "101.5",
         "101.5 fm",
         "estación",
         "fm",
@@ -224540,7 +224540,7 @@
       "homepage": "https://escucha.los40.com.mx/emisora/los40_veracruz/",
       "country": "MX",
       "tags": [
-        98.9,
+        "98.9",
         "98.9 fm",
         "entretenimiento",
         "estación",
@@ -224561,7 +224561,7 @@
       "homepage": "https://radioytvmexiquense.mx/index.php/radio/104-5-fm-valle-de-bravo/",
       "country": "MX",
       "tags": [
-        104.5,
+        "104.5",
         "104.5 fm",
         "estación",
         "estado de mexico",
@@ -224611,7 +224611,7 @@
       "homepage": "https://grupozer.mx/portada.php?id=805",
       "country": "MX",
       "tags": [
-        98.5,
+        "98.5",
         "98.5 fm",
         "entretenimiento",
         "estación",
@@ -224637,7 +224637,7 @@
       "homepage": "http://www.audioramabajio.mx/los40/",
       "country": "MX",
       "tags": [
-        93.1,
+        "93.1",
         "93.1 fm",
         "entretenimiento",
         "estación",
@@ -224714,7 +224714,7 @@
       "homepage": "https://www.radiocanion.com/xhjh/",
       "country": "MX",
       "tags": [
-        92.9,
+        "92.9",
         "92.9 fm",
         "abc radio",
         "estación",
@@ -224761,7 +224761,7 @@
       "homepage": "https://www.globalmedia.mx/ImagenRadio",
       "country": "MX",
       "tags": [
-        103.1,
+        "103.1",
         "103.1 fm",
         "business news",
         "cultural news",
@@ -224787,7 +224787,7 @@
       "homepage": "http://www.sensitivaradio.com/",
       "country": "MX",
       "tags": [
-        88.3,
+        "88.3",
         "88.3 fm",
         "banda",
         "banda norteña",
@@ -224812,7 +224812,7 @@
       "homepage": "http://www.audioramaguerrero.mx/super107/",
       "country": "MX",
       "tags": [
-        102.7,
+        "102.7",
         "102.7 fm",
         "chilpancingo",
         "entretenimiento",
@@ -224910,7 +224910,7 @@
       "homepage": "https://grupozer.mx/portada.php?id=807",
       "country": "MX",
       "tags": [
-        90.7,
+        "90.7",
         "90.7 fm",
         "balada",
         "balada en español",
@@ -224936,7 +224936,7 @@
       "homepage": "http://www.radiozitacuaro.com/",
       "country": "MX",
       "tags": [
-        95.1,
+        "95.1",
         "95.1 fm",
         "estación",
         "fm",
@@ -224961,7 +224961,7 @@
       "homepage": "https://radiocanion.com/xhabca/",
       "country": "MX",
       "tags": [
-        101.3,
+        "101.3",
         "101.3 fm",
         "abc radio",
         "baja california",
@@ -225080,7 +225080,7 @@
       "homepage": "http://radiocanion.com/xhcts",
       "country": "MX",
       "tags": [
-        95.7,
+        "95.7",
         "95.7 fm",
         "adult top 40",
         "chiapas",
@@ -225205,7 +225205,7 @@
       "homepage": "https://radiocanion.com/xhvox/",
       "country": "MX",
       "tags": [
-        98.7,
+        "98.7",
         "98.7 fm",
         "estación",
         "fm",
@@ -225281,7 +225281,7 @@
       "homepage": "https://www.radiorama.mx/aradios.php?id=129",
       "country": "MX",
       "tags": [
-        101.5,
+        "101.5",
         "101.5 fm",
         "balada",
         "balada en español",
@@ -225311,10 +225311,10 @@
         "1980s",
         "1990s",
         "70 80 hits",
-        80,
+        "80",
         "80's",
         "80s",
-        90
+        "90"
       ],
       "favicon": "https://www.globalmedia.mx/assets/favicon/apple-touch-icon-e3be40001a772e7d3c8486aedd7b55cf7211916d6fc9ce7fac6ed6efe8b7688d.png",
       "bitrate": 128,
@@ -225350,7 +225350,7 @@
       "country": "MX",
       "tags": [
         "80s en español",
-        99.3,
+        "99.3",
         "99.3 fm",
         "balada",
         "balada en español",
@@ -225443,7 +225443,7 @@
       "homepage": "http://lamejor.com.mx/piedrasnegras",
       "country": "MX",
       "tags": [
-        99.1,
+        "99.1",
         "99.1 fm",
         "aquí nomás",
         "banda",
@@ -225560,7 +225560,7 @@
       "homepage": "https://exafm.com/tuxtepec/",
       "country": "MX",
       "tags": [
-        101.3,
+        "101.3",
         "101.3 fm",
         "en todas partes",
         "estación",
@@ -225683,7 +225683,7 @@
       "homepage": "https://www.exafm.com/ciudadobregon/",
       "country": "MX",
       "tags": [
-        99.3,
+        "99.3",
         "99.3 fm",
         "ciudad obregón",
         "entretenimiento",
@@ -225709,7 +225709,7 @@
       "homepage": "https://www.laoctava.com/",
       "country": "MX",
       "tags": [
-        700,
+        "700",
         "700 am",
         "adult contemporary",
         "am",
@@ -225825,7 +225825,7 @@
       "homepage": "https://www.exafm.com/cuernavaca/",
       "country": "MX",
       "tags": [
-        95.7,
+        "95.7",
         "95.7 fm",
         "cuernavaca",
         "entretenimiento",
@@ -225899,7 +225899,7 @@
       "homepage": "https://www.lavozdelpitic.com/",
       "country": "MX",
       "tags": [
-        88.1,
+        "88.1",
         "88.1 fm",
         "concesión social",
         "cultura",
@@ -225925,7 +225925,7 @@
       "homepage": "http://www.radiozamora.com.mx/xhzn.html",
       "country": "MX",
       "tags": [
-        88.1,
+        "88.1",
         "88.1 fm",
         "estación",
         "fm",
@@ -225949,7 +225949,7 @@
         "70s",
         "80s",
         "90s",
-        95.9,
+        "95.9",
         "95.9 fm",
         "abc radio",
         "clasicos en ingles",
@@ -225984,7 +225984,7 @@
       "homepage": "https://www.sizart.org.mx/",
       "country": "MX",
       "tags": [
-        97.9,
+        "97.9",
         "97.9 fm",
         "cultura",
         "cultural",
@@ -226010,7 +226010,7 @@
       "homepage": "http://www.sensitivaradio.com/",
       "country": "MX",
       "tags": [
-        88.3,
+        "88.3",
         "88.3 fm",
         "banda",
         "banda norteña",
@@ -226133,7 +226133,7 @@
       "homepage": "https://radioytvmexiquense.mx/index.php/radio/1600-am-metepec/",
       "country": "MX",
       "tags": [
-        1600,
+        "1600",
         "1600 am",
         "am",
         "estación",
@@ -226158,9 +226158,9 @@
       "homepage": "http://imer.mx/radioimer",
       "country": "MX",
       "tags": [
-        107.9,
+        "107.9",
         "107.9 fm",
-        540,
+        "540",
         "540 am",
         "am",
         "bachata",
@@ -226232,7 +226232,7 @@
       "homepage": "https://www.exafm.com/torreon/",
       "country": "MX",
       "tags": [
-        95.5,
+        "95.5",
         "95.5 fm",
         "coahuila",
         "en todas partes",
@@ -226257,9 +226257,9 @@
       "homepage": "http://laacerera.mx/",
       "country": "MX",
       "tags": [
-        560,
+        "560",
         "560 am",
-        88.1,
+        "88.1",
         "88.1 fm",
         "am",
         "coahuila",
@@ -226326,7 +226326,7 @@
       "homepage": "https://radioytvmexiquense.mx/index.php/radio/91-7-fm-metepec/",
       "country": "MX",
       "tags": [
-        91.7,
+        "91.7",
         "91.7 fm",
         "estación",
         "estado de mexico",
@@ -226352,7 +226352,7 @@
       "homepage": "https://radioytvmexiquense.mx/index.php/radio/88-5-fm-zumpango/",
       "country": "MX",
       "tags": [
-        88.5,
+        "88.5",
         "88.5 fm",
         "estación",
         "estado de mexico",
@@ -226403,7 +226403,7 @@
       "homepage": "http://www.audioramaguerrero.mx/vida/",
       "country": "MX",
       "tags": [
-        89.7,
+        "89.7",
         "89.7 fm",
         "acapulco",
         "estación",
@@ -226428,7 +226428,7 @@
       "homepage": "https://www.exafm.com/merida/",
       "country": "MX",
       "tags": [
-        99.3,
+        "99.3",
         "99.3 fm",
         "entretenimiento",
         "estación",
@@ -226450,7 +226450,7 @@
       "homepage": "http://www.audioramachihuahua.mx/love/",
       "country": "MX",
       "tags": [
-        90.1,
+        "90.1",
         "90.1 fm",
         "balada",
         "balada en español",
@@ -226791,7 +226791,7 @@
       "homepage": "https://radiocanion.com/xhnx/",
       "country": "MX",
       "tags": [
-        104.3,
+        "104.3",
         "104.3 fm",
         "banda",
         "banda norteña",
@@ -226817,7 +226817,7 @@
       "homepage": "http://www.audioramaguerrero.mx/super/",
       "country": "MX",
       "tags": [
-        94.5,
+        "94.5",
         "94.5 fm",
         "acapulco",
         "entretenimiento",
@@ -226842,7 +226842,7 @@
       "homepage": "http://www.audioramaguerrero.mx/retro/",
       "country": "MX",
       "tags": [
-        92.1,
+        "92.1",
         "92.1 fm",
         "acapulco",
         "entrevistas",
@@ -226904,9 +226904,9 @@
       "homepage": "https://grupozer.mx/portada.php?id=301",
       "country": "MX",
       "tags": [
-        560,
+        "560",
         "560 am",
-        89.7,
+        "89.7",
         "89.7 fm",
         "am",
         "cihuatlán",
@@ -227151,7 +227151,7 @@
       "homepage": "https://www.radiorama.mx/aradios.php?id=249",
       "country": "MX",
       "tags": [
-        96.1,
+        "96.1",
         "96.1 fm",
         "banda",
         "banda norteña",
@@ -227203,7 +227203,7 @@
       "homepage": "https://tunein.com/radio/La-Grande-de-Ro-Grande--XHZC-810-s91604/",
       "country": "MX",
       "tags": [
-        97.1,
+        "97.1",
         "97.1 fm",
         "entretenimiento",
         "estación",
@@ -227229,7 +227229,7 @@
       "homepage": "https://www.grupozer.mx/portada.php?id=701",
       "country": "MX",
       "tags": [
-        99.9,
+        "99.9",
         "99.9 fm",
         "agua prieta",
         "estación",
@@ -227305,7 +227305,7 @@
       "homepage": "http://sonidoestrella.net/",
       "country": "MX",
       "tags": [
-        89.9,
+        "89.9",
         "89.9 fm",
         "estación",
         "fm",
@@ -227460,7 +227460,7 @@
       "homepage": "https://www.facebook.com/lanuestra",
       "country": "MX",
       "tags": [
-        1270,
+        "1270",
         "1270 am",
         "642 media",
         "am",
@@ -227612,9 +227612,9 @@
       "homepage": "http://jaliscoradio.com/",
       "country": "MX",
       "tags": [
-        107.1,
+        "107.1",
         "107.1 fm",
-        96.3,
+        "96.3",
         "96.3 fm",
         "ciudad guzmán",
         "cultura",
@@ -227680,7 +227680,7 @@
       "homepage": "https://radioxhikefm.com/paginaWP",
       "country": "MX",
       "tags": [
-        89.1,
+        "89.1",
         "89.1 fm",
         "community",
         "community news",
@@ -227790,7 +227790,7 @@
       "homepage": "https://www.exafm.com/nogales/",
       "country": "MX",
       "tags": [
-        102.7,
+        "102.7",
         "102.7 fm",
         "entretenimiento",
         "estación",
@@ -227812,7 +227812,7 @@
       "homepage": "https://escucha.los40.com.mx/emisora/los40_vallarta/",
       "country": "MX",
       "tags": [
-        91.1,
+        "91.1",
         "91.1 fm",
         "entretenimiento",
         "estación",
@@ -227976,7 +227976,7 @@
       "homepage": "https://www.exafm.com/tuxtepec/",
       "country": "MX",
       "tags": [
-        101.3,
+        "101.3",
         "101.3 fm",
         "en todas partes",
         "entretenimiento",
@@ -228027,7 +228027,7 @@
       "homepage": "https://radiocanion.com/xhxc/",
       "country": "MX",
       "tags": [
-        96.1,
+        "96.1",
         "96.1 fm",
         "estación",
         "fm",
@@ -228250,7 +228250,7 @@
       "homepage": "https://escucha.los40.com.mx/emisora/los40_ensenada/",
       "country": "MX",
       "tags": [
-        96.9,
+        "96.9",
         "96.9 fm",
         "baja california",
         "ensenada",
@@ -228379,7 +228379,7 @@
       "homepage": "https://www.exafm.com/ensenada/",
       "country": "MX",
       "tags": [
-        104.1,
+        "104.1",
         "104.1 fm",
         "baja california",
         "ensenada",
@@ -228628,7 +228628,7 @@
       "homepage": "https://www.focusradio.mx/",
       "country": "MX",
       "tags": [
-        1670,
+        "1670",
         "1670 am",
         "am",
         "concesión social",
@@ -228680,7 +228680,7 @@
       "homepage": "https://tunein.com/radio/Radio-Jerez-891-s90232/",
       "country": "MX",
       "tags": [
-        89.1,
+        "89.1",
         "89.1 fm",
         "entretenimiento",
         "español",
@@ -229055,7 +229055,7 @@
       "homepage": "https://www.arroba.fm/Celaya",
       "country": "MX",
       "tags": [
-        99.5,
+        "99.5",
         "99.5 fm",
         "@fm",
         "@fm te conecta",
@@ -231488,7 +231488,7 @@
       "homepage": "https://radionucleo.com/",
       "country": "MX",
       "tags": [
-        100.1,
+        "100.1",
         "la ke buena",
         "radio núcleo",
         "radiópolis"
@@ -232810,7 +232810,7 @@
       "homepage": "https://radiocanon.com.mx/",
       "country": "MX",
       "tags": [
-        98.5,
+        "98.5",
         "grupera",
         "radiópolis",
         "regional mexicano"
@@ -232828,7 +232828,7 @@
       "homepage": "https://lakebuenaguasave.com/mobile.php",
       "country": "MX",
       "tags": [
-        88.9,
+        "88.9",
         "grupera",
         "radiópolis",
         "regional mexicano"
@@ -234590,7 +234590,7 @@
       "homepage": "https://radionucleo.com/",
       "country": "MX",
       "tags": [
-        90.3,
+        "90.3",
         "grupera",
         "la tg",
         "radio núcleo",
@@ -235544,10 +235544,10 @@
       "tags": [
         "2000-2021",
         "2000s",
-        2021,
-        2022,
-        2023,
-        2024,
+        "2021",
+        "2022",
+        "2023",
+        "2024",
         "english",
         "hip-hop"
       ],
@@ -240215,7 +240215,7 @@
       "homepage": "https://grupomradio.mx/",
       "country": "MX",
       "tags": [
-        93.1,
+        "93.1",
         "coahuila",
         "fm",
         "mexico",
@@ -240309,8 +240309,8 @@
       "homepage": "https://xhxu.yolasite.com/",
       "country": "MX",
       "tags": [
-        1480,
-        94.7,
+        "1480",
+        "94.7",
         "am",
         "coahuila",
         "fm",
@@ -240419,8 +240419,8 @@
       "homepage": "https://www.facebook.com/LaSuperEstacion1031/",
       "country": "MX",
       "tags": [
-        103.1,
-        1330,
+        "103.1",
+        "1330",
         "am",
         "coahuila",
         "fm",
@@ -240563,7 +240563,7 @@
       "homepage": "https://player.listenlive.co/38241/es",
       "country": "MX",
       "tags": [
-        91.1,
+        "91.1",
         "capital media",
         "coahuila",
         "fm",
@@ -251462,7 +251462,7 @@
       "homepage": "http://www.am1470.com/home_c.php?1634199366",
       "country": "CA",
       "tags": [
-        96.1,
+        "96.1",
         "96.1 fm",
         "music",
         "news",
@@ -251481,9 +251481,9 @@
       "homepage": "https://radiosuitenetwork.torontocast.stream/70-80-90-italia-dautore/",
       "country": "CA",
       "tags": [
-        70,
-        80,
-        90,
+        "70",
+        "80",
+        "90",
         "classic italian pop",
         "italian pop",
         "musica italiana"
@@ -251552,7 +251552,7 @@
       "homepage": "https://radiodimensionemix.torontocast.stream/",
       "country": "CA",
       "tags": [
-        1980,
+        "1980",
         "1980s",
         "1980s hits",
         "80's",

--- a/src/builtins.ts
+++ b/src/builtins.ts
@@ -1463,7 +1463,14 @@ function normaliseStation(raw: unknown): Station | null {
     streamUrl: r.streamUrl,
     homepage: r.homepage,
     country: r.country,
-    tags: Array.isArray(r.tags) ? r.tags : undefined,
+    // Coerce every tag to a string at the boundary. YAML auto-parses
+    // bare numerics ("70", "11.11") and reserved words (true/false/null/
+    // yes/no) as non-strings, and `t.toLowerCase()` in the local
+    // search filter throws on those. Fixed at the importer layer
+    // already; this is the runtime second line of defense.
+    tags: Array.isArray(r.tags)
+      ? r.tags.map((t) => String(t)).filter((t): t is string => t.length > 0)
+      : undefined,
     favicon: resolveFavicon(r.favicon),
     bitrate: typeof r.bitrate === 'number' ? r.bitrate : undefined,
     codec: r.codec,

--- a/tools/backfill-tags.mjs
+++ b/tools/backfill-tags.mjs
@@ -93,7 +93,14 @@ function yamlSafe(t) {
   // block-sequence start inside a flow array. Without this, RB tags
   // like "#top100", "- dj charts", "?something" or "* hot" silently
   // corrupt the YAML when written into a flow-style `tags: [...]` line.
+  // Also: quote anything that YAML would coerce to a non-string scalar
+  // (numbers, true/false/null, "yes"/"no") — string tags written bare
+  // come back as numbers/booleans on parse, and downstream JS filters
+  // crash on `t.toLowerCase()`. Was the root cause of the WDR5 e2e
+  // failure post-#187 (tags "70", "80", "11.11" → numeric in JSON).
   if (!t) return '""';
+  if (/^-?\d+(?:\.\d+)?$/.test(t)) return JSON.stringify(t);
+  if (/^(true|false|null|yes|no|on|off|~)$/i.test(t)) return JSON.stringify(t);
   if (/[:#&*!|>'"%@`,\[\]{}?]/.test(t)) return JSON.stringify(t);
   if (/^[-\s?:!&*|>%@`]/.test(t)) return JSON.stringify(t);
   if (/^\s|\s$/.test(t)) return JSON.stringify(t);

--- a/tools/batch-import.mjs
+++ b/tools/batch-import.mjs
@@ -134,6 +134,19 @@ function quote(s) {
     : s;
 }
 
+function yamlTag(t) {
+  // See backfill-tags.mjs:yamlSafe for the full rationale. Mirrors
+  // that quoting logic so RB tags never round-trip as non-strings.
+  if (!t) return '""';
+  if (/^-?\d+(?:\.\d+)?$/.test(t)) return JSON.stringify(t);
+  if (/^(true|false|null|yes|no|on|off|~)$/i.test(t)) return JSON.stringify(t);
+  if (/[:#&*!|>'"%@`,\[\]{}?]/.test(t)) return JSON.stringify(t);
+  if (/^[-\s?:!&*|>%@`]/.test(t)) return JSON.stringify(t);
+  if (/^\s|\s$/.test(t)) return JSON.stringify(t);
+  if (/\s-\s/.test(t)) return JSON.stringify(t);
+  return t;
+}
+
 function normaliseTags(rbTags) {
   if (!rbTags) return [];
   return rbTags
@@ -155,7 +168,10 @@ function buildYamlEntry(s, id) {
   if (s.bitrate && s.bitrate > 0) lines.push(`  bitrate: ${s.bitrate}`);
   if (s.codec) lines.push(`  codec: ${s.codec.toUpperCase()}`);
   const tags = normaliseTags(s.tags);
-  if (tags.length > 0) lines.push(`  tags: [${tags.join(', ')}]`);
+  // Per-tag quote: bare numerics ("70", "11.11") and YAML reserved
+  // forms (true/false/null, leading "-", "#", etc.) would round-trip
+  // as non-strings and crash downstream `t.toLowerCase()` calls.
+  if (tags.length > 0) lines.push(`  tags: [${tags.map(yamlTag).join(', ')}]`);
   if (s.favicon) lines.push(`  favicon: ${s.favicon}`);
   if (s.homepage) lines.push(`  homepage: ${s.homepage}`);
   if (s.country) lines.push(`  country: ${s.country}`);

--- a/tools/import-rb-tier.mjs
+++ b/tools/import-rb-tier.mjs
@@ -163,6 +163,22 @@ function normalizeTags(rbTags) {
     .slice(0, 6);
 }
 
+function yamlTag(t) {
+  // Quote anything YAML would coerce to a non-string scalar (numbers,
+  // true/false/null, "yes"/"no"), or anything with YAML-significant
+  // chars / leading indicators / " - " sequences. Without this the
+  // tag round-trips as a number/boolean and `t.toLowerCase()` throws
+  // at runtime. See backfill-tags.mjs:yamlSafe for the full rationale.
+  if (!t) return '""';
+  if (/^-?\d+(?:\.\d+)?$/.test(t)) return JSON.stringify(t);
+  if (/^(true|false|null|yes|no|on|off|~)$/i.test(t)) return JSON.stringify(t);
+  if (/[:#&*!|>'"%@`,\[\]{}?]/.test(t)) return JSON.stringify(t);
+  if (/^[-\s?:!&*|>%@`]/.test(t)) return JSON.stringify(t);
+  if (/^\s|\s$/.test(t)) return JSON.stringify(t);
+  if (/\s-\s/.test(t)) return JSON.stringify(t);
+  return t;
+}
+
 function buildYamlEntry(station, id) {
   const lines = [];
   lines.push('');
@@ -174,7 +190,7 @@ function buildYamlEntry(station, id) {
   if (station.bitrate && station.bitrate > 0) lines.push(`  bitrate: ${station.bitrate}`);
   if (station.codec) lines.push(`  codec: ${station.codec.toUpperCase()}`);
   const tags = normalizeTags(station.tags);
-  if (tags.length > 0) lines.push(`  tags: [${tags.join(', ')}]`);
+  if (tags.length > 0) lines.push(`  tags: [${tags.map(yamlTag).join(', ')}]`);
   // Skip data: URIs — not allowed by check-catalog
   if (station.favicon && !station.favicon.startsWith('data:')) {
     lines.push(`  favicon: ${quoteYaml(station.favicon)}`);

--- a/tools/quote-tag-scalars.mjs
+++ b/tools/quote-tag-scalars.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+/**
+ * One-shot patch for `data/stations.yaml` rows whose `tags: [...]`
+ * line emitted earlier through batch-import.mjs / import-rb-tier.mjs /
+ * backfill-tags.mjs included entries that YAML auto-coerces to a
+ * non-string scalar — bare numerics like 70, 80, 11.11 and YAML
+ * reserved forms like true/false/null/yes/no/on/off/~.
+ *
+ * Those entries were the root cause of the WDR5 e2e regression on
+ * main: at runtime the local search filter calls `t.toLowerCase()`
+ * on each tag, and `(70).toLowerCase()` throws TypeError, killing
+ * the whole filter pass.
+ *
+ * Operates only on flow-style `tags: [...]` lines (the format the
+ * three importers emit). Hand-curated block-style lists are
+ * untouched. Run once after the tools themselves are fixed.
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, '..');
+
+const path = join(root, 'data/stations.yaml');
+const text = readFileSync(path, 'utf8');
+
+const NUMERIC_RE = /^-?\d+(?:\.\d+)?$/;
+const RESERVED_RE = /^(true|false|null|yes|no|on|off|~)$/i;
+
+let patchedRows = 0;
+let patchedItems = 0;
+
+const out = text.replace(/^(  tags: )\[(.*?)\]$/gm, (_, prefix, inner) => {
+  // Split on commas — but a quoted item may itself contain a comma.
+  // The importers we're cleaning up after never use commas inside
+  // tag values, so a naive split is fine here. (If we ever did, this
+  // tool would need a real CSV-style parser.)
+  const parts = inner.split(/,\s*/);
+  let rowChanged = false;
+  const fixed = parts.map((raw) => {
+    const t = raw.trim();
+    if (!t) return t;
+    if (/^["']/.test(t)) return t; // already quoted
+    if (NUMERIC_RE.test(t) || RESERVED_RE.test(t)) {
+      rowChanged = true;
+      patchedItems++;
+      return JSON.stringify(t);
+    }
+    return t;
+  });
+  if (rowChanged) patchedRows++;
+  return `${prefix}[${fixed.join(', ')}]`;
+});
+
+if (out === text) {
+  console.log('quote-tag-scalars: no changes');
+  process.exit(0);
+}
+
+writeFileSync(path, out);
+console.log(`quote-tag-scalars: patched ${patchedItems} item(s) across ${patchedRows} row(s)`);


### PR DESCRIPTION
## What broke

After #187 backfilled tags from RB, **334 tag entries across 303 stations** landed in YAML as bare numerics (`70`, `80`, `11.11`, `90s`) and YAML reserved forms (`true`, `false`, `null`, `yes`, `no`). YAML auto-coerces those to non-string scalars → \`public/stations.json\` shipped \`tags: [70, 80, ...]\` (numbers) → at runtime the local search filter calls \`t.toLowerCase()\` on each tag, which throws TypeError on a number, killing the whole filter pass.

User-visible: typing **\"WDR5\"** in the search box no longer surfaced WDR 5. Caught by the smoke e2e (\`whitespace-insensitive search (\"WDR5\" finds \"WDR 5\")\`) which flipped red on #187 and stayed red on #188.

## Why no one noticed sooner

\`npm run dev\` and \`npm run catalog\` both pass even with broken data — neither path actually exercises the runtime tag filter. The smoke e2e is the only thing that does, and it only runs in CI's \`web\` job. The unit-test suite uses fixture data (no real catalog tags), so vitest stayed green throughout.

## Fix — three layers

| Layer | What changed |
|---|---|
| Importers | \`tools/backfill-tags.mjs\`, \`tools/batch-import.mjs\`, \`tools/import-rb-tier.mjs\` now per-tag-quote via a shared \`yamlTag()\` helper. Anything YAML would coerce (bare numerics, reserved words, leading-indicator chars, ` - ` mid-string, …) gets JSON-quoted. |
| Existing data | New \`tools/quote-tag-scalars.mjs\` scans flow-style \`tags: [...]\` lines and re-quotes numeric / reserved items. **334 items repaired across 303 rows.** Hand-curated block-style lists untouched. |
| Runtime | \`normaliseStation\` in \`src/builtins.ts\` coerces every parsed tag through \`String(t)\`. Second line of defense in case a future YAML bug or surprising RB record sneaks a non-string in. |

## Gates

- [x] \`npm run catalog\` → 0 non-string tags in \`public/stations.json\`
- [x] \`tsc --noEmit\` clean
- [x] \`vitest run\` → 322/322
- [x] \`playwright test e2e/smoke.spec.ts\` → 8/8 (was 7/8 pre-fix; the failing WDR5 test now passes)

## Followups (not for this PR)

- Add a unit test that exercises the local-catalog filter against a non-string tag → would have caught this without needing e2e.
- The smoke e2e is the only signal that the runtime filter is alive; consider promoting it to be required in branch protection, since the WDR5 case is exactly the kind of regression unit tests miss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)