### PR TITLE
iOS: gate music-service buttons on iTunes Search verification (#389 mirror)

### DIFF
--- a/ios/rrradio/Player/AudioPlayer.swift
+++ b/ios/rrradio/Player/AudioPlayer.swift
@@ -104,6 +104,13 @@ final class AudioPlayer {
     }
     private(set) var nowPlayingTitle: String?
     private(set) var nowPlayingArtist: String?
+    /// Result of iTunes Search verification for the current track:
+    /// `true` if iTunes returned a match (plausibly a real song),
+    /// `false` if it returned 0 results (typical for news IDs,
+    /// program names, station jingles), and `nil` while the lookup
+    /// is in-flight or hasn't run. Drives the visibility of the
+    /// Apple Music / Spotify / YT Music buttons in NowPlayingView.
+    private(set) var nowPlayingTrackVerified: Bool?
     private(set) var nowPlayingProgramName: String?
     private(set) var nowPlayingProgramSubtitle: String?
     private(set) var nowPlayingCoverUrl: URL?
@@ -210,6 +217,7 @@ final class AudioPlayer {
         isStreamRetryScheduled = false
         nowPlayingTitle = nil
         nowPlayingArtist = nil
+        nowPlayingTrackVerified = nil
         nowPlayingProgramName = nil
         nowPlayingProgramSubtitle = nil
         nowPlayingCoverUrl = nil
@@ -305,6 +313,7 @@ final class AudioPlayer {
         activePlaybackQueueSourceID = nil
         nowPlayingTitle = nil
         nowPlayingArtist = nil
+        nowPlayingTrackVerified = nil
         nowPlayingProgramName = nil
         nowPlayingProgramSubtitle = nil
         nowPlayingCoverUrl = nil
@@ -1024,11 +1033,23 @@ final class AudioPlayer {
         isLyricsLoading = false
     }
 
+    /// Runs an iTunes Search whenever the current track changes. The
+    /// search serves two purposes:
+    ///
+    ///   1. Cover-art upgrade — applied only when `sourceCoverUrl` is
+    ///      missing or known low-res (we don't downgrade a good
+    ///      station-supplied cover).
+    ///   2. Track verification — `result.hit` populates
+    ///      `nowPlayingTrackVerified`, which NowPlayingView reads to
+    ///      decide whether to surface Apple Music / Spotify / YT Music
+    ///      buttons. News/talk channels emit show names and station
+    ///      IDs that iTunes returns 0 results for; those titles should
+    ///      not surface music-service buttons.
+    ///
+    /// Both signals come from one request, so we always issue the
+    /// search on every new track (not just when cover is needed) and
+    /// let the module-level cache short-circuit repeats.
     private func startCoverArtLoadingIfNeeded(sourceCoverUrl: URL?) {
-        guard sourceCoverUrl == nil || sourceCoverUrl.map(isLowResolutionCoverURL) == true else {
-            resetCoverArtLookup()
-            return
-        }
         guard let title = cleanLyricsComponent(nowPlayingTitle) else {
             resetCoverArtLookup()
             return
@@ -1040,17 +1061,29 @@ final class AudioPlayer {
 
         coverArtTask?.cancel()
         coverArtKey = key
+        // Reset verification while the new lookup is in flight — the
+        // NowPlayingView gate is `=== true`, so `nil` hides the
+        // buttons until the iTunes result arrives.
+        nowPlayingTrackVerified = nil
+
+        let wantsCoverUpgrade =
+            sourceCoverUrl == nil || sourceCoverUrl.map(isLowResolutionCoverURL) == true
+
         coverArtTask = Task { [weak self] in
-            let coverUrl = await lookupCoverArt(artist: artist, title: title)
+            let result = await searchITunes(artist: artist, title: title)
             guard !Task.isCancelled else { return }
             await MainActor.run { [weak self] in
                 guard let self, self.coverArtKey == key else { return }
-                guard let coverUrl else {
-                    diagnosticRecord("cover-art", "not found")
-                    return
+                self.nowPlayingTrackVerified = result.hit
+                if wantsCoverUpgrade, let cover = result.cover {
+                    self.nowPlayingCoverUrl = cover
+                    diagnosticRecord(
+                        "cover-art", "loaded",
+                        details: ["host": cover.host() ?? ""],
+                    )
+                } else if !result.hit {
+                    diagnosticRecord("itunes", "miss")
                 }
-                self.nowPlayingCoverUrl = coverUrl
-                diagnosticRecord("cover-art", "loaded", details: ["host": coverUrl.host() ?? ""])
                 self.updateNowPlaying()
             }
         }
@@ -1060,6 +1093,7 @@ final class AudioPlayer {
         coverArtTask?.cancel()
         coverArtTask = nil
         coverArtKey = ""
+        nowPlayingTrackVerified = nil
     }
 
     private func cleanLyricsComponent(_ value: String?) -> String? {

--- a/ios/rrradio/Player/Metadata/CoverArtFetcher.swift
+++ b/ios/rrradio/Player/Metadata/CoverArtFetcher.swift
@@ -3,6 +3,7 @@ import Foundation
 private let coverArtCacheLimit = 64
 
 private struct ITunesSearchResponse: Decodable {
+    let resultCount: Int
     let results: [ITunesTrack]
 }
 
@@ -12,19 +13,35 @@ private struct ITunesTrack: Decodable {
     let artworkUrl100: String?
 }
 
-private actor CoverArtCache {
-    static let shared = CoverArtCache()
+/// Outcome of an iTunes Search call. `hit` mirrors `resultCount > 0`
+/// and is the signal NowPlayingView uses to decide whether to surface
+/// Apple Music / Spotify / YT Music buttons. `cover` is set only when
+/// the best match also carries 100×100 artwork (which we upgrade to
+/// 600×600 for retina rendering).
+public struct ITunesSearchResult: Equatable {
+    public let hit: Bool
+    public let cover: URL?
 
-    private var values: [String: URL?] = [:]
-    private var order: [String] = []
-
-    func value(for key: String) -> URL?? {
-        guard values.keys.contains(key) else { return nil }
-        return values[key]
+    public init(hit: Bool, cover: URL? = nil) {
+        self.hit = hit
+        self.cover = cover
     }
 
-    func set(_ value: URL?, for key: String) {
-        if !values.keys.contains(key) {
+    public static let miss = ITunesSearchResult(hit: false, cover: nil)
+}
+
+private actor ITunesSearchCache {
+    static let shared = ITunesSearchCache()
+
+    private var values: [String: ITunesSearchResult] = [:]
+    private var order: [String] = []
+
+    func value(for key: String) -> ITunesSearchResult? {
+        values[key]
+    }
+
+    func set(_ value: ITunesSearchResult, for key: String) {
+        if values[key] == nil {
             order.append(key)
         }
         values[key] = value
@@ -36,20 +53,27 @@ private actor CoverArtCache {
     }
 }
 
-func lookupCoverArt(
+/// Run an iTunes Search and cache the outcome. Returns `.miss` on
+/// transport errors *without* caching so the next poll can retry
+/// (network blips don't poison the cache).
+func searchITunes(
     artist: String?,
     title: String,
     fetch: @escaping MetadataDataFetcher = { try await URLSession.shared.data(for: $0) },
-) async -> URL? {
+) async -> ITunesSearchResult {
     let cleanedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard cleanedTitle.count >= 3, cleanedTitle != "-", cleanedTitle != "—" else { return nil }
+    guard cleanedTitle.count >= 3, cleanedTitle != "-", cleanedTitle != "—" else {
+        return .miss
+    }
 
     let key = coverArtCacheKey(artist: artist, title: cleanedTitle)
-    if let cached = await CoverArtCache.shared.value(for: key) {
+    if let cached = await ITunesSearchCache.shared.value(for: key) {
         return cached
     }
 
-    guard let url = coverArtSearchURL(artist: artist, title: cleanedTitle) else { return nil }
+    guard let url = coverArtSearchURL(artist: artist, title: cleanedTitle) else {
+        return .miss
+    }
     var request = URLRequest(url: url)
     request.cachePolicy = .reloadIgnoringLocalCacheData
     request.timeoutInterval = 8
@@ -57,18 +81,49 @@ func lookupCoverArt(
     do {
         let (data, response) = try await fetch(request)
         guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
-            await CoverArtCache.shared.set(nil, for: key)
-            return nil
+            // Treat as a miss for the duration of the cache — better
+            // than re-hitting a flaky endpoint, and a real song will
+            // resurface on a later track.
+            await ITunesSearchCache.shared.set(.miss, for: key)
+            return .miss
         }
 
         let decoded = try JSONDecoder().decode(ITunesSearchResponse.self, from: data)
-        let best = pickBestCoverArtMatch(decoded.results, artist: artist, title: cleanedTitle)
+        let hit = decoded.resultCount > 0
+        let best = hit ? pickBestCoverArtMatch(decoded.results, artist: artist, title: cleanedTitle) : nil
         let cover = best?.artworkUrl100.flatMap(highResolutionITunesArtworkURL)
-        await CoverArtCache.shared.set(cover, for: key)
-        return cover
+        let result = ITunesSearchResult(hit: hit, cover: cover)
+        await ITunesSearchCache.shared.set(result, for: key)
+        return result
     } catch {
-        return nil
+        // Don't cache transient/aborted errors — let the next poll retry.
+        return .miss
     }
+}
+
+/// Cover-art-only wrapper. Returns the high-res artwork URL on hit
+/// (assuming the iTunes record carries one), `nil` otherwise.
+func lookupCoverArt(
+    artist: String?,
+    title: String,
+    fetch: @escaping MetadataDataFetcher = { try await URLSession.shared.data(for: $0) },
+) async -> URL? {
+    await searchITunes(artist: artist, title: title, fetch: fetch).cover
+}
+
+/// Existence-check wrapper. Returns whether iTunes has at least one
+/// result for the given artist+title query. Drives the visibility of
+/// Apple Music / Spotify / YT Music buttons in NowPlayingView — we
+/// only surface them when iTunes confirms the title resolves to
+/// something searchable. News/talk channels emit show names and
+/// station IDs ("BR24 Aktuell", "Nachrichten 12:00 Uhr") that iTunes
+/// won't match; those should NOT surface music-service buttons.
+func verifyTrack(
+    artist: String?,
+    title: String,
+    fetch: @escaping MetadataDataFetcher = { try await URLSession.shared.data(for: $0) },
+) async -> Bool {
+    await searchITunes(artist: artist, title: title, fetch: fetch).hit
 }
 
 func isLowResolutionCoverURL(_ url: URL) -> Bool {

--- a/ios/rrradio/Views/NowPlayingView.swift
+++ b/ios/rrradio/Views/NowPlayingView.swift
@@ -879,15 +879,24 @@ struct NowPlayingView: View {
 
     @ViewBuilder
     private var musicServiceButtons: some View {
-        let links = musicServiceLinks(artist: player.nowPlayingArtist, title: player.nowPlayingTitle)
-        ForEach(links) { link in
-            Button {
-                openURL(link.url)
-            } label: {
-                musicServiceLabel(link)
+        // Only render once iTunes Search has confirmed the title
+        // resolves to a real song (player.nowPlayingTrackVerified ==
+        // true). While the lookup is in-flight (nil) or after a
+        // confirmed miss (false), the buttons stay hidden — the
+        // alternative is sending users to empty Apple Music /
+        // Spotify / YT Music search results, which is the bug this
+        // gate fixes for news/talk stations.
+        if player.nowPlayingTrackVerified == true {
+            let links = musicServiceLinks(artist: player.nowPlayingArtist, title: player.nowPlayingTitle)
+            ForEach(links) { link in
+                Button {
+                    openURL(link.url)
+                } label: {
+                    musicServiceLabel(link)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Open in \(link.title)")
             }
-            .buttonStyle(.plain)
-            .accessibilityLabel("Open in \(link.title)")
         }
     }
 

--- a/ios/rrradioTests/CoverArtFetcherTests.swift
+++ b/ios/rrradioTests/CoverArtFetcherTests.swift
@@ -6,22 +6,32 @@ final class CoverArtFetcherTests: XCTestCase {
         HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: "HTTP/1.1", headerFields: nil)!
     }
 
-    func testLooksUpHighResolutionITunesArtwork() async throws {
-        let artwork = "https://is1-ssl.mzstatic.com/image/thumb/Music123/v4/example/100x100bb.jpg"
-        let payload = """
+    private func hitPayload(artist: String, title: String, artwork: String) -> Data {
+        """
         {
           "resultCount": 1,
           "results": [
             {
-              "artistName": "The Artist",
-              "trackName": "The Song",
+              "artistName": "\(artist)",
+              "trackName": "\(title)",
               "artworkUrl100": "\(artwork)"
             }
           ]
         }
         """.data(using: .utf8)!
+    }
 
-        let cover = await lookupCoverArt(artist: "The Artist", title: "The Song") { request in
+    private var missPayload: Data {
+        """
+        { "resultCount": 0, "results": [] }
+        """.data(using: .utf8)!
+    }
+
+    func testLooksUpHighResolutionITunesArtwork() async throws {
+        let artwork = "https://is1-ssl.mzstatic.com/image/thumb/Music123/v4/example/100x100bb.jpg"
+        let payload = hitPayload(artist: "The Artist A", title: "The Song A", artwork: artwork)
+
+        let cover = await lookupCoverArt(artist: "The Artist A", title: "The Song A") { request in
             XCTAssertEqual(request.url?.host, "itunes.apple.com")
             XCTAssertTrue(request.url?.query?.contains("entity=song") == true)
             return (payload, self.response(for: request.url!))
@@ -34,5 +44,91 @@ final class CoverArtFetcherTests: XCTestCase {
         XCTAssertTrue(isLowResolutionCoverURL(URL(string: "https://example.com/Medias/Covers/m/cover.jpg")!))
         XCTAssertTrue(isLowResolutionCoverURL(URL(string: "https://cdne-satr-prd-rsp-covers.azureedge.net/50/abc.jpg")!))
         XCTAssertFalse(isLowResolutionCoverURL(URL(string: "https://example.com/600x600bb.jpg")!))
+    }
+
+    // MARK: - searchITunes / verifyTrack
+
+    func testSearchITunesReturnsHitAndUpgradedCover() async {
+        let artwork = "https://is1-ssl.mzstatic.com/image/thumb/Music456/v4/100x100bb.jpg"
+        let payload = hitPayload(artist: "Radiohead B", title: "Pyramid Song B", artwork: artwork)
+        let result = await searchITunes(artist: "Radiohead B", title: "Pyramid Song B") { request in
+            (payload, self.response(for: request.url!))
+        }
+        XCTAssertTrue(result.hit)
+        XCTAssertEqual(result.cover?.absoluteString, "https://is1-ssl.mzstatic.com/image/thumb/Music456/v4/600x600bb.jpg")
+    }
+
+    func testSearchITunesReturnsMissOnResultCountZero() async {
+        let result = await searchITunes(artist: nil, title: "BR24 Aktuell C") { request in
+            (self.missPayload, self.response(for: request.url!))
+        }
+        XCTAssertFalse(result.hit)
+        XCTAssertNil(result.cover)
+    }
+
+    func testSearchITunesSkipsShortAndDashTitles() async {
+        let resultEmDash = await searchITunes(artist: nil, title: "—") { _ in
+            XCTFail("network should not be hit for em-dash title")
+            return (Data(), HTTPURLResponse())
+        }
+        XCTAssertFalse(resultEmDash.hit)
+
+        let resultShort = await searchITunes(artist: nil, title: "ab") { _ in
+            XCTFail("network should not be hit for <3-char title")
+            return (Data(), HTTPURLResponse())
+        }
+        XCTAssertFalse(resultShort.hit)
+    }
+
+    func testSearchITunesCachesHitAcrossCalls() async {
+        let payload = hitPayload(
+            artist: "Cached Artist D",
+            title: "Cached Title D",
+            artwork: "https://is1-ssl.mzstatic.com/image/thumb/D/100x100bb.jpg",
+        )
+        var calls = 0
+        let fetch: MetadataDataFetcher = { request in
+            calls += 1
+            return (payload, self.response(for: request.url!))
+        }
+        let first = await searchITunes(artist: "Cached Artist D", title: "Cached Title D", fetch: fetch)
+        let second = await searchITunes(artist: "Cached Artist D", title: "Cached Title D", fetch: fetch)
+        XCTAssertEqual(first, second)
+        XCTAssertEqual(calls, 1)
+    }
+
+    func testSearchITunesCachesMissAcrossCalls() async {
+        var calls = 0
+        let fetch: MetadataDataFetcher = { request in
+            calls += 1
+            return (self.missPayload, self.response(for: request.url!))
+        }
+        let first = await searchITunes(artist: nil, title: "Cached News E", fetch: fetch)
+        let second = await searchITunes(artist: nil, title: "Cached News E", fetch: fetch)
+        XCTAssertFalse(first.hit)
+        XCTAssertFalse(second.hit)
+        XCTAssertEqual(calls, 1)
+    }
+
+    func testVerifyTrackReturnsTrueOnHitAndFalseOnMiss() async {
+        let hit = await verifyTrack(
+            artist: "Radiohead F",
+            title: "Pyramid Song F",
+        ) { request in
+            (
+                self.hitPayload(
+                    artist: "Radiohead F",
+                    title: "Pyramid Song F",
+                    artwork: "https://is1-ssl.mzstatic.com/image/thumb/F/100x100bb.jpg",
+                ),
+                self.response(for: request.url!),
+            )
+        }
+        XCTAssertTrue(hit)
+
+        let miss = await verifyTrack(artist: nil, title: "Nachrichten G") { request in
+            (self.missPayload, self.response(for: request.url!))
+        }
+        XCTAssertFalse(miss)
     }
 }


### PR DESCRIPTION
## Summary

Mirrors **#389** for the iOS app. Apple Music / Spotify / YT Music buttons in NowPlayingView were rendered whenever an ICY `trackTitle` was present, so news/talk stations (BR24 Aktuell, Nachrichten 12:00, etc.) sent users to empty search-result pages. Same bug as on web, same fix: gate the buttons on iTunes Search confirming the title resolves to a real song.

Note: even more appropriate on iOS than on web — Apple's own API on Apple's own platform.

## How it works

The existing `CoverArtFetcher.swift` already hits iTunes Search for cover-art enrichment when the station-supplied cover is missing or low-res. Refactored so the iTunes call lives in `searchITunes(...)` returning `ITunesSearchResult { hit, cover }`, with `lookupCoverArt` kept as a back-compat wrapper and a new `verifyTrack` wrapper. The actor-based cache now stores the full result, so cover enrichment and verification share one network request per `(artist, title)` — no extra iTunes calls on the common case.

`AudioPlayer.startCoverArtLoadingIfNeeded` is now invoked on **every** new track (not just when cover is needed), so the verify signal arrives for all stations. Cover-art application still gates on `sourceCoverUrl == nil || isLowResolution`, so we never downgrade good station-supplied covers.

`NowPlayingView.musicServiceButtons` gates on `player.nowPlayingTrackVerified == true`. Trade-off: ~1–2 s between a new ICY title and the buttons lighting up. Acceptable — preferable to garbage-search-result taps.

## Files

| File | Change |
|---|---|
| `ios/rrradio/Player/Metadata/CoverArtFetcher.swift` | Shared `searchITunes` + `verifyTrack`; `lookupCoverArt` becomes a thin wrapper. Cache stores `ITunesSearchResult`. |
| `ios/rrradio/Player/AudioPlayer.swift` | New `nowPlayingTrackVerified: Bool?` published property. iTunes search runs on every track. All state-reset paths reset it to nil. |
| `ios/rrradio/Views/NowPlayingView.swift` | `musicServiceButtons` gates on `nowPlayingTrackVerified == true`. |
| `ios/rrradioTests/CoverArtFetcherTests.swift` | +6 cases for `searchITunes` / `verifyTrack` / cache / short-title shortcut. |

## Test plan

- [x] `xcodebuild build` (generic iOS Simulator, Debug, CODE_SIGNING_ALLOWED=NO) — **BUILD SUCCEEDED**
- [x] `xcodebuild test` on iPhone 17 Pro Simulator — **All tests passed**, including all 8 CoverArtFetcher cases (2 existing + 6 new)
- [x] Spot-checked `MetadataDataFetcher` typealias plumbing — unchanged, all 4 callers still compile

## Coordination note

Branched from `main` in a separate worktree. No conflict with the in-flight `jiggle-long-press` branch's iOS work — that branch only touches NowPlayingView.swift in the prefix-truncated-results commit, in a different method (`titleNameText`) than `musicServiceButtons`. Should rebase clean if needed.

## Future opportunity (not in this PR)

On iOS specifically, the Apple Music link could use **MusicKit deep-link** to open the Apple Music app directly with the resolved track id (which iTunes Search already returns to us). That's a much better UX than a Safari hop. The gate in this PR is the prerequisite. Worth a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)