### PR TITLE
Mark CloudKit sync store sendable

### DIFF
--- a/ios/rrradio/CloudSync/CloudSyncStore.swift
+++ b/ios/rrradio/CloudSync/CloudSyncStore.swift
@@ -54,7 +54,9 @@ struct CloudSyncUnavailableError: LocalizedError {
     }
 }
 
-final class CloudKitSyncStore: CloudSyncStoring {
+// CloudKit handle types are immutable references used only through async APIs here,
+// but the SDK does not currently annotate them as Sendable.
+final class CloudKitSyncStore: CloudSyncStoring, @unchecked Sendable {
     static let containerIdentifier = "iCloud.ios.rrradio.org"
 
     private enum RecordType {


### PR DESCRIPTION
## Summary

- mark `CloudKitSyncStore` as `@unchecked Sendable`
- document why the unchecked conformance is constrained to immutable CloudKit handles used through async APIs

## Verification

- `git diff --check`
- `xcodebuild test -project ios/rrradio.xcodeproj -scheme rrradio -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath /private/tmp/rrradio-cloudkit-sendable-derived` (208 tests)
- `npm run build`
- `npm run test` (328 tests; sandbox logged localhost `EPERM`, suite passed)
- `npm run check-catalog`
