### PR TITLE
[codex] Android: update parity spec audit

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -11,25 +11,41 @@ The cross-platform contract lives in `docs/spec/`. Android is intentionally
 local-only for this first aligned version: there is no CloudKit, no iCloud
 compatibility layer, no account requirement, and no shared backend.
 
-| Spec area | Android status | Notes |
+| Spec area | Android status | Remaining parity |
 |---|---|---|
-| `docs/spec/platforms.md` | Partial | Kotlin + Jetpack Compose, Media3/ExoPlayer, MediaSessionService, DataStore, and cache-backed catalog loading are in place. Wear OS is out of scope for the first Android port. |
-| `docs/spec/data-sync.md` | Supported for local data | Favorites, recents, custom stations, and station lists are device-local DataStore data. Manual backup export/import is explicitly deferred; it should mirror the web favorites/custom-stations file flow when added. |
-| `docs/spec/playback.md` | Partial | MP3/AAC/HLS playback uses ExoPlayer. Starting playback passes the current visible list as the active queue, so Browse, Favorites, Recents, and station-list detail media next/previous controls stay scoped. Media3 errors trigger bounded source rebuild retries before surfacing a generic error. Real background/lock-screen behavior still needs device validation. |
-| `docs/spec/features/browse.md` | Supported except deferred views | Android loads `https://rrradio.org/stations.json`, falls back to the cache, searches station names/tags/countries with whitespace-insensitive and diacritic-tolerant matching, exposes country/genre filters, and supports Browse batch-add into station lists. Map browse and advanced sort controls are deferred. |
-| `docs/spec/features/favorites.md` | Partial | Add/remove favorites and capped recents are supported. Favorites now follow the iOS display-mode model with List, Tiles, and App-style views, and list mode has basic up/down reorder controls. Drag reorder is deferred. |
-| `docs/spec/features/station-lists.md` | Partial | Android now uses the iOS tab structure with a Lists surface, list-summary rows for Favorites/Recents/Custom Stations, named user-created lists, Browse batch-add, list delete, and station removal from a list. Rename, drag reorder, and fuller list-as-queue management still need the iOS behavior ported. |
-| `docs/spec/features/custom-stations.md` | Partial | Custom stations require HTTPS, reject local/private stream hosts, reject duplicate stream URLs against catalog/custom stations, probe the stream before save, auto-favorite on save, confirm before delete, and persist locally. Backup/export remains deferred. |
-| `docs/spec/features/now-playing.md` | Partial | The current sheet shows station identity, artwork/logo fallback, metadata, favorite toggle, playback control, and sleep entry. A fuller destination view, previous/next buttons, secondary panels, lyrics, schedules, and music-service links are deferred. |
-| `docs/spec/features/metadata-artwork.md` | Partial | Basic ICY `StreamTitle` parsing and bounded ICY metadata fetch are present for `status: icy-only` stations. The broadcaster metadata registry from web/iOS, schedule panes, lyrics, station-logo policy, and track cover-art lookup are deferred. |
-| `docs/spec/features/sleep-timer.md` | Partial | The off / 15 / 30 / 60 / 90 minute cycle pauses playback without clearing station context. Background firing still needs real-device validation with the media notification active. |
-| `docs/spec/features/wake-to-radio.md` | Deferred decision | Android wake-to-radio needs a separate decision covering exact alarm permission, foreground service behavior, notification fallback, and battery optimization language. |
-| `docs/spec/features/preferences-diagnostics.md` | Partial | Theme toggle exists. System/light/dark preference, accent color, language, landing page, listening history, local diagnostics, broken-station reporting, and Android Auto-specific behavior are deferred. |
+| `docs/spec/platforms.md` | Partial | Kotlin + Jetpack Compose, Media3/ExoPlayer, MediaSessionService, DataStore, cache-backed catalog loading, native app-shell logo, tab structure, station lists, and Favorites modes are in place. Wear OS remains out of scope for the first Android port. |
+| `docs/spec/data-sync.md` | Supported for local library data | Favorites, recents, custom stations, and station lists are device-local DataStore data. Manual backup export/import, listening history, diagnostics, and richer preference persistence are tracked in #406. |
+| `docs/spec/playback.md` | Partial | MP3/AAC/HLS playback uses ExoPlayer, visible-list playback creates an active queue, and bounded source rebuild retries exist. Real background/lock-screen behavior, playlist resolution, and media-control validation are tracked in #404. |
+| `docs/spec/features/browse.md` | Supported except deferred views | Catalog load/cache, normalized search, country/genre filters, favorite/play from rows, recents, and Browse batch-add into station lists are in place. Map browse, advanced sort controls, and presentation refinements are tracked in #400. |
+| `docs/spec/features/favorites.md` | Partial | Add/remove favorites, capped recents, List/Tiles/App display modes, local persistence, and basic up/down reorder controls are in place. Native drag/reorder, mode preference persistence, visible/order settings, and metadata polish are tracked in #398. |
+| `docs/spec/features/station-lists.md` | Partial | Lists overview, create/delete, Browse batch-add, station removal, local persistence, and list-scoped playback queues are in place. Rename, list reorder, station reorder, and fuller management polish are tracked in #401. |
+| `docs/spec/features/custom-stations.md` | Supported except backup | HTTPS-only save, private/local host rejection, duplicate stream checks, stream probe before save, auto-favorite, delete confirmation, and local persistence are in place. Backup/export is tracked in #406. |
+| `docs/spec/features/now-playing.md` | Partial | The current Android surface shows station identity, artwork/logo fallback, basic metadata, favorite toggle, playback control, sleep entry, and mini-player handoff. A fuller destination view, previous/next buttons, secondary panels, lyrics, schedules, and music-service links are tracked in #403. |
+| `docs/spec/features/metadata-artwork.md` | Partial | Basic ICY `StreamTitle` parsing and bounded ICY metadata fetch are present for `status: icy-only` stations. Broadcaster fetcher parity, schedules, full station-logo policy, track cover art, and lyrics are tracked in #407. |
+| `docs/spec/features/sleep-timer.md` | Partial | The off / 15 / 30 / 60 / 90 minute cycle pauses playback without clearing station context. Visible remaining time and background firing validation belong with #403 and #404. |
+| `docs/spec/features/wake-to-radio.md` | Deferred decision | Exact-alarm permission, foreground service behavior, notification fallback, and battery optimization language need a design decision before implementation in #405. |
+| `docs/spec/features/preferences-diagnostics.md` | Partial | Runtime theme toggle and Favorites display-mode controls exist. Persisted system/light/dark preference, accent color, language, landing page, sleep default, history, diagnostics, broken-station reporting, and Android Auto scope are tracked in #399, #406, and #405. |
 
