### PR TITLE
[codex] Android: persist theme preference

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -24,7 +24,7 @@ compatibility layer, no account requirement, and no shared backend.
 | `docs/spec/features/metadata-artwork.md` | Partial | Basic ICY `StreamTitle` parsing and bounded ICY metadata fetch are present for `status: icy-only` stations. Broadcaster fetcher parity, schedules, full station-logo policy, track cover art, and lyrics are tracked in #407. |
 | `docs/spec/features/sleep-timer.md` | Partial | The off / 15 / 30 / 60 / 90 minute cycle pauses playback without clearing station context. Visible remaining time and background firing validation belong with #403 and #404. |
 | `docs/spec/features/wake-to-radio.md` | Deferred decision | Exact-alarm permission, foreground service behavior, notification fallback, and battery optimization language need a design decision before implementation in #405. |
-| `docs/spec/features/preferences-diagnostics.md` | Partial | Runtime theme toggle and Favorites display-mode controls exist. Persisted system/light/dark preference, accent color, language, landing page, sleep default, history, diagnostics, broken-station reporting, and Android Auto scope are tracked in #399, #406, and #405. |
+| `docs/spec/features/preferences-diagnostics.md` | Partial | Persisted system/light/dark theme preference and Favorites display-mode controls exist. Accent color, a fuller Preferences surface, language, landing page, sleep default, history, diagnostics, broken-station reporting, and Android Auto scope are tracked in #399, #406, and #405. |
 
 ## Parity Tracking
 

--- a/android/app/src/main/java/org/rrradio/android/MainActivity.kt
+++ b/android/app/src/main/java/org/rrradio/android/MainActivity.kt
@@ -7,6 +7,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import org.rrradio.android.ui.RrradioApp
@@ -26,8 +27,13 @@ class MainActivity : ComponentActivity() {
         }
         setContent {
             val state by viewModel.uiState.collectAsState()
-            RrradioTheme(darkTheme = state.darkTheme) {
-                RrradioApp(state = state, actions = viewModel)
+            val darkTheme = state.themePreference.resolvedDarkTheme(isSystemInDarkTheme())
+            RrradioTheme(darkTheme = darkTheme) {
+                RrradioApp(
+                    state = state,
+                    actions = viewModel,
+                    resolvedDarkTheme = darkTheme,
+                )
             }
         }
     }

