### PR TITLE
recon: investigated ndr metadata APIs

### DIFF
--- a/data/metadata-discovery/ndr-playlist-ndr1niedersachsen.json
+++ b/data/metadata-discovery/ndr-playlist-ndr1niedersachsen.json
@@ -1,0 +1,126 @@
+{
+    "action": "radioPlaylist",
+    "timeStamp": 1778307104,
+    "nextVisitIn": "10",
+    "more_songs": [
+        {
+            "song": "Talk Talk - It's my life",
+            "song_interpret": "Talk Talk",
+            "song_title": "It's my life",
+            "song_cover": "9353d634-79f4-4aa7-9a4b-20021a372b3f",
+            "song_album": "114 Original Hits - Drivetime",
+            "song_order_number": "5099990602726",
+            "song_ean": "5099990602726"
+        },
+        {
+            "song": "Beach Boys - Barbara Ann",
+            "song_interpret": "Beach Boys",
+            "song_title": "Barbara Ann",
+            "song_cover": "864eeaac-5786-4c44-84a8-4a8e4537d83c",
+            "song_album": "California gold - The very best of The Beach Boys - 40 classic tracks",
+            "song_order_number": "796549-2",
+            "song_ean": "77779654925"
+        },
+        {
+            "song": "Colbie Caillat - Bubbly",
+            "song_interpret": "Colbie Caillat",
+            "song_title": "Bubbly",
+            "song_cover": "6b3ce867-9c64-4112-92b3-c6409ae5b61e",
+            "song_album": "Bubbly",
+            "song_order_number": "1747414",
+            "song_ean": "602517474147"
+        },
+        {
+            "song": "Olivia Newton-John - Physical",
+            "song_interpret": "Olivia Newton-John",
+            "song_title": "Physical",
+            "song_cover": "39248a72-9f32-44d6-bbc6-b2979df2033f",
+            "song_album": "Back to Basics - The Essential Collection 1971-1992",
+            "song_order_number": "512641-2",
+            "song_ean": "731451264122"
+        },
+        {
+            "song": "Level 42 - Lessons in love",
+            "song_interpret": "Level 42",
+            "song_title": "Lessons in love",
+            "song_cover": "df893c2b-0134-44c8-a3da-bc6fa9e8bd66",
+            "song_album": "The best of 1980 - 1990, Vol. 8",
+            "song_order_number": "827529-2",
+            "song_ean": "724382752929"
+        },
+        {
+            "song": "Dr. Hook - When you're in love with a beautiful woman",
+            "song_interpret": "Dr. Hook",
+            "song_title": "When you're in love with a beautiful woman",
+            "song_cover": "40e53639-90f0-44eb-ad85-0308c8f2e994",
+            "song_album": "Pure gold",
+            "song_order_number": "2158572",
+            "song_ean": "5099921585722"
+        }
+    ],
+    "song_next": "Ocean - Put your hand in the hand",
+    "song_next_interpret": "Ocean",
+    "song_next_title": "Put your hand in the hand",
+    "song_next_cover": "396459ff-4d6e-4599-bd0a-cb270aa50ab9",
+    "song_next_album": "Tolle Scheibe",
+    "song_next_order_number": "795327-2",
+    "song_next_ean": "77779532728",
+    "song_now": "Nik Kershaw - Wouldn't it be good",
+    "song_now_interpret": "Nik Kershaw",
+    "song_now_title": "Wouldn't it be good",
+    "song_now_cover": "6741ea1b-338e-48bc-95c1-39dc81d6d32e",
+    "song_now_album": "Die ultimative 80'er Fete",
+    "song_now_order_number": "560935-2",
+    "song_now_ean": "731456093529",
+    "song_previous": "Nick Straker Band - A walk in the park",
+    "song_previous_interpret": "Nick Straker Band",
+    "song_previous_title": "A walk in the park",
+    "song_previous_cover": "788bc632-d37f-4bc1-a0b4-7a62e8ff38ec",
+    "song_previous_album": "One hit wonder, Vol. 9",
+    "song_previous_order_number": "770658-2",
+    "song_previous_ean": "603877065822",
+    "persons": [
+        {
+            "name": "Kershaw, Nik",
+            "role": "AUTHOR",
+            "sort": "5",
+            "info": null
+        },
+        {
+            "name": "Kershaw, Nik",
+            "role": "SOLOIST",
+            "sort": "2",
+            "info": null
+        },
+        {
+            "name": "Kershaw, Nik",
+            "role": "ARRANGER",
+            "sort": "3",
+            "info": null
+        },
+        {
+            "name": "Kershaw, Nik",
+            "role": "PERFORMER",
+            "sort": "1",
+            "info": null
+        },
+        {
+            "name": "Kershaw, Nik",
+            "role": "COMPOSER",
+            "sort": "1",
+            "info": null
+        },
+        {
+            "name": "Horn Section",
+            "role": "ORCHESTRA",
+            "sort": "4",
+            "info": null
+        },
+        {
+            "name": "Hey, Jerry",
+            "role": "ARRANGER",
+            "sort": "1",
+            "info": null
+        }
+    ]
+}