-Deferred features should remain documented here until each area gets its own
-issue or ADR. Android Auto, wake-to-radio exact alarms, and any future
-cross-platform sync backend are separate product decisions, not hidden scope in
-this port.
+## Parity Tracking
+
+The Android parity plan is tracked by #397. The current implementation sequence
+is:
+
+1. #402 - audit/spec matrix update.
+2. #399 - app shell, theme, logo, and preferences.
+3. #400 - Browse parity.
+4. #398 - Favorites parity.
+5. #401 - station lists parity.
+6. #403 - Now Playing destination parity.
+7. #407 - metadata and artwork parity.
+8. #404 - playback, background audio, and media controls validation.
+9. #406 - local data, backup export, and diagnostics.
+10. #405 - wake-to-radio and Android Auto decisions.
+
+Deferred features should remain documented here until each area is implemented
+or explicitly deferred in an issue or ADR. Android Auto, wake-to-radio exact
+alarms, and any future cross-platform sync backend are separate product
+decisions, not hidden scope in this port.
 
 ## Building
 

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -74,14 +74,14 @@ Canonical implementation references remain in:
 | Browse/search/filter | Supported | Reference | Supported | [Browse](features/browse.md) |
 | Map browse | Supported | Supported | Planned | [Browse](features/browse.md) |
 | Favorites | Supported | Reference | Supported | [Favorites](features/favorites.md) |
-| Favorites display modes | Partial | Reference | Planned | [Favorites](features/favorites.md) |
+| Favorites display modes | Partial | Reference | Partial | [Favorites](features/favorites.md) |
 | Recents | Supported | Supported | Supported | [Favorites](features/favorites.md) |
