### PR TITLE
[codex] Android: use iOS brand logo

### DIFF
--- a/android/app/src/main/java/org/rrradio/android/ui/RrradioApp.kt
+++ b/android/app/src/main/java/org/rrradio/android/ui/RrradioApp.kt
@@ -1,6 +1,7 @@
 package org.rrradio.android.ui
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -76,6 +77,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardCapitalization
@@ -84,6 +86,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil3.compose.AsyncImage
+import org.rrradio.android.R
 import org.rrradio.android.data.CatalogLoadState
 import org.rrradio.android.data.PlaybackUiState
 import org.rrradio.android.data.PlayerState
@@ -345,7 +348,7 @@ private fun Header(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(10.dp),
             ) {
-                BrandMark()
+                BrandLogo(darkTheme = state.darkTheme)
                 Text(
                     text = when (state.tab) {
                         AppTab.StationLists -> state.selectedStationList?.name ?: "Lists"
@@ -400,33 +403,16 @@ private fun Header(
 }
 
 @Composable
-private fun BrandMark() {
-    Box(
-        Modifier
-            .size(34.dp)
-            .clip(RoundedCornerShape(8.dp))
-            .background(MaterialTheme.colorScheme.surfaceVariant)
-            .border(BorderStroke(1.dp, MaterialTheme.colorScheme.outline), RoundedCornerShape(8.dp)),
-        contentAlignment = Alignment.Center,
-    ) {
-        val active = MaterialTheme.colorScheme.primary
-        val inactive = MaterialTheme.colorScheme.outline
-        Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
-            repeat(3) { row ->
-                Row(horizontalArrangement = Arrangement.spacedBy(3.dp)) {
-                    repeat(3) { col ->
-                        val lit = row == 2 || (row == 1 && col != 0)
-                        Box(
-                            Modifier
-                                .size(5.dp)
-                                .clip(RoundedCornerShape(1.5.dp))
-                                .background(if (lit) active else inactive),
-                        )
-                    }
-                }
-            }
-        }
-    }
+private fun BrandLogo(darkTheme: Boolean) {
+    Image(
+        painter = painterResource(
+            id = if (darkTheme) R.drawable.rrradio_logo_app_dark else R.drawable.rrradio_logo_app_light,
+        ),
+        contentDescription = null,
+        modifier = Modifier
+            .size(36.dp)
+            .clip(RoundedCornerShape(8.dp)),
+    )
 }
 
 @Composable

--- a/android/app/src/main/res/drawable/rrradio_logo_app_dark.xml
+++ b/android/app/src/main/res/drawable/rrradio_logo_app_dark.xml
@@ -1,0 +1,135 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="36dp"
+    android:height="36dp"
+    android:viewportWidth="1024"
+    android:viewportHeight="1024">
+    <path
+        android:fillColor="#3E3E39"
+        android:pathData="M-1.64,-2.14L1043.32,-2.14L1043.32,1045.08L-1.64,1045.08L-1.64,-2.14Z" />
+    <path
+        android:fillColor="#FFFF00"
+        android:pathData="M71.22,659.49C71.22,657.17 73.1,655.29 75.42,655.29L136.02,655.29C138.34,655.29 140.22,657.17 140.22,659.49L140.22,720.09C140.22,722.41 138.34,724.29 136.02,724.29L75.42,724.29C73.1,724.29 71.22,722.41 71.22,720.09L71.22,659.49Z"
+        android:strokeColor="#C4C4C1"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1" />
+    <path
+        android:fillColor="#FFFF00"
+        android:pathData="M176.95,654.21C176.95,651.89 178.83,650.01 181.15,650.01L241.75,650.01C244.07,650.01 245.95,651.89 245.95,654.21L245.95,714.81C245.95,717.12 244.07,719.01 241.75,719.01L181.15,719.01C178.83,719.01 176.95,717.12 176.95,714.81L176.95,654.21Z"
+        android:strokeColor="#C4C4C1"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1" />
+    <path
+        android:fillColor="#FFFF00"
+        android:pathData="M282.9,661.59C282.9,659.27 284.78,657.39 287.1,657.39L347.7,657.39C350.02,657.39 351.9,659.27 351.9,661.59L351.9,722.19C351.9,724.51 350.02,726.39 347.7,726.39L287.1,726.39C284.78,726.39 282.9,724.51 282.9,722.19L282.9,661.59Z"
+        android:strokeColor="#C4C4C1"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1" />
+    <path
+        android:fillColor="#FFFF00"
+        android:pathData="M379.06,654.05C379.06,651.73 380.94,649.85 383.26,649.85L443.86,649.85C446.18,649.85 448.06,651.73 448.06,654.05L448.06,714.65C448.06,716.96 446.18,718.85 443.86,718.85L383.26,718.85C380.94,718.85 379.06,716.96 379.06,714.65L379.06,654.05Z"
+        android:strokeColor="#C4C4C1"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1" />
+    <path
+        android:fillColor="#FFFF00"
+        android:pathData="M477.75,658.13C477.75,655.81 479.63,653.93 481.95,653.93L542.55,653.93C544.87,653.93 546.75,655.81 546.75,658.13L546.75,718.73C546.75,721.05 544.87,722.93 542.55,722.93L481.95,722.93C479.63,722.93 477.75,721.05 477.75,718.73L477.75,658.13Z"
+        android:strokeColor="#C4C4C1"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1" />
+    <path
+        android:fillColor="#FFFF00"
+        android:pathData="M582.74,648.6C582.74,646.28 584.62,644.4 586.94,644.4L647.54,644.4C649.86,644.4 651.74,646.28 651.74,648.6L651.74,709.2C651.74,711.52 649.86,713.4 647.54,713.4L586.94,713.4C584.62,713.4 582.74,711.52 582.74,709.2L582.74,648.6Z"
+        android:strokeColor="#C4C4C1"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1" />
+    <path
+        android:fillColor="#FFFF00"
+        android:pathData="M676.2,653.89C676.2,651.57 678.08,649.69 680.4,649.69L741,649.69C743.32,649.69 745.2,651.57 745.2,653.89L745.2,714.49C745.2,716.81 743.32,718.69 741,718.69L680.4,718.69C678.08,718.69 676.2,716.81 676.2,714.49L676.2,653.89Z"
+        android:strokeColor="#C4C4C1"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1" />
+    <path
+        android:fillColor="#FFFF00"
+        android:pathData="M774.02,646.77C774.02,644.45 775.9,642.57 778.22,642.57L838.82,642.57C841.14,642.57 843.02,644.45 843.02,646.77L843.02,707.37C843.02,709.69 841.14,711.57 838.82,711.57L778.22,711.57C775.9,711.57 774.02,709.69 774.02,707.37L774.02,646.77Z"
+        android:strokeColor="#C4C4C1"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1" />
+    <path
+        android:fillColor="#FFFF00"
+        android:pathData="M874.17,653.65C874.17,651.33 876.05,649.45 878.37,649.45L938.97,649.45C941.29,649.45 943.17,651.33 943.17,653.65L943.17,714.25C943.17,716.57 941.29,718.45 938.97,718.45L878.37,718.45C876.05,718.45 874.17,716.57 874.17,714.25L874.17,653.65Z"
+        android:strokeColor="#C4C4C1"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1" />
+    <path
+        android:fillColor="#FFFF00"
+        android:pathData="M179.12,567.01C179.12,564.69 181,562.81 183.32,562.81L243.92,562.81C246.24,562.81 248.12,564.69 248.12,567.01L248.12,627.61C248.12,629.93 246.24,631.81 243.92,631.81L183.32,631.81C181,631.81 179.12,629.93 179.12,627.61L179.12,567.01Z"
+        android:strokeColor="#C4C4C1"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1" />
+    <path
+        android:fillColor="#FFFF00"
+        android:pathData="M178.55,480.02C178.55,477.7 180.43,475.82 182.75,475.82L243.35,475.82C245.67,475.82 247.55,477.7 247.55,480.02L247.55,540.62C247.55,542.94 245.67,544.82 243.35,544.82L182.75,544.82C180.43,544.82 178.55,542.94 178.55,540.62L178.55,480.02Z"
+        android:strokeColor="#C4C4C1"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1" />
+    <path
+        android:fillColor="#FFFF00"
+        android:pathData="M178.02,391.38C178.02,389.06 179.9,387.18 182.22,387.18L242.82,387.18C245.14,387.18 247.02,389.06 247.02,391.38L247.02,451.98C247.02,454.3 245.14,456.18 242.82,456.18L182.22,456.18C179.9,456.18 178.02,454.3 178.02,451.98L178.02,391.38Z"
+        android:strokeColor="#C4C4C1"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1" />
+    <path
+        android:fillColor="#FFFF00"
+        android:pathData="M268.84,391C268.84,388.68 270.72,386.8 273.04,386.8L333.64,386.8C335.96,386.8 337.84,388.68 337.84,391L337.84,451.6C337.84,453.92 335.96,455.8 333.64,455.8L273.04,455.8C270.72,455.8 268.84,453.92 268.84,451.6L268.84,391Z"
+        android:strokeColor="#C4C4C1"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1" />
+    <path
+        android:fillColor="#FFFF00"
+        android:pathData="M479.02,482.29C479.02,479.97 480.9,478.09 483.22,478.09L543.82,478.09C546.14,478.09 548.02,479.97 548.02,482.29L548.02,542.89C548.02,545.21 546.14,547.09 543.82,547.09L483.22,547.09C480.9,547.09 479.02,545.21 479.02,542.89L479.02,482.29Z"
+        android:strokeColor="#C4C4C1"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1" />
+    <path
+        android:fillColor="#FFFF00"
+        android:pathData="M478.5,393.66C478.5,391.34 480.38,389.46 482.7,389.46L543.3,389.46C545.62,389.46 547.5,391.34 547.5,393.66L547.5,454.26C547.5,456.58 545.62,458.46 543.3,458.46L482.7,458.46C480.38,458.46 478.5,456.58 478.5,454.26L478.5,393.66Z"
+        android:strokeColor="#C4C4C1"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1" />
+    <path
+        android:fillColor="#FFFF00"
+        android:pathData="M569.32,393.28C569.32,390.96 571.2,389.08 573.52,389.08L634.12,389.08C636.44,389.08 638.32,390.96 638.32,393.28L638.32,453.88C638.32,456.19 636.44,458.08 634.12,458.08L573.52,458.08C571.2,458.08 569.32,456.19 569.32,453.88L569.32,393.28Z"
+        android:strokeColor="#C4C4C1"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1" />
+    <path
+        android:fillColor="#FFFF00"
+        android:pathData="M475.88,569.05C475.88,566.73 477.76,564.85 480.08,564.85L540.68,564.85C543,564.85 544.88,566.73 544.88,569.05L544.88,629.65C544.88,631.96 543,633.85 540.68,633.85L480.08,633.85C477.76,633.85 475.88,631.96 475.88,629.65L475.88,569.05Z"
+        android:strokeColor="#C4C4C1"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1" />
+    <path
+        android:fillColor="#FFFF00"
+        android:pathData="M775.31,472.48C775.31,470.16 777.19,468.28 779.51,468.28L840.11,468.28C842.43,468.28 844.31,470.16 844.31,472.48L844.31,533.08C844.31,535.4 842.43,537.28 840.11,537.28L779.51,537.28C777.19,537.28 775.31,535.4 775.31,533.08L775.31,472.48Z"
+        android:strokeColor="#C4C4C1"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1" />
+    <path
+        android:fillColor="#FFFF00"
+        android:pathData="M774.79,383.85C774.79,381.53 776.67,379.65 778.99,379.65L839.59,379.65C841.91,379.65 843.79,381.53 843.79,383.85L843.79,444.45C843.79,446.77 841.91,448.65 839.59,448.65L778.99,448.65C776.67,448.65 774.79,446.77 774.79,444.45L774.79,383.85Z"
+        android:strokeColor="#C4C4C1"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1" />
+    <path
+        android:fillColor="#FFFF00"
+        android:pathData="M865.6,383.46C865.6,381.14 867.49,379.26 869.8,379.26L930.4,379.26C932.72,379.26 934.6,381.14 934.6,383.46L934.6,444.06C934.6,446.38 932.72,448.26 930.4,448.26L869.8,448.26C867.49,448.26 865.6,446.38 865.6,444.06L865.6,383.46Z"
+        android:strokeColor="#C4C4C1"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1" />
+    <path
+        android:fillColor="#FFFF00"
+        android:pathData="M772.17,559.23C772.17,556.91 774.05,555.03 776.37,555.03L836.97,555.03C839.29,555.03 841.17,556.91 841.17,559.23L841.17,619.83C841.17,622.15 839.29,624.03 836.97,624.03L776.37,624.03C774.05,624.03 772.17,622.15 772.17,619.83L772.17,559.23Z"
+        android:strokeColor="#C4C4C1"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1" />
+</vector>

--- a/android/app/src/main/res/drawable/rrradio_logo_app_light.xml
+++ b/android/app/src/main/res/drawable/rrradio_logo_app_light.xml
@@ -1,0 +1,135 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="36dp"
+    android:height="36dp"
+    android:viewportWidth="1024"
+    android:viewportHeight="1024">
+    <path
+        android:fillColor="#F1F1EC"
+        android:pathData="M-1.64,-2.14L1043.32,-2.14L1043.32,1045.08L-1.64,1045.08L-1.64,-2.14Z" />
+    <path
+        android:fillColor="#01A040"
+        android:pathData="M71.22,659.49C71.22,657.17 73.1,655.29 75.42,655.29L136.02,655.29C138.34,655.29 140.22,657.17 140.22,659.49L140.22,720.09C140.22,722.41 138.34,724.29 136.02,724.29L75.42,724.29C73.1,724.29 71.22,722.41 71.22,720.09L71.22,659.49Z"
+        android:strokeColor="#D2EED8"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1" />
+    <path
+        android:fillColor="#01A040"
+        android:pathData="M176.95,654.21C176.95,651.89 178.83,650.01 181.15,650.01L241.75,650.01C244.07,650.01 245.95,651.89 245.95,654.21L245.95,714.81C245.95,717.12 244.07,719.01 241.75,719.01L181.15,719.01C178.83,719.01 176.95,717.12 176.95,714.81L176.95,654.21Z"
+        android:strokeColor="#D2EED8"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1" />
+    <path
+        android:fillColor="#01A040"
+        android:pathData="M282.9,661.59C282.9,659.27 284.78,657.39 287.1,657.39L347.7,657.39C350.02,657.39 351.9,659.27 351.9,661.59L351.9,722.19C351.9,724.51 350.02,726.39 347.7,726.39L287.1,726.39C284.78,726.39 282.9,724.51 282.9,722.19L282.9,661.59Z"
+        android:strokeColor="#D2EED8"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1" />
+    <path
+        android:fillColor="#01A040"
+        android:pathData="M379.06,654.05C379.06,651.73 380.94,649.85 383.26,649.85L443.86,649.85C446.18,649.85 448.06,651.73 448.06,654.05L448.06,714.65C448.06,716.96 446.18,718.85 443.86,718.85L383.26,718.85C380.94,718.85 379.06,716.96 379.06,714.65L379.06,654.05Z"
+        android:strokeColor="#D2EED8"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1" />
+    <path
+        android:fillColor="#01A040"
+        android:pathData="M477.75,658.13C477.75,655.81 479.63,653.93 481.95,653.93L542.55,653.93C544.87,653.93 546.75,655.81 546.75,658.13L546.75,718.73C546.75,721.05 544.87,722.93 542.55,722.93L481.95,722.93C479.63,722.93 477.75,721.05 477.75,718.73L477.75,658.13Z"
+        android:strokeColor="#D2EED8"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1" />
+    <path
+        android:fillColor="#01A040"
+        android:pathData="M582.74,648.6C582.74,646.28 584.62,644.4 586.94,644.4L647.54,644.4C649.86,644.4 651.74,646.28 651.74,648.6L651.74,709.2C651.74,711.52 649.86,713.4 647.54,713.4L586.94,713.4C584.62,713.4 582.74,711.52 582.74,709.2L582.74,648.6Z"
+        android:strokeColor="#C4C4C1"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1" />
+    <path
+        android:fillColor="#01A040"
+        android:pathData="M676.2,653.89C676.2,651.57 678.08,649.69 680.4,649.69L741,649.69C743.32,649.69 745.2,651.57 745.2,653.89L745.2,714.49C745.2,716.81 743.32,718.69 741,718.69L680.4,718.69C678.08,718.69 676.2,716.81 676.2,714.49L676.2,653.89Z"
+        android:strokeColor="#C4C4C1"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1" />
+    <path
+        android:fillColor="#01A040"
+        android:pathData="M774.02,646.77C774.02,644.45 775.9,642.57 778.22,642.57L838.82,642.57C841.14,642.57 843.02,644.45 843.02,646.77L843.02,707.37C843.02,709.69 841.14,711.57 838.82,711.57L778.22,711.57C775.9,711.57 774.02,709.69 774.02,707.37L774.02,646.77Z"
+        android:strokeColor="#C4C4C1"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1" />
+    <path
+        android:fillColor="#01A040"
+        android:pathData="M874.17,653.65C874.17,651.33 876.05,649.45 878.37,649.45L938.97,649.45C941.29,649.45 943.17,651.33 943.17,653.65L943.17,714.25C943.17,716.57 941.29,718.45 938.97,718.45L878.37,718.45C876.05,718.45 874.17,716.57 874.17,714.25L874.17,653.65Z"
+        android:strokeColor="#C4C4C1"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1" />
+    <path
+        android:fillColor="#01A040"
+        android:pathData="M179.12,567.01C179.12,564.69 181,562.81 183.32,562.81L243.92,562.81C246.24,562.81 248.12,564.69 248.12,567.01L248.12,627.61C248.12,629.93 246.24,631.81 243.92,631.81L183.32,631.81C181,631.81 179.12,629.93 179.12,627.61L179.12,567.01Z"
+        android:strokeColor="#D2EED8"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1" />
+    <path
+        android:fillColor="#01A040"
+        android:pathData="M178.55,480.02C178.55,477.7 180.43,475.82 182.75,475.82L243.35,475.82C245.67,475.82 247.55,477.7 247.55,480.02L247.55,540.62C247.55,542.94 245.67,544.82 243.35,544.82L182.75,544.82C180.43,544.82 178.55,542.94 178.55,540.62L178.55,480.02Z"
+        android:strokeColor="#D2EED8"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1" />
+    <path
+        android:fillColor="#01A040"
+        android:pathData="M178.02,391.38C178.02,389.06 179.9,387.18 182.22,387.18L242.82,387.18C245.14,387.18 247.02,389.06 247.02,391.38L247.02,451.98C247.02,454.3 245.14,456.18 242.82,456.18L182.22,456.18C179.9,456.18 178.02,454.3 178.02,451.98L178.02,391.38Z"
+        android:strokeColor="#D2EED8"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1" />
+    <path
+        android:fillColor="#01A040"
+        android:pathData="M268.84,391C268.84,388.68 270.72,386.8 273.04,386.8L333.64,386.8C335.96,386.8 337.84,388.68 337.84,391L337.84,451.6C337.84,453.92 335.96,455.8 333.64,455.8L273.04,455.8C270.72,455.8 268.84,453.92 268.84,451.6L268.84,391Z"
+        android:strokeColor="#D2EED8"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1" />
+    <path
+        android:fillColor="#01A040"
+        android:pathData="M479.02,482.29C479.02,479.97 480.9,478.09 483.22,478.09L543.82,478.09C546.14,478.09 548.02,479.97 548.02,482.29L548.02,542.89C548.02,545.21 546.14,547.09 543.82,547.09L483.22,547.09C480.9,547.09 479.02,545.21 479.02,542.89L479.02,482.29Z"
+        android:strokeColor="#D2EED8"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1" />
+    <path
+        android:fillColor="#01A040"
+        android:pathData="M478.5,393.66C478.5,391.34 480.38,389.46 482.7,389.46L543.3,389.46C545.62,389.46 547.5,391.34 547.5,393.66L547.5,454.26C547.5,456.58 545.62,458.46 543.3,458.46L482.7,458.46C480.38,458.46 478.5,456.58 478.5,454.26L478.5,393.66Z"
+        android:strokeColor="#D2EED8"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1" />
+    <path
+        android:fillColor="#01A040"
+        android:pathData="M569.32,393.28C569.32,390.96 571.2,389.08 573.52,389.08L634.12,389.08C636.44,389.08 638.32,390.96 638.32,393.28L638.32,453.88C638.32,456.19 636.44,458.08 634.12,458.08L573.52,458.08C571.2,458.08 569.32,456.19 569.32,453.88L569.32,393.28Z"
+        android:strokeColor="#C4C4C1"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1" />
+    <path
+        android:fillColor="#01A040"
+        android:pathData="M475.88,569.05C475.88,566.73 477.76,564.85 480.08,564.85L540.68,564.85C543,564.85 544.88,566.73 544.88,569.05L544.88,629.65C544.88,631.96 543,633.85 540.68,633.85L480.08,633.85C477.76,633.85 475.88,631.96 475.88,629.65L475.88,569.05Z"
+        android:strokeColor="#D2EED8"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1" />
+    <path
+        android:fillColor="#01A040"
+        android:pathData="M775.31,472.48C775.31,470.16 777.19,468.28 779.51,468.28L840.11,468.28C842.43,468.28 844.31,470.16 844.31,472.48L844.31,533.08C844.31,535.4 842.43,537.28 840.11,537.28L779.51,537.28C777.19,537.28 775.31,535.4 775.31,533.08L775.31,472.48Z"
+        android:strokeColor="#C4C4C1"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1" />
+    <path
+        android:fillColor="#01A040"
+        android:pathData="M774.79,383.85C774.79,381.53 776.67,379.65 778.99,379.65L839.59,379.65C841.91,379.65 843.79,381.53 843.79,383.85L843.79,444.45C843.79,446.77 841.91,448.65 839.59,448.65L778.99,448.65C776.67,448.65 774.79,446.77 774.79,444.45L774.79,383.85Z"
+        android:strokeColor="#C4C4C1"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1" />
+    <path
+        android:fillColor="#01A040"
+        android:pathData="M865.6,383.46C865.6,381.14 867.49,379.26 869.8,379.26L930.4,379.26C932.72,379.26 934.6,381.14 934.6,383.46L934.6,444.06C934.6,446.38 932.72,448.26 930.4,448.26L869.8,448.26C867.49,448.26 865.6,446.38 865.6,444.06L865.6,383.46Z"
+        android:strokeColor="#C4C4C1"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1" />
+    <path
+        android:fillColor="#01A040"
+        android:pathData="M772.17,559.23C772.17,556.91 774.05,555.03 776.37,555.03L836.97,555.03C839.29,555.03 841.17,556.91 841.17,559.23L841.17,619.83C841.17,622.15 839.29,624.03 836.97,624.03L776.37,624.03C774.05,624.03 772.17,622.15 772.17,619.83L772.17,559.23Z"
+        android:strokeColor="#C4C4C1"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1" />
+</vector>


### PR DESCRIPTION
## Summary
- replace the hand-drawn Android header brand mark with the iOS RrradioLogo artwork
- add light and dark Android vector drawable variants derived from the iOS SVG asset
- keep the change scoped to the Android app shell work tracked in #399

## Validation
- git diff --check -- android/app/src/main/java/org/rrradio/android/ui/RrradioApp.kt android/app/src/main/res/drawable/rrradio_logo_app_light.xml android/app/src/main/res/drawable/rrradio_logo_app_dark.xml
- env JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home GRADLE_USER_HOME=/Users/markussteinbrecher/Code/rrradio/android/.gradle-home gradle --no-daemon testDebugUnitTest assembleDebug
- installed android/app/build/outputs/apk/debug/app-debug.apk on the emulator and visually verified the header logo in a screenshot

Part of #399.