--- a/data/metadata-discovery/ndr-playlist-ndr1radiomv.json
+++ b/data/metadata-discovery/ndr-playlist-ndr1radiomv.json
@@ -1,0 +1,156 @@
+{
+    "action": "radioPlaylist",
+    "timeStamp": 1778307205,
+    "nextVisitIn": "10",
+    "more_songs": [
+        {
+            "song": "Take That - Back for good",
+            "song_interpret": "Take That",
+            "song_title": "Back for good",
+            "song_cover": "f45b1b02-f9a3-4b04-8f0c-0cec0f47c893",
+            "song_album": "Back for good",
+            "song_order_number": "TAKE21",
+            "song_ean": ""
+        },
+        {
+            "song": "Michael Bubl\u00e9 - I believe in you",
+            "song_interpret": "Michael Bubl\u00e9",
+            "song_title": "I believe in you",
+            "song_cover": "8c075d87-60a8-488b-8bb3-23a71bb3e6c3",
+            "song_album": "Nobody but me",
+            "song_order_number": "9362-49176-6",
+            "song_ean": "93624917663"
+        },
+        {
+            "song": "Laid Back - Bakerman",
+            "song_interpret": "Laid Back",
+            "song_title": "Bakerman",
+            "song_cover": "d5fb5bc7-a6a7-4d66-a926-004bf33a2e0c",
+            "song_album": "Laidest greatest",
+            "song_order_number": "128070-2",
+            "song_ean": "743212807028"
+        },
+        {
+            "song": "John Kincade - Dreams are ten a penny",
+            "song_interpret": "John Kincade",
+            "song_title": "Dreams are ten a penny",
+            "song_cover": "ddedbe6a-9aab-4f11-8638-21ebeba745e0",
+            "song_album": "Superhits der 70er, Folge 2",
+            "song_order_number": "845742-2",
+            "song_ean": "42284574228"
+        },
+        {
+            "song": "Adele - Someone like you",
+            "song_interpret": "Adele",
+            "song_title": "Someone like you",
+            "song_cover": "0688c66d-cc1b-40c3-9755-8db8f046b7b1",
+            "song_album": "21",
+            "song_order_number": "953282",
+            "song_ean": "634904052027"
+        },
+        {
+            "song": "Herbert Gr\u00f6nemeyer - Kinder an die Macht",
+            "song_interpret": "Herbert Gr\u00f6nemeyer",
+            "song_title": "Kinder an die Macht",
+            "song_cover": "d499d8bb-d149-455a-ae47-a8aa5622adac",
+            "song_album": "KINDER AN DIE MACHT",
+            "song_order_number": "746236-2",
+            "song_ean": ""
+        }
+    ],
+    "song_next": "Terry Jacks - Seasons in the sun",
+    "song_next_interpret": "Terry Jacks",
+    "song_next_title": "Seasons in the sun",
+    "song_next_cover": "b95fdccf-09a2-439f-a00a-14937337cd4f",
+    "song_next_album": "TIME FOR TENDERNESS",
+    "song_next_order_number": "291.07.019",
+    "song_next_ean": "4003099833524",
+    "song_now": "Zonderling & Kelvin Jones Lost Frequencies - Love to go",
+    "song_now_interpret": "Zonderling & Kelvin Jones Lost Frequencies",
+    "song_now_title": "Love to go",
+    "song_now_cover": "2f05061c-abca-48e0-9d53-77f0ee87ff23",
+    "song_now_album": "Love to go",
+    "song_now_order_number": "-",
+    "song_now_ean": "4251603242724",
+    "song_previous": "Depeche Mode - Shake the disease",
+    "song_previous_interpret": "Depeche Mode",
+    "song_previous_title": "Shake the disease",
+    "song_previous_cover": "b90bbb8d-1e60-436d-9eac-a46f89bf7f11",
+    "song_previous_album": "Best of, Vol. 1",
+    "song_previous_order_number": "3750732",
+    "song_previous_ean": "94637507322",
+    "persons": [
+        {
+            "name": "Lost Frequencies",
+            "role": "SOLOIST",
+            "sort": "1",
+            "info": null
+        },
+        {
+            "name": "Mupani, Tinashi Kelvin",
+            "role": "COMPOSER",
+            "sort": "2",
+            "info": null
+        },
+        {
+            "name": "Salmy, Patrick",
+            "role": "COMPOSER",
+            "sort": "6",
+            "info": null
+        },
+        {
+            "name": "Zonderling",
+            "role": "ENSEMBLE",
+            "sort": "1",
+            "info": null
+        },
+        {
+            "name": "Vries, Jaap de",
+            "role": "COMPOSER",
+            "sort": "7",
+            "info": null
+        },
+        {
+            "name": "Munoz, Ricardo",
+            "role": "COMPOSER",
+            "sort": "5",
+            "info": null
+        },
+        {
+            "name": "Laet, Felix de",
+            "role": "COMPOSER",
+            "sort": "1",
+            "info": null
+        },
+        {
+            "name": "Flamm, Daniel",
+            "role": "COMPOSER",
+            "sort": "3",
+            "info": null
+        },
+        {
+            "name": "Sonderen, Martijn van",
+            "role": "COMPOSER",
+            "sort": "8",
+            "info": null
+        },
+        {
+            "name": "Lost Frequencies, Zonderling & Kelvin Jones",
+            "role": "PERFORMER",
+            "sort": "1",
+            "info": null
+        },
+        {
+            "name": "Jones, Kelvin",
+            "role": "SOLOIST",
+            "sort": "2",
+            "info": null
+        },
+        {
+            "name": "Irvine, Molly",
+            "role": "COMPOSER",
+            "sort": "4",
+            "info": null
+        }
+    ]
+}

--- a/data/metadata-discovery/ndr-playlist-ndr1wellenord.json
+++ b/data/metadata-discovery/ndr-playlist-ndr1wellenord.json
@@ -1,0 +1,174 @@
+{
+    "action": "radioPlaylist",
+    "timeStamp": 1778307190,
+    "nextVisitIn": "10",
+    "more_songs": [
+        {
+            "song": "Lionel Richie - Dancing on the ceiling",
+            "song_interpret": "Lionel Richie",
+            "song_title": "Dancing on the ceiling",
+            "song_cover": "0e2d28a2-bf38-4a34-91df-6fc731cce625",
+            "song_album": "Back to front (ecopak)",
+            "song_order_number": "5318818",
+            "song_ean": "600753188187"
+        },
+        {
+            "song": "Sniff'n'The Tears - Driver's seat",
+            "song_interpret": "Sniff'n'The Tears",
+            "song_title": "Driver's seat",
+            "song_cover": "c112c760-2b22-4c48-b852-7a6c275e2693",
+            "song_album": "One for the road",
+            "song_order_number": "8800138",
+            "song_ean": "4014548001388"
+        },
+        {
+            "song": "Michael Jackson - Will you be there",
+            "song_interpret": "Michael Jackson",
+            "song_title": "Will you be there",
+            "song_cover": "4bf55f0d-86cd-4d51-b574-13f86aa9aad6",
+            "song_album": "King of Pop - German Edition",
+            "song_order_number": "88697356342",
+            "song_ean": "886973563427"
+        },
+        {
+            "song": "Hot Chocolate - No doubt about it",
+            "song_interpret": "Hot Chocolate",
+            "song_title": "No doubt about it",
+            "song_cover": "049d59ae-d4ca-440a-ba34-aa053f175338",
+            "song_album": "Disco 80, Folge 2",
+            "song_order_number": "161909-2",
+            "song_ean": "743216190928"
+        },
+        {
+            "song": "Andreas Bourani - Auf uns",
+            "song_interpret": "Andreas Bourani",
+            "song_title": "Auf uns",
+            "song_cover": "6fc9fe9e-badf-401f-8911-cd4d3130ae0a",
+            "song_album": "Auf uns",
+            "song_order_number": "",
+            "song_ean": "9700000007740"
+        },
+        {
+            "song": "Umberto Tozzi - Gloria",
+            "song_interpret": "Umberto Tozzi",
+            "song_title": "Gloria",
+            "song_cover": "f090095b-3ac7-4cfb-826f-a6c02f17a604",
+            "song_album": "Umberto Tozzi - Seine gr\u00f6\u00dften Erfolge - Ti amo",
+            "song_order_number": "244847-2",
+            "song_ean": "22924484728"
+        }
+    ],
+    "song_next": "George Ezra - Anyone for you",
+    "song_next_interpret": "George Ezra",
+    "song_next_title": "Anyone for you",
+    "song_next_cover": "d5b2ac08-e4dd-4c54-b673-3d02fd6bfd4e",
+    "song_next_album": "Anyone for you",
+    "song_next_order_number": "-",
+    "song_next_ean": "886449836956",
+    "song_now": "John Waite - Missing you",
+    "song_now_interpret": "John Waite",
+    "song_now_title": "Missing you",
+    "song_now_cover": "7b0c2324-f68b-4165-8fa4-96ff35d29035",
+    "song_now_album": "This is... 1984",
+    "song_now_order_number": "2279032",
+    "song_now_ean": "5099922790323",
+    "song_previous": "Bellamy Brothers - Crossfire",
+    "song_previous_interpret": "Bellamy Brothers",
+    "song_previous_title": "Crossfire",
+    "song_previous_cover": "7256062a-8f83-4745-9d7d-21feadc904e4",
+    "song_previous_album": "Thomas Jeier pr\u00e4sentiert den Country Club",
+    "song_previous_order_number": "354502",
+    "song_previous_ean": "4007193545024",
+    "persons": [
+        {
+            "name": "Thoener, David",
+            "role": "SOUND_ENGINEER",
+            "sort": "2",
+            "info": null
+        },
+        {
+            "name": "Thoener, David",
+            "role": "AUDIO_ENGINEER",
+            "sort": "1",
+            "info": null
+        },
+        {
+            "name": "Ensemble: Myrick, Gary",
+            "role": "ENSEMBLE",
+            "sort": "1",
+            "info": null
+        },
+        {
+            "name": "Brody, Bruce",
+            "role": "ENSEMBLE",
+            "sort": "4",
+            "info": null
+        },
+        {
+            "name": "Scales, Steven",
+            "role": "ENSEMBLE",
+            "sort": "5",
+            "info": null
+        },
+        {
+            "name": "Nossov, Don",
+            "role": "ENSEMBLE",
+            "sort": "3",
+            "info": null
+        },
+        {
+            "name": "Smith, Curly",
+            "role": "ENSEMBLE",
+            "sort": "2",
+            "info": null
+        },
+        {
+            "name": "Sandford, Chas",
+            "role": "COMPOSER",
+            "sort": "2",
+            "info": null
+        },
+        {
+            "name": "Leonard, M.",
+            "role": "COMPOSER",
+            "sort": "3",
+            "info": null
+        },
+        {
+            "name": "Gersh, Gary",
+            "role": "SOUND_ENGINEER",
+            "sort": "3",
+            "info": null
+        },
+        {
+            "name": "Waite, John",
+            "role": "AUTHOR",
+            "sort": "1",
+            "info": null
+        },
+        {
+            "name": "Waite, John",
+            "role": "SOLOIST",
+            "sort": "1",
+            "info": null
+        },
+        {
+            "name": "Waite, John",
+            "role": "SOUND_ENGINEER",
+            "sort": "1",
+            "info": null
+        },
+        {
+            "name": "Waite, John",
+            "role": "PERFORMER",
+            "sort": "1",
+            "info": null
+        },
+        {
+            "name": "Waite, John",
+            "role": "COMPOSER",
+            "sort": "1",
+            "info": null
+        }
+    ]
+}

