### PR TITLE
fix(ios): replace Form with ScrollView in AddStationContentView

### DIFF
--- a/ios/rrradio/Views/AddStationView.swift
+++ b/ios/rrradio/Views/AddStationView.swift
@@ -34,82 +34,83 @@ struct AddStationContentView: View {
     @State private var errorMessage: String?
     @State private var stationPendingDeletion: Station?
 
+    // Lives inside the Settings page-style TabView (SettingsView.swift:16).
+    // SwiftUI `Form` (UICollectionView-backed) crashed during the page
+    // transition's layout pass when swiping About → Add Station — see
+    // issue #212. ScrollView + VStack matches the pattern AboutContentView
+    // and SettingsPageView use in the same TabView.
     var body: some View {
-        Form {
-            Section {
-                TextField("Name", text: $name)
-                    .textInputAutocapitalization(.words)
-                TextField("Stream URL", text: $streamURL)
-                    .keyboardType(.URL)
-                    .textInputAutocapitalization(.never)
-                    .autocorrectionDisabled()
-            }
-
-            Section {
-                Button(duplicateStations.isEmpty ? locale.text(.saveAndPlay) : locale.text(.saveAnyway)) {
-                    saveAndPlay()
+        ScrollView {
+            VStack(alignment: .leading, spacing: 22) {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(locale.text(.addStation))
+                        .font(.system(size: 30, weight: .medium))
+                        .foregroundStyle(RrradioTheme.ink)
                 }
-                    .font(.system(size: 12, weight: .semibold, design: .monospaced))
-                    .textCase(.uppercase)
-                    .tracking(1.1)
-                    .foregroundStyle(RrradioTheme.bg)
-                    .frame(maxWidth: .infinity, minHeight: 38)
-                    .background(RrradioTheme.buttonFill)
-                    .clipShape(RoundedRectangle(cornerRadius: 6))
-                    .listRowBackground(Color.clear)
-            }
 
-            if !duplicateStations.isEmpty {
-                Section("Already in rrradio") {
-                    ForEach(duplicateStations.prefix(4)) { station in
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text(station.name)
-                                .font(.body)
-                                .foregroundStyle(RrradioTheme.ink)
-                            Text(station.streamUrl.absoluteString)
-                                .font(.caption.monospaced())
-                                .foregroundStyle(RrradioTheme.ink3)
-                                .lineLimit(1)
-                                .truncationMode(.middle)
-                        }
+                addStationSection("Station") {
+                    VStack(spacing: 10) {
+                        TextField("Name", text: $name)
+                            .textInputAutocapitalization(.words)
+                            .rrradioFieldStyle()
+                        TextField("Stream URL", text: $streamURL)
+                            .keyboardType(.URL)
+                            .textInputAutocapitalization(.never)
+                            .autocorrectionDisabled()
+                            .rrradioFieldStyle()
                     }
                 }
-            }
 
-            if let errorMessage {
-                Section {
+                Button(action: saveAndPlay) {
+                    Text(duplicateStations.isEmpty ? locale.text(.saveAndPlay) : locale.text(.saveAnyway))
+                        .font(.system(size: 12, weight: .semibold, design: .monospaced))
+                        .textCase(.uppercase)
+                        .tracking(1.1)
+                        .foregroundStyle(RrradioTheme.bg)
+                        .frame(maxWidth: .infinity, minHeight: 44)
+                        .background(RrradioTheme.buttonFill)
+                        .clipShape(RoundedRectangle(cornerRadius: 6))
+                }
+                .buttonStyle(.plain)
+
+                if !duplicateStations.isEmpty {
+                    addStationSection("Already in rrradio") {
+                        VStack(spacing: 0) {
+                            ForEach(duplicateStations.prefix(4)) { station in
+                                duplicateRow(station)
+                            }
+                        }
+                        .background(RrradioTheme.bg2)
+                        .overlay(RoundedRectangle(cornerRadius: 8).stroke(RrradioTheme.line))
+                        .clipShape(RoundedRectangle(cornerRadius: 8))
+                    }
+                }
+
+                if let errorMessage {
                     Text(errorMessage)
+                        .font(.system(size: 13))
                         .foregroundStyle(.red)
                 }
-            }
 
-            if !library.customStations.isEmpty {
-                Section("Added stations") {
-                    ForEach(library.customStations) { station in
-                        HStack(spacing: 12) {
-                            VStack(alignment: .leading, spacing: 4) {
-                                Text(station.name)
-                                    .foregroundStyle(RrradioTheme.ink)
-                                Text(station.streamUrl.host() ?? station.streamUrl.absoluteString)
-                                    .font(.caption.monospaced())
-                                    .foregroundStyle(RrradioTheme.ink3)
-                                    .lineLimit(1)
+                if !library.customStations.isEmpty {
+                    addStationSection("Added stations") {
+                        VStack(spacing: 0) {
+                            ForEach(library.customStations) { station in
+                                customStationRow(station)
                             }
-                            Spacer()
-                            Button(role: .destructive) {
-                                stationPendingDeletion = station
-                            } label: {
-                                Image(systemName: "trash")
-                            }
-                            .buttonStyle(.borderless)
-                            .accessibilityLabel("Delete \(station.name)")
                         }
+                        .background(RrradioTheme.bg2)
+                        .overlay(RoundedRectangle(cornerRadius: 8).stroke(RrradioTheme.line))
+                        .clipShape(RoundedRectangle(cornerRadius: 8))
                     }
                 }
             }
+            .font(.system(size: 14))
+            .foregroundStyle(RrradioTheme.ink2)
+            .padding(.horizontal, 24)
+            .padding(.top, 20)
+            .padding(.bottom, 32)
         }
-        .scrollContentBackground(.hidden)
-        .background(RrradioTheme.bg)
         .confirmationDialog(
             "Delete added station?",
             isPresented: Binding(
@@ -135,6 +136,74 @@ struct AddStationContentView: View {
             if let station = stationPendingDeletion {
                 Text("Remove \(station.name) from added stations and favorites?")
             }
+        }
+    }
+
+    private func duplicateRow(_ station: Station) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(station.name)
+                .font(.system(size: 14, weight: .medium))
+                .foregroundStyle(RrradioTheme.ink)
+            Text(station.streamUrl.absoluteString)
+                .font(.system(size: 11, design: .monospaced))
+                .foregroundStyle(RrradioTheme.ink3)
+                .lineLimit(1)
+                .truncationMode(.middle)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(RrradioTheme.line)
+                .frame(height: 1)
+        }
+    }
+
+    private func customStationRow(_ station: Station) -> some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(station.name)
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(RrradioTheme.ink)
+                    .lineLimit(1)
+                Text(station.streamUrl.host() ?? station.streamUrl.absoluteString)
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundStyle(RrradioTheme.ink3)
+                    .lineLimit(1)
+            }
+            Spacer()
+            Button {
+                stationPendingDeletion = station
+            } label: {
+                Image(systemName: "trash")
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(.red)
+                    .frame(width: 36, height: 36)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Delete \(station.name)")
+        }
+        .padding(.horizontal, 14)
+        .frame(minHeight: 52)
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(RrradioTheme.line)
+                .frame(height: 1)
+        }
+    }
+
+    private func addStationSection<Content: View>(
+        _ title: String,
+        @ViewBuilder content: () -> Content,
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(title)
+                .font(.system(size: 12, weight: .medium, design: .monospaced))
+                .textCase(.uppercase)
+                .tracking(1.4)
+                .foregroundStyle(RrradioTheme.ink3)
+            content()
         }
     }
 
@@ -183,6 +252,19 @@ struct AddStationContentView: View {
             return nil
         }
         return url
+    }
+}
+
+extension View {
+    fileprivate func rrradioFieldStyle() -> some View {
+        self
+            .font(.system(size: 14))
+            .foregroundStyle(RrradioTheme.ink)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .background(RrradioTheme.bg)
+            .overlay(RoundedRectangle(cornerRadius: 8).stroke(RrradioTheme.line))
+            .clipShape(RoundedRectangle(cornerRadius: 8))
     }
 }
 


### PR DESCRIPTION
## Summary

`AddStationContentView` lives inside `SettingsView`'s page-style `TabView` alongside three sibling pages all built with `ScrollView` + `VStack`. The odd one out — the `Form` — is `UICollectionView`-backed and crashed during the page transition's layout pass when swiping About → Add Station (the page TabView pre-renders adjacent pages, and `Form`'s layout invalidation conflicts with the page transition's own layout pass).

Port to `ScrollView` + `VStack` matching the existing pattern. **All behavior preserved**:

- Name + Stream URL fields with the same keyboard / autocap / autocorrect rules.
- Save button text toggles `saveAndPlay` ↔ `saveAnyway` based on `duplicateStations`.
- "Already in rrradio" section (top 4 duplicates) renders when the entered URL matches existing stations.
- Error message display.
- "Added stations" list with the delete-confirmation dialog (`stationPendingDeletion`).
- `matchingCatalogStations` + `library.addCustom(station, favorite:)` save flow unchanged.

Visual style follows `AboutContentView` and `SettingsPageView` — `addStationSection` helper for section headers, `rrradioFieldStyle()` extension for the input fields, manual styled rows for the lists.

## Test plan

- [ ] Open Settings → swipe from About to Add Station → does not crash (the original report).
- [ ] Type a name + a stream URL that matches an existing catalog station → "Already in rrradio" appears, save button text changes to "Save anyway".
- [ ] Tap Save → station is added, plays, and the sheet behavior is correct.
- [ ] Tap the trash icon on a custom station → confirmation dialog appears, Delete removes it, Cancel keeps it.
- [ ] Test with the keyboard up — fields scroll correctly when focused.
- [ ] Re-test the swipe in both directions a few times.

Closes #212.

🤖 Generated with [Claude Code](https://claude.com/claude-code)