### PR TITLE
Surface geo-restricted stations and friendly playback message

### DIFF
--- a/data/stations.yaml
+++ b/data/stations.yaml
@@ -44,6 +44,14 @@
   country: CH
   status: working
   featured: true
+  # All four Infomaniak stream URLs (grrif-128.aac, grrif-48.mp3,
+  # grrif-high.mp3, grrif-64.aac) return HTTP 401 "Authorization
+  # required" from non-Swiss IPs (AIS9 server's geo-block response).
+  # Music-licensing decision (SUISA/SwissPerform); no international
+  # stream exists. Sister station RJB on the same Infomaniak fleet is
+  # not geo-gated, confirming this is broadcaster-side and intentional.
+  availableIn:
+    - CH
 - id: builtin-fm4
   stationuuid: 1e13ed4e-daa9-4728-8550-e08d89c1c8e7
   changeuuid: ae34eaf7-5e77-4144-9eb9-c27a9f33ada2

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -55,6 +55,36 @@ Existing fetchers cover Grrif, ORF (any channel via metadataUrl), BR (any channe
 3. **Logo**: drop a PNG into `public/stations/`, point `favicon:` at it, and record the source URL/retrieval date in the PR body or `THIRD_PARTY_NOTICES.md`.
 4. **Done** — `npm run dev` regenerates the catalog automatically.
 
+## Geo-restricted stations
+
+Some broadcasters geo-gate their streams for music-licensing reasons — SUISA/SwissPerform for Switzerland, GEMA for Germany, similar agencies elsewhere. The stream returns an `HTTP 401` (Infomaniak's AIS9 server) or a 403 to non-allowed IPs, with no auth challenge body; it's a server-side IP geo-block dressed up as auth.
+
+Catalog flag: set `availableIn: [<ISO-3166-alpha-2 codes>]` on the station entry in `data/stations.yaml`.
+
+```yaml
+- id: builtin-grrif
+  ...
+  availableIn:
+    - CH
+```
+
+Effect:
+- **Web** dims the row, adds a "Switzerland only" badge in `.row-tags`, and the player error path translates the 401-driven `MediaError` into a friendly geo-restricted message instead of generic "stream failed".
+- **iOS** dims the row + adds the same badge, and `AudioPlayer`'s `.failed` path overrides the error message with the curated reason. The visitor's country comes from the rrradio-stats Worker's `/api/public/region` endpoint, which surfaces Cloudflare's `CF-IPCountry` header. Result is cached per session (web `localStorage`, iOS `UserDefaults`) for 24h.
+- **Absent or empty** ⇒ no restriction known. Default for the overwhelming majority of stations; the UI and player behave exactly as before.
+
+How to confirm a station is geo-restricted before flagging:
+
+```bash
+# From a non-broadcaster country. Look for 401/403 with no WWW-Authenticate
+# challenge — that's the geo-gate signature, not real HTTP auth.
+curl -sI 'https://example.broadcaster.com/stream'
+```
+
+A control test on a sibling station from the same broadcaster's infrastructure (RJB on Infomaniak responded 200 OK from DE while Grrif on the same fleet returned 401) is the cleanest way to distinguish "broadcaster geo-block" from "broadcaster down".
+
+Do not set `availableIn` speculatively — it dims and labels the row for everyone outside the allow-list. Only set it after a confirmed reproduction from at least one out-of-region IP.
+
 ## Adding a NEW broadcaster (different metadata API shape)
 
 1. **Research** the broadcaster's now-playing endpoint (DevTools network tab on their player page). Verify CORS allow-origin.

--- a/ios/rrradio/Models/RegionResolver.swift
+++ b/ios/rrradio/Models/RegionResolver.swift
@@ -1,0 +1,131 @@
+import Foundation
+import Observation
+
+/// Visitor region detection for geo-restricted stations.
+///
+/// Hits the rrradio-stats Worker's `/api/public/region` endpoint, which
+/// echoes Cloudflare's `CF-IPCountry` header — the visitor's network
+/// location, not the device locale. Cached for 24h in UserDefaults so
+/// repeated launches don't pay the round-trip.
+///
+/// `current` is nil when:
+///   • the fetch hasn't completed yet (first launch, expired cache),
+///   • the Worker returned `null` (Tor, anycast, unknown IP), or
+///   • the network is unreachable.
+///
+/// Callers should treat nil as "unknown" and fall back to "no
+/// restriction" UX — better to show a working station than to badge
+/// one as unavailable because we can't read the IP geo header.
+@Observable
+@MainActor
+final class RegionResolver {
+    static let shared = RegionResolver()
+
+    /// Latest known country code (uppercase ISO 3166-1 alpha-2) or
+    /// nil when unknown. SwiftUI views observing this redraw when
+    /// the value flips after the initial fetch resolves.
+    private(set) var current: String?
+
+    private let cacheKey = "rrradio.region.v1"
+    private let cacheKeyFetchedAt = "rrradio.region.v1.fetchedAt"
+    // 24h — countries don't change often, and a stale day on a trip
+    // is preferable to refetching on every app launch.
+    private let cacheTTL: TimeInterval = 24 * 60 * 60
+
+    private var fetchTask: Task<Void, Never>?
+
+    private init() {
+        loadFromCache()
+        refreshIfStale()
+    }
+
+    private func loadFromCache() {
+        let defaults = UserDefaults.standard
+        guard
+            let country = defaults.string(forKey: cacheKey),
+            let fetchedAt = defaults.object(forKey: cacheKeyFetchedAt) as? Date,
+            Date().timeIntervalSince(fetchedAt) < cacheTTL
+        else { return }
+        current = country.isEmpty ? nil : country
+    }
+
+    /// Fire-and-forget refresh. Idempotent — concurrent calls share a
+    /// single in-flight task so the Worker isn't hit per-view.
+    func refreshIfStale() {
+        if fetchTask != nil { return }
+        let defaults = UserDefaults.standard
+        if
+            let fetchedAt = defaults.object(forKey: cacheKeyFetchedAt) as? Date,
+            Date().timeIntervalSince(fetchedAt) < cacheTTL
+        {
+            return
+        }
+        fetchTask = Task { [weak self] in
+            defer { Task { @MainActor [weak self] in self?.fetchTask = nil } }
+            await self?.performFetch()
+        }
+    }
+
+    private func performFetch() async {
+        let urlString = "\(WorkerAPI.base)/api/public/region"
+        guard let url = URL(string: urlString) else { return }
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 8
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard
+                let http = response as? HTTPURLResponse,
+                http.statusCode == 200
+            else { return }
+            struct Body: Decodable { let country: String? }
+            let body = try JSONDecoder().decode(Body.self, from: data)
+            let country = body.country?.uppercased()
+            await MainActor.run {
+                self.current = country
+                let defaults = UserDefaults.standard
+                defaults.set(country ?? "", forKey: self.cacheKey)
+                defaults.set(Date(), forKey: self.cacheKeyFetchedAt)
+            }
+        } catch {
+            // Fail open — leave `current` unchanged, don't update the
+            // cache. Next launch retries instead of pinning unknown
+            // for a day after a transient network blip.
+        }
+    }
+
+    /// True when the station has no known geo-restriction, the
+    /// visitor is in the allow-list, or the visitor's country is
+    /// unknown. Fails open — when in doubt we show the station as
+    /// available rather than badge a working one as unavailable.
+    func isAvailable(_ station: Station) -> Bool {
+        guard let allowed = station.availableIn, !allowed.isEmpty else { return true }
+        guard let me = current else { return true }
+        return allowed.contains(me.uppercased())
+    }
+
+    /// Short user-facing label for the geo restriction. Returns nil
+    /// when no badge should be shown — same gating as `isAvailable`
+    /// but inverted, plus a nil when the visitor's region is unknown
+    /// (we don't want to badge with copy that may be misleading).
+    func restrictionLabel(
+        _ station: Station,
+        countryName: (String) -> String,
+    ) -> String? {
+        guard let allowed = station.availableIn, !allowed.isEmpty else { return nil }
+        guard let me = current else { return nil }
+        let upper = allowed.map { $0.uppercased() }
+        if upper.contains(me.uppercased()) { return nil }
+        if upper.count == 1 {
+            return "\(countryName(upper[0])) only"
+        }
+        return "Only in " + upper.map(countryName).joined(separator: ", ")
+    }
+}
+
+/// Single source of truth for the rrradio-stats Worker base URL.
+/// Kept here next to `RegionResolver` because that's where it's
+/// introduced; promote to a shared config file if a second caller
+/// needs it.
+enum WorkerAPI {
+    static let base = "https://rrradio-stats.markussteinbrecher.workers.dev"
+}

--- a/ios/rrradio/Models/Station.swift
+++ b/ios/rrradio/Models/Station.swift
@@ -29,11 +29,20 @@ struct Station: Identifiable, Hashable, Codable {
     /// `[lat, lon]` for map view.
     var geo: [Double]? = nil
     var featured: Bool? = nil
+    /// ISO 3166-1 alpha-2 country codes where the stream is known to be
+    /// reachable. Absent (or empty) means "no known restriction" — the
+    /// default and the case for the overwhelming majority of stations.
+    /// When set, the UI dims the row with a "<Country> only" badge for
+    /// users outside the allow-list, and the AVPlayer error path maps
+    /// upstream 401s to a friendly geo-restricted message instead of
+    /// the generic "stream failed". Set by curation when a broadcaster
+    /// geo-gates (typically a SUISA/SwissPerform/GEMA licensing issue).
+    var availableIn: [String]? = nil
 
     enum CodingKeys: String, CodingKey {
         case id, name, streamUrl, broadcaster, homepage, country, tags, favicon
         case bitrate, codec, listeners, metadataUrl, metadata, status
-        case geo, featured
+        case geo, featured, availableIn
     }
 }
 
@@ -66,6 +75,10 @@ extension Station {
         status = try container.decodeIfPresent(String.self, forKey: .status)
         geo = try container.decodeIfPresent([Double].self, forKey: .geo)
         featured = try container.decodeIfPresent(Bool.self, forKey: .featured)
+        // Uppercase on decode so callers can compare against the visitor's
+        // country code (also stored uppercase) without per-call normalization.
+        availableIn = try container.decodeIfPresent([String].self, forKey: .availableIn)?
+            .map { $0.uppercased() }
     }
 
     private static func decodeOptionalURL(

--- a/ios/rrradio/Player/AudioPlayer.swift
+++ b/ios/rrradio/Player/AudioPlayer.swift
@@ -579,7 +579,26 @@ final class AudioPlayer {
                         diagnosticRecord("playback", "ready to play", details: self.stationDiagnostics(current))
                     }
                 case .failed:
-                    self.state = .error(errMsg ?? "playback failed")
+                    // Translate generic playback failures into a
+                    // friendly geo-restricted message when the
+                    // curated `availableIn` field tells us this
+                    // station is region-locked and the visitor is
+                    // outside the allow-list. The 401 the AIS9
+                    // streaming server returns gets buried under a
+                    // generic NSURLError, so without this override
+                    // the user just sees "playback failed".
+                    let geoMessage: String? = {
+                        guard let station = self.current,
+                              !RegionResolver.shared.isAvailable(station),
+                              let label = RegionResolver.shared.restrictionLabel(
+                                station,
+                                countryName: countryDisplayName,
+                              )
+                        else { return nil }
+                        return "\(label) — region-locked by the broadcaster."
+                    }()
+                    let displayMsg = geoMessage ?? errMsg ?? "playback failed"
+                    self.state = .error(displayMsg)
                     diagnosticRecord(
                         "playback",
                         "item failed",
@@ -588,6 +607,7 @@ final class AudioPlayer {
                             "stationID": self.current?.id ?? "",
                             "streamHost": self.current?.streamUrl.host() ?? "",
                             "error": errMsg ?? "playback failed",
+                            "geoRestricted": geoMessage != nil ? "true" : "false",
                         ],
                     )
                     self.handlePlayerItemPlaybackProblem(reason: "item failed", error: errMsg)

--- a/ios/rrradio/Views/StationListView.swift
+++ b/ios/rrradio/Views/StationListView.swift
@@ -4177,6 +4177,13 @@ struct StationRow: View {
                 }
             }
             .frame(minHeight: usesFavoritesMetadataLayout ? 72 : 38)
+            // Dim the artwork + text body when this station is
+            // geo-restricted away from the user's region. We still
+            // let them tap (in case they're VPN'd to CH or the
+            // CF-IPCountry lookup misread their region); the player
+            // then surfaces the friendly restriction message if the
+            // stream fails.
+            .opacity(isGeoRestricted ? 0.6 : 1)
             .contentShape(Rectangle())
             .onTapGesture {
                 if suppressNextPlay {
@@ -4388,6 +4395,19 @@ struct StationRow: View {
     @ViewBuilder
     private var stationTagLine: some View {
         HStack(spacing: 6) {
+            if let label = geoRestrictionLabel {
+                Text(label)
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundStyle(Color(red: 0.94, green: 0.72, blue: 0.36))
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 1)
+                    .background(
+                        RoundedRectangle(cornerRadius: 4, style: .continuous)
+                            .fill(Color(red: 1.0, green: 0.72, blue: 0.30).opacity(0.16)),
+                    )
+                    .lineLimit(1)
+                    .accessibilityLabel("Geo-restricted: \(label)")
+            }
             if isCustom {
                 Text("added station")
                     .font(.system(size: 10.5, weight: .regular, design: .monospaced))
@@ -4405,6 +4425,20 @@ struct StationRow: View {
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    /// Non-nil when the station has a curated `availableIn` allow-list
+    /// and the visitor's region (per RegionResolver) is outside it.
+    /// Touching `RegionResolver.shared.current` here means SwiftUI
+    /// observation re-renders the row when the fetch resolves.
+    private var geoRestrictionLabel: String? {
+        RegionResolver.shared.restrictionLabel(station, countryName: countryDisplayName)
+    }
+
+    /// True when the station has a geo-restriction and the visitor
+    /// isn't inside the allow-list. Drives the dimmed appearance.
+    private var isGeoRestricted: Bool {
+        !RegionResolver.shared.isAvailable(station)
     }
 
     private enum DetailTextStyle {

--- a/public/station-duplicates.json
+++ b/public/station-duplicates.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-15T07:12:41.903Z",
+  "generatedAt": "2026-05-15T13:43:01.581Z",
   "totalScanned": 17105,
   "collisionCount": 7,
   "byKind": {

--- a/public/stations.json
+++ b/public/stations.json
@@ -25,7 +25,10 @@
         7.3434
       ],
       "featured": true,
-      "status": "working"
+      "status": "working",
+      "availableIn": [
+        "CH"
+      ]
     },
     {
       "id": "builtin-fm4",

--- a/src/main.ts
+++ b/src/main.ts
@@ -46,6 +46,11 @@ import {
 import { STATS_WORKER_BASE } from './config';
 import { countryName } from './country';
 import {
+  fetchUserRegion,
+  geoRestrictionLabel,
+  isAvailableInUserRegion,
+} from './region';
+import {
   activeCountryMap,
   aggregateDashboard,
   type DashboardData,
@@ -510,9 +515,17 @@ function buildRow(station: Station, currentId: string, state: NowPlaying['state'
   const isCurrent = !!currentId && station.id === currentId;
   const isPaused = isCurrent && state !== 'playing';
   const isFav = favs.has(station.id);
+  // `availableIn` is a curated list of countries where the stream is
+  // known to be reachable. When the visitor's country (from the
+  // worker's CF-IPCountry lookup) is outside that list, dim the row
+  // and append a "Switzerland only" / "Only in CH, FR" badge so the
+  // user knows up front rather than discovering it on a tap.
+  const geoRestricted = !isAvailableInUserRegion(station);
+  const geoLabel = geoRestricted ? geoRestrictionLabel(station, countryName) : null;
 
   const row = document.createElement('div');
-  row.className = 'row' + (isCurrent ? ' is-playing' : '');
+  row.className =
+    'row' + (isCurrent ? ' is-playing' : '') + (geoRestricted ? ' is-geo-restricted' : '');
   row.setAttribute('role', 'button');
   row.tabIndex = 0;
   row.dataset.id = station.id;
@@ -536,6 +549,15 @@ function buildRow(station: Station, currentId: string, state: NowPlaying['state'
   tags.className = 'row-tags';
   const stars = buildCapabilityStars(station);
   if (stars) tags.append(stars);
+  if (geoLabel) {
+    const geo = document.createElement('span');
+    geo.className = 'row-geo';
+    geo.textContent = geoLabel;
+    // Hover/long-press tooltip — same copy the player error path
+    // falls back to when AVPlayer or the browser fails on the 401.
+    geo.title = `${geoLabel} — likely a music-licensing geo-block from the broadcaster.`;
+    tags.append(geo);
+  }
   const tagsText = document.createElement('span');
   tagsText.className = 'row-tags__text';
   tagsText.textContent = (station.tags ?? []).slice(0, 3).join(' · ');
@@ -3442,6 +3464,21 @@ let prevStationId = '';
 let lastErrorMessage = '';
 
 player.subscribe((np) => {
+  // Translate a generic stream-failed error into a friendly
+  // geo-restricted message when the curated `availableIn` flag tells
+  // us this station is region-locked and the visitor is outside the
+  // allow-list. The browser only surfaces a vague MediaError code on
+  // the 401 the AIS9 streaming server returns, so without this
+  // override the user would see "Cannot decode stream" or "Stream
+  // error" for what's really a licensing geo-gate. Telemetry then
+  // records the override message too, which is actually more useful
+  // than the generic code — confirmed-geo errors get their own bucket.
+  if (np.state === 'error' && !isAvailableInUserRegion(np.station)) {
+    const label = geoRestrictionLabel(np.station, countryName);
+    if (label) {
+      np = { ...np, errorMessage: `${label} — region-locked by the broadcaster.` };
+    }
+  }
   const stationLost = !np.station.id && currentNP.station.id && activeTab === 'playing';
   const stationChanged = np.station.id && np.station.id !== currentNP.station.id;
   currentNP = np;
@@ -3533,6 +3570,17 @@ void loadBuiltinStations().then(() => {
   syncCountryOptions();
   if (activeTab === 'browse') renderContent();
   autoLoadStationFromUrl();
+});
+// Fetch the visitor's country from the worker so geo-restricted
+// station rows can show a "<Country> only" badge instead of failing
+// silently at play time. Fire-and-forget — the result is cached in
+// localStorage for 24h, and the rerender on resolve is cheap when
+// nothing geo-restricted is visible. We re-render unconditionally
+// because the answer could just as easily be "unknown" (in which
+// case we already render correctly), but a single extra renderContent
+// pass on page load is harmless.
+void fetchUserRegion().then(() => {
+  renderContent();
 });
 // Sitelinks search box (Google / Bing) and any inbound link with
 // `?q=...` lands on '/' with a query — prefill the search input so

--- a/src/region.test.ts
+++ b/src/region.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  __resetRegionCacheForTests,
+  fetchUserRegion,
+  geoRestrictionLabel,
+  getCachedUserRegion,
+  isAvailableInUserRegion,
+} from './region';
+
+const countryName = (cc: string): string =>
+  ({ CH: 'Switzerland', DE: 'Germany', FR: 'France' })[cc] ?? cc;
+
+beforeEach(() => {
+  __resetRegionCacheForTests();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('isAvailableInUserRegion', () => {
+  it('returns true when station has no restriction', () => {
+    expect(isAvailableInUserRegion({}, 'DE')).toBe(true);
+    expect(isAvailableInUserRegion({ availableIn: [] }, 'DE')).toBe(true);
+  });
+
+  it('returns true when user country is in the allow-list (case-insensitive)', () => {
+    expect(isAvailableInUserRegion({ availableIn: ['CH'] }, 'CH')).toBe(true);
+    expect(isAvailableInUserRegion({ availableIn: ['CH'] }, 'ch')).toBe(true);
+  });
+
+  it('returns false when user country is outside the allow-list', () => {
+    expect(isAvailableInUserRegion({ availableIn: ['CH'] }, 'DE')).toBe(false);
+  });
+
+  it('fails open when user country is unknown', () => {
+    // We'd rather show a geo-restricted station and let it fail at
+    // playback than badge a working station as unavailable because we
+    // can't read CF-IPCountry from an anycast / Tor edge.
+    expect(isAvailableInUserRegion({ availableIn: ['CH'] }, null)).toBe(true);
+  });
+});
+
+describe('geoRestrictionLabel', () => {
+  it('returns null when no restriction', () => {
+    expect(geoRestrictionLabel({}, countryName, 'DE')).toBeNull();
+  });
+
+  it('returns null when user country is unknown', () => {
+    expect(geoRestrictionLabel({ availableIn: ['CH'] }, countryName, null)).toBeNull();
+  });
+
+  it('returns null when user is in the allow-list', () => {
+    expect(geoRestrictionLabel({ availableIn: ['CH'] }, countryName, 'CH')).toBeNull();
+  });
+
+  it('formats a single-country restriction', () => {
+    expect(geoRestrictionLabel({ availableIn: ['CH'] }, countryName, 'DE')).toBe(
+      'Switzerland only',
+    );
+  });
+
+  it('formats a multi-country restriction', () => {
+    expect(
+      geoRestrictionLabel({ availableIn: ['CH', 'FR'] }, countryName, 'DE'),
+    ).toBe('Only in Switzerland, France');
+  });
+});
+
+describe('fetchUserRegion', () => {
+  it('reads CF-IPCountry through the worker and caches the result', async () => {
+    // mockImplementation builds a fresh Response per call. mockResolvedValue
+    // reuses the same Response object across calls, and Response bodies are
+    // single-shot streams — so a re-fetch (e.g., if cache reads fail under
+    // happy-dom) silently produces `country: undefined` and the bug masks
+    // itself as a cache miss.
+    const fetchSpy = vi.spyOn(global, 'fetch').mockImplementation(
+      async () =>
+        new Response(JSON.stringify({ country: 'DE' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    );
+    expect(await fetchUserRegion()).toBe('DE');
+    expect(getCachedUserRegion()).toBe('DE');
+    // Cached call doesn't refetch — important so we don't ping the
+    // worker on every page navigation.
+    expect(await fetchUserRegion()).toBe('DE');
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null when the worker says country is unknown', async () => {
+    vi.spyOn(global, 'fetch').mockImplementation(
+      async () =>
+        new Response(JSON.stringify({ country: null }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    );
+    expect(await fetchUserRegion()).toBeNull();
+  });
+
+  it('returns null on network error and does not pin the cache', async () => {
+    // Network errors fail open: next fetch retries instead of locking
+    // the user to "unknown" for a full day.
+    vi.spyOn(global, 'fetch').mockRejectedValue(new Error('network'));
+    expect(await fetchUserRegion()).toBeNull();
+    // No cache entry was written, so a subsequent successful fetch
+    // does refetch.
+    const second = vi.spyOn(global, 'fetch').mockImplementation(
+      async () => new Response(JSON.stringify({ country: 'CH' }), { status: 200 }),
+    );
+    expect(await fetchUserRegion()).toBe('CH');
+    expect(second).toHaveBeenCalled();
+  });
+
+  it('coalesces concurrent calls into a single fetch', async () => {
+    let resolveFetch: (r: Response) => void = () => {};
+    const pending = new Promise<Response>((r) => (resolveFetch = r));
+    const fetchSpy = vi.spyOn(global, 'fetch').mockReturnValue(pending);
+    const a = fetchUserRegion();
+    const b = fetchUserRegion();
+    resolveFetch(
+      new Response(JSON.stringify({ country: 'CH' }), { status: 200 }),
+    );
+    expect(await a).toBe('CH');
+    expect(await b).toBe('CH');
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/region.ts
+++ b/src/region.ts
@@ -1,0 +1,147 @@
+/**
+ * Visitor region detection for geo-restricted stations.
+ *
+ * The Cloudflare Worker hands us back the visitor's country via
+ * `/api/public/region`, sourced from Cloudflare's `CF-IPCountry`
+ * header (network location, not the device locale — exactly what we
+ * want for "can this station's stream reach you"). The result is
+ * cached in localStorage for a day so most page loads don't pay
+ * the round-trip.
+ *
+ * Country can legitimately be `null` (Tor exits, anycast, missing
+ * header). Callers should treat null as "unknown" and fall back to
+ * "no restriction" UX — better to over-show a station than to badge
+ * a working one as inaccessible.
+ */
+import { STATS_WORKER_BASE } from './config';
+import type { Station } from './types';
+
+const CACHE_KEY = 'rrradio.region.v1';
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 h
+
+interface CacheEntry {
+  country: string | null;
+  fetchedAt: number;
+}
+
+let inMemoryCountry: string | null | undefined = undefined;
+let inFlight: Promise<string | null> | null = null;
+
+function readCache(): CacheEntry | null {
+  try {
+    const raw = localStorage.getItem(CACHE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as CacheEntry;
+    if (typeof parsed.fetchedAt !== 'number') return null;
+    if (Date.now() - parsed.fetchedAt > CACHE_TTL_MS) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function writeCache(country: string | null): void {
+  try {
+    localStorage.setItem(CACHE_KEY, JSON.stringify({ country, fetchedAt: Date.now() }));
+  } catch {
+    // Storage full or denied — fine, we'll just refetch next time.
+  }
+}
+
+/** Synchronous cached read. Returns the user's country (uppercase
+ *  ISO-3166 alpha-2) when known, or null when unknown or not yet
+ *  fetched. Use `fetchUserRegion()` to populate the cache on boot. */
+export function getCachedUserRegion(): string | null {
+  if (inMemoryCountry !== undefined) return inMemoryCountry;
+  const cached = readCache();
+  inMemoryCountry = cached?.country ?? null;
+  return inMemoryCountry;
+}
+
+/** Fetch the visitor's country from the worker, with cache + dedupe.
+ *  Always resolves — network errors map to `null` (unknown). Safe to
+ *  call repeatedly; subsequent calls return the same in-flight or
+ *  cached value. */
+export async function fetchUserRegion(): Promise<string | null> {
+  // In-memory cache first. Doesn't depend on localStorage being
+  // reachable (private-mode Safari, sandboxed iframes), and is the
+  // only state that's guaranteed to round-trip in the same session.
+  if (inMemoryCountry !== undefined) return inMemoryCountry;
+  const cached = readCache();
+  if (cached) {
+    inMemoryCountry = cached.country;
+    return cached.country;
+  }
+  if (inFlight) return inFlight;
+  inFlight = (async () => {
+    try {
+      const res = await fetch(`${STATS_WORKER_BASE}/api/public/region`);
+      if (!res.ok) return null;
+      const data = (await res.json()) as { country?: unknown };
+      const country =
+        typeof data.country === 'string' && data.country.length === 2
+          ? data.country.toUpperCase()
+          : null;
+      writeCache(country);
+      inMemoryCountry = country;
+      return country;
+    } catch {
+      // Don't poison the cache on network errors — fail open so the
+      // next visit retries instead of pinning "unknown" for a day.
+      // Importantly, leave inMemoryCountry as `undefined` (the
+      // "unset" sentinel) rather than setting it to `null` (the
+      // "known-unknown" value), otherwise the in-memory cache would
+      // short-circuit subsequent calls and never recover from a
+      // transient network blip.
+      return null;
+    } finally {
+      inFlight = null;
+    }
+  })();
+  return inFlight;
+}
+
+/** Returns true when the station has no known geo-restriction OR the
+ *  user is inside the allow-list OR we don't know where the user is.
+ *  Fails open — when in doubt we show the station as available.
+ *  `userCountry` defaults to the cached region but can be overridden
+ *  for tests. */
+export function isAvailableInUserRegion(
+  station: Pick<Station, 'availableIn'>,
+  userCountry: string | null = getCachedUserRegion(),
+): boolean {
+  if (!station.availableIn || station.availableIn.length === 0) return true;
+  if (!userCountry) return true;
+  return station.availableIn.includes(userCountry.toUpperCase());
+}
+
+/** Short user-facing label for the geo restriction, e.g. "Switzerland
+ *  only" when the station has `availableIn: ['CH']` and the visitor
+ *  isn't in CH. Returns null when no badge should be shown. */
+export function geoRestrictionLabel(
+  station: Pick<Station, 'availableIn'>,
+  countryName: (cc: string) => string,
+  userCountry: string | null = getCachedUserRegion(),
+): string | null {
+  if (!station.availableIn || station.availableIn.length === 0) return null;
+  if (!userCountry) return null;
+  if (station.availableIn.map((c) => c.toUpperCase()).includes(userCountry.toUpperCase())) {
+    return null;
+  }
+  if (station.availableIn.length === 1) {
+    return `${countryName(station.availableIn[0])} only`;
+  }
+  return `Only in ${station.availableIn.map(countryName).join(', ')}`;
+}
+
+/** Test seam: reset the in-memory cache. Not exported through index;
+ *  reach in via the module import in test files. */
+export function __resetRegionCacheForTests(): void {
+  inMemoryCountry = undefined;
+  inFlight = null;
+  try {
+    localStorage.removeItem(CACHE_KEY);
+  } catch {
+    // ignore
+  }
+}

--- a/src/style.css
+++ b/src/style.css
@@ -767,6 +767,34 @@ html.theme-switching *::after {
 }
 .row-stars__star svg { width: 11px; height: 11px; display: block; }
 
+/* Geo-restriction badge — shown on rows whose curated `availableIn`
+   excludes the visitor's country. Sits inside .row-tags between the
+   capability stars and the tag list, in the warm-amber accent so it
+   reads as "heads up" rather than as an error. The whole row is
+   dimmed via .row.is-geo-restricted so the badge isn't the only
+   visual cue. */
+.row-geo {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  padding: 1px 6px;
+  border-radius: 4px;
+  background: rgba(255, 184, 76, 0.16);
+  color: #f0b75c;
+  text-transform: none;
+  letter-spacing: 0.02em;
+  font-size: 10px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+.row.is-geo-restricted .row-name,
+.row.is-geo-restricted .row-tags__text {
+  opacity: 0.6;
+}
+.row.is-geo-restricted .row-favicon {
+  opacity: 0.7;
+}
+
 .row-right {
   display: flex;
   align-items: center;

--- a/src/types.ts
+++ b/src/types.ts
@@ -77,6 +77,15 @@ export interface Station {
    *  - `stream-only` — stream confirmed, no metadata source
    *  Drives the row capability badges. Absent on RB long-tail / custom adds. */
   status?: 'working' | 'icy-only' | 'stream-only';
+  /** ISO-3166 alpha-2 country codes where the stream is known to be
+   *  reachable. Absent means "no known restriction" — the default and
+   *  the case for the overwhelming majority of stations. When set, the
+   *  UI dims the row with a "<Country> only" badge for users outside
+   *  the allow-list, and the playback error path translates upstream
+   *  401s into a friendly geo-restricted message rather than a generic
+   *  stream-failed alert. Set by curation when a broadcaster geo-gates
+   *  (typically a music-licensing constraint — SUISA, GEMA, etc.). */
+  availableIn?: string[];
 }
 
 export type PlayerState = 'idle' | 'loading' | 'playing' | 'paused' | 'error';

--- a/tools/build-catalog.mjs
+++ b/tools/build-catalog.mjs
@@ -188,6 +188,14 @@ function merged(s) {
     geo: Array.isArray(s.geo) && s.geo.length === 2 ? s.geo : fromRb.geo,
     featured: s.featured === true ? true : undefined,
     status: s.status,
+    // Geo-restriction allow-list (ISO 3166-1 alpha-2, uppercase). Only
+    // emitted when the local YAML sets the field — there's no RB
+    // equivalent and no broadcaster fallback. Empty arrays are
+    // intentionally dropped (treated as "no restriction known").
+    availableIn:
+      Array.isArray(s.availableIn) && s.availableIn.length > 0
+        ? s.availableIn.map((cc) => String(cc).toUpperCase())
+        : undefined,
     _rb: rb, // kept for post-merge validation; stripped before write
   };
 }

--- a/worker/README.md
+++ b/worker/README.md
@@ -30,6 +30,7 @@ are JSON. All endpoints accept GET. All errors have shape
 | --- | --- | --- | --- |
 | `/api/public/top-stations` | `days` (1–90, default 7), `limit` (1–50, default 5) | `{ items: [{ name, count, series }], total, range_days, days }` — top stations from `play: <name>` events. `series[i]` is the play count on `days[i]` (oldest → newest, zero-filled for empty days). | 1 h |
 | `/api/public/totals` | `days` | `{ total, total_events, range_days }` — site-wide pageview + event counts | 1 h |
+| `/api/public/region` | — | `{ country }` — visitor's ISO 3166-1 alpha-2 country code from `CF-IPCountry`, or `null` when unknown (Tor, anycast, etc.). Used by the apps to surface geo-restricted-station badges. | no-store |
 | `/api/public/locations` | `days`, `limit` | `{ items: [{ code, name, count }], total, range_days }` — visitor country breakdown | 1 h |
 | `/api/public/proxy` | `url=<encoded>` | Forwarded JSON body of the upstream URL, **only** if the URL matches the allowlist (else 403) | 1 m |
 | `/api/public/bbc/schedule/<service>` | `service` is the BBC station slug (e.g. `bbc_world_service`) | Forwarded `rms.api.bbc.co.uk` schedule JSON | 10 m |

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -392,6 +392,32 @@ describe('public endpoints', () => {
     const res = await call('/api/public/nope');
     expect(res.status).toBe(404);
   });
+
+  it('GET /api/public/region surfaces the CF-IPCountry country code', async () => {
+    const res = await worker.fetch(
+      new Request('https://worker.test/api/public/region', {
+        headers: { 'CF-IPCountry': 'de' },
+      }),
+      ENV,
+    );
+    expect(res.status).toBe(200);
+    const body = await json<{ country: string | null }>(res);
+    expect(body.country).toBe('DE');
+    expect(res.headers.get('Cache-Control')).toBe('no-store');
+  });
+
+  it('GET /api/public/region returns null for unknown / Tor / missing geo', async () => {
+    for (const header of [undefined, 'XX', 'T1', '']) {
+      const headers: Record<string, string> = {};
+      if (header !== undefined) headers['CF-IPCountry'] = header;
+      const res = await worker.fetch(
+        new Request('https://worker.test/api/public/region', { headers }),
+        ENV,
+      );
+      const body = await json<{ country: string | null }>(res);
+      expect(body.country).toBeNull();
+    }
+  });
 });
 
 describe('proxy allowlist', () => {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -457,6 +457,30 @@ export default {
           );
         }
 
+        // Public region — visitor's country code from Cloudflare's
+        // CF-IPCountry header. Used by the apps to decide whether to
+        // dim a geo-restricted station's row ("Switzerland only" badge,
+        // etc.). Country code only — no city, no IP, no coordinates —
+        // so this is intentionally less identifying than the
+        // /api/public/locations stats endpoint we already ship.
+        //
+        // Not edge-cached (Vary on the country header would shard the
+        // cache and the response is tiny anyway). The frontend caches
+        // the value in localStorage for a session.
+        if (url.pathname === '/api/public/region') {
+          const country = (req.headers.get('CF-IPCountry') || '').toUpperCase();
+          // CF returns "XX" for unrecognized and "T1" for Tor exits;
+          // surface both as "unknown" rather than a fake country code
+          // so the frontend doesn't try to badge with garbage.
+          const known =
+            country.length === 2 && country !== 'XX' && country !== 'T1' ? country : null;
+          return noStoreJsonResponse(
+            { country: known },
+            200,
+            publicCors,
+          );
+        }
+
         // Public totals — same shape as /api/totals (admin) but with no
         // PII to redact in the first place. GoatCounter `/stats/total`
         // returns aggregate visit + event counts only. Used by the


### PR DESCRIPTION
## Summary

Grrif's four Infomaniak stream URLs return **HTTP 401** from non-Swiss IPs — a music-licensing geo-block (SUISA / SwissPerform) dressed up as auth by AIS9. The previous behaviour was a generic "stream failed" on tap with no explanation. This PR ships the end-to-end fix:

- **Catalog flag** `availableIn?: string[]` on the Station schema.
- **Visitor region detection** via a new lightweight Worker endpoint that surfaces Cloudflare's `CF-IPCountry`.
- **Web + iOS UI** dim the row, add a "Switzerland only" badge, and override the player's error message with a friendly geo-restricted reason when playback fails.

Tagging Grrif as `availableIn: [CH]` is included; the same pattern applies to any future broadcaster that geo-gates.

## What's in the catalog schema

Single optional field. Absent ⇒ no restriction known (every other station). Set by curation only after a confirmed reproduction from at least one out-of-region IP.

```yaml
- id: builtin-grrif
  ...
  availableIn:
    - CH
```

`build-catalog.mjs` plumbs the field through with uppercase normalisation; empty arrays are dropped.

## How visitor region is detected

New Worker endpoint `GET /api/public/region` returns `{ country: "DE" | null }`. Sourced from Cloudflare's `CF-IPCountry` header — visitor's network location, not device locale. Unknown country codes (`XX`, Tor `T1`, missing header) map to `null` so frontends don't badge with garbage. Not edge-cached (Vary on country would shard; response is tiny anyway).

Apps cache the result for 24h:
- **Web**: `localStorage` (`src/region.ts`), with in-memory dedupe.
- **iOS**: `UserDefaults` (`Models/RegionResolver.swift`), `@Observable` so SwiftUI redraws rows when the fetch resolves.

Both fail open on network errors — transient blips don't pin "unknown" for a day.

## What the user sees

- **Row treatment**: amber "Switzerland only" badge in the tag line, whole row dimmed to ~60% opacity. Still tappable (a CH user on a Berlin VPN might want to try anyway).
- **Playback error**: the web `MediaError` and iOS `AVPlayer .failed` paths consult the catalog flag and override the generic "stream failed" with `"Switzerland only — region-locked by the broadcaster."` when the visitor is outside the allow-list. Telemetry records the override message, which is more useful than the underlying browser/AVFoundation error code.
- **No-cf-country case**: when the worker returns `null`, we fail open — no badge, no dim, no override. We'd rather show a working station than confuse a CH user whose IP didn't geo-resolve.

## File map

| Layer | Files |
|---|---|
| Schema | `src/types.ts`, `ios/rrradio/Models/Station.swift`, `tools/build-catalog.mjs` |
| Data | `data/stations.yaml` (Grrif tagged), `public/stations.json` (regenerated) |
| Worker | `worker/src/index.ts` (+ tests), `worker/README.md` |
| Web | `src/region.ts` (new) + `src/region.test.ts`, `src/main.ts`, `src/style.css` |
| iOS | `ios/rrradio/Models/RegionResolver.swift` (new), `ios/rrradio/Player/AudioPlayer.swift`, `ios/rrradio/Views/StationListView.swift` |
| Docs | `docs/operations.md` (new "Geo-restricted stations" section) |

## Test plan

- [x] **Worker**: 39 tests pass — 2 new cover the new `/api/public/region` endpoint (known country + unknown / Tor / missing-header cases).
- [x] **Web**: 375 tests pass — `src/region.test.ts` covers the allow-list logic, label formatting, cache + dedupe, and the fail-open network-error path.
- [x] **iOS**: 253 tests pass on iPhone 17 simulator. `xcodebuild build` succeeds.
- [ ] **Manual verification on rrradio.org from a non-Swiss IP**: Grrif row should be dimmed with a "Switzerland only" badge. Tapping plays nothing and surfaces the friendly message in the mini-player.
- [ ] **Manual verification on iOS in DE**: same behaviour. Tap Grrif → AudioPlayer surfaces the geo message instead of "playback failed".
- [ ] **Catch-up build**: Radio Browser API was down at commit time so `npm run catalog` couldn't fully regenerate `public/stations.json` from YAML. The Grrif entry was patched in-place; CI's `catalog-watch` will fully regenerate on its next successful run.

## Out of scope / follow-ups

- **Runtime 401 fallback** for stations we forgot to flag — a HEAD probe on play failure that classifies the 401 and shows the geo message even without curation. Useful as a safety net but needs careful tuning to avoid false positives. Worth filing as a follow-up issue if you want it.
- **Sweep other Swiss stations** for the same geo-gate (RTS, RSR, possibly SRG-Schweizer Radio family). Each needs out-of-region verification before flagging.
- **Android wiring**: schema is JSON-compatible; the in-progress Android port can read `availableIn` directly when it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)