### PR TITLE
[codex] Android: add preferences surface

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -24,7 +24,7 @@ compatibility layer, no account requirement, and no shared backend.
 | `docs/spec/features/metadata-artwork.md` | Partial | Basic ICY `StreamTitle` parsing and bounded ICY metadata fetch are present for `status: icy-only` stations. Broadcaster fetcher parity, schedules, full station-logo policy, track cover art, and lyrics are tracked in #407. |
 | `docs/spec/features/sleep-timer.md` | Partial | The off / 15 / 30 / 60 / 90 minute cycle pauses playback without clearing station context. Visible remaining time and background firing validation belong with #403 and #404. |
 | `docs/spec/features/wake-to-radio.md` | Deferred decision | Exact-alarm permission, foreground service behavior, notification fallback, and battery optimization language need a design decision before implementation in #405. |
-| `docs/spec/features/preferences-diagnostics.md` | Partial | Persisted system/light/dark theme preference and Favorites display-mode controls exist. Accent color, a fuller Preferences surface, language, landing page, sleep default, history, diagnostics, broken-station reporting, and Android Auto scope are tracked in #399, #406, and #405. |
+| `docs/spec/features/preferences-diagnostics.md` | Partial | Native Preferences sheet, persisted system/light/dark theme, preset accent palette, landing page, sleep default, and Favorites display-mode controls exist. Custom accent entry, language, history, diagnostics, broken-station reporting, and Android Auto scope are tracked in #399, #406, and #405. |
 
 ## Parity Tracking
 

