### PR TITLE
recon: investigated radio-france metadata APIs

### DIFF
--- a/data/metadata-discovery/radio-france-fip-now-playing.json
+++ b/data/metadata-discovery/radio-france-fip-now-playing.json
@@ -1,0 +1,37 @@
+{
+    "prev": [
+        {
+            "title": "Le direct",
+            "interpreters": null,
+            "album": null,
+            "label": null,
+            "cover": null,
+            "musicalKind": null,
+            "startTime": null,
+            "endTime": null
+        }
+    ],
+    "now": {
+        "title": "Emotion",
+        "interpreters": "Destiny's Child & Beyonce",
+        "album": "Survivor",
+        "label": "COLUMBIA",
+        "cover": "58823f41-f06a-44be-aee7-fcf7374116bc",
+        "musicalKind": "Soul / RnB ",
+        "startTime": 1778310418,
+        "endTime": 1778310653
+    },
+    "next": [
+        {
+            "title": "Love t.k.o.",
+            "interpreters": "Teddy Pendergrass",
+            "album": "Greatest hits",
+            "label": "PHILADELPHIA INTERNATIONAL RECORDS",
+            "cover": "27ef8330-8c98-480a-bf7d-9b96f693b815",
+            "musicalKind": "Soul / RnB ",
+            "startTime": 1778310652,
+            "endTime": 1778310871
+        }
+    ],
+    "delayToRefresh": 180000
+}

--- a/data/metadata-discovery/radio-france-fip-rock-now-playing.json
+++ b/data/metadata-discovery/radio-france-fip-rock-now-playing.json
@@ -1,0 +1,35 @@
+{
+    "prev": [
+        {
+            "firstLine": "FIP Rock",
+            "secondLine": "Le direct",
+            "thirdLine": null,
+            "cover": "cda37279-f985-4017-bc03-2dad643c7306",
+            "startTime": null,
+            "endTime": null
+        }
+    ],
+    "now": {
+        "firstLine": "FIP Rock",
+        "secondLine": "Te Quiero Igual",
+        "secondLineSongUuid": "0cfe2bae-8233-42d4-99c6-7813fbd44f63",
+        "thirdLine": "Novedades Carminha",
+        "thirdLineSongUuid": "0cfe2bae-8233-42d4-99c6-7813fbd44f63",
+        "cover": "26190730-8121-43a7-ab82-0189c8740b06",
+        "startTime": 1778310356,
+        "endTime": 1778310535
+    },
+    "next": [
+        {
+            "firstLine": "FIP Rock",
+            "secondLine": "Let's stick together",
+            "secondLineSongUuid": "857ed38b-51fa-4955-8946-d9cda8170ab7",
+            "thirdLine": "Bryan Ferry",
+            "thirdLineSongUuid": "857ed38b-51fa-4955-8946-d9cda8170ab7",
+            "cover": "3c0a5cfc-a7b8-46ea-82c6-ca79980ecb48",
+            "startTime": 1778310535,
+            "endTime": 1778310710
+        }
+    ],
+    "delayToRefresh": 120000
+}

--- a/data/metadata-discovery/radio-france-info-now-playing.json
+++ b/data/metadata-discovery/radio-france-info-now-playing.json
@@ -1,0 +1,36 @@
+{
+    "prev": [
+        {
+            "firstLine": "Le direct",
+            "secondLine": "Le direct",
+            "cover": "52bb749e-f832-4dd1-ba0a-8c5d11e0aa3a",
+            "startTime": null,
+            "endTime": null
+        }
+    ],
+    "now": {
+        "firstLine": "Le 7/10 du week-end",
+        "firstLineUuid": "3c358631-1c12-4d35-a2f1-0a2ec3f42c94",
+        "firstLineConceptUuid": "3c358631-1c12-4d35-a2f1-0a2ec3f42c94",
+        "secondLine": "Le 7/10 du week-end",
+        "secondLineUuid": "3c358631-1c12-4d35-a2f1-0a2ec3f42c94",
+        "secondLineConceptUuid": "3c358631-1c12-4d35-a2f1-0a2ec3f42c94",
+        "cover": "cf87e6c3-cbe9-411f-89b3-6001c15af7d3",
+        "startTime": 1778302800,
+        "endTime": 1778313600
+    },
+    "next": [
+        {
+            "firstLine": "Le 7/10 du week-end",
+            "firstLineUuid": "3c358631-1c12-4d35-a2f1-0a2ec3f42c94",
+            "firstLineConceptUuid": "3c358631-1c12-4d35-a2f1-0a2ec3f42c94",
+            "secondLine": "Le fil info \u00e0 9h20",
+            "secondLineUuid": "87af3c41-c22c-457d-b595-aea22ebeb01f",
+            "secondLineConceptUuid": "87af3c41-c22c-457d-b595-aea22ebeb01f",
+            "cover": "0d63ce04-39b3-4075-97f6-24da0e9414b2",
+            "startTime": 1778311140,
+            "endTime": 1778311200
+        }
+    ],
+    "delayToRefresh": 490000
+}

