### PR TITLE
fix(genre): funk no longer matches "rundfunk" (German broadcasting word)

### DIFF
--- a/src/genre-taxonomy.test.ts
+++ b/src/genre-taxonomy.test.ts
@@ -13,7 +13,10 @@ describe('GENRES', () => {
       expect(g.label.length).toBeGreaterThan(0);
       expect(g.rbTag.length).toBeGreaterThan(0);
       expect(g.match.length).toBeGreaterThan(0);
-      for (const m of g.match) expect(m).toBe(m.toLowerCase());
+      for (const m of g.match) {
+        if (typeof m === 'string') expect(m).toBe(m.toLowerCase());
+        else expect(m).toBeInstanceOf(RegExp);
+      }
     }
   });
 });
@@ -89,5 +92,40 @@ describe('stationMatchesGenre', () => {
     expect(stationMatchesGenre({ tags: ['chillout'] }, ambient)).toBe(true);
     expect(stationMatchesGenre({ tags: ['lounge'] }, ambient)).toBe(true);
     expect(stationMatchesGenre({ tags: ['easy listening'] }, ambient)).toBe(true);
+  });
+
+  describe('Soul/R&B funk regex (regression)', () => {
+    const soul = byId.get('soul')!;
+
+    it('matches plain funk', () => {
+      expect(stationMatchesGenre({ tags: ['funk'] }, soul)).toBe(true);
+    });
+
+    it('matches funk variants (funky, funkadelic, future funk)', () => {
+      expect(stationMatchesGenre({ tags: ['funky'] }, soul)).toBe(true);
+      expect(stationMatchesGenre({ tags: ['funkadelic'] }, soul)).toBe(true);
+      expect(stationMatchesGenre({ tags: ['future funk'] }, soul)).toBe(true);
+    });
+
+    it('matches funk in multi-word tags', () => {
+      expect(stationMatchesGenre({ tags: ['groove, funk, motown'] }, soul)).toBe(true);
+      expect(stationMatchesGenre({ tags: ['funk soul brother'] }, soul)).toBe(true);
+    });
+
+    it('does NOT match the German "rundfunk" (broadcasting)', () => {
+      // The original bug: every German public broadcaster tagged
+      // "mitteldeutscher rundfunk", "westdeutscher rundfunk", etc.
+      // was getting bucketed under Soul/R&B because "funk" matched
+      // as a substring of "rundfunk".
+      expect(stationMatchesGenre({ tags: ['mitteldeutscher rundfunk'] }, soul)).toBe(false);
+      expect(stationMatchesGenre({ tags: ['westdeutscher rundfunk'] }, soul)).toBe(false);
+      expect(stationMatchesGenre({ tags: ['ard', 'rundfunk'] }, soul)).toBe(false);
+    });
+
+    it('still matches when a station has BOTH rundfunk and a real funk tag', () => {
+      expect(
+        stationMatchesGenre({ tags: ['mitteldeutscher rundfunk', 'funk'] }, soul),
+      ).toBe(true);
+    });
   });
 });

