### PR TITLE
worker: bind stats.rrradio.org custom domain to rrradio-stats

### DIFF
--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -2,6 +2,17 @@ name = "rrradio-stats"
 main = "src/index.ts"
 compatibility_date = "2025-04-01"
 
+# Bind the first-party custom domain the apps actually call. The iOS app uses
+# WorkerAPI.base = "https://stats.rrradio.org" (RegionResolver.swift) per the
+# privacy contract (must be first-party, no *.workers.dev). Without this route
+# that host is NXDOMAIN, so every Worker-backed feature silently fails: now-
+# playing metadata proxy + BBC fetchers, region resolution, "report broken
+# station", and the stats dashboard. Requires the rrradio.org zone in this
+# Cloudflare account; `wrangler deploy` provisions the proxied DNS record.
+routes = [
+  { pattern = "stats.rrradio.org", custom_domain = true },
+]
+
 # Public, non-secret config. Secrets (GOATCOUNTER_TOKEN, ADMIN_TOKEN)
 # are set via `wrangler secret put` and stored on Cloudflare's side.
 [vars]


### PR DESCRIPTION
Closes #451.

`WorkerAPI.base = https://stats.rrradio.org` (iOS, first-party per the privacy contract) was never bound to the `rrradio-stats` Worker → **NXDOMAIN**, silently breaking the metadata proxy + BBC fetchers, region resolution, report-broken, and the dashboard. This adds the `custom_domain` route so `wrangler deploy` provisions the host.

**Already deployed + verified live** (the deploy reported `stats.rrradio.org (custom domain)`):
```
dig +short stats.rrradio.org            -> 172.67.192.203 / 104.21.44.12
/api/public/region                      -> HTTP 200
/api/public/proxy?url=...bayern1...     -> HTTP 200   (was -1003)
```

This PR just lands the config in `main` so a future clean-checkout deploy retains the route. iOS-side tracking: MarkusSteinbrecher/rrradio-ios#53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)