### PR TITLE
Redact shared diagnostics exports

### DIFF
--- a/ios/rrradio/Diagnostics.swift
+++ b/ios/rrradio/Diagnostics.swift
@@ -77,7 +77,7 @@ final class Diagnostics {
         if events.isEmpty {
             lines.append("- none")
         } else {
-            lines.append(contentsOf: events.map(Self.format))
+            lines.append(contentsOf: events.map { Self.format($0, redactingSensitiveDetails: true) })
         }
         return lines.joined(separator: "\n")
     }
@@ -85,7 +85,7 @@ final class Diagnostics {
     var recentSummary: String {
         if !isEnabled { return "Diagnostics collection is off." }
         if events.isEmpty { return "No diagnostic events yet." }
-        return events.suffix(6).map(Self.format).joined(separator: "\n")
+        return events.suffix(6).map { Self.format($0, redactingSensitiveDetails: false) }.joined(separator: "\n")
     }
 
     private func persist() {
@@ -121,14 +121,54 @@ final class Diagnostics {
         return String(value.prefix(Constants.maxValueLength - 1)) + "..."
     }
 
-    private static func format(_ event: Event) -> String {
-        let detailText = event.details
+    private static func format(_ event: Event, redactingSensitiveDetails: Bool) -> String {
+        let details = redactingSensitiveDetails ? exportableDetails(event.details) : event.details
+        let detailText = details
             .sorted { $0.key < $1.key }
             .map { "\($0.key)=\($0.value)" }
             .joined(separator: " ")
         let suffix = detailText.isEmpty ? "" : " \(detailText)"
         return "- \(timestampFormatter.string(from: event.timestamp)) [\(event.category)] \(event.message)\(suffix)"
     }
+
+    private static func exportableDetails(_ details: [String: String]) -> [String: String] {
+        details.reduce(into: [String: String]()) { result, item in
+            let normalizedKey = item.key.lowercased()
+            guard !sensitiveExportKeys.contains(normalizedKey) else { return }
+            let value = redactExportValue(item.value)
+            if !value.isEmpty {
+                result[item.key] = value
+            }
+        }
+    }
+
+    private static func redactExportValue(_ value: String) -> String {
+        let withoutURLs = value.replacingOccurrences(
+            of: #"https?://[^\s]+"#,
+            with: "[url]",
+            options: .regularExpression,
+        )
+        return withoutURLs.replacingOccurrences(
+            of: #"\b[A-Za-z0-9][A-Za-z0-9.-]*\.[A-Za-z]{2,}\b"#,
+            with: "[host]",
+            options: .regularExpression,
+        )
+    }
+
+    private static let sensitiveExportKeys: Set<String> = [
+        "coverhost",
+        "host",
+        "hostname",
+        "homepage",
+        "metadataurl",
+        "station",
+        "stationid",
+        "stationname",
+        "stream",
+        "streamhost",
+        "streamurl",
+        "url",
+    ]
 
     private static let timestampFormatter: ISO8601DateFormatter = {
         let formatter = ISO8601DateFormatter()

--- a/ios/rrradio/Views/SettingsView.swift
+++ b/ios/rrradio/Views/SettingsView.swift
@@ -309,7 +309,7 @@ private struct SettingsPageView: View {
                         Text("Collect Diagnostics")
                             .font(.system(size: 15, weight: .medium))
                             .foregroundStyle(RrradioTheme.ink)
-                        Text("Off by default. Stores a local troubleshooting log on this device so you can share it with the app owner when issues happen.")
+                        Text("Off by default. Stores a local troubleshooting log on this device; shared copies redact station and host details.")
                             .font(.system(size: 12))
                             .foregroundStyle(RrradioTheme.ink3)
                             .lineLimit(4)

--- a/ios/rrradioTests/DiagnosticsTests.swift
+++ b/ios/rrradioTests/DiagnosticsTests.swift
@@ -16,6 +16,34 @@ final class DiagnosticsTests: XCTestCase {
 
         XCTAssertEqual(diagnostics.events.first?.details["stream"], "example.com")
         XCTAssertFalse(diagnostics.exportText().contains("token=secret"))
+        XCTAssertFalse(diagnostics.exportText().contains("example.com"))
+    }
+
+    func testDiagnosticsExportRedactsListeningIdentifiersButKeepsLocalSummary() {
+        let suiteName = "org.rrradio.tests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        let diagnostics = Diagnostics(defaults: defaults)
+        diagnostics.isEnabled = true
+
+        diagnostics.record("playback", "failed", details: [
+            "station": "Test FM",
+            "stationID": "abc123",
+            "streamHost": "stream.example.com",
+            "count": "2",
+            "error": "failed loading https://stream.example.com/live?token=secret",
+        ])
+
+        XCTAssertTrue(diagnostics.recentSummary.contains("Test FM"))
+        XCTAssertTrue(diagnostics.recentSummary.contains("stream.example.com"))
+
+        let export = diagnostics.exportText()
+        XCTAssertTrue(export.contains("[playback] failed"))
+        XCTAssertTrue(export.contains("count=2"))
+        XCTAssertFalse(export.contains("Test FM"))
+        XCTAssertFalse(export.contains("abc123"))
+        XCTAssertFalse(export.contains("stream.example.com"))
+        XCTAssertFalse(export.contains("token=secret"))
     }
 
     func testDiagnosticsKeepOnlyRecentHundredEvents() {


### PR DESCRIPTION
## Summary

- redact station, host, and URL identity fields from shared diagnostics exports
- scrub URL-like values from remaining exported diagnostic details
- keep local recent summaries detailed for on-device troubleshooting
- update Settings copy to state that shared diagnostics are redacted

## Verification

- `git diff --check`
- `xcodebuild test -project ios/rrradio.xcodeproj -scheme rrradio -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:rrradioTests/DiagnosticsTests -derivedDataPath /private/tmp/rrradio-diagnostics-derived`
- `xcodebuild test -project ios/rrradio.xcodeproj -scheme rrradio -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath /private/tmp/rrradio-diagnostics-full-derived`

Result: full iOS suite passed, 209 tests.