--- a/data/metadata-discovery/ndr-playlist-ndr2.json
+++ b/data/metadata-discovery/ndr-playlist-ndr2.json
@@ -1,0 +1,96 @@
+{
+    "action": "radioPlaylist",
+    "timeStamp": 1778307145,
+    "nextVisitIn": "10",
+    "more_songs": [
+        {
+            "song": "Duck Sauce - Barbra Streisand",
+            "song_interpret": "Duck Sauce",
+            "song_title": "Barbra Streisand",
+            "song_cover": "374bf480-27ee-475c-8219-c496aa3abe9d",
+            "song_album": "Barbra Streisand",
+            "song_order_number": "1",
+            "song_ean": "9705003370174"
+        },
+        {
+            "song": "Reamonn - Supergirl",
+            "song_interpret": "Reamonn",
+            "song_title": "Supergirl",
+            "song_cover": "fa950e44-c26d-4d3c-b0d2-6e6d27369e16",
+            "song_album": "Tuesday",
+            "song_order_number": "8491752",
+            "song_ean": "724384917524"
+        },
+        {
+            "song": "Alan Walker - Faded",
+            "song_interpret": "Alan Walker",
+            "song_title": "Faded",
+            "song_cover": "821f5396-d3ce-4911-b83a-062ce58e7063",
+            "song_album": "Faded",
+            "song_order_number": "-",
+            "song_ean": "886445615616"
+        },
+        {
+            "song": "Pet Shop Boys - Go West",
+            "song_interpret": "Pet Shop Boys",
+            "song_title": "Go West",
+            "song_cover": "07d3e6ba-38ef-4f4b-972f-ecc6b7b7748c",
+            "song_album": "Go West",
+            "song_order_number": "880910-2",
+            "song_ean": ""
+        },
+        {
+            "song": "Lost Frequencies & Bastille - Head Down",
+            "song_interpret": "Lost Frequencies & Bastille",
+            "song_title": "Head Down",
+            "song_cover": "a77eb137-f835-4c18-9d5f-7e49aef41e30",
+            "song_album": "Head Down",
+            "song_order_number": "",
+            "song_ean": "196871698788"
+        },
+        {
+            "song": "Jennifer Lopez - On The Floor",
+            "song_interpret": "Jennifer Lopez",
+            "song_title": "On The Floor",
+            "song_cover": "e02e1524-97d1-44b0-8473-34cc0a053425",
+            "song_album": "On The Floor",
+            "song_order_number": "-",
+            "song_ean": "9705800194157"
+        }
+    ],
+    "song_next": "Philip Bailey & Phil Collins - Easy Lover",
+    "song_next_interpret": "Philip Bailey & Phil Collins",
+    "song_next_title": "Easy Lover",
+    "song_next_cover": "ec1717f4-73eb-4ed1-a6d6-67a4fcb33381",
+    "song_next_album": "Chinese Wall",
+    "song_next_order_number": "CDCBS26161",
+    "song_next_ean": "5099702616126",
+    "song_now": "Udo Lindenberg & Apache 207 - Komet",
+    "song_now_interpret": "Udo Lindenberg & Apache 207",
+    "song_now_title": "Komet",
+    "song_now_cover": "b38672de-4680-409b-a5eb-79fc6b344e1c",
+    "song_now_album": "Komet",
+    "song_now_order_number": "-",
+    "song_now_ean": "5054197494963",
+    "song_previous": "Taylor Swift - Anti-Hero",
+    "song_previous_interpret": "Taylor Swift",
+    "song_previous_title": "Anti-Hero",
+    "song_previous_cover": "6bb4dc29-6f8f-4e1b-9df2-5d34b29d1a87",
+    "song_previous_album": "Anti-hero",
+    "song_previous_order_number": "-",
+    "song_previous_ean": "9705800150924",
+    "persons": [
+        {
+            "name": "Chris James , Jumpa , Sira , Chris James , Marco Tscheschlok , Udo Lindenberg ,",
+            "role": "COMPOSER",
+            "sort": "1",
+            "info": null
+        },
+        {
+            "name": "Lindenberg,Udo & Apache 207",
+            "role": "PERFORMER",
+            "sort": "1",
+            "info": null
+        }
+    ]
+}

