### PR TITLE
skill(curate-logos): default scrape to --mode upgrade; chain rasterise + pngquant

### DIFF
--- a/.claude/skills/curate-logos/SKILL.md
+++ b/.claude/skills/curate-logos/SKILL.md
@@ -175,15 +175,45 @@ limits within seconds. Hit rate typically 15–40% per country.
 
 ### 4. Broadcaster scrape
 
-Re-derive the still-missing subset (some of the 30 may have been filled
-by stage 3) and feed `scrape-logos.mjs`:
+Feed the in-scope IDs to `scrape-logos.mjs` in **upgrade mode** —
+that's the critical detail. The default `--mode missing` only touches
+stations with no favicon at all, which misses the most common gap:
+stations that currently ship a weak placeholder (apple-touch-icon,
+`favicon.ico`, third-party-host upload, etc.) when the broadcaster's
+own site actually advertises a proper og:image / JSON-LD logo.
+`--mode upgrade` includes those rows; `--replace-good` lets a verified
+broadcaster-domain hit replace even a previously-classified-good logo
+when scoring says it's strictly better.
 
 ```bash
 IDS=$(cat /tmp/curate-logos-scope.csv)
-node tools/scrape-logos.mjs --id "$IDS" --concurrency 12
+node tools/scrape-logos.mjs --id "$IDS" --mode upgrade --replace-good --concurrency 12
 ```
 
-Hit rate ~25–40% for stations that have a homepage.
+Hit rate ~25–50% across mode=upgrade — significantly higher than
+mode=missing because most rows in the dashboard's "poor" / "warn"
+buckets already have *something*, just not the right something.
+
+If a station's site is a JavaScript SPA (1cloud.fm, modern Vue/React
+broadcaster pages, …), the static HTML scraper sees only the app
+shell. The tool will report `no verifiable upgrade`; these rows go
+into stage 6 (LLM research) for manual scraping via WebFetch +
+DOM-rendered preview.
+
+### 4b. Rasterise any new SVG hits + optimise the bundle
+
+```bash
+npm run catalog                       # so rasteriser sees the new YAML
+npm run rasterise-remote-svgs         # SVG → local 500px PNG bundle
+npm run pngquant-stations             # ~60% PNG size win
+```
+
+The scrape pass often writes SVG URLs (broadcaster sites prefer SVG
+sources). iOS' `UIImage(data:)` and Android Coil don't decode SVG at
+runtime, so the rasteriser converts each new SVG into a local
+`public/stations/<id>.png`. `pngquant-stations` then shrinks the
+bundle. Both tools are idempotent — running them on the already-baked
+set is a no-op.
 
 ### 5. Quarantine
 
@@ -207,6 +237,19 @@ For each candidate (highest-votes-first):
    the homepage itself. Look for `<meta property="og:image">`, JSON-LD
    `image`, web app manifest icons, apple-touch-icon. Prefer SVG / 500px+
    PNGs.
+
+   **SPA fallback** — if the broadcaster/aggregator page is a JavaScript
+   SPA (1cloud.fm, modern Vue/React/Next sites), `WebFetch` only gets the
+   app shell and you won't find a logo signal. Two paths from here:
+   - `WebFetch` the broadcaster's own homepage (not the aggregator) —
+     often a static-rendered marketing page with og:image.
+   - If even the broadcaster site is SPA: `WebSearch` for the station
+     on Wikipedia / Wikimedia Commons — many stations have a curated
+     SVG/PNG there even when their own site renders client-side. The
+     `tools/wiki-logos.mjs` file-namespace path may already have caught
+     it; double-check by hand.
+   Document the SPA case in the PR body so future runs know which sites
+   to skip the static scrape on.
 4. **Validate the candidate.** A logo passes if:
    - URL is `https://`
    - HEAD returns `image/*` content-type


### PR DESCRIPTION
## Summary

Stacks on #419. Addresses sponsor feedback: hand-found logos (e.g. 1Live's official page) don't surface from our automated pipeline.

**Root cause** (not in any tool — in the skill): \`tools/scrape-logos.mjs\` defaulted to \`--mode missing\`, which only targets stations with **no** favicon. Most rows in the dashboard's "warn" / "poor" buckets already have *something* (an apple-touch-icon, a \`favicon.ico\`, a third-party-host upload), so they were never in scope for scrape — and the better broadcaster og:image / JSON-LD hit was never tried.

\`scrape-logos\` already supports \`--mode upgrade --replace-good\` and produces meaningful hits there — verified on \`wdr-1live\` (skill-stub scrape upgrades it from a 180×180 apple-touch-icon to the proper \`einslive.de\` og:image logo).

## Changes to `.claude/skills/curate-logos/SKILL.md`

1. **Step 4 default**: \`node tools/scrape-logos.mjs --id "$IDS" --mode upgrade --replace-good --concurrency 12\` (was \`--mode missing\` by default).
2. **New step 4b**: chains \`npm run catalog\` → \`npm run rasterise-remote-svgs\` → \`npm run pngquant-stations\` so every new SVG hit becomes a local PNG (mobile-renderable) and the bundle stays compact.
3. **Stage 6 SPA-fallback note**: when the broadcaster/aggregator page is a JavaScript SPA (1cloud.fm, modern Vue/React/Next sites), \`WebFetch\` only sees the app shell. Fall back to the broadcaster's marketing homepage or Wikimedia Commons; document the SPA case in the PR for future runs.

## Test plan

- [x] Skill docs only; no code changes.
- [ ] Next \`/curate-logos\` invocation should now upgrade existing-but-weak rows, not just blank-favicon ones.

## Why stack on #419?

This skill update references \`npm run pngquant-stations\` and chained behaviour that lives in #419's tool. Stacking keeps the docs internally consistent — if this PR merges before #419 ships pngquant-stations, the skill would describe a non-existent command. After #419 merges to main, this branch's base can be flipped to \`main\` automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)