### PR TITLE
[codex] Implement Android local data backup diagnostics

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -14,17 +14,17 @@ compatibility layer, no account requirement, and no shared backend.
 | Spec area | Android status | Remaining parity |
 |---|---|---|
 | `docs/spec/platforms.md` | Partial | Kotlin + Jetpack Compose, Media3/ExoPlayer, MediaSessionService, DataStore, cache-backed catalog loading, native app-shell logo, tab structure, station lists, and Favorites modes are in place. Wear OS remains out of scope for the first Android port. |
-| `docs/spec/data-sync.md` | Supported for local library data | Favorites, recents, custom stations, and station lists are device-local DataStore data. Manual backup export/import, listening history, diagnostics, and richer preference persistence are tracked in #406. |
+| `docs/spec/data-sync.md` | Supported for local library data | Favorites, recents, custom stations, station lists, selected preferences, opt-in history settings, capped diagnostics, and backup schema versioning are device-local DataStore data. Manual backup export/import supports favorites, custom stations, station lists, and preferences. No CloudKit/account sync is implied. |
 | `docs/spec/playback.md` | Partial | MP3/AAC/HLS playback uses ExoPlayer, visible-list playback creates an active queue, bounded source rebuild retries exist, and plain `.m3u` / `.pls` playlist URLs resolve before playback. Real background/lock-screen behavior and media-control validation are tracked in #404. |
 | `docs/spec/features/browse.md` | Supported except deferred views | Catalog load/cache, normalized search, country/genre filters, name/quality/favorite sorting, long-press station preview, favorite/play from rows, recents, and Browse batch-add into station lists are in place. Map browse and presentation refinements are tracked in #400. |
 | `docs/spec/features/favorites.md` | Partial | Add/remove favorites, capped recents, List/Tiles/App display modes with persisted mode preference, local persistence, and basic up/down reorder controls are in place. Native drag/reorder, visible/order settings, and metadata polish are tracked in #398. |
 | `docs/spec/features/station-lists.md` | Partial | Lists overview, create/rename/delete, Browse batch-add, station removal, up/down list reorder, up/down station reorder, local persistence, and list-scoped playback queues are in place. Native drag/reorder polish is tracked in #401. |
-| `docs/spec/features/custom-stations.md` | Supported except backup | HTTPS-only save, private/local host rejection, duplicate stream checks, stream probe before save, auto-favorite, delete confirmation, and local persistence are in place. Backup/export is tracked in #406. |
+| `docs/spec/features/custom-stations.md` | Supported | HTTPS-only save, private/local host rejection, duplicate stream checks, stream probe before save, auto-favorite, delete confirmation, local persistence, and backup export/import are in place. |
 | `docs/spec/features/now-playing.md` | Partial | The Android destination shows station identity, artwork/logo fallback, basic metadata, favorite toggle, play/pause plus active-queue previous/next, sleep entry, and mini-player handoff. Secondary panels, lyrics, schedules, and music-service links are tracked in #403. |
 | `docs/spec/features/metadata-artwork.md` | Partial | Basic ICY `StreamTitle` parsing, Grrif and ORF/FM4 native fetchers, ORF current-program metadata, broadcaster cover URLs, and iTunes cover/track verification fallback are in place. Remaining broadcaster fetchers, full schedule grids, station-logo policy polish, and lyrics are tracked in #407. |
 | `docs/spec/features/sleep-timer.md` | Partial | The off / 15 / 30 / 60 / 90 minute cycle pauses playback without clearing station context. Visible remaining time and background firing validation belong with #403 and #404. |
 | `docs/spec/features/wake-to-radio.md` | Deferred decision | Exact-alarm permission, foreground service behavior, notification fallback, and battery optimization language need a design decision before implementation in #405. |
-| `docs/spec/features/preferences-diagnostics.md` | Partial | Native Preferences sheet, persisted system/light/dark theme, preset accent palette, landing page, sleep default, and Favorites display-mode controls exist. Custom accent entry, language, history, diagnostics, broken-station reporting, and Android Auto scope are tracked in #399, #406, and #405. |
+| `docs/spec/features/preferences-diagnostics.md` | Partial | Native Preferences sheet, persisted system/light/dark theme, preset accent palette, landing page, sleep default, Favorites display-mode controls, opt-in station history, opt-in capped diagnostics export, manual backup import/export, and broken-station reporting exist. Custom accent entry, language, track-history metadata expansion, and Android Auto scope remain tracked in #399 and #405. |
 
 ## Parity Tracking
 
@@ -46,6 +46,18 @@ Deferred features should remain documented here until each area is implemented
 or explicitly deferred in an issue or ADR. Android Auto, wake-to-radio exact
 alarms, and any future cross-platform sync backend are separate product
 decisions, not hidden scope in this port.
+
+## Local Data And Backup
+
+Android remains device-local. The backup file is a user-selected JSON document,
+not a cloud sync protocol. The current `schemaVersion: 1` backup contains
+favorites, custom stations, station lists, and selected preferences. Import
+merges library objects by id and applies included preferences.
+
+Backups do not include recents, listening-history records, diagnostic logs,
+playback errors, active wake state, or account/cloud identifiers. Listening
+history and diagnostics are off by default; when enabled, both stay local, and
+diagnostics can be exported separately from Preferences.
 
 ## Building
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -23,6 +23,10 @@ android {
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
+
+    buildFeatures {
+        buildConfig = true
+    }
 }
 
 kotlin {

--- a/android/app/src/main/java/org/rrradio/android/data/BrokenStationReporter.kt
+++ b/android/app/src/main/java/org/rrradio/android/data/BrokenStationReporter.kt
@@ -1,0 +1,73 @@
+package org.rrradio.android.data
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.rrradio.android.BuildConfig
+import java.io.IOException
+import java.net.URI
+
+private const val BROKEN_STATION_ENDPOINT =
+    "https://rrradio-stats.markussteinbrecher.workers.dev/api/public/report-broken"
+
+class BrokenStationReporter(
+    private val client: OkHttpClient = OkHttpClient(),
+    private val endpoint: String = BROKEN_STATION_ENDPOINT,
+) {
+    suspend fun report(station: Station, reason: String?) {
+        val payload = brokenStationReportPayload(
+            station = station,
+            reason = reason.orEmpty(),
+            appVersion = BuildConfig.VERSION_NAME,
+        )
+        val body = defaultJson
+            .encodeToString(payload)
+            .toRequestBody("application/json".toMediaType())
+        val request = Request.Builder()
+            .url(endpoint)
+            .post(body)
+            .build()
+
+        withContext(Dispatchers.IO) {
+            client.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) {
+                    throw IOException("report failed: ${response.code}")
+                }
+            }
+        }
+    }
+}
+
+@Serializable
+internal data class BrokenStationReportPayload(
+    val stationId: String,
+    val stationName: String,
+    val streamHost: String,
+    val platform: String,
+    val appVersion: String,
+    val reason: String,
+    val source: String,
+)
+
+internal fun brokenStationReportPayload(
+    station: Station,
+    reason: String,
+    appVersion: String,
+): BrokenStationReportPayload =
+    BrokenStationReportPayload(
+        stationId = station.id,
+        stationName = station.displayName(),
+        streamHost = streamHost(station.streamUrl),
+        platform = "android",
+        appVersion = appVersion,
+        reason = reason.take(160),
+        source = "manual",
+    )
+
+internal fun streamHost(streamUrl: String): String =
+    runCatching { URI(streamUrl).host.orEmpty() }.getOrDefault("")