--- a/data/metadata-discovery/ndr-playlist-ndr903.json
+++ b/data/metadata-discovery/ndr-playlist-ndr903.json
@@ -1,0 +1,120 @@
+{
+    "action": "radioPlaylist",
+    "timeStamp": 1778307073,
+    "nextVisitIn": "10",
+    "more_songs": [
+        {
+            "song": "Michael Sembello - Maniac",
+            "song_interpret": "Michael Sembello",
+            "song_title": "Maniac",
+            "song_cover": "8252ccb4-ce1f-41a5-9afb-8250916e1762",
+            "song_album": "T2",
+            "song_order_number": "7708902",
+            "song_ean": "603877089026"
+        },
+        {
+            "song": "Beatles - Hey Jude",
+            "song_interpret": "Beatles",
+            "song_title": "Hey Jude",
+            "song_cover": "3244a79c-e82b-48e0-9eb9-a2e542dd4cc9",
+            "song_album": "T4",
+            "song_order_number": "797039-2",
+            "song_ean": "77779703920"
+        },
+        {
+            "song": "Midge Ure - If I was",
+            "song_interpret": "Midge Ure",
+            "song_title": "If I was",
+            "song_cover": "c2d4b892-2611-4369-a895-39d7ff9e8041",
+            "song_album": "T4",
+            "song_order_number": "27000367",
+            "song_ean": "4010427000367"
+        },
+        {
+            "song": "Marit Larsen - If a song could get me you",
+            "song_interpret": "Marit Larsen",
+            "song_title": "If a song could get me you",
+            "song_cover": "5f216133-8129-4c6e-a14d-8d424f22f3b2",
+            "song_album": "T2",
+            "song_order_number": "-",
+            "song_ean": "886975340125"
+        },
+        {
+            "song": "Donna Summer - Hot stuff",
+            "song_interpret": "Donna Summer",
+            "song_title": "Hot stuff",
+            "song_cover": "4766292f-94b5-4aa0-ab48-6fe204bc8032",
+            "song_album": "T4",
+            "song_order_number": "845059-2",
+            "song_ean": "42284505925"
+        },
+        {
+            "song": "Pet Shop Boys - West end girls",
+            "song_interpret": "Pet Shop Boys",
+            "song_title": "West end girls",
+            "song_cover": "620a9bdd-6297-48cb-a3a9-fc2134e378da",
+            "song_album": "T4",
+            "song_order_number": "0097222ULT",
+            "song_ean": "4009880972229"
+        }
+    ],
+    "song_next": "Pharrell Williams - Happy",
+    "song_next_interpret": "Pharrell Williams",
+    "song_next_title": "Happy",
+    "song_next_cover": "9e54b4c9-595c-41e7-b1be-b1eabeb2df07",
+    "song_next_album": "T4",
+    "song_next_order_number": "-",
+    "song_next_ean": "9705800288504",
+    "song_now": "Boney M. - Sunny",
+    "song_now_interpret": "Boney M.",
+    "song_now_title": "Sunny",
+    "song_now_cover": "7f627339-4a48-4328-a839-3d71f4760c70",
+    "song_now_album": "T4",
+    "song_now_order_number": "121271-2",
+    "song_now_ean": "743212127126",
+    "song_previous": "Cliff Richard - Some people",
+    "song_previous_interpret": "Cliff Richard",
+    "song_previous_title": "Some people",
+    "song_previous_cover": "fc7b802b-695a-4929-bf82-f1fcb886c219",
+    "song_previous_album": "T4",
+    "song_previous_order_number": "748742-2",
+    "song_previous_ean": "77774874229",
+    "persons": [
+        {
+            "name": "Orchester",
+            "role": "ORCHESTRA",
+            "sort": "1",
+            "info": null
+        },
+        {
+            "name": "Hebb, Bobby",
+            "role": "AUTHOR",
+            "sort": "1",
+            "info": null
+        },
+        {
+            "name": "Hebb, Bobby",
+            "role": "COMPOSER",
+            "sort": "1",
+            "info": null
+        },
+        {
+            "name": "Farian, Frank",
+            "role": "SOUND_ENGINEER",
+            "sort": "1",
+            "info": null
+        },
+        {
+            "name": "Boney M.",
+            "role": "PERFORMER",
+            "sort": "1",
+            "info": null
+        },
+        {
+            "name": "Boney M.",
+            "role": "CHOIR",
+            "sort": "1",
+            "info": null
+        }
+    ]
+}

--- a/data/metadata-discovery/ndr-playlist-ndrblue.json
+++ b/data/metadata-discovery/ndr-playlist-ndrblue.json
@@ -1,0 +1,108 @@
+{
+    "action": "radioPlaylist",
+    "timeStamp": 1778307245,
+    "nextVisitIn": "10",
+    "more_songs": [
+        {
+            "song": "Michael Kiwanuka - Light",
+            "song_interpret": "Michael Kiwanuka",
+            "song_title": "Light",
+            "song_cover": "704ff830-f14a-4aa2-965a-c6dc94266587",
+            "song_album": "Light (Radio Edit)",
+            "song_order_number": "-",
+            "song_ean": "9705800161470"
+        },
+        {
+            "song": "The Black Keys - The Night Before",
+            "song_interpret": "The Black Keys",
+            "song_title": "The Night Before",
+            "song_cover": "9382f801-7579-45c4-aca3-917476450253",
+            "song_album": "The night before",
+            "song_order_number": "-",
+            "song_ean": "54391236814"
+        },
+        {
+            "song": "Paul Simon - Diamonds On The Soles Of Her Shoes",
+            "song_interpret": "Paul Simon",
+            "song_title": "Diamonds On The Soles Of Her Shoes",
+            "song_cover": "704ff830-f14a-4aa2-965a-c6dc94266587",
+            "song_album": "Graceland",
+            "song_order_number": "88765457652",
+            "song_ean": "887654576521"
+        },
+        {
+            "song": "Saya Gray - Shell (Of A Man)",
+            "song_interpret": "Saya Gray",
+            "song_title": "Shell (Of A Man)",
+            "song_cover": "704ff830-f14a-4aa2-965a-c6dc94266587",
+            "song_album": "SHELL ( OF A MAN )",
+            "song_order_number": "-",
+            "song_ean": "9705248371509"
+        },
+        {
+            "song": "Caribou - Climbing",
+            "song_interpret": "Caribou",
+            "song_title": "Climbing",
+            "song_cover": "704ff830-f14a-4aa2-965a-c6dc94266587",
+            "song_album": "Climbing",
+            "song_order_number": "-",
+            "song_ean": "9705694469089"
+        },
+        {
+            "song": "Biig Piig - Cuenta Lo",
+            "song_interpret": "Biig Piig",
+            "song_title": "Cuenta Lo",
+            "song_cover": "704ff830-f14a-4aa2-965a-c6dc94266587",
+            "song_album": "Cuenta lo",
+            "song_order_number": "-",
+            "song_ean": "886448762447"
+        }
+    ],
+    "song_next": "Isaac Roux - Brotherhood",
+    "song_next_interpret": "Isaac Roux",
+    "song_next_title": "Brotherhood",
+    "song_next_cover": "704ff830-f14a-4aa2-965a-c6dc94266587",
+    "song_next_album": "Brotherhood",
+    "song_next_order_number": "-",
+    "song_next_ean": "9705038660417",
+    "song_now": "Hooverphonic - The Wrong Place",
+    "song_now_interpret": "Hooverphonic",
+    "song_now_title": "The Wrong Place",
+    "song_now_cover": "704ff830-f14a-4aa2-965a-c6dc94266587",
+    "song_now_album": "The Wrong Place",
+    "song_now_order_number": "-",
+    "song_now_ean": "9705800116890",
+    "song_previous": "Anne Clark - Sleeper In Metropolis",
+    "song_previous_interpret": "Anne Clark",
+    "song_previous_title": "Sleeper In Metropolis",
+    "song_previous_cover": "704ff830-f14a-4aa2-965a-c6dc94266587",
+    "song_previous_album": "Generation Underground",
+    "song_previous_order_number": "0879032",
+    "song_previous_ean": "5099908790323",
+    "persons": [
+        {
+            "name": "Hooverphonic",
+            "role": "ENSEMBLE",
+            "sort": "1",
+            "info": null
+        },
+        {
+            "name": "Hooverphonic",
+            "role": "PERFORMER",
+            "sort": "1",
+            "info": null
+        },
+        {
+            "name": "Alex Callier",
+            "role": "COMPOSER",
+            "sort": "1",
+            "info": null
+        },
+        {
+            "name": "Charlotte Foret",
+            "role": "COMPOSER",
+            "sort": "2",
+            "info": null
+        }
+    ]
+}

