### PR TITLE
worker: snap stats window to UTC day boundary

### DIFF
--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -202,7 +202,10 @@ describe('public endpoints', () => {
     expect(body.items[0].series.every((v: number) => v === 0)).toBe(true);
     expect(body.total).toBe(15);
     expect(body.range_days).toBe(7);
-    expect(body.days).toHaveLength(8); // 7-day window = today + 7 prior days
+    // Snap-to-yesterday: a `days=7` window is 7 complete calendar days
+    // ending yesterday UTC. "Today" is intentionally excluded so totals
+    // don't ratchet upward across the day.
+    expect(body.days).toHaveLength(7);
   });
 
   it('GET /api/public/top-stations zero-fills the series and maps stats by day', async () => {
@@ -221,9 +224,9 @@ describe('public endpoints', () => {
           path: 'play: Alpha FM',
           count: 12,
           stats: [
-            { day: day(0), daily: 5 }, // today
+            { day: day(1), daily: 5 }, // yesterday — latest slot in the snapped window
             { day: day(3), daily: 7 }, // 3 days ago
-            // GC would normally omit zero-event days; we test that fill.
+            { day: day(0), daily: 99 }, // "today" — should be dropped (out of window)
           ],
         },
         { path: 'play: Beta FM', count: 0 }, // no stats at all
@@ -234,15 +237,17 @@ describe('public endpoints', () => {
       items: Array<{ name: string; count: number; series: number[] }>;
       days: string[];
     }>(res);
-    expect(body.days[body.days.length - 1]).toBe(day(0));
-    expect(body.days[body.days.length - 1 - 3]).toBe(day(3));
+    // Last slot is yesterday (today − 1), not today.
+    expect(body.days[body.days.length - 1]).toBe(day(1));
+    expect(body.days[body.days.length - 1 - 2]).toBe(day(3));
     expect(body.items[0].name).toBe('Alpha FM');
-    // today and (today-3) should be the only non-zero slots
+    // yesterday and (today-3) should be the only non-zero slots; the
+    // "today" stat is outside the window and gets dropped.
     const nonZero = body.items[0].series
       .map((v, i) => ({ v, i }))
       .filter((e) => e.v > 0);
     expect(nonZero).toEqual([
-      { i: body.days.length - 1 - 3, v: 7 },
+      { i: body.days.length - 1 - 2, v: 7 },
       { i: body.days.length - 1, v: 5 },
     ]);
     // Hit with no stats → fully zero-filled series matching `days`.
@@ -282,11 +287,12 @@ describe('public endpoints', () => {
       d.setUTCDate(d.getUTCDate() - offset);
       return d.toISOString().slice(0, 10);
     };
-    // Build a per-day fixture: oldest → newest, 8 days for days=7.
-    // CH grows linearly; DE has one big spike; FR appears on day 5 only.
+    // Build a per-day fixture: oldest → newest, 7 days for days=7 (the
+    // snap-to-yesterday window excludes today). CH grows linearly; DE
+    // has one big spike; FR appears on day 5 only.
     const fixture: Record<string, { stats: Array<{ id: string; name: string; count: number }>; total: number }> = {};
-    for (let i = 0; i <= 7; i++) {
-      const d = day(7 - i); // oldest first
+    for (let i = 0; i <= 6; i++) {
+      const d = day(7 - i); // oldest first — day(7) … day(1)
       fixture[d] = {
         stats: [
           { id: 'CH', name: 'Switzerland', count: i + 1 },
@@ -320,19 +326,19 @@ describe('public endpoints', () => {
       days: string[];
     }>(res);
     expect(body.range_days).toBe(7);
-    expect(body.days).toHaveLength(8);
+    expect(body.days).toHaveLength(7);
     const ch = body.items.find((i) => i.code === 'CH');
     const de = body.items.find((i) => i.code === 'DE');
     const fr = body.items.find((i) => i.code === 'FR');
     expect(ch).toBeDefined();
     expect(de).toBeDefined();
     expect(fr).toBeDefined();
-    // CH series: 1..8 across the 8 days. Sum = 36.
-    expect(ch!.series).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
-    expect(ch!.count).toBe(36);
-    // DE series: 5 every day except day index 3 = 100. Sum = 5*7 + 100 = 135.
-    expect(de!.series).toEqual([5, 5, 5, 100, 5, 5, 5, 5]);
-    expect(de!.count).toBe(135);
+    // CH series: 1..7 across the 7 days. Sum = 28.
+    expect(ch!.series).toEqual([1, 2, 3, 4, 5, 6, 7]);
+    expect(ch!.count).toBe(28);
+    // DE series: 5 every day except day index 3 = 100. Sum = 5*6 + 100 = 130.
+    expect(de!.series).toEqual([5, 5, 5, 100, 5, 5, 5]);
+    expect(de!.count).toBe(130);
     // FR series: 0 everywhere except day index 5 = 7. Sum = 7.
     expect(fr!.series[5]).toBe(7);
     expect(fr!.count).toBe(7);

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -187,9 +187,22 @@ async function gcFetch<T>(path: string, env: Env): Promise<T> {
   return (await res.json()) as T;
 }
 
+// The stats window is snapped to UTC day boundaries — it always ends at
+// yesterday EOD UTC and spans `daysBack` complete calendar days back from
+// there. The previous behaviour pulled "start..now" (no end), so totals
+// ratcheted upward through the day and two devices on different edge
+// cache populations (5-minute TTL) showed different snapshots. Snapping
+// to yesterday means numbers only jump once per day at UTC midnight and
+// every reader sees the same stable window all day long.
 function rangeStart(daysBack: number): string {
   const d = new Date();
   d.setUTCDate(d.getUTCDate() - daysBack);
+  return d.toISOString().slice(0, 10);
+}
+
+function rangeEnd(): string {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() - 1);
   return d.toISOString().slice(0, 10);
 }
 
@@ -211,6 +224,7 @@ function clampDays(raw: string | null): number {
 async function fetchAllHits(daysBack: number, env: Env): Promise<GcHit[]> {
   const params = new URLSearchParams({
     start: rangeStart(daysBack),
+    end: rangeEnd(),
     limit: '500',
     daily: 'true',
   });
@@ -218,14 +232,17 @@ async function fetchAllHits(daysBack: number, env: Env): Promise<GcHit[]> {
   return data.hits ?? [];
 }
 
-// Build the canonical [oldest..today] list of YYYY-MM-DD day strings
-// for a `daysBack`-window. Used as the index for per-item series so
-// every item's series array has the same length and lines up with the
-// same days, even when GC omits days where the item had zero events.
+// Build the canonical [oldest..yesterday] list of YYYY-MM-DD day strings
+// for a `daysBack`-window. Same end-date that fetchAllHits passes to GC,
+// so each station's stats array indexes cleanly into this list. Used as
+// the per-item series index so every item's series array has the same
+// length and lines up with the same days, even when GC omits days where
+// the item had zero events. Length == daysBack (no longer includes the
+// incomplete "today").
 function rangeDays(daysBack: number): string[] {
   const days: string[] = [];
   const today = new Date();
-  for (let i = daysBack; i >= 0; i--) {
+  for (let i = daysBack; i >= 1; i--) {
     const d = new Date(today);
     d.setUTCDate(d.getUTCDate() - i);
     days.push(d.toISOString().slice(0, 10));
@@ -267,7 +284,8 @@ function pickByPrefix(
 
 async function totals(daysBack: number, env: Env): Promise<GcTotals & { range_days: number }> {
   const start = rangeStart(daysBack);
-  const data = await gcFetch<GcTotals>(`/stats/total?start=${start}`, env);
+  const end = rangeEnd();
+  const data = await gcFetch<GcTotals>(`/stats/total?start=${start}&end=${end}`, env);
   return { ...data, range_days: daysBack };
 }
 
@@ -384,6 +402,7 @@ async function fetchStatGroup(
 ): Promise<ListResponse> {
   const params = new URLSearchParams({
     start: rangeStart(daysBack),
+    end: rangeEnd(),
     limit: String(limit),
   });
   const data = await gcFetch<GcStatGroup>(`/stats/${group}?${params}`, env);
@@ -732,7 +751,8 @@ export default {
           // Returns the raw GoatCounter /stats/total response so we can
           // see exactly which field names this account/version exposes.
           const start = rangeStart(days);
-          const raw = await gcFetch<unknown>(`/stats/total?start=${start}`, env);
+          const end = rangeEnd();
+          const raw = await gcFetch<unknown>(`/stats/total?start=${start}&end=${end}`, env);
           data = { range_days: days, raw_totals: raw };
           break;
         }


### PR DESCRIPTION
## Summary

The dashboard at `/dashboard.html` was showing different numbers across devices and changing values throughout the day. Root cause: the worker queried GoatCounter with `start = today − N days` and **no end date** — meaning the window endpoint was always "right now". Two side-effects:

1. **Totals ratcheted upward through the day** as new events came in. "Visits" and "events" for the same 7-day window changed hour to hour even when nothing else moved.
2. **CDN edge caches diverged**: each PoP had its own 5-minute snapshot of an ever-moving window. Phone vs. laptop hit different edges and reliably showed different numbers.

## Fix

Snap the window to UTC day boundaries. Pass an explicit `end = yesterday UTC` to every GoatCounter call:
- \`fetchAllHits\` (used by every public list endpoint + \`/api/everything\`)
- \`totals\` (used by metrics card)
- \`fetchStatGroup\` (\`/api/locations\`, \`/api/browsers\`, \`/api/systems\`)
- \`/api/debug\`

Window is now **N complete calendar days ending yesterday**. Totals only jump once per day at UTC midnight; every reader sees the same stable snapshot all day. The dashboard's "this period · 7d" now means "the 7 most recent **complete** days," which is what users intuitively expect from analytics.

`rangeDays(N)` shrinks from N+1 to N entries (no longer includes the incomplete "today"), and dashboard series arrays line up cleanly with the snapped window.

## Test plan

- [x] \`worker/\` test suite: 39/39 pass (test fixtures updated to expect 7-day arrays + the new "today is dropped" semantics)
- [x] Root \`tsc --noEmit\` clean
- [ ] After deploy: open \`/dashboard.html\` on phone and laptop simultaneously, confirm identical numbers for the same range button.
- [ ] After deploy: reload the dashboard a few times within an hour, confirm numbers stay constant (will jump once at next UTC midnight).

## Notes

- 5-minute edge cache remains — it just no longer hides an unstable underlying window. The cache will populate with the same data at every PoP within 5 min.
- "Today" stats are intentionally excluded from the public dashboard. The homepage's "trending stations" view shares this same worker endpoint and will also exclude today — for radio that's fine (trends don't pivot hour-to-hour), but worth knowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)