--- a/data/metadata-discovery/radio-france-inter-now-playing.json
+++ b/data/metadata-discovery/radio-france-inter-now-playing.json
@@ -1,0 +1,66 @@
+{
+    "prev": [
+        {
+            "firstLine": "Le direct",
+            "secondLine": "Le direct",
+            "cover": "31d1838e-da34-4579-878b-0fb1027378b1",
+            "startTime": null,
+            "endTime": null,
+            "contact": null
+        }
+    ],
+    "now": {
+        "firstLine": "Le 6/9",
+        "firstLinePath": "franceinter/podcasts/le-6-9",
+        "firstLineUuid": "c3c143f7-f54c-403a-b206-554091e6c66a",
+        "firstLineConceptUuid": "c3c143f7-f54c-403a-b206-554091e6c66a",
+        "secondLine": "Le journal de 9h - Le journal de 09h00 du samedi 09 mai 2026",
+        "secondLinePath": "franceinter/podcasts/le-journal-de-9h",
+        "secondLinePaths": [
+            "franceinter/podcasts/le-journal-de-9h"
+        ],
+        "secondLineUuid": "4ebdaf30-16bb-11e1-a6ab-842b2b72cd1d",
+        "secondLineUuids": [
+            "4ebdaf30-16bb-11e1-a6ab-842b2b72cd1d",
+            "374d0808-efb6-4d5f-8ff3-9f0266d224cb"
+        ],
+        "secondLineConceptUuid": "4ebdaf30-16bb-11e1-a6ab-842b2b72cd1d",
+        "cover": "369c09d6-3bae-4e2f-ad31-c838a0dfa945",
+        "startTime": 1778299200,
+        "endTime": 1778310804,
+        "contact": [
+            {
+                "type": "mail",
+                "url": "6-9duweekend@radiofrance.com",
+                "title": null
+            }
+        ],
+        "contactPath": "franceinter/podcasts/le-6-9",
+        "contactUuid": "c3c143f7-f54c-403a-b206-554091e6c66a"
+    },
+    "next": [
+        {
+            "firstLine": "Le 6/9",
+            "firstLinePath": "franceinter/podcasts/le-6-9",
+            "firstLineUuid": "c3c143f7-f54c-403a-b206-554091e6c66a",
+            "firstLineConceptUuid": "c3c143f7-f54c-403a-b206-554091e6c66a",
+            "secondLine": "Le 6/9 du samedi 09 mai 2026",
+            "secondLinePath": "franceinter/podcasts/le-6-9/le-6-9-du-samedi-09-mai-2026-1345093",
+            "secondLineUuid": "5ee886ce-c6d6-45a8-95ab-860dda79464a",
+            "secondLineExpressionUuid": "5ee886ce-c6d6-45a8-95ab-860dda79464a",
+            "cover": "369c09d6-3bae-4e2f-ad31-c838a0dfa945",
+            "startTime": 1778299200,
+            "endTime": 1778310804,
+            "contact": [
+                {
+                    "type": "mail",
+                    "url": "6-9duweekend@radiofrance.com",
+                    "title": null
+                }
+            ],
+            "contactPath": "franceinter/podcasts/le-6-9",
+            "contactUuid": "c3c143f7-f54c-403a-b206-554091e6c66a"
+        }
+    ],
+    "delayToRefresh": 230000
+}