--- a/data/metadata-discovery/ndr-playlist-ndrkultur.json
+++ b/data/metadata-discovery/ndr-playlist-ndrkultur.json
@@ -1,0 +1,108 @@
+{
+    "action": "radioPlaylist",
+    "timeStamp": 1778307244,
+    "nextVisitIn": "10",
+    "more_songs": [
+        {
+            "song": "Gitarrenkonzert A-Dur, op. 8a - Polonaise (2. Satz) - Ferdinando Carulli",
+            "song_interpret": "Ferdinando Carulli",
+            "song_title": "Gitarrenkonzert A-Dur, op. 8a - Polonaise (2. Satz)",
+            "song_cover": "5c436f24-0f32-41be-b4bb-137e4873916f",
+            "song_album": "",
+            "song_order_number": "10735",
+            "song_ean": ""
+        },
+        {
+            "song": "Sinfonie D-Dur - Minuetto: Allegro (3. Satz) - Juan Cris\u00f3stomo de Arriaga",
+            "song_interpret": "Juan Cris\u00f3stomo de Arriaga",
+            "song_title": "Sinfonie D-Dur - Minuetto: Allegro (3. Satz)",
+            "song_cover": "5c436f24-0f32-41be-b4bb-137e4873916f",
+            "song_album": "\u00d6.K. 04.11.2022 Aula der Uni G\u00f6ttingen",
+            "song_order_number": "-",
+            "song_ean": ""
+        },
+        {
+            "song": "Concerto grosso B-Dur, op. 3  Nr. 2, HWV 313 - Largo (2. Satz) - Georg Friedrich H\u00e4ndel",
+            "song_interpret": "Georg Friedrich H\u00e4ndel",
+            "song_title": "Concerto grosso B-Dur, op. 3  Nr. 2, HWV 313 - Largo (2. Satz)",
+            "song_cover": "5c436f24-0f32-41be-b4bb-137e4873916f",
+            "song_album": "",
+            "song_order_number": "0011392 BC",
+            "song_ean": ""
+        },
+        {
+            "song": "Die Forelle - Franz Liszt",
+            "song_interpret": "Franz Liszt",
+            "song_title": "Die Forelle",
+            "song_cover": "5c436f24-0f32-41be-b4bb-137e4873916f",
+            "song_album": "",
+            "song_order_number": "456871-2",
+            "song_ean": ""
+        },
+        {
+            "song": "Soundtrack: \"Jenseits von Afrika\" - Titelthema - John Barry",
+            "song_interpret": "John Barry",
+            "song_title": "Soundtrack: \"Jenseits von Afrika\" - Titelthema",
+            "song_cover": "5c436f24-0f32-41be-b4bb-137e4873916f",
+            "song_album": "",
+            "song_order_number": "744884-2",
+            "song_ean": ""
+        },
+        {
+            "song": "Klavierkonzert Nr. 4 G-Dur, op. 58 - Rondo: Vivace (3. Satz) - Ludwig van Beethoven",
+            "song_interpret": "Ludwig van Beethoven",
+            "song_title": "Klavierkonzert Nr. 4 G-Dur, op. 58 - Rondo: Vivace (3. Satz)",
+            "song_cover": "5c436f24-0f32-41be-b4bb-137e4873916f",
+            "song_album": "",
+            "song_order_number": "446082-2",
+            "song_ean": ""
+        }
+    ],
+    "song_next": "Estancia, op. 8 (Ballett) - Danza del trigo - Alberto Ginastera",
+    "song_next_interpret": "Alberto Ginastera",
+    "song_next_title": "Estancia, op. 8 (Ballett) - Danza del trigo",
+    "song_next_cover": "5c436f24-0f32-41be-b4bb-137e4873916f",
+    "song_next_album": "",
+    "song_next_order_number": "002894777457",
+    "song_next_ean": "",
+    "song_now": "Suite dal\u00e9carlienne, op. 22 - Scherzo: Danses Rustiques (3. Satz) - Helena Munktell",
+    "song_now_interpret": "Helena Munktell",
+    "song_now_title": "Suite dal\u00e9carlienne, op. 22 - Scherzo: Danses Rustiques (3. Satz)",
+    "song_now_cover": "5c436f24-0f32-41be-b4bb-137e4873916f",
+    "song_now_album": "",
+    "song_now_order_number": "CDS-1066-2",
+    "song_now_ean": "",
+    "song_previous": "Meditation - Fr\u00e9d\u00e9ric Chopin",
+    "song_previous_interpret": "Fr\u00e9d\u00e9ric Chopin",
+    "song_previous_title": "Meditation",
+    "song_previous_cover": "5c436f24-0f32-41be-b4bb-137e4873916f",
+    "song_previous_album": "Return to Warsaw",
+    "song_previous_order_number": "88985431442",
+    "song_previous_ean": "",
+    "persons": [
+        {
+            "name": "Helena Munktell (1852-1919)",
+            "role": "COMPOSER",
+            "sort": "1",
+            "info": null
+        },
+        {
+            "name": "G\u00e4vle Symphony Orchestra",
+            "role": "ORCHESTRA",
+            "sort": "1",
+            "info": null
+        },
+        {
+            "name": "Tobias Ringborg",
+            "role": "CONDUCTOR",
+            "sort": "1",
+            "info": null
+        },
+        {
+            "name": "Tobias Ringborg",
+            "role": "PERFORMER",
+            "sort": "1",
+            "info": null
+        }
+    ]
+}

