### PR TITLE
tracker: sortable column headers (asc → desc → off cycle)

### DIFF
--- a/src/station-tracker.css
+++ b/src/station-tracker.css
@@ -490,6 +490,47 @@ h1 {
   padding: 0 10px;
 }
 
+.matrix-cols th[data-sort-key] {
+  cursor: pointer;
+  user-select: none;
+}
+
+.matrix-cols th[data-sort-key]:hover {
+  color: var(--ink-2);
+}
+
+/* Caret after the label. Reserves space so column width doesn't jump when
+ * sort engages; renders the active asc/desc glyph via aria-sort. */
+.matrix-cols th[data-sort-key]::after {
+  content: "";
+  display: inline-block;
+  width: 8px;
+  margin-left: 6px;
+  opacity: 0.35;
+}
+
+.matrix-cols th[data-sort-key]:hover::after {
+  content: "▴";
+  opacity: 0.55;
+}
+
+.matrix-cols th[aria-sort="ascending"]::after {
+  content: "▴";
+  color: var(--accent);
+  opacity: 1;
+}
+
+.matrix-cols th[aria-sort="descending"]::after {
+  content: "▾";
+  color: var(--accent);
+  opacity: 1;
+}
+
+.matrix-cols th[aria-sort="ascending"],
+.matrix-cols th[aria-sort="descending"] {
+  color: var(--ink);
+}
+
 .matrix td {
   padding: 8px 10px;
   border-bottom: 1px solid var(--line);

--- a/src/station-tracker.ts
+++ b/src/station-tracker.ts
@@ -82,6 +82,10 @@ interface MatrixRow {
 
 type ImageState = 'all' | 'ok' | 'warn' | 'bad';
 
+type SortKey = 'name' | 'country' | 'status' | 'favicon' | 'sourceType' | 'source'
+             | 'license' | 'tier' | 'state' | 'size';
+type SortDir = 'asc' | 'desc';
+
 const state: {
   rows: MatrixRow[];
   filtered: MatrixRow[];
@@ -96,12 +100,16 @@ const state: {
     license: string;
     npQuality: NpQuality;
   };
+  /** Active sort. `null` = catalog order (the default). Clicking a header
+   *  cycles: catalog → asc → desc → catalog. */
+  sort: { key: SortKey; dir: SortDir } | null;
   collapsedGroups: Set<string>;
 } = {
   rows: [],
   filtered: [],
   page: 0,
   filters: { query: '', country: 'all', status: 'all', imageState: 'all', license: 'all', npQuality: 'all' },
+  sort: null,
   collapsedGroups: new Set(),
 };
 
@@ -373,8 +381,76 @@ function rowMatchesFilters(
 function applyFilters(resetPage = true): void {
   if (resetPage) state.page = 0;
   state.filtered = state.rows.filter((r) => rowMatchesFilters(r));
+  if (state.sort) sortRows(state.filtered, state.sort.key, state.sort.dir);
   renderMatrix();
   renderDonuts();
+}
+
+// Tie-broken comparator helpers. Strings compare via localeCompare so accents
+// and umlauts land where readers expect them; missing values sort last on asc.
+function cmpStr(a: string | undefined, b: string | undefined): number {
+  if (a === b) return 0;
+  if (!a) return 1;
+  if (!b) return -1;
+  return a.localeCompare(b, undefined, { sensitivity: 'base' });
+}
+
+function cmpNum(a: number | undefined, b: number | undefined): number {
+  const av = Number.isFinite(a as number) ? (a as number) : Number.NEGATIVE_INFINITY;
+  const bv = Number.isFinite(b as number) ? (b as number) : Number.NEGATIVE_INFINITY;
+  return av - bv;
+}
+
+function rowKey(row: MatrixRow, key: SortKey): string | number | undefined {
+  switch (key) {
+    case 'name':       return row.name;
+    case 'country':    return row.country ? countryName(row.country) : undefined;
+    case 'status':     return row.status;
+    case 'favicon':    return row.favicon;
+    case 'sourceType': return row.sourceType;
+    case 'source':     return row.source;
+    case 'license':    return row.faviconLicense;
+    case 'tier':       return row.tier;
+    case 'state':      return row.state;
+    case 'size':       return (row.probeWidth ?? 0) * (row.probeHeight ?? 0);
+  }
+}
+
+function sortRows(rows: MatrixRow[], key: SortKey, dir: SortDir): void {
+  const factor = dir === 'asc' ? 1 : -1;
+  rows.sort((a, b) => {
+    const av = rowKey(a, key);
+    const bv = rowKey(b, key);
+    const c = typeof av === 'number' || typeof bv === 'number'
+      ? cmpNum(av as number, bv as number)
+      : cmpStr(av as string, bv as string);
+    // Stable tie-break on id so equal-value rows don't churn between renders.
+    return (c !== 0 ? c : a.id.localeCompare(b.id)) * factor;
+  });
+}
+
+/** Click → asc → desc → off cycle. Updates header aria-sort + applies sort
+ *  to the existing filtered set without re-filtering. Page resets to 0. */
+function cycleSort(key: SortKey): void {
+  const cur = state.sort;
+  let next: typeof state.sort;
+  if (!cur || cur.key !== key) next = { key, dir: 'asc' };
+  else if (cur.dir === 'asc')  next = { key, dir: 'desc' };
+  else                          next = null;
+  state.sort = next;
+  // Reflect on the headers.
+  for (const th of refs.table.querySelectorAll<HTMLTableCellElement>('th[data-sort-key]')) {
+    if (next && th.dataset.sortKey === next.key) {
+      th.setAttribute('aria-sort', next.dir === 'asc' ? 'ascending' : 'descending');
+    } else {
+      th.removeAttribute('aria-sort');
+    }
+  }
+  // Re-derive from rows in catalog order so toggling 'off' restores it.
+  state.filtered = state.rows.filter((r) => rowMatchesFilters(r));
+  if (next) sortRows(state.filtered, next.key, next.dir);
+  state.page = 0;
+  renderMatrix();
 }
 
 function appendIdGroupCells(tr: HTMLTableRowElement, row: MatrixRow): void {
@@ -941,6 +1017,12 @@ function bindEvents(): void {
     btn.addEventListener('click', () => {
       const group = btn.dataset.toggleGroup;
       if (group) toggleGroup(group);
+    });
+  }
+  for (const th of refs.table.querySelectorAll<HTMLTableCellElement>('th[data-sort-key]')) {
+    th.addEventListener('click', () => {
+      const key = th.dataset.sortKey as SortKey | undefined;
+      if (key) cycleSort(key);
     });
   }
 }

--- a/station-tracker.html
+++ b/station-tracker.html
@@ -121,17 +121,17 @@
               </tr>
               <tr class="matrix-cols">
                 <th class="matrix-col-thumb" data-group="id">Logo</th>
-                <th data-group="id">Station</th>
-                <th data-group="id">Country</th>
-                <th data-group="id">Status</th>
-                <th data-group="image">Favicon URL</th>
-                <th data-group="image">Source type</th>
-                <th data-group="image">Provenance</th>
+                <th data-group="id" data-sort-key="name">Station</th>
+                <th data-group="id" data-sort-key="country">Country</th>
+                <th data-group="id" data-sort-key="status">Status</th>
+                <th data-group="image" data-sort-key="favicon">Favicon URL</th>
+                <th data-group="image" data-sort-key="sourceType">Source type</th>
+                <th data-group="image" data-sort-key="source">Provenance</th>
                 <th data-group="image">Original URL</th>
-                <th data-group="image">License</th>
-                <th data-group="image">Tier</th>
-                <th data-group="image">State</th>
-                <th data-group="image">Size</th>
+                <th data-group="image" data-sort-key="license">License</th>
+                <th data-group="image" data-sort-key="tier">Tier</th>
+                <th data-group="image" data-sort-key="state">State</th>
+                <th data-group="image" data-sort-key="size">Size</th>
                 <th data-group="image">Action</th>
               </tr>
             </thead>


### PR DESCRIPTION
## Summary

The station-tracker matrix only supported filtering, not sorting — reviewing a fresh logo-curation pass meant scrolling through catalog order. This PR adds click-to-sort on the 10 data columns (Logo column stays inert).

## UX

- First click on a header → asc, \`aria-sort="ascending"\`, accent-coloured caret \`▴\`.
- Second click → desc, \`aria-sort="descending"\`, \`▾\`.
- Third click → cleared, back to catalog order.
- Click a different header → switches focus, resets to asc.

## Sortable columns

| Column | Comparator |
|---|---|
| Station | locale-aware string |
| Country | display-name (`countryName(code)`), locale-aware |
| Status | string |
| Favicon URL | string |
| Source type | string |
| Provenance | string |
| License | string |
| Tier | string |
| State | string |
| Size | numeric (W × H pixel area; missing rows lowest) |

The Logo, Original URL, and Action columns are intentionally not sortable (thumbnail / free-text-URL / textual recommendation — sorting them doesn't help review).

## Implementation

- HTML: \`data-sort-key="<key>"\` on each sortable \`<th>\`.
- CSS: pointer cursor, hover state, asc/desc carets via \`aria-sort\` attribute selector. The caret reserves width on every sortable header so the column doesn't jump when sort engages.
- TS: \`state.sort = { key, dir } | null\` plus a comparator router (`cmpStr` / `cmpNum`). Tie-break on \`id\` keeps order stable between renders of equal-key rows. Plays cleanly with the existing filter / pagination / donut-highlight logic.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] \`vitest run\` — 406/406 pass
- [x] Playwright end-to-end against dev server:
  - 3-click cycle on "Station" returns to catalog order ✓
  - aria-sort attribute transitions ascending → descending → null ✓
  - Size column sorts numerically (unprobed rows first on asc) ✓
- [ ] Visual: open \`/station-tracker.html\`, click any sortable header, confirm the caret + order change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)