-| Station lists | Not planned for current web | Reference | Planned | [Station lists](features/station-lists.md) |
+| Station lists | Not planned for current web | Reference | Partial | [Station lists](features/station-lists.md) |
 | Custom stations | Supported | Reference | Supported | [Custom stations](features/custom-stations.md) |
 | Metadata and cover art | Supported | Reference | Partial | [Metadata and artwork](features/metadata-artwork.md) |
 | Program schedules | Supported for wired broadcasters | Supported for wired broadcasters | Planned | [Now Playing](features/now-playing.md) |
 | Lyrics | Supported on web | Planned/partial on native | Planned | [Now Playing](features/now-playing.md) |
-| Sleep timer | Supported | Reference | Supported | [Sleep timer](features/sleep-timer.md) |
+| Sleep timer | Supported | Reference | Partial | [Sleep timer](features/sleep-timer.md) |
 | Wake to radio | Partial, browser-limited | Reference, iOS-limited | Planned, Android-limited | [Wake to radio](features/wake-to-radio.md) |
 | iCloud/CloudKit sync | Not planned | Supported | Not applicable | [Data and sync](data-sync.md) |
 | Manual file export/import | Supported for favorites and custom stations | Planned/optional | Planned/optional | [Data and sync](data-sync.md) |

--- a/docs/spec/data-sync.md
+++ b/docs/spec/data-sync.md
@@ -26,13 +26,13 @@ offers private iCloud/CloudKit sync between the user's Apple devices.
 |---|---|---|---|
 | Favorites | `localStorage`, export/import supported. | Local UserDefaults plus optional CloudKit sync. | Local DataStore. |
 | Recents | `localStorage`, capped. | Local-only, capped. | Local DataStore, capped. |
-| Station lists | Not planned for current web. | Local plus optional CloudKit sync. | Planned local-only. |
+| Station lists | Not planned for current web. | Local plus optional CloudKit sync. | Local DataStore. |
 | Custom stations | `localStorage`, export/import supported. | Local plus optional CloudKit sync. | Local DataStore. |
 | Preferences | Local browser preferences. | Local plus optional CloudKit sync for selected preferences. | Local-only for first port. |
 | Wake state | Local-only, one armed wake. | Local-only for active wake; selected wake preferences may sync. | Local-only. |
 | Listening history | Not part of current web storage contract. | Local-only, opt-in, retention-controlled. | Planned local-only, opt-in. |
 | Diagnostics | Anonymous production events only. | Local opt-in diagnostic log. | Planned local opt-in diagnostic log. |
-| Catalog cache | Browser/runtime cache. | Disk cache and bundled index fallback. | Planned disk cache and optional search index. |
+| Catalog cache | Browser/runtime cache. | Disk cache and bundled index fallback. | Cache-backed catalog loading; optional search index is deferred. |
 | Backup file | Manual export/import for favorites and custom stations. | Planned/optional import path if needed. | Planned/optional import path if needed. |
 
 ## iCloud And CloudKit
@@ -92,12 +92,17 @@ The Android app is local-only:
 - No shared backend.
 - Manual backup import/export can be added as a user-controlled transfer path,
   but it is not a substitute for a shared sync backend.
+- Favorites, recents, custom stations, and station lists are persisted in
+  DataStore today.
+- Preferences are currently only partly modeled on Android; system/light/dark,
+  accent, landing page, history, and diagnostics preferences remain parity
+  work.
 - Data should be structured so a future sync backend can be added without
   rewriting feature logic.
 
 Android storage should use stable schema versions for user data. Prefer a
 simple local model first; introduce Room only when the feature set needs
-queryable history, station lists, or catalog search.
+queryable history, more complex list management, or catalog search.
 
 ## Future Cross-Platform Sync
 

--- a/docs/spec/features/browse.md
+++ b/docs/spec/features/browse.md
@@ -27,7 +27,7 @@ the generated catalog, search, filters, and map exploration.
 | Country filter | Supported. | Supported with native picker rows. | Supported. |
 | Genre/tag filter | Supported. | Supported. | Supported. |
 | Map browse | Supported with web map asset. | Supported with MapKit. | Planned with native map, provider TBD. |