--- a/data/metadata-discovery/ndr-playlist-ndrschlager.json
+++ b/data/metadata-discovery/ndr-playlist-ndrschlager.json
@@ -1,0 +1,144 @@
+{
+    "action": "radioPlaylist",
+    "timeStamp": 1778307376,
+    "nextVisitIn": "10",
+    "more_songs": [
+        {
+            "song": "J\u00fcrgen Marcus - Eine neue Liebe ist wie ein neues Leben",
+            "song_interpret": "J\u00fcrgen Marcus",
+            "song_title": "Eine neue Liebe ist wie ein neues Leben",
+            "song_cover": "2dc89b3a-e31c-42e0-9d46-76080ab62166",
+            "song_album": "Die deutsche Single Hitparade 1972",
+            "song_order_number": "845243-2",
+            "song_ean": "42284524322"
+        },
+        {
+            "song": "Wolfgang Petry - Verlieben, verloren, vergessen, verzeih'n",
+            "song_interpret": "Wolfgang Petry",
+            "song_title": "Verlieben, verloren, vergessen, verzeih'n",
+            "song_cover": "74e93522-7362-4fe3-a983-38a4f6b2cc3f",
+            "song_album": "",
+            "song_order_number": "665011",
+            "song_ean": "4007196650114"
+        },
+        {
+            "song": "Tanja Lasch - Paris ist auch nur eine Stadt",
+            "song_interpret": "Tanja Lasch",
+            "song_title": "Paris ist auch nur eine Stadt",
+            "song_cover": "7b104466-a770-4ed6-9213-1dadbc451858",
+            "song_album": "Paris ist auch nur eine Stadt",
+            "song_order_number": "-",
+            "song_ean": "9705156993473"
+        },
+        {
+            "song": "Tony Christie - Avenues and alleyways",
+            "song_interpret": "Tony Christie",
+            "song_title": "Avenues and alleyways",
+            "song_cover": "5ec7948c-b5ab-4c51-9db5-b1470ab327bf",
+            "song_album": "Welcome to my music, 2",
+            "song_order_number": "111012-2",
+            "song_ean": "743211101226"
+        },
+        {
+            "song": "Udo J\u00fcrgens - Anuschka",
+            "song_interpret": "Udo J\u00fcrgens",
+            "song_title": "Anuschka",
+            "song_cover": "5aa60781-726b-4534-9b6b-4481876a7482",
+            "song_album": "Die deutsche Single Hitparade 1970",
+            "song_order_number": "845241-2",
+            "song_ean": "42284524124"
+        },
+        {
+            "song": "Peter Sebastian - Gl\u00fcck ist ein Teil von dir",
+            "song_interpret": "Peter Sebastian",
+            "song_title": "Gl\u00fcck ist ein Teil von dir",
+            "song_cover": "7b104466-a770-4ed6-9213-1dadbc451858",
+            "song_album": "Gl\u00fcck ist ein Teil von dir",
+            "song_order_number": "-",
+            "song_ean": "401240711754"
+        }
+    ],
+    "song_next": "Achim Reichel - Aloha heja he",
+    "song_next_interpret": "Achim Reichel",
+    "song_next_title": "Aloha heja he",
+    "song_next_cover": "d384487e-728c-444d-963c-cf0dcbbd1c91",
+    "song_next_album": "Der Spieler",
+    "song_next_order_number": "67012",
+    "song_next_ean": "4001504670122",
+    "song_now": "Gazebo - I like Chopin",
+    "song_now_interpret": "Gazebo",
+    "song_now_title": "I like Chopin",
+    "song_now_cover": "1780c8eb-51ef-4d7e-9eff-67384f546dea",
+    "song_now_album": "Viva Italia",
+    "song_now_order_number": "88697853552",
+    "song_now_ean": "886978535528",
+    "song_previous": "Drafi Deutscher - Marmor, Stein und Eisen bricht",
+    "song_previous_interpret": "Drafi Deutscher",
+    "song_previous_title": "Marmor, Stein und Eisen bricht",
+    "song_previous_cover": "8da12744-c652-4128-bbd2-acc56f4314c8",
+    "song_previous_album": "Die deutsche Single Hitparade 1966",
+    "song_previous_order_number": "845237-2",
+    "song_previous_ean": "42284523721",
+    "persons": [
+        {
+            "name": "Wilson, Derek",
+            "role": "ENSEMBLE",
+            "sort": "2",
+            "info": null
+        },
+        {
+            "name": "Gazebo",
+            "role": "PERFORMER",
+            "sort": "1",
+            "info": null
+        },
+        {
+            "name": "Gazebo",
+            "role": "SOLOIST",
+            "sort": "1",
+            "info": null
+        },
+        {
+            "name": "Giombini, Pierluigi",
+            "role": "ARRANGER",
+            "sort": "1",
+            "info": null
+        },
+        {
+            "name": "Giombini, Pierluigi",
+            "role": "SOUND_ENGINEER",
+            "sort": "1",
+            "info": null
+        },
+        {
+            "name": "Giombini, Pierluigi",
+            "role": "ENSEMBLE",
+            "sort": "3",
+            "info": null
+        },
+        {
+            "name": "Giombini, Pierluigi",
+            "role": "COMPOSER",
+            "sort": "2",
+            "info": null
+        },
+        {
+            "name": "Mazzolini, Paolo",
+            "role": "COMPOSER",
+            "sort": "1",
+            "info": null
+        },
+        {
+            "name": "Ensemble: Meinardi, Lawrence",
+            "role": "ENSEMBLE",
+            "sort": "1",
+            "info": null
+        },
+        {
+            "name": "Bresciani, Gian Paolo",
+            "role": "AUDIO_ENGINEER",
+            "sort": "1",
+            "info": null
+        }
+    ]
+}