--- a/android/app/src/main/java/org/rrradio/android/data/LibraryRepository.kt
+++ b/android/app/src/main/java/org/rrradio/android/data/LibraryRepository.kt
@@ -1,11 +1,13 @@
 package org.rrradio.android.data
 
 import android.content.Context
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
@@ -34,6 +36,16 @@ class LibraryRepository(
         store.data.map { prefs -> FavoritesDisplayMode.fromRaw(prefs[Keys.favoritesDisplayMode]) }
     val sleepDefaultMinutes: Flow<Int> =
         store.data.map { prefs -> normalizedSleepDefaultMinutes(prefs[Keys.sleepDefaultMinutes]) }
+    val schemaVersion: Flow<Int> =
+        store.data.map { prefs -> normalizedSchemaVersion(prefs[Keys.schemaVersion]) }
+    val listeningHistoryPreference: Flow<ListeningHistoryPreference> =
+        store.data.map { prefs -> ListeningHistoryPreference.fromRaw(prefs[Keys.listeningHistoryPreference]) }
+    val listeningHistory: Flow<List<ListeningHistoryEntry>> =
+        store.data.map { prefs -> readListeningHistory(prefs[Keys.listeningHistory]) }
+    val diagnosticsEnabled: Flow<Boolean> =
+        store.data.map { prefs -> prefs[Keys.diagnosticsEnabled] ?: false }
+    val diagnosticLog: Flow<List<DiagnosticLogEntry>> =
+        store.data.map { prefs -> readDiagnosticLog(prefs[Keys.diagnosticLog]) }
 
     suspend fun toggleFavorite(station: Station): Boolean {
         var added = false
@@ -226,6 +238,131 @@ class LibraryRepository(
         }
     }
 
+    suspend fun ensureCurrentSchemaVersion() {
+        store.edit { prefs ->
+            if (prefs[Keys.schemaVersion] != ANDROID_LIBRARY_SCHEMA_VERSION) {
+                prefs[Keys.schemaVersion] = ANDROID_LIBRARY_SCHEMA_VERSION
+            }
+        }
+    }
+
+    suspend fun setListeningHistoryPreference(preference: ListeningHistoryPreference) {
+        store.edit { prefs ->
+            prefs[Keys.listeningHistoryPreference] = preference.rawValue
+            prefs[Keys.schemaVersion] = ANDROID_LIBRARY_SCHEMA_VERSION
+        }
+    }
+
+    suspend fun clearListeningHistory() {
+        store.edit { prefs ->
+            prefs[Keys.listeningHistory] = json.encodeToString(emptyList<ListeningHistoryEntry>())
+            prefs[Keys.schemaVersion] = ANDROID_LIBRARY_SCHEMA_VERSION
+        }
+    }
+
+    suspend fun setDiagnosticsEnabled(enabled: Boolean) {
+        store.edit { prefs ->
+            prefs[Keys.diagnosticsEnabled] = enabled
+            prefs[Keys.schemaVersion] = ANDROID_LIBRARY_SCHEMA_VERSION
+        }
+    }
+
+    suspend fun clearDiagnostics() {
+        store.edit { prefs ->
+            prefs[Keys.diagnosticLog] = json.encodeToString(emptyList<DiagnosticLogEntry>())
+            prefs[Keys.schemaVersion] = ANDROID_LIBRARY_SCHEMA_VERSION
+        }
+    }
+
+    suspend fun recordStationHistory(station: Station) {
+        store.edit { prefs ->
+            val preference = ListeningHistoryPreference.fromRaw(prefs[Keys.listeningHistoryPreference])
+            if (preference == ListeningHistoryPreference.Off) return@edit
+            val current = readListeningHistory(prefs[Keys.listeningHistory])
+            prefs[Keys.listeningHistory] = json.encodeToString(
+                cappedListeningHistory(listOf(stationHistoryEntry(station)) + current),
+            )
+            prefs[Keys.schemaVersion] = ANDROID_LIBRARY_SCHEMA_VERSION
+        }
+    }
+
+    suspend fun recordDiagnostic(category: String, message: String) {
+        store.edit { prefs ->
+            if (prefs[Keys.diagnosticsEnabled] != true) return@edit
+            val current = readDiagnosticLog(prefs[Keys.diagnosticLog])
+            prefs[Keys.diagnosticLog] = json.encodeToString(
+                cappedDiagnosticLog(listOf(diagnosticLogEntry(category, message)) + current),
+            )
+            prefs[Keys.schemaVersion] = ANDROID_LIBRARY_SCHEMA_VERSION
+        }
+    }
+
+    suspend fun exportLibraryBackup(): String {
+        val prefs = store.data.first()
+        val backup = buildLibraryBackupFile(
+            favorites = readStations(prefs[Keys.favorites]),
+            customStations = readStations(prefs[Keys.customStations]),
+            stationLists = readStationLists(prefs[Keys.stationLists]),
+            preferences = LibraryBackupPreferences(
+                theme = AppThemePreference.fromRaw(prefs[Keys.themePreference]).rawValue,
+                accent = AccentPreference.fromRaw(prefs[Keys.accentPreference]).rawValue,
+                landingPage = LandingPagePreference.fromRaw(prefs[Keys.landingPagePreference]).rawValue,
+                favoritesDisplayMode = FavoritesDisplayMode.fromRaw(prefs[Keys.favoritesDisplayMode]).rawValue,
+                sleepDefaultMinutes = normalizedSleepDefaultMinutes(prefs[Keys.sleepDefaultMinutes]),
+                listeningHistory = ListeningHistoryPreference.fromRaw(prefs[Keys.listeningHistoryPreference]).rawValue,
+                diagnosticsEnabled = prefs[Keys.diagnosticsEnabled] ?: false,
+            ),
+        )
+        return json.encodeToString(backup)
+    }
+
+    suspend fun importLibraryBackup(raw: String): LibraryImportResult {
+        val backup = decodeLibraryBackup(raw, json)
+        val result = LibraryImportResult(
+            favoritesImported = backup.favorites.size,
+            customStationsImported = backup.customStations.size,
+            stationListsImported = backup.stationLists.size,
+            preferencesImported = backup.preferences.hasAnyValue(),
+        )
+
+        store.edit { prefs ->
+            prefs[Keys.favorites] = json.encodeToString(
+                uniqueStations(backup.favorites + readStations(prefs[Keys.favorites])),
+            )
+            prefs[Keys.customStations] = json.encodeToString(
+                uniqueStations(backup.customStations + readStations(prefs[Keys.customStations])),
+            )
+            prefs[Keys.stationLists] = json.encodeToString(
+                mergeStationLists(
+                    current = readStationLists(prefs[Keys.stationLists]),
+                    imported = backup.stationLists,
+                ),
+            )
+            backup.preferences.theme?.let { prefs[Keys.themePreference] = AppThemePreference.fromRaw(it).rawValue }
+            backup.preferences.accent?.let { prefs[Keys.accentPreference] = AccentPreference.fromRaw(it).rawValue }
+            backup.preferences.landingPage?.let {
+                prefs[Keys.landingPagePreference] = LandingPagePreference.fromRaw(it).rawValue
+            }
+            backup.preferences.favoritesDisplayMode?.let {
+                prefs[Keys.favoritesDisplayMode] = FavoritesDisplayMode.fromRaw(it).rawValue
+            }
+            backup.preferences.sleepDefaultMinutes?.let {
+                prefs[Keys.sleepDefaultMinutes] = normalizedSleepDefaultMinutes(it)
+            }
+            backup.preferences.listeningHistory?.let {
+                prefs[Keys.listeningHistoryPreference] = ListeningHistoryPreference.fromRaw(it).rawValue
+            }
+            backup.preferences.diagnosticsEnabled?.let { prefs[Keys.diagnosticsEnabled] = it }
+            prefs[Keys.schemaVersion] = ANDROID_LIBRARY_SCHEMA_VERSION
+        }
+        return result
+    }
+
+    suspend fun exportDiagnostics(): String {
+        val prefs = store.data.first()
+        return json.encodeToString(buildDiagnosticsExportFile(readDiagnosticLog(prefs[Keys.diagnosticLog])))
+    }
+
     private fun stationList(key: androidx.datastore.preferences.core.Preferences.Key<String>): Flow<List<Station>> =
         store.data.map { prefs -> readStations(prefs[key]) }
 
@@ -239,7 +376,40 @@ class LibraryRepository(
         return runCatching { json.decodeFromString<List<StationList>>(raw) }.getOrDefault(emptyList())
     }
 
+    private fun readListeningHistory(raw: String?): List<ListeningHistoryEntry> {
+        if (raw.isNullOrBlank()) return emptyList()
+        return runCatching { json.decodeFromString<List<ListeningHistoryEntry>>(raw) }.getOrDefault(emptyList())
+    }
+
+    private fun readDiagnosticLog(raw: String?): List<DiagnosticLogEntry> {
+        if (raw.isNullOrBlank()) return emptyList()
+        return runCatching { json.decodeFromString<List<DiagnosticLogEntry>>(raw) }.getOrDefault(emptyList())
+    }
+
+    private fun mergeStationLists(current: List<StationList>, imported: List<StationList>): List<StationList> {
+        val cleanedImported = imported
+            .filter { it.id.isNotBlank() }
+            .map { list ->
+                list.copy(
+                    name = cleanedStationListName(list.name),
+                    stations = uniqueStations(list.stations),
+                )
+            }
+        val importedIds = cleanedImported.mapTo(mutableSetOf()) { it.id }
+        return cleanedImported + current.filterNot { it.id in importedIds }
+    }
+
+    private fun LibraryBackupPreferences.hasAnyValue(): Boolean =
+        theme != null ||
+            accent != null ||
+            landingPage != null ||
+            favoritesDisplayMode != null ||
+            sleepDefaultMinutes != null ||
+            listeningHistory != null ||
+            diagnosticsEnabled != null
+
     private object Keys {
+        val schemaVersion = intPreferencesKey("rrradio.schema-version.v1")
         val favorites = stringPreferencesKey("rrradio.favorites.v2")
         val recents = stringPreferencesKey("rrradio.recents.v2")
         val customStations = stringPreferencesKey("rrradio.custom.v1")
@@ -249,6 +419,10 @@ class LibraryRepository(
         val landingPagePreference = stringPreferencesKey("rrradio.landing-page.v1")
         val favoritesDisplayMode = stringPreferencesKey("rrradio.favorites-display-mode.v1")
         val sleepDefaultMinutes = intPreferencesKey("rrradio.sleep-default-minutes.v1")
+        val listeningHistoryPreference = stringPreferencesKey("rrradio.listening-history-preference.v1")
+        val listeningHistory = stringPreferencesKey("rrradio.listening-history.v1")
+        val diagnosticsEnabled = booleanPreferencesKey("rrradio.diagnostics-enabled.v1")
+        val diagnosticLog = stringPreferencesKey("rrradio.diagnostic-log.v1")
     }
 
     companion object {
@@ -291,5 +465,8 @@ class LibraryRepository(
 
         fun normalizedSleepDefaultMinutes(minutes: Int?): Int =
             minutes?.takeIf { it in SLEEP_DEFAULT_OPTIONS } ?: DEFAULT_SLEEP_MINUTES
+
+        fun normalizedSchemaVersion(version: Int?): Int =
+            version?.takeIf { it in 1..ANDROID_LIBRARY_SCHEMA_VERSION } ?: ANDROID_LIBRARY_SCHEMA_VERSION
     }
 }

--- a/android/app/src/main/java/org/rrradio/android/data/LocalData.kt
+++ b/android/app/src/main/java/org/rrradio/android/data/LocalData.kt
@@ -1,0 +1,158 @@
+package org.rrradio.android.data
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import java.time.Instant
+import java.util.Locale
+
+const val ANDROID_LIBRARY_SCHEMA_VERSION = 1
+const val LISTENING_HISTORY_LIMIT = 100
+const val DIAGNOSTIC_LOG_LIMIT = 200
+
+enum class ListeningHistoryPreference(val rawValue: String) {
+    Off("off"),
+    Stations("stations"),
+    Tracks("tracks"),
+    ;
+
+    companion object {
+        fun fromRaw(rawValue: String?): ListeningHistoryPreference =
+            entries.firstOrNull { it.rawValue == rawValue } ?: Off
+    }
+}
+
+@Serializable
+data class ListeningHistoryEntry(
+    val playedAt: String,
+    val stationId: String,
+    val stationName: String,
+    val trackArtist: String? = null,
+    val trackTitle: String? = null,
+)
+
+@Serializable
+data class DiagnosticLogEntry(
+    val loggedAt: String,
+    val category: String,
+    val message: String,
+)
+
+@Serializable
+data class LibraryBackupFile(
+    val schemaVersion: Int = ANDROID_LIBRARY_SCHEMA_VERSION,
+    val exportedAt: String,
+    val platform: String = "android",
+    val favorites: List<Station> = emptyList(),
+    val customStations: List<Station> = emptyList(),
+    val stationLists: List<StationList> = emptyList(),
+    val preferences: LibraryBackupPreferences = LibraryBackupPreferences(),
+)
+
+@Serializable
+data class LibraryBackupPreferences(
+    val theme: String? = null,
+    val accent: String? = null,
+    val landingPage: String? = null,
+    val favoritesDisplayMode: String? = null,
+    val sleepDefaultMinutes: Int? = null,
+    val listeningHistory: String? = null,
+    val diagnosticsEnabled: Boolean? = null,
+)
+
+data class LibraryImportResult(
+    val favoritesImported: Int,
+    val customStationsImported: Int,
+    val stationListsImported: Int,
+    val preferencesImported: Boolean,
+) {
+    val summary: String
+        get() {
+            val parts = buildList {
+                if (favoritesImported > 0) add("$favoritesImported favorites")
+                if (customStationsImported > 0) add("$customStationsImported custom stations")
+                if (stationListsImported > 0) add("$stationListsImported lists")
+                if (preferencesImported) add("preferences")
+            }
+            return if (parts.isEmpty()) "Backup imported." else "Imported ${parts.joinToString(", ")}."
+        }
+}
+
+@Serializable
+data class DiagnosticsExportFile(
+    val schemaVersion: Int = ANDROID_LIBRARY_SCHEMA_VERSION,
+    val exportedAt: String,
+    val platform: String = "android",
+    val entries: List<DiagnosticLogEntry> = emptyList(),
+)
+
+fun buildLibraryBackupFile(
+    favorites: List<Station>,
+    customStations: List<Station>,
+    stationLists: List<StationList>,
+    preferences: LibraryBackupPreferences,
+    exportedAt: String = Instant.now().toString(),
+): LibraryBackupFile =
+    LibraryBackupFile(
+        exportedAt = exportedAt,
+        favorites = favorites,
+        customStations = customStations,
+        stationLists = stationLists,
+        preferences = preferences,
+    )
+
+fun decodeLibraryBackup(raw: String, json: Json = defaultJson): LibraryBackupFile {
+    val backup = json.decodeFromString<LibraryBackupFile>(raw)
+    require(backup.schemaVersion in 1..ANDROID_LIBRARY_SCHEMA_VERSION) {
+        "Unsupported backup version"
+    }
+    return backup
+}
+
+fun buildDiagnosticsExportFile(
+    entries: List<DiagnosticLogEntry>,
+    exportedAt: String = Instant.now().toString(),
+): DiagnosticsExportFile =
+    DiagnosticsExportFile(
+        exportedAt = exportedAt,
+        entries = entries.take(DIAGNOSTIC_LOG_LIMIT),
+    )
+
+fun stationHistoryEntry(station: Station, playedAt: String = Instant.now().toString()): ListeningHistoryEntry =
+    ListeningHistoryEntry(
+        playedAt = playedAt,
+        stationId = station.id,
+        stationName = station.displayName(),
+    )
+
+fun diagnosticLogEntry(
+    category: String,
+    message: String,
+    loggedAt: String = Instant.now().toString(),
+): DiagnosticLogEntry =
+    DiagnosticLogEntry(
+        loggedAt = loggedAt,
+        category = cleanDiagnosticCategory(category),
+        message = cleanDiagnosticMessage(message),
+    )
+
+fun cappedListeningHistory(entries: List<ListeningHistoryEntry>): List<ListeningHistoryEntry> =
+    entries.take(LISTENING_HISTORY_LIMIT)
+
+fun cappedDiagnosticLog(entries: List<DiagnosticLogEntry>): List<DiagnosticLogEntry> =
+    entries.take(DIAGNOSTIC_LOG_LIMIT)
+
+private fun cleanDiagnosticCategory(raw: String): String {
+    val token = raw
+        .trim()
+        .lowercase(Locale.US)
+        .replace(Regex("[^a-z0-9_.-]+"), "-")
+        .trim('-', '.', '_')
+        .take(40)
+    return token.ifBlank { "event" }
+}
+
+private fun cleanDiagnosticMessage(raw: String): String {
+    val withoutUrls = raw.replace(Regex("https?://\\S+"), "[url]")
+    return withoutUrls.trim().take(140).ifBlank { "event" }
+}

--- a/android/app/src/main/java/org/rrradio/android/ui/RrradioApp.kt
+++ b/android/app/src/main/java/org/rrradio/android/ui/RrradioApp.kt
@@ -1,6 +1,10 @@
 package org.rrradio.android.ui
 
+import android.content.Context
+import android.net.Uri
 import androidx.activity.compose.BackHandler
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
@@ -86,6 +90,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -103,6 +108,7 @@ import org.rrradio.android.data.CatalogLoadState
 import org.rrradio.android.data.FavoritesDisplayMode
 import org.rrradio.android.data.LandingPagePreference
 import org.rrradio.android.data.LibraryRepository
+import org.rrradio.android.data.ListeningHistoryPreference
 import org.rrradio.android.data.PlaybackUiState
 import org.rrradio.android.data.PlayerState
 import org.rrradio.android.data.Station
@@ -120,16 +126,37 @@ fun RrradioApp(
     actions: RrradioViewModel,
     resolvedDarkTheme: Boolean,
 ) {
+    val context = LocalContext.current
     var showAddStation by remember { mutableStateOf(false) }
     var showNowPlaying by remember { mutableStateOf(false) }
     var showChooseStationList by remember { mutableStateOf(false) }
     var showCreateStationList by remember { mutableStateOf(false) }
     var showPreferences by remember { mutableStateOf(false) }
+    var preferenceStatus by remember { mutableStateOf<String?>(null) }
+    var pendingDocumentText by remember { mutableStateOf<String?>(null) }
     var createListFromSelection by remember { mutableStateOf(false) }
     var customStationPendingDelete by remember { mutableStateOf<Station?>(null) }
     var stationListPendingDelete by remember { mutableStateOf<String?>(null) }
     var stationListPendingRename by remember { mutableStateOf<StationList?>(null) }
     var stationPreview by remember { mutableStateOf<Station?>(null) }
+    val exportDocumentLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.CreateDocument("application/json"),
+    ) { uri ->
+        val text = pendingDocumentText
+        pendingDocumentText = null
+        if (uri == null || text == null) return@rememberLauncherForActivityResult
+        runCatching { writeTextDocument(context, uri, text) }
+            .onSuccess { preferenceStatus = "Export saved." }
+            .onFailure { preferenceStatus = "Could not save export." }
+    }
+    val importDocumentLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.OpenDocument(),
+    ) { uri ->
+        if (uri == null) return@rememberLauncherForActivityResult
+        runCatching { readTextDocument(context, uri) }
+            .onSuccess { text -> actions.importLibraryBackup(text) { preferenceStatus = it } }
+            .onFailure { preferenceStatus = "Could not read that backup file." }
+    }
 
     Box(Modifier.fillMaxSize()) {
         Scaffold(
@@ -224,7 +251,10 @@ fun RrradioApp(
         }
 
         if (showNowPlaying && state.playback.station != null) {
-            BackHandler { showNowPlaying = false }
+            BackHandler {
+                actions.clearBrokenStationReportMessage()
+                showNowPlaying = false
+            }
             NowPlayingDestination(
                 state = state,
                 onFavorite = actions::toggleFavorite,
@@ -232,7 +262,11 @@ fun RrradioApp(
                 onToggle = actions::togglePlayback,
                 onNext = actions::playNext,
                 onSleep = actions::cycleSleepTimer,
-                onDismiss = { showNowPlaying = false },
+                onReportBroken = actions::reportBrokenStation,
+                onDismiss = {
+                    actions.clearBrokenStationReportMessage()
+                    showNowPlaying = false
+                },
             )
         }
     }
@@ -285,6 +319,34 @@ fun RrradioApp(
                 onAccentPreference = actions::setAccentPreference,
                 onLandingPagePreference = actions::setLandingPagePreference,
                 onSleepDefaultMinutes = actions::setSleepDefaultMinutes,
+                onListeningHistoryPreference = actions::setListeningHistoryPreference,
+                onDiagnosticsEnabled = actions::setDiagnosticsEnabled,
+                onClearListeningHistory = actions::clearListeningHistory,
+                onClearDiagnostics = actions::clearDiagnostics,
+                onExportBackup = {
+                    actions.exportLibraryBackup(
+                        onReady = { text ->
+                            pendingDocumentText = text
+                            exportDocumentLauncher.launch("rrradio-android-backup.json")
+                        },
+                        onError = { preferenceStatus = it },
+                    )
+                },
+                onImportBackup = {
+                    importDocumentLauncher.launch(
+                        arrayOf("application/json", "text/json", "text/plain", "application/octet-stream"),
+                    )
+                },
+                onExportDiagnostics = {
+                    actions.exportDiagnostics(
+                        onReady = { text ->
+                            pendingDocumentText = text
+                            exportDocumentLauncher.launch("rrradio-android-diagnostics.json")
+                        },
+                        onError = { preferenceStatus = it },
+                    )
+                },
+                preferenceStatus = preferenceStatus,
                 onDismiss = { showPreferences = false },
             )
         }
@@ -527,6 +589,14 @@ private fun PreferencesSheet(
     onAccentPreference: (AccentPreference) -> Unit,
     onLandingPagePreference: (LandingPagePreference) -> Unit,
     onSleepDefaultMinutes: (Int) -> Unit,
+    onListeningHistoryPreference: (ListeningHistoryPreference) -> Unit,
+    onDiagnosticsEnabled: (Boolean) -> Unit,
+    onClearListeningHistory: () -> Unit,
+    onClearDiagnostics: () -> Unit,
+    onExportBackup: () -> Unit,
+    onImportBackup: () -> Unit,
+    onExportDiagnostics: () -> Unit,
+    preferenceStatus: String?,
     onDismiss: () -> Unit,
 ) {
     Column(
@@ -615,6 +685,88 @@ private fun PreferencesSheet(
                 if (index != LibraryRepository.SLEEP_DEFAULT_OPTIONS.lastIndex) PreferenceDivider()
             }
         }
+
+        PreferenceSection(title = "Backup") {
+            PreferenceActionRow(
+                icon = Icons.Rounded.Public,
+                title = "Export backup",
+                detail = "Favorites, custom stations, lists, and preferences.",
+                onClick = onExportBackup,
+            )
+            PreferenceDivider()
+            PreferenceActionRow(
+                icon = Icons.Rounded.Public,
+                title = "Import backup",
+                detail = "Merge a rrradio Android backup into this device.",
+                onClick = onImportBackup,
+            )
+        }
+
+        if (preferenceStatus != null) {
+            Text(
+                preferenceStatus,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontSize = 12.sp,
+                lineHeight = 16.sp,
+            )
+        }
+
+        PreferenceSection(title = "Listening history") {
+            ListeningHistoryPreference.entries.forEachIndexed { index, preference ->
+                PreferenceChoiceRow(
+                    icon = Icons.Rounded.BarChart,
+                    title = listeningHistoryPreferenceLabel(preference),
+                    detail = listeningHistoryPreferenceDetail(preference),
+                    selected = state.listeningHistoryPreference == preference,
+                    onClick = { onListeningHistoryPreference(preference) },
+                )
+                if (index != ListeningHistoryPreference.entries.lastIndex || state.listeningHistoryCount > 0) {
+                    PreferenceDivider()
+                }
+            }
+            if (state.listeningHistoryCount > 0) {
+                PreferenceActionRow(
+                    icon = Icons.Rounded.Delete,
+                    title = "Clear history",
+                    detail = "${state.listeningHistoryCount} local records.",
+                    onClick = onClearListeningHistory,
+                )
+            }
+        }
+
+        PreferenceSection(title = "Diagnostics") {
+            PreferenceChoiceRow(
+                icon = Icons.Rounded.BarChart,
+                title = "Diagnostics off",
+                detail = "Do not store local diagnostic events.",
+                selected = !state.diagnosticsEnabled,
+                onClick = { onDiagnosticsEnabled(false) },
+            )
+            PreferenceDivider()
+            PreferenceChoiceRow(
+                icon = Icons.Rounded.BarChart,
+                title = "Diagnostics on",
+                detail = "Store a capped privacy-preserving log on this device.",
+                selected = state.diagnosticsEnabled,
+                onClick = { onDiagnosticsEnabled(true) },
+            )
+            PreferenceDivider()
+            PreferenceActionRow(
+                icon = Icons.Rounded.BarChart,
+                title = "Export diagnostics",
+                detail = "${state.diagnosticLogCount} local log entries.",
+                onClick = onExportDiagnostics,
+            )
+            if (state.diagnosticLogCount > 0) {
+                PreferenceDivider()
+                PreferenceActionRow(
+                    icon = Icons.Rounded.Delete,
+                    title = "Clear diagnostics",
+                    detail = "Delete the local diagnostic log.",
+                    onClick = onClearDiagnostics,
+                )
+            }
+        }
     }
 }
 
@@ -679,6 +831,39 @@ private fun PreferenceChoiceRow(
                 contentDescription = null,
                 tint = MaterialTheme.colorScheme.primary,
                 modifier = Modifier.size(18.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun PreferenceActionRow(
+    icon: ImageVector,
+    title: String,
+    detail: String,
+    onClick: () -> Unit,
+) {
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 14.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        PreferenceLeadingIcon(icon = icon, selected = false)
+        Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+            Text(
+                title,
+                color = MaterialTheme.colorScheme.onBackground,
+                fontSize = 15.sp,
+                fontWeight = FontWeight.Medium,
+            )
+            Text(
+                detail,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontSize = 12.sp,
+                lineHeight = 16.sp,
             )
         }
     }
@@ -812,6 +997,31 @@ private fun landingPagePreferenceIcon(preference: LandingPagePreference): ImageV
     LandingPagePreference.StationLists -> Icons.AutoMirrored.Rounded.Article
     LandingPagePreference.Browse -> Icons.Rounded.Public
     LandingPagePreference.Favorites -> Icons.Rounded.Favorite
+}
+
+private fun listeningHistoryPreferenceLabel(preference: ListeningHistoryPreference): String = when (preference) {
+    ListeningHistoryPreference.Off -> "Off"
+    ListeningHistoryPreference.Stations -> "Stations only"
+    ListeningHistoryPreference.Tracks -> "Stations and tracks"
+}
+
+private fun listeningHistoryPreferenceDetail(preference: ListeningHistoryPreference): String = when (preference) {
+    ListeningHistoryPreference.Off -> "Do not store listening history."
+    ListeningHistoryPreference.Stations -> "Store station plays locally on this device."
+    ListeningHistoryPreference.Tracks -> "Allow track-level history when metadata is available."
+}
+
+private fun writeTextDocument(context: Context, uri: Uri, text: String) {
+    val bytes = text.toByteArray(Charsets.UTF_8)
+    val stream = context.contentResolver.openOutputStream(uri)
+        ?: error("Could not open document")
+    stream.use { it.write(bytes) }
+}
+
+private fun readTextDocument(context: Context, uri: Uri): String {
+    val stream = context.contentResolver.openInputStream(uri)
+        ?: error("Could not open document")
+    return stream.bufferedReader(Charsets.UTF_8).use { it.readText() }
 }
 
 @Composable
@@ -2183,6 +2393,7 @@ private fun NowPlayingDestination(
     onToggle: () -> Unit,
     onNext: () -> Unit,
     onSleep: () -> Unit,
+    onReportBroken: (Station) -> Unit,
     onDismiss: () -> Unit,
 ) {
     val station = state.playback.station ?: return
@@ -2350,6 +2561,39 @@ private fun NowPlayingDestination(
                     fontSize = 11.sp,
                     fontFamily = FontFamily.Monospace,
                     fontWeight = FontWeight.Medium,
+                )
+            }
+        }
+        Column(
+            Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            TextButton(
+                onClick = { onReportBroken(station) },
+                enabled = !state.isReportingBrokenStation,
+            ) {
+                Icon(
+                    Icons.Rounded.Flag,
+                    contentDescription = null,
+                    modifier = Modifier.size(15.dp),
+                )
+                Spacer(Modifier.width(6.dp))
+                Text(
+                    if (state.isReportingBrokenStation) "Sending report..." else "Report broken station",
+                    fontSize = 11.sp,
+                    fontFamily = FontFamily.Monospace,
+                    fontWeight = FontWeight.Medium,
+                )
+            }
+            if (state.brokenStationReportMessage != null) {
+                Text(
+                    state.brokenStationReportMessage,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    fontSize = 12.sp,
+                    textAlign = TextAlign.Center,
                 )
             }
         }