--- a/android/app/src/main/java/org/rrradio/android/data/LibraryRepository.kt
+++ b/android/app/src/main/java/org/rrradio/android/data/LibraryRepository.kt
@@ -23,6 +23,8 @@ class LibraryRepository(
     val recents: Flow<List<Station>> = stationList(Keys.recents)
     val customStations: Flow<List<Station>> = stationList(Keys.customStations)
     val stationLists: Flow<List<StationList>> = store.data.map { prefs -> readStationLists(prefs[Keys.stationLists]) }
+    val themePreference: Flow<AppThemePreference> =
+        store.data.map { prefs -> AppThemePreference.fromRaw(prefs[Keys.themePreference]) }
 
     suspend fun toggleFavorite(station: Station): Boolean {
         var added = false
@@ -152,6 +154,12 @@ class LibraryRepository(
         }
     }
 
+    suspend fun setThemePreference(preference: AppThemePreference) {
+        store.edit { prefs ->
+            prefs[Keys.themePreference] = preference.rawValue
+        }
+    }
+
     private fun stationList(key: androidx.datastore.preferences.core.Preferences.Key<String>): Flow<List<Station>> =
         store.data.map { prefs -> readStations(prefs[key]) }
 
@@ -170,6 +178,7 @@ class LibraryRepository(
         val recents = stringPreferencesKey("rrradio.recents.v2")
         val customStations = stringPreferencesKey("rrradio.custom.v1")
         val stationLists = stringPreferencesKey("rrradio.station-lists.v1")
+        val themePreference = stringPreferencesKey("rrradio.theme-preference.v1")
     }
 
     companion object {

--- a/android/app/src/main/java/org/rrradio/android/data/Models.kt
+++ b/android/app/src/main/java/org/rrradio/android/data/Models.kt
@@ -57,6 +57,24 @@ data class CatalogResponse(
     val stations: List<Station>,
 )
 
+enum class AppThemePreference(val rawValue: String) {
+    System("system"),
+    Light("light"),
+    Dark("dark"),
+    ;
+
+    fun resolvedDarkTheme(systemDarkTheme: Boolean): Boolean = when (this) {
+        System -> systemDarkTheme
+        Light -> false
+        Dark -> true
+    }
+
+    companion object {
+        fun fromRaw(rawValue: String?): AppThemePreference =
+            entries.firstOrNull { it.rawValue == rawValue } ?: System
+    }
+}
+
 internal object StringCompatibleSerializer : KSerializer<String> {
     override val descriptor = PrimitiveSerialDescriptor("StringCompatible", PrimitiveKind.STRING)
 

--- a/android/app/src/main/java/org/rrradio/android/ui/RrradioApp.kt
+++ b/android/app/src/main/java/org/rrradio/android/ui/RrradioApp.kt
@@ -87,6 +87,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil3.compose.AsyncImage
 import org.rrradio.android.R
+import org.rrradio.android.data.AppThemePreference
 import org.rrradio.android.data.CatalogLoadState
 import org.rrradio.android.data.PlaybackUiState
 import org.rrradio.android.data.PlayerState
@@ -99,6 +100,7 @@ import org.rrradio.android.data.countryDisplayName
 fun RrradioApp(
     state: RrradioUiState,
     actions: RrradioViewModel,
+    resolvedDarkTheme: Boolean,
 ) {
     var showAddStation by remember { mutableStateOf(false) }
     var showNowPlaying by remember { mutableStateOf(false) }
@@ -158,7 +160,8 @@ fun RrradioApp(
             Header(
                 state = state,
                 onQuery = actions::setQuery,
-                onToggleTheme = actions::toggleTheme,
+                onThemePreference = actions::setThemePreference,
+                resolvedDarkTheme = resolvedDarkTheme,
                 onAddStation = { showAddStation = true },
                 onCountry = actions::setCountry,
                 onTag = actions::setTag,
@@ -318,7 +321,8 @@ fun RrradioApp(
 private fun Header(
     state: RrradioUiState,
     onQuery: (String) -> Unit,
-    onToggleTheme: () -> Unit,
+    onThemePreference: (AppThemePreference) -> Unit,
+    resolvedDarkTheme: Boolean,
     onAddStation: () -> Unit,
     onCountry: (String?) -> Unit,
     onTag: (String?) -> Unit,
@@ -348,7 +352,7 @@ private fun Header(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(10.dp),
             ) {
-                BrandLogo(darkTheme = state.darkTheme)
+                BrandLogo(darkTheme = resolvedDarkTheme)
                 Text(
                     text = when (state.tab) {
                         AppTab.StationLists -> state.selectedStationList?.name ?: "Lists"
@@ -363,10 +367,10 @@ private fun Header(
 
             Spacer(Modifier.weight(1f))
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                CircleIconButton(
-                    icon = if (state.darkTheme) Icons.Rounded.LightMode else Icons.Rounded.DarkMode,
-                    label = "Switch theme",
-                    onClick = onToggleTheme,
+                ThemePreferenceButton(
+                    selected = state.themePreference,
+                    resolvedDarkTheme = resolvedDarkTheme,
+                    onSelected = onThemePreference,
                 )
                 if (state.tab == AppTab.Browse) {
                     CircleIconButton(
@@ -413,6 +417,64 @@ private fun BrandLogo(darkTheme: Boolean) {
             .size(36.dp)
             .clip(RoundedCornerShape(8.dp)),
     )
+}
+
+@Composable
+private fun ThemePreferenceButton(
+    selected: AppThemePreference,
+    resolvedDarkTheme: Boolean,
+    onSelected: (AppThemePreference) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    Box {
+        CircleIconButton(
+            icon = themePreferenceIcon(selected, resolvedDarkTheme),
+            label = "Theme",
+            onClick = { expanded = true },
+        )
+        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            AppThemePreference.entries.forEach { preference ->
+                DropdownMenuItem(
+                    text = { Text(themePreferenceLabel(preference)) },
+                    leadingIcon = {
+                        Icon(
+                            themePreferenceIcon(preference, resolvedDarkTheme),
+                            contentDescription = null,
+                            modifier = Modifier.size(18.dp),
+                        )
+                    },
+                    trailingIcon = {
+                        if (preference == selected) {
+                            Icon(
+                                Icons.Rounded.Check,
+                                contentDescription = null,
+                                modifier = Modifier.size(18.dp),
+                            )
+                        }
+                    },
+                    onClick = {
+                        expanded = false
+                        onSelected(preference)
+                    },
+                )
+            }
+        }
+    }
+}
+
+private fun themePreferenceLabel(preference: AppThemePreference): String = when (preference) {
+    AppThemePreference.System -> "System"
+    AppThemePreference.Light -> "Light"
+    AppThemePreference.Dark -> "Dark"
+}
+
+private fun themePreferenceIcon(
+    preference: AppThemePreference,
+    resolvedDarkTheme: Boolean,
+): ImageVector = when (preference) {
+    AppThemePreference.System -> if (resolvedDarkTheme) Icons.Rounded.DarkMode else Icons.Rounded.LightMode
+    AppThemePreference.Light -> Icons.Rounded.LightMode
+    AppThemePreference.Dark -> Icons.Rounded.DarkMode
 }
 
 @Composable

--- a/android/app/src/main/java/org/rrradio/android/ui/RrradioViewModel.kt
+++ b/android/app/src/main/java/org/rrradio/android/ui/RrradioViewModel.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import org.rrradio.android.data.AppThemePreference
 import org.rrradio.android.data.CatalogLoadState
 import org.rrradio.android.data.CatalogRepository
 import org.rrradio.android.data.CatalogState
@@ -62,7 +63,7 @@ data class RrradioUiState(
     val selectedCountry: String? = null,
     val selectedTag: String? = null,
     val sleepMinutes: Int = 0,
-    val darkTheme: Boolean = false,
+    val themePreference: AppThemePreference = AppThemePreference.System,
     val favoritesDisplayMode: FavoritesDisplayMode = FavoritesDisplayMode.List,
 ) {
     val allStations: List<Station>
@@ -137,6 +138,11 @@ class RrradioViewModel(application: Application) : AndroidViewModel(application)
                     val selectedId = state.selectedStationListId?.takeIf { id -> stationLists.any { it.id == id } }
                     state.copy(stationLists = stationLists, selectedStationListId = selectedId)
                 }
+            }
+        }
+        viewModelScope.launch {
+            libraryRepository.themePreference.collect { preference ->
+                _uiState.update { it.copy(themePreference = preference) }
             }
         }
         viewModelScope.launch {
@@ -273,8 +279,8 @@ class RrradioViewModel(application: Application) : AndroidViewModel(application)
         viewModelScope.launch { libraryRepository.reorderFavorites(mutable.map { it.id }) }
     }
 
-    fun toggleTheme() {
-        _uiState.update { it.copy(darkTheme = !it.darkTheme) }
+    fun setThemePreference(preference: AppThemePreference) {
+        viewModelScope.launch { libraryRepository.setThemePreference(preference) }
     }
 
     fun play(station: Station) {

--- a/android/app/src/test/java/org/rrradio/android/data/LibraryRepositoryTest.kt
+++ b/android/app/src/test/java/org/rrradio/android/data/LibraryRepositoryTest.kt
@@ -5,6 +5,20 @@ import org.junit.Test
 
 class LibraryRepositoryTest {
     @Test
+    fun themePreferenceFallsBackToSystemForUnknownRawValue() {
+        assertEquals(AppThemePreference.System, AppThemePreference.fromRaw(null))
+        assertEquals(AppThemePreference.System, AppThemePreference.fromRaw("unknown"))
+    }
+
+    @Test
+    fun themePreferenceResolvesSystemAgainstDeviceTheme() {
+        assertEquals(false, AppThemePreference.System.resolvedDarkTheme(systemDarkTheme = false))
+        assertEquals(true, AppThemePreference.System.resolvedDarkTheme(systemDarkTheme = true))
+        assertEquals(false, AppThemePreference.Light.resolvedDarkTheme(systemDarkTheme = true))
+        assertEquals(true, AppThemePreference.Dark.resolvedDarkTheme(systemDarkTheme = false))
+    }
+
+    @Test
     fun uniqueStationsKeepsFirstOccurrence() {
         val first = station("first")
         val duplicate = station("first", name = "Duplicate")

--- a/docs/spec/features/preferences-diagnostics.md
+++ b/docs/spec/features/preferences-diagnostics.md
@@ -20,7 +20,7 @@ Platform matrix:
 
 | Preference | Web | iOS | Android |
 |---|---|---|---|
-| Theme | Supported. | Reference. | Partial; runtime toggle exists, persisted system/light/dark preference remains. |
+| Theme | Supported. | Reference. | Partial; persisted system/light/dark preference exists, fuller Preferences surface remains. |
 | Accent color | Supported/partial by web theme design. | Supported. | Planned. |
 | Language | Browser/content dependent. | Supported. | Planned after localization scope. |
 | Landing page | Not a primary web contract. | Supported. | Planned if useful on Android. |


### PR DESCRIPTION
Part of #399.

## Summary
- add a persisted Android `System` / `Light` / `Dark` theme preference backed by DataStore
- resolve the theme at the app root and keep the header logo tied to the resolved light/dark theme
- replace the temporary one-tap theme toggle with a native menu and update Android/spec status docs

## Validation
- `git diff --check -- android/README.md android/app/src/main/java/org/rrradio/android/MainActivity.kt android/app/src/main/java/org/rrradio/android/data/Models.kt android/app/src/main/java/org/rrradio/android/data/LibraryRepository.kt android/app/src/main/java/org/rrradio/android/ui/RrradioApp.kt android/app/src/main/java/org/rrradio/android/ui/RrradioViewModel.kt android/app/src/test/java/org/rrradio/android/data/LibraryRepositoryTest.kt docs/spec/features/preferences-diagnostics.md`
- `env JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home GRADLE_USER_HOME=/Users/markussteinbrecher/Code/rrradio/android/.gradle-home gradle --no-daemon testDebugUnitTest assembleDebug`
- emulator install/launch smoke
- UI dump confirmed the theme menu shows `System`, `Light`, and `Dark`
- selected `Dark`, relaunched, and screenshot-checked the dark native Android UI
