### PR TITLE
Surface custom station HTTPS upgrades

### DIFF
--- a/ios/rrradio/Views/AddStationView.swift
+++ b/ios/rrradio/Views/AddStationView.swift
@@ -28,6 +28,8 @@ struct AddStationContentView: View {
     @State private var name = ""
     @State private var streamURL = ""
     @State private var errorMessage: String?
+    @State private var streamURLNoticeMessage: String?
+    @State private var upgradedHTTPStreamURL: String?
     @State private var shouldHighlightNameField = false
     @State private var stationBeingEdited: Station?
     @State private var stationPendingDeletion: Station?
@@ -50,6 +52,9 @@ struct AddStationContentView: View {
                     .autocorrectionDisabled()
                 if streamCheckState.showsStatusMessage {
                     streamCheckStatusView
+                }
+                if let streamURLNoticeMessage {
+                    streamURLNoticeView(streamURLNoticeMessage)
                 }
                 if hasEnteredFormData {
                     addStationControlsRow
@@ -170,6 +175,16 @@ struct AddStationContentView: View {
             }
         }
         .font(.caption)
+        .listRowBackground(Color.clear)
+    }
+
+    private func streamURLNoticeView(_ message: String) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: "lock.fill")
+            Text(message)
+        }
+        .font(.caption)
+        .foregroundStyle(RrradioTheme.ink3)
         .listRowBackground(Color.clear)
     }
 
