### PR TITLE
fix(ci): scope deploy concurrency per-ref (stop PRs cancelling the main deploy)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,8 +22,13 @@ permissions:
   pages: write
   id-token: write
 
+# Scope concurrency per workflow + ref. A static `pages` group meant ANY
+# run on ANY branch (e.g. a Dependabot PR) cancelled the in-progress main
+# deploy — which silently dropped publishes. Per-ref keeps each branch in
+# its own lane: a new push to main supersedes an older one, but unrelated
+# PR runs can't cancel the main deploy.
 concurrency:
-  group: pages
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Why highlights.json is still 404 even after #447 merged

The #447 merge **did** start a main deploy run — but it was **cancelled mid-flight**, so nothing published. Cause: the workflow's `concurrency` uses a **static group** with cancel-on-new:

```yaml
concurrency:
  group: pages
  cancel-in-progress: true
```

Every run on every branch shares the one `pages` lane, so a newer run cancels whatever's in progress. The actual timeline:

| time | run | effect |
|---|---|---|
| 14:10:56 | #447 merge → **main deploy** | started |
| 14:13:24 | Dependabot PR (`upload-artifact` bump) | **cancelled the main deploy** |
| 14:13:27 | Dependabot PR (`checkout` bump) | cancelled that one |

So an unrelated Dependabot PR killed the publish. (`worker` + `catalog` had already finished; `web`/`deploy`/`e2e` were cancelled.)

## Fix

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

Per-ref lanes: a newer push to `main` still supersedes an older one (good), but PR runs (Dependabot or otherwise) can no longer cancel the main deploy.

## Effect of merging

Concurrency is read from the **triggering commit's** workflow file, so the merge of *this* PR runs under the new per-ref group — it won't be cancelled by PR runs, the deploy completes, and **`highlights.json` finally publishes** (it's already committed on `main`). Future main deploys are protected too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)