--- a/android/app/src/main/java/org/rrradio/android/ui/RrradioViewModel.kt
+++ b/android/app/src/main/java/org/rrradio/android/ui/RrradioViewModel.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import org.rrradio.android.data.AccentPreference
 import org.rrradio.android.data.AppThemePreference
+import org.rrradio.android.data.BrokenStationReporter
 import org.rrradio.android.data.BrowseStationSort
 import org.rrradio.android.data.CatalogLoadState
 import org.rrradio.android.data.CatalogRepository
@@ -20,6 +21,7 @@ import org.rrradio.android.data.CatalogState
 import org.rrradio.android.data.FavoritesDisplayMode
 import org.rrradio.android.data.LandingPagePreference
 import org.rrradio.android.data.LibraryRepository
+import org.rrradio.android.data.ListeningHistoryPreference
 import org.rrradio.android.data.PlaybackUiState
 import org.rrradio.android.data.PlayerState
 import org.rrradio.android.data.Station
@@ -69,6 +71,12 @@ data class RrradioUiState(
     val accentPreference: AccentPreference = AccentPreference.Classic,
     val landingPagePreference: LandingPagePreference = LandingPagePreference.Browse,
     val favoritesDisplayMode: FavoritesDisplayMode = FavoritesDisplayMode.List,
+    val listeningHistoryPreference: ListeningHistoryPreference = ListeningHistoryPreference.Off,
+    val listeningHistoryCount: Int = 0,
+    val diagnosticsEnabled: Boolean = false,
+    val diagnosticLogCount: Int = 0,
+    val isReportingBrokenStation: Boolean = false,
+    val brokenStationReportMessage: String? = null,
 ) {
     val allStations: List<Station>
         get() = customStations + catalog.browseOrdered
@@ -123,6 +131,7 @@ class RrradioViewModel(application: Application) : AndroidViewModel(application)
     private val catalogRepository = CatalogRepository(application)
     private val libraryRepository = LibraryRepository(application)
     private val streamProbe = StreamProbe()
+    private val brokenStationReporter = BrokenStationReporter()
     private var sleepJob: Job? = null
     private var appliedLandingPagePreference = false
 
@@ -130,6 +139,9 @@ class RrradioViewModel(application: Application) : AndroidViewModel(application)
     val uiState: StateFlow<RrradioUiState> = _uiState.asStateFlow()
 
     init {
+        viewModelScope.launch {
+            libraryRepository.ensureCurrentSchemaVersion()
+        }
         refreshCatalog()
         viewModelScope.launch {
             libraryRepository.favorites.collect { favorites ->
@@ -187,6 +199,26 @@ class RrradioViewModel(application: Application) : AndroidViewModel(application)
             }
         }
         viewModelScope.launch {
+            libraryRepository.listeningHistoryPreference.collect { preference ->
+                _uiState.update { it.copy(listeningHistoryPreference = preference) }
+            }
+        }
+        viewModelScope.launch {
+            libraryRepository.listeningHistory.collect { history ->
+                _uiState.update { it.copy(listeningHistoryCount = history.size) }
+            }
+        }
+        viewModelScope.launch {
+            libraryRepository.diagnosticsEnabled.collect { enabled ->
+                _uiState.update { it.copy(diagnosticsEnabled = enabled) }
+            }
+        }
+        viewModelScope.launch {
+            libraryRepository.diagnosticLog.collect { log ->
+                _uiState.update { it.copy(diagnosticLogCount = log.size) }
+            }
+        }
+        viewModelScope.launch {
             PlaybackStateStore.state.collect { playback ->
                 _uiState.update { it.copy(playback = playback) }
             }
@@ -202,7 +234,11 @@ class RrradioViewModel(application: Application) : AndroidViewModel(application)
                     it.copy(catalog = CatalogState(stations = cached, loadState = CatalogLoadState.Loaded))
                 }
             }
-            _uiState.update { it.copy(catalog = catalogRepository.load()) }
+            val loaded = catalogRepository.load()
+            _uiState.update { it.copy(catalog = loaded) }
+            if (loaded.loadState == CatalogLoadState.Failed) {
+                libraryRepository.recordDiagnostic("network", "catalog load failed")
+            }
         }
     }
 