@@ -323,6 +338,8 @@ struct AddStationContentView: View {
         name = ""
         streamURL = ""
         errorMessage = nil
+        streamURLNoticeMessage = nil
+        upgradedHTTPStreamURL = nil
         shouldHighlightNameField = false
         stationBeingEdited = nil
         savedStationSignature = nil
@@ -335,6 +352,8 @@ struct AddStationContentView: View {
         name = station.name
         streamURL = station.streamUrl.absoluteString
         errorMessage = nil
+        streamURLNoticeMessage = nil
+        upgradedHTTPStreamURL = nil
         shouldHighlightNameField = false
         savedStationSignature = currentStationSignature(name: station.name, streamURL: station.streamUrl.absoluteString)
         streamCheckState = .playable
@@ -347,7 +366,14 @@ struct AddStationContentView: View {
         let value = rawURL.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !value.isEmpty else {
             streamCheckState = .idle
+            streamURLNoticeMessage = nil
+            upgradedHTTPStreamURL = nil
             return
+        }
+
+        if upgradedHTTPStreamURL != value {
+            streamURLNoticeMessage = nil
+            upgradedHTTPStreamURL = nil
         }
 
         streamCheckState = .checking
@@ -357,7 +383,13 @@ struct AddStationContentView: View {
                 try Task.checkCancellation()
                 let normalizedValue = normalizedHTTPSStreamURLString(value)
                 if normalizedValue != value {
+                    let showsUpgradeNotice = shouldShowHTTPSUpgradeNotice(for: value)
                     await MainActor.run {
+                        if showsUpgradeNotice {
+                            upgradedHTTPStreamURL = normalizedValue
+                            streamURLNoticeMessage = "Saved and tested as https://. If this stream only supports http://, it may not play."
+                            diagnosticRecord("add-station", "stream URL upgraded to HTTPS", details: ["sourceScheme": "http"])
+                        }
                         streamURL = normalizedValue
                     }
                     return
@@ -597,6 +629,12 @@ func normalizedHTTPSStreamURLString(_ raw: String) -> String {
         return value
     }
     return "https://\(value)"
+}
+
+func shouldShowHTTPSUpgradeNotice(for raw: String) -> Bool {
+    let value = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    return value.lowercased().hasPrefix("http://") &&
+        normalizedHTTPSStreamURLString(value) != value
 }
 
 #Preview {

--- a/ios/rrradioTests/AddStationActionTests.swift
+++ b/ios/rrradioTests/AddStationActionTests.swift
@@ -31,6 +31,18 @@ final class AddStationActionTests: XCTestCase {
         XCTAssertEqual(normalizedHTTPSStreamURLString("http://example.com/live"), "https://example.com/live")
     }
 
+    func testShowsNoticeForExplicitHTTPUpgrade() {
+        XCTAssertTrue(shouldShowHTTPSUpgradeNotice(for: " http://example.com/live "))
+    }
+
+    func testDoesNotShowNoticeForBareHTTPSNormalization() {
+        XCTAssertFalse(shouldShowHTTPSUpgradeNotice(for: "example.com/live"))
+    }
+
+    func testDoesNotShowNoticeForAlreadyHTTPSURL() {
+        XCTAssertFalse(shouldShowHTTPSUpgradeNotice(for: "https://example.com/live"))
+    }
+
     func testCollapsesDuplicateHTTPSStreamURLScheme() {
         XCTAssertEqual(normalizedHTTPSStreamURLString("https://https://example.com/live"), "https://example.com/live")
     }

--- a/tools/build-catalog.mjs
+++ b/tools/build-catalog.mjs
@@ -117,19 +117,19 @@ function pickGeo(rb) {
 }
 
 function pickTags(rb) {
-  if (!rb?.tags) return undefined;
-  const list = rb.tags
-    .split(/[,;]/)
-    .map((t) => t.trim().toLowerCase())
-    .filter(Boolean);
-  return list.length > 0 ? [...new Set(list)].slice(0, 6) : undefined;
+  return normalizeTags(rb?.tags, 6);
 }
 
-function normalizeTags(tags) {
+function normalizeTags(tags, limit) {
   if (tags === null || tags === undefined) return undefined;
   const source = Array.isArray(tags) ? tags : [tags];
-  const list = source.map((t) => String(t).trim().toLowerCase()).filter(Boolean);
-  return list.length > 0 ? [...new Set(list)] : undefined;
+  const list = source
+    .flatMap((t) => String(t).split(/[,;]/))
+    .map((t) => t.trim().toLowerCase())
+    .filter(Boolean);
+  const unique = [...new Set(list)];
+  const normalized = typeof limit === 'number' ? unique.slice(0, limit) : unique;
+  return normalized.length > 0 ? normalized : undefined;
 }
 
 function merged(s) {

--- a/tools/build-station-pages.mjs
+++ b/tools/build-station-pages.mjs
@@ -97,7 +97,10 @@ function clip(s, max = 155) {
 function normalizeTags(tags) {
   if (tags === null || tags === undefined) return [];
   const source = Array.isArray(tags) ? tags : [tags];
-  return source.map((t) => String(t).trim().toLowerCase()).filter(Boolean);
+  return source
+    .flatMap((t) => String(t).split(/[,;]/))
+    .map((t) => t.trim().toLowerCase())
+    .filter(Boolean);
 }
 
 function pickTags(s) {


### PR DESCRIPTION
## Summary

- show an inline Add Station notice when an explicit `http://` stream URL is normalized to `https://`
- record a privacy-safe diagnostic for that normalization without host or URL details
- normalize scalar local catalog tags in `build-catalog` and tolerate scalar tags in station-page generation

## Verification

- `git diff --check`
- `xcodebuild test -project ios/rrradio.xcodeproj -scheme rrradio -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:rrradioTests/AddStationActionTests -derivedDataPath /private/tmp/rrradio-http-upgrade-derived` (10 tests)
- `xcodebuild test -project ios/rrradio.xcodeproj -scheme rrradio -destination 'platform=iOS Simulator,name=iPhone 17' -derivedDataPath /private/tmp/rrradio-http-upgrade-derived-full` (212 tests)
- `npm run test` (328 tests; sandbox logged localhost `EPERM`, suite passed)
- `npm run build`
- `npm run check-catalog`

## Known Existing Issue

- `npm run check-duplicates` currently fails on 25 duplicate catalog groups inherited from the merged station sweeps on `main`; this branch does not change station entries.