-| Add several stations to a station list | Not planned for current web. | Supported from Browse. | Planned after station lists exist. |
+| Add several stations to a station list | Not planned for current web. | Supported from Browse. | Supported. |
 
 ## Android First-Port Requirement
 
@@ -40,11 +40,12 @@ Android currently includes the first-port basics:
 - Favorite/unfavorite from rows.
 - Play from rows.
 - Local recents update on play.
+- Batch selection from Browse into station lists.
 
 Remaining Android alignment work:
 
 - Map browse.
-- Station-list batch selection.
 - Advanced sort controls.
+- Station info preview and native Browse presentation refinements.
 - Bundled full-text index, unless in-memory search is too slow on target
   devices.

--- a/docs/spec/features/favorites.md
+++ b/docs/spec/features/favorites.md
@@ -33,9 +33,9 @@ The selected mode and the visible/order settings are user preferences.
 | Behavior | Web | iOS | Android |
 |---|---|---|---|
 | Add/remove favorites | Supported. | Supported. | Supported. |
-| Reorder favorites | Supported. | Reference native behavior. | Planned. |
+| Reorder favorites | Supported. | Reference native behavior. | Partial; basic controls exist, native drag/reorder remains. |
 | Favorites list view | Supported. | Supported. | Supported. |
-| Favorites tile/app views | Partial/current web behavior may differ. | Reference. | Planned after list parity. |
+| Favorites tile/app views | Partial/current web behavior may differ. | Reference. | Supported; persistence and ordering preferences still need parity. |
 | Recents | Supported, capped. | Supported, capped. | Supported, capped. |
 | iCloud sync | Not planned. | Supported for favorites and order. | Not applicable. |
 | Manual file export/import | Supported. | Planned/optional. | Planned/optional. |
@@ -49,6 +49,9 @@ The selected mode and the visible/order settings are user preferences.
 - Android persists locally in DataStore.
 - Recents remain local-only on every platform unless a future sync ADR changes
   that decision.
+- Android currently keeps the selected Favorites display mode in memory only;
+  persisting the selected mode and visible/order settings is part of the
+  remaining native parity work.
 
 ## Empty And Search States
 

--- a/docs/spec/features/metadata-artwork.md
+++ b/docs/spec/features/metadata-artwork.md
@@ -25,7 +25,7 @@ language implementation.
 | Broadcaster fetchers | Reference proving ground. | Native parity for wired fetchers. | Planned native parity. |
 | ICY metadata | Supported via fetch where CORS/proxy allows. | Supported through AV metadata and bounded fetch fallback. | Partial; basic ICY parser/fetcher exists. |
 | Program schedule | Supported for wired broadcasters. | Supported for wired broadcasters. | Planned. |
-| Station logos | Supported. | Supported. | Planned. |
+| Station logos | Supported. | Supported. | Partial; row/header rendering exists, full policy parity remains. |
 | Track cover art | Supported. | Supported. | Planned. |
 | Lyrics lookup | Supported. | Planned/partial native parity. | Planned. |
 

--- a/docs/spec/features/now-playing.md
+++ b/docs/spec/features/now-playing.md
@@ -23,10 +23,10 @@ and secondary listening actions.
 
 | Behavior | Web | iOS | Android |
 |---|---|---|---|
-| Destination view | Supported. | Reference. | Planned. |
-| Mini-player handoff | Supported. | Supported. | Planned. |
-| Track metadata | Supported. | Reference. | Planned. |
-| Cover art fallback | Supported. | Reference. | Planned. |
+| Destination view | Supported. | Reference. | Partial; current Android surface is still a thin sheet. |
+| Mini-player handoff | Supported. | Supported. | Supported. |
+| Track metadata | Supported. | Reference. | Partial; basic ICY metadata exists. |
+| Cover art fallback | Supported. | Reference. | Partial; station artwork fallback exists, track cover art is deferred. |
 | Program schedule | Supported for wired broadcasters. | Supported for wired broadcasters. | Planned. |
 | Lyrics | Supported where lookup matches. | Planned/partial native parity. | Planned. |
 | Music-service search links | Supported. | Planned/partial native parity. | Planned. |