--- a/android/app/src/main/java/org/rrradio/android/MainActivity.kt
+++ b/android/app/src/main/java/org/rrradio/android/MainActivity.kt
@@ -28,7 +28,10 @@ class MainActivity : ComponentActivity() {
         setContent {
             val state by viewModel.uiState.collectAsState()
             val darkTheme = state.themePreference.resolvedDarkTheme(isSystemInDarkTheme())
-            RrradioTheme(darkTheme = darkTheme) {
+            RrradioTheme(
+                darkTheme = darkTheme,
+                accentPreference = state.accentPreference,
+            ) {
                 RrradioApp(
                     state = state,
                     actions = viewModel,

--- a/android/app/src/main/java/org/rrradio/android/data/LibraryRepository.kt
+++ b/android/app/src/main/java/org/rrradio/android/data/LibraryRepository.kt
@@ -2,6 +2,7 @@ package org.rrradio.android.data
 
 import android.content.Context
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import kotlinx.coroutines.flow.Flow
@@ -25,6 +26,12 @@ class LibraryRepository(
     val stationLists: Flow<List<StationList>> = store.data.map { prefs -> readStationLists(prefs[Keys.stationLists]) }
     val themePreference: Flow<AppThemePreference> =
         store.data.map { prefs -> AppThemePreference.fromRaw(prefs[Keys.themePreference]) }
+    val accentPreference: Flow<AccentPreference> =
+        store.data.map { prefs -> AccentPreference.fromRaw(prefs[Keys.accentPreference]) }
+    val landingPagePreference: Flow<LandingPagePreference> =
+        store.data.map { prefs -> LandingPagePreference.fromRaw(prefs[Keys.landingPagePreference]) }
+    val sleepDefaultMinutes: Flow<Int> =
+        store.data.map { prefs -> normalizedSleepDefaultMinutes(prefs[Keys.sleepDefaultMinutes]) }
 
     suspend fun toggleFavorite(station: Station): Boolean {
         var added = false
@@ -160,6 +167,24 @@ class LibraryRepository(
         }
     }
 
+    suspend fun setAccentPreference(preference: AccentPreference) {
+        store.edit { prefs ->
+            prefs[Keys.accentPreference] = preference.rawValue
+        }
+    }
+
+    suspend fun setLandingPagePreference(preference: LandingPagePreference) {
+        store.edit { prefs ->
+            prefs[Keys.landingPagePreference] = preference.rawValue
+        }
+    }
+
+    suspend fun setSleepDefaultMinutes(minutes: Int) {
+        store.edit { prefs ->
+            prefs[Keys.sleepDefaultMinutes] = normalizedSleepDefaultMinutes(minutes)
+        }
+    }
+
     private fun stationList(key: androidx.datastore.preferences.core.Preferences.Key<String>): Flow<List<Station>> =
         store.data.map { prefs -> readStations(prefs[key]) }
 
@@ -179,10 +204,15 @@ class LibraryRepository(
         val customStations = stringPreferencesKey("rrradio.custom.v1")
         val stationLists = stringPreferencesKey("rrradio.station-lists.v1")
         val themePreference = stringPreferencesKey("rrradio.theme-preference.v1")
+        val accentPreference = stringPreferencesKey("rrradio.accent-preference.v1")
+        val landingPagePreference = stringPreferencesKey("rrradio.landing-page.v1")
+        val sleepDefaultMinutes = intPreferencesKey("rrradio.sleep-default-minutes.v1")
     }
 
     companion object {
         const val RECENTS_LIMIT = 12
+        const val DEFAULT_SLEEP_MINUTES = 30
+        val SLEEP_DEFAULT_OPTIONS = listOf(15, 30, 60, 90)
         private const val FALLBACK_STATION_LIST_NAME = "Station List"
 
         fun cleanedStationListName(name: String): String =
@@ -204,5 +234,8 @@ class LibraryRepository(
             next.addAll(stations.filterNot { it.id in seen })
             return next
         }
+
+        fun normalizedSleepDefaultMinutes(minutes: Int?): Int =
+            minutes?.takeIf { it in SLEEP_DEFAULT_OPTIONS } ?: DEFAULT_SLEEP_MINUTES
     }
 }

--- a/android/app/src/main/java/org/rrradio/android/data/Models.kt
+++ b/android/app/src/main/java/org/rrradio/android/data/Models.kt
@@ -75,6 +75,32 @@ enum class AppThemePreference(val rawValue: String) {
     }
 }
 
+enum class AccentPreference(val rawValue: String) {
+    Classic("classic"),
+    Yellow("yellow"),
+    Green("green"),
+    Blue("blue"),
+    Pink("pink"),
+    ;
+
+    companion object {
+        fun fromRaw(rawValue: String?): AccentPreference =
+            entries.firstOrNull { it.rawValue == rawValue } ?: Classic
+    }
+}
+
+enum class LandingPagePreference(val rawValue: String) {
+    StationLists("lists"),
+    Browse("browse"),
+    Favorites("favorites"),
+    ;
+
+    companion object {
+        fun fromRaw(rawValue: String?): LandingPagePreference =
+            entries.firstOrNull { it.rawValue == rawValue } ?: Browse
+    }
+}
+
 internal object StringCompatibleSerializer : KSerializer<String> {
     override val descriptor = PrimitiveSerialDescriptor("StringCompatible", PrimitiveKind.STRING)
 

--- a/android/app/src/main/java/org/rrradio/android/ui/RrradioApp.kt
+++ b/android/app/src/main/java/org/rrradio/android/ui/RrradioApp.kt
@@ -6,10 +6,12 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
@@ -47,7 +49,9 @@ import androidx.compose.material.icons.rounded.Pause
 import androidx.compose.material.icons.rounded.PlayArrow
 import androidx.compose.material.icons.rounded.Public
 import androidx.compose.material.icons.rounded.Search
+import androidx.compose.material.icons.rounded.Settings
 import androidx.compose.material.icons.rounded.Star
+import androidx.compose.material.icons.rounded.Timer
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -87,13 +91,17 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil3.compose.AsyncImage
 import org.rrradio.android.R
+import org.rrradio.android.data.AccentPreference
 import org.rrradio.android.data.AppThemePreference
 import org.rrradio.android.data.CatalogLoadState
+import org.rrradio.android.data.LandingPagePreference
+import org.rrradio.android.data.LibraryRepository
 import org.rrradio.android.data.PlaybackUiState
 import org.rrradio.android.data.PlayerState
 import org.rrradio.android.data.Station
 import org.rrradio.android.data.StationList
 import org.rrradio.android.data.countryDisplayName
+import org.rrradio.android.ui.theme.rrradioAccentColor
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -106,6 +114,7 @@ fun RrradioApp(
     var showNowPlaying by remember { mutableStateOf(false) }
     var showChooseStationList by remember { mutableStateOf(false) }
     var showCreateStationList by remember { mutableStateOf(false) }
+    var showPreferences by remember { mutableStateOf(false) }
     var createListFromSelection by remember { mutableStateOf(false) }
     var customStationPendingDelete by remember { mutableStateOf<Station?>(null) }
     var stationListPendingDelete by remember { mutableStateOf<String?>(null) }
@@ -160,7 +169,7 @@ fun RrradioApp(
             Header(
                 state = state,
                 onQuery = actions::setQuery,
-                onThemePreference = actions::setThemePreference,
+                onOpenPreferences = { showPreferences = true },
                 resolvedDarkTheme = resolvedDarkTheme,
                 onAddStation = { showAddStation = true },
                 onCountry = actions::setCountry,
@@ -225,6 +234,25 @@ fun RrradioApp(
                 onToggle = actions::togglePlayback,
                 onSleep = actions::cycleSleepTimer,
                 onDismiss = { showNowPlaying = false },
+            )
+        }
+    }
+
+    if (showPreferences) {
+        ModalBottomSheet(
+            sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+            containerColor = MaterialTheme.colorScheme.background,
+            dragHandle = null,
+            onDismissRequest = { showPreferences = false },
+        ) {
+            PreferencesSheet(
+                state = state,
+                resolvedDarkTheme = resolvedDarkTheme,
+                onThemePreference = actions::setThemePreference,
+                onAccentPreference = actions::setAccentPreference,
+                onLandingPagePreference = actions::setLandingPagePreference,
+                onSleepDefaultMinutes = actions::setSleepDefaultMinutes,
+                onDismiss = { showPreferences = false },
             )
         }
     }
@@ -321,7 +349,7 @@ fun RrradioApp(
 private fun Header(
     state: RrradioUiState,
     onQuery: (String) -> Unit,
-    onThemePreference: (AppThemePreference) -> Unit,
+    onOpenPreferences: () -> Unit,
     resolvedDarkTheme: Boolean,
     onAddStation: () -> Unit,
     onCountry: (String?) -> Unit,
@@ -367,10 +395,10 @@ private fun Header(
 
             Spacer(Modifier.weight(1f))
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                ThemePreferenceButton(
-                    selected = state.themePreference,
-                    resolvedDarkTheme = resolvedDarkTheme,
-                    onSelected = onThemePreference,
+                CircleIconButton(
+                    icon = Icons.Rounded.Settings,
+                    label = "Preferences",
+                    onClick = onOpenPreferences,
                 )
                 if (state.tab == AppTab.Browse) {
                     CircleIconButton(
@@ -419,49 +447,6 @@ private fun BrandLogo(darkTheme: Boolean) {
     )
 }
 
-@Composable
-private fun ThemePreferenceButton(
-    selected: AppThemePreference,
-    resolvedDarkTheme: Boolean,
-    onSelected: (AppThemePreference) -> Unit,
-) {
-    var expanded by remember { mutableStateOf(false) }
-    Box {
-        CircleIconButton(
-            icon = themePreferenceIcon(selected, resolvedDarkTheme),
-            label = "Theme",
-            onClick = { expanded = true },
-        )
-        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
-            AppThemePreference.entries.forEach { preference ->
-                DropdownMenuItem(
-                    text = { Text(themePreferenceLabel(preference)) },
-                    leadingIcon = {
-                        Icon(
-                            themePreferenceIcon(preference, resolvedDarkTheme),
-                            contentDescription = null,
-                            modifier = Modifier.size(18.dp),
-                        )
-                    },
-                    trailingIcon = {
-                        if (preference == selected) {
-                            Icon(
-                                Icons.Rounded.Check,
-                                contentDescription = null,
-                                modifier = Modifier.size(18.dp),
-                            )
-                        }
-                    },
-                    onClick = {
-                        expanded = false
-                        onSelected(preference)
-                    },
-                )
-            }
-        }
-    }
-}
-
 private fun themePreferenceLabel(preference: AppThemePreference): String = when (preference) {
     AppThemePreference.System -> "System"
     AppThemePreference.Light -> "Light"
@@ -475,6 +460,301 @@ private fun themePreferenceIcon(
     AppThemePreference.System -> if (resolvedDarkTheme) Icons.Rounded.DarkMode else Icons.Rounded.LightMode
     AppThemePreference.Light -> Icons.Rounded.LightMode
     AppThemePreference.Dark -> Icons.Rounded.DarkMode
+}
+
+@Composable
+private fun PreferencesSheet(
+    state: RrradioUiState,
+    resolvedDarkTheme: Boolean,
+    onThemePreference: (AppThemePreference) -> Unit,
+    onAccentPreference: (AccentPreference) -> Unit,
+    onLandingPagePreference: (LandingPagePreference) -> Unit,
+    onSleepDefaultMinutes: (Int) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    Column(
+        Modifier
+            .fillMaxWidth()
+            .statusBarsPadding()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 20.dp)
+            .padding(top = 18.dp, bottom = 28.dp),
+        verticalArrangement = Arrangement.spacedBy(18.dp),
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Column(Modifier.weight(1f)) {
+                Text(
+                    "Preferences",
+                    color = MaterialTheme.colorScheme.onBackground,
+                    fontSize = 22.sp,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Text(
+                    "Device-local settings",
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    fontSize = 12.sp,
+                )
+            }
+            CircleIconButton(
+                icon = Icons.Rounded.Close,
+                label = "Close preferences",
+                size = 34,
+                iconSize = 16,
+                onClick = onDismiss,
+            )
+        }
+
+        PreferenceSection(title = "Appearance") {
+            AppThemePreference.entries.forEachIndexed { index, preference ->
+                PreferenceChoiceRow(
+                    icon = themePreferenceIcon(preference, resolvedDarkTheme),
+                    title = themePreferenceLabel(preference),
+                    detail = themePreferenceDetail(preference, resolvedDarkTheme),
+                    selected = state.themePreference == preference,
+                    onClick = { onThemePreference(preference) },
+                )
+                if (index != AppThemePreference.entries.lastIndex) PreferenceDivider()
+            }
+        }
+
+        PreferenceSection(title = "Accent") {
+            AccentPreference.entries.forEachIndexed { index, preference ->
+                AccentPreferenceRow(
+                    preference = preference,
+                    resolvedDarkTheme = resolvedDarkTheme,
+                    selected = state.accentPreference == preference,
+                    onClick = { onAccentPreference(preference) },
+                )
+                if (index != AccentPreference.entries.lastIndex) PreferenceDivider()
+            }
+        }
+
+        PreferenceSection(title = "Start") {
+            LandingPagePreference.entries.forEachIndexed { index, preference ->
+                PreferenceChoiceRow(
+                    icon = landingPagePreferenceIcon(preference),
+                    title = landingPagePreferenceLabel(preference),
+                    detail = landingPagePreferenceDetail(preference),
+                    selected = state.landingPagePreference == preference,
+                    onClick = { onLandingPagePreference(preference) },
+                )
+                if (index != LandingPagePreference.entries.lastIndex) PreferenceDivider()
+            }
+        }
+
+        PreferenceSection(title = "Sleep timer") {
+            LibraryRepository.SLEEP_DEFAULT_OPTIONS.forEachIndexed { index, minutes ->
+                PreferenceChoiceRow(
+                    icon = Icons.Rounded.Timer,
+                    title = "$minutes minutes",
+                    detail = if (state.sleepDefaultMinutes == minutes) {
+                        "First Sleep tap starts here."
+                    } else {
+                        "Use $minutes minutes as the default."
+                    },
+                    selected = state.sleepDefaultMinutes == minutes,
+                    onClick = { onSleepDefaultMinutes(minutes) },
+                )
+                if (index != LibraryRepository.SLEEP_DEFAULT_OPTIONS.lastIndex) PreferenceDivider()
+            }
+        }
+    }
+}
+
+@Composable
+private fun PreferenceSection(
+    title: String,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text(
+            title,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            fontSize = 12.sp,
+            fontWeight = FontWeight.SemiBold,
+        )
+        Column(
+            Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(8.dp))
+                .background(MaterialTheme.colorScheme.surfaceVariant)
+                .border(BorderStroke(1.dp, MaterialTheme.colorScheme.outline), RoundedCornerShape(8.dp)),
+            content = content,
+        )
+    }
+}
+
+@Composable
+private fun PreferenceChoiceRow(
+    icon: ImageVector,
+    title: String,
+    detail: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .background(if (selected) MaterialTheme.colorScheme.primary.copy(alpha = 0.10f) else Color.Transparent)
+            .clickable(onClick = onClick)
+            .padding(horizontal = 14.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        PreferenceLeadingIcon(icon = icon, selected = selected)
+        Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+            Text(
+                title,
+                color = MaterialTheme.colorScheme.onBackground,
+                fontSize = 15.sp,
+                fontWeight = FontWeight.Medium,
+            )
+            Text(
+                detail,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontSize = 12.sp,
+                lineHeight = 16.sp,
+            )
+        }
+        if (selected) {
+            Icon(
+                Icons.Rounded.Check,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(18.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun AccentPreferenceRow(
+    preference: AccentPreference,
+    resolvedDarkTheme: Boolean,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .background(if (selected) MaterialTheme.colorScheme.primary.copy(alpha = 0.10f) else Color.Transparent)
+            .clickable(onClick = onClick)
+            .padding(horizontal = 14.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Box(
+            Modifier
+                .size(30.dp)
+                .clip(CircleShape)
+                .background(rrradioAccentColor(preference, resolvedDarkTheme))
+                .border(BorderStroke(1.dp, MaterialTheme.colorScheme.outline), CircleShape),
+        )
+        Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+            Text(
+                accentPreferenceLabel(preference),
+                color = MaterialTheme.colorScheme.onBackground,
+                fontSize = 15.sp,
+                fontWeight = FontWeight.Medium,
+            )
+            Text(
+                accentPreferenceDetail(preference),
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontSize = 12.sp,
+                lineHeight = 16.sp,
+            )
+        }
+        if (selected) {
+            Icon(
+                Icons.Rounded.Check,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(18.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun PreferenceLeadingIcon(icon: ImageVector, selected: Boolean) {
+    Box(
+        Modifier
+            .size(30.dp)
+            .clip(CircleShape)
+            .background(
+                if (selected) {
+                    MaterialTheme.colorScheme.primary.copy(alpha = 0.20f)
+                } else {
+                    MaterialTheme.colorScheme.background
+                },
+            )
+            .border(BorderStroke(1.dp, MaterialTheme.colorScheme.outline), CircleShape),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            icon,
+            contentDescription = null,
+            tint = if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(16.dp),
+        )
+    }
+}
+
+@Composable
+private fun PreferenceDivider() {
+    Box(
+        Modifier
+            .fillMaxWidth()
+            .height(1.dp)
+            .background(MaterialTheme.colorScheme.outline),
+    )
+}
+
+private fun themePreferenceDetail(
+    preference: AppThemePreference,
+    resolvedDarkTheme: Boolean,
+): String = when (preference) {
+    AppThemePreference.System -> if (resolvedDarkTheme) {
+        "Follow Android. Currently dark."
+    } else {
+        "Follow Android. Currently light."
+    }
+    AppThemePreference.Light -> "Always use the light app theme."
+    AppThemePreference.Dark -> "Always use the dark app theme."
+}
+
+private fun accentPreferenceLabel(preference: AccentPreference): String = when (preference) {
+    AccentPreference.Classic -> "Classic"
+    AccentPreference.Yellow -> "Yellow"
+    AccentPreference.Green -> "Green"
+    AccentPreference.Blue -> "Blue"
+    AccentPreference.Pink -> "Pink"
+}
+
+private fun accentPreferenceDetail(preference: AccentPreference): String = when (preference) {
+    AccentPreference.Classic -> "Green in light mode, yellow in dark mode."
+    AccentPreference.Yellow -> "Use the night-radio yellow accent everywhere."
+    AccentPreference.Green -> "Use the original green accent everywhere."
+    AccentPreference.Blue -> "Use a cooler Android accent."
+    AccentPreference.Pink -> "Use a warmer high-contrast accent."
+}
+
+private fun landingPagePreferenceLabel(preference: LandingPagePreference): String = when (preference) {
+    LandingPagePreference.StationLists -> "Lists"
+    LandingPagePreference.Browse -> "Browse"
+    LandingPagePreference.Favorites -> "Favorites"
+}
+
+private fun landingPagePreferenceDetail(preference: LandingPagePreference): String = when (preference) {
+    LandingPagePreference.StationLists -> "Open your station lists on launch."
+    LandingPagePreference.Browse -> "Open the full catalog on launch."
+    LandingPagePreference.Favorites -> "Open your favorite stations on launch."
+}
+
+private fun landingPagePreferenceIcon(preference: LandingPagePreference): ImageVector = when (preference) {
+    LandingPagePreference.StationLists -> Icons.AutoMirrored.Rounded.Article
+    LandingPagePreference.Browse -> Icons.Rounded.Public
+    LandingPagePreference.Favorites -> Icons.Rounded.Favorite
 }
 
 @Composable

--- a/android/app/src/main/java/org/rrradio/android/ui/RrradioViewModel.kt
+++ b/android/app/src/main/java/org/rrradio/android/ui/RrradioViewModel.kt
@@ -10,10 +10,12 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import org.rrradio.android.data.AccentPreference
 import org.rrradio.android.data.AppThemePreference
 import org.rrradio.android.data.CatalogLoadState
 import org.rrradio.android.data.CatalogRepository
 import org.rrradio.android.data.CatalogState
+import org.rrradio.android.data.LandingPagePreference
 import org.rrradio.android.data.LibraryRepository
 import org.rrradio.android.data.PlaybackUiState
 import org.rrradio.android.data.PlayerState
@@ -63,7 +65,10 @@ data class RrradioUiState(
     val selectedCountry: String? = null,
     val selectedTag: String? = null,
     val sleepMinutes: Int = 0,
+    val sleepDefaultMinutes: Int = LibraryRepository.DEFAULT_SLEEP_MINUTES,
     val themePreference: AppThemePreference = AppThemePreference.System,
+    val accentPreference: AccentPreference = AccentPreference.Classic,
+    val landingPagePreference: LandingPagePreference = LandingPagePreference.Browse,
     val favoritesDisplayMode: FavoritesDisplayMode = FavoritesDisplayMode.List,
 ) {
     val allStations: List<Station>
@@ -111,6 +116,7 @@ class RrradioViewModel(application: Application) : AndroidViewModel(application)
     private val libraryRepository = LibraryRepository(application)
     private val streamProbe = StreamProbe()
     private var sleepJob: Job? = null
+    private var appliedLandingPagePreference = false
 
     private val _uiState = MutableStateFlow(RrradioUiState())
     val uiState: StateFlow<RrradioUiState> = _uiState.asStateFlow()
@@ -143,6 +149,25 @@ class RrradioViewModel(application: Application) : AndroidViewModel(application)
         viewModelScope.launch {
             libraryRepository.themePreference.collect { preference ->
                 _uiState.update { it.copy(themePreference = preference) }
+            }
+        }
+        viewModelScope.launch {
+            libraryRepository.accentPreference.collect { preference ->
+                _uiState.update { it.copy(accentPreference = preference) }
+            }
+        }
+        viewModelScope.launch {
+            libraryRepository.landingPagePreference.collect { preference ->
+                _uiState.update { state ->
+                    val startupTab = if (!appliedLandingPagePreference) landingTab(preference) else state.tab
+                    state.copy(landingPagePreference = preference, tab = startupTab)
+                }
+                appliedLandingPagePreference = true
+            }
+        }
+        viewModelScope.launch {
+            libraryRepository.sleepDefaultMinutes.collect { minutes ->
+                _uiState.update { it.copy(sleepDefaultMinutes = minutes) }
             }
         }
         viewModelScope.launch {
@@ -283,6 +308,18 @@ class RrradioViewModel(application: Application) : AndroidViewModel(application)
         viewModelScope.launch { libraryRepository.setThemePreference(preference) }
     }
 
+    fun setAccentPreference(preference: AccentPreference) {
+        viewModelScope.launch { libraryRepository.setAccentPreference(preference) }
+    }
+
+    fun setLandingPagePreference(preference: LandingPagePreference) {
+        viewModelScope.launch { libraryRepository.setLandingPagePreference(preference) }
+    }
+
+    fun setSleepDefaultMinutes(minutes: Int) {
+        viewModelScope.launch { libraryRepository.setSleepDefaultMinutes(minutes) }
+    }
+
     fun play(station: Station) {
         val context = getApplication<Application>()
         val queue = activePlaybackQueue(uiState.value.visibleStations, station)
@@ -339,7 +376,12 @@ class RrradioViewModel(application: Application) : AndroidViewModel(application)
     fun cycleSleepTimer() {
         val cycle = listOf(0, 15, 30, 60, 90)
         val current = uiState.value.sleepMinutes
-        val next = cycle[(cycle.indexOf(current).takeIf { it >= 0 } ?: 0).let { (it + 1) % cycle.size }]
+        val default = uiState.value.sleepDefaultMinutes
+        val next = if (current == 0) {
+            default
+        } else {
+            cycle[(cycle.indexOf(current).takeIf { it >= 0 } ?: 0).let { (it + 1) % cycle.size }]
+        }
         sleepJob?.cancel()
         if (next == 0) {
             _uiState.update { it.copy(sleepMinutes = 0) }
@@ -352,6 +394,12 @@ class RrradioViewModel(application: Application) : AndroidViewModel(application)
             context.startService(RadioPlaybackService.pauseIntent(context))
             _uiState.update { it.copy(sleepMinutes = 0) }
         }
+    }
+
+    private fun landingTab(preference: LandingPagePreference): AppTab = when (preference) {
+        LandingPagePreference.StationLists -> AppTab.StationLists
+        LandingPagePreference.Browse -> AppTab.Browse
+        LandingPagePreference.Favorites -> AppTab.Favorites
     }
 
     override fun onCleared() {

--- a/android/app/src/main/java/org/rrradio/android/ui/theme/Theme.kt
+++ b/android/app/src/main/java/org/rrradio/android/ui/theme/Theme.kt
@@ -7,9 +7,12 @@ import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
+import org.rrradio.android.data.AccentPreference
 
 val RrGreen = Color(0xFF00A040)
 val RrYellow = Color(0xFFFFFF00)
+val RrBlue = Color(0xFF2F80ED)
+val RrPink = Color(0xFFFF4FA3)
 val RrLightBg = Color(0xFFF8F8F3)
 val RrLightPanel = Color(0xFFFFFFFB)
 val RrLightInk = Color(0xFF0E0E0D)
@@ -20,17 +23,34 @@ val RrDarkInk = Color(0xFFF4F4F2)
 @Composable
 fun RrradioTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
+    accentPreference: AccentPreference = AccentPreference.Classic,
     content: @Composable () -> Unit,
 ) {
     MaterialTheme(
-        colorScheme = if (darkTheme) darkScheme else lightScheme,
+        colorScheme = if (darkTheme) darkScheme(accentPreference) else lightScheme(accentPreference),
         content = content,
     )
 }
 
-private val lightScheme: ColorScheme = lightColorScheme(
-    primary = RrGreen,
-    onPrimary = RrLightBg,
+fun rrradioAccentColor(preference: AccentPreference, darkTheme: Boolean): Color = when (preference) {
+    AccentPreference.Classic -> if (darkTheme) RrYellow else RrGreen
+    AccentPreference.Yellow -> RrYellow
+    AccentPreference.Green -> RrGreen
+    AccentPreference.Blue -> RrBlue
+    AccentPreference.Pink -> RrPink
+}
+
+private fun onAccentColor(preference: AccentPreference, darkTheme: Boolean): Color = when (preference) {
+    AccentPreference.Blue,
+    AccentPreference.Pink -> Color.White
+    AccentPreference.Classic -> if (darkTheme) RrDarkBg else RrLightBg
+    AccentPreference.Yellow,
+    AccentPreference.Green -> if (darkTheme) RrDarkBg else RrLightBg
+}
+
+private fun lightScheme(accentPreference: AccentPreference): ColorScheme = lightColorScheme(
+    primary = rrradioAccentColor(accentPreference, darkTheme = false),
+    onPrimary = onAccentColor(accentPreference, darkTheme = false),
     background = RrLightBg,
     onBackground = RrLightInk,
     surface = RrLightBg,
@@ -40,9 +60,9 @@ private val lightScheme: ColorScheme = lightColorScheme(
     outline = RrLightInk.copy(alpha = 0.10f),
 )
 
-private val darkScheme: ColorScheme = darkColorScheme(
-    primary = RrYellow,
-    onPrimary = RrDarkBg,
+private fun darkScheme(accentPreference: AccentPreference): ColorScheme = darkColorScheme(
+    primary = rrradioAccentColor(accentPreference, darkTheme = true),
+    onPrimary = onAccentColor(accentPreference, darkTheme = true),
     background = RrDarkBg,
     onBackground = RrDarkInk,
     surface = RrDarkBg,

--- a/android/app/src/test/java/org/rrradio/android/data/LibraryRepositoryTest.kt
+++ b/android/app/src/test/java/org/rrradio/android/data/LibraryRepositoryTest.kt
@@ -19,6 +19,28 @@ class LibraryRepositoryTest {
     }
 
     @Test
+    fun accentPreferenceFallsBackToClassicForUnknownRawValue() {
+        assertEquals(AccentPreference.Classic, AccentPreference.fromRaw(null))
+        assertEquals(AccentPreference.Classic, AccentPreference.fromRaw("unknown"))
+        assertEquals(AccentPreference.Blue, AccentPreference.fromRaw("blue"))
+    }
+
+    @Test
+    fun landingPagePreferenceFallsBackToBrowseForUnknownRawValue() {
+        assertEquals(LandingPagePreference.Browse, LandingPagePreference.fromRaw(null))
+        assertEquals(LandingPagePreference.Browse, LandingPagePreference.fromRaw("unknown"))
+        assertEquals(LandingPagePreference.Favorites, LandingPagePreference.fromRaw("favorites"))
+    }
+
+    @Test
+    fun sleepDefaultMinutesUsesSupportedValuesOnly() {
+        assertEquals(30, LibraryRepository.normalizedSleepDefaultMinutes(null))
+        assertEquals(30, LibraryRepository.normalizedSleepDefaultMinutes(0))
+        assertEquals(15, LibraryRepository.normalizedSleepDefaultMinutes(15))
+        assertEquals(90, LibraryRepository.normalizedSleepDefaultMinutes(90))
+    }
+
+    @Test
     fun uniqueStationsKeepsFirstOccurrence() {
         val first = station("first")
         val duplicate = station("first", name = "Duplicate")

--- a/docs/spec/features/preferences-diagnostics.md
+++ b/docs/spec/features/preferences-diagnostics.md
@@ -20,12 +20,12 @@ Platform matrix:
 
 | Preference | Web | iOS | Android |
 |---|---|---|---|
-| Theme | Supported. | Reference. | Partial; persisted system/light/dark preference exists, fuller Preferences surface remains. |
-| Accent color | Supported/partial by web theme design. | Supported. | Planned. |
+| Theme | Supported. | Reference. | Supported for system/light/dark in a native Preferences sheet. |
+| Accent color | Supported/partial by web theme design. | Supported. | Partial; native preset accent palette exists, custom color entry remains deferred. |
 | Language | Browser/content dependent. | Supported. | Planned after localization scope. |
-| Landing page | Not a primary web contract. | Supported. | Planned if useful on Android. |
+| Landing page | Not a primary web contract. | Supported. | Supported for Lists, Browse, and Favorites startup targets. |
 | Favorites display modes | Partial. | Reference. | Partial; modes exist, preference persistence/order controls remain. |
-| Sleep default | Supported where exposed. | Supported. | Planned. |
+| Sleep default | Supported where exposed. | Supported. | Supported for the first sleep-timer tap. |
 | Wake default/notifications | Supported where exposed. | Supported. | Planned with wake feature. |
 
 ## Listening History


### PR DESCRIPTION
Part of #399.

## Summary
- add a native Android Preferences sheet behind the header gear
- persist accent, landing page, and sleep-default preferences in DataStore
- apply the chosen accent through the app Material theme and apply the chosen landing tab on startup
- update Android/spec parity docs for the Preferences work that is now implemented

## Validation
- `git diff --check -- android/README.md docs/spec/features/preferences-diagnostics.md android/app/src/main/java/org/rrradio/android/MainActivity.kt android/app/src/main/java/org/rrradio/android/data/Models.kt android/app/src/main/java/org/rrradio/android/data/LibraryRepository.kt android/app/src/main/java/org/rrradio/android/ui/RrradioApp.kt android/app/src/main/java/org/rrradio/android/ui/RrradioViewModel.kt android/app/src/main/java/org/rrradio/android/ui/theme/Theme.kt android/app/src/test/java/org/rrradio/android/data/LibraryRepositoryTest.kt`
- `env JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home GRADLE_USER_HOME=/Users/markussteinbrecher/Code/rrradio/android/.gradle-home gradle --no-daemon testDebugUnitTest assembleDebug`
- emulator install/launch smoke
- Preferences sheet screenshot after status-bar padding
- Blue accent selection and relaunch screenshot
- Lists landing-page selection, force-stop, relaunch, and UI dump confirming startup on `Lists`