--- a/data/metadata-discovery/radio-france-musique-now-playing.json
+++ b/data/metadata-discovery/radio-france-musique-now-playing.json
@@ -1,0 +1,53 @@
+{
+    "prev": [
+        {
+            "firstLine": "France Musique",
+            "secondLine": "Le direct",
+            "cover": "df8d1b79-8823-4421-a694-2b7561430b79",
+            "startTime": null,
+            "endTime": null
+        }
+    ],
+    "now": {
+        "firstLine": "Les Sagas musicales par Producteurs en alternance",
+        "firstLinePath": "francemusique/podcasts/les-sagas-musicales",
+        "firstLinePaths": [
+            "francemusique/podcasts/les-sagas-musicales",
+            "personnes/producteurs-en-alternance"
+        ],
+        "firstLineUuid": "c6201610-91ff-4200-a2d3-cd619c818e42",
+        "firstLineUuids": [
+            "c6201610-91ff-4200-a2d3-cd619c818e42",
+            "2033fdff-c4c8-4500-9f2d-bb3af3269cb3"
+        ],
+        "firstLineConceptUuid": "c6201610-91ff-4200-a2d3-cd619c818e42",
+        "secondLine": "Sous le signe du feu (1867-1894)",
+        "secondLineUuid": "f2ea6c4f-8ecd-4b3f-8e72-1fcf041bea85",
+        "secondLineExpressionUuid": "f2ea6c4f-8ecd-4b3f-8e72-1fcf041bea85",
+        "cover": "6acdd2e8-00a0-4b3e-879c-3230c7de0e53",
+        "startTime": 1778310000,
+        "endTime": 1778315310
+    },
+    "next": [
+        {
+            "firstLine": "Les Sagas musicales par Producteurs en alternance",
+            "firstLinePath": "francemusique/podcasts/les-sagas-musicales",
+            "firstLinePaths": [
+                "francemusique/podcasts/les-sagas-musicales",
+                "personnes/producteurs-en-alternance"
+            ],
+            "firstLineUuid": "c6201610-91ff-4200-a2d3-cd619c818e42",
+            "firstLineUuids": [
+                "c6201610-91ff-4200-a2d3-cd619c818e42",
+                "2033fdff-c4c8-4500-9f2d-bb3af3269cb3"
+            ],
+            "firstLineConceptUuid": "c6201610-91ff-4200-a2d3-cd619c818e42",
+            "secondLine": "Zais - ouverture",
+            "secondLineSongUuid": "f4ec157c-7ee3-4a6d-8cc7-f06e5934da52",
+            "cover": "aa9c385c-2809-477d-847a-1dd8842d592a",
+            "startTime": 1778315305,
+            "endTime": 1778315472
+        }
+    ],
+    "delayToRefresh": 3600000
+}

--- a/docs/broadcaster-research.md
+++ b/docs/broadcaster-research.md
@@ -1062,3 +1062,269 @@ Register as `rai` in `FETCHERS_BY_KEY`. A schedule fetcher could also be built u
 - ToS: RAI is Italy's national public broadcaster. No explicit API ToS; endpoints are
   publicly served without authentication and are called by every raiplaysound.it visitor.
   Reasonable polling cadence is appropriate.
