### PR TITLE
Keep geo-restricted error message visible past the retry loop

### DIFF
--- a/ios/rrradio/Player/AudioPlayer.swift
+++ b/ios/rrradio/Player/AudioPlayer.swift
@@ -587,16 +587,14 @@ final class AudioPlayer {
                     // streaming server returns gets buried under a
                     // generic NSURLError, so without this override
                     // the user just sees "playback failed".
-                    let geoMessage: String? = {
-                        guard let station = self.current,
-                              !RegionResolver.shared.isAvailable(station),
-                              let label = RegionResolver.shared.restrictionLabel(
-                                station,
-                                countryName: countryDisplayName,
-                              )
-                        else { return nil }
-                        return "\(label) — region-locked by the broadcaster."
-                    }()
+                    //
+                    // handlePlayerItemPlaybackProblem (below) also
+                    // short-circuits retries for geo-restricted
+                    // stations and keeps the friendly message
+                    // sticking — without that, the retry loop would
+                    // overwrite this state with the raw error string
+                    // after 3 attempts.
+                    let geoMessage = self.geoRestrictionErrorMessage()
                     let displayMsg = geoMessage ?? errMsg ?? "playback failed"
                     self.state = .error(displayMsg)
                     diagnosticRecord(
@@ -667,7 +665,32 @@ final class AudioPlayer {
     }
 
     func handlePlayerItemPlaybackProblem(reason: String, error: String?) {
-        guard allowsAutomaticStreamRetry, current != nil else { return }
+        guard let station = current else { return }
+        // Geo-restricted stations don't retry — the 401 from the
+        // upstream geo-gate is permanent, not transient. Retrying
+        // would flip state between .loading and .error three times
+        // and overwrite the friendly message with the raw upstream
+        // error from the retry-exhausted branch. Stop now, keep the
+        // curated message, save the user (and our diagnostics
+        // budget) from three pointless retries.
+        if let geoMessage = geoRestrictionErrorMessage() {
+            allowsAutomaticStreamRetry = false
+            isStreamRetryScheduled = false
+            streamRetryTask?.cancel()
+            streamRetryTask = nil
+            state = .error(geoMessage)
+            diagnosticRecord(
+                "playback",
+                "geo restricted",
+                details: stationDiagnostics(station).merging(
+                    ["reason": reason, "error": error ?? ""],
+                    uniquingKeysWith: { _, new in new },
+                ),
+            )
+            updateNowPlaying()
+            return
+        }
+        guard allowsAutomaticStreamRetry else { return }
         scheduleStreamRetry(reason: reason, error: error)
     }
 
@@ -678,7 +701,13 @@ final class AudioPlayer {
         let attempt = streamRetryAttempt
         guard attempt <= Self.maxStreamRetryAttempts else {
             allowsAutomaticStreamRetry = false
-            state = .error(error ?? "stream unavailable")
+            // Defence in depth: if we somehow reach the
+            // exhausted-retry branch for a geo-restricted station
+            // (e.g., the catalog flag was added between the .failed
+            // case firing and now), still surface the friendly
+            // message instead of the raw upstream error.
+            let geoMessage = geoRestrictionErrorMessage()
+            state = .error(geoMessage ?? error ?? "stream unavailable")
             diagnosticRecord(
                 "playback",
                 "stream retry exhausted",
@@ -764,6 +793,22 @@ final class AudioPlayer {
             "codec": station.codec ?? "",
             "bitrate": station.bitrate.map(String.init) ?? "",
         ]
+    }
+
+    /// Friendly error string for a station whose `availableIn` excludes
+    /// the visitor's region, or nil when the station has no curated
+    /// restriction (or we don't know where the visitor is). Used by
+    /// every code path that sets `state = .error(...)` so the message
+    /// stays consistent regardless of which retry branch fires.
+    func geoRestrictionErrorMessage() -> String? {
+        guard let station = current,
+              !RegionResolver.shared.isAvailable(station),
+              let label = RegionResolver.shared.restrictionLabel(
+                station,
+                countryName: countryDisplayName,
+              )
+        else { return nil }
+        return "\(label) — region-locked by the broadcaster."
     }
 
     private func metadataDiagnostics(_ metadata: NowPlayingMetadata, station: Station) -> [String: String] {

--- a/ios/rrradio/Views/MiniPlayerView.swift
+++ b/ios/rrradio/Views/MiniPlayerView.swift
@@ -282,8 +282,16 @@ struct MiniPlayerView: View {
             return "Live"
         case .paused:
             return "Paused"
-        case .error:
-            return "Error"
+        case .error(let message):
+            // Short enough to fit the miniplayer — the regular geo
+            // message is "Switzerland only — region-locked by the
+            // broadcaster.", which would truncate. Trim to the
+            // country phrase ahead of the em-dash when present, fall
+            // back to the message otherwise.
+            if let dash = message.range(of: " — "), dash.lowerBound > message.startIndex {
+                return String(message[..<dash.lowerBound])
+            }
+            return message
         }
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #378. The friendly geo message from PR #378 was being shown briefly and then overwritten — for two reasons:

1. **Retry loop overwrites it.** `handlePlayerItemPlaybackProblem` schedules up to 3 retries on every `.failed` state. Each retry hits the same 401 geo-gate, so after ~5–10 seconds of flicker `scheduleStreamRetry`'s exhausted branch sets `state = .error("stream unavailable")` using the raw upstream string, blowing away the curated message that the `.failed` branch had just written.

2. **Miniplayer ignores the payload.** Its `stateLine` was hard-coded to `"Error"` for any `.error(_)` state, regardless of the message inside.

End user effect from Germany on Grrif: brief geo flash → Now Playing subtitle shows "stream unavailable" or empty → miniplayer shows "Error". Hence "It just says Playback error."

## Fixes

**`AudioPlayer.handlePlayerItemPlaybackProblem`** — short-circuit retries when the curated `availableIn` excludes the visitor's region. The upstream 401 is permanent, not transient. Tear down the retry bookkeeping, set `state = .error(geoMessage)` once, stop.

**`AudioPlayer.scheduleStreamRetry`** (exhausted-retry branch) — defence-in-depth. If the geo flag is added mid-retry, the exhausted branch also consults `RegionResolver` and writes the friendly message instead of the raw upstream error.

**`AudioPlayer.geoRestrictionErrorMessage()`** — extracted the message construction so all three call sites (`.failed`, retry short-circuit, retry exhausted) use one string. Less drift risk.

**`MiniPlayerView.stateLine`** — reads the `.error(message)` payload. For geo-restricted stations the message is "Switzerland only — region-locked by the broadcaster."; the miniplayer slices off the prefix before the em-dash so "Switzerland only" fits the small status slot. Falls back to the full string for any other error.

## What the user sees after this lands

- **Now Playing** — title still "Playback error" (existing locale string, kept unchanged so non-English locales aren't broken). Subtitle now reliably reads "Switzerland only — region-locked by the broadcaster." because the state stops being overwritten.
- **Miniplayer** — small status line shows "Switzerland only" instead of "Error".
- **No retry flicker** — playback fails to start, geo message appears immediately, stays put.

## Test plan

- [x] `xcodebuild build` on iPhone simulator → succeeded.
- [x] `xcodebuild test` on iPhone 17 simulator → 253 tests pass.
- [ ] Manual on device from Germany: tap Grrif → no retry flicker, NP subtitle reads "Switzerland only — region-locked by the broadcaster.", miniplayer reads "Switzerland only".
- [ ] Manual on device from Switzerland: Grrif still plays normally (geo check returns "available", code paths unchanged).
- [ ] Non-geo stream failure (e.g., a broken stream in Germany): NP subtitle shows the raw error, miniplayer shows the raw message. Confirms no regression for the existing path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)