--- a/data/metadata-discovery/ndr-playlist-njoy.json
+++ b/data/metadata-discovery/ndr-playlist-njoy.json
@@ -1,0 +1,96 @@
+{
+    "action": "radioPlaylist",
+    "timeStamp": 1778307374,
+    "nextVisitIn": "10",
+    "more_songs": [
+        {
+            "song": "Marshmello x Khalid - Silence",
+            "song_interpret": "Marshmello x Khalid",
+            "song_title": "Silence",
+            "song_cover": "06a0e2b4-3f94-40c1-bbc4-b0e23fbf16d7",
+            "song_album": "Silence",
+            "song_order_number": "",
+            "song_ean": "886446681832"
+        },
+        {
+            "song": "Haven. feat. Kaitlin Aragon - I Run",
+            "song_interpret": "Haven. feat. Kaitlin Aragon",
+            "song_title": "I Run",
+            "song_cover": "dac5752a-c3ed-4ffe-b13e-09617066930e",
+            "song_album": "I run",
+            "song_order_number": "",
+            "song_ean": "663918669853"
+        },
+        {
+            "song": "Dasha - Austin",
+            "song_interpret": "Dasha",
+            "song_title": "Austin",
+            "song_cover": "e4586eed-8ca7-4d4c-a036-a61b594feff8",
+            "song_album": "Austin",
+            "song_order_number": "",
+            "song_ean": "9705800558799"
+        },
+        {
+            "song": "Olivia Rodrigo - drop dead",
+            "song_interpret": "Olivia Rodrigo",
+            "song_title": "drop dead",
+            "song_cover": "e005965f-2bb5-4fd7-93e9-c6bc4d8c0cf1",
+            "song_album": "drop dead",
+            "song_order_number": "",
+            "song_ean": "9725800117321"
+        },
+        {
+            "song": "Purple Disco Machine & Sophie And The Giants - Hypnotized",
+            "song_interpret": "Purple Disco Machine & Sophie And The Giants",
+            "song_title": "Hypnotized",
+            "song_cover": "ea6a4136-c400-47e0-ad20-bff305a1a587",
+            "song_album": "Hypnotized",
+            "song_order_number": "",
+            "song_ean": "886448374701"
+        },
+        {
+            "song": "RAYE - Where Is My Husband!",
+            "song_interpret": "RAYE",
+            "song_title": "Where Is My Husband!",
+            "song_cover": "5ec971e1-db56-427a-a483-86e9ce39dc78",
+            "song_album": "Where Is My Husband!",
+            "song_order_number": "",
+            "song_ean": "199538765458"
+        }
+    ],
+    "song_next": "Tate McRae - 2 Hands",
+    "song_next_interpret": "Tate McRae",
+    "song_next_title": "2 Hands",
+    "song_next_cover": "795a2621-15cd-4ee5-99e9-1b11332f7a70",
+    "song_next_album": "2 hands",
+    "song_next_order_number": "",
+    "song_next_ean": "196872486612",
+    "song_now": "EMINEM - Lose Yourself",
+    "song_now_interpret": "EMINEM",
+    "song_now_title": "Lose Yourself",
+    "song_now_cover": "08350c0c-7587-40fe-bf2d-2e490dfbc219",
+    "song_now_album": "",
+    "song_now_order_number": "497 824-2",
+    "song_now_ean": "",
+    "song_previous": "Zartmann - Wei\u00dft du \u00fcberhaupt noch wer ich bin?",
+    "song_previous_interpret": "Zartmann",
+    "song_previous_title": "Wei\u00dft du \u00fcberhaupt noch wer ich bin?",
+    "song_previous_cover": "93cc90af-fa1b-46b6-80f4-f54f2a19322e",
+    "song_previous_album": "",
+    "song_previous_order_number": "",
+    "song_previous_ean": "",
+    "persons": [
+        {
+            "name": "Eminem",
+            "role": "PERFORMER",
+            "sort": "1",
+            "info": null
+        },
+        {
+            "name": "Eminem",
+            "role": "COMPOSER",
+            "sort": "1",
+            "info": null
+        }
+    ]
+}

--- a/docs/broadcaster-research.md
+++ b/docs/broadcaster-research.md
@@ -8,6 +8,152 @@ See issue #193 for the backlog of broadcasters to investigate.
 
 ---
 