+
+---
+
+## radio-france — Radio France (FR)
+
+Investigated: 2026-05-09.
+
+### Channels in catalog
+
+| Station | Status before | Channel ID | Recommended format |
+|---|---|---|---|
+| France Inter | `fetcher-todo` | `1` | `inter_player` |
+| France Info | `fetcher-todo` | `2` | `info_player` |
+| France Musique | `fetcher-todo` | `4` | `musique_player` |
+| France Culture | `fetcher-todo` | `5` | `culture_player` |
+| Mouv' | `fetcher-todo` | `6` | `mouv_player` |
+| FIP (main) | `fetcher-todo` | `7` | `fip_extended` |
+| FIP Rock | `fetcher-todo` | `64` | `fip_extended` |
+| FIP Jazz | `fetcher-todo` | `65` | `fip_extended` |
+| FIP Groove | `fetcher-todo` | `66` | `fip_extended` |
+| FIP Monde | `fetcher-todo` | `69` | `fip_extended` |
+| FIP Nouveautés | `fetcher-todo` | `70` | `fip_extended` |
+| FIP Reggae | `fetcher-todo` | `71` | `fip_extended` |
+| FIP Electro | `fetcher-todo` | `74` | `fip_extended` |
+| FIP Pop | `fetcher-todo` | `78` | `fip_extended` |
+| FIP Metal | `fetcher-todo` | `77` | `fip_extended` |
+
+Note: IDs 11–50 are France Bleu regional stations (not in rrradio catalog). IDs 75 (`Mouv' 100% Mix`)
+and 77/78 (`FIP Metal`/`FIP Pop`) are bonus sub-channels. `fip_extended` is the richest format for
+music channels; talk stations (`inter_player`, `culture_player`, `info_player`, `mouv_player`) use
+their own format but any format works — the `musique_player` format additionally includes presenter
+credits in `firstLine`.
+
+### Endpoints
+
+| What | URL template | Auth | CORS | Sample |
+|---|---|---|---|---|
+| Now-playing (music — FIP family) | `https://api.radiofrance.fr/livemeta/live/{id}/fip_extended` | none | `*` | `data/metadata-discovery/radio-france-fip-now-playing.json` |
+| Now-playing (programme — France Inter) | `https://api.radiofrance.fr/livemeta/live/{id}/inter_player` | none | `*` | `data/metadata-discovery/radio-france-inter-now-playing.json` |
+| Now-playing (programme — France Musique) | `https://api.radiofrance.fr/livemeta/live/{id}/musique_player` | none | `*` | `data/metadata-discovery/radio-france-musique-now-playing.json` |
+| Now-playing (programme — France Info) | `https://api.radiofrance.fr/livemeta/live/{id}/info_player` | none | `*` | `data/metadata-discovery/radio-france-info-now-playing.json` |
+| Now-playing (programme — FIP sub-channels, compact) | `https://api.radiofrance.fr/livemeta/live/{id}/fip_player` | none | `*` | `data/metadata-discovery/radio-france-fip-rock-now-playing.json` |
+| Cover art image | `https://www.radiofrance.fr/pikapi/images/{uuid}/{size}` | none | none (img-only) | (UUID embedded in now-playing response) |
+| GraphQL API (Open API) | `https://openapi.radiofrance.fr/v1/graphql` | `x-token` required | `*` | ❌ blocked (401 without token) |
+
+**CORS:** `api.radiofrance.fr` returns `access-control-allow-origin: *` — directly callable
+from the browser, no worker proxy needed.
+
+**pikapi images:** No CORS headers on `www.radiofrance.fr/pikapi/images/…`. Safe for `<img>` src
+use, but not for `fetch()`. Use URL directly in `coverUrl` — the rrradio UI renders covers as `<img>`.
+Image sizes available: `200x200`, `400x400`, `132x132`, `300x169`, `2048` (original). Recommended: `400x400`.
+
+**delayToRefresh:** The `fip_extended` response includes a `delayToRefresh` field in milliseconds
+(values observed: 30 000–180 000 ms). This is the broadcaster's own polling cadence hint.
+
+### Channel ID discovery
+
+The channel numeric ID and format string together identify the endpoint. The format string can
+be any valid value from the allowlist — the channel ID is the primary discriminant. Both are
+embedded in the URL: `…/livemeta/live/{id}/{format}`. The wrong format for a station returns
+either `errCode: e400` (Bad Request) or valid data with a different programme context.
+
+Channel IDs were confirmed by matching `firstLinePath` in responses against known station paths
+(e.g. `franceinter/podcasts/…`, `franceinfo/podcasts/…`, `franceculture/podcasts/…`).
+
+### Response shapes
+
+#### `fip_extended` — FIP family (music stations)
+
+```json
+{
+  "prev": [
+    {
+      "title": "Le direct",
+      "interpreters": null,
+      "album": null,
+      "label": null,
+      "cover": null,
+      "musicalKind": null,
+      "startTime": null,
+      "endTime": null
+    }
+  ],
+  "now": {
+    "title": "Emotion",
+    "interpreters": "Destiny's Child & Beyonce",
+    "album": "Survivor",
+    "label": "COLUMBIA",
+    "cover": "58823f41-f06a-44be-aee7-fcf7374116bc",
+    "musicalKind": "Soul / RnB ",
+    "startTime": 1778310418,
+    "endTime": 1778310653
+  },
+  "next": [
+    {
+      "title": "Love t.k.o.",
+      "interpreters": "Teddy Pendergrass",
+      "album": "Greatest hits",
+      "label": "PHILADELPHIA INTERNATIONAL RECORDS",
+      "cover": "27ef8330-8c98-480a-bf7d-9b96f693b815",
+      "musicalKind": "Soul / RnB ",
+      "startTime": 1778310652,
+      "endTime": 1778310871
+    }
+  ],
+  "delayToRefresh": 180000
+}
+```
+
+**Key field mappings (music channels):**
+- Track title → `now.title`
+- Artist → `now.interpreters` (single string, may contain `&` for multi-artist)
+- Album → `now.album`
+- Record label → `now.label`
+- Genre → `now.musicalKind` (e.g. `"Soul / RnB "` — note trailing space; trim before use)
+- Cover UUID → `now.cover`; build URL as `https://www.radiofrance.fr/pikapi/images/{uuid}/400x400`
+- Start/end → `now.startTime` / `now.endTime` — **Unix seconds** (not milliseconds)
+- Next track → `next[0]` (same shape as `now`, available for lookahead)
+- Polling cadence hint → `delayToRefresh` (milliseconds)
+
+When `now.title` is null or `now.interpreters` is null but `now.title` is not null, the station
+is in a programme segment (jingle, live set, programme). When `now.cover` is null, skip cover art.
+
+#### `inter_player` / `culture_player` / `info_player` / `mouv_player` — talk/news stations
+
+```json
+{
+  "prev": [{ "firstLine": "Le direct", "secondLine": "Le direct", "cover": "...", "startTime": null, "endTime": null, "contact": null }],
+  "now": {
+    "firstLine": "Le 6/9",
+    "firstLinePath": "franceinter/podcasts/le-6-9",
+    "firstLineUuid": "c3c143f7-f54c-403a-b206-554091e6c66a",
+    "firstLineConceptUuid": "c3c143f7-f54c-403a-b206-554091e6c66a",
+    "secondLine": "Le journal de 9h - Le journal de 09h00 du samedi 09 mai 2026",
+    "secondLinePath": "franceinter/podcasts/le-journal-de-9h",
+    "secondLineUuid": "4ebdaf30-16bb-11e1-a6ab-842b2b72cd1d",
+    "cover": "369c09d6-3bae-4e2f-ad31-c838a0dfa945",
+    "startTime": 1778299200,
+    "endTime": 1778310804,
+    "contact": [{ "type": "mail", "url": "6-9duweekend@radiofrance.com", "title": null }]
+  },
+  "next": [{ ... same shape ... }],
+  "delayToRefresh": 230000
+}
+```
+
+**Key field mappings (talk/programme stations):**
+- Programme name → `now.firstLine` (show title)
+- Programme subtitle → `now.secondLine` (episode title or bulletin name)
+- Programme cover → `now.cover` UUID → `https://www.radiofrance.fr/pikapi/images/{uuid}/400x400`
+- Programme start/end → `now.startTime` / `now.endTime` — **Unix seconds**
+- Contact → `now.contact[0].url` (editorial email; not useful for UI)
+
+The `musique_player` format adds presenter credit to `firstLine` as `"Programme par Présentateur"`.
+
+#### `fip_player` — compact format for FIP sub-channels
+
+```json
+{
+  "now": {
+    "firstLine": "FIP Rock",
+    "secondLine": "Te Quiero Igual",
+    "secondLineSongUuid": "0cfe2bae-8233-42d4-99c6-7813fbd44f63",
+    "thirdLine": "Novedades Carminha",
+    "thirdLineSongUuid": "0cfe2bae-8233-42d4-99c6-7813fbd44f63",
+    "cover": "26190730-8121-43a7-ab82-0189c8740b06",
+    "startTime": 1778310356,
+    "endTime": 1778310535
+  }
+}
+```
+
+Fields: `secondLine` = track title, `thirdLine` = artist, `cover` = UUID. Less rich than
+`fip_extended` (no album, label, genre). **Use `fip_extended` for all FIP channels instead.**
+
+### Track history
+
+The livemeta API always returns exactly three items: `prev[0]` (most recently completed track),
+`now` (current track), `next[0]` (upcoming track). `prev[0]` on first load is typically
+`{"title": "Le direct", …}` (a placeholder), not a real previous track. There is **no multi-track
+history endpoint** discoverable from the browser-side API. The FIP "Titres diffusés" page
+renders client-side from the same livemeta API; it only shows current/next, not a scrollable
+history. The GraphQL API (`openapi.radiofrance.fr/v1/graphql`) would support richer queries
+but requires an `x-token` API key — not publicly accessible.
+
+### Wirable today?
+
+| Channel family | Track | Programme | Cover art | Verdict |
+|---|---|---|---|---|
+| FIP main + all sub-channels | ✅ wire-now — `fip_extended` gives title + artist + album + label + genre | ✅ via `fip_player` firstLine | ✅ pikapi UUID → `<img>` src | **Wire-now — richest of all European public broadcasters** |
+| France Inter | ❌ no track API (talk radio) | ✅ wire-now — `inter_player` gives show + episode | ✅ pikapi cover | Wire programme-only |
+| France Culture | ❌ no track API (talk radio) | ✅ wire-now — `culture_player` | ✅ pikapi cover | Wire programme-only |
+| France Musique | ⚠️ partial — classical pieces do appear in `fip_extended` when using ID 4, but `musique_player` is programme-level | ✅ wire-now — `musique_player` | ✅ pikapi cover | Wire programme-only; revisit track wiring |
+| France Info | ❌ no track API (24/7 news) | ✅ wire-now — `info_player` | ✅ pikapi cover | Wire programme-only |
+| Mouv' | ⚠️ has music but `mouv_player` returns programme-level; `fip_extended` returns `null` for ID 6 | ✅ wire-now — `mouv_player` | ✅ pikapi cover | Wire programme-only; FIP-style track wiring possible if format confirmed |
+
+**No proxy needed for any channel.** All `api.radiofrance.fr` endpoints have `CORS: *`.
+
+### Suggested fetcher
+
+New `fetchRadioFranceMetadata` in `src/builtins.ts`. The broadcaster has two distinct response
+shapes gated by which format string is used:
+
+**Shape A — music (FIP family):** `fip_extended` format, fields `now.title` / `now.interpreters` /
+`now.album` / `now.cover`. Closest analogues: `fetchCroMetadata` (structured JSON, now/next shape)
+and `fetchSwrMetadata` (track + programme + cover in one response).
+
+**Shape B — programme (France Inter/Culture/Info/Mouv'):** `*_player` format, fields
+`now.firstLine` / `now.secondLine` / `now.cover`. Closest analogues: `fetchSrMetadata` and
+`fetchRadioBremenMetadata` (programme-only, no tracks).
+
+Recommended implementation:
+1. `station.metadataUrl` = `https://api.radiofrance.fr/livemeta/live/{id}/{format}` — the full
+   endpoint URL including the numeric ID and format string. This keeps the fetcher generic and lets
+   each station declare its own format.
+2. Fetch with `cache: 'no-store'`; no proxy.
+3. Branch on response shape: if `now.title` is defined → Shape A (music); else → Shape B (programme).
+4. Shape A: return `{ artist: now.interpreters, track: now.title, album: now.album, coverUrl }`.
+5. Shape B: return `{ track: undefined, raw: '', program: { name: now.firstLine, subtitle: now.secondLine } }`.
+6. Cover URL: `https://www.radiofrance.fr/pikapi/images/${now.cover}/400x400` (when `now.cover` is a UUID string).
+7. `delayToRefresh` (ms) can inform the polling interval — use `Math.max(delayToRefresh, 15_000)`.
+
+`station.metadataUrl` examples:
+```
+FIP main:       https://api.radiofrance.fr/livemeta/live/7/fip_extended
+FIP Rock:       https://api.radiofrance.fr/livemeta/live/64/fip_extended
+France Inter:   https://api.radiofrance.fr/livemeta/live/1/inter_player
+France Culture: https://api.radiofrance.fr/livemeta/live/5/culture_player
+France Musique: https://api.radiofrance.fr/livemeta/live/4/musique_player
+France Info:    https://api.radiofrance.fr/livemeta/live/2/info_player
+Mouv':          https://api.radiofrance.fr/livemeta/live/6/mouv_player
+```
+
+Register as `radio-france` in `FETCHERS_BY_KEY`. A schedule fetcher is not needed since `next[0]`
+(the upcoming track/programme) is already embedded in the livemeta response.
+
+### Notes
+
+- `now.startTime` / `now.endTime` are **Unix seconds** (not milliseconds). Multiply by 1000 for
+  `Date.now()` comparisons.
+- `delayToRefresh` is the broadcaster's explicit polling cadence hint in **milliseconds**. Observed
+  values: 30 000 ms (FIP live, active track), 90 000–180 000 ms (FIP between tracks), 3 600 000 ms
+  (France Musique, long programme). Use `Math.min(delayToRefresh, 30_000)` for music channels to
+  stay responsive; for talk channels 60–90 s is fine.
+- `now.interpreters` is a free-form string (may contain `&` or `,` for multi-artist). No separate
+  array structure — treat as a single display string. It can be `null` during programme/jingle segments.
+- `now.cover` is a UUID string (or `null`). The `pikapi` service at
+  `https://www.radiofrance.fr/pikapi/images/{uuid}/{size}` serves it as WebP. No CORS on the image
+  CDN — use only in `<img>` src, not in `fetch()`. Sizes: `200x200`, `400x400` confirmed working.
+- The `fip_rds` format returns all-caps combined string `"TRACK - ARTIST (YEAR) - FIP"` in
+  `now.firstLine`, plus raw `songId` and `stepId` UUIDs — designed for RDS display hardware, not
+  useful for rrradio.
+- The `openapi.radiofrance.fr/v1/graphql` endpoint would provide richer data (multi-track song
+  history, podcast metadata, programme schedule depth). It requires an `x-token` API key obtained
+  via `https://openapi.radiofrance.fr` developer registration. Not blocked — Radio France invites
+  API consumers — but needs a registered token. The free livemeta API is sufficient for rrradio's
+  needs.
+- No rate-limit headers observed. France Bleu regional stations (IDs 11–50) also work with the
+  same livemeta endpoint — those stations are not in the rrradio catalog but the fetcher supports
+  them for free.
+- ToS: Radio France is France's national public broadcaster. The livemeta API is served publicly,
+  called by every radiofrance.fr visitor. No explicit API ToS for the livemeta endpoint. The
+  `openapi.radiofrance.fr` developer API has a formal ToS via the portal. The livemeta endpoint
+  is not the portal API.
+
+---


### PR DESCRIPTION
## Summary

- `api.radiofrance.fr/livemeta/live/{id}/{format}` serves all 15+ Radio France channels with `CORS: *`, no auth required, no proxy needed
- `fip_extended` format is the richest music metadata found among European public broadcasters: title, artist, album, label, genre, cover art UUID, and next track in one response
- Full FIP sub-channel mapping confirmed: IDs 64 (Rock), 65 (Jazz), 66 (Groove), 69 (Monde), 70 (Nouveautés), 71 (Reggae), 74 (Electro), 77 (Metal), 78 (Pop)
- Talk stations (France Inter ID=1, France Info ID=2, France Culture ID=5, Mouv' ID=6) wire programme-level only via their channel-specific format strings
- Cover art via pikapi CDN (`https://www.radiofrance.fr/pikapi/images/{uuid}/400x400`) — use as `<img>` src only (no CORS headers on the image CDN)
- `delayToRefresh` field in responses gives broadcaster-recommended poll cadence (ms)

## Findings (from `docs/broadcaster-research.md`)

See the appended `## radio-france` section.

**Channel ID mapping:**

| Station | ID | Format | Track? |
|---|---|---|---|
| FIP (main) | 7 | `fip_extended` | ✅ title + artist + album + label + genre + cover |
| FIP Rock | 64 | `fip_extended` | ✅ |
| FIP Jazz | 65 | `fip_extended` | ✅ |
| FIP Groove | 66 | `fip_extended` | ✅ |
| FIP Monde | 69 | `fip_extended` | ✅ |
| FIP Nouveautés | 70 | `fip_extended` | ✅ |
| FIP Reggae | 71 | `fip_extended` | ✅ |
| FIP Electro | 74 | `fip_extended` | ✅ |
| FIP Pop | 78 | `fip_extended` | ✅ |
| FIP Metal | 77 | `fip_extended` | ✅ |
| France Inter | 1 | `inter_player` | ❌ (programme only) |
| France Info | 2 | `info_player` | ❌ (programme only) |
| France Musique | 4 | `musique_player` | ⚠️ (programme-level; classical pieces via fip_extended possible) |
| France Culture | 5 | `culture_player` | ❌ (programme only) |
| Mouv' | 6 | `mouv_player` | ❌ (programme only) |

## Wirable status

- FIP family (10 channels): ✅ **wire-now** — HTTPS, CORS=\*, no auth, richest track data in catalog
- Talk stations (Inter, Culture, Info, Mouv'): ✅ **wire-now** for programme info + cover art
- No proxy entry needed in `worker/src/index.ts`

## Suggested next broadcaster

After merging this: **npo** (Dutch public broadcaster) is also `fetcher-todo` and ready to wire.

Closes part of #193.

🤖 Generated with [Claude Code](https://claude.com/claude-code)