### PR TITLE
Harden iOS metadata network behavior

### DIFF
--- a/ios/rrradio/Player/AudioPlayer.swift
+++ b/ios/rrradio/Player/AudioPlayer.swift
@@ -69,6 +69,9 @@ final class AudioPlayer {
     private weak var listeningHistory: ListeningHistory?
     private var lyricsKey = ""
 
+    private static let lockScreenArtworkMaximumBytes = 5_000_000
+    private static let lockScreenArtworkTimeout: TimeInterval = 8
+
     var isWaitingForConnection: Bool {
         if case .error = state {
             return true
@@ -917,7 +920,11 @@ final class AudioPlayer {
         guard let url else { return }
 
         lockScreenArtworkTask = Task { [weak self] in
-            guard let (data, _) = try? await URLSession.shared.data(from: url),
+            var request = URLRequest(url: url)
+            request.timeoutInterval = Self.lockScreenArtworkTimeout
+            guard let (data, response) = try? await URLSession.shared.data(for: request),
+                  (response as? HTTPURLResponse).map({ (200...299).contains($0.statusCode) }) != false,
+                  data.count <= Self.lockScreenArtworkMaximumBytes,
                   !Task.isCancelled,
                   let image = UIImage(data: data) else { return }
 

--- a/ios/rrradio/Player/Metadata/FavoriteNowPlayingStore.swift
+++ b/ios/rrradio/Player/Metadata/FavoriteNowPlayingStore.swift
@@ -85,13 +85,18 @@ final class FavoriteNowPlayingStore {
         }
     }
 
-    private nonisolated static func metadata(for station: Station) async throws -> NowPlayingMetadata? {
-        if let fetcher = metadataFetcher(for: station) {
-            if let metadata = try await fetcher(station) {
-                return metadata
-            }
+    nonisolated static func metadata(
+        for station: Station,
+        fetcher: StationMetadataFetcher? = nil,
+        icyFetch: @escaping StationMetadataFetcher = { try await fetchIcyMetadata(station: $0) },
+    ) async throws -> NowPlayingMetadata? {
+        let resolvedFetcher = fetcher ?? (station.status == "icy-only" ? nil : metadataFetcher(for: station))
+        if let fetcher = resolvedFetcher,
+           let metadata = try await fetcher(station) {
+            return metadata
         }
-        return try await fetchIcyMetadata(station: station)
+        guard station.status == "icy-only" else { return nil }
+        return try await icyFetch(station)
     }
 
     private nonisolated static func clean(_ value: String?) -> String? {

--- a/ios/rrradio/Player/Metadata/MetadataPoller.swift
+++ b/ios/rrradio/Player/Metadata/MetadataPoller.swift
@@ -16,25 +16,34 @@ final class MetadataPoller {
         stop()
         let myGeneration = generation
 
-        let tick = {
-            Task {
+        let tick = { [weak self] in
+            Task { [weak self] in
+                guard let self else { return }
                 do {
                     let metadata = try await fetcher(station)
-                    await MainActor.run {
-                        guard self.generation == myGeneration else { return }
+                    await MainActor.run { [weak self] in
+                        guard let self, self.generation == myGeneration else { return }
                         onUpdate(metadata)
                     }
                 } catch {
-                    await MainActor.run {
-                        guard self.generation == myGeneration else { return }
-                        self.stop()
+                    await MainActor.run { [weak self] in
+                        guard let self, self.generation == myGeneration else { return }
+                        var details = ["station": station.name]
+                        if let urlError = error as? URLError {
+                            details["error"] = String(urlError.code.rawValue)
+                        }
+                        diagnosticRecord("metadata", "polling failed", details: details)
                     }
                 }
             }
         }
 
         _ = tick()
-        timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { _ in
+        timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] timer in
+            guard self != nil else {
+                timer.invalidate()
+                return
+            }
             _ = tick()
         }
     }

--- a/ios/rrradioTests/FavoriteNowPlayingStoreTests.swift
+++ b/ios/rrradioTests/FavoriteNowPlayingStoreTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+@testable import rrradio
+
+final class FavoriteNowPlayingStoreTests: XCTestCase {
+    private func station(status: String? = "stream-only") -> Station {
+        Station(
+            id: "test",
+            name: "Test FM",
+            streamUrl: URL(string: "https://example.com/stream")!,
+            status: status,
+        )
+    }
+
+    func testSkipsIcyFallbackForNonIcyStations() async throws {
+        var icyCalled = false
+
+        let metadata = try await FavoriteNowPlayingStore.metadata(
+            for: station(status: "stream-only"),
+            fetcher: { _ in nil },
+            icyFetch: { _ in
+                icyCalled = true
+                return NowPlayingMetadata(artist: "Icy", title: "Track", raw: "Icy - Track")
+            },
+        )
+
+        XCTAssertNil(metadata)
+        XCTAssertFalse(icyCalled)
+    }
+
+    func testUsesIcyFallbackForIcyOnlyStations() async throws {
+        var icyCalled = false
+
+        let metadata = try await FavoriteNowPlayingStore.metadata(
+            for: station(status: "icy-only"),
+            fetcher: { _ in nil },
+            icyFetch: { _ in
+                icyCalled = true
+                return NowPlayingMetadata(artist: "Icy", title: "Track", raw: "Icy - Track")
+            },
+        )
+
+        XCTAssertTrue(icyCalled)
+        XCTAssertEqual(metadata, NowPlayingMetadata(artist: "Icy", title: "Track", raw: "Icy - Track"))
+    }
+
+    func testDirectFetcherWinsBeforeIcyFallback() async throws {
+        var icyCalled = false
+
+        let metadata = try await FavoriteNowPlayingStore.metadata(
+            for: station(status: "icy-only"),
+            fetcher: { _ in NowPlayingMetadata(artist: "Direct", title: "Track", raw: "Direct - Track") },
+            icyFetch: { _ in
+                icyCalled = true
+                return NowPlayingMetadata(artist: "Icy", title: "Track", raw: "Icy - Track")
+            },
+        )
+
+        XCTAssertFalse(icyCalled)
+        XCTAssertEqual(metadata, NowPlayingMetadata(artist: "Direct", title: "Track", raw: "Direct - Track"))
+    }
+}

--- a/ios/rrradioTests/MetadataPollerTests.swift
+++ b/ios/rrradioTests/MetadataPollerTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import rrradio
+
+@MainActor
+final class MetadataPollerTests: XCTestCase {
+    private func station() -> Station {
+        Station(
+            id: "test",
+            name: "Test FM",
+            streamUrl: URL(string: "https://example.com/stream")!,
+        )
+    }
+
+    func testContinuesAfterTransientFetcherError() async {
+        let poller = MetadataPoller()
+        var attempts = 0
+        let recovered = expectation(description: "poller recovered")
+
+        poller.start(
+            station: station(),
+            fetcher: { _ in
+                let attempt = await MainActor.run {
+                    attempts += 1
+                    return attempts
+                }
+                if attempt == 1 {
+                    throw URLError(.timedOut)
+                }
+                return NowPlayingMetadata(artist: "Artist", title: "Recovered", raw: "Artist - Recovered")
+            },
+            interval: 0.01,
+        ) { metadata in
+            if metadata?.title == "Recovered" {
+                recovered.fulfill()
+            }
+        }
+
+        await fulfillment(of: [recovered], timeout: 1)
+        poller.stop()
+        XCTAssertGreaterThanOrEqual(attempts, 2)
+    }
+}


### PR DESCRIPTION
## Summary

- limit FavoriteNowPlayingStore raw ICY fallback to stations marked `icy-only`
- keep MetadataPoller alive after transient fetch errors and avoid retaining it through timer/task closures
- cap lock-screen artwork fetches with an 8s timeout, HTTP success validation, and a 5 MB response limit
- add XCTest coverage for ICY fallback gating and poller recovery

## Verification

- `xcodegen generate`
- `git diff --check`
- `xcodebuild test -project ios/rrradio.xcodeproj -scheme rrradio -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath /private/tmp/rrradio-metadata-derived`

Result: 203 tests passed.
