### PR TITLE
test(ios): UAT scripts + cycle issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/uat-cycle.yml
+++ b/.github/ISSUE_TEMPLATE/uat-cycle.yml
@@ -1,0 +1,102 @@
+name: UAT cycle
+description: Open one issue per UAT cycle. One tester, one build, dated.
+title: "UAT cycle: <build-label> (<YYYY-MM-DD>)"
+labels: [test, uat-cycle]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Per [HQ testing convention](https://github.com/MarkusSteinbrecher/HQ/blob/main/wiki/conventions/testing.md). One issue per cycle. Failures spawn child bug issues — link back here. Close this issue when all flows are accounted for (passed, failed-and-handed-off, or skipped-with-reason).
+
+  - type: input
+    id: build
+    attributes:
+      label: Build under test
+      description: "Commit SHA, release tag, or TestFlight build number."
+      placeholder: "abc1234 / v0.5.0 / TF build 12"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Surface
+      description: "Which surface of rrradio is being tested."
+      options:
+        - web (PWA)
+        - iOS app
+        - Android app
+        - Worker proxy
+    validations:
+      required: true
+
+  - type: dropdown
+    id: environment
+    attributes:
+      label: Environment
+      options:
+        - simulator
+        - real-device
+        - local (npm run dev)
+        - prod (rrradio.org)
+        - TestFlight
+        - prod-canary
+    validations:
+      required: true
+
+  - type: input
+    id: device
+    attributes:
+      label: Device / browser
+      description: "iPhone Air iOS 18.3 / iPhone 15 Pro iOS 17.5 / Safari 17 macOS 14 / Chrome 121 etc."
+      placeholder: "iPhone 15 Pro, iOS 17.5"
+    validations:
+      required: false
+
+  - type: input
+    id: tester
+    attributes:
+      label: Tester
+      description: "GitHub @-handle, or 'self'."
+      placeholder: "@MarkusSteinbrecher"
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope (flows in this cycle)
+      description: "Check off each flow as it passes. For failures, change the label to '— failed, see #<bug>' and open a child bug issue."
+      value: |
+        - [ ] tests/manual/ios/first-run.md
+        - [ ] tests/manual/ios/browse-and-play.md
+        - [ ] tests/manual/ios/search-and-filter.md
+        - [ ] tests/manual/ios/favorites-and-recents.md
+        - [ ] tests/manual/ios/custom-station.md
+        - [ ] tests/manual/ios/background-and-lock-screen.md
+        - [ ] tests/manual/ios/audio-interruption.md
+        - [ ] tests/manual/ios/network-recovery.md
+        - [ ] tests/manual/ios/sleep-timer.md
+        - [ ] tests/manual/ios/icloud-sync.md
+    validations:
+      required: true
+
+  - type: textarea
+    id: known
+    attributes:
+      label: Known issues / things to ignore
+      description: "Anything in this build the tester should know about going in (broken catalog entries, in-progress features, etc.)."
+      value: "_None._"
+
+  - type: textarea
+    id: result
+    attributes:
+      label: Result (filled at close)
+      description: "Per-flow outcomes. Link any child bug issues opened from this cycle."
+      value: |
+        _To be filled at cycle close._
+
+        - **Passed:** ...
+        - **Failed:** ... — see #<bug>
+        - **Skipped:** ... — reason: ...
+        - **Bundle/build delta vs previous cycle:** ...

--- a/tests/manual/README.md
+++ b/tests/manual/README.md
@@ -1,0 +1,28 @@
+# Manual UAT scripts — rrradio
+
+> Per [HQ testing convention](https://github.com/MarkusSteinbrecher/HQ/blob/main/wiki/conventions/testing.md). Markdown scripts a non-engineer (or the sponsor) can follow without reading code. Self-contained: open the file, follow the steps, tick the boxes.
+
+## How to run a UAT cycle
+
+1. **Open a cycle issue** in this repo using the `UAT cycle` issue template (`.github/ISSUE_TEMPLATE/uat-cycle.yml`). Fill in build, environment, tester. The template seeds the per-flow checklist.
+2. **Walk each script** in `tests/manual/<surface>/` listed in the cycle's scope. Tick the cycle's checkbox when a flow passes.
+3. **On failure:** open a child bug issue with `Found in #<cycle>` in the body, and `Per tests/manual/<flow>.md` referencing the script. Update the cycle issue's checklist row to `tests/manual/<flow>.md — failed, see #<bug>`.
+4. **Close the cycle issue** when every flow is accounted for (passed, failed-and-handed-off, or skipped-with-reason). The closing comment fills the **Result** block.
+
+## Surfaces
+
+- **`ios/`** — iOS native app (SwiftUI + AVFoundation). See [`ios/README.md`](ios/README.md).
+- **`web/`** — Web PWA. *(Not yet populated; web has automated coverage in `tests/e2e/` for now.)*
+
+## Discipline
+
+- **Update scripts when you touch the feature.** Same PR. If you don't have time to update the script, you don't have time to ship the change.
+- **Empty `[?]` slots in scripts are honest signals**, not blockers. Filling them precisely is the discipline.
+- **Stale scripts get pruned** during the wiki/portfolio audit (HQ improvement-loop). If a flow no longer exists, delete its script — confused testers cause more rework than missing scripts.
+
+## Related
+
+- [HQ testing convention](https://github.com/MarkusSteinbrecher/HQ/blob/main/wiki/conventions/testing.md) — authority for this folder.
+- [`tests/e2e/`](../e2e/) — automated counterparts (Playwright + Vitest).
+- [`docs/testing.md`](../../docs/testing.md) — how rrradio's four test stacks fit together.
+- Issue template: [`.github/ISSUE_TEMPLATE/uat-cycle.yml`](../../.github/ISSUE_TEMPLATE/uat-cycle.yml).

--- a/tests/manual/ios/README.md
+++ b/tests/manual/ios/README.md
@@ -1,0 +1,42 @@
+# iOS UAT scripts — rrradio
+
+> Manual user-acceptance tests for the rrradio iOS native app (SwiftUI + AVFoundation). One script per critical user flow. See [`../README.md`](../README.md) for cycle workflow.
+
+## Test environments
+
+Each flow declares its required environment in **Preconditions**. The major axis:
+
+- **Simulator** — fine for layout, navigation, search, library persistence (within a session). **Not adequate for:** lock-screen controls, AirPods, real audio interruptions, real network drops, iCloud sync between devices.
+- **Real device** — required for everything in the "Not adequate for" list above. iPhone running iOS 17+.
+- **TestFlight** — same as real device but the build is signed for distribution (catches App Store sandboxing differences).
+
+When in doubt, prefer real-device. Lock-screen audio is the most common spot for divergence between simulator and shipping behaviour.
+
+## Setup expectations
+
+- Xcode 15.4+ (iOS 17 SDK).
+- TestFlight build installed, **or** local build via `xcodegen && xcodebuild` (see [`../../../ios/README.md`](../../../ios/README.md) §Building).
+- Wi-Fi available; cellular if testing network-recovery flows.
+- For iCloud sync: two iOS devices signed into the **same Apple ID**, both with iCloud Drive on, both running the same build of rrradio.
+
+## Flow index
+
+Sorted roughly by how essential to a release ("happy path → edge case"):
+
+1. [`first-run.md`](first-run.md) — fresh install, catalog fetch, empty library.
+2. [`browse-and-play.md`](browse-and-play.md) — find a station, start playback, mini-player + now-playing.
+3. [`search-and-filter.md`](search-and-filter.md) — search ("WDR5" → "WDR 5" normalization), country, tag.
+4. [`favorites-and-recents.md`](favorites-and-recents.md) — favorite, reorder, recents dedupe.
+5. [`custom-station.md`](custom-station.md) — add HTTPS stream, validation errors, persistence.
+6. [`background-and-lock-screen.md`](background-and-lock-screen.md) — lock screen card, AirPods controls, Control Center.
+7. [`audio-interruption.md`](audio-interruption.md) — phone call, alarm, other-app audio, recovery.
+8. [`network-recovery.md`](network-recovery.md) — Wi-Fi drop, airplane mode, return.
+9. [`sleep-timer.md`](sleep-timer.md) — set / fire / cancel across all durations.
+10. [`icloud-sync.md`](icloud-sync.md) — two-device sync of favorites + custom stations.
+
+## Notes for the tester
+
+- **Audio in the simulator** routes through your Mac's audio output; ICY metadata still works, but the Bluetooth / AirPlay paths do not. Real device for those.
+- **Lock-screen card** doesn't appear on the simulator's "fake lock". Use a real device.
+- **iCloud sync** can take 30–120 seconds in either direction. If a change doesn't appear, wait a minute before declaring failure.
+- **Per-broadcaster metadata fetchers** (ORF, BBC, AzuraCast, Laut.FM, etc.) are tested implicitly via [`browse-and-play.md`](browse-and-play.md) by selecting a station that uses each. The script lists representative stations — pick one of each broadcaster family in a thorough cycle.

--- a/tests/manual/ios/audio-interruption.md
+++ b/tests/manual/ios/audio-interruption.md
@@ -1,0 +1,56 @@
+# Audio interruption — phone calls, alarms, other apps
+
+> Verify that an interruption (phone call, alarm, another audio app starting) pauses rrradio cleanly and that playback recovers (or stays paused) per AVAudioSession behaviour. **Real device required.** ~8 minutes; you'll need a second phone or a known-callable contact.
+
+## Preconditions
+
+- [ ] Build under test: __________
+- [ ] Test environment: **real device**
+- [ ] A second phone or a contact who will pick up a test call (or use Apple's automated voicemail — call your own number from the same device's voicemail menu)
+- [ ] An alarm set for ~3 minutes from test start (use the Clock app)
+- [ ] Another audio app installed (Apple Music, Spotify, YouTube — any will do)
+
+## Steps
+
+### Phone call interruption
+
+1. Start playing a station — expected: audio audible.
+2. Have someone call you (or initiate a call from a second device) — expected: rrradio audio **pauses immediately** when the call rings; ringtone plays; lock-screen / Now-Playing card shows paused state.
+3. Answer the call, talk for 5 seconds, hang up — expected: rrradio either **resumes automatically** (default AVAudioSession behaviour) **or stays paused** (project may opt out of auto-resume — note current behaviour). Either is correct; document which.
+4. If it stayed paused, manually press Play — expected: audio resumes within 2 seconds.
+
+### Alarm interruption
+
+5. Start playback again — expected: audible.
+6. Wait for the pre-set alarm to fire — expected: rrradio audio ducks or pauses; alarm sound plays.
+7. Dismiss the alarm — expected: rrradio audio recovers per the same auto-resume behaviour as the phone-call case (consistent with step 3).
+
+### Other audio app interruption
+
+8. Start rrradio playback — expected: audible.
+9. Open another audio app (Apple Music, Spotify) and play a track — expected: rrradio **pauses**; the other app plays.
+10. Pause the other app and return to rrradio — expected: rrradio either auto-resumes or stays paused (consistent with steps 3 / 7); manual Play resumes within 2 seconds.
+
+### Siri interruption (if Siri is configured)
+
+11. Start playback; trigger Siri ("Hey Siri" or side-button hold) — expected: rrradio ducks or pauses while Siri listens; resumes (or stays paused) per consistency.
+
+### Recovery after a long interruption
+
+12. Start playback; place a long phone call (3+ minutes); end the call — expected: stream re-establishes within 5 seconds without manual intervention (assuming auto-resume); no infinite buffering spinner.
+
+## Acceptance
+
+- [ ] Phone call pauses rrradio cleanly and consistently
+- [ ] Alarm pauses or ducks rrradio
+- [ ] Another audio app pausing rrradio is the expected interaction
+- [ ] Recovery is **consistent** across all interruption sources (auto-resume always, or paused always — not mixed)
+- [ ] No infinite buffering spinner after recovery
+- [ ] Lock-screen card reflects state through every transition
+
+## Notes for the tester
+
+- Auto-resume vs stay-paused is an AVAudioSession policy choice. Either is OK; the bug is *inconsistency* across sources.
+- If rrradio fails to pause on a phone call, the audio session is probably not configured as `.playback` with the right mode — that's a wiring bug.
+- "Ducking" (rrradio plays quieter under another sound) vs "pausing" (rrradio stops entirely) is also a policy choice. Document which behaviour ships.
+- Long-call recovery (>1 minute) sometimes fails because the underlying TCP connection drops. The fix is reconnect-on-resume; if it spins forever, that's a high-severity bug.

--- a/tests/manual/ios/background-and-lock-screen.md
+++ b/tests/manual/ios/background-and-lock-screen.md
@@ -1,0 +1,43 @@
+# Background audio and lock-screen controls
+
+> Verify audio continues in the background, lock-screen card appears with metadata, and remote controls (lock-screen, Control Center, AirPods) work. **Real device required** — the simulator does not render the lock-screen card. ~8 minutes.
+
+## Preconditions
+
+- [ ] Build under test: __________
+- [ ] Test environment: **real device** (iPhone running iOS 17+)
+- [ ] AirPods or other Bluetooth headphones if you want to test pair-controls (optional but recommended)
+- [ ] App has Background Modes → Audio capability enabled (verify in Xcode → Signing & Capabilities, or Info.plist `UIBackgroundModes: [audio]`)
+- [ ] You're holding the phone unlocked, ready to lock it on cue
+
+## Steps
+
+1. Start playing a station with metadata support (e.g. **BBC Radio 1**, **FM4**, or **Radio Swiss Pop**) — expected: audio audible; metadata appears within ~30 seconds.
+2. Press the side button to **lock the device** — expected: audio continues uninterrupted.
+3. Wake the screen (lift to wake or tap) — expected: a **now-playing card** is visible on the lock screen showing station name, current track (if available), play/pause, and (optionally) artwork.
+4. Tap **Pause** on the lock-screen card — expected: audio stops within 1 second; card updates to show play icon.
+5. Tap **Play** again — expected: audio resumes within ~2 seconds.
+6. Open **Control Center** (swipe down from top-right on iOS 17+) — expected: media-control widget shows rrradio with the same metadata; play/pause works.
+7. Unlock the phone, swipe up or press Home — expected: rrradio's mini-player still visible; audio still playing.
+8. Open another app (e.g. Notes, Safari) — expected: rrradio audio continues; lock-screen card still works.
+9. **AirPods test** (if available): tap the AirPod stem (or use the press control configured for play/pause) — expected: audio pauses; tap again — resumes.
+10. **AirPods skip-track test** (if your AirPods support it): try forward/back — expected: rrradio either ignores skip (no track concept for live radio) **or** uses skip as next/previous favorite (note current behaviour, neither is wrong).
+11. While playing, swipe up or hit Home to background the app — expected: audio continues; the lock-screen card remains responsive.
+12. Force-quit the app from the app switcher while audio is playing — expected: audio stops; lock-screen card is dismissed.
+
+## Acceptance
+
+- [ ] Audio continues uninterrupted across screen lock
+- [ ] Lock-screen now-playing card appears with the correct station
+- [ ] Lock-screen play/pause controls audio
+- [ ] Control Center widget mirrors the lock-screen card and controls correctly
+- [ ] Audio continues when other apps are foregrounded
+- [ ] AirPods stem-press play/pause works (if AirPods available)
+- [ ] Force-quit cleanly stops audio and dismisses the card
+
+## Notes for the tester
+
+- The lock-screen card is wired via `MPNowPlayingInfoCenter` + `MPRemoteCommandCenter` in `ios/rrradio/Player/AudioPlayer.swift`. If it never appears, that's a wiring bug — file with `severity:high`.
+- Track artwork on the lock-screen card is **not yet implemented** for live radio — only station name + current track (if metadata supplies it). Missing artwork is expected, not a bug.
+- AirPods next/prev behaviour for live radio is project-decided. Neither "ignore" nor "skip favorite" is wrong; document whichever ships.
+- If audio cuts on lock, check Info.plist `UIBackgroundModes: [audio]`. This is the most common cause.

--- a/tests/manual/ios/browse-and-play.md
+++ b/tests/manual/ios/browse-and-play.md
@@ -1,0 +1,40 @@
+# Browse and play — happy-path playback
+
+> Find a station via the list, start playback, verify mini-player and now-playing surface. Real-device preferred so audio output and metadata are real. ~10 minutes if testing across broadcasters.
+
+## Preconditions
+
+- [ ] Build under test: __________
+- [ ] Test environment: real-device (preferred) or simulator
+- [ ] Catalog loaded (run [`first-run.md`](first-run.md) first if this is a fresh install)
+- [ ] Volume up; AirPods or speakers connected if you want to hear it
+- [ ] Network: Wi-Fi or cellular OK
+
+## Steps
+
+1. From the **Stations** list, scroll until you find a station you can verify by ear (e.g. **BBC Radio 1**, **WDR 5**, **FM4 (ORF)**, **Radio Swiss Pop**) — expected: tile shows name, country flag/code, possibly tags.
+2. Tap the tile — expected: **Now Playing** screen opens; large play button visible; metadata area shows station info; if the station has a `metadataUrl` the artist/title may load within a few seconds.
+3. Tap **Play** — expected: button changes to pause icon within ~3 seconds; audio is audible at moderate volume; the mini-player will be visible after closing the sheet.
+4. Tap **Pause**, then **Play** again — expected: audio stops then resumes within ~2 seconds; no buffering spinner forever.
+5. Dismiss the Now-Playing sheet — expected: list returns; **mini-player** appears at the bottom showing station name + play/pause control.
+6. Scroll the list while playback continues — expected: audio continues uninterrupted; mini-player stays at the bottom.
+7. Tap the mini-player — expected: full Now-Playing sheet opens again; current station and metadata are correct.
+8. Pick a station from a different **broadcaster family** (one of: ORF, BBC, SRG/SSR, AzuraCast, Laut.FM, raw ICY-only) — expected: switching takes < 5 seconds; old stream stops, new stream starts; metadata updates.
+9. **For an ICY-only station** (catalog `status: icy-only`, e.g. some Shoutcast/Icecast streams) — expected: audio plays; track title appears within ~30 seconds if the stream embeds StreamTitle; absence is allowed but no crash.
+10. Stop playback — expected: audio stops within 1 second; mini-player remains visible until the user navigates away or it auto-dismisses (project-decided behaviour — note current behaviour for the tester report).
+
+## Acceptance
+
+- [ ] All steps completed without error
+- [ ] Audio audibly plays for at least three different stations from different broadcaster families
+- [ ] Pause/resume responds within 2 seconds
+- [ ] Switching stations completes within 5 seconds
+- [ ] Metadata (artist/title) appears within 30 seconds for at least one station that supports it (ORF / BBC / Laut.FM / etc.)
+- [ ] Mini-player is visible across list scrolling and persists between view changes
+
+## Notes for the tester
+
+- Playback latency over cellular can be a few seconds longer than Wi-Fi. The 5-second buffer above assumes Wi-Fi.
+- If an HLS station never starts, check the HLS variant resolution — sometimes the highest-bitrate variant is unreachable; the fallback should still play.
+- "Metadata never appears" is acceptable for stations marked `stream-only` in the catalog. It's a problem only for stations marked `working` or `icy-only`.
+- Per-broadcaster fetcher quirks live in `ios/rrradio/Player/Metadata/` — if a specific broadcaster misbehaves, file the bug with the broadcaster name and station UUID.

--- a/tests/manual/ios/custom-station.md
+++ b/tests/manual/ios/custom-station.md
@@ -1,0 +1,39 @@
+# Custom station — add HTTPS stream
+
+> Add a user-defined HTTPS stream, verify HTTPS-only validation, persistence, and playback. Simulator OK for the form; real-device or simulator for actual playback. ~7 minutes.
+
+## Preconditions
+
+- [ ] Build under test: __________
+- [ ] Test environment: simulator or real-device
+- [ ] Catalog loaded
+- [ ] You have a known-good public HTTPS stream URL handy (e.g. an SomaFM `https://ice2.somafm.com/groovesalad-128-mp3`, an ORF FM4 HLS playlist, or any other HTTPS audio stream you trust)
+- [ ] You also have an HTTP-only URL to test rejection (any old `http://...mp3` will do)
+
+## Steps
+
+1. Open the **Add Station** tab (or button) — expected: an empty form with fields: Name, Stream URL, optional Tags / Country.
+2. Submit the form blank — expected: validation error (e.g. "Stream URL required"); no station added; no crash.
+3. Enter a malformed URL like `not a url` — expected: validation rejects it; clear error message.
+4. Enter an **HTTP** (not HTTPS) URL — expected: validation rejects it with a message about HTTPS-only ([`CustomStationBuilderTests.swift`](../../../ios/rrradioTests/CustomStationBuilderTests.swift) is the second source of truth).
+5. Enter a valid **HTTPS** URL with an empty Name — expected: validation rejects it OR auto-fills a name from the URL (note current behaviour).
+6. Enter a valid HTTPS URL plus a Name (e.g. **"Test SomaFM Groove"**) — expected: form accepts; toast/confirmation; redirected to the custom-stations list (or home).
+7. Find the new custom station in the **Custom** list (or in the main list, depending on UX) — expected: it appears with the name and tags you entered.
+8. Tap to play — expected: playback starts within 5 seconds, audible audio.
+9. Force-quit and relaunch — expected: custom station persists; still playable.
+10. Long-press / swipe the custom station — expected: option to delete; deletion removes it immediately.
+
+## Acceptance
+
+- [ ] Empty form is rejected with a clear error
+- [ ] Malformed URL is rejected
+- [ ] HTTP-only URL is rejected (HTTPS-only enforced)
+- [ ] Valid HTTPS URL plus name persists and plays
+- [ ] Custom station survives force-quit + relaunch
+- [ ] Deletion removes it cleanly
+
+## Notes for the tester
+
+- HTTPS-only is a **hard rule** per the project's security model. If an HTTP URL is somehow accepted, that's a critical bug — file with `severity:critical`.
+- If a stream times out on tap-to-play, this is usually a stream/server problem (broadcaster down, geo-blocked); use a different test URL before declaring an app bug.
+- iCloud sync of custom stations is tested separately in [`icloud-sync.md`](icloud-sync.md).

--- a/tests/manual/ios/favorites-and-recents.md
+++ b/tests/manual/ios/favorites-and-recents.md
@@ -1,0 +1,39 @@
+# Favorites and recents
+
+> Favorite a station, reorder, remove. Verify recents dedupe and limit. UserDefaults persistence across launches. Simulator OK. ~5 minutes.
+
+## Preconditions
+
+- [ ] Build under test: __________
+- [ ] Test environment: simulator or real-device
+- [ ] Catalog loaded
+- [ ] You can identify the **Favorites** view and the **Recents** view in the Library tab
+
+## Steps
+
+1. Open the **Library** tab — expected: Favorites and Recents lists (currently empty if first run).
+2. Return to **Stations**, find a station, and tap the favorite control (heart icon, swipe action, or context menu — note current UX) — expected: visual confirmation (filled heart / toast / row indicator); haptic on real device.
+3. Repeat for a total of **3 different stations** — expected: each appears in Favorites in the order added (most-recent first or last — note which).
+4. Open Library → **Favorites** — expected: all 3 stations appear with the correct names; none duplicated.
+5. **Reorder** favorites if the UX supports it (long-press drag, or edit mode) — expected: order persists immediately; visible re-render.
+6. **Remove** one favorite — expected: it disappears from the Favorites list immediately; tile in the Stations list reflects un-favorited state.
+7. Play one station, then a different station, then a third station — expected: each play adds an entry to **Recents**.
+8. Play one of the same stations again — expected: it does **not** create a duplicate Recents entry; it moves to the top (or the most-recent slot, depending on UX).
+9. Play more stations until you exceed the Recents limit (test expects ~10 entries — confirm vs. `LibraryTests.swift`) — expected: oldest entries are evicted; list never exceeds the cap.
+10. Force-quit the app and relaunch — expected: Favorites and Recents are exactly as they were; nothing lost.
+11. Quickly toggle a favorite on/off twice — expected: state is consistent; no flicker, no duplicate.
+
+## Acceptance
+
+- [ ] Favoriting works; the favorite badge persists across navigation and launches
+- [ ] Removing a favorite removes it from Library and updates Stations
+- [ ] Reordering persists (if reordering UX exists)
+- [ ] Recents dedupes — playing the same station twice doesn't double-list it
+- [ ] Recents limit is enforced (oldest evicted)
+- [ ] All state survives a force-quit and relaunch
+
+## Notes for the tester
+
+- `LibraryTests.swift` covers the persistence + dedupe + limit logic; manual UAT verifies the UI binds correctly.
+- The exact Recents cap (10 vs 20 vs other) is in `Library.swift` — read once before testing so you know what to expect.
+- iCloud sync of favorites is **not** part of this script — see [`icloud-sync.md`](icloud-sync.md).

--- a/tests/manual/ios/first-run.md
+++ b/tests/manual/ios/first-run.md
@@ -1,0 +1,36 @@
+# First run — fresh install
+
+> Fresh install of rrradio iOS. Verify catalog fetch, initial UI, empty library state. Run on a clean device or a freshly-deleted-and-reinstalled app. ~5 minutes.
+
+## Preconditions
+
+- [ ] Build under test: __________ (commit SHA / TF build #)
+- [ ] Test environment: real-device or simulator
+- [ ] App is **not installed**, OR was installed and then deleted (so UserDefaults + iCloud cache are cleared)
+- [ ] Wi-Fi available; signed in to an Apple ID (iCloud not strictly required for this flow)
+- [ ] You can reach `https://rrradio.org/stations.json` from this network
+
+## Steps
+
+1. Launch rrradio for the first time — expected: app opens to the **Stations** tab; no flash of empty/error before content.
+2. Wait up to ~5 seconds for catalog load — expected: a list of stations appears, scrollable. Country chips and/or tag chips visible above the list.
+3. Pull-to-refresh the list — expected: refresh spinner shows briefly, list reloads, no error toast.
+4. Tap any station tile — expected: the **Now Playing** sheet (or full screen) opens; play button visible; metadata area shows station name, possibly tags / country.
+5. Dismiss the sheet — expected: returns to the list; mini-player **does not** appear (no playback was started yet).
+6. Tap the **Library** tab (or its equivalent for favorites/recents) — expected: empty-state copy is friendly; no crash; hint about how to add favorites.
+7. Tap the **Add Station** tab (or button) — expected: empty form for adding an HTTPS stream; no crash. Cancel back without entering anything.
+8. Force-quit the app and relaunch — expected: catalog is served from disk cache (loads immediately, no spinner); list state preserved.
+
+## Acceptance
+
+- [ ] All steps completed without error
+- [ ] Catalog loaded from network on first launch within 5 seconds
+- [ ] Catalog loaded from cache on second launch (no visible network spinner)
+- [ ] Library and Add-Station screens have empty-state copy, not blank
+- [ ] No crash, no error toast, no console error visible if a debugger is attached
+
+## Notes for the tester
+
+- If catalog fetch is slow or fails, check network. The fallback is the published `stations.json` at `rrradio.org/stations.json`; if that file is itself broken, the bug is upstream of the iOS app.
+- "Mini-player not appearing" means the persistent bottom bar with play/pause and current station — which only appears once at least one station has been played in this session.
+- Empty-state copy is allowed to be terse but should never be a blank screen.

--- a/tests/manual/ios/icloud-sync.md
+++ b/tests/manual/ios/icloud-sync.md
@@ -1,0 +1,64 @@
+# iCloud sync — two-device flow
+
+> Verify that favorites, custom stations, theme, language, and default sleep timer sync across two devices via the user's private iCloud database. **Two real devices required, both signed into the same Apple ID with iCloud Drive on.** ~15 minutes; iCloud propagation is intrinsically slow.
+
+## Preconditions
+
+- [ ] Build under test: __________ (same build on both devices)
+- [ ] Test environment: **two real devices** signed into the same Apple ID, both with iCloud Drive on, both with rrradio's "Use iCloud" toggled on
+- [ ] Both devices on Wi-Fi, recently signed-in, awake (iCloud sync slows when devices are sleeping)
+- [ ] Each device has the catalog loaded (run [`first-run.md`](first-run.md) on each)
+- [ ] Optional but useful: a fresh state on at least one device — favorites cleared, custom stations cleared, so you start "clean → synced"
+
+## Steps
+
+### Initial sync — favorites
+
+1. On **Device A**, favorite **3 different stations** (e.g. WDR 5, FM4, Radio Swiss Pop) — expected: heart icons fill; Library shows them.
+2. Wait 60 seconds. Open **Device B** — expected: the same 3 favorites appear in Library on Device B without manual refresh. (Pull-to-refresh on Device B if you want to force the check.)
+3. On **Device B**, remove one favorite — expected: it disappears on Device B immediately.
+4. Wait 60 seconds. Check **Device A** — expected: the removed favorite is gone there too.
+
+### Custom stations
+
+5. On **Device A**, add a custom HTTPS station (per [`custom-station.md`](custom-station.md)) — expected: appears in the Custom list locally.
+6. Wait 60 seconds. Check **Device B** — expected: the custom station appears there too; tappable, playable.
+7. On **Device B**, delete the custom station — expected: gone locally.
+8. Wait 60 seconds. Check **Device A** — expected: deletion has propagated.
+
+### Theme / language / default sleep timer
+
+9. On **Device A**, change the accent theme (Orange / Teal / Blue, or whatever the project supports) — expected: UI re-themes.
+10. Wait 60 seconds. Check **Device B** — expected: the theme has switched to match. (Theme sync is a documented feature per [`ios/README.md`](../../../ios/README.md).)
+11. On **Device A**, change the **default sleep timer** to 30 min — expected: change persists locally.
+12. Wait 60 seconds. Check **Device B**'s sleep-timer settings — expected: default is now 30 min.
+13. (Optional) On **Device A**, switch the language preference — expected: UI re-localizes; sync to **Device B** within 60 seconds.
+
+### Conflict / divergence
+
+14. Disable iCloud (turn off the "Use iCloud" toggle in rrradio) on **Device A**. Make a divergent local change (favorite or remove a station).
+15. Re-enable iCloud on **Device A** — expected: the merge/conflict policy in [`CloudSyncSnapshot.swift`](../../../ios/rrradio/CloudSync/CloudSyncSnapshot.swift) takes effect. Document the resolved state on both devices. Neither device should crash, neither should lose data unexpectedly (no silent overwrites).
+
+### Recovery — iCloud unavailable
+
+16. On **Device A**, sign out of iCloud (Settings → Apple ID → Sign Out) — expected: rrradio still launches and works locally; favorites/custom stations remain in the local UserDefaults; banner or status indicator notes iCloud is unavailable.
+17. Sign back into iCloud — expected: app re-syncs within 60–120 seconds; local state merges with cloud state per the documented policy.
+
+## Acceptance
+
+- [ ] Favorites added on one device appear on the other within ~60 seconds
+- [ ] Favorites removed on one device disappear on the other within ~60 seconds
+- [ ] Custom stations sync (add and remove) within ~60 seconds
+- [ ] Theme syncs across devices
+- [ ] Default sleep timer syncs across devices
+- [ ] Disabling and re-enabling iCloud on one device handles conflicts without data loss or crash
+- [ ] Signing out of iCloud entirely keeps the app local-only and functional
+- [ ] No spinner-stuck-forever, no crash, no silent data loss across any of the above
+
+## Notes for the tester
+
+- iCloud propagation is **not deterministic** — 30 to 120 seconds is the expected range, occasionally longer. Don't declare failure under 2 minutes.
+- The merge/conflict logic is exercised by `CloudSyncMergeTests.swift`; manual UAT verifies the integration. If you find an unexpected conflict resolution, capture both devices' state in the bug report (favorites list before/after on each side).
+- Recents are intentionally **not** synced (recents are device-local). If you see them syncing, that's a bug.
+- If iCloud appears completely silent (no sync ever), check: both devices are on the same Apple ID, "Use iCloud" toggle is on in rrradio's settings on both, iCloud Drive is on globally on both, and Settings → Apple ID → iCloud → rrradio is enabled.
+- TestFlight builds and App Store builds use **the same iCloud container**; mixing them between devices is fine. Local Xcode builds (development) use the **development container** and won't sync to TestFlight/AppStore installs.

--- a/tests/manual/ios/network-recovery.md
+++ b/tests/manual/ios/network-recovery.md
@@ -1,0 +1,60 @@
+# Network recovery — Wi-Fi drop, airplane mode
+
+> Verify that the stream survives network transitions: Wi-Fi → cellular → no network → recovery. **Real device strongly preferred** (simulator's network controls are unreliable). ~10 minutes.
+
+## Preconditions
+
+- [ ] Build under test: __________
+- [ ] Test environment: **real device** with both Wi-Fi and cellular available
+- [ ] Wi-Fi network you can disconnect from on demand
+- [ ] Cellular plan with data
+- [ ] A station playing reliably to start the test
+
+## Steps
+
+### Wi-Fi → cellular transition
+
+1. Start playing a station on Wi-Fi — expected: audio audible.
+2. Walk out of Wi-Fi range (or disable Wi-Fi in Settings → Wi-Fi) — expected: audio briefly stutters or pauses, then recovers within 10 seconds **on cellular**; status icon flips from Wi-Fi to cellular.
+3. Continue playing for 30 seconds — expected: continuous audio; no recurring re-buffering.
+
+### Cellular → Wi-Fi transition
+
+4. Re-enable Wi-Fi (or walk back into range) — expected: audio either continues uninterrupted or has a brief stutter; eventually network status returns to Wi-Fi.
+
+### Airplane mode mid-playback
+
+5. Start playback on Wi-Fi.
+6. Toggle **airplane mode ON** — expected: audio stops (no network); error toast or status indicator shows offline state; **no infinite buffering spinner**; user-facing message is friendly ("Network unavailable" or similar).
+7. Wait 10 seconds with airplane on — expected: app does not crash; tapping play during airplane mode either does nothing or shows a clear error.
+8. Toggle airplane mode **OFF** — expected: network returns; user can manually press Play and audio recovers within 10 seconds.
+
+### Brief network blip (1–2 seconds)
+
+9. Start playback.
+10. Toggle airplane on, wait 2 seconds, toggle off — expected: AVPlayer's built-in retry handles this; audio resumes automatically without user intervention within 10 seconds.
+
+### Stream-server failure (simulated)
+
+11. Start a station whose URL we know we can break (e.g. a custom station pointing to a URL that returns 404 after a delay — easiest to set up by adding a custom station with a deliberately wrong URL like `https://rrradio.org/does-not-exist.mp3`).
+12. Tap play — expected: clear failure within 10 seconds; toast or error message; no silent buffering forever.
+
+### Catalog vs stream
+
+13. Force-quit the app, enable airplane mode, relaunch — expected: catalog loads from disk cache; the list is fully usable for browsing/favoriting; tapping a station shows a network-unavailable error rather than infinite buffering.
+
+## Acceptance
+
+- [ ] Wi-Fi → cellular transition recovers within 10 seconds
+- [ ] Airplane-mode-on stops audio cleanly with friendly messaging
+- [ ] Airplane-mode-off + manual Play recovers within 10 seconds
+- [ ] Brief blip (1–2s offline) recovers automatically without manual intervention
+- [ ] Bad stream URL fails clearly within 10 seconds; no infinite spinner
+- [ ] Offline launch loads cached catalog and stays usable for browsing
+
+## Notes for the tester
+
+- Stream reconnection is the #1 bug source for radio apps (per [`docs/architecture.md`](../../../docs/architecture.md)). If you find recovery taking longer than 10 seconds, file with detail about which transition.
+- The 10-second recovery target is generous — many transitions complete in 2–3 seconds. Document the actual time observed.
+- "Infinite buffering spinner with no error" is the worst failure mode. A clear error within 10 seconds is preferable to silent buffering.
+- For step 11 (forced failure), if you don't want to set up a bad custom URL, find a station marked `status: stream-only` in the catalog that you suspect is currently broken — same effect.

--- a/tests/manual/ios/search-and-filter.md
+++ b/tests/manual/ios/search-and-filter.md
@@ -1,0 +1,41 @@
+# Search and filter
+
+> Verify station search (incl. whitespace-insensitive matching like "WDR5" → "WDR 5"), country filter, tag filter, and combinations. Simulator is fine for this flow. ~5 minutes.
+
+## Preconditions
+
+- [ ] Build under test: __________
+- [ ] Test environment: simulator or real-device
+- [ ] Catalog loaded; at least 100 stations in the list
+- [ ] You know roughly what stations exist (skim the list once before starting)
+
+## Steps
+
+1. Tap the search field — expected: keyboard appears; field gains focus; placeholder "Search stations" or similar.
+2. Type **"wdr"** — expected: list filters to include all WDR stations (WDR 2, WDR 3, WDR 4, WDR 5, 1Live, etc.). No empty state.
+3. Replace search with **"wdr5"** (no space) — expected: WDR 5 appears in the list. Whitespace-insensitive matching is the load-bearing behaviour ([`SearchTests.swift`](../../../ios/rrradioTests/SearchTests.swift)).
+4. Replace with **"BBC"** uppercase — expected: BBC stations appear. Case-insensitive.
+5. Replace with **"radio swiss pop"** (multi-word) — expected: Radio Swiss Pop appears. Word-order-insensitive matching: "swiss radio pop" should also match.
+6. Clear the search — expected: full list returns.
+7. Open the **country filter** (chip / picker / dropdown) — expected: list of countries appears, sorted alphabetically.
+8. Select **Austria** (or **AT**) — expected: list filters to Austrian stations (FM4, Ö1, Ö3, ORF Sounds, etc.).
+9. Without clearing the country filter, select a **tag** (e.g. **alternative** or **news**) — expected: list narrows further to AT-stations matching that tag.
+10. Clear filters — expected: full list restored; chips/badges show no active filter.
+11. Apply an unusual combination ("country: DE" + tag "jazz") — expected: small set of stations or a graceful empty state with friendly copy. No crash.
+
+## Acceptance
+
+- [ ] Whitespace-insensitive search works: "wdr5" returns "WDR 5"
+- [ ] Case-insensitive search works
+- [ ] Multi-word search works regardless of word order
+- [ ] Country filter narrows the list
+- [ ] Tag filter narrows the list
+- [ ] Combined country + tag filter narrows further
+- [ ] Empty result has friendly copy, not a blank screen
+- [ ] Clearing filters returns the full list
+
+## Notes for the tester
+
+- The search/filter logic is exercised by `ios/rrradioTests/SearchTests.swift` and `StationFiltersTests.swift` — if a result feels wrong, the unit test is the second source of truth.
+- Country names vs codes: the picker shows full names, but the tags themselves are stored as ISO codes (`DE`, `AT`, `CH`). Either should work in search.
+- Tag normalization: `News` and `news` should both match; `pop-music` and `pop music` ideally both match (catalog cleanup may not be fully consistent — surface mismatches as data bugs, not app bugs).

--- a/tests/manual/ios/sleep-timer.md
+++ b/tests/manual/ios/sleep-timer.md
@@ -1,0 +1,53 @@
+# Sleep timer
+
+> Verify sleep timer durations (off / 15 / 30 / 60 / 90 minutes), mid-playback set, and fire behaviour (pauses playback). Simulator works for non-fire steps; real device or patient simulator session for fire confirmation. ~15 minutes if fully tested; ~5 minutes if you accept that the 15-minute timer fires correctly and assume the rest are equivalent.
+
+## Preconditions
+
+- [ ] Build under test: __________
+- [ ] Test environment: simulator or real-device
+- [ ] You have ~15 minutes for the minimum test (waiting for the 15-minute timer to fire), OR you're prepared to inspect logs / use a debugger to confirm fire behaviour without waiting
+
+## Steps
+
+### UI / state
+
+1. Start playback. Open the sleep-timer control (button, menu, or sheet — note the entry point) — expected: shows current state (off) and options off / 15 / 30 / 60 / 90.
+2. Pick **15 min** — expected: UI confirms; control shows remaining time (e.g. "15:00") or "Sleeps in 15 min".
+3. Cancel back to the playback screen — expected: timer indicator persists somewhere visible (mini-player, now-playing screen, or settings).
+4. Open the sleep-timer control again — expected: it shows the remaining time, counting down. Pick **30 min** — expected: timer resets to 30 min; old 15-min timer is replaced.
+5. Pick **off** — expected: timer is canceled; remaining-time indicator disappears.
+
+### Cycle through all durations
+
+6. Set **15 min**, observe display, cancel, set **30 min**, cancel, set **60 min**, cancel, set **90 min** — expected: every option behaves the same; UI updates correctly.
+
+### Fire behaviour (15-minute test)
+
+7. Start playback; set **15 min**.
+8. Wait. (Real device: leave the device alone, screen can lock.) Optionally do other things on the phone — playback should continue throughout the 15 minutes.
+9. At ~14:55 mark — expected: playback continues; timer indicator shows ~5 sec remaining.
+10. At fire time — expected: **playback pauses** (audio stops); the timer indicator clears; the lock-screen card (if visible) shows paused state.
+11. Manually press Play — expected: audio resumes within 2 seconds. (The timer is one-shot; resuming does not re-arm it.)
+
+### Persistence
+
+12. Start playback, set 30 min, force-quit the app — expected: on next launch, the timer is **not** restored (project decision; typical for sleep timers — confirm current behaviour and document).
+13. Set sleep timer; switch to a different station mid-playback — expected: timer continues uninterrupted; firing pauses the new station.
+
+## Acceptance
+
+- [ ] All five options (off/15/30/60/90) selectable and visible
+- [ ] Selecting a new duration replaces an existing one (not adds)
+- [ ] **Off** cancels an active timer cleanly
+- [ ] 15-minute timer fires within ±10 seconds of the expected mark
+- [ ] Fire pauses playback (stop, not crash, not silent buffering)
+- [ ] Timer does not persist across force-quit (or, if it does, it's intentional and documented)
+- [ ] Switching stations during the timer keeps the timer running
+
+## Notes for the tester
+
+- `SleepTimerTests.swift` covers the duration cycle and state transitions in the unit tests; this script verifies the integration with `AudioPlayer`.
+- The ±10 second tolerance on fire timing accounts for real-device timer drift. Anything > 30 seconds drift is a bug.
+- If you don't want to wait the full 15 minutes, dropping the minimum option down to 1-min via debugger (or a temporary build with `[1, 2, 5, 10, 15]`) is fine — but verify with a real 15-min run before shipping.
+- iCloud sync of the **default** sleep timer setting is part of [`icloud-sync.md`](icloud-sync.md), not this script.


### PR DESCRIPTION
## Summary

10 user-acceptance test scripts covering the iOS app's real surface area, plus a reusable issue-form template for tracking UAT cycles. Per the [HQ testing convention](https://github.com/MarkusSteinbrecher/HQ/blob/main/wiki/conventions/testing.md).

**Files**
- `.github/ISSUE_TEMPLATE/uat-cycle.yml` — issue form: build SHA, surface, environment, device, tester, scope (seeded with all 10 iOS flow paths), known issues, result block.
- `tests/manual/README.md`, `tests/manual/ios/README.md` — index pages with cycle workflow + environment notes.
- `tests/manual/ios/{first-run,browse-and-play,search-and-filter,favorites-and-recents,custom-station,background-and-lock-screen,audio-interruption,network-recovery,sleep-timer,icloud-sync}.md` — one per critical user flow.

Each script follows testing.md §4: preconditions, numbered steps with expected outcomes, binary acceptance checklist, tester notes. Real-device requirements flagged where the simulator can't verify (lock-screen card, AirPods, audio interruption, network transitions, iCloud sync).

No source-code changes — pure documentation + GitHub issue-template wiring.

## Test plan

- [ ] Open a fresh issue in this repo using the **UAT cycle** template — verify the form renders, fields are present, scope checklist seeds with the 10 flow paths.
- [ ] Skim 2–3 scripts (suggested: `first-run.md`, `audio-interruption.md`, `icloud-sync.md`) for accuracy against the current iOS build. Flag any drift.
- [ ] Verify the index links resolve (no broken paths in `tests/manual/README.md` or `tests/manual/ios/README.md`).
- [ ] (Optional) Run one cycle for real on a TestFlight build and surface any script gaps as follow-up issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)