### PR TITLE
Unflag Grrif as Switzerland-only (block isn't uniform)

### DIFF
--- a/data/stations.yaml
+++ b/data/stations.yaml
@@ -44,14 +44,15 @@
   country: CH
   status: working
   featured: true
-  # All four Infomaniak stream URLs (grrif-128.aac, grrif-48.mp3,
-  # grrif-high.mp3, grrif-64.aac) return HTTP 401 "Authorization
-  # required" from non-Swiss IPs (AIS9 server's geo-block response).
-  # Music-licensing decision (SUISA/SwissPerform); no international
-  # stream exists. Sister station RJB on the same Infomaniak fleet is
-  # not geo-gated, confirming this is broadcaster-side and intentional.
-  availableIn:
-    - CH
+  # Geo-restriction note (do NOT re-flag without fresh evidence):
+  # Grrif's four Infomaniak streams return HTTP 401 from some non-CH
+  # IPs (Deutsche Telekom DSL from Munich, confirmed 2026-05-15). But
+  # the block is NOT uniform — other DE egresses can play the station
+  # fine, and the AIS9 deny-list appears to be edited per-ASN over
+  # time. A `availableIn: [CH]` flag was removed 2026-05-15 because
+  # the resulting "Switzerland only" badge gave false negatives for
+  # German visitors who could in fact listen. Re-flag only if a sweep
+  # across multiple non-CH ASNs shows the block is universal.
 - id: builtin-fm4
   stationuuid: 1e13ed4e-daa9-4728-8550-e08d89c1c8e7
   changeuuid: ae34eaf7-5e77-4144-9eb9-c27a9f33ada2

--- a/public/station-duplicates.json
+++ b/public/station-duplicates.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-15T13:43:01.581Z",
+  "generatedAt": "2026-05-15T20:08:04.993Z",
   "totalScanned": 17105,
   "collisionCount": 7,
   "byKind": {

--- a/public/stations.json
+++ b/public/stations.json
@@ -25,10 +25,7 @@
         7.3434
       ],
       "featured": true,
-      "status": "working",
-      "availableIn": [
-        "CH"
-      ]
+      "status": "working"
     },
     {
       "id": "builtin-fm4",


### PR DESCRIPTION
## Summary

PR #378 set `availableIn: [CH]` on Grrif because four Infomaniak stream URLs returned 401 from a Munich DSL IP. The sponsor reports Grrif *does* play from their phone in Germany. Re-checking the catalog flag: Grrif's AIS9 deny-list is apparently edited per-ASN, not uniform across non-CH egresses. The `availableIn: [CH]` flag was producing false negatives — the "Switzerland only" badge dimmed the row for German visitors who could in fact listen.

Drops `availableIn: [CH]` from the Grrif YAML entry and from `public/stations.json`. Leaves a comment in YAML explaining the evidence and what would be needed to re-flag (consistent block across multiple non-CH ASNs, not a single test path).

## What stays in place

All the infrastructure from PRs #378 and #379 is intact, so any future station where the geo-gate is genuinely uniform can be flagged with one YAML line:

- `Station.availableIn?: string[]` schema field (TS + Swift)
- Worker `GET /api/public/region` endpoint
- `src/region.ts` (web) + `RegionResolver` (iOS)
- Runtime error override + retry short-circuit for geo-restricted stations
- Curator docs in `docs/operations.md`

## Test plan

- [x] `npm test` → 375 pass.
- [x] `check-catalog` + `check-duplicates` pass.
- [ ] On rrradio.org from a German IP: Grrif row no longer dimmed, no "Switzerland only" badge.
- [ ] On iOS in Germany: same — Grrif appears as a regular station, no badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)