### PR TITLE
fix(ios/genre): funk no longer matches "rundfunk" (mirror of #191)

### DIFF
--- a/ios/rrradio/Search/StationFilters.swift
+++ b/ios/rrradio/Search/StationFilters.swift
@@ -1,9 +1,35 @@
 import Foundation
 
+/// One entry in a `Genre.match` list. `.text` is a case-insensitive
+/// substring check (the default — "rock" also matches "classic rock",
+/// "punk rock", "alpenrock"). `.regex` is used as-is against the
+/// lowercased tag — reserve it for the rare term whose substring
+/// would catch a non-music word.
+///
+/// The motivating case is "funk" vs the German "rundfunk"
+/// ("broadcasting"): plain-substring "funk" matches every public
+/// broadcaster tagged "mitteldeutscher rundfunk" /
+/// "westdeutscher rundfunk" and dumps them into Soul/R&B. The
+/// word-boundary regex `\bfunk[a-z]*\b` keeps "funk", "funky",
+/// "future funk" while excluding "rundfunk". Mirrors the web fix
+/// in src/genre-taxonomy.ts (PR #191).
+///
+/// `ExpressibleByStringLiteral` lets every other (non-tricky) genre
+/// keep declaring its match list as `["pop", "pop music"]` without
+/// per-entry wrapping.
+enum MatchPattern: Equatable, ExpressibleByStringLiteral {
+    case text(String)
+    case regex(String)
+
+    init(stringLiteral value: StringLiteralType) {
+        self = .text(value)
+    }
+}
+
 struct Genre: Equatable, Identifiable {
     let id: String
     let label: String
-    let match: [String]
+    let match: [MatchPattern]
     let rbTag: String
 }
 
@@ -28,7 +54,7 @@ let genres: [Genre] = [
     Genre(id: "sports", label: "Sports", match: ["sports", "sport"], rbTag: "sports"),
     Genre(id: "folk", label: "Folk", match: ["folk"], rbTag: "folk"),
     Genre(id: "reggae", label: "Reggae", match: ["reggae", "ska", "dancehall"], rbTag: "reggae"),
-    Genre(id: "soul", label: "Soul/R&B", match: ["soul", "rnb", "rhythm and blues", "funk"], rbTag: "soul"),
+    Genre(id: "soul", label: "Soul/R&B", match: ["soul", "rnb", "rhythm and blues", .regex(#"\bfunk[a-z]*\b"#)], rbTag: "soul"),
     Genre(id: "metal", label: "Metal", match: ["metal"], rbTag: "metal"),
 ]
 
@@ -74,8 +100,19 @@ func stationMatchesGenre(_ station: Station, genre: Genre) -> Bool {
     guard let tags = station.tags, !tags.isEmpty else { return false }
     for tag in tags {
         let normalizedTag = tag.lowercased()
-        if genre.match.contains(where: { normalizedTag.contains($0) }) {
-            return true
+        for pattern in genre.match {
+            switch pattern {
+            case .text(let needle):
+                if normalizedTag.contains(needle) { return true }
+            case .regex(let raw):
+                // Case-insensitive — both the tag and the regex are
+                // lowercased already, so we don't need NSRegularExpression
+                // case flags. Compiled per-call; the patterns are short
+                // and the genre list is fixed, so this isn't hot.
+                if normalizedTag.range(of: raw, options: .regularExpression) != nil {
+                    return true
+                }
+            }
         }
     }
     return false

--- a/ios/rrradioTests/StationFiltersTests.swift
+++ b/ios/rrradioTests/StationFiltersTests.swift
@@ -108,4 +108,46 @@ final class StationFiltersTests: XCTestCase {
         XCTAssertTrue(stationMatchesFilters(station(tags: ["news"], country: "DE"), country: "DE", tag: "news"))
         XCTAssertFalse(stationMatchesFilters(station(tags: ["jazz"], country: "DE"), country: "DE", tag: "news"))
     }
+
+    // MARK: - Soul/R&B funk regex (regression for the rundfunk false positive)
+
+    func testFunkPlainTagMatchesSoul() {
+        XCTAssertTrue(stationMatchesGenre(station(tags: ["funk"]), genre: findGenre("soul")!))
+    }
+
+    func testFunkVariantsMatchSoul() {
+        XCTAssertTrue(stationMatchesGenre(station(tags: ["funky"]), genre: findGenre("soul")!))
+        XCTAssertTrue(stationMatchesGenre(station(tags: ["funkadelic"]), genre: findGenre("soul")!))
+        XCTAssertTrue(stationMatchesGenre(station(tags: ["future funk"]), genre: findGenre("soul")!))
+    }
+
+    func testRundfunkDoesNotMatchSoul() {
+        // Pre-fix: every German public broadcaster tagged
+        // "mitteldeutscher rundfunk" / "westdeutscher rundfunk" was
+        // showing up under Soul/R&B because plain-substring "funk"
+        // matched inside "rundfunk" (German for "broadcasting").
+        // Concrete report: MDR Klassik (a classical-music station)
+        // appeared in the R&B chip on iOS.
+        XCTAssertFalse(stationMatchesGenre(
+            station(tags: ["mitteldeutscher rundfunk"]),
+            genre: findGenre("soul")!
+        ))
+        XCTAssertFalse(stationMatchesGenre(
+            station(tags: ["classical", "ard", "mitteldeutscher rundfunk"]),
+            genre: findGenre("soul")!
+        ))
+        XCTAssertFalse(stationMatchesGenre(
+            station(tags: ["westdeutscher rundfunk"]),
+            genre: findGenre("soul")!
+        ))
+    }
+
+    func testFunkAndRundfunkTogetherStillMatchSoul() {
+        // If a station carries both rundfunk and a real funk tag, the
+        // funk tag should still earn it the Soul match.
+        XCTAssertTrue(stationMatchesGenre(
+            station(tags: ["mitteldeutscher rundfunk", "funk"]),
+            genre: findGenre("soul")!
+        ))
+    }
 }


### PR DESCRIPTION
## What

Codex mirrored the web genre taxonomy into iOS in \`e2c9d15\` "Mirror genre taxonomy in iOS", but did so **before #191 landed on web** — so iOS shipped with the same plain-substring \`funk\` match that catches the German word "rundfunk" ("broadcasting").

User report: **MDR Klassik** (a classical-music station tagged with \`mitteldeutscher rundfunk\`) appeared under the iOS R&B chip.

## Fix — mirrors web #191

| | |
|---|---|
| \`Genre.match\` type | \`[String]\` → \`[MatchPattern]\` |
| New \`MatchPattern\` enum | \`.text(String)\` (default substring, unchanged) / \`.regex(String)\` |
| \`ExpressibleByStringLiteral\` | every non-tricky genre keeps its \`match: ["pop", "rock"]\` syntax — only the funk entry uses \`.regex(#"\\bfunk[a-z]*\\b"#)\` |
| Matcher | \`stationMatchesGenre\` switches on the pattern; substring unchanged; regex uses \`range(of:options:.regularExpression)\` |

## Tests

4 new regressions in \`StationFiltersTests\`, mirroring the vitest cases on web:

- \`funk\` plain tag still matches Soul
- Funk variants (\`funky\`, \`funkadelic\`, \`future funk\`) still match
- \`mitteldeutscher rundfunk\` does **not** match (the bug)
- Station with **both** \`rundfunk\` and \`funk\` still matches via funk

🤖 Generated with [Claude Code](https://claude.com/claude-code)