### PR TITLE
recon: investigated rbb metadata APIs

### DIFF
--- a/data/metadata-discovery/rbb-antenne-epg.json
+++ b/data/metadata-discovery/rbb-antenne-epg.json
@@ -1,0 +1,86 @@
+      {
+    "202605090600" : {
+        "pg_link": "https://www.antennebrandenburg.de/programm/sendeschema/sendungen/guten_morgen_brandenburg.html",
+        "pg_title": "Guten Morgen Brandenburg",
+        "pg_time": "06:00",
+        "pg_begin": 1778299200000,
+        "pg_end":   1778313600000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 06:00 - 10:00",
+                "img": "https://www.antennebrandenburg.de/content/dam/rbb/ant/moderatoren/090923-Heber-12_1920.jpg.jpg/size=320x180.jpg",
+                "alt": "Claudia Heber, Bild: Mark Garner",
+                "shorttext": "<p>Geweckt werden mit der schönsten Musik für Brandenburg und mit allem Wichtigen in den Tag gehen: Wetter, Verkehr, Nachrichten.</p><br/>",
+                "picturesource": "rbb"
+        }
+    },  
+    "202605091000" : {
+        "pg_link": "https://www.antennebrandenburg.de/programm/sendeschema/sendungen/hallo_brandenburg.html",
+        "pg_title": "Hallo Brandenburg",
+        "pg_time": "10:00",
+        "pg_begin": 1778313600000,
+        "pg_end":   1778331600000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 10:00 - 15:00",
+                "img": "https://www.antennebrandenburg.de/content/dam/rbb/ant/moderatoren/Monique-M-rz26_1920.jpg.jpg/size=320x180.jpg",
+                "alt": "Monique Ehmke, Foto: privat",
+                "shorttext": "<p>Ob zu Hause, unterwegs oder im Büro begleitet Sie die schönste Musik - Service inklusive mit aktuellen Tagestipps, Namenforscher Prof. Udolph und Veranstaltungsempfehlungen, am Sonntag mit einem prominenten Gast.</p><br/>",
+                "picturesource": "rbb"
+        }
+    },  
+    "202605091500" : {
+        "pg_link": "https://www.antennebrandenburg.de/programm/sendungen/260509/15_00_antenne_das_wochenende_202605091500.html",
+        "pg_title": "Antenne das Wochenende",
+        "pg_time": "15:00",
+        "pg_begin": 1778331600000,
+        "pg_end":   1778349600000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 15:00 - 20:00",
+                "img": "https://www.antennebrandenburg.de/content/dam/rbb/ant/moderatoren/P5040664_neu_1280.jpg.jpg/size=320x180.jpg",
+                "alt": "Inez Lang",
+                "shorttext": "",
+                "picturesource": "rbb"
+        }
+    },  
+    "202605092000" : {
+        "pg_link": "https://www.antennebrandenburg.de/programm/sendeschema/sendungen/ard-abend---radio-fuer-alle.html",
+        "pg_title": "ARD Abend",
+        "pg_time": "20:00",
+        "pg_begin": 1778349600000,
+        "pg_end":   1778360400000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 20:00 - 23:00",
+                "img": "",
+                "alt": "",
+                "shorttext": "<p>&quot;Der ARD Abend – Radio für alle&quot; ist eine gemeinsame Abendsendung der ARD Landesprogramme. Es gibt die beste Musik zum Tagesausklang von den 80ern bis heute sowie regionale Nachrichten. Die Sendung wird täglich von 20 – 23 Uhr im wöchentlichen Wechsel von den MDR Landesprogrammen in Thüringen, Sachsen und Sachsen Anhalt produziert.</p><br/>",
+                "picturesource": ""
+        }
+    },  
+    "202605092300" : {
+        "pg_link": "https://www.antennebrandenburg.de/programm/sendeschema/sendungen/ard_hitnacht.html",
+        "pg_title": "ARD Hitnacht",
+        "pg_time": "23:00",
+        "pg_begin": 1778360400000,
+        "pg_end":   1778363999000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 23:00 - 23:59",
+                "img": "",
+                "alt": "",
+                "shorttext": "<p>Auch nachts gut informiert und unterhalten mit Nachrichten, Verkehrsservice und viel Musik.</p><br/>",
+                "picturesource": ""
+        }
+    },  
+    "202605100000" : {
+        "pg_link": "https://www.antennebrandenburg.de/programm/sendeschema/sendungen/ard_hitnacht.html",
+        "pg_title": "ARD Hitnacht",
+        "pg_time": "00:00",
+        "pg_begin": 1778364000000,
+        "pg_end":   1778385600000,
+        "flyout": {
+                "roofline": "So 10.05.2026 | 00:00 - 06:00",
+                "img": "",
+                "alt": "",
+                "shorttext": "<p>Auch nachts gut informiert und unterhalten mit Nachrichten, Verkehrsservice und viel Musik.</p><br/>",
+                "picturesource": ""
+        }
+    }
+}

--- a/data/metadata-discovery/rbb-antenne-nowonair.json
+++ b/data/metadata-discovery/rbb-antenne-nowonair.json
@@ -1,0 +1,7 @@
+{
+  "captured_at": "2026-05-09T06:16:59.778178Z",
+  "endpoint": "https://www.antennebrandenburg.de/include/ant/nowonair/now_on_air.html",
+  "cors": "*",
+  "content_type": "text/html",
+  "body": "<em class=\"now_running\">Es l&auml;uft:</em>\n<h3 class=\"interpret\">Ed Sheeran</h3>\n<p class=\"title\">Perfect</p>\n"
+}

--- a/data/metadata-discovery/rbb-fritz-nowonair.json
+++ b/data/metadata-discovery/rbb-fritz-nowonair.json
@@ -1,0 +1,7 @@
+{
+  "captured_at": "2026-05-09T06:16:59.569300Z",
+  "endpoint": "https://www.fritz.de/include/frz/nowonair/now_on_air.html",
+  "cors": "*",
+  "content_type": "text/html",
+  "body": "<p class=\"artist\">Katy Perry</p><p class=\"songtitle\">California Gurls</p>\n"
+}

