### PR TITLE
iOS: Apple Music deep-link (redo — re-target #392 to main)

### DIFF
--- a/ios/rrradio/Player/AudioPlayer.swift
+++ b/ios/rrradio/Player/AudioPlayer.swift
@@ -111,6 +111,12 @@ final class AudioPlayer {
     /// is in-flight or hasn't run. Drives the visibility of the
     /// Apple Music / Spotify / YT Music buttons in NowPlayingView.
     private(set) var nowPlayingTrackVerified: Bool?
+    /// Universal-link URL to the exact song on Apple Music, surfaced
+    /// from the iTunes Search response (`trackViewUrl` field) when a
+    /// match is found. `UIApplication.open(_:)` on this URL launches
+    /// the Apple Music app directly to the song; without it the
+    /// button falls back to a generic Apple Music search URL.
+    private(set) var nowPlayingAppleMusicUrl: URL?
     private(set) var nowPlayingProgramName: String?
     private(set) var nowPlayingProgramSubtitle: String?
     private(set) var nowPlayingCoverUrl: URL?
@@ -218,6 +224,7 @@ final class AudioPlayer {
         nowPlayingTitle = nil
         nowPlayingArtist = nil
         nowPlayingTrackVerified = nil
+        nowPlayingAppleMusicUrl = nil
         nowPlayingProgramName = nil
         nowPlayingProgramSubtitle = nil
         nowPlayingCoverUrl = nil
@@ -314,6 +321,7 @@ final class AudioPlayer {
         nowPlayingTitle = nil
         nowPlayingArtist = nil
         nowPlayingTrackVerified = nil
+        nowPlayingAppleMusicUrl = nil
         nowPlayingProgramName = nil
         nowPlayingProgramSubtitle = nil
         nowPlayingCoverUrl = nil
@@ -1065,6 +1073,7 @@ final class AudioPlayer {
         // NowPlayingView gate is `=== true`, so `nil` hides the
         // buttons until the iTunes result arrives.
         nowPlayingTrackVerified = nil
+        nowPlayingAppleMusicUrl = nil
 
         let wantsCoverUpgrade =
             sourceCoverUrl == nil || sourceCoverUrl.map(isLowResolutionCoverURL) == true
@@ -1075,6 +1084,7 @@ final class AudioPlayer {
             await MainActor.run { [weak self] in
                 guard let self, self.coverArtKey == key else { return }
                 self.nowPlayingTrackVerified = result.hit
+                self.nowPlayingAppleMusicUrl = result.appleMusicUrl
                 if wantsCoverUpgrade, let cover = result.cover {
                     self.nowPlayingCoverUrl = cover
                     diagnosticRecord(
@@ -1094,6 +1104,7 @@ final class AudioPlayer {
         coverArtTask = nil
         coverArtKey = ""
         nowPlayingTrackVerified = nil
+        nowPlayingAppleMusicUrl = nil
     }
 
     private func cleanLyricsComponent(_ value: String?) -> String? {

--- a/ios/rrradio/Player/Metadata/CoverArtFetcher.swift
+++ b/ios/rrradio/Player/Metadata/CoverArtFetcher.swift
@@ -11,23 +11,35 @@ private struct ITunesTrack: Decodable {
     let artistName: String
     let trackName: String
     let artworkUrl100: String?
+    /// Apple's universal-link URL for the song, e.g.
+    /// `https://music.apple.com/us/album/song-name/123?i=987`.
+    /// Opening it via `UIApplication.open(_:)` deep-links to the
+    /// Apple Music app when installed and falls back to the
+    /// browser-based player otherwise — no MusicKit entitlement
+    /// or auth required. Populated by every iTunes Search "song"
+    /// entity hit; we keep it Optional defensively.
+    let trackViewUrl: String?
 }
 
 /// Outcome of an iTunes Search call. `hit` mirrors `resultCount > 0`
 /// and is the signal NowPlayingView uses to decide whether to surface
 /// Apple Music / Spotify / YT Music buttons. `cover` is set only when
 /// the best match also carries 100×100 artwork (which we upgrade to
-/// 600×600 for retina rendering).
+/// 600×600 for retina rendering). `appleMusicUrl` is the deep link
+/// to the exact song on the best match — when present, callers can
+/// open Apple Music directly to the song rather than a search page.
 public struct ITunesSearchResult: Equatable {
     public let hit: Bool
     public let cover: URL?
+    public let appleMusicUrl: URL?
 
-    public init(hit: Bool, cover: URL? = nil) {
+    public init(hit: Bool, cover: URL? = nil, appleMusicUrl: URL? = nil) {
         self.hit = hit
         self.cover = cover
+        self.appleMusicUrl = appleMusicUrl
     }
 
-    public static let miss = ITunesSearchResult(hit: false, cover: nil)
+    public static let miss = ITunesSearchResult(hit: false, cover: nil, appleMusicUrl: nil)
 }
 
 private actor ITunesSearchCache {
@@ -92,7 +104,8 @@ func searchITunes(
         let hit = decoded.resultCount > 0
         let best = hit ? pickBestCoverArtMatch(decoded.results, artist: artist, title: cleanedTitle) : nil
         let cover = best?.artworkUrl100.flatMap(highResolutionITunesArtworkURL)
-        let result = ITunesSearchResult(hit: hit, cover: cover)
+        let appleMusicUrl = best?.trackViewUrl.flatMap(URL.init(string:))
+        let result = ITunesSearchResult(hit: hit, cover: cover, appleMusicUrl: appleMusicUrl)
         await ITunesSearchCache.shared.set(result, for: key)
         return result
     } catch {

--- a/ios/rrradio/Player/Metadata/MusicServiceLinks.swift
+++ b/ios/rrradio/Player/Metadata/MusicServiceLinks.swift
@@ -12,13 +12,25 @@ func musicSearchQuery(artist: String?, title: String?) -> String? {
     return "\(cleanArtist) - \(cleanTitle)"
 }
 
-func musicServiceLinks(artist: String?, title: String?) -> [MusicServiceLink] {
+func musicServiceLinks(
+    artist: String?,
+    title: String?,
+    /// Deep-link URL to the exact song on Apple Music — typically the
+    /// `trackViewUrl` from iTunes Search. When non-nil it replaces the
+    /// generic search URL so the Apple Music button opens the song
+    /// directly in the native app. Pass `nil` to fall back to search
+    /// (e.g. when iTunes Search wasn't run or the response omitted
+    /// `trackViewUrl`). Spotify and YouTube Music stay on search URLs
+    /// either way — neither has an unauthenticated direct-link path
+    /// from artist+title alone.
+    appleMusicURL: URL? = nil,
+) -> [MusicServiceLink] {
     guard let query = musicSearchQuery(artist: artist, title: title) else { return [] }
     return [
         MusicServiceLink(
             id: "apple-music",
             title: "Apple Music",
-            url: appleMusicSearchURL(query),
+            url: appleMusicURL ?? appleMusicSearchURL(query),
         ),
         MusicServiceLink(
             id: "spotify",

--- a/ios/rrradio/Views/NowPlayingView.swift
+++ b/ios/rrradio/Views/NowPlayingView.swift
@@ -887,7 +887,11 @@ struct NowPlayingView: View {
         // Spotify / YT Music search results, which is the bug this
         // gate fixes for news/talk stations.
         if player.nowPlayingTrackVerified == true {
-            let links = musicServiceLinks(artist: player.nowPlayingArtist, title: player.nowPlayingTitle)
+            let links = musicServiceLinks(
+                artist: player.nowPlayingArtist,
+                title: player.nowPlayingTitle,
+                appleMusicURL: player.nowPlayingAppleMusicUrl,
+            )
             ForEach(links) { link in
                 Button {
                     openURL(link.url)

--- a/ios/rrradioTests/CoverArtFetcherTests.swift
+++ b/ios/rrradioTests/CoverArtFetcherTests.swift
@@ -6,7 +6,12 @@ final class CoverArtFetcherTests: XCTestCase {
         HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: "HTTP/1.1", headerFields: nil)!
     }
 
-    private func hitPayload(artist: String, title: String, artwork: String) -> Data {
+    private func hitPayload(
+        artist: String,
+        title: String,
+        artwork: String,
+        trackViewUrl: String = "https://music.apple.com/us/album/song/100?i=200",
+    ) -> Data {
         """
         {
           "resultCount": 1,
@@ -14,7 +19,8 @@ final class CoverArtFetcherTests: XCTestCase {
             {
               "artistName": "\(artist)",
               "trackName": "\(title)",
-              "artworkUrl100": "\(artwork)"
+              "artworkUrl100": "\(artwork)",
+              "trackViewUrl": "\(trackViewUrl)"
             }
           ]
         }
@@ -56,6 +62,31 @@ final class CoverArtFetcherTests: XCTestCase {
         }
         XCTAssertTrue(result.hit)
         XCTAssertEqual(result.cover?.absoluteString, "https://is1-ssl.mzstatic.com/image/thumb/Music456/v4/600x600bb.jpg")
+    }
+
+    func testSearchITunesSurfacesAppleMusicDeepLink() async {
+        // `trackViewUrl` from the response should round-trip into
+        // `appleMusicUrl` for callers to deep-link the Apple Music app.
+        let deepLink = "https://music.apple.com/us/album/pyramid-song/123?i=987"
+        let payload = hitPayload(
+            artist: "Radiohead H",
+            title: "Pyramid Song H",
+            artwork: "https://is1-ssl.mzstatic.com/image/thumb/H/100x100bb.jpg",
+            trackViewUrl: deepLink,
+        )
+        let result = await searchITunes(artist: "Radiohead H", title: "Pyramid Song H") { request in
+            (payload, self.response(for: request.url!))
+        }
+        XCTAssertTrue(result.hit)
+        XCTAssertEqual(result.appleMusicUrl?.absoluteString, deepLink)
+    }
+
+    func testSearchITunesMissHasNoAppleMusicURL() async {
+        let result = await searchITunes(artist: nil, title: "Nachrichten 10:00 I") { request in
+            (self.missPayload, self.response(for: request.url!))
+        }
+        XCTAssertFalse(result.hit)
+        XCTAssertNil(result.appleMusicUrl)
     }
 
     func testSearchITunesReturnsMissOnResultCountZero() async {

--- a/ios/rrradioTests/MusicServiceLinksTests.swift
+++ b/ios/rrradioTests/MusicServiceLinksTests.swift
@@ -38,4 +38,41 @@ final class MusicServiceLinksTests: XCTestCase {
             "https://music.youtube.com/search?q=Bj%C3%B6rk%20-%20Human%20Behaviour",
         )
     }
+
+    func testUsesAppleMusicDeepLinkWhenProvided() {
+        // When iTunes Search returned a trackViewUrl, the Apple Music
+        // button opens the exact song instead of a generic search page.
+        // Spotify + YT Music continue to fall back to search URLs —
+        // neither has an unauthenticated direct-link path.
+        let deepLink = URL(string: "https://music.apple.com/us/album/human-behaviour/123?i=987")!
+        let links = musicServiceLinks(
+            artist: "Björk",
+            title: "Human Behaviour",
+            appleMusicURL: deepLink,
+        )
+        XCTAssertEqual(links[0].id, "apple-music")
+        XCTAssertEqual(links[0].url, deepLink)
+        // Spotify + YT Music unchanged
+        XCTAssertEqual(
+            links[1].url.absoluteString,
+            "https://open.spotify.com/search/Bj%C3%B6rk%20-%20Human%20Behaviour",
+        )
+        XCTAssertEqual(
+            links[2].url.absoluteString,
+            "https://music.youtube.com/search?q=Bj%C3%B6rk%20-%20Human%20Behaviour",
+        )
+    }
+
+    func testFallsBackToSearchWhenAppleMusicURLIsNil() {
+        // Explicit nil should behave identically to the default-arg case.
+        let links = musicServiceLinks(
+            artist: "Björk",
+            title: "Human Behaviour",
+            appleMusicURL: nil,
+        )
+        XCTAssertEqual(
+            links[0].url.absoluteString,
+            "https://music.apple.com/search?term=Bj%C3%B6rk%20-%20Human%20Behaviour",
+        )
+    }
 }


### PR DESCRIPTION
## Why this exists

#392 was created with `verify-track-itunes-ios` (#390) as its base. When #390 was squash-merged to main, GitHub didn't auto-rebase #392 onto main. Clicking "Merge" on #392 then squashed it into the orphaned `verify-track-itunes-ios` branch — so the deep-link plumbing never actually landed on `main`.

User-visible symptom: the Apple Music button on iOS verifies tracks (the #390 gate works) but opens a generic Apple Music search URL instead of the exact song.

This PR cherry-picks the original #392 commit (`d2f03b89`) onto a fresh branch from `main`.

## Content

Identical to #392 — no changes:
- `CoverArtFetcher.swift` — `trackViewUrl` → `ITunesSearchResult.appleMusicUrl`
- `AudioPlayer.swift` — `nowPlayingAppleMusicUrl: URL?` published, reset on every state path
- `MusicServiceLinks.swift` — optional `appleMusicURL:` parameter
- `NowPlayingView.swift` — passes the deep link through
- Tests: +2 in `CoverArtFetcherTests`, +2 in `MusicServiceLinksTests`

## Test plan

- [x] `xcodebuild build` — **BUILD SUCCEEDED**
- [x] `xcodebuild test` (targeted: `CoverArtFetcherTests` + `MusicServiceLinksTests`) — **TEST SUCCEEDED**

## To avoid this next time

When a stacked PR's base merges, GitHub doesn't auto-rebase. Either:
- Manually flip the stacked PR's base to `main` *before* merging it, or
- Don't stack — open the second PR off `main` after the first lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)