### PR TITLE
Restore source-tile visibility until a drop move fires

### DIFF
--- a/ios/rrradio/Views/StationListView.swift
+++ b/ios/rrradio/Views/StationListView.swift
@@ -2615,12 +2615,21 @@ struct StationListView: View {
         @ViewBuilder content: () -> Content,
     ) -> some View {
         if canReorderFavorites {
-            // Hide the source as soon as the drag is picked up — not
-            // after the first drop target registers. Previously the
-            // original tile stayed full-opacity until lastHandledTarget
-            // was set, so the user saw both the drag preview and the
-            // source at full opacity during the initial pickup.
+            // Only hide the source AFTER the first reorder move has
+            // registered — `lastFavoriteDropMoveAt != nil` confirms
+            // some drop machinery actually fired. PR #371 tried to
+            // hide on `draggedFavoriteStationID == station.id` alone
+            // for smoother initial pickup, but SwiftUI's .onDrag has
+            // no drag-cancel callback: if the user lifts their finger
+            // outside any drop target, `draggedStationID` stays set,
+            // the tile stays at opacity 0, and its tap target keeps
+            // firing playback for a station the user can't see. The
+            // proper fix (Transferable + .draggable / .dropDestination)
+            // is tracked in #374; until then we eat the initial-pickup
+            // ghosting to avoid the worse "invisible-but-tappable"
+            // regression.
             let showsReorderPlaceholder = draggedFavoriteStationID == station.id
+                && lastFavoriteDropMoveAt != nil
             let showsDeleteButton = favoriteDeleteModeEnabled
                 && targetedFavoriteStationID == nil
             // SpringBoard-style jiggle while the user is in delete mode.


### PR DESCRIPTION
## Summary

Hotfix for the regression introduced in PR #371: drag a favorite, release outside the grid, the logo disappears but the empty slot still plays the station when tapped.

## Root cause

PR #371 changed the source-tile visibility gate from:

```swift
draggedFavoriteStationID == station.id && lastHandledTarget != nil
```

to:

```swift
draggedFavoriteStationID == station.id
```

for a smoother initial pickup. The known limitation flagged in PR #371's body was: SwiftUI's `.onDrag` has no drag-cancel callback. If the user lifts their finger outside any drop target, `performDrop` never fires, `draggedFavoriteStationID` stays set forever, the tile stays at `opacity(0)`, and — because `.opacity(0)` keeps hit testing on — the row still consumes taps. Visually missing, functionally tappable.

## Fix

Restore the pre-#371 gate. The source tile only goes to `opacity(0)` AFTER `moveIfReady` fires at least once on this drag (i.e., the system has confirmed we're really reordering, not just picking up and canceling).

```swift
let showsReorderPlaceholder = draggedFavoriteStationID == station.id
    && lastFavoriteDropMoveAt != nil
```

Drag-cancel without ever crossing into another tile now leaves the source visible. The brief double-render at pickup (drag preview + source both at full opacity for ~200 ms before the first move) comes back — same as the pre-#371 behavior the smoothness PR was trying to avoid.

## Why not fix the underlying drag-cancel issue

SwiftUI's `.onDrag` legacy API doesn't expose drag-end as a callback. The proper fix is the `Transferable` + `.draggable / .dropDestination` migration, which has a clean drag-end signal regardless of whether a drop happened — already filed as issue #374. Until that lands we trade some pickup smoothness for correctness.

## Test plan

- [x] `xcodebuild build` → succeeded.
- [ ] On device: enter delete mode, drag a favorite, release outside the grid. The tile should remain visible at its original position. Tapping should play it.
- [ ] On device: enter delete mode, drag a favorite onto another tile, drop. Reorder still works as before; placeholder gap shows mid-drag.
- [ ] On device: enter delete mode, no drag. Jiggle still runs on all tiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)