--- a/data/metadata-discovery/rbb-inforadio-epg.json
+++ b/data/metadata-discovery/rbb-inforadio-epg.json
@@ -1,0 +1,1290 @@
+      {
+    "202605090558" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097454.html",
+        "pg_title": "Nachrichten, Wetter",
+        "pg_time": "05:58",
+        "pg_begin": 1778299080000,
+        "pg_end":   1778299380000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 05:58 - 06:03",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605090603" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097451.html",
+        "pg_title": "Reportage aus Berlin und Brandenburg",
+        "pg_time": "06:03",
+        "pg_begin": 1778299380000,
+        "pg_end":   1778301000000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 06:03 - 06:30",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605090630" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097456.html",
+        "pg_title": "Nachrichten, Wetter",
+        "pg_time": "06:30",
+        "pg_begin": 1778301000000,
+        "pg_end":   1778301180000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 06:30 - 06:33",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605090633" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097452.html",
+        "pg_title": "Spreepolitik",
+        "pg_time": "06:33",
+        "pg_begin": 1778301180000,
+        "pg_end":   1778302789000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 06:33 - 06:59",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605090659" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097476.html",
+        "pg_title": "Nachrichten, Wetter",
+        "pg_time": "06:59",
+        "pg_begin": 1778302789000,
+        "pg_end":   1778302980000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 06:59 - 07:03",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605090703" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097458.html",
+        "pg_title": "Aktuelle Hintergrundberichte",
+        "pg_time": "07:03",
+        "pg_begin": 1778302980000,
+        "pg_end":   1778303640000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 07:03 - 07:14",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605090714" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097459.html",
+        "pg_title": "Sport",
+        "pg_time": "07:14",
+        "pg_begin": 1778303640000,
+        "pg_end":   1778304000000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 07:14 - 07:20",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605090720" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097480.html",
+        "pg_title": "Nachrichten, Wetter",
+        "pg_time": "07:20",
+        "pg_begin": 1778304000000,
+        "pg_end":   1778304180000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 07:20 - 07:23",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605090723" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097460.html",
+        "pg_title": "Aktuelle Hintergrundberichte",
+        "pg_time": "07:23",
+        "pg_begin": 1778304180000,
+        "pg_end":   1778304840000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 07:23 - 07:34",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605090734" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097461.html",
+        "pg_title": "Wirtschaft aktuell",
+        "pg_time": "07:34",
+        "pg_begin": 1778304840000,
+        "pg_end":   1778305200000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 07:34 - 07:40",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605090740" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097484.html",
+        "pg_title": "Nachrichten, Wetter",
+        "pg_time": "07:40",
+        "pg_begin": 1778305200000,
+        "pg_end":   1778305380000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 07:40 - 07:43",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605090743" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097462.html",
+        "pg_title": "Aktuelle Hintergrundberichte",
+        "pg_time": "07:43",
+        "pg_begin": 1778305380000,
+        "pg_end":   1778306040000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 07:43 - 07:54",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605090754" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097463.html",
+        "pg_title": "Kultur",
+        "pg_time": "07:54",
+        "pg_begin": 1778306040000,
+        "pg_end":   1778306400000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 07:54 - 08:00",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605090800" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097488.html",
+        "pg_title": "Nachrichten, Wetter",
+        "pg_time": "08:00",
+        "pg_begin": 1778306400000,
+        "pg_end":   1778306580000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 08:00 - 08:03",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605090803" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097464.html",
+        "pg_title": "Aktuelle Hintergrundberichte",
+        "pg_time": "08:03",
+        "pg_begin": 1778306580000,
+        "pg_end":   1778307240000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 08:03 - 08:14",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605090814" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097465.html",
+        "pg_title": "Sport",
+        "pg_time": "08:14",
+        "pg_begin": 1778307240000,
+        "pg_end":   1778307600000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 08:14 - 08:20",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605090820" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097492.html",
+        "pg_title": "Nachrichten, Wetter",
+        "pg_time": "08:20",
+        "pg_begin": 1778307600000,
+        "pg_end":   1778307780000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 08:20 - 08:23",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605090823" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097466.html",
+        "pg_title": "Aktuelle Hintergrundberichte",
+        "pg_time": "08:23",
+        "pg_begin": 1778307780000,
+        "pg_end":   1778308440000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 08:23 - 08:34",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605090834" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097467.html",
+        "pg_title": "Wirtschaft aktuell",
+        "pg_time": "08:34",
+        "pg_begin": 1778308440000,
+        "pg_end":   1778308800000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 08:34 - 08:40",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605090840" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097496.html",
+        "pg_title": "Nachrichten, Wetter",
+        "pg_time": "08:40",
+        "pg_begin": 1778308800000,
+        "pg_end":   1778308980000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 08:40 - 08:43",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605090843" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097468.html",
+        "pg_title": "Aktuelle Hintergrundberichte",
+        "pg_time": "08:43",
+        "pg_begin": 1778308980000,
+        "pg_end":   1778309640000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 08:43 - 08:54",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605090854" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097469.html",
+        "pg_title": "Kultur",
+        "pg_time": "08:54",
+        "pg_begin": 1778309640000,
+        "pg_end":   1778310000000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 08:54 - 09:00",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605090900" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097500.html",
+        "pg_title": "Nachrichten, Wetter",
+        "pg_time": "09:00",
+        "pg_begin": 1778310000000,
+        "pg_end":   1778310180000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 09:00 - 09:03",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605090903" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097470.html",
+        "pg_title": "Aktuelle Hintergrundberichte",
+        "pg_time": "09:03",
+        "pg_begin": 1778310180000,
+        "pg_end":   1778310840000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 09:03 - 09:14",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605090914" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097471.html",
+        "pg_title": "Sport",
+        "pg_time": "09:14",
+        "pg_begin": 1778310840000,
+        "pg_end":   1778311200000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 09:14 - 09:20",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605090920" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097504.html",
+        "pg_title": "Nachrichten, Wetter",
+        "pg_time": "09:20",
+        "pg_begin": 1778311200000,
+        "pg_end":   1778311380000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 09:20 - 09:23",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605090923" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097472.html",
+        "pg_title": "Aktuelle Hintergrundberichte",
+        "pg_time": "09:23",
+        "pg_begin": 1778311380000,
+        "pg_end":   1778312040000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 09:23 - 09:34",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605090934" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097473.html",
+        "pg_title": "Wirtschaft aktuell",
+        "pg_time": "09:34",
+        "pg_begin": 1778312040000,
+        "pg_end":   1778312400000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 09:34 - 09:40",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605090940" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097508.html",
+        "pg_title": "Nachrichten, Wetter",
+        "pg_time": "09:40",
+        "pg_begin": 1778312400000,
+        "pg_end":   1778312580000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 09:40 - 09:43",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605090943" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097474.html",
+        "pg_title": "Aktuelle Hintergrundberichte",
+        "pg_time": "09:43",
+        "pg_begin": 1778312580000,
+        "pg_end":   1778313240000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 09:43 - 09:54",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605090954" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097475.html",
+        "pg_title": "Kultur",
+        "pg_time": "09:54",
+        "pg_begin": 1778313240000,
+        "pg_end":   1778313589000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 09:54 - 09:59",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605090959" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097532.html",
+        "pg_title": "Nachrichten, Wetter",
+        "pg_time": "09:59",
+        "pg_begin": 1778313589000,
+        "pg_end":   1778313780000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 09:59 - 10:03",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091003" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097512.html",
+        "pg_title": "Aktuelle Hintergrundberichte",
+        "pg_time": "10:03",
+        "pg_begin": 1778313780000,
+        "pg_end":   1778314560000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 10:03 - 10:16",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091016" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097513.html",
+        "pg_title": "Sport",
+        "pg_time": "10:16",
+        "pg_begin": 1778314560000,
+        "pg_end":   1778314740000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 10:16 - 10:19",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091019" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097514.html",
+        "pg_title": "Aktuelle Hintergrundberichte",
+        "pg_time": "10:19",
+        "pg_begin": 1778314740000,
+        "pg_end":   1778315100000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 10:19 - 10:25",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091025" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097515.html",
+        "pg_title": "Kultur",
+        "pg_time": "10:25",
+        "pg_begin": 1778315100000,
+        "pg_end":   1778315400000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 10:25 - 10:30",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091030" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097535.html",
+        "pg_title": "Nachrichten, Wetter",
+        "pg_time": "10:30",
+        "pg_begin": 1778315400000,
+        "pg_end":   1778315580000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 10:30 - 10:33",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091033" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097516.html",
+        "pg_title": "Spreepolitik",
+        "pg_time": "10:33",
+        "pg_begin": 1778315580000,
+        "pg_end":   1778317200000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 10:33 - 11:00",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091100" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097537.html",
+        "pg_title": "Nachrichten, Wetter",
+        "pg_time": "11:00",
+        "pg_begin": 1778317200000,
+        "pg_end":   1778317380000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 11:00 - 11:03",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091103" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097517.html",
+        "pg_title": "Aktuelle Hintergrundberichte",
+        "pg_time": "11:03",
+        "pg_begin": 1778317380000,
+        "pg_end":   1778318160000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 11:03 - 11:16",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091116" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097518.html",
+        "pg_title": "Sport",
+        "pg_time": "11:16",
+        "pg_begin": 1778318160000,
+        "pg_end":   1778318340000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 11:16 - 11:19",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091119" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097519.html",
+        "pg_title": "Abgedreht",
+        "pg_time": "11:19",
+        "pg_begin": 1778318340000,
+        "pg_end":   1778319000000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 11:19 - 11:30",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091130" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097540.html",
+        "pg_title": "Nachrichten, Wetter",
+        "pg_time": "11:30",
+        "pg_begin": 1778319000000,
+        "pg_end":   1778319180000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 11:30 - 11:33",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091133" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097520.html",
+        "pg_title": "Reportage aus Berlin und Brandenburg",
+        "pg_time": "11:33",
+        "pg_begin": 1778319180000,
+        "pg_end":   1778320800000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 11:33 - 12:00",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091200" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097542.html",
+        "pg_title": "Nachrichten, Wetter",
+        "pg_time": "12:00",
+        "pg_begin": 1778320800000,
+        "pg_end":   1778320980000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 12:00 - 12:03",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091203" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097521.html",
+        "pg_title": "Aktuelle Hintergrundberichte",
+        "pg_time": "12:03",
+        "pg_begin": 1778320980000,
+        "pg_end":   1778321760000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 12:03 - 12:16",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091216" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097522.html",
+        "pg_title": "Sport",
+        "pg_time": "12:16",
+        "pg_begin": 1778321760000,
+        "pg_end":   1778322000000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 12:16 - 12:20",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091220" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097523.html",
+        "pg_title": "Aktuelle Hintergrundberichte",
+        "pg_time": "12:20",
+        "pg_begin": 1778322000000,
+        "pg_end":   1778322600000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 12:20 - 12:30",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091230" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097544.html",
+        "pg_title": "Nachrichten, Wetter",
+        "pg_time": "12:30",
+        "pg_begin": 1778322600000,
+        "pg_end":   1778322780000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 12:30 - 12:33",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091233" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097524.html",
+        "pg_title": "Matthay fragt",
+        "pg_time": "12:33",
+        "pg_begin": 1778322780000,
+        "pg_end":   1778324400000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 12:33 - 13:00",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091300" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097546.html",
+        "pg_title": "Nachrichten, Wetter",
+        "pg_time": "13:00",
+        "pg_begin": 1778324400000,
+        "pg_end":   1778324580000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 13:00 - 13:03",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091303" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097525.html",
+        "pg_title": "Aktuelle Hintergrundberichte",
+        "pg_time": "13:03",
+        "pg_begin": 1778324580000,
+        "pg_end":   1778325360000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 13:03 - 13:16",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091316" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097526.html",
+        "pg_title": "Sport",
+        "pg_time": "13:16",
+        "pg_begin": 1778325360000,
+        "pg_end":   1778325600000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 13:16 - 13:20",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091320" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097527.html",
+        "pg_title": "Deutschlandreportage",
+        "pg_time": "13:20",
+        "pg_begin": 1778325600000,
+        "pg_end":   1778326200000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 13:20 - 13:30",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091330" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097548.html",
+        "pg_title": "Nachrichten, Wetter",
+        "pg_time": "13:30",
+        "pg_begin": 1778326200000,
+        "pg_end":   1778326380000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 13:30 - 13:33",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091333" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097528.html",
+        "pg_title": "7 Tage wach",
+        "pg_time": "13:33",
+        "pg_begin": 1778326380000,
+        "pg_end":   1778328000000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 13:33 - 14:00",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091400" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097550.html",
+        "pg_title": "Nachrichten, Wetter",
+        "pg_time": "14:00",
+        "pg_begin": 1778328000000,
+        "pg_end":   1778328180000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 14:00 - 14:03",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091403" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097551.html",
+        "pg_title": "Aktuelle Hintergrundberichte",
+        "pg_time": "14:03",
+        "pg_begin": 1778328180000,
+        "pg_end":   1778328960000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 14:03 - 14:16",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091416" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097529.html",
+        "pg_title": "Sport",
+        "pg_time": "14:16",
+        "pg_begin": 1778328960000,
+        "pg_end":   1778329200000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 14:16 - 14:20",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091420" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097530.html",
+        "pg_title": "Abgedreht",
+        "pg_time": "14:20",
+        "pg_begin": 1778329200000,
+        "pg_end":   1778329800000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 14:20 - 14:30",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091430" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097553.html",
+        "pg_title": "Nachrichten, Wetter",
+        "pg_time": "14:30",
+        "pg_begin": 1778329800000,
+        "pg_end":   1778329980000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 14:30 - 14:33",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091433" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097531.html",
+        "pg_title": "Interview der Woche",
+        "pg_time": "14:33",
+        "pg_begin": 1778329980000,
+        "pg_end":   1778331589000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 14:33 - 14:59",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091459" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097560.html",
+        "pg_title": "Nachrichten, Wetter",
+        "pg_time": "14:59",
+        "pg_begin": 1778331589000,
+        "pg_end":   1778331780000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 14:59 - 15:03",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091503" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097561.html",
+        "pg_title": "Die Bundesliga",
+        "pg_time": "15:03",
+        "pg_begin": 1778331780000,
+        "pg_end":   1778333400000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 15:03 - 15:30",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091530" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097563.html",
+        "pg_title": "Nachrichten, Wetter",
+        "pg_time": "15:30",
+        "pg_begin": 1778333400000,
+        "pg_end":   1778333580000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 15:30 - 15:33",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091533" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097555.html",
+        "pg_title": "Die Bundesliga",
+        "pg_time": "15:33",
+        "pg_begin": 1778333580000,
+        "pg_end":   1778335200000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 15:33 - 16:00",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091600" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097566.html",
+        "pg_title": "Nachrichten, Wetter",
+        "pg_time": "16:00",
+        "pg_begin": 1778335200000,
+        "pg_end":   1778335380000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 16:00 - 16:03",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091603" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097556.html",
+        "pg_title": "Die Bundesliga",
+        "pg_time": "16:03",
+        "pg_begin": 1778335380000,
+        "pg_end":   1778337000000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 16:03 - 16:30",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091630" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097568.html",
+        "pg_title": "Nachrichten, Wetter",
+        "pg_time": "16:30",
+        "pg_begin": 1778337000000,
+        "pg_end":   1778337180000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 16:30 - 16:33",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091633" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097557.html",
+        "pg_title": "Die Bundesliga",
+        "pg_time": "16:33",
+        "pg_begin": 1778337180000,
+        "pg_end":   1778338200000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 16:33 - 16:50",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091650" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097558.html",
+        "pg_title": "Die Bundesliga",
+        "pg_time": "16:50",
+        "pg_begin": 1778338200000,
+        "pg_end":   1778340600000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 16:50 - 17:30",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091730" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097572.html",
+        "pg_title": "Nachrichten, Wetter",
+        "pg_time": "17:30",
+        "pg_begin": 1778340600000,
+        "pg_end":   1778340780000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 17:30 - 17:33",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091733" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097559.html",
+        "pg_title": "Die Bundesliga",
+        "pg_time": "17:33",
+        "pg_begin": 1778340780000,
+        "pg_end":   1778342389000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 17:33 - 17:59",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091759" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097576.html",
+        "pg_title": "Nachrichten, Wetter",
+        "pg_time": "17:59",
+        "pg_begin": 1778342389000,
+        "pg_end":   1778342580000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 17:59 - 18:03",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091803" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097577.html",
+        "pg_title": "Sport Update",
+        "pg_time": "18:03",
+        "pg_begin": 1778342580000,
+        "pg_end":   1778342700000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 18:03 - 18:05",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091805" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097578.html",
+        "pg_title": "ARD-Infosamstag",
+        "pg_time": "18:05",
+        "pg_begin": 1778342700000,
+        "pg_end":   1778343300000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 18:05 - 18:15",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091815" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097579.html",
+        "pg_title": "Sport",
+        "pg_time": "18:15",
+        "pg_begin": 1778343300000,
+        "pg_end":   1778344200000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 18:15 - 18:30",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091830" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097580.html",
+        "pg_title": "Nachrichten, Wetter",
+        "pg_time": "18:30",
+        "pg_begin": 1778344200000,
+        "pg_end":   1778344380000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 18:30 - 18:33",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091833" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097581.html",
+        "pg_title": "Matthay fragt",
+        "pg_time": "18:33",
+        "pg_begin": 1778344380000,
+        "pg_end":   1778346000000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 18:33 - 19:00",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091900" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097582.html",
+        "pg_title": "Nachrichten, Wetter",
+        "pg_time": "19:00",
+        "pg_begin": 1778346000000,
+        "pg_end":   1778346180000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 19:00 - 19:03",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091903" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097583.html",
+        "pg_title": "Sport Update",
+        "pg_time": "19:03",
+        "pg_begin": 1778346180000,
+        "pg_end":   1778346300000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 19:03 - 19:05",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091905" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097584.html",
+        "pg_title": "ARD-Infosamstag",
+        "pg_time": "19:05",
+        "pg_begin": 1778346300000,
+        "pg_end":   1778346900000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 19:05 - 19:15",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091915" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097585.html",
+        "pg_title": "Sport",
+        "pg_time": "19:15",
+        "pg_begin": 1778346900000,
+        "pg_end":   1778347800000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 19:15 - 19:30",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091930" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097586.html",
+        "pg_title": "Nachrichten, Wetter",
+        "pg_time": "19:30",
+        "pg_begin": 1778347800000,
+        "pg_end":   1778347980000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 19:30 - 19:33",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091933" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097575.html",
+        "pg_title": "7 Tage wach",
+        "pg_time": "19:33",
+        "pg_begin": 1778347980000,
+        "pg_end":   1778349589000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 19:33 - 19:59",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605091959" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097588.html",
+        "pg_title": "Tagesschau",
+        "pg_time": "19:59",
+        "pg_begin": 1778349589000,
+        "pg_end":   1778350500000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 19:59 - 20:15",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605092015" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097589.html",
+        "pg_title": "Sport",
+        "pg_time": "20:15",
+        "pg_begin": 1778350500000,
+        "pg_end":   1778351400000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 20:15 - 20:30",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605092030" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097590.html",
+        "pg_title": "ARD-Infoabend",
+        "pg_time": "20:30",
+        "pg_begin": 1778351400000,
+        "pg_end":   1778353200000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 20:30 - 21:00",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605092100" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097591.html",
+        "pg_title": "Nachrichten, Wetter",
+        "pg_time": "21:00",
+        "pg_begin": 1778353200000,
+        "pg_end":   1778353380000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 21:00 - 21:03",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605092103" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097592.html",
+        "pg_title": "ARD-Infoabend",
+        "pg_time": "21:03",
+        "pg_begin": 1778353380000,
+        "pg_end":   1778355000000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 21:03 - 21:30",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605092130" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097593.html",
+        "pg_title": "Nachrichten, Wetter",
+        "pg_time": "21:30",
+        "pg_begin": 1778355000000,
+        "pg_end":   1778355180000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 21:30 - 21:33",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605092133" :  {
+        "pg_link": "https://www.inforadio.de/programm/sendungen/20260509/group_1097594.html",
+        "pg_title": "ARD-Infoabend",
+        "pg_time": "21:33",
+        "pg_begin": 1778355180000,
+        "pg_end":   1778356788000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 21:33 - 21:59",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    }
+}

--- a/data/metadata-discovery/rbb-radio3-epg.json
+++ b/data/metadata-discovery/rbb-radio3-epg.json
@@ -1,0 +1,352 @@
+      {
+    "202605090500" : {
+        "pg_link": "https://www.radiodrei.de/programm/schema/sendungen/nachrichten_wetter.html",
+        "pg_title": "Nachrichten, Wetter",
+        "pg_time": "05:00",
+        "pg_begin": 1778295600000,
+        "pg_end":   1778295780000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 05:00 - 05:03",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605090503" : {
+        "pg_link": "https://www.radiodrei.de/programm/vorlagen/hilfuebersicht-epg-kul-json.html",
+        "pg_title": "ARD-Nachtkonzert (IV)",
+        "pg_time": "05:03",
+        "pg_begin": 1778295780000,
+        "pg_end":   1778299200000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 05:03 - 06:00",
+                "img": "",
+                "alt": "",
+                "shorttext": "Joseph Haydn: <br/>Trompetenkonzert Es-Dur, Allegro, Hob. VIIe/1<br/>Alison Balsom<br/>Die Deutsche Kammerphilharmonie Bremen<br/>Carl Philipp Emanuel Bach: <br/>Sinfonie e-Moll, Wq 177<br/>Freiburger Barockorchester<br/>Leitung: Gottfried von der Goltz<br/>Franz Danzi: <br/>Sinfonia concertante B-Dur, Allegro moderato, op. 41<br/>Dagmar Becker, Flöte<br/>Wolfgang Meyer, Klarinette<br/>Württembergisches Kammerorchester Heilbronn<br/>Leitung: Jörg Faerber<br/>Wolfgang Amadeus Mozart: <br/>Klavierquartett g-Moll, Rondo, KV 478<br/>Alfred Brendel, Klavier<br/>Thomas Zehetmair, Violine<br/>Tabea Zimmermann, Viola<br/>Richard Duven, Violoncello<br/>Johann Gottlieb Graun: <br/>Violinkonzert c-Moll<br/>moderntimes_1800<br/>Violine und Leitung: Ilia Korol<br/>Johann Peter Pixis: <br/>Klavierkonzert Es-Dur, Rondo, op. 68<br/>Tasmanian Symphony Orchestra<br/>Klavier und Leitung: Howard Shelley",
+                "picturesource": ""
+        }
+    },  
+    "202605090600" : {
+        "pg_link": "https://www.radiodrei.de/programm/schema/sendungen/klassik_am_morgen/archiv/20260509_0600.html",
+        "pg_title": "Klassik am Morgen",
+        "pg_time": "06:00",
+        "pg_begin": 1778299200000,
+        "pg_end":   1778306400000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 06:00 - 08:00",
+                "img": "https://www.radiodrei.de/content/dam/rbb/kul/radio3/klassik_am_morgen_1920x1080px.png.png/size=320x180.png",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": "radio3"
+        }
+    },  
+    "202605090650" : {
+        "pg_link": "https://www.radiodrei.de/programm/vorlagen/hilfuebersicht-epg-kul-json.html",
+        "pg_title": "Worte für den Tag",
+        "pg_time": "06:50",
+        "pg_begin": 1778302200000,
+        "pg_end":   1778302500000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 06:50 - 06:55",
+                "img": "",
+                "alt": "",
+                "shorttext": "Frank Städler, Beeskow",
+                "picturesource": ""
+        }
+    },  
+    "202605090730" : {
+        "pg_link": "https://www.radiodrei.de/programm/vorlagen/hilfuebersicht-epg-kul-json.html",
+        "pg_title": "Klassiksplits",
+        "pg_time": "07:30",
+        "pg_begin": 1778304600000,
+        "pg_end":   1778304900000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 07:30 - 07:35",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605090800" : {
+        "pg_link": "https://www.radiodrei.de/programm/schema/sendungen/klassik_bis_zwoelf/archiv/20260509_0800.html",
+        "pg_title": "Klassik bis Zwölf 09.05.2026 08:00",
+        "pg_time": "08:00",
+        "pg_begin": 1778306400000,
+        "pg_end":   1778320800000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 08:00 - 12:00",
+                "img": "https://www.radiodrei.de/content/dam/rbb/kul/team/Moderation/herzog_DSC02484-1920.jpg.jpg/size=320x180.jpg",
+                "alt": "",
+                "shorttext": "Moderation: Anja Herzog",
+                "picturesource": "Carsten Kampf"
+        }
+    },  
+    "202605090840" : {
+        "pg_link": "https://www.radiodrei.de/programm/schema/sendungen/klassik_bis_zwoelf/archiv/20260509_0800/der_stichtag_0840.html",
+        "pg_title": "80. Geburtstag von Drafi Deutscher",
+        "pg_time": "08:40",
+        "pg_begin": 1778308800000,
+        "pg_end":   1778308800000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 08:40 - 08:40",
+                "img": "https://www.radiodrei.de/content/dam/rbb/kul/_dpa/2026/05/drafi-deutscher-40784843-1920.jpg.jpg/size=320x180.jpg",
+                "alt": "",
+                "shorttext": "Ein Beitrag von Bernd Schleßelmann",
+                "picturesource": "radio3"
+        }
+    },  
+    "202605090910" : {
+        "pg_link": "https://www.radiodrei.de/programm/schema/sendungen/klassik_bis_zwoelf/archiv/20260509_0800/album_der_woche_0910.html",
+        "pg_title": "Bruno Delepelaire: &quot;Haydn – Lalo&quot;",
+        "pg_time": "09:10",
+        "pg_begin": 1778310600000,
+        "pg_end":   1778310900000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 09:10 - 09:15",
+                "img": "https://www.radiodrei.de/content/dam/rbb/kul/rezensionen/cd/2026/haydn-lalo.png.png/size=320x180.png",
+                "alt": "",
+                "shorttext": "Ein Beitrag von Christian Schruff",
+                "picturesource": "radio3"
+        }
+    },  
+    "202605091010" : {
+        "pg_link": "https://www.radiodrei.de/programm/schema/sendungen/klassik_bis_zwoelf/archiv/20260509_0800/kurz_und_gut_1010.html",
+        "pg_title": "AnniKa von Trier: &quot;Prachtmotte&quot;",
+        "pg_time": "10:10",
+        "pg_begin": 1778314200000,
+        "pg_end":   1778314500000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 10:10 - 10:15",
+                "img": "https://www.radiodrei.de/content/dam/rbb/kul/personen/autoren0/AnniKa_von_Trier_Garten-Hannah_Ho-ch_Foto_Michael_Zeidler-1920.jpg.jpg/size=320x180.jpg",
+                "alt": "",
+                "shorttext": "Gedicht der Woche",
+                "picturesource": "radio3/rbb"
+        }
+    },  
+    "202605091110" : {
+        "pg_link": "https://www.radiodrei.de/programm/schema/sendungen/klassik_bis_zwoelf/archiv/20260509_0800/gast_1110.html",
+        "pg_title": "40 Jahre &quot;Kissinger Sommer&quot;",
+        "pg_time": "11:10",
+        "pg_begin": 1778317800000,
+        "pg_end":   1778318100000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 11:10 - 11:15",
+                "img": "https://www.radiodrei.de/content/dam/rbb/kul/personen/Kultur%20und%20Wissenschaft/steinbeis2-1920.jpg.jpg/size=320x180.jpg",
+                "alt": "",
+                "shorttext": "Alexander Steinbeis, Festival-Intendant, zu Gast auf radio3",
+                "picturesource": "radio3"
+        }
+    },  
+    "202605091200" : {
+        "pg_link": "https://www.radiodrei.de/programm/schema/sendungen/holzapfels_klassik/archiv/20260509_1200.html",
+        "pg_title": "Holzapfels Klassik",
+        "pg_time": "12:00",
+        "pg_begin": 1778320800000,
+        "pg_end":   1778324400000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 12:00 - 13:00",
+                "img": "https://www.radiodrei.de/content/dam/rbb/kul/team/Moderation/stephan-holzapfel_1280.jpg.jpg/size=320x180.jpg",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": "Gregor Baron"
+        }
+    },  
+    "202605091300" : {
+        "pg_link": "https://www.radiodrei.de/programm/schema/sendungen/der_zweite_gedanke/archiv/20260509_1300.html",
+        "pg_title": "Wie frei ist die Kunstfreiheit?",
+        "pg_time": "13:00",
+        "pg_begin": 1778324400000,
+        "pg_end":   1778328000000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 13:00 - 14:00",
+                "img": "https://www.radiodrei.de/content/dam/rbb/kul/_dpa/2026/05/492266894-kunst-alle_1920.jpg.jpg/size=320x180.jpg",
+                "alt": "",
+                "shorttext": "&quot;Dass der Verfassungsschutz Buchhandlungen beurteilt, ist wahrscheinlich rechtswidrig.&quot; (Christoph Möllers)",
+                "picturesource": "radio3"
+        }
+    },  
+    "202605091400" : {
+        "pg_link": "https://www.radiodrei.de/programm/schema/sendungen/schrammek_kaether/archiv/20260509_1400.html",
+        "pg_title": "Die schönsten musikalischen Widmungen",
+        "pg_time": "14:00",
+        "pg_begin": 1778328000000,
+        "pg_end":   1778335200000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 14:00 - 16:00",
+                "img": "https://www.radiodrei.de/content/dam/rbb/rad/bilder0/202507/B.-Schrammek_M.-Kaether_Konrad-Bott6.jpg.jpg/size=320x180.jpg",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": "radio3"
+        }
+    },  
+    "202605091600" : {
+        "pg_link": "https://www.radiodrei.de/programm/schema/sendungen/sondersendung/archiv/20260509_1600.html",
+        "pg_title": "Der Gute Salon",
+        "pg_time": "16:00",
+        "pg_begin": 1778335200000,
+        "pg_end":   1778338800000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 16:00 - 17:00",
+                "img": "https://www.radiodrei.de/content/dam/rbb/rbb/fernsehen/2_moderatoren/gute_petra/petra_gute0.jpg.jpg/size=320x180.jpg",
+                "alt": "",
+                "shorttext": "Die rbb-Kulturjournalistin Petra Gute begrüßt in ihrem Salon im Studio 14 – DIE rbb-DACHLOUNGE illustre Gäste aus der vielfältigen Berliner und Brandenburger Kulturlandschaft. Diesmal zu Gast: das ATZE Musiktheater mit der musikalischen und künstlerischen Leiterin Sinem Altan und dem ATZE-Gründer und langjährigen Intendanten Thomas Sutter sowie mit Sängerinnen und Sängern aus dem Team. Special Guest ist der Singer-Songwriter Felix Meyer.",
+                "picturesource": "radio3"
+        }
+    },  
+    "202605091700" : {
+        "pg_link": "https://www.radiodrei.de/programm/schema/sendungen/unser_leben/archiv/20260509_1700.html",
+        "pg_title": "Mutterschaft - ein Auslaufmodell?",
+        "pg_time": "17:00",
+        "pg_begin": 1778338800000,
+        "pg_end":   1778342400000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 17:00 - 18:00",
+                "img": "https://www.radiodrei.de/content/dam/rbb/kul/_imago/2026/05/mutter_imago51320082-1920.jpg.jpg/size=320x180.jpg",
+                "alt": "",
+                "shorttext": "Der Muttertag ist für viele heutzutage ein Konjunkturprogramm für den Blumenhandel. Doch seine christlichen Wurzeln verweisen auf etwas Grundsätzliches: Mutterschaft wird in allen Religionen zelebriert – und der Kult um Mutter Maria ist dafür nur das bekannteste Beispiel. Was bedeutet Mutterschaft in Zeiten global sinkender Geburtenraten? Und wie gehen andere Länder mit der neuen Vielfalt an weiblichen Lebensmodellen abseits der Mutterrolle um?",
+                "picturesource": "radio3"
+        }
+    },  
+    "202605091800" : {
+        "pg_link": "https://www.radiodrei.de/programm/schema/sendungen/orte_und_worte/archiv/20260509_1800.html",
+        "pg_title": "Mit Sharon Dodua Otoo in Berlin Kreuzberg",
+        "pg_time": "18:00",
+        "pg_begin": 1778342400000,
+        "pg_end":   1778346000000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 18:00 - 19:00",
+                "img": "https://www.radiodrei.de/content/dam/rbb/kul/programmtipps/05_26/sharon-dodua-otoo-u-anne-dore-krohn_1920.jpg.jpg/size=320x180.jpg",
+                "alt": "",
+                "shorttext": "Es beginnt mit einem Mord. Amata Haller hat ihren Chef Heinz Brockhaus umgebracht, bei einem gemeinsamen Roadtrip an die Ostsee. Das ist gleich am Anfang klar. Und: Sie hat keine Reue.",
+                "picturesource": "rbb"
+        }
+    },  
+    "202605091900" : {
+        "pg_link": "https://www.radiodrei.de/programm/schema/sendungen/the_voice/archiv/20260509_1900.html",
+        "pg_title": "Michael Mayo",
+        "pg_time": "19:00",
+        "pg_begin": 1778346000000,
+        "pg_end":   1778349600000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 19:00 - 20:00",
+                "img": "https://www.radiodrei.de/content/dam/rbb/kul/musik/solisten/Michael-Mayo-by-Lauren-Desberg_1920.jpg.jpg/size=320x180.jpg",
+                "alt": "",
+                "shorttext": "<br/>&nbsp;<br/>\n&nbsp;",
+                "picturesource": "radio3"
+        }
+    },  
+    "202605092000" : {
+        "pg_link": "https://www.radiodrei.de/programm/schema/sendungen/ard_oper/archiv/20260509_2000.html",
+        "pg_title": "Giuseppe Verdi: Un ballo in maschera",
+        "pg_time": "20:00",
+        "pg_begin": 1778349600000,
+        "pg_end":   1778360400000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 20:00 - 23:00",
+                "img": "https://www.radiodrei.de/content/dam/rbb/kul/programmtipps/04_26/Staatsoper_netrebko_1920.jpg.jpg/size=320x180.jpg",
+                "alt": "",
+                "shorttext": "Melodramma in drei Akten (1859)<br>",
+                "picturesource": "picture alliance/shotshop/Joana Kruse"
+        }
+    },  
+    "202605092300" : {
+        "pg_link": "https://www.radiodrei.de/programm/schema/sendungen/radio3_global_sounds/archiv/20260509_2300.html",
+        "pg_title": "radio3 Global Sounds",
+        "pg_time": "23:00",
+        "pg_begin": 1778360400000,
+        "pg_end":   1778364000000,
+        "flyout": {
+                "roofline": "Sa 09.05.2026 | 23:00 - 00:00",
+                "img": "https://www.radiodrei.de/content/dam/rbb/kul/radio3/rbb-radio3_r3_global_1920px_b.png.png/size=320x180.png",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605100000" : {
+        "pg_link": "https://www.radiodrei.de/programm/schema/sendungen/nachrichten_wetter.html",
+        "pg_title": "Nachrichten, Wetter",
+        "pg_time": "00:00",
+        "pg_begin": 1778364000000,
+        "pg_end":   1778364180000,
+        "flyout": {
+                "roofline": "So 10.05.2026 | 00:00 - 00:03",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605100003" : {
+        "pg_link": "https://www.radiodrei.de/programm/vorlagen/hilfuebersicht-epg-kul-json.html",
+        "pg_title": "ARD-Nachtkonzert (I)",
+        "pg_time": "00:03",
+        "pg_begin": 1778364180000,
+        "pg_end":   1778371200000,
+        "flyout": {
+                "roofline": "So 10.05.2026 | 00:03 - 02:00",
+                "img": "",
+                "alt": "",
+                "shorttext": "Präsentiert von BR Klassik<br/>Joseph Haydn: <br/>Violinkonzert G-Dur, Hob. VIIa/4<br/>Deutsche Radio Philharmonie Saarbrücken Kaiserslautern<br/>Leitung: Christoph Altstaedt<br/>Carl Maria von Weber: <br/>Trio g-Moll, op. 63<br/>Shawnigan-Trio<br/>Ludwig van Beethoven: <br/>Sinfonie Nr. 1 C-Dur<br/>Rundfunk-Sinfonieorchester Saarbrücken<br/>Leitung: StanisIaw Skrowaczewski<br/>Dmitrij Schostakowitsch: <br/>Streichquartett D-Dur, op. 83<br/>Rasumowsky Quartett<br/>Igor Strawinsky: <br/>Violinkonzert D-Dur<br/>Liana Gourdjia<br/>Deutsche Radio Philharmonie Saarbrücken Kaiserslautern<br/>Leitung: Zsolt Nagy",
+                "picturesource": ""
+        }
+    },  
+    "202605100200" : {
+        "pg_link": "https://www.radiodrei.de/programm/schema/sendungen/nachrichten_wetter.html",
+        "pg_title": "Nachrichten, Wetter",
+        "pg_time": "02:00",
+        "pg_begin": 1778371200000,
+        "pg_end":   1778371380000,
+        "flyout": {
+                "roofline": "So 10.05.2026 | 02:00 - 02:03",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605100203" : {
+        "pg_link": "https://www.radiodrei.de/programm/vorlagen/hilfuebersicht-epg-kul-json.html",
+        "pg_title": "ARD-Nachtkonzert (II)",
+        "pg_time": "02:03",
+        "pg_begin": 1778371380000,
+        "pg_end":   1778378400000,
+        "flyout": {
+                "roofline": "So 10.05.2026 | 02:03 - 04:00",
+                "img": "",
+                "alt": "",
+                "shorttext": "Hector Berlioz: <br/>'Le carnaval romain', op. 9<br/>Deutsches Symphonie-Orchester Berlin<br/>Leitung: Kent Nagano<br/>Georg Philipp Telemann: <br/>Ouvertüre F-Dur<br/>L'Orfeo Barockorchester<br/>Leitung: Carin van Heerden<br/>Antonín Dvorák: <br/>Violoncellokonzert h-Moll, op. 104<br/>Sebastian Klinger<br/>Deutsche Radio Philharmonie Saarbrücken Kaiserslautern<br/>Leitung: Simon Gaudenz<br/>Louise Farrenc: <br/>Variations brillantes sur un thème de la Cenerentola, op. 5<br/>Maria Stratigou, Klavier<br/>Christian Sinding: <br/>Sinfonie Nr. 1 d-Moll<br/>NDR Radiophilharmonie<br/>Leitung: Thomas Dausgaard",
+                "picturesource": ""
+        }
+    },  
+    "202605100400" : {
+        "pg_link": "https://www.radiodrei.de/programm/schema/sendungen/nachrichten_wetter.html",
+        "pg_title": "Nachrichten, Wetter",
+        "pg_time": "04:00",
+        "pg_begin": 1778378400000,
+        "pg_end":   1778378580000,
+        "flyout": {
+                "roofline": "So 10.05.2026 | 04:00 - 04:03",
+                "img": "",
+                "alt": "",
+                "shorttext": "",
+                "picturesource": ""
+        }
+    },  
+    "202605100403" : {
+        "pg_link": "https://www.radiodrei.de/programm/vorlagen/hilfuebersicht-epg-kul-json.html",
+        "pg_title": "ARD-Nachtkonzert (III)",
+        "pg_time": "04:03",
+        "pg_begin": 1778378580000,
+        "pg_end":   1778382000000,
+        "flyout": {
+                "roofline": "So 10.05.2026 | 04:03 - 05:00",
+                "img": "",
+                "alt": "",
+                "shorttext": "Antonio Salieri: <br/>'Il giorno onomastico'<br/>Akademie für Alte Musik Berlin<br/>Leitung: Marcus Creed<br/>Josef Suk: <br/>Vier Stücke, op. 17<br/>The Nash Ensemble<br/>Camille Saint-Saëns: <br/>Violoncellokonzert Nr. 1 a-Moll<br/>Pieter Wispelwey<br/>Deutsche Kammerphilharmonie Bremen",
+                "picturesource": ""
+        }
+    }
+}

--- a/data/metadata-discovery/rbb-radio3-nowonair.json
+++ b/data/metadata-discovery/rbb-radio3-nowonair.json
@@ -1,0 +1,7 @@
+{
+  "captured_at": "2026-05-09T06:17:21.537419Z",
+  "endpoint": "https://www.radiodrei.de/include/kul/nowonair/now_on_air.html",
+  "cors": "*",
+  "content_type": "text/html",
+  "body": "<em class=\"now_running\">Es l&auml;uft:</em>\n<h3 class=\"interpret\">Joseph Haydn</h3>\n<p class=\"title\">Cellokonzert D-Dur, Hob. VIIb:2</p>\n"
+}

--- a/data/metadata-discovery/rbb-rbb888-nowonair.json
+++ b/data/metadata-discovery/rbb-rbb888-nowonair.json
@@ -1,0 +1,7 @@
+{
+  "captured_at": "2026-05-09T06:16:59.973643Z",
+  "endpoint": "https://www.rbb888.de/include/ach/nowonair/now_on_air.html",
+  "cors": "*",
+  "content_type": "text/html",
+  "body": "<em class=\"now_running\">Es l&auml;uft:</em>\n<h3 class=\"interpret\">Milli Vanilli</h3>\n<p class=\"title\">Girl I'm Gonna Miss You</p>\n"
+}

--- a/docs/broadcaster-research.md
+++ b/docs/broadcaster-research.md
@@ -1,0 +1,199 @@
+# Broadcaster API Research
+
+Per-broadcaster findings from the API discovery skill. Each entry documents the
+now-playing / schedule endpoints found, CORS status, response shape, and whether
+the station is wirable today.
+
+See issue #193 for the backlog of broadcasters to investigate.
+
+---
+
+## rbb — Rundfunk Berlin-Brandenburg (DE)
+
+Investigated: 2026-05-09.
+
+### Channels in catalog
+
+| Station | Status before | Fetcher key |
+|---|---|---|
+| Radio Eins | `working` | `rbb-radioeins` (already wired) |
+| Fritz | `icy-only` | not wired |
+| Antenne Brandenburg | `icy-only` | not wired |
+| radioBerlin 88,8 | `icy-only` | not wired |
+| radio3 (Kulturradio) | `icy-only` | not wired |
+| Inforadio | `icy-only` | not wired |
+
+### Background
+
+All RBB channels share the same CMS platform (Adobe CQ / AEM on `rbb-online.de`).
+Each channel lives on its own subdomain with its own **slug** (2–3 letters):
+
+| Channel | Domain | Slug |
+|---|---|---|
+| Radio Eins | `radioeins.de` | `rad` |
+| Fritz | `fritz.de` | `frz` |
+| Antenne Brandenburg | `antennebrandenburg.de` | `ant` |
+| radioBerlin 88,8 | `rbb888.de` | `ach` |
+| radio3 (Kulturradio) | `radiodrei.de` | `kul` |
+| Inforadio | `inforadio.de` | `inf` |
+
+### Endpoints
+
+#### Now-playing (track-level HTML fragment)
+
+Two HTML shapes exist across the six channels.
+
+**Shape A — Radio Eins + Fritz** (`<p class="artist">` / `<p class="songtitle">`):
+
+```
+https://www.radioeins.de/include/rad/nowonair/now_on_air.html
+https://www.fritz.de/include/frz/nowonair/now_on_air.html
+```
+
+URL template: `https://www.<domain>/include/<slug>/nowonair/now_on_air.html`
+
+Sample body:
+```html
+<p class="artist">Katy Perry</p><p class="songtitle">California Gurls</p>
+```
+
+Fields: `p.artist` → artist, `p.songtitle` → track title.
+
+**Shape B — Antenne Brandenburg, radioBerlin 88,8, radio3** (`<h3 class="interpret">` / `<p class="title">`):
+
+```
+https://www.antennebrandenburg.de/include/ant/nowonair/now_on_air.html
+https://www.rbb888.de/include/ach/nowonair/now_on_air.html
+https://www.radiodrei.de/include/kul/nowonair/now_on_air.html
+```
+
+Sample body:
+```html
+<em class="now_running">Es läuft:</em>
+<h3 class="interpret">Ed Sheeran</h3>
+<p class="title">Perfect</p>
+```
+
+Fields: `h3.interpret` → artist, `p.title` → track title.
+Body is **empty** (whitespace only) when no music is playing (news, speech segments, between tracks).
+
+**Inforadio**: No now-playing widget. Pure news/talk — no track-level data expected; the station has no `jsb_NowOnAir` component on its player page.
+
+| What | URL template | Auth | CORS | Sample |
+|---|---|---|---|---|
+| Now-playing (Shape A) | `https://www.<domain>/include/<slug>/nowonair/now_on_air.html` | none | `*` | `data/metadata-discovery/rbb-fritz-nowonair.json` |
+| Now-playing (Shape A) | radioeins: `/include/rad/nowonair/now_on_air.html` | none | `*` | `data/metadata-discovery/rbb-eins.json` |
+| Now-playing (Shape B) | antenne: `/include/ant/nowonair/now_on_air.html` | none | `*` | `data/metadata-discovery/rbb-antenne-nowonair.json` |
+| Now-playing (Shape B) | rbb888: `/include/ach/nowonair/now_on_air.html` | none | `*` | `data/metadata-discovery/rbb-rbb888-nowonair.json` |
+| Now-playing (Shape B) | radio3: `/include/kul/nowonair/now_on_air.html` | none | `*` | `data/metadata-discovery/rbb-radio3-nowonair.json` |
+
+#### Programme schedule (EPG — programme-level, no track titles)
+
+URL template: `https://www.<domain>/programm/vorlagen/hilfuebersicht-epg-<slug>-json.jsn/from=<DD-MM-YYYY>_05-00/sitelabel=<slug>/to=<DD-MM-YYYY+1>_05-00.jsn`
+
+Date window starts at 05:00 (local) and runs 24 h. Use today/tomorrow dates. Keys are `YYYYMMDDHHSS` strings.
+
+| Channel | Domain | Slug | CORS | Sample |
+|---|---|---|---|---|
+| Radio Eins | `radioeins.de` | `rad` | `*` | (empty `{}` today — may be CMS latency) |
+| Antenne Brandenburg | `antennebrandenburg.de` | `ant` | `*` | `data/metadata-discovery/rbb-antenne-epg.json` |
+| radioBerlin 88,8 | `rbb888.de` | `ach` | none | (needs worker proxy) |
+| radio3 | `radiodrei.de` | `kul` | `*` | `data/metadata-discovery/rbb-radio3-epg.json` |
+| Inforadio | `inforadio.de` | `inf` | `*` | `data/metadata-discovery/rbb-inforadio-epg.json` |
+| Fritz | `fritz.de` | `frz` | — | 404 (no EPG in this path pattern) |
+
+EPG response shape:
+```json
+{
+  "202605090600": {
+    "pg_title": "Guten Morgen Brandenburg",
+    "pg_time":  "06:00",
+    "pg_begin": 1778299200000,
+    "pg_end":   1778313600000,
+    "flyout": {
+      "roofline": "Sa 09.05.2026 | 06:00 - 10:00",
+      "img": "https://www.antennebrandenburg.de/...jpg",
+      "shorttext": "<p>...</p>"
+    }
+  }
+}
+```
+
+Fields: `pg_title` → programme name, `pg_begin` / `pg_end` → Unix ms timestamps (no TZ
+conversion needed — they are already UTC-based ms). `flyout.img` → programme art
+(resizable: change `size=320x180` suffix). No track titles in EPG.
+
+### Response shape — now-playing
+
+The now-playing HTML bodies are tiny (60–150 bytes) and need DOMParser or regex.
+
+**Shape A** (radioeins, fritz): regex `/<p\s+class="artist">([^<]*)<\/p>\s*<p\s+class="songtitle">([^<]*)<\/p>/i`
+→ `[1]` = artist, `[2]` = title. Already implemented in `src/builtins.ts` as `fetchRadioEinsMetadata`.
+
+**Shape B** (antenne, rbb888, radio3): regex `/<h3\s+class="interpret">([^<]*)<\/h3>\s*<p\s+class="title">([^<]*)<\/p>/i`
+→ `[1]` = artist (HTML-entity-encoded), `[2]` = title. Entities (`&auml;` etc.) must be decoded.
+
+Both shapes return empty body (no match) when no music is on-air — the fetcher should
+return `null` in that case so the ICY fallback can still run.
+
+### Cover art
+
+None of the now-playing endpoints carry cover URLs. No per-track cover art available.
+Programme artwork is available via `flyout.img` in the EPG endpoint (per show, not per track).
+
+### Wirable today?
+
+| Channel | Track | Programme | Verdict |
+|---|---|---|---|
+| Radio Eins | ✅ (already wired as `rbb-radioeins`) | ⚠️ (EPG returned empty today) | Done |
+| Fritz | ✅ wire-now — CORS open, Shape A | ❌ no EPG endpoint found | wire-now for track |
+| Antenne Brandenburg | ✅ wire-now — CORS open, Shape B | ✅ wire-now — CORS open, EPG works | wire-now for both |
+| radioBerlin 88,8 | ✅ wire-now — CORS open, Shape B | ⚠️ via-worker — EPG lacks CORS | track direct; EPG via proxy |
+| radio3 | ✅ wire-now — CORS open, Shape B | ✅ wire-now — CORS open, EPG works | wire-now for both |
+| Inforadio | ❌ news station — no track data | ✅ wire-now — CORS open, EPG works | EPG only |
+
+### Suggested fetcher
+
+**Track fetcher (Shape A — fritz):** Extend the existing `fetchRadioEinsMetadata` to also
+handle fritz. That fetcher already implements the exact regex and URL pattern needed.
+The simplest approach: rename to `fetchRbbHtmlMetadata`, accept the URL from
+`station.metadataUrl`, keep the same regex. Radio Eins can be migrated to the same
+function with its URL stored in `metadataUrl`.
+
+**Track fetcher (Shape B — antenne, rbb888, radio3):** New `fetchRbbHtmlBMetadata` (or
+same function with a regex variant selected by metadataUrl host, or a single function
+with both patterns tried in order). Closest analogue: `fetchRadioEinsMetadata`.
+
+**EPG / programme fetcher:** New `fetchRbbEpgSchedule`. URL template:
+```
+https://www.<host>/programm/vorlagen/hilfuebersicht-epg-<slug>-json.jsn/from=<DD-MM-YYYY>_05-00/sitelabel=<slug>/to=<DD+1-MM-YYYY>_05-00.jsn
+```
+Store the base host + slug in `metadataUrl` (e.g.
+`https://www.antennebrandenburg.de#ant`). Find the current programme by matching
+`pg_begin <= Date.now() < pg_end`. Closest analogue: `fetchHrSchedule`
+(also programme-only, no track, uses worker for CORS — except most RBB EPG endpoints
+are CORS-open so no proxy needed except rbb888).
+
+### Notes
+
+- The now-playing HTML endpoint uses a **cache-killer** in the original JS
+  (`cacheKiller=<timestamp>`) — the fetcher should append `?_=<Date.now()>` to prevent
+  stale cache responses.
+- Bodies are HTML-entity-encoded (`&auml;` = ä, `&ouml;` = ö, `&uuml;` = ü, `&szlig;` = ß).
+  The fetcher should decode these before returning. A small helper function or
+  `document.createElement('textarea').innerHTML = …` trick works in the browser.
+- `radioBerlin 88,8` redirects `radioberlin.de → rbb888.de`. Use `rbb888.de` as canonical.
+- `radio3` redirects `kulturradio.de → radiodrei.de`. Use `radiodrei.de` as canonical.
+- Fritz has no EPG endpoint in the standard `.jsn` path. Programme info for Fritz
+  is not available via a machine-readable API (the livestream page shows programme via
+  a full-page SSI reload, not a parseable JSON feed).
+- Inforadio is a 24/7 news station. The EPG is dense (entries every few minutes) and
+  useful for showing which programme is on. Status should remain `icy-only` or
+  be set to `stream-only` (no ICY from the rndfnk.com stream) — the EPG gives
+  programme-level only. Recommend keeping as `icy-only` unless the EPG fetcher
+  is wired (which would give programme info but no track).
+- No rate-limit headers observed on any endpoint. These are lightly-polled HTML
+  fragments that the public web player polls every 20–60 s.
+- ToS: RBB is a German public broadcaster (ARD). No explicit API ToS; the endpoints
+  are served publicly from their CMS without authentication. Reasonable polling cadence
+  (30–60 s) is appropriate.


### PR DESCRIPTION
## Summary

- Found `now_on_air.html` HTML-fragment endpoints for all five unwired RBB music channels (Fritz, Antenne Brandenburg, radioBerlin 88,8, radio3 — Inforadio is news-only, no track data)
- Two HTML shapes across the channels: Shape A (`p.artist` / `p.songtitle`) for radioeins + fritz; Shape B (`h3.interpret` / `p.title`) for antenne + rbb888 + radio3
- Found EPG/programme schedule `.jsn` endpoints for Antenne Brandenburg, radioBerlin 88,8, radio3, and Inforadio (but not Fritz)
- All now-playing endpoints: `Access-Control-Allow-Origin: *` — no worker proxy needed
- EPG endpoints: mostly CORS-open; `rbb888.de` EPG lacks CORS (would need worker proxy)

## Findings

See full findings in `docs/broadcaster-research.md`.

URL templates discovered:
- Now-playing: `https://www.<domain>/include/<slug>/nowonair/now_on_air.html`
- EPG: `https://www.<domain>/programm/vorlagen/hilfuebersicht-epg-<slug>-json.jsn/from=<DD-MM-YYYY>_05-00/sitelabel=<slug>/to=<DD+1-MM-YYYY>_05-00.jsn`

Slugs: `rad` (radioeins), `frz` (fritz), `ant` (antenne), `ach` (rbb888), `kul` (radio3/radiodrei), `inf` (inforadio)

## Suggested next steps

1. Extend `fetchRadioEinsMetadata` (or generalise to `fetchRbbHtmlMetadata`) to handle Fritz via Shape A — store URL in `metadataUrl`, remove hardcoded radioeins.de URL
2. New `fetchRbbHtmlBMetadata` (or extend same function) for Shape B channels (antenne, rbb888, radio3) — regex `/<h3\s+class="interpret">([^<]*)<\/h3>.*<p\s+class="title">([^<]*)<\/p>/i`, decode HTML entities
3. New `fetchRbbEpgSchedule` for programme info — parse `pg_title` / `pg_begin` / `pg_end` from the `.jsn` EPG, find current slot
4. No fetcher for Inforadio track-level (news station) — wire EPG only if programme info is desired
5. Suggested next broadcaster to investigate: **WDR** (Westdeutscher Rundfunk) — 3 stations in catalog, ARD family, no fetcher

Closes part of #193.