@@ -411,11 +447,72 @@ class RrradioViewModel(application: Application) : AndroidViewModel(application)
         viewModelScope.launch { libraryRepository.setSleepDefaultMinutes(minutes) }
     }
 
+    fun setListeningHistoryPreference(preference: ListeningHistoryPreference) {
+        viewModelScope.launch {
+            libraryRepository.setListeningHistoryPreference(preference)
+            libraryRepository.recordDiagnostic("persistence", "history preference changed")
+        }
+    }
+
+    fun clearListeningHistory() {
+        viewModelScope.launch {
+            libraryRepository.clearListeningHistory()
+            libraryRepository.recordDiagnostic("persistence", "listening history cleared")
+        }
+    }
+
+    fun setDiagnosticsEnabled(enabled: Boolean) {
+        viewModelScope.launch {
+            libraryRepository.setDiagnosticsEnabled(enabled)
+            if (enabled) {
+                libraryRepository.recordDiagnostic("diagnostics", "diagnostics enabled")
+            }
+        }
+    }
+
+    fun clearDiagnostics() {
+        viewModelScope.launch { libraryRepository.clearDiagnostics() }
+    }
+
+    fun exportLibraryBackup(onReady: (String) -> Unit, onError: (String) -> Unit) {
+        viewModelScope.launch {
+            runCatching { libraryRepository.exportLibraryBackup() }
+                .onSuccess { backup ->
+                    libraryRepository.recordDiagnostic("persistence", "backup exported")
+                    onReady(backup)
+                }
+                .onFailure { onError("Could not prepare backup.") }
+        }
+    }
+
+    fun importLibraryBackup(raw: String, onResult: (String) -> Unit) {
+        viewModelScope.launch {
+            runCatching { libraryRepository.importLibraryBackup(raw) }
+                .onSuccess { result ->
+                    libraryRepository.recordDiagnostic("persistence", "backup imported")
+                    onResult(result.summary)
+                }
+                .onFailure { onResult("Could not import that backup file.") }
+        }
+    }
+
+    fun exportDiagnostics(onReady: (String) -> Unit, onError: (String) -> Unit) {
+        viewModelScope.launch {
+            runCatching { libraryRepository.exportDiagnostics() }
+                .onSuccess { onReady(it) }
+                .onFailure { onError("Could not prepare diagnostics.") }
+        }
+    }
+
     fun play(station: Station) {
         val context = getApplication<Application>()
         val queue = activePlaybackQueue(uiState.value.visibleStations, station)
         context.startService(RadioPlaybackService.playIntent(context, station, queue))
-        viewModelScope.launch { libraryRepository.pushRecent(station) }
+        viewModelScope.launch {
+            libraryRepository.pushRecent(station)
+            libraryRepository.recordStationHistory(station)
+            libraryRepository.recordDiagnostic("playback", "play requested")
+        }
     }
 
     fun togglePlayback() {
@@ -460,9 +557,13 @@ class RrradioViewModel(application: Application) : AndroidViewModel(application)
                     StreamProbeResult.Playable -> {
                         libraryRepository.addCustom(station)
                         libraryRepository.addFavorite(station)
+                        libraryRepository.recordDiagnostic("persistence", "custom station saved")
                         onSaved()
                     }
-                    is StreamProbeResult.Failed -> onError(result.message)
+                    is StreamProbeResult.Failed -> {
+                        libraryRepository.recordDiagnostic("playback", "custom station probe failed")
+                        onError(result.message)
+                    }
                 }
             } catch (error: IllegalArgumentException) {
                 onError(error.message ?: "Invalid station")
@@ -472,6 +573,42 @@ class RrradioViewModel(application: Application) : AndroidViewModel(application)
 
     fun removeCustom(station: Station) {
         viewModelScope.launch { libraryRepository.removeCustom(station.id) }
+    }
+
+    fun reportBrokenStation(station: Station) {
+        if (uiState.value.isReportingBrokenStation) return
+        val reason = uiState.value.playback.errorMessage.orEmpty()
+        _uiState.update {
+            it.copy(
+                isReportingBrokenStation = true,
+                brokenStationReportMessage = null,
+            )
+        }
+        viewModelScope.launch {
+            runCatching { brokenStationReporter.report(station, reason) }
+                .onSuccess {
+                    libraryRepository.recordDiagnostic("report", "broken station report sent")
+                    _uiState.update {
+                        it.copy(
+                            isReportingBrokenStation = false,
+                            brokenStationReportMessage = "Broken-station report sent.",
+                        )
+                    }
+                }
+                .onFailure {
+                    libraryRepository.recordDiagnostic("report", "broken station report failed")
+                    _uiState.update {
+                        it.copy(
+                            isReportingBrokenStation = false,
+                            brokenStationReportMessage = "Could not send report. Try again later.",
+                        )
+                    }
+                }
+        }
+    }
+
+    fun clearBrokenStationReportMessage() {
+        _uiState.update { it.copy(brokenStationReportMessage = null) }
     }
 
     fun cycleSleepTimer() {

--- a/android/app/src/test/java/org/rrradio/android/data/LibraryRepositoryTest.kt
+++ b/android/app/src/test/java/org/rrradio/android/data/LibraryRepositoryTest.kt
@@ -1,6 +1,7 @@
 package org.rrradio.android.data
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
 import org.junit.Test
 
 class LibraryRepositoryTest {
@@ -41,11 +42,27 @@ class LibraryRepositoryTest {
     }
 
     @Test
+    fun listeningHistoryPreferenceDefaultsToOff() {
+        assertEquals(ListeningHistoryPreference.Off, ListeningHistoryPreference.fromRaw(null))
+        assertEquals(ListeningHistoryPreference.Off, ListeningHistoryPreference.fromRaw("unknown"))
+        assertEquals(ListeningHistoryPreference.Stations, ListeningHistoryPreference.fromRaw("stations"))
+        assertEquals(ListeningHistoryPreference.Tracks, ListeningHistoryPreference.fromRaw("tracks"))
+    }
+
+    @Test
     fun sleepDefaultMinutesUsesSupportedValuesOnly() {
         assertEquals(30, LibraryRepository.normalizedSleepDefaultMinutes(null))
         assertEquals(30, LibraryRepository.normalizedSleepDefaultMinutes(0))
         assertEquals(15, LibraryRepository.normalizedSleepDefaultMinutes(15))
         assertEquals(90, LibraryRepository.normalizedSleepDefaultMinutes(90))
+    }
+
+    @Test
+    fun schemaVersionUsesCurrentVersionForMissingOrUnknownValues() {
+        assertEquals(ANDROID_LIBRARY_SCHEMA_VERSION, LibraryRepository.normalizedSchemaVersion(null))
+        assertEquals(ANDROID_LIBRARY_SCHEMA_VERSION, LibraryRepository.normalizedSchemaVersion(0))
+        assertEquals(ANDROID_LIBRARY_SCHEMA_VERSION, LibraryRepository.normalizedSchemaVersion(99))
+        assertEquals(ANDROID_LIBRARY_SCHEMA_VERSION, LibraryRepository.normalizedSchemaVersion(1))
     }
 
     @Test
@@ -85,6 +102,94 @@ class LibraryRepositoryTest {
         )
 
         assertEquals(listOf(second, first, third), result)
+    }
+
+    @Test
+    fun libraryBackupRoundTripsSupportedSchema() {
+        val backup = buildLibraryBackupFile(
+            favorites = listOf(station("fm4")),
+            customStations = listOf(station("custom")),
+            stationLists = listOf(stationList("morning")),
+            preferences = LibraryBackupPreferences(
+                theme = AppThemePreference.Dark.rawValue,
+                accent = AccentPreference.Yellow.rawValue,
+                landingPage = LandingPagePreference.Favorites.rawValue,
+                favoritesDisplayMode = FavoritesDisplayMode.App.rawValue,
+                sleepDefaultMinutes = 60,
+                listeningHistory = ListeningHistoryPreference.Stations.rawValue,
+                diagnosticsEnabled = true,
+            ),
+            exportedAt = "2026-05-17T10:00:00Z",
+        )
+        val raw = defaultJson.encodeToString(LibraryBackupFile.serializer(), backup)
+
+        val decoded = decodeLibraryBackup(raw)
+
+        assertEquals(ANDROID_LIBRARY_SCHEMA_VERSION, decoded.schemaVersion)
+        assertEquals("android", decoded.platform)
+        assertEquals(listOf("fm4"), decoded.favorites.map { it.id })
+        assertEquals("stations", decoded.preferences.listeningHistory)
+    }
+
+    @Test
+    fun libraryBackupRejectsFutureSchema() {
+        val raw = """
+            {
+              "schemaVersion": 99,
+              "exportedAt": "2026-05-17T10:00:00Z",
+              "platform": "android"
+            }
+        """.trimIndent()
+
+        assertThrows(IllegalArgumentException::class.java) {
+            decodeLibraryBackup(raw)
+        }
+    }
+
+    @Test
+    fun localDiagnosticEntriesAreSanitizedAndCapped() {
+        val entries = (1..205).map {
+            diagnosticLogEntry(
+                category = "Playback Retry $it",
+                message = "failed at https://private.example/$it",
+                loggedAt = "2026-05-17T10:00:00Z",
+            )
+        }
+
+        val capped = cappedDiagnosticLog(entries)
+
+        assertEquals(DIAGNOSTIC_LOG_LIMIT, capped.size)
+        assertEquals("playback-retry-1", capped.first().category)
+        assertEquals("failed at [url]", capped.first().message)
+    }
+
+    @Test
+    fun listeningHistoryEntriesAreCapped() {
+        val entries = (1..105).map {
+            ListeningHistoryEntry(
+                playedAt = "2026-05-17T10:00:00Z",
+                stationId = "station-$it",
+                stationName = "Station $it",
+            )
+        }
+
+        val capped = cappedListeningHistory(entries)
+
+        assertEquals(LISTENING_HISTORY_LIMIT, capped.size)
+        assertEquals("station-1", capped.first().stationId)
+    }
+
+    @Test
+    fun brokenStationPayloadKeepsOnlyHostAndTruncatedReason() {
+        val payload = brokenStationReportPayload(
+            station = station("fm4").copy(streamUrl = "https://stream.example.test/live.mp3?token=secret"),
+            reason = "x".repeat(200),
+            appVersion = "0.1.0",
+        )
+
+        assertEquals("stream.example.test", payload.streamHost)
+        assertEquals("android", payload.platform)
+        assertEquals(160, payload.reason.length)
     }
 
     private fun station(id: String, name: String = id): Station =

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -84,9 +84,9 @@ Canonical implementation references remain in:
 | Sleep timer | Supported | Reference | Partial | [Sleep timer](features/sleep-timer.md) |
 | Wake to radio | Partial, browser-limited | Reference, iOS-limited | Planned, Android-limited | [Wake to radio](features/wake-to-radio.md) |
 | iCloud/CloudKit sync | Not planned | Supported | Not applicable | [Data and sync](data-sync.md) |
-| Manual file export/import | Supported for favorites and custom stations | Planned/optional | Planned/optional | [Data and sync](data-sync.md) |
+| Manual file export/import | Supported for favorites and custom stations | Planned/optional | Supported for Android library backup | [Data and sync](data-sync.md) |
 | Cross-platform account sync | Not planned | Not planned | Not planned for first Android port | [Data and sync](data-sync.md) |
-| Diagnostics | Privacy-preserving telemetry | Local opt-in diagnostics | Planned local diagnostics | [Preferences and diagnostics](features/preferences-diagnostics.md) |
+| Diagnostics | Privacy-preserving telemetry | Local opt-in diagnostics | Local opt-in diagnostics | [Preferences and diagnostics](features/preferences-diagnostics.md) |
 | Watch companion | Not applicable | Supported as iPhone remote | Not applicable | [Platforms](platforms.md) |
 | Car mode / vehicle surfaces | Browser/OS dependent | Supported in app, CarPlay controls via media session | Partial media controls; Android Auto TBD | [Preferences and diagnostics](features/preferences-diagnostics.md) |
 

--- a/docs/spec/data-sync.md
+++ b/docs/spec/data-sync.md
@@ -30,10 +30,10 @@ offers private iCloud/CloudKit sync between the user's Apple devices.
 | Custom stations | `localStorage`, export/import supported. | Local plus optional CloudKit sync. | Local DataStore. |
 | Preferences | Local browser preferences. | Local plus optional CloudKit sync for selected preferences. | Local-only for first port. |
 | Wake state | Local-only, one armed wake. | Local-only for active wake; selected wake preferences may sync. | Local-only. |
-| Listening history | Not part of current web storage contract. | Local-only, opt-in, retention-controlled. | Planned local-only, opt-in. |
-| Diagnostics | Anonymous production events only. | Local opt-in diagnostic log. | Planned local opt-in diagnostic log. |
+| Listening history | Not part of current web storage contract. | Local-only, opt-in, retention-controlled. | Local-only, off by default, opt-in. |
+| Diagnostics | Anonymous production events only. | Local opt-in diagnostic log. | Local opt-in diagnostic log, capped and exportable. |
 | Catalog cache | Browser/runtime cache. | Disk cache and bundled index fallback. | Cache-backed catalog loading; optional search index is deferred. |
-| Backup file | Manual export/import for favorites and custom stations. | Planned/optional import path if needed. | Planned/optional import path if needed. |
+| Backup file | Manual export/import for favorites and custom stations. | Planned/optional import path if needed. | Manual export/import for library data and preferences. |
 
 ## iCloud And CloudKit
 
@@ -90,19 +90,42 @@ The Android app is local-only:
 - No iCloud compatibility layer.
 - No account requirement.
 - No shared backend.
-- Manual backup import/export can be added as a user-controlled transfer path,
-  but it is not a substitute for a shared sync backend.
+- Manual backup import/export is a user-controlled transfer path, but it is
+  not a substitute for a shared sync backend.
 - Favorites, recents, custom stations, and station lists are persisted in
   DataStore today.
-- Preferences are currently only partly modeled on Android; system/light/dark,
-  accent, landing page, history, and diagnostics preferences remain parity
-  work.
+- Preferences are currently partly modeled on Android; system/light/dark,
+  accent, landing page, Favorites display mode, sleep default, history, and
+  diagnostics preferences are local DataStore data. Language, custom accent,
+  wake, and car-surface preferences remain separate parity work.
+- Listening history remains off by default and does not sync.
+- Diagnostics remain off by default, are capped locally, and export only when
+  the user explicitly requests it.
 - Data should be structured so a future sync backend can be added without
   rewriting feature logic.
 
 Android storage should use stable schema versions for user data. Prefer a
 simple local model first; introduce Room only when the feature set needs
 queryable history, more complex list management, or catalog search.
+
+## Android Backup File
+
+Android backup files are JSON with `schemaVersion: 1`, `platform: "android"`,
+`exportedAt`, and these top-level data sets:
+
+- `favorites`
+- `customStations`
+- `stationLists`
+- `preferences`
+
+The `preferences` object currently stores theme, accent, landing page,
+Favorites display mode, sleep default, listening-history preference, and
+diagnostics preference. Import merges favorites, custom stations, and station
+lists by id, then applies included preferences.
+
+Android backup files intentionally exclude recents, listening-history records,
+diagnostic log entries, active wake state, raw playback errors, and any
+automatic account/cloud state.
 
 ## Future Cross-Platform Sync
 

--- a/docs/spec/features/custom-stations.md
+++ b/docs/spec/features/custom-stations.md
@@ -26,7 +26,7 @@ catalog.
 | Duplicate detection | Supported where implemented. | Reference. | Supported. |
 | Auto-favorite on save | Product-preferred behavior. | Supported. | Supported. |
 | Local persistence | `localStorage`. | UserDefaults. | DataStore. |
-| Manual file export/import | Supported. | Planned/optional. | Planned/optional. |
+| Manual file export/import | Supported. | Planned/optional. | Supported through Android library backup. |
 | Cloud/account sync | Not planned. | Optional CloudKit sync. | Not planned for first port. |
 
 ## Android First-Port Requirement

--- a/docs/spec/features/favorites.md
+++ b/docs/spec/features/favorites.md
@@ -38,7 +38,7 @@ The selected mode and the visible/order settings are user preferences.
 | Favorites tile/app views | Partial/current web behavior may differ. | Reference. | Supported; visible/order settings still need parity. |
 | Recents | Supported, capped. | Supported, capped. | Supported, capped. |
 | iCloud sync | Not planned. | Supported for favorites and order. | Not applicable. |
-| Manual file export/import | Supported. | Planned/optional. | Planned/optional. |
+| Manual file export/import | Supported. | Planned/optional. | Supported through Android library backup. |
 | Cross-platform sync | Not planned. | Not planned outside CloudKit. | Not planned for first port. |
 
 ## Persistence
@@ -46,7 +46,8 @@ The selected mode and the visible/order settings are user preferences.
 - Web persists favorites and recents in browser storage; favorites can be
   exported/imported through the manual backup file.
 - iOS persists locally and can sync favorites through CloudKit.
-- Android persists locally in DataStore.
+- Android persists locally in DataStore; favorites are included in the manual
+  Android backup file.
 - Recents remain local-only on every platform unless a future sync ADR changes
   that decision.
 - Android persists the selected Favorites display mode in DataStore and restores

--- a/docs/spec/features/preferences-diagnostics.md
+++ b/docs/spec/features/preferences-diagnostics.md
@@ -42,8 +42,8 @@ Platform matrix:
 
 | Behavior | Web | iOS | Android |
 |---|---|---|---|
-| Station history | Not part of current web contract beyond recents. | Supported as opt-in listening history. | Planned local opt-in. |
-| Track-level history | Not planned for current web. | Supported only when user selects it. | Planned only with explicit opt-in. |
+| Station history | Not part of current web contract beyond recents. | Supported as opt-in listening history. | Supported as local opt-in history. |
+| Track-level history | Not planned for current web. | Supported only when user selects it. | Gated behind explicit opt-in; metadata-recording expansion remains future polish. |
 | Sync | Not planned. | Not synced. | Not planned. |
 
 ## Diagnostics
@@ -73,8 +73,8 @@ Platform matrix:
 | Behavior | Web | iOS | Android |
 |---|---|---|---|
 | Anonymous aggregate telemetry | Supported through GoatCounter. | Not the native support surface. | Not planned for first port. |
-| Local diagnostics | Not primary web contract. | Supported, opt-in, capped, exportable. | Planned, opt-in, capped, exportable. |
-| Broken-station report | Supported. | Supported where implemented. | Planned. |
+| Local diagnostics | Not primary web contract. | Supported, opt-in, capped, exportable. | Supported, opt-in, capped, exportable. |
+| Broken-station report | Supported. | Supported where implemented. | Supported through the shared anonymous report endpoint. |
 
 ## Car Mode And Vehicle Surfaces
 


### PR DESCRIPTION
## Summary

Closes #406.

This adds the Android local data and diagnostics parity slice while keeping Android device-local:

- DataStore schema-version tracking for Android local data.
- Manual JSON backup export/import for favorites, custom stations, station lists, and selected preferences.
- Opt-in listening-history preference controls, with history off by default.
- Opt-in capped local diagnostics with export and clear actions.
- Android broken-station reporting from Now Playing through the shared anonymous Worker endpoint.
- README/spec updates documenting backup format, local-only boundaries, exclusions, and current Android status.

Backups intentionally exclude recents, listening-history records, diagnostic logs, active wake state, raw playback errors, and account/cloud identifiers.

## Validation

- git diff --check
- Android testDebugUnitTest
- Android assembleDebug
- npm run check-catalog
- Emulator smoke: install/launch, Preferences sections visible for Backup / Listening history / Diagnostics, diagnostics-on tap increments local log count, Favorites playback opens full-screen Now Playing, and the new Report broken station action is visible.