--- a/docs/spec/features/preferences-diagnostics.md
+++ b/docs/spec/features/preferences-diagnostics.md
@@ -20,11 +20,11 @@ Platform matrix:
 
 | Preference | Web | iOS | Android |
 |---|---|---|---|
-| Theme | Supported. | Reference. | Planned. |
+| Theme | Supported. | Reference. | Partial; runtime toggle exists, persisted system/light/dark preference remains. |
 | Accent color | Supported/partial by web theme design. | Supported. | Planned. |
 | Language | Browser/content dependent. | Supported. | Planned after localization scope. |
 | Landing page | Not a primary web contract. | Supported. | Planned if useful on Android. |
-| Favorites display modes | Partial. | Reference. | Planned. |
+| Favorites display modes | Partial. | Reference. | Partial; modes exist, preference persistence/order controls remain. |
 | Sleep default | Supported where exposed. | Supported. | Planned. |
 | Wake default/notifications | Supported where exposed. | Supported. | Planned with wake feature. |
 

--- a/docs/spec/features/station-lists.md
+++ b/docs/spec/features/station-lists.md
@@ -21,16 +21,20 @@ favorite dial.
 
 | Behavior | Web | iOS | Android |
 |---|---|---|---|
-| Station-list overview | Not planned for current web. | Reference. | Planned. |
-| Create/rename/delete list | Not planned for current web. | Supported. | Planned. |
-| Add stations from Browse | Not planned for current web. | Supported. | Planned. |
-| Play list as queue | Not planned for current web. | Supported. | Planned. |
+| Station-list overview | Not planned for current web. | Reference. | Supported. |
+| Create/delete list | Not planned for current web. | Supported. | Supported. |
+| Rename list | Not planned for current web. | Supported. | Planned. |
+| Add stations from Browse | Not planned for current web. | Supported. | Supported. |
+| Remove stations from a list | Not planned for current web. | Supported. | Supported. |
+| Reorder lists | Not planned for current web. | Supported. | Planned. |
+| Reorder stations inside a list | Not planned for current web. | Supported. | Planned. |
+| Play list as queue | Not planned for current web. | Supported. | Supported. |
 | Cloud sync | Not applicable. | Supported through CloudKit. | Not applicable. |
-| Local persistence | Not planned for current web. | Supported. | Planned. |
+| Local persistence | Not planned for current web. | Supported. | Supported. |
 
-## Android First-Port Scope
+## Android Current Status
 
-Android can ship without station lists if the first port is focused on playback,
-Browse, Favorites, Recents, and custom stations. Once station lists are in
-scope, Android should follow the iOS product behavior but use Android-native
-list management and drag/reorder affordances.
+Android now has the core station-list model in scope: list overview, create,
+delete, Browse batch-add, station removal, local persistence, and queue-scoped
+playback are implemented. Remaining parity work is rename, reorder lists,
+reorder stations inside a list, and Android-native list management polish.

--- a/docs/spec/platforms.md
+++ b/docs/spec/platforms.md
@@ -78,10 +78,12 @@ Current implementation shape:
 - Jetpack Compose for UI.
 - Media3/ExoPlayer for stream playback.
 - MediaSessionService for background playback and notification controls.
-- DataStore for favorites, recents, and custom stations.
+- DataStore for favorites, recents, custom stations, and station lists.
 - Catalog decoding and cache-backed network loading.
 - Search parity for station names, tags, countries, and whitespace-insensitive
   matches.
+- Lists/Browse/Favorites tab structure with station-list batch add and
+  Favorites list/tile/app display modes.
 - Sleep timer cycle.
 - Basic ICY `StreamTitle` parsing and bounded ICY metadata fetcher.
 


### PR DESCRIPTION
## Summary
- update the Android column in the product parity matrix after the merged Android parity work
- refresh feature specs for Browse, Favorites, station lists, Now Playing, metadata/artwork, preferences, platform, and data-sync status
- turn android/README.md into the current Android parity checklist linked to #397 and scoped issues #398-#407

## Validation
- git diff --cached --check
- rg stale-reference checks for old Android planned rows around station lists, Favorites modes, and Browse batch-add

Closes #402.
Part of #397.