+## ndr — Norddeutscher Rundfunk (DE)
+
+Investigated: 2026-05-09.
+
+### Channels in catalog
+
+| Station | Status before | Playlist slug | Has playlist? |
+|---|---|---|---|
+| NDR 2 | `icy-only` | `ndr2` | yes |
+| NDR 90,3 | `icy-only` | `ndr903` | yes |
+| NDR Kultur | `icy-only` | `ndrkultur` | yes |
+| NDR 1 Niedersachsen | `icy-only` | `ndr1niedersachsen` | yes |
+| NDR 1 Welle Nord | `icy-only` | `ndr1wellenord` | yes |
+| N-JOY | `icy-only` | `njoy` | yes |
+| NDR Schlager | `icy-only` | `ndrschlager` | yes |
+| NDR Blue | `icy-only` | `ndrblue` | yes |
+| NDR 1 Radio MV | `icy-only` | `ndr1radiomv` | yes |
+| NDR Info | `icy-only` | — | no (news/talk) |
+
+### Endpoints
+
+| What | URL template | Auth | CORS | Sample |
+|---|---|---|---|---|
+| Now-playing + track history + cover | `https://www.ndr.de/public/radioplaylists/<slug>.json` | none | `*` | `data/metadata-discovery/ndr-playlist-ndr2.json` |
+| Cover art image | `https://www.ndr.de/public/radioplaylists/coverimages/<uuid>_300x300.jpg` | none | `*` | (URL embedded in now-playing response) |
+| NDR Kultur `persons` (composer, conductor, etc.) | embedded in now-playing response `persons` array | none | `*` | `data/metadata-discovery/ndr-playlist-ndrkultur.json` |
+
+**Slug mapping** (derived by probing `https://www.ndr.de/public/radioplaylists/<slug>.json`):
+
+| Station | Slug |
+|---|---|
+| NDR 2 | `ndr2` |
+| NDR 90,3 | `ndr903` |
+| NDR Kultur | `ndrkultur` |
+| NDR 1 Niedersachsen | `ndr1niedersachsen` |
+| NDR 1 Welle Nord | `ndr1wellenord` |
+| N-JOY | `njoy` |
+| NDR Schlager | `ndrschlager` |
+| NDR Blue | `ndrblue` |
+| NDR 1 Radio MV | `ndr1radiomv` |
+
+All return HTTP 200 with `access-control-allow-origin: *`. NDR Info has no music playlist endpoint (tried: `ndrinfo`, `info`, `ndrinfo2`, `ndrinfospezial` — all 404).
+
+### Response shape
+
+```json
+{
+  "action": "radioPlaylist",
+  "timeStamp": 1778307145,
+  "nextVisitIn": "10",
+  "song_now":          "Udo Lindenberg & Apache 207 - Komet",
+  "song_now_interpret":"Udo Lindenberg & Apache 207",
+  "song_now_title":    "Komet",
+  "song_now_cover":    "b38672de-4680-409b-a5eb-79fc6b344e1c",
+  "song_now_album":    "Komet",
+  "song_now_ean":      "5054197494963",
+  "song_previous":     "Taylor Swift - Anti-Hero",
+  "song_previous_interpret": "Taylor Swift",
+  "song_previous_title":     "Anti-Hero",
+  "song_previous_cover":     "6bb4dc29-...",
+  "song_next":         "Philip Bailey & Phil Collins - Easy Lover",
+  "song_next_interpret":"Philip Bailey & Phil Collins",
+  "song_next_title":   "Easy Lover",
+  "song_next_cover":   "ec1717f4-...",
+  "more_songs": [
+    {
+      "song":           "Duck Sauce - Barbra Streisand",
+      "song_interpret": "Duck Sauce",
+      "song_title":     "Barbra Streisand",
+      "song_cover":     "374bf480-...",
+      "song_album":     "Barbra Streisand",
+      "song_order_number": "1",
+      "song_ean":       "9705003370174"
+    }
+  ]
+}
+```
+
+**Key field mappings:**
+- Artist → `song_now_interpret`
+- Track title → `song_now_title`
+- Cover UUID → `song_now_cover`; build URL as `https://www.ndr.de/public/radioplaylists/coverimages/<uuid>_300x300.jpg`
+- `nextVisitIn` → polling interval hint (seconds, typically `"10"`)
+- `more_songs` → track history list (6 recent tracks)
+- `song_previous` / `song_next` → previous and upcoming track (with cover UUIDs)
+
+**NDR Kultur special case** — the `persons` array carries classical music metadata:
+```json
+"persons": [
+  { "name": "Helena Munktell (1852-1919)", "role": "COMPOSER", "sort": "1" },
+  { "name": "Gävle Symphony Orchestra",   "role": "ORCHESTRA",  "sort": "1" },
+  { "name": "Tobias Ringborg",             "role": "CONDUCTOR",  "sort": "1" }
+]
+```
+Roles present: `COMPOSER`, `ORCHESTRA`, `CONDUCTOR`, `PERFORMER`. The `song_now_interpret`
+field on Kultur often contains the composer name (since classical tracks list composer as
+"artist"). The `persons` array can augment with ensemble/conductor info in the subtitle.
+
+### Wirable today?
+
+✅ **wire-now** for 9 of 10 channels. HTTPS-only, `CORS: *`, no auth, structured JSON.
+`nextVisitIn: "10"` is the broadcaster's own 10-second polling cadence hint.
+
+NDR Info: ❌ no playlist endpoint exists (news/talk station; expected).
+
+### Suggested fetcher
+
+New `fetchNdrMetadata` in `src/builtins.ts`. Closest analogues are `fetchSwrMetadata`
+(single endpoint per channel, structured JSON, cover URL embedded) and `fetchMdrMetadata`
+(German ARD family, per-channel `metadataUrl`).
+
+Pattern:
+1. `station.metadataUrl` stores the full playlist URL:
+   `https://www.ndr.de/public/radioplaylists/<slug>.json`
+2. Fetch with `cache: 'no-store'`; no proxy needed (CORS open).
+3. Read `song_now_interpret` → artist, `song_now_title` → track.
+4. Build cover URL from `song_now_cover` UUID:
+   `https://www.ndr.de/public/radioplaylists/coverimages/${uuid}_300x300.jpg`
+5. For NDR Kultur: optionally extract `persons` composer/conductor for a programme subtitle.
+6. No programme/schedule API was found for NDR beyond the track playlist — no equivalent
+   to SWR's `show.title` field. Programme info is not available via this endpoint.
+
+Register as `ndr` in the `METADATA_FETCHERS` / `SCHEDULE_FETCHERS` maps.
+
+### Notes
+
+- `nextVisitIn` is always `"10"` (string) in all captured responses — treat as the
+  broadcaster-suggested poll interval in seconds.
+- The `more_songs` array is ordered most-recent-first and typically contains 6 items.
+  No pagination — the full recent playlist is in a single response.
+- NDR Kultur's `song_now_interpret` field sometimes holds the composer name rather than
+  the performer. The `persons` array is the better source for role-specific metadata on
+  that channel; other channels don't populate `persons`.
+- Cover images are served with `CORS: *` as well — safe to use directly in `<img>` or
+  CSS `background-image`. The 300×300 size is the only documented variant (UUID-based
+  URLs don't expose size parameters publicly).
+- NDR Info has no playlist endpoint — keep at `stream-only` / `icy-only`. The station's
+  live page (`/nachrichten/info/live`) uses `data-brand="ndrinfo"` but no music is played.
+- No rate-limit headers observed on any endpoint. 10-second polling is the broadcaster's
+  own cadence hint.
+- ToS: NDR is a German public broadcaster (ARD). No explicit API ToS; the endpoints are
+  served publicly without authentication. The 10-second poll cadence from `nextVisitIn`
+  is a safe default.
+
+---
+
 ## rbb — Rundfunk Berlin-Brandenburg (DE)
 
 Investigated: 2026-05-09.


### PR DESCRIPTION
## Summary

NDR (Norddeutscher Rundfunk) has a clean, public, CORS-open radioplaylist JSON API that covers 9 of 10 channels in the catalog. Investigation complete; no src/ changes — fetcher wiring is human work.

- Endpoint: `https://www.ndr.de/public/radioplaylists/<slug>.json`
- CORS: `Access-Control-Allow-Origin: *` on all responses (including cover images)
- Auth: none
- Fields: `song_now_interpret` (artist), `song_now_title` (track), `song_now_cover` (UUID → cover URL), `more_songs[]` (history), `song_next`/`song_previous`
- Cover URL pattern: `https://www.ndr.de/public/radioplaylists/coverimages/<uuid>_300x300.jpg`
- Poll cadence: `nextVisitIn: "10"` (10-second hint from broadcaster)
- NDR Kultur additionally exposes a `persons` array with `COMPOSER`/`ORCHESTRA`/`CONDUCTOR` roles for classical metadata
- NDR Info has no playlist endpoint (news/talk station — expected)

**Wirable today:** ✅ for all 9 music channels. Single fetcher `fetchNdrMetadata`, one `metadataUrl` per station, no proxy required.

## Captures

9 channel captures in `data/metadata-discovery/ndr-playlist-<slug>.json`:
`ndr2`, `ndr903`, `ndrkultur`, `ndr1niedersachsen`, `ndr1wellenord`, `njoy`, `ndrschlager`, `ndrblue`, `ndr1radiomv`.

## Test plan

- [ ] Review `docs/broadcaster-research.md` NDR section for accuracy
- [ ] Confirm sample captures contain live track data (artist/title/cover UUID non-empty)
- [ ] Spot-check one capture URL manually in a browser with CORS headers visible
- [ ] Wire `fetchNdrMetadata` in a follow-up PR per the suggested pattern in the findings doc
- [ ] Set `metadataUrl` on all 9 NDR stations and flip status to `working` after fetcher is wired

Closes part of #193. Next broadcaster to investigate: **WDR** (Westdeutscher Rundfunk) — another ARD member with 6 stations in the catalog and no fetcher yet; WDR's live player likely uses a similar `wdr.de/public/...` endpoint pattern worth probing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)