--- a/src/genre-taxonomy.ts
+++ b/src/genre-taxonomy.ts
@@ -28,9 +28,16 @@ export interface Genre {
   id: string;
   /** Display label for the chip / dropdown option. */
   label: string;
-  /** Tag forms that count as this genre. Case-insensitive. Substring
-   *  match — "rock" also matches "classic rock", "punk rock", … */
-  match: string[];
+  /** Tag forms that count as this genre. Each entry is either:
+   *    · a string — case-insensitive substring match. "rock" matches
+   *      "rock", "classic rock", "punk rock", "alpenrock", …
+   *    · a RegExp — used as-is. Reserve for the rare term whose
+   *      substring would catch a non-music word. The motivating case
+   *      is "funk" matching "rundfunk" (German for "broadcasting"),
+   *      which mis-bucketed every German public broadcaster into
+   *      Soul/R&B. Use word-boundary regex `/\bfunk[a-z]*\b/` to keep
+   *      "funk", "funky", "future funk" while excluding "rundfunk". */
+  match: Array<string | RegExp>;
   /** Tag string sent to Radio Browser when this chip is active on the
    *  long-tail browse view. */
   rbTag: string;
@@ -57,7 +64,7 @@ export const GENRES: Genre[] = [
   { id: 'sports',       label: 'Sports',       match: ['sports', 'sport'],                                                                                                                                                                                                   rbTag: 'sports' },
   { id: 'folk',         label: 'Folk',         match: ['folk'],                                                                                                                                                                                                              rbTag: 'folk' },
   { id: 'reggae',       label: 'Reggae',       match: ['reggae', 'ska', 'dancehall'],                                                                                                                                                                                        rbTag: 'reggae' },
-  { id: 'soul',         label: 'Soul/R&B',     match: ['soul', 'rnb', 'rhythm and blues', 'funk'],                                                                                                                                                                           rbTag: 'soul' },
+  { id: 'soul',         label: 'Soul/R&B',     match: ['soul', 'rnb', 'rhythm and blues', /\bfunk[a-z]*\b/i],                                                                                                                                                                rbTag: 'soul' },
   { id: 'metal',        label: 'Metal',        match: ['metal'],                                                                                                                                                                                                             rbTag: 'metal' },
 ];
 
@@ -68,9 +75,10 @@ export function findGenre(id: string | null | undefined): Genre | undefined {
   return BY_ID.get(id);
 }
 
-/** Does the station's tag list match this genre? Case-insensitive
- *  substring against any of the genre's `match` terms. Empty/missing
- *  tag list → no match. */
+/** Does the station's tag list match this genre? String entries in
+ *  `genre.match` are case-insensitive substring checks; RegExp entries
+ *  are tested against the lowercased tag as-is. Empty/missing tag list
+ *  → no match. */
 export function stationMatchesGenre(
   station: { tags?: string[] | null },
   genre: Genre,
@@ -80,7 +88,11 @@ export function stationMatchesGenre(
   for (const t of tags) {
     const tl = String(t).toLowerCase();
     for (const m of genre.match) {
-      if (tl.includes(m)) return true;
+      if (typeof m === 'string') {
+        if (tl.includes(m)) return true;
+      } else if (m.test(tl)) {
+        return true;
+      }
     }
   }
   return false;


### PR DESCRIPTION
## What

Soul/R&B chip's \`funk\` match term was a plain substring, which caught every German public broadcaster tagged \`mitteldeutscher rundfunk\` / \`westdeutscher rundfunk\` — \`rundfunk\` is the German word for "broadcasting" and contains "funk" inside it.

Result: news stations (MDR Aktuell, MDR Sachsen-Anhalt, MDR Thüringen, …) showed up under R&B. **29 false positives** found in the catalog.

## Fix

Extend \`Genre.match\` to accept \`RegExp\` entries alongside strings:

\`\`\`ts
match: ['soul', 'rnb', 'rhythm and blues', /\\bfunk[a-z]*\\b/i]
\`\`\`

Word-boundary anchors keep \`funk\` / \`funky\` / \`funkadelic\` / \`future funk\` matching while excluding \`rundfunk\` (no word boundary before the \`f\` inside the German word).

## Why only funk

Audited the other potentially-tricky terms across the live catalog:

| Term | Substring matches | Word-boundary matches | Diff is legitimate? |
|---|---:|---:|---|
| funk | 150 | 121 | **No** — diff is the 29 rundfunk false positives. |
| rap | 165 | 103 | Yes — diff includes \`deutschrap\`, \`trap\`, all hip-hop adjacent. |
| pop | 1905 | 1691 | Yes — \`electropop\`, \`austropop\`, \`k-pop\` are pop. |
| rock | 1294 | 1267 | Yes — \`alpenrock\`, \`weihnachtsrock\` are rock. |
| house | 271 | 266 | Yes — \`deephouse\`, \`techhouse\` are house. |
| talk | 667 | 660 | Yes — \`talks\` (plural) should fold in. |

So substring stays the default; only \`funk\` flips to regex.

## Tests

5 new regression cases:
- Funk variants (\`funk\`, \`funky\`, \`funkadelic\`, \`future funk\`) all match.
- Multi-word tags (\`groove, funk, motown\`, \`funk soul brother\`) match.
- \`mitteldeutscher rundfunk\` does **not** match.
- A station with both \`rundfunk\` and \`funk\` still matches (other tag rescues it).

322 → 327 vitest cases. tsc clean. build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)