### PR TITLE
fix(ios-local): inherit curated art for orphan RB rows + staleness gate

### DIFF
--- a/data/stations.yaml
+++ b/data/stations.yaml
@@ -393660,6 +393660,10 @@
   homepage: https://www.radiogong.de/
   country: DE
   status: stream-only
+  # Legacy pre-HTTPS-migration Radio Browser record for this channel (old nmdn
+  # channel5 stream, RB never refreshed). Bound so the iOS-local test catalog
+  # inherits this station's per-channel art instead of rendering blank.
+  akaStationUuids: [961f120a-0601-11e8-ae97-52543be04c81] # "Radio Gong 96.3 München - Party Gong"
 - id: de-radio-gong-96-3-acoustic-covers
   favicon: "https://www.radiogong.de/08_PROGRAMM/musik/Streams/NEU%20ab%20September%202025/NEU%20ab%20September%202025%20quadrat/27247550/image-thumb__27247550__streams-slider/Gong%2096.3_Acoustic%20Covers_600x600.6436dad6.png"
   faviconSource: broadcaster-site
@@ -393800,6 +393804,10 @@
   homepage: https://www.radiogong.de/
   country: DE
   status: stream-only
+  # Legacy Radio Browser record for the flagship live stream (old
+  # radiogong.de/app/live.m3u, no RB favicon). Bound so the iOS-local test
+  # catalog inherits this station's per-channel art instead of rendering blank.
+  akaStationUuids: [7eb433a9-fba5-4c86-9e08-2727ec9835de] # "Radio Gong 96.3 München - Live"
 - id: de-radio-gong-96-3-oktoberfest-radio
   favicon: "https://www.radiogong.de/08_PROGRAMM/musik/Streams/NEU%20ab%20September%202025/NEU%20ab%20September%202025%20quadrat/27247557/image-thumb__27247557__streams-slider/Gong%2096.3_Oktoberfest%20Radio_600x600.62812555.png"
   faviconSource: broadcaster-site
@@ -393841,3 +393849,7 @@
   homepage: https://www.089kult.de/
   country: DE
   status: stream-only
+  # Legacy Radio Browser record from before the 089 Kult rebrand (old nmdn
+  # channel4 stream, listed under radiogong.de as "Kulthits"). Bound so the
+  # iOS-local test catalog inherits this station's logo instead of rendering blank.
+  akaStationUuids: [960d39bd-0601-11e8-ae97-52543be04c81] # "Radio Gong 96.3 München - Kulthits"

--- a/docs/logo-extraction.md
+++ b/docs/logo-extraction.md
@@ -217,6 +217,42 @@ YAML insert/replace as `scrape-logos`. Report: `.cache/channel-art-report.json`
 After a real run, regenerate and verify exactly as for `scrape-logos` (catalog,
 favicon-variants, check-catalog, check-duplicates, build).
 
+## iOS-local Catalog: Favicon Inheritance
+
+`public/stations-ios-local.json` (built by `npm run catalog:ios-local`) is the
+local-only iOS *test* catalog: the curated set **plus** the full Radio Browser
+candidate pool, one row per playable source, HTTP streams included. It is **not**
+the shipped web catalog. Each row resolves its favicon through four tiers, in
+order:
+
+1. **curated catalog art** — the candidate's `matchedCatalogId` station's favicon
+   (per-channel art flows here automatically once it lands in `stations.json`);
+2. **`akaStationUuids` alias** — when the uuid/streamUrl matcher in
+   `build-sources` *can't* link a stale RB record (different uuid, dead old
+   stream, drifted name) to the curated station it really is, list that record's
+   `stationuuid` under `akaStationUuids:` on the curated YAML row so this catalog
+   inherits the correct per-channel art;
+3. **raw Radio Browser favicon** (HTTPS only);
+4. **family brand mark** — an RB orphan from a broadcaster we curate, carrying its
+   family's name-token core (gated by `detectFamilies`, *not* a bare host bucket),
+   gets the family's representative logo (`faviconSource: catalog-family-brand`)
+   rather than rendering blank.
+
+This is why a Radio Gong 96.3 channel can have perfect per-channel art in the
+shipped catalog yet still show blank rows in the iOS-local catalog: those rows are
+RB's own (often pre-HTTPS-migration) duplicate records, not our curated stations.
+
+**Freshness is gated.** `check-catalog` fails when any iOS-local row linked to a
+curated station (`localMatchedCatalogId`) lacks a favicon that station actually
+has — i.e. the artifact drifted behind a logo change. Fix by rebuilding:
+
+```bash
+npm run catalog:ios-local   # then commit public/stations-ios-local.json
+```
+
+Run this after any curated-favicon change (per-channel art sweeps especially), the
+same way you regenerate `stations.json`.
+
 ## Review Rules
 
 Do not apply a scrape run blindly. Review the report and spot-check images.

--- a/public/station-capabilities-ios-local.json
+++ b/public/station-capabilities-ios-local.json
@@ -1,27 +1,27 @@
 {
   "$schema": "local iOS test metadata capabilities generated from public/stations-ios-local.json + src/fetchers.json",
-  "generatedAt": "2026-05-22T06:34:47.335Z",
+  "generatedAt": "2026-06-08T08:00:05.109Z",
   "sourceCatalog": "public/stations-ios-local.json",
   "sourceManifest": "src/fetchers.json",
   "counts": {
-    "stations": 44562,
+    "stations": 44117,
     "byStatus": {
-      "icy-only": 78,
-      "stream-only": 44345,
-      "working": 139
+      "icy-only": 54,
+      "stream-only": 43858,
+      "working": 205
     },
     "byMetadataStrategy": {
-      "api": 149,
-      "icy": 84,
+      "api": 215,
+      "icy": 60,
       "hls": 1,
-      "none": 44328
+      "none": 43841
     },
     "byBackgroundPollPriority": {
-      "normal": 149,
-      "low": 85,
-      "never": 44328
+      "normal": 215,
+      "low": 61,
+      "never": 43841
     },
-    "knownFetcherStations": 149,
+    "knownFetcherStations": 215,
     "unknownFetcherStations": 0
   },
   "stations": [
@@ -235,17 +235,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ae-andrea-bocelli-classical-radio-d945dcb6",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-ae-aretha-franklin-68ebb0ea",
       "status": "stream-only",
       "metadataKey": null,
@@ -280,17 +269,6 @@
     },
     {
       "id": "rb-ae-bavarian-radio-symphony-orchestra-d0c78e57",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ae-beethoven-classical-radio-3cef4f77",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -499,95 +477,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ae-c-r-mozart-666d8062",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ae-c-r-andre-rieu-c02b71c8",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ae-c-r-arturo-toscanini-9f36db14",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ae-c-r-bavarian-radio-symphony-orchestra-2b6d8233",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ae-c-r-berlin-philarmonic-ee590a3b",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ae-c-r-brahms-6a0d43ca",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-ae-c-r-bryn-terfel-831599d1",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ae-c-r-calm-62181b85",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ae-c-r-chopin-2e600e35",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -620,29 +510,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ae-c-r-debussy-24150c6b",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-ae-c-r-essential-classics-c8616d03",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ae-c-r-handel-fe0a80b1",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -664,29 +532,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ae-c-r-j-s-bach-61d44e59",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-ae-c-r-jacqueline-du-pre-cb0b7565",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ae-c-r-john-williams-58d6ea13",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -719,73 +565,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ae-c-r-julian-lloyd-webber-cda52901",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ae-c-r-katherine-jenkins-8db81c43",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ae-c-r-kiri-te-kanawa-6f9c84ff",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ae-c-r-lang-lang-cdb946e7",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-ae-c-r-liszt-73786815",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ae-c-r-lorin-maazel-0dae0628",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ae-c-r-luciano-pavarotti-db701f14",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -818,50 +598,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ae-c-r-marin-alsop-f99b16ef",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ae-c-r-monserrat-caballe-efd37411",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ae-c-r-nadia-boulanger-bd902d68",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ae-c-r-new-release-df109b1c",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-ae-c-r-nigel-kennedy-4e27cc6f",
       "status": "stream-only",
       "metadataKey": null,
@@ -873,29 +609,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ae-c-r-placido-domingo-566a3739",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-ae-c-r-ralph-vaugham-williams-1a33442b",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ae-c-r-ravel-f0f31c93",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -928,84 +642,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ae-c-r-shostakovich-cadba2ad",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ae-c-r-sibelius-6aa07bdd",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-ae-c-r-simon-rattle-d9107274",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ae-c-r-strauss-415289e5",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ae-c-r-stravinsky-8dffd8d4",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ae-c-r-tchaikovsky-26d77602",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ae-c-r-vanessa-mae-1f5b021b",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ae-c-r-verdi-9d4a75d2",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -1038,29 +675,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ae-c-r-vladimir-horovitz-ca201cd4",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-ae-c-r-wagner-7e8db69d",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ae-c-r-yehudi-menuin-6acc5877",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -1841,17 +1456,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ae-easy-radio-andrea-bocelli-9fbd368a",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-ae-easy-radio-celine-dion-4928bfc5",
       "status": "stream-only",
       "metadataKey": null,
@@ -2029,17 +1633,6 @@
     },
     {
       "id": "rb-ae-exclusive-radio-george-michael-hits-47c0c887",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ae-exclusive-radio-italy-6cdf3547",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -8155,17 +7748,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ae-world-music-radio-bollywood-36a6e64c",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-af-quran-e5170b20",
       "status": "stream-only",
       "metadataKey": null,
@@ -8244,17 +7826,6 @@
     },
     {
       "id": "rb-af-abdulbasit-abdulsamad-2e1e773f",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-af-al-jazeera-19130893",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -8474,29 +8045,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-af-flac-e29d243f",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-af-fm-320fa22e",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-af-focus-97dba420",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -8804,17 +8353,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-af-qamislo-aadf72bc",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-af-r-radio-e8e74398",
       "status": "stream-only",
       "metadataKey": null,
@@ -8958,17 +8496,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-af-rtvs-fa055899",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-af-sbs-fm-7e76fdc5",
       "status": "stream-only",
       "metadataKey": null,
@@ -9014,17 +8541,6 @@
     },
     {
       "id": "rb-af-solar-radio-2647df7b",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-af-sunshine-live-fokus-585ef7aa",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -11862,17 +11378,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ar-fm-alas-correa-sta-fe-cfb1d1f7",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-ar-fm-alas-106-9-a0de4ec4",
       "status": "stream-only",
       "metadataKey": null,
@@ -13282,17 +12787,6 @@
     },
     {
       "id": "rb-ar-k2-radio-96-3-fm-c514f0b7",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ar-kinshasa-fm-bbb93064",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -17659,17 +17153,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-at-antenne-vorarlber-partymix-df0568b8",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-at-antenne-vorarlberg-2e70591f",
       "status": "stream-only",
       "metadataKey": null,
@@ -18353,17 +17836,6 @@
     },
     {
       "id": "rb-at-erf-plus-oesterreich-192k-a1-612bd03c",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-at-erf-plus-oesterreich-320k-6d6f6bb6",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -19705,17 +19177,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-at-radio-helsinki-92-6-fm-36db63ed",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-at-radio-himmelberg-511bb1f6",
       "status": "stream-only",
       "metadataKey": null,
@@ -19739,17 +19200,6 @@
     },
     {
       "id": "rb-at-radio-maria-austria-96096b11",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-at-radio-maria-austria-56-kbps-de5bc257",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -20365,17 +19815,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-at-transhits-ab0dd7b5",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-at-u1-tirol-a01d985a",
       "status": "stream-only",
       "metadataKey": null,
@@ -20794,17 +20233,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-au-2bob-radio-taree-104-7-fm-mp3-a10750a9",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-au-2bob-radio-104-7fm-8cb338b2",
       "status": "stream-only",
       "metadataKey": null,
@@ -20850,17 +20278,6 @@
     },
     {
       "id": "rb-au-2cbd-fm-glen-innes-105-9-fm-aac-e536ad8a",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-au-2cc-1206-am-b0df6818",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -21080,17 +20497,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-au-2mcr-campbelltown-100-3-fm-mp3-e97e1ca5",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-au-2mcr-100-3-sounds-of-macarthur-macarthur-com-50fc26c7",
       "status": "stream-only",
       "metadataKey": null,
@@ -21169,17 +20575,6 @@
     },
     {
       "id": "rb-au-2nm-muswellbrook-981-am-mp3-71b1cf7d",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-au-2nur-fm-newcastle-103-7-fm-mp3-6e51dba6",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -21454,17 +20849,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-au-3cr-melbourne-855-am-aac-75890ccc",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-au-3cr-community-radio-f0c91eac",
       "status": "stream-only",
       "metadataKey": null,
@@ -21664,28 +21048,6 @@
     },
     {
       "id": "rb-au-4eb-3c94fcb6",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-au-4eb-brisbane-98-1-fm-aac-5f8fc8c9",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-au-4k1g-townsville-107-1-fm-mp3-c5a9a6f4",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -22752,17 +22114,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-au-abc-country-3a9e3a9b",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-au-abc-country-aac-9623d032",
       "status": "stream-only",
       "metadataKey": null,
@@ -22830,17 +22181,6 @@
     },
     {
       "id": "rb-au-abc-grandstand-aac-9623b030",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-au-abc-grandstand-mp3-961a05dc",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -22994,17 +22334,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-au-abc-local-radio-666-canberra-aac-9623b63c",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-au-abc-local-radio-666-canberra-act-mp3-96139428",
       "status": "stream-only",
       "metadataKey": null,
@@ -23061,17 +22390,6 @@
     },
     {
       "id": "rb-au-abc-local-radio-720-perth-aac-960b9c4f",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-au-abc-local-radio-720-perth-wa-mp3-96230ea6",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -23864,17 +23182,6 @@
     },
     {
       "id": "rb-au-artsound-fm-a96c47e5",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-au-artsound-fm-canberra-92-7-fm-mp3-97c865e2",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -27735,17 +27042,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-au-bay-93-9-geelong-93-9-fm-aac-7eabd41e",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-au-bay-fm-redland-city-brisbane-100-3-fm-aac-1c5691ce",
       "status": "stream-only",
       "metadataKey": null,
@@ -27878,17 +27174,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-au-byron-bayfm-byron-bay-99-9-fm-aac-b4fb61ae",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-au-c91-3-cdd191dd",
       "status": "stream-only",
       "metadataKey": null,
@@ -27901,17 +27186,6 @@
     },
     {
       "id": "rb-au-c91-3-fm-macarthur-s-radio-station-20521f5e",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-au-c91-3fm-campbelltown-91-3-fm-aac-d13b4349",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -28439,17 +27713,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-au-curtin-radio-perth-100-1-fm-aac-5ae783e8",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-au-dance-hits-d45994e0",
       "status": "stream-only",
       "metadataKey": null,
@@ -28539,17 +27802,6 @@
     },
     {
       "id": "rb-au-double-j-adbcdfba",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-au-double-j-aac-nsw-vic-act-tas-0718374f",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -28670,17 +27922,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-au-edge-fm-bega-valley-community-radio-93-7-fm--6ee3cb94",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-au-edge-radio-hobart-99-3-fm-aac-81c6b494",
       "status": "stream-only",
       "metadataKey": null,
@@ -28748,17 +27989,6 @@
     },
     {
       "id": "rb-au-five-finger-death-punch-844f7218",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-au-fiveaa-adelaide-1395-am-aac-320k-5f97c60d",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -28968,17 +28198,6 @@
     },
     {
       "id": "rb-au-gdr-golden-days-radio-glen-huntly-melbourne--1965b5a2",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-au-gem-fm-bowen-95-1-fm-aac-3cee6f51",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -30155,17 +29374,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-au-k-rock-95-5-geelong-95-5-fm-mp3-73ad0c5d",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-au-k-rock-geelong-95-5-5b7173fd",
       "status": "stream-only",
       "metadataKey": null,
@@ -30200,17 +29408,6 @@
     },
     {
       "id": "rb-au-katherine-fm-a072699e",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-au-katherine-fm-katherine-101-3-fm-mp3-74bed929",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -30277,17 +29474,6 @@
     },
     {
       "id": "rb-au-kiis-1065-sydney-106-5-fm-aac-21ad1151",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-au-kiis-97-3-brisbane-97-3-fm-aac-6e9b824e",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -30518,17 +29704,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-au-listnr-2010s-hls-13b135cc",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-au-listnr-2010s-dance-hls-1e5432c8",
       "status": "stream-only",
       "metadataKey": null,
@@ -30606,17 +29781,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-au-listnr-80s-new-wave-hls-032e1063",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-au-listnr-90s-soft-pop-9484a8e5",
       "status": "stream-only",
       "metadataKey": null,
@@ -30628,29 +29792,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-au-listnr-90s-soft-pop-hls-09243b37",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-au-listnr-afrobeats-hls-dc02e866",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-au-listnr-almost-acoustic-hls-522a39d7",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -30683,17 +29825,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-au-listnr-aussie-dance-hls-91559b79",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-au-listnr-aussie-hip-hop-hls-e52d3e0e",
       "status": "stream-only",
       "metadataKey": null,
@@ -30706,17 +29837,6 @@
     },
     {
       "id": "rb-au-listnr-aussie-pub-rock-b17c5a84",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-au-listnr-aussie-pub-rock-hls-a1f5a73f",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -30749,7 +29869,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-au-listnr-billion-streams-club-hls-a9f99ae4",
+      "id": "rb-au-listnr-billion-streams-club-da84d51e",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -30793,17 +29913,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-au-listnr-buddha-hls-92914ce4",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-au-listnr-cafe-hls-cb2c8b4b",
       "status": "stream-only",
       "metadataKey": null,
@@ -30815,7 +29924,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-au-listnr-chill-electronic-hls-25ca30bb",
+      "id": "rb-au-listnr-chill-electronic-9fafb3aa",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -30859,17 +29968,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-au-listnr-chill-pop-hits-hls-5a2fcb1d",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-au-listnr-club-classics-hls-4841f408",
       "status": "stream-only",
       "metadataKey": null,
@@ -30893,17 +29991,6 @@
     },
     {
       "id": "rb-au-listnr-cooling-fan-white-noise-soundscapes-59ef236d",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-au-listnr-cooling-fan-white-noise-soundscapes-h-75bccfc5",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -30969,17 +30056,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-au-listnr-crooners-swooners-hls-ab7190bc",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-au-listnr-deep-calm-hls-6630088d",
       "status": "stream-only",
       "metadataKey": null,
@@ -31013,17 +30089,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-au-listnr-drum-bass-hls-4b275f4b",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-au-listnr-easy-hits-13db7ce4",
       "status": "stream-only",
       "metadataKey": null,
@@ -31046,7 +30111,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-au-listnr-essential-emo-hls-676ab1ac",
+      "id": "rb-au-listnr-essential-emo-1742cc0a",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -31112,29 +30177,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-au-listnr-festival-bangers-hls-90495c6e",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-au-listnr-fit-hits-1a9bf9a6",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-au-listnr-fit-hits-hls-c15fc727",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -31156,7 +30199,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-au-listnr-fresh-folk-hits-hls-a0636303",
+      "id": "rb-au-listnr-fresh-folk-hits-fb17dbf4",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -31189,29 +30232,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-au-listnr-girl-power-hls-654e4b71",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-au-listnr-good-vibes-8f4c2360",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-au-listnr-good-vibes-hls-8e2fe839",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -31255,17 +30276,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-au-listnr-guilty-pleasures-hls-f97b7ec0",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-au-listnr-happy-hits-hls-2cb0db9a",
       "status": "stream-only",
       "metadataKey": null,
@@ -31278,17 +30288,6 @@
     },
     {
       "id": "rb-au-listnr-hard-n-heavy-32e0049c",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-au-listnr-hard-n-heavy-hls-ca39d796",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -31376,17 +30375,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-au-listnr-homegrown-hls-78cac547",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-au-listnr-hot-country-hls-8afc4b71",
       "status": "stream-only",
       "metadataKey": null,
@@ -31442,17 +30430,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-au-listnr-indie-alt-hls-b151c8cb",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-au-listnr-indie-pop-hls-7294c40b",
       "status": "stream-only",
       "metadataKey": null,
@@ -31486,7 +30463,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-au-listnr-k-pop-hls-815f8406",
+      "id": "rb-au-listnr-k-pop-6dc82b72",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -31519,17 +30496,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-au-listnr-kids-hits-hls-0b8b8e88",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-au-listnr-light-rain-soundscapes-6d41bef8",
       "status": "stream-only",
       "metadataKey": null,
@@ -31541,18 +30507,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-au-listnr-light-rain-soundscapes-hls-0ec4bce1",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-au-listnr-lofi-study-beats-hls-bfba21cf",
+      "id": "rb-au-listnr-lofi-study-beats-51bf784e",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -31673,17 +30628,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-au-listnr-party-hls-64ff492e",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-au-listnr-passenger-princess-hls-2f895477",
       "status": "stream-only",
       "metadataKey": null,
@@ -31728,7 +30672,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-au-listnr-pride-hls-1bcb816b",
+      "id": "rb-au-listnr-pride-a7da2f23",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -31772,18 +30716,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-au-listnr-rainforest-soundscapes-hls-f83523c0",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-au-listnr-rap-revolution-hls-a2e52b99",
+      "id": "rb-au-listnr-rap-revolution-aa3ce9c1",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -31805,7 +30738,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-au-listnr-rnb-chill-hls-9b89e40f",
+      "id": "rb-au-listnr-rnb-chill-0fc0218c",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -31817,17 +30750,6 @@
     },
     {
       "id": "rb-au-listnr-rock-n-road-trip-4f6d0637",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-au-listnr-rock-n-road-trip-hls-873cafa6",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -31871,7 +30793,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-au-listnr-run-club-hls-9d2019bc",
+      "id": "rb-au-listnr-run-club-e46b09cf",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -31948,17 +30870,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-au-listnr-stress-free-hls-8e96e9b0",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-au-listnr-top-30-f1f59ecd",
       "status": "stream-only",
       "metadataKey": null,
@@ -31970,29 +30881,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-au-listnr-top-30-hls-ea808ac1",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-au-listnr-trending-now-889ecf8f",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-au-listnr-trending-now-hls-b2789370",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -32015,17 +30904,6 @@
     },
     {
       "id": "rb-au-listnr-waterfall-soundscapes-45177ab1",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-au-listnr-waterfall-soundscapes-hls-c63def42",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -32081,17 +30959,6 @@
     },
     {
       "id": "rb-au-listnr-yacht-rock-aa8fedb1",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-au-listnr-yacht-rock-hls-9769eeb5",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -32542,17 +31409,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-au-northside-radio-chatswood-99-3-fm-aac-dc3f2368",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-au-northside-radio-99-3-b4144354",
       "status": "stream-only",
       "metadataKey": null,
@@ -32608,17 +31464,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-au-nova-100-melbourne-100-3-fm-aac-48k-de9a7b99",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-au-nova-106-9-960a2859",
       "status": "stream-only",
       "metadataKey": null,
@@ -32631,17 +31476,6 @@
     },
     {
       "id": "rb-au-nova-106-9-brisbane-106-9-fm-aac-320k-905aee51",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-au-nova-106-9-brisbane-106-9-fm-aac-48k-d6d5deb8",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -32674,40 +31508,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-au-nova-919-adelaide-91-9-fm-aac-320k-0845f3ce",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-au-nova-919-adelaide-91-9-fm-aac-48k-e0be0311",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-au-nova-93-7-960a29d2",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-au-nova-93-7-perth-93-7-fm-aac-48k-fc5f4cce",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -32740,51 +31541,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-au-nova-96-9-sydney-96-9-fm-aac-128k-2e23b8f1",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-au-nova-96-9-sydney-96-9-fm-aac-48k-7be91afc",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-au-nova-all-stars-aac-320k-2974d912",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-au-nova-all-stars-aac-48k-f0b5fe2f",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-au-nova-jamz-aac-48k-cf06abfb",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -33323,17 +32080,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-au-radio-adelaide-adelaide-101-5-fm-aac-f7d3909e",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-au-radio-adelaide-101-5-28c83847",
       "status": "stream-only",
       "metadataKey": null,
@@ -33456,17 +32202,6 @@
     },
     {
       "id": "rb-au-radio-mansfield-95536c23",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-au-radio-mansfield-mansfield-tolmie-woods-point-41b1e8cc",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -34016,17 +32751,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-au-rim-fm-boonah-100-1-fm-mp3-6eaa7406",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-au-rim-fm-100-1-35d1ec37",
       "status": "stream-only",
       "metadataKey": null,
@@ -34138,17 +32862,6 @@
     },
     {
       "id": "rb-au-rose-city-fm-35c358b6",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-au-rose-city-fm-warwick-89-3-fm-aac-2a517f01",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -34511,29 +33224,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-au-smooth-fm-91-5-melbourne-91-5-fm-aac-48k-eb336598",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-au-smooth-fm-95-3-964fb9c9",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-au-smooth-fm-95-3-sydney-95-3-fm-aac-320k-f7c04bff",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -34555,17 +33246,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-au-smooth-fm-adelaide-aac-48k-21ef932e",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-au-smooth-fm-brisbane-aac-128k-00c84aeb",
       "status": "stream-only",
       "metadataKey": null,
@@ -34577,29 +33257,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-au-smooth-fm-brisbane-aac-48k-15bca0b8",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-au-smooth-fm-perth-aac-320k-aebdf589",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-au-smooth-fm-perth-aac-48k-94eebec2",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -34787,17 +33445,6 @@
     },
     {
       "id": "rb-au-star-104-5-9609a895",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-au-star-104-5-gosford-104-5-fm-aac-320k-496d48c0",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -36106,17 +34753,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-au-triple-r-melbourne-102-7-fm-aac-7c520692",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-au-triple-r-102-7fm-6a34086c",
       "status": "stream-only",
       "metadataKey": null,
@@ -36250,17 +34886,6 @@
     },
     {
       "id": "rb-au-vintage-fm-e695d417",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-au-vintage-fm-camden-88-7-fm-aac-8cffcb63",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -37196,17 +35821,6 @@
     },
     {
       "id": "rb-ba-big2-9c421149",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ba-day-dee-eurodance-radio-fad97ae1",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -38856,17 +37470,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-be-candie-1e7ae76b",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-be-charleking-radio-07043eda",
       "status": "stream-only",
       "metadataKey": null,
@@ -40121,17 +38724,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-be-paradise-f0c7bb84",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-be-phare-fm-belgique-5bb69f23",
       "status": "stream-only",
       "metadataKey": null,
@@ -40364,17 +38956,6 @@
     },
     {
       "id": "rb-be-radio-accent-03019320",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-be-radio-accent-b8e10b1a",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -40804,17 +39385,6 @@
     },
     {
       "id": "rb-be-radio-noordzee-192k-dd9fbcab",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-be-radio-noordzee-48k-e857ee67",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -41628,17 +40198,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-be-slow-radio-06803d46",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-be-stadradio-tienen-5a982b98",
       "status": "stream-only",
       "metadataKey": null,
@@ -41673,17 +40232,6 @@
     },
     {
       "id": "rb-be-studio-brussel-550f4b47",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-be-studio-brussel-zware-gitaren-ed0e2d7a",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -41783,17 +40331,6 @@
     },
     {
       "id": "rb-be-tommorowland-one-world-radio-daybreak-sessio-c77644fa",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-be-tomorrowland-daybreak-sessions-19df8029",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -42058,17 +40595,6 @@
     },
     {
       "id": "rb-be-vrt-radio-1-de-lagelandenlijst-66c0eb09",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-be-vrt-radio-1-low-f27427e9",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -42663,6 +41189,17 @@
     },
     {
       "id": "rb-bg-city-latin-a149f4b4",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-bg-city-radio-027dee86",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -52320,17 +50857,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-br-radio-cidade-9ab23180",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-br-radio-cidade-classic-rock-6e56e3eb",
       "status": "stream-only",
       "metadataKey": null,
@@ -55125,17 +53651,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-br-radio-music-hall-8ea74eba",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-br-radio-musical-19de4652",
       "status": "stream-only",
       "metadataKey": null,
@@ -57227,17 +55742,6 @@
     },
     {
       "id": "rb-br-radio-vale-feliz-fm-9c6caf67",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-br-radio-venceslau-fm-9ba217b0",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -59910,17 +58414,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ca-107-5-dave-fm-cdf0a0b3",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-ca-107-5-kool-fm-db3aaa9d",
       "status": "stream-only",
       "metadataKey": null,
@@ -62264,17 +60757,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ca-cfny-102-1-toronto-on-aac-961aee5d",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-ca-cfob-fm-93-1-the-border-fort-frances-on-23c77648",
       "status": "stream-only",
       "metadataKey": null,
@@ -63749,17 +62231,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ca-chqr-770-calgary-ab-962103f8",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-ca-chqr-770-global-news-radio-calgary-ab-93aa791f",
       "status": "stream-only",
       "metadataKey": null,
@@ -63838,17 +62309,6 @@
     },
     {
       "id": "rb-ca-chrm-fm-plaisir105-3-matane-qc-4fec3b06",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ca-chrn-1610-radio-humsafar-montreal-qc-96227bad",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -64410,17 +62870,6 @@
     },
     {
       "id": "rb-ca-cihr-104-7-heart-fm-woodstock-on-9621dda4",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ca-ciht-hot-89-9-ottawa-on-9621df06",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -66400,17 +64849,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ca-cjrw-102-1-spud-fm-summerside-pe-9639810a",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-ca-cjrx-106-7-rock-lethbridge-ab-fcd7cac4",
       "status": "stream-only",
       "metadataKey": null,
@@ -67434,17 +65872,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ca-ckgl-7a93f065",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-ca-ckgl-city-news-570-kitchener-on-89444c43",
       "status": "stream-only",
       "metadataKey": null,
@@ -67611,17 +66038,6 @@
     },
     {
       "id": "rb-ca-ckjr-w1440-wetaskiwin-ab-04fff7df",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ca-ckjr-1440-w1440-wetaskiwin-ab-960dad8d",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -68425,17 +66841,6 @@
     },
     {
       "id": "rb-ca-ckrv-97-5-the-river-kamloops-bc-96219cc2",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ca-ckrv-fm-k-97-5-classic-rock-kamloops-bc-82625a71",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -70163,17 +68568,6 @@
     },
     {
       "id": "rb-ca-j-pop-powerplay-kawaii-baeda35f",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ca-j-pop-powerplay-kawaii-http-66be6d60",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -73165,28 +71559,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ca-techno-fm-ca-192k-mp3-e906b683",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ca-techno-fm-ca-320-kbps-67a75e09",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-ca-the-base-fa78faf3",
       "status": "stream-only",
       "metadataKey": null,
@@ -73551,17 +71923,6 @@
     },
     {
       "id": "rb-ca-umfm-101-5-cjum-ae1ac708",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ca-uturn-radio-drum-bass-32kb-s-86521b86",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -73958,17 +72319,6 @@
     },
     {
       "id": "rb-cd-top-congo-fm-351eaaf0",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-cd-top-congo-fm-88-4-kinshasa-9649c8f1",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -74540,17 +72890,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ch-country-radio-switzerland-f06f548b",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-ch-country-radio-switzerland-crs-8ac2325b",
       "status": "stream-only",
       "metadataKey": null,
@@ -74881,17 +73220,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ch-ip-music-slow-96-kbps-aac-9608c6fe",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-ch-jam-on-radio-a805fab4",
       "status": "stream-only",
       "metadataKey": null,
@@ -74914,29 +73242,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ch-jazz-black-music-c71cac32",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-ch-jazz-radio-19a4a007",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ch-jazz-radio-lounge-6b7e2c05",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -75915,17 +74221,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ch-radio-bern-rabe-hd-stream-12fa87b5",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-ch-radio-bern1-95142051",
       "status": "stream-only",
       "metadataKey": null,
@@ -76476,17 +74771,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ch-radio-rtr-c66c41ff",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-ch-radio-rumantsch-9608933a",
       "status": "working",
       "metadataKey": "srgssr-il",
@@ -76542,17 +74826,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ch-radio-srf-1-basel-baselland-c50ec229",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-ch-radio-srf-1-bern-freibourg-wallis-23e99d6c",
       "status": "stream-only",
       "metadataKey": null,
@@ -76587,17 +74860,6 @@
     },
     {
       "id": "rb-ch-radio-srf-1-graubunden-96k-aac-2cf05159",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ch-radio-srf-1-ostschweiz-a0c2924c",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -76708,28 +74970,6 @@
     },
     {
       "id": "rb-ch-radio-srf-1-zurich-schaffhausen-76a8392c",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ch-radio-srf-2-kultur-229170ac",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ch-radio-srf-2-kultur-c8ae73b1",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -76961,17 +75201,6 @@
     },
     {
       "id": "rb-ch-radio-zuerich-nord-musikbox-a0803c30",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ch-radio-zuerisee-dcfb893c",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -77268,17 +75497,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ch-rouge-bd8c85d6",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-ch-rouge-fm-90s-961f8454",
       "status": "stream-only",
       "metadataKey": null,
@@ -77367,29 +75585,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ch-rsr-espace-2-8f6a70f6",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-ch-rsr-la-premiere-2b9f1cb3",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ch-rsr-option-musique-478e5429",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -80128,17 +78324,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-cl-radio-beethoven-fm-fc8b670f",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-cl-radio-bio-bio-76d84052",
       "status": "stream-only",
       "metadataKey": null,
@@ -82438,6 +80623,17 @@
       "hasProviderCover": false
     },
     {
+      "id": "rb-cn-asiafm-9fed76be",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
       "id": "rb-cn-asiafm-1328e18b",
       "status": "stream-only",
       "metadataKey": null,
@@ -82570,6 +80766,50 @@
       "hasProviderCover": false
     },
     {
+      "id": "rb-cn-brtv-e5af9df0",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-cn-brtv-8bb437c1",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-cn-brtv-c202d338",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-cn-brtv-cfffc0a9",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
       "id": "rb-cn-brtv-2abdf5b4",
       "status": "stream-only",
       "metadataKey": null,
@@ -82581,7 +80821,106 @@
       "hasProviderCover": false
     },
     {
+      "id": "rb-cn-brtv-cc120955",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
       "id": "rb-cn-brtv-5f7ac40f",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-cn-brtv-331b2b44",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-cn-brtv-72482946",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-cn-brtv-ecbe92bf",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-cn-btv-25551838",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-cn-btv-8c04d491",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-cn-btv-f71a0ebf",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-cn-btv-ab18612b",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-cn-btv-366b62b4",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -82724,7 +81063,29 @@
       "hasProviderCover": false
     },
     {
+      "id": "rb-cn-cctv-4-6fc00fa2",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
       "id": "rb-cn-cctv-4-1bd95c33",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-cn-cctv-5-965467f3",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -82780,6 +81141,17 @@
     },
     {
       "id": "rb-cn-cctv-9-a01ba6df",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-cn-cctv-b5f0cac4",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -83110,6 +81482,17 @@
     },
     {
       "id": "rb-cn-cnr-2-431eb0c9",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-cn-cnr-3-4bec4d73",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -83978,17 +82361,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-cn-radio-collection-4cd5e1fd",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-cn-radio-impetus-e312b524",
       "status": "stream-only",
       "metadataKey": null,
@@ -84705,17 +83077,6 @@
     },
     {
       "id": "rb-cn-wuyi-news-tv-550c09b0",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-cn-xuzhou-f4e04ea4",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -87267,29 +85628,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-cn-station-859f575a",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-cn-station-379a0b25",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-cn-station-47ab10f1",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -87355,29 +85694,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-cn-station-f0b8d295",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-cn-station-21bbd28e",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-cn-station-e044cfce",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -88225,17 +86542,6 @@
     },
     {
       "id": "rb-cn-station-8539abda",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-cn-station-8462ac96",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -89918,17 +88224,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-cn-station-78ed6f74",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-cn-station-c71afa91",
       "status": "stream-only",
       "metadataKey": null,
@@ -90667,17 +88962,6 @@
     },
     {
       "id": "rb-cn-station-07e26e09",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-cn-station-7c064051",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -91580,17 +89864,6 @@
     },
     {
       "id": "rb-cn-station-7192df7a",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-cn-station-d872fc0c",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -94164,17 +92437,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-cn-station-8636630a",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-cn-2-221bea90",
       "status": "stream-only",
       "metadataKey": null,
@@ -94472,17 +92734,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-cn-station-69ab09eb",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-cn-station-0fede3e6",
       "status": "stream-only",
       "metadataKey": null,
@@ -94527,29 +92778,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-cn-station-5eb60978",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-cn-station-0a437125",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-cn-station-f41619a1",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -94604,29 +92833,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-cn-station-1851c9e5",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-cn-station-e39410e4",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-cn-station-0fd3c9e6",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -95902,6 +94109,28 @@
       "hasProviderCover": false
     },
     {
+      "id": "rb-cn-fm100-1-23c21683",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-cn-fm106-5-7b68b046",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
       "id": "rb-cn-station-28582658",
       "status": "stream-only",
       "metadataKey": null,
@@ -96024,17 +94253,6 @@
     },
     {
       "id": "rb-cn-station-53597adc",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-cn-station-4dd72a56",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -97398,17 +95616,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-cn-station-dd31d54a",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-cn-875-d3a63a00",
       "status": "stream-only",
       "metadataKey": null,
@@ -97893,17 +96100,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-cn-station-b8800d03",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-cn-station-aa4ab95d",
       "status": "stream-only",
       "metadataKey": null,
@@ -97926,29 +96122,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-cn-station-8fc78bb6",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-cn-station-e778bbe0",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-cn-station-4db8992a",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -98245,17 +96419,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-cn-station-d28431e3",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-cn-station-bbe13b7a",
       "status": "stream-only",
       "metadataKey": null,
@@ -98267,29 +96430,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-cn-station-13f95665",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-cn-station-36655b37",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-cn-station-e701e76e",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -98466,6 +96607,17 @@
     },
     {
       "id": "rb-cn-station-19c2d3be",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-cn-fm106-6-b1496878",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -98807,39 +96959,6 @@
     },
     {
       "id": "rb-cn-station-deae95a8",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-cn-station-17b26a3e",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-cn-station-215605fc",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-cn-station-31934c99",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -100148,17 +98267,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-cn-station-3a74d437",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-cn-station-1697206a",
       "status": "stream-only",
       "metadataKey": null,
@@ -100171,17 +98279,6 @@
     },
     {
       "id": "rb-cn-station-7b19084a",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-cn-station-4f09fca0",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -102887,17 +100984,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-co-b-mor-43de2f39",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-co-bacana-93-3-fm-5c48eff7",
       "status": "stream-only",
       "metadataKey": null,
@@ -103790,17 +101876,6 @@
     },
     {
       "id": "rb-co-ciudad-stereo-tunja-94-7-fm-153bc544",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-co-clasica-fm919-e229b2ba",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -107474,17 +105549,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-co-universal-stereo-52e3194f",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-co-universal-stereo-fm-22c2952f",
       "status": "stream-only",
       "metadataKey": null,
@@ -109443,17 +107507,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-cy-station-79a6c099",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-cy-station-a217bafc",
       "status": "stream-only",
       "metadataKey": null,
@@ -109818,17 +107871,6 @@
     },
     {
       "id": "rb-cz-cro-d-dur-flac-0933cedf",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-cz-cro-d-dur-hd-309a02c6",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -111192,17 +109234,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-cz-radio-dechovka-256-kbps-90762bd0",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-cz-radio-depeche-mode-961d4a91",
       "status": "stream-only",
       "metadataKey": null,
@@ -111633,28 +109664,6 @@
     },
     {
       "id": "rb-cz-radio-svoboda-ru-official-stream-979f5cb0",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-cz-radio-svoboda-rus-22427bf9",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-cz-radio-wave-9d87a8ad",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -115350,17 +113359,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-de-1000-70er-2f4ac24c",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-de-1000-70er-laut-fm-5328e3f0",
       "status": "stream-only",
       "metadataKey": null,
@@ -116066,11 +114064,11 @@
     },
     {
       "id": "rb-de-1live-14cb94a3",
-      "status": "icy-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "icy",
-      "backgroundPollPriority": "low",
+      "status": "working",
+      "metadataKey": "wdr",
+      "metadataUrl": "https://www.wdr.de/radio/radiotext/streamtitle_1live.txt",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
       "hasProgram": false,
       "hasSchedule": false,
       "hasProviderCover": false
@@ -116088,22 +114086,22 @@
     },
     {
       "id": "rb-de-1live-b2cbd1fd",
-      "status": "icy-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "icy",
-      "backgroundPollPriority": "low",
+      "status": "working",
+      "metadataKey": "wdr",
+      "metadataUrl": "https://www.wdr.de/radio/radiotext/streamtitle_1live.txt",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
       "hasProgram": false,
       "hasSchedule": false,
       "hasProviderCover": false
     },
     {
       "id": "rb-de-1live-https-0fd9d46c",
-      "status": "icy-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "icy",
-      "backgroundPollPriority": "low",
+      "status": "working",
+      "metadataKey": "wdr",
+      "metadataUrl": "https://www.wdr.de/radio/radiotext/streamtitle_1live.txt",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
       "hasProgram": false,
       "hasSchedule": false,
       "hasProviderCover": false
@@ -116198,11 +114196,11 @@
     },
     {
       "id": "rb-de-1live-fm-32206891",
-      "status": "icy-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "icy",
-      "backgroundPollPriority": "low",
+      "status": "working",
+      "metadataKey": "wdr",
+      "metadataUrl": "https://www.wdr.de/radio/radiotext/streamtitle_1live.txt",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
       "hasProgram": false,
       "hasSchedule": false,
       "hasProviderCover": false
@@ -116385,17 +114383,6 @@
     },
     {
       "id": "rb-de-70er-80er-kultnight-0d9562fd",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-80er-274f661c",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -117034,17 +115021,6 @@
     },
     {
       "id": "rb-de-90s90s-chill-out-731b2882",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-90s90s-dance-3be3c4dc",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -117946,17 +115922,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-de-afk-m94-5-aac-lq-96421aed",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-de-afk-m94-5-mp3-hq-96421632",
       "status": "stream-only",
       "metadataKey": null,
@@ -118750,17 +116715,6 @@
     },
     {
       "id": "rb-de-antenne-bayern-coffeemusic-52ba8d13",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-antenne-bayern-event-8f694c93",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -119871,17 +117825,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-de-antennebayern-64-kbps-aac-42a08e4f",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-de-antennebayern-black-beatz-64-kbps-aac-bcd0631b",
       "status": "stream-only",
       "metadataKey": null,
@@ -119893,29 +117836,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-de-antennebayern-chillout-64-kbps-aac-daf3c1c5",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-de-antennebayern-coffeemusic-64-kbps-aac-4a9a2b37",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-antennebayern-hitmix-64-kbps-aac-1218a2db",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -119948,51 +117869,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-de-antennebayern-oldies-but-goldies-64-kbps-aac-a3ec1de2",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-de-antennebayern-radio-fresh-64-kbps-aac-d86d2ef3",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-antennebayern-relax-64-kbps-aac-bf38a745",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-antennebayern-schlagersahne-64-kbps-aac-f83b716b",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-antennebayern-workout-64-kbps-aac-7087394d",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -120784,17 +118661,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-de-bayernwelle-suedost-0e72e052",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-de-bayerwaldradio-de-volksmusik-pur-rund-um-die-383f8e58",
       "status": "stream-only",
       "metadataKey": null,
@@ -121247,17 +119113,6 @@
     },
     {
       "id": "rb-de-beste-fm-ca2e0a0b",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-bestefm-lounge-fe4cad2a",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -122159,17 +120014,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-de-bluewolf-radio-feac96d8",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-de-bn-radio-ac57d65b",
       "status": "stream-only",
       "metadataKey": null,
@@ -122398,39 +120242,6 @@
       "backgroundPollPriority": "normal",
       "hasProgram": true,
       "hasSchedule": true,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-br24-hls-192-f1e4f80e",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-br24-hls-96-aefb134e",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-br24live-65e1287a",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
       "hasProviderCover": false
     },
     {
@@ -122731,17 +120542,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-de-bremen-zwei-unencrypted-ab1051e1",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-de-brexit-laut-fm-20581fd5",
       "status": "stream-only",
       "metadataKey": null,
@@ -122776,17 +120576,6 @@
     },
     {
       "id": "rb-de-brillux-radio-ec0d2c7b",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-britpop-99a6e42a",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -123369,17 +121158,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-de-charthits-fm-960dd29f",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-de-chartradio24-c0f6174a",
       "status": "stream-only",
       "metadataKey": null,
@@ -123491,17 +121269,6 @@
     },
     {
       "id": "rb-de-christliches-radio-munchen-fdcc91c5",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-christmas-by-rautemusik-960cc274",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -124667,17 +122434,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-de-delta-radio-deutsch-64-aac-6d2a3de9",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-de-delta-radio-alternative-96120bb1",
       "status": "stream-only",
       "metadataKey": null,
@@ -125437,17 +123193,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-de-die-nieue-107-7-oldies-9626cef8",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-de-die-sendung-mit-der-maus-zum-horen-3d20f066",
       "status": "stream-only",
       "metadataKey": null,
@@ -125625,17 +123370,6 @@
     },
     {
       "id": "rb-de-djbronko-laut-fm-0a910b60",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-dlf-die-nachrichten-cdee9b38",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -125932,17 +123666,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-de-drgnu-metallica-da88f032",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-de-drgnu-prog-rock-classics-20c21c03",
       "status": "stream-only",
       "metadataKey": null,
@@ -126174,29 +123897,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-de-egofm-baden-wuerttemberg-4763827b",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-de-egofm-bayern-43d17c5a",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-egofm-bw-928c44c8",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -126251,29 +123952,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-de-egofm-fame-e34a232d",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-de-egofm-fame-37e54711",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-egofm-flash-aac-c5b65578",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -129122,17 +126801,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-de-fluxfm-chillhop-a9ab4514",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-de-fluxfm-chillout-radio-f9df19ee",
       "status": "stream-only",
       "metadataKey": null,
@@ -129177,17 +126845,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-de-fluxfm-dubradio-7a8640b5",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-de-fluxfm-eclectic-electric-964157a5",
       "status": "stream-only",
       "metadataKey": null,
@@ -129211,17 +126868,6 @@
     },
     {
       "id": "rb-de-fluxfm-ferienprogramm-9645c3da",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-fluxfm-fluxkompensator-963b20ef",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -130838,17 +128484,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-de-get-ready-to-rock-0d5973d8",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-de-gewandhaus-radio-5b733e6b",
       "status": "stream-only",
       "metadataKey": null,
@@ -131333,17 +128968,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-de-harmony-70er-f84f8e06",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-de-harmony-90er-bfaa5981",
       "status": "stream-only",
       "metadataKey": null,
@@ -131488,17 +129112,6 @@
     },
     {
       "id": "rb-de-hazzard-of-darkness-148531bd",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-hb-hd-37c2031f",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -131878,17 +129491,6 @@
       "metadataUrl": "ffh",
       "metadataStrategy": "api",
       "backgroundPollPriority": "normal",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-hit-radio-ffh-aac-48-0d19bf23",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
       "hasProgram": false,
       "hasSchedule": false,
       "hasProviderCover": false
@@ -132368,17 +129970,6 @@
     },
     {
       "id": "rb-de-housetime-fm-960ed525",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-housetimehd-79550270",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -132994,17 +130585,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-de-i-love-radio-harder-music-c4ae18fd",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-de-i-love-radio-hip-hop-turnup-5b48d259",
       "status": "stream-only",
       "metadataKey": null,
@@ -133072,17 +130652,6 @@
     },
     {
       "id": "rb-de-i-love-radio-robin-schulz-eec5e831",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-i-love-radio-the-batlle-4a75ac6b",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -133588,17 +131157,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-de-inforadio-vom-rbb-23a4e727",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-de-insane-country-radio-b02723ea",
       "status": "stream-only",
       "metadataKey": null,
@@ -133764,17 +131322,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-de-japanradio-e-v-a90a6616",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-de-japanradio-de-4579447c",
       "status": "stream-only",
       "metadataKey": null,
@@ -133897,17 +131444,6 @@
     },
     {
       "id": "rb-de-jazzradio-106-8-berlin-96074d8b",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-jazzradio-berlin-s-best-jazz-4492f6db",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -134458,17 +131994,6 @@
     },
     {
       "id": "rb-de-klassik-1-c528303b",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-klassik-mozart-aac-64-stream-e9fe1d47",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -135299,17 +132824,6 @@
       "metadataUrl": null,
       "metadataStrategy": "icy",
       "backgroundPollPriority": "low",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-kulturradio-48-kbit-s-9614af72",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
       "hasProgram": false,
       "hasSchedule": false,
       "hasProviderCover": false
@@ -137471,17 +134985,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-de-lovesong-41e6e6a5",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-de-lubeck-fm-962afcce",
       "status": "stream-only",
       "metadataKey": null,
@@ -139573,14 +137076,14 @@
     },
     {
       "id": "rb-de-n-joy-eac50ec2",
-      "status": "icy-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "icy",
-      "backgroundPollPriority": "low",
+      "status": "working",
+      "metadataKey": "ndr",
+      "metadataUrl": "https://www.ndr.de/public/radioplaylists/njoy.json",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
       "hasProgram": false,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-de-n-tv-audio-b1689b78",
@@ -139639,14 +137142,14 @@
     },
     {
       "id": "rb-de-ndr-1-niedersachsen-b6240170",
-      "status": "icy-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "icy",
-      "backgroundPollPriority": "low",
+      "status": "working",
+      "metadataKey": "ndr",
+      "metadataUrl": "https://www.ndr.de/public/radioplaylists/ndr1niedersachsen.json",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
       "hasProgram": false,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-de-ndr-1-niedersachsen-braunschweig-9c123508",
@@ -139694,25 +137197,25 @@
     },
     {
       "id": "rb-de-ndr-1-radio-mv-960cb2ea",
-      "status": "icy-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "icy",
-      "backgroundPollPriority": "low",
+      "status": "working",
+      "metadataKey": "ndr",
+      "metadataUrl": "https://www.ndr.de/public/radioplaylists/ndr1radiomv.json",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
       "hasProgram": false,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-de-ndr-1-radio-mv-4968933d",
-      "status": "icy-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "icy",
-      "backgroundPollPriority": "low",
+      "status": "working",
+      "metadataKey": "ndr",
+      "metadataUrl": "https://www.ndr.de/public/radioplaylists/ndr1radiomv.json",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
       "hasProgram": false,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-de-ndr-1-radio-mv-hgw-9611eb1e",
@@ -139760,14 +137263,14 @@
     },
     {
       "id": "rb-de-ndr-1-welle-nord-dbce97a5",
-      "status": "icy-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "icy",
-      "backgroundPollPriority": "low",
+      "status": "working",
+      "metadataKey": "ndr",
+      "metadataUrl": "https://www.ndr.de/public/radioplaylists/ndr1wellenord.json",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
       "hasProgram": false,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-de-ndr-1-welle-nord-lubeck-d5e198fc",
@@ -139804,14 +137307,14 @@
     },
     {
       "id": "rb-de-ndr-2-9e3b0f8e",
-      "status": "icy-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "icy",
-      "backgroundPollPriority": "low",
+      "status": "working",
+      "metadataKey": "ndr",
+      "metadataUrl": "https://www.ndr.de/public/radioplaylists/ndr2.json",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
       "hasProgram": false,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-de-ndr-2-hamburg-96496f03",
@@ -139859,47 +137362,47 @@
     },
     {
       "id": "rb-de-ndr-90-3-c0cb1e13",
-      "status": "icy-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "icy",
-      "backgroundPollPriority": "low",
+      "status": "working",
+      "metadataKey": "ndr",
+      "metadataUrl": "https://www.ndr.de/public/radioplaylists/ndr903.json",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
       "hasProgram": false,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-de-ndr-90-3-5bf6031d",
-      "status": "icy-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "icy",
-      "backgroundPollPriority": "low",
+      "status": "working",
+      "metadataKey": "ndr",
+      "metadataUrl": "https://www.ndr.de/public/radioplaylists/ndr903.json",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
       "hasProgram": false,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-de-ndr-blue-960e4255",
-      "status": "icy-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "icy",
-      "backgroundPollPriority": "low",
+      "status": "working",
+      "metadataKey": "ndr",
+      "metadataUrl": "https://www.ndr.de/public/radioplaylists/ndrblue.json",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
       "hasProgram": false,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-de-ndr-blue-ad7ad60d",
-      "status": "icy-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "icy",
-      "backgroundPollPriority": "low",
+      "status": "working",
+      "metadataKey": "ndr",
+      "metadataUrl": "https://www.ndr.de/public/radioplaylists/ndrblue.json",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
       "hasProgram": false,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-de-ndr-fernsehen-hamburg-09f7e455",
@@ -140046,14 +137549,14 @@
     },
     {
       "id": "rb-de-ndr-kultur-aa673098",
-      "status": "icy-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "icy",
-      "backgroundPollPriority": "low",
+      "status": "working",
+      "metadataKey": "ndr",
+      "metadataUrl": "https://www.ndr.de/public/radioplaylists/ndrkultur.json",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
       "hasProgram": false,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-de-ndr-kultur-aac-192-59886778",
@@ -140068,14 +137571,14 @@
     },
     {
       "id": "rb-de-ndr-schlager-8f37c5fe",
-      "status": "icy-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "icy",
-      "backgroundPollPriority": "low",
+      "status": "working",
+      "metadataKey": "ndr",
+      "metadataUrl": "https://www.ndr.de/public/radioplaylists/ndrschlager.json",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
       "hasProgram": false,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-de-ndr2-mv-29bb5edf",
@@ -140705,17 +138208,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-de-offener-kanal-saarland-1-5d3c5fbd",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-de-ohrenweide-c9458731",
       "status": "stream-only",
       "metadataKey": null,
@@ -141233,17 +138725,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-de-parlaradio-landtag-schleswig-holstein-stream-0e70cda9",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-de-party-radio-0cdab305",
       "status": "stream-only",
       "metadataKey": null,
@@ -141525,17 +139006,6 @@
       "metadataUrl": "planet",
       "metadataStrategy": "api",
       "backgroundPollPriority": "normal",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-planet-radio-black-beats-96100335",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
       "hasProgram": false,
       "hasSchedule": false,
       "hasProviderCover": false
@@ -142180,17 +139650,6 @@
     },
     {
       "id": "rb-de-r-sa-80er-italo-disco-hits-c311142f",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-r-sa-beatles-64-kbps-8996a646",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -144115,29 +141574,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-de-radio-corax-halle-192kbps-77ad88db",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-de-radio-corax-halle-256kbps-6a917a5b",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-radio-corax-halle-64kbps-8cffe4f2",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -144226,17 +141663,6 @@
     },
     {
       "id": "rb-de-radio-diefflen-b506cb9c",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-radio-diefflen-a7b75d08",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -144429,17 +141855,6 @@
       "metadataUrl": null,
       "metadataStrategy": "api",
       "backgroundPollPriority": "normal",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-radio-eins-rbb-neuer-stream-niedrige-qualita-52e18f3e",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
       "hasProgram": false,
       "hasSchedule": false,
       "hasProviderCover": false
@@ -144720,17 +142135,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-de-radio-euroherz-lq-963cae2f",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-de-radio-euskirchen-a677b362",
       "status": "stream-only",
       "metadataKey": null,
@@ -144842,17 +142246,6 @@
     },
     {
       "id": "rb-de-radio-ffn-2bfcb9c4",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-radio-ffn-ed8d5259",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -145875,29 +143268,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-de-radio-horeb-32-kbps-33986943",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-de-radio-horeb-128k-9605faf6",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-radio-horeb-48k-964305ec",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -146030,17 +143401,6 @@
     },
     {
       "id": "rb-de-radio-jodlerwirt-812195ec",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-radio-joystick-joy-de54a47b",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -147107,17 +144467,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-de-radio-online-vivaldi-2e1059af",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-de-radio-orient-d266eae4",
       "status": "stream-only",
       "metadataKey": null,
@@ -148020,17 +145369,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-de-radio-rock-on-846a3bb1",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-de-radio-roland-190383c8",
       "status": "stream-only",
       "metadataKey": null,
@@ -148911,28 +146249,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-de-radio-t-chemnitz-401a5fa2",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-radio-t-chemnitz-192kbps-778697ca",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-de-radio-t-chemnitz-256kbps-d517d4c9",
       "status": "stream-only",
       "metadataKey": null,
@@ -148945,28 +146261,6 @@
     },
     {
       "id": "rb-de-radio-t-chemnitz-102-7-38c8786b",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-radio-t-karl-marx-stadt-64kbps-7896013d",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-radio-taddy-classics-bcad41c0",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -149483,17 +146777,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-de-radio-unicc-einzig-nicht-artig-www-radio-uni-8ea1ee6e",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-de-radio-universelles-leben-c6dcb65d",
       "status": "stream-only",
       "metadataKey": null,
@@ -149660,17 +146943,6 @@
     },
     {
       "id": "rb-de-radio-wellenrausch-dca7a933",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-radio-wellenrausch-aac-2651edde",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -150715,17 +147987,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-de-raute-musik-house-9646e134",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-de-raute-musik-happyhardcore-da623e76",
       "status": "stream-only",
       "metadataKey": null,
@@ -150749,17 +148010,6 @@
     },
     {
       "id": "rb-de-rautemusik-techno-5eeb05d3",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-rautemusik-90s-961e57c5",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -150803,17 +148053,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-de-rautemusik-club-48kbs-acc-91c8d5bc",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-de-rautemusik-cofee-music-58e692de",
       "status": "stream-only",
       "metadataKey": null,
@@ -150836,51 +148075,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-de-rautemusik-country-96158dbd",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-rautemusik-deutschrap-961882e4",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-rautemusik-goldies-9615a41f",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-de-rautemusik-happy-hardcore-9612c8db",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-rautemusik-harder-964720c7",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -150913,40 +148108,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-de-rautemusik-klassik-9615e5d5",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-rautemusik-lounge-9610cad0",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-de-rautemusik-lounge-aac-48-kbps-8d05693c",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-rautemusik-lovehits-962cf214",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -150979,17 +148141,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-de-rautemusik-oriental-961e6397",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-de-rautemusik-progressive-960defbe",
       "status": "stream-only",
       "metadataKey": null,
@@ -151012,39 +148163,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-de-rautemusik-rock-9610c965",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-rautemusik-sex-963202b9",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-rautemusik-solopiano-961e6505",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-de-rautemusik-techhouse-fd0cfcb9",
       "status": "stream-only",
       "metadataKey": null,
@@ -151057,17 +148175,6 @@
     },
     {
       "id": "rb-de-rautemusik-techhouse-b103cc32",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-rautemusik-wacken-radio-9610ca1a",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -151112,17 +148219,6 @@
     },
     {
       "id": "rb-de-rbb-88-8-radio-berlin-961eff93",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-rbb-fritz-48-kbit-s-c14ed506",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -151793,17 +148889,6 @@
       "hasProviderCover": true
     },
     {
-      "id": "rb-de-rock-antenne-7e994572",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-de-rock-antenne-70er-rock-bf42d0ff",
       "status": "stream-only",
       "metadataKey": null,
@@ -152266,17 +149351,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-de-rock-antenne-modern-rock-6159f143",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-de-rock-antenne-punkrock-3a363c7c",
       "status": "stream-only",
       "metadataKey": null,
@@ -152398,17 +149472,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-de-rock-fm-90er-rock-7a411214",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-de-rock-fm-alternative-d72221fc",
       "status": "stream-only",
       "metadataKey": null,
@@ -152421,17 +149484,6 @@
     },
     {
       "id": "rb-de-rock-fm-baden-wurttemberg-270c8869",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-rock-fm-beatles-79c5c702",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -152465,17 +149517,6 @@
     },
     {
       "id": "rb-de-rock-fm-country-d83e5c70",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-rock-fm-deutschrock-0bc6cbc2",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -152618,29 +149659,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-de-rockantenne-alternative-64-kbps-aac-d6dd9870",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-de-rockantenne-alternative-mp3-d608bb74",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-rockantenne-classic-perlen-64-kbps-aac-aea5f052",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -152695,17 +149714,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-de-rockantenne-heavy-metal-64-kbps-aac-4ce3f3f1",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-de-rockantenne-lagerfeuer-rock-9b2a4474",
       "status": "stream-only",
       "metadataKey": null,
@@ -152718,17 +149726,6 @@
     },
     {
       "id": "rb-de-rockantenne-munich-city-nights-06d33d0f",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-rockantenne-munich-city-nights-64-kbps-aac-1cdc2c84",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -153696,17 +150693,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-de-rsh-radio-schleswig-holstein-aac-64-kbit-d16eb115",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-de-rsmusic-71c0b898",
       "status": "stream-only",
       "metadataKey": null,
@@ -154301,17 +151287,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-de-schlagerradio-fm-960ebf79",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-de-schlagerwelle-f91fcd63",
       "status": "stream-only",
       "metadataKey": null,
@@ -154521,29 +151496,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-de-schwany-weihnacht-http-02a0e7d4",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-de-schwany3-echte-volksmusik-fb29f8a1",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-schwany5-oberkrain-39285775",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -154665,28 +151618,6 @@
     },
     {
       "id": "rb-de-secondradio-zwei-e0248362",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-segenswelle-deutsch-98ba28e8",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-segenswelle-plautdietsch-2a439496",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -155104,17 +152035,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-de-soundstorm-relax-radio-fdddb1df",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-de-soundsystem-b4416c70",
       "status": "stream-only",
       "metadataKey": null,
@@ -155309,17 +152229,6 @@
       "metadataStrategy": "api",
       "backgroundPollPriority": "normal",
       "hasProgram": true,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-sr-2-kulturradio-56-kbit-s-96153b70",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
       "hasSchedule": false,
       "hasProviderCover": false
     },
@@ -155644,17 +152553,6 @@
     },
     {
       "id": "rb-de-star-fm-maximum-rock-berlin-87-9-d70bc21e",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-star-fm-nrw-192kbps-9e62b9a8",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -156666,17 +153564,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-de-sunshine-live-aac-64-kbps-7e83fcfc",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-de-sunshine-live-2000er-1d6cb61f",
       "status": "stream-only",
       "metadataKey": null,
@@ -156886,17 +153773,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-de-sw-radio-deutsch-963713ff",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-de-sw-radio-deutsch-32kbps-96261217",
       "status": "stream-only",
       "metadataKey": null,
@@ -156909,17 +153785,6 @@
     },
     {
       "id": "rb-de-sw-radio-live-3ac8bee4",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-sw-radio-plautdietsch-962e79c5",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -157843,28 +154708,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-de-technobase-fm-hd-acc-4c01b429",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-technobase-fm-low-411c4656",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-de-technolovers-afro-house-11bb3621",
       "status": "stream-only",
       "metadataKey": null,
@@ -158383,17 +155226,6 @@
     },
     {
       "id": "rb-de-the-industrial-complex-47f1445f",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-the-radio-cc-b30c1c3b",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -159449,17 +156281,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-de-vinyl-maxi-fm-1f74c457",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-de-vinyl-xl-6374b168",
       "status": "stream-only",
       "metadataKey": null,
@@ -159593,11 +156414,11 @@
     },
     {
       "id": "rb-de-wdr-1live-mp3-128-kbit-s-0178794a",
-      "status": "icy-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "icy",
-      "backgroundPollPriority": "low",
+      "status": "working",
+      "metadataKey": "wdr",
+      "metadataUrl": "https://www.wdr.de/radio/radiotext/streamtitle_1live.txt",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
       "hasProgram": false,
       "hasSchedule": false,
       "hasProviderCover": false
@@ -159747,11 +156568,11 @@
     },
     {
       "id": "rb-de-wdr-2-rhein-und-ruhr-https-feb978ba",
-      "status": "icy-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "icy",
-      "backgroundPollPriority": "low",
+      "status": "working",
+      "metadataKey": "wdr",
+      "metadataUrl": "https://www.wdr.de/radio/radiotext/streamtitle_wdr2.txt",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
       "hasProgram": false,
       "hasSchedule": false,
       "hasProviderCover": false
@@ -159868,22 +156689,22 @@
     },
     {
       "id": "rb-de-wdr-4-14c82dd4",
-      "status": "icy-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "icy",
-      "backgroundPollPriority": "low",
+      "status": "working",
+      "metadataKey": "wdr",
+      "metadataUrl": "https://www.wdr.de/radio/radiotext/streamtitle_wdr4.txt",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
       "hasProgram": false,
       "hasSchedule": false,
       "hasProviderCover": false
     },
     {
       "id": "rb-de-wdr-4-9bedd22b",
-      "status": "icy-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "icy",
-      "backgroundPollPriority": "low",
+      "status": "working",
+      "metadataKey": "wdr",
+      "metadataUrl": "https://www.wdr.de/radio/radiotext/streamtitle_wdr4.txt",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
       "hasProgram": false,
       "hasSchedule": false,
       "hasProviderCover": false
@@ -159934,11 +156755,11 @@
     },
     {
       "id": "rb-de-wdr-cosmo-9605ced9",
-      "status": "icy-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "icy",
-      "backgroundPollPriority": "low",
+      "status": "working",
+      "metadataKey": "wdr",
+      "metadataUrl": "https://www.wdr.de/radio/radiotext/streamtitle_fhe.txt",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
       "hasProgram": false,
       "hasSchedule": false,
       "hasProviderCover": false
@@ -160175,28 +156996,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-de-wdr-sportschau-1-fussball-bundesliga-konfere-5196db10",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-de-wdr-sportschau-2-fussball-bundesliga-konfere-28a80aa0",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-de-wdr-2-bewrgisch-land-29292a02",
       "status": "stream-only",
       "metadataKey": null,
@@ -160209,11 +157008,11 @@
     },
     {
       "id": "rb-de-wdr2-faeddc9c",
-      "status": "icy-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "icy",
-      "backgroundPollPriority": "low",
+      "status": "working",
+      "metadataKey": "wdr",
+      "metadataUrl": "https://www.wdr.de/radio/radiotext/streamtitle_wdr2.txt",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
       "hasProgram": false,
       "hasSchedule": false,
       "hasProviderCover": false
@@ -160253,22 +157052,22 @@
     },
     {
       "id": "rb-de-wdr4-44ee797f",
-      "status": "icy-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "icy",
-      "backgroundPollPriority": "low",
+      "status": "working",
+      "metadataKey": "wdr",
+      "metadataUrl": "https://www.wdr.de/radio/radiotext/streamtitle_wdr4.txt",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
       "hasProgram": false,
       "hasSchedule": false,
       "hasProviderCover": false
     },
     {
       "id": "rb-de-wdr4-44bdb9fd",
-      "status": "icy-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "icy",
-      "backgroundPollPriority": "low",
+      "status": "working",
+      "metadataKey": "wdr",
+      "metadataUrl": "https://www.wdr.de/radio/radiotext/streamtitle_wdr4.txt",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
       "hasProgram": false,
       "hasSchedule": false,
       "hasProviderCover": false
@@ -161550,17 +158349,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-dk-drr-7c2fae8d",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-dk-esbjerg-classic-fm-6c6a6e97",
       "status": "stream-only",
       "metadataKey": null,
@@ -162595,28 +159383,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-dk-technobase-fm-aacplus-96k-0a84a978",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-dk-technobase-fm-mp3-192k-30b51c98",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-dk-the-voice-24d8b54f",
       "status": "stream-only",
       "metadataKey": null,
@@ -162662,17 +159428,6 @@
     },
     {
       "id": "rb-dk-vinylhits-dk-067fd720",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-dk-vox-pop-4a2c9e36",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -165488,17 +162243,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ec-radio-hcjb-german-32kbps-96398cf8",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-ec-radio-impacto-107-9-d1af721c",
       "status": "stream-only",
       "metadataKey": null,
@@ -166379,40 +163123,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ee-klara-klassika-128-kbps-ogg-opus-eesti-rahvu-bea3ee49",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-ee-klara-nostalgia-1b6fd0fd",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ee-klara-nostalgia-128-kbps-ogg-opus-eesti-rahv-4f188dc4",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ee-klassikaraadio-128-kbps-ogg-opus-eesti-rahvu-5502ef32",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -166588,17 +163299,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ee-raadio-2-128-kbps-ogg-opus-eesti-rahvusringh-6e25ec62",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-ee-raadio-2-hq-3b55fb9b",
       "status": "stream-only",
       "metadataKey": null,
@@ -166699,17 +163399,6 @@
     },
     {
       "id": "rb-ee-raadio-tallinn-96072324",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ee-raadio-tallinn-128-kbps-ogg-opus-eesti-rahvu-26a83979",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -166996,17 +163685,6 @@
     },
     {
       "id": "rb-ee-vikerraadio-a265bb0d",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ee-vikerraadio-128-kbps-ogg-opus-eesti-rahvusri-dbc2c642",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -171648,17 +168326,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-es-free-fm-top-100-7bf11719",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-es-free-fm-x-mas-b5ee7066",
       "status": "stream-only",
       "metadataKey": null,
@@ -173178,17 +169845,6 @@
     },
     {
       "id": "rb-es-locafm-90-s-3c631c6a",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-es-locafm-melodic-deep-1e6c0e57",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -177291,17 +173947,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-es-radio-planeta-fbe6d584",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-es-radio-planeta-costa-del-sol-6ad5e93f",
       "status": "stream-only",
       "metadataKey": null,
@@ -178843,17 +175488,6 @@
     },
     {
       "id": "rb-es-rock-radioo-09ca95f0",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-es-rockfm-f94e5764",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -182142,17 +178776,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-fr-100-radio-albi-96141797",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-fr-100-radio-auch-96141920",
       "status": "stream-only",
       "metadataKey": null,
@@ -182638,17 +179261,6 @@
     },
     {
       "id": "rb-fr-ado-414a268f",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-fr-adofm-b8bbc931",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -183242,17 +179854,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-fr-allzic-radio-classic-3ce7722d",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-fr-allzic-radio-classic-violon-8dfccf91",
       "status": "stream-only",
       "metadataKey": null,
@@ -183309,17 +179910,6 @@
     },
     {
       "id": "rb-fr-allzic-radio-disco-671e40e6",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-fr-allzic-radio-disney-43a188fd",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -184188,17 +180778,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-fr-bible-esperance-29be6151",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-fr-bide-et-musique-9605a4dd",
       "status": "stream-only",
       "metadataKey": null,
@@ -184508,17 +181087,6 @@
     },
     {
       "id": "rb-fr-c9-radio-603111e6",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-fr-c9radio-f9ec2cd0",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -185728,17 +182296,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-fr-efr-12-radio-5d7ed374",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-fr-efr12-radio-ba5d1af9",
       "status": "stream-only",
       "metadataKey": null,
@@ -186091,17 +182648,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-fr-europe-2-aac-958681a9",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-fr-europe-2-centre-db435270",
       "status": "stream-only",
       "metadataKey": null,
@@ -186411,36 +182957,36 @@
     },
     {
       "id": "rb-fr-fip-1fbc9d0a",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
+      "status": "working",
+      "metadataKey": "radio-france",
+      "metadataUrl": "https://api.radiofrance.fr/livemeta/live/7/fip_extended",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
+      "hasProgram": true,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-fr-fip-932eb148",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
+      "status": "working",
+      "metadataKey": "radio-france",
+      "metadataUrl": "https://api.radiofrance.fr/livemeta/live/7/fip_extended",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
+      "hasProgram": true,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-fr-fip-adb90745",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
+      "status": "working",
+      "metadataKey": "radio-france",
+      "metadataUrl": "https://api.radiofrance.fr/livemeta/live/7/fip_extended",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
+      "hasProgram": true,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-fr-fip-metal-05232733",
@@ -186466,14 +183012,14 @@
     },
     {
       "id": "rb-fr-fip-hifi-aac-a349e1e9",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
+      "status": "working",
+      "metadataKey": "radio-france",
+      "metadataUrl": "https://api.radiofrance.fr/livemeta/live/7/fip_extended",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
+      "hasProgram": true,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-fr-fip-metadata-70ea44d2",
@@ -186565,14 +183111,14 @@
     },
     {
       "id": "rb-fr-fip-electro-b809226c",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
+      "status": "working",
+      "metadataKey": "radio-france",
+      "metadataUrl": "https://api.radiofrance.fr/livemeta/live/74/fip_extended",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
+      "hasProgram": true,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-fr-fip-groove-e8e2dbc6",
@@ -186587,25 +183133,25 @@
     },
     {
       "id": "rb-fr-fip-groove-c454908c",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
+      "status": "working",
+      "metadataKey": "radio-france",
+      "metadataUrl": "https://api.radiofrance.fr/livemeta/live/66/fip_extended",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
+      "hasProgram": true,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-fr-fip-groove-hifi-aac-0bb104c7",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
+      "status": "working",
+      "metadataKey": "radio-france",
+      "metadataUrl": "https://api.radiofrance.fr/livemeta/live/66/fip_extended",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
+      "hasProgram": true,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-fr-fip-groove-metadata-143f94a4",
@@ -186653,14 +183199,14 @@
     },
     {
       "id": "rb-fr-fip-jazz-5b9ceedf",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
+      "status": "working",
+      "metadataKey": "radio-france",
+      "metadataUrl": "https://api.radiofrance.fr/livemeta/live/65/fip_extended",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
+      "hasProgram": true,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-fr-fip-jazz-hi-fi-f1aad29c",
@@ -186675,14 +183221,14 @@
     },
     {
       "id": "rb-fr-fip-jazz-hifi-aac-25ce1dda",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
+      "status": "working",
+      "metadataKey": "radio-france",
+      "metadataUrl": "https://api.radiofrance.fr/livemeta/live/65/fip_extended",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
+      "hasProgram": true,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-fr-fip-metal-75b6b22f",
@@ -186730,14 +183276,14 @@
     },
     {
       "id": "rb-fr-fip-musiques-du-monde-cbc50678",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
+      "status": "working",
+      "metadataKey": "radio-france",
+      "metadataUrl": "https://api.radiofrance.fr/livemeta/live/69/fip_extended",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
+      "hasProgram": true,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-fr-fip-pop-36dda8c3",
@@ -186774,14 +183320,14 @@
     },
     {
       "id": "rb-fr-fip-reggae-84764bda",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
+      "status": "working",
+      "metadataKey": "radio-france",
+      "metadataUrl": "https://api.radiofrance.fr/livemeta/live/71/fip_extended",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
+      "hasProgram": true,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-fr-fip-reggae-metadata-a155dd83",
@@ -186796,14 +183342,14 @@
     },
     {
       "id": "rb-fr-fip-rock-ddc49aac",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
+      "status": "working",
+      "metadataKey": "radio-france",
+      "metadataUrl": "https://api.radiofrance.fr/livemeta/live/64/fip_extended",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
+      "hasProgram": true,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-fr-fip-rock-dea60d64",
@@ -187654,14 +184200,14 @@
     },
     {
       "id": "rb-fr-france-culture-6a1440b2",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
+      "status": "working",
+      "metadataKey": "radio-france",
+      "metadataUrl": "https://api.radiofrance.fr/livemeta/live/5/culture_player",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
+      "hasProgram": true,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-fr-france-culture-9cd3d0dd",
@@ -187709,25 +184255,25 @@
     },
     {
       "id": "rb-fr-france-culture-2-f13fae4a",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
+      "status": "working",
+      "metadataKey": "radio-france",
+      "metadataUrl": "https://api.radiofrance.fr/livemeta/live/5/culture_player",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
+      "hasProgram": true,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-fr-france-info-1cfb151d",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
+      "status": "working",
+      "metadataKey": "radio-france",
+      "metadataUrl": "https://api.radiofrance.fr/livemeta/live/2/info_player",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
+      "hasProgram": true,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-fr-france-info-ab6a33e5",
@@ -187763,48 +184309,37 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-fr-france-inter-bf14c06f",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-fr-france-inter-d2bbffaf",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
+      "status": "working",
+      "metadataKey": "radio-france",
+      "metadataUrl": "https://api.radiofrance.fr/livemeta/live/1/inter_player",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
+      "hasProgram": true,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-fr-france-inter-0b80555f",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
+      "status": "working",
+      "metadataKey": "radio-france",
+      "metadataUrl": "https://api.radiofrance.fr/livemeta/live/1/inter_player",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
+      "hasProgram": true,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-fr-france-inter-f760fce4",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
+      "status": "working",
+      "metadataKey": "radio-france",
+      "metadataUrl": "https://api.radiofrance.fr/livemeta/live/1/inter_player",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
+      "hasProgram": true,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-fr-france-inter-1effdc77",
@@ -187830,14 +184365,14 @@
     },
     {
       "id": "rb-fr-france-inter-icecast-465ec3e6",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
+      "status": "working",
+      "metadataKey": "radio-france",
+      "metadataUrl": "https://api.radiofrance.fr/livemeta/live/1/inter_player",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
+      "hasProgram": true,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-fr-france-inter-la-musique-d-inter-a33727b7",
@@ -187873,37 +184408,26 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-fr-france-maghreb-2-province-961469e2",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-fr-france-musique-f207564e",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
+      "status": "working",
+      "metadataKey": "radio-france",
+      "metadataUrl": "https://api.radiofrance.fr/livemeta/live/4/musique_player",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
+      "hasProgram": true,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-fr-france-musique-81440088",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
+      "status": "working",
+      "metadataKey": "radio-france",
+      "metadataUrl": "https://api.radiofrance.fr/livemeta/live/4/musique_player",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
+      "hasProgram": true,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-fr-france-musique-avec-metadata-839fda79",
@@ -188214,17 +184738,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-fr-frequence-3-flac-c671f4a6",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-fr-frequence-3-gold-35815119",
       "status": "stream-only",
       "metadataKey": null,
@@ -188402,17 +184915,6 @@
     },
     {
       "id": "rb-fr-frequence-plus-96418b24",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-fr-frequence-plus-0d17982c",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -189886,17 +186388,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-fr-impact-fm-e99703c4",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-fr-in2-mix-fr-b82db9ef",
       "status": "stream-only",
       "metadataKey": null,
@@ -190183,17 +186674,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-fr-jazz-radio-jazz-classique-3ca92c2c",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-fr-jazz-radio-afro-5417b987",
       "status": "stream-only",
       "metadataKey": null,
@@ -190349,17 +186829,6 @@
     },
     {
       "id": "rb-fr-jazz-radio-jazz-fusion-7e27dacb",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-fr-jazz-radio-jazzy-french-961363c4",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -191646,17 +188115,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-fr-libre-toi-8479744f",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-fr-line-out-radio-819108bd",
       "status": "stream-only",
       "metadataKey": null,
@@ -191767,17 +188225,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-fr-m-radio-960678ee",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-fr-m-radio-au-travail-36618520",
       "status": "stream-only",
       "metadataKey": null,
@@ -191878,17 +188325,6 @@
     },
     {
       "id": "rb-fr-m-radio-100-johnny-9649b390",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-fr-m-radio-100-live-4b4538de",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -192625,17 +189061,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-fr-mbs-good-aac-96-fe58bc55",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-fr-mc-doualiya-4e172524",
       "status": "stream-only",
       "metadataKey": null,
@@ -192681,17 +189106,6 @@
     },
     {
       "id": "rb-fr-meteo-terrasse-fab-51b628f9",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-fr-metis-fm-961add89",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -193033,14 +189447,14 @@
     },
     {
       "id": "rb-fr-mouv-c998424a",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
+      "status": "working",
+      "metadataKey": "radio-france",
+      "metadataUrl": "https://api.radiofrance.fr/livemeta/live/6/mouv_player",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
+      "hasProgram": true,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-fr-mouv-lq-963719b3",
@@ -193253,17 +189667,6 @@
     },
     {
       "id": "rb-fr-nova-danse-3b5b5b7d",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-fr-nova-hip-hop-cc394300",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -194407,17 +190810,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-fr-phaune-fec103f7",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-fr-phaune-radio-9620acd9",
       "status": "stream-only",
       "metadataKey": null,
@@ -194903,17 +191295,6 @@
     },
     {
       "id": "rb-fr-pulsradio-90-41451362",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-fr-pulsradio-franca-d9cb2fcb",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -196960,28 +193341,6 @@
     },
     {
       "id": "rb-fr-radio-isa-bourgoin-9614ec46",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-fr-radio-isa-grenoble-9614e8d6",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-fr-radio-isa-voiron-96174db9",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -199643,17 +196002,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-fr-rfi-musique-dcda1221",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-fr-rfi-persian-96167407",
       "status": "stream-only",
       "metadataKey": null,
@@ -199754,17 +196102,6 @@
     },
     {
       "id": "rb-fr-rfm-100-francais-a3036ea3",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-fr-rfm-80-3d935b47",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -200776,17 +197113,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-fr-skyrock-5fab9ea3",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-fr-skyrock-01b61e49",
       "status": "stream-only",
       "metadataKey": null,
@@ -201007,17 +197333,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-fr-starsystemfm-b28591b2",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-fr-station-b-067809db",
       "status": "stream-only",
       "metadataKey": null,
@@ -201085,17 +197400,6 @@
     },
     {
       "id": "rb-fr-sud-radio-b4ef5a64",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-fr-sud-radio-a179e484",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -201788,17 +198092,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-fr-urban-hit-a6d75335",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-fr-urban-hit-latino-b8448cfb",
       "status": "stream-only",
       "metadataKey": null,
@@ -201833,17 +198126,6 @@
     },
     {
       "id": "rb-fr-urban-hit-rai-b1985c38",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-fr-urban-hit-rai-00c88dbf",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -202151,17 +198433,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-fr-virage-radio-rock-80-db4b66b6",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-fr-virage-radio-rock-90-86393845",
       "status": "stream-only",
       "metadataKey": null,
@@ -202174,17 +198445,6 @@
     },
     {
       "id": "rb-fr-virgin-radio-france-la-rock-station-ba9b776d",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-fr-virgin-radio-france-metal-1f966d64",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -204593,17 +200853,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-gb-bbc-live-news-48k-3f98c448",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-gb-bbc-news-hd-720p-ea391ded",
       "status": "stream-only",
       "metadataKey": null,
@@ -205913,17 +202162,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-gb-box-uk-danceradiouk-com-128k-mp3-8a15bdc8",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-gb-box-uk-radio-ce62430f",
       "status": "stream-only",
       "metadataKey": null,
@@ -205958,17 +202196,6 @@
     },
     {
       "id": "rb-gb-brap-fm-47101fd9",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-gb-breezy-radio-uk-821098ce",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -209609,17 +205836,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-gb-gb-news-ee09cbb0",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-gb-gb-news-22eb42bb",
       "status": "stream-only",
       "metadataKey": null,
@@ -212777,28 +208993,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-gb-like-radio-danceland-mp3-f2279ae8",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-gb-like-radio-danceland-anthems-aac-409374c0",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-gb-like-radio-holiday-mp3-afc380ed",
       "status": "stream-only",
       "metadataKey": null,
@@ -213339,17 +209533,6 @@
     },
     {
       "id": "rb-gb-lyca-gold-2-c4bb8fe8",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-gb-lyca-radio-3275a0ad",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -214229,17 +210412,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-gb-nation-radio-80s-240598b5",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-gb-nation-radio-south-coast-dorset-8ec14db4",
       "status": "stream-only",
       "metadataKey": null,
@@ -214406,17 +210578,6 @@
     },
     {
       "id": "rb-gb-nonstopplay-pure-dance-005917e5",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-gb-nonstopplay-com-dance-radio-51ff6ba0",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -215957,28 +212118,6 @@
     },
     {
       "id": "rb-gb-radio-caroline-9605a234",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-gb-radio-caroline-48k-aac-83a33803",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-gb-radio-caroline-aac-96-kbps-b157c703",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -218651,17 +214790,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-gb-smooth-chill-uk-48k-aac-e063d808",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-gb-smooth-chill-focus-a6491d20",
       "status": "stream-only",
       "metadataKey": null,
@@ -218861,17 +214989,6 @@
     },
     {
       "id": "rb-gb-solar-radio-05a082a6",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-gb-solar-radio-256-3892cc14",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -219762,17 +215879,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-gb-techno-fm-320-kbit-7ccca232",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-gb-teenage-kicks-radio-c9aabff3",
       "status": "stream-only",
       "metadataKey": null,
@@ -220246,17 +216352,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-gb-times-radio-uk-48k-aac-de7f87da",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-gb-times-radio-uk-d1b0b82d",
       "status": "stream-only",
       "metadataKey": null,
@@ -220665,17 +216760,6 @@
     },
     {
       "id": "rb-gb-ujima-radio-23687a64",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-gb-uk-bass-6e59a7ea",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -223964,6 +220048,17 @@
       "hasProviderCover": false
     },
     {
+      "id": "rb-gr-aktina-104-7-175c64bb",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
       "id": "rb-gr-alepou-radio-5773364f",
       "status": "stream-only",
       "metadataKey": null,
@@ -224427,6 +220522,28 @@
     },
     {
       "id": "rb-gr-arion-radio-b255a734",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-gr-arion-52e3cd40",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-gr-arion-67e21923",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -225846,6 +221963,17 @@
     },
     {
       "id": "rb-gr-default-stream-d1b8662d",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-gr-deftero-laika-77d13110",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -228057,17 +224185,6 @@
     },
     {
       "id": "rb-gr-glenti-892-44f0447e",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-gr-gnomi-93-7-fm-3acd0946",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -231048,17 +227165,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-gr-north-d4c61efa",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-gr-nostos-100-6-761b40cb",
       "status": "stream-only",
       "metadataKey": null,
@@ -231994,6 +228100,17 @@
       "hasProviderCover": false
     },
     {
+      "id": "rb-gr-polis-91-1-1071f86c",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
       "id": "rb-gr-polis-91-1-heykids-77946df6",
       "status": "stream-only",
       "metadataKey": null,
@@ -232006,6 +228123,17 @@
     },
     {
       "id": "rb-gr-polis-91-1-hip-hop-e1e29ec4",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-gr-polis-91-1-c563dc48",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -235272,6 +231400,17 @@
       "hasProviderCover": false
     },
     {
+      "id": "rb-gr-rainbow-89-a0d7a649",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
       "id": "rb-gr-real-classic-c1c292d9",
       "status": "stream-only",
       "metadataKey": null,
@@ -236043,6 +232182,17 @@
     },
     {
       "id": "rb-gr-sfera-kids-df231d5e",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-gr-sfera-52fe7ea5",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -237869,17 +234019,6 @@
     },
     {
       "id": "rb-gr-xmas-love-97-5-6efe0ad3",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-gr-xroma-105-8-fafa833d",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -240167,6 +236306,17 @@
       "hasProviderCover": false
     },
     {
+      "id": "rb-gr-95-5-d650ba6d",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
       "id": "rb-gr-99-8-9e1fb996",
       "status": "stream-only",
       "metadataKey": null,
@@ -240398,7 +236548,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-gr-96-9a7979b5",
+      "id": "rb-gr-96-8f05d319",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -240409,7 +236559,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-gr-87-5-c778502c",
+      "id": "rb-gr-96-9a7979b5",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -241025,17 +237175,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-gr-92-5-7ec93361",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-gr-106-8fcbe351",
       "status": "stream-only",
       "metadataKey": null,
@@ -241311,6 +237450,17 @@
       "hasProviderCover": false
     },
     {
+      "id": "rb-gr-91-6fbdc9fb",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
       "id": "rb-gr-station-0d05da31",
       "status": "stream-only",
       "metadataKey": null,
@@ -241444,6 +237594,17 @@
     },
     {
       "id": "rb-gr-station-753aef0e",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-gr-105-7-5a2abdb6",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -243325,6 +239486,17 @@
     },
     {
       "id": "rb-hk-cnr-14-ce998ec3",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-hk-cnr-14-bda613a3",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -245700,17 +241872,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-hr-prigorski-radio-96-6mhz-630e56b9",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-hr-prolaznik-evergreen-lepoglava-c64c83f7",
       "status": "stream-only",
       "metadataKey": null,
@@ -247251,40 +243412,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-hu-bdpst-rock-70e0cdbe",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-hu-bdpst-rock-192-kbit-s-699ce987",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-hu-bdpst-rock-320-kbit-s-83eb8d1e",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-hu-bdpst-rock-96-kbit-s-b7f335dd",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -248692,17 +244820,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-hu-magyar-evangeliumi-radio-ea8630b1",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-hu-magyar-katolikus-radio-960cb72e",
       "status": "stream-only",
       "metadataKey": null,
@@ -249034,17 +245151,6 @@
     },
     {
       "id": "rb-hu-nota-fm-128k-mp3-48812636",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-hu-nota-fm-48k-aac-6697d4ae",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -249726,17 +245832,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-hu-radio-e-9628febf",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-hu-radio-groove-0c5f64c2",
       "status": "stream-only",
       "metadataKey": null,
@@ -250353,28 +246448,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-hu-tilos-radio-32-kbit-sec-557e07e9",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-hu-tilos-radio-fm-90-3-19cf80e9",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-hu-top-fm-max-c2ca600c",
       "status": "stream-only",
       "metadataKey": null,
@@ -250419,29 +246492,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-hu-youventus-radio-2305ca67",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-hu-youventus-radio-51138997",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-hu-youventus-radio-96-kbps-c5732a0b",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -256469,6 +252520,17 @@
       "hasProviderCover": false
     },
     {
+      "id": "rb-il-eco-99fm-dd08fbb3",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
       "id": "rb-il-eco99fm-5357dc24",
       "status": "stream-only",
       "metadataKey": null,
@@ -256557,17 +252619,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-il-guitar-j-williams-d902048f",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-il-hedva-shaltiel-0eb7423c",
       "status": "stream-only",
       "metadataKey": null,
@@ -256646,6 +252697,17 @@
     },
     {
       "id": "rb-il-kan-bet-c2b724db",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-il-kan-gimel-e8c19fc3",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -257107,6 +253169,17 @@
       "hasProviderCover": false
     },
     {
+      "id": "rb-il-glglz-fc22f9c5",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
       "id": "rb-il-galey-yisrael-c7a3001d",
       "status": "stream-only",
       "metadataKey": null,
@@ -257130,6 +253203,17 @@
     },
     {
       "id": "rb-il-hakatze-80d7414f",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-il-kan-reka-20818139",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -257514,17 +253598,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-in-4lobos-bollywood-radio-d2800e15",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-in-60sforever-53e1a910",
       "status": "stream-only",
       "metadataKey": null,
@@ -257680,17 +253753,6 @@
     },
     {
       "id": "rb-in-aaha-radio-4a4fb00f",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-in-aahafmradio-06a36508",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -258428,17 +254490,6 @@
     },
     {
       "id": "rb-in-air-pune-fm-high-bit-rate-b6cc934d",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-in-air-punjabi-75a423ed",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -259549,17 +255600,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-in-balurghat-fm-8b44aaa6",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-in-bbcasiannetwork-d3960015",
       "status": "stream-only",
       "metadataKey": null,
@@ -260177,17 +256217,6 @@
     },
     {
       "id": "rb-in-bolpunjabi-f482a97f",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-in-brisvaani-7fb29515",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -262398,17 +258427,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-in-j-u-radio-a3124352",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-in-jagat-radio-3d85491b",
       "status": "stream-only",
       "metadataKey": null,
@@ -263498,17 +259516,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-in-mohabbat-radio-punjabi-1abf7785",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-in-mohammed-rafi-db15bf87",
       "status": "stream-only",
       "metadataKey": null,
@@ -263554,17 +259561,6 @@
     },
     {
       "id": "rb-in-mohanlal-hits-d39f366b",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-in-mohanlalhits-83206b43",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -263873,17 +259869,6 @@
     },
     {
       "id": "rb-in-np-24-radio-472d887b",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-in-numtamilradio-d0d0c9aa",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -264621,17 +260606,6 @@
     },
     {
       "id": "rb-in-radio-girmit-kannada-6533a16a",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-in-radio-gujarati-885cb3a8",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -265390,17 +261364,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-in-radio-suno-91-7-fm-7e9a96a6",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-in-radio-suno-malayalam-91-7-9e9b8485",
       "status": "stream-only",
       "metadataKey": null,
@@ -265985,17 +261948,6 @@
     },
     {
       "id": "rb-in-radiosunomalayalam-3d843738",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-in-radiosunotamil-5ced578e",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -267822,17 +263774,6 @@
     },
     {
       "id": "rb-in-vividh-bharati-vijayawada-7f7dd7f2",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-in-vividh-bharti-74c09a82",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -270142,17 +266083,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-it-electrolounge-9e6de184",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-it-electrolounge-3720d7b5",
       "status": "stream-only",
       "metadataKey": null,
@@ -270814,17 +266744,6 @@
     },
     {
       "id": "rb-it-gr-news-08e8a188",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-it-gr-ultima-ora-a717be48",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -272078,29 +267997,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-it-music-star-george-michael-962d4041",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-it-music-star-giorgia-962d8f90",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-it-music-star-jovanotti-962d89b8",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -272156,17 +268053,6 @@
     },
     {
       "id": "rb-it-music-star-roger-waters-pink-floyd-266c9ba9",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-it-music-star-rolling-stones-963896b6",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -272782,17 +268668,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-it-r101-80-96391dda",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-it-r101-90-9639f338",
       "status": "stream-only",
       "metadataKey": null,
@@ -272981,17 +268856,6 @@
     },
     {
       "id": "rb-it-radio-105-classics-9627bc91",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-it-radio-105-coldplay-47d3cfa8",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -273322,6 +269186,17 @@
     },
     {
       "id": "rb-it-radio-80-961f659a",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-it-radio-80-e8eff2b7",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -273926,17 +269801,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-it-radio-ascoli-962b5819",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-it-radio-asiago-a183e979",
       "status": "stream-only",
       "metadataKey": null,
@@ -274070,17 +269934,6 @@
     },
     {
       "id": "rb-it-radio-base-venezia-a2c4432a",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-it-radio-bau-co-96286f7e",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -277622,17 +273475,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-it-radio-megamix-80-8ca598da",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-it-radio-mela-9625b135",
       "status": "stream-only",
       "metadataKey": null,
@@ -278360,17 +274202,6 @@
     },
     {
       "id": "rb-it-radio-onda-verde-964172bf",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-it-radio-ondarossa-ce63c422",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -279239,17 +275070,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-it-radio-rock-roma-c74405f4",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-it-radio-roma-mobilita-6f2b201c",
       "status": "stream-only",
       "metadataKey": null,
@@ -279548,17 +275368,6 @@
     },
     {
       "id": "rb-it-radio-sei-italia-22d0e6ba",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-it-radio-seisei-961e10b0",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -285641,17 +281450,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-jp-nightwave-plaza-hls-98d8f89b",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-jp-nightwave-plaza-opus-64-661c6656",
       "status": "stream-only",
       "metadataKey": null,
@@ -286488,17 +282286,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ke-ghett-bc861a93",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-ke-ghett-kenya-6b002723",
       "status": "stream-only",
       "metadataKey": null,
@@ -287127,17 +282914,6 @@
     },
     {
       "id": "rb-kp-station-87978669",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-kp-fm105-2-be116145",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -290756,17 +286532,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-lt-ziniu-radijas-961eed0d",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-lt-ziniu-radijas-64-kbps-mp3-963d075d",
       "status": "stream-only",
       "metadataKey": null,
@@ -291064,17 +286829,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-lu-rtl-die-besten-hits-aller-zeiten-5fdc15c7",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-lu-rtl-gold-8259a0dc",
       "status": "stream-only",
       "metadataKey": null,
@@ -291207,17 +286961,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-lv-ehr-dance-3c201538",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-lv-ehr-darbam-eb8f210a",
       "status": "stream-only",
       "metadataKey": null,
@@ -291307,17 +287050,6 @@
     },
     {
       "id": "rb-lv-ehr-5e61272f",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-lv-eiropas-hitu-radio-a634b031",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -294189,17 +289921,6 @@
     },
     {
       "id": "rb-mk-samo-mk-b6d9d575",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-mk-samomk-8f5c53f4",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -303604,17 +299325,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-mx-fm-globo-monterrey-88-1-fm-xhjm-fm-mvs-radio-5826b04e",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-mx-fm-globo-tijuana-99-3-fm-xhocl-fm-mvs-radio--011634c4",
       "status": "stream-only",
       "metadataKey": null,
@@ -304639,17 +300349,6 @@
     },
     {
       "id": "rb-mx-kiuu-91-1-fm-torreon-coahuila-72e1f046",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-mx-kiuu-torreon-91-1-fm-xhtc-fm-grem-grupo-radi-655fd5bd",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -307455,17 +303154,6 @@
     },
     {
       "id": "rb-mx-la-numero-uno-104-9-fm-d72d28cf",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-mx-la-octava-ciudad-de-mexico-88-1-fm-xhred-fm--7739e3b5",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -311810,17 +307498,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-mx-radio-90s-dancemix-675ae4fc",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-mx-radio-activa-salina-cruz-89-1-fm-xhike-fm-ik-022d9042",
       "status": "stream-only",
       "metadataKey": null,
@@ -312031,17 +307708,6 @@
     },
     {
       "id": "rb-mx-radio-canon-mazatlan-98-7-fm-xhvox-fm-radio--d72b371a",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-mx-radio-canon-mexicali-101-3-fm-820-am-xhabca--df6ea905",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -312767,17 +308433,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-mx-radio-formula-culiacan-88-7-fm-xhex-fm-grupo-60d45871",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-mx-radio-formula-culiacan-88-7-fm-culiacan-sina-0716b97a",
       "status": "stream-only",
       "metadataKey": null,
@@ -312943,29 +308598,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-mx-radio-formula-queretaro-88-7-fm-xhjx-fm-grup-536b329a",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-mx-radio-formula-queretaro-88-7-fm-queretaro-qu-4bee38b3",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-mx-radio-formula-tabasco-94-1-fm-xhhgr-fm-grupo-83220405",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -317058,17 +312691,6 @@
     },
     {
       "id": "rb-mx-w-radio-107-9-queretaro-107-9-fm-xhqg-fm-glo-ad67c606",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-mx-w-radio-1310-queretaro-1310-am-xeqrmd-am-glo-cbd0241b",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -321182,17 +316804,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-nl-bnr-nieuwsradio-http-97464fa0",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-nl-boemerangfm-5247b819",
       "status": "stream-only",
       "metadataKey": null,
@@ -321678,17 +317289,6 @@
     },
     {
       "id": "rb-nl-coastline-iradio-clfm-nl-59ff5d9a",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-nl-colinblackburn1980-bbff686f",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -322778,14 +318378,14 @@
     },
     {
       "id": "rb-nl-funx-11714c16",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
+      "status": "working",
+      "metadataKey": "npo",
+      "metadataUrl": "npo-funx",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
+      "hasProgram": true,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-nl-funx-fissa-927adb6e",
@@ -323075,17 +318675,6 @@
     },
     {
       "id": "rb-nl-grandprix-radio-caf20a8f",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-nl-grandprix-radio-http-42db7286",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -324339,17 +319928,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-nl-kink-http-664a427e",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-nl-kink-128k-aac-f7f14f0d",
       "status": "stream-only",
       "metadataKey": null,
@@ -325219,17 +320797,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-nl-npo-2-c3fc1409",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-nl-npo-2-soul-and-jazz-a0a4ce6e",
       "status": "stream-only",
       "metadataKey": null,
@@ -325241,26 +320808,15 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-nl-npo-3fm-bdc1e08f",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-nl-npo-3fm-0c62b9d7",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
+      "status": "working",
+      "metadataKey": "npo",
+      "metadataUrl": "npo-3fm",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
+      "hasProgram": true,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-nl-npo-3fm-alternative-962ae396",
@@ -325286,28 +320842,17 @@
     },
     {
       "id": "rb-nl-npo-3fm-serious-radio-960e38b8",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
+      "status": "working",
+      "metadataKey": "npo",
+      "metadataUrl": "npo-3fm",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
+      "hasProgram": true,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-nl-npo-blend-44baf21a",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-nl-npo-blend-http-e11234e2",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -325407,14 +320952,14 @@
     },
     {
       "id": "rb-nl-npo-klassiek-428fecbf",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
+      "status": "working",
+      "metadataKey": "npo",
+      "metadataUrl": "npo-radio-4",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
+      "hasProgram": true,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-nl-npo-klassiek-31d93b4c",
@@ -325440,14 +320985,14 @@
     },
     {
       "id": "rb-nl-npo-klassiek-383f2ed8",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
+      "status": "working",
+      "metadataKey": "npo",
+      "metadataUrl": "npo-radio-4",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
+      "hasProgram": true,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-nl-npo-radio-1dd46cb3",
@@ -325462,36 +321007,36 @@
     },
     {
       "id": "rb-nl-npo-radio-1-96126f56",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
+      "status": "working",
+      "metadataKey": "npo",
+      "metadataUrl": "npo-radio-1",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
+      "hasProgram": true,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-nl-npo-radio-2-96126e82",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
+      "status": "working",
+      "metadataKey": "npo",
+      "metadataUrl": "npo-radio-2",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
+      "hasProgram": true,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-nl-npo-radio-2-soul-jazz-9633a95e",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
+      "status": "working",
+      "metadataKey": "npo",
+      "metadataUrl": "npo-radio-2-soul-jazz",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
+      "hasProgram": true,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-nl-npo-radio-4-ebc406ab",
@@ -325506,14 +321051,14 @@
     },
     {
       "id": "rb-nl-npo-radio-4-9c2f41c2",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
+      "status": "working",
+      "metadataKey": "npo",
+      "metadataUrl": "npo-radio-4",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
+      "hasProgram": true,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-nl-npo-radio-4-concerten-9612e85d",
@@ -325539,25 +321084,14 @@
     },
     {
       "id": "rb-nl-npo-radio-5-46e55863",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
+      "status": "working",
+      "metadataKey": "npo",
+      "metadataUrl": "npo-radio-5",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
+      "hasProgram": true,
       "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-nl-npo-radio-5-96127036",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-nl-npo-radio-5-ee32e4ab",
@@ -325572,14 +321106,14 @@
     },
     {
       "id": "rb-nl-npo-radio-6-soul-jazz-675c24a5",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
+      "status": "working",
+      "metadataKey": "npo",
+      "metadataUrl": "npo-radio-2-soul-jazz",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
+      "hasProgram": true,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-nl-npo-radio5-dee9025b",
@@ -327079,14 +322613,14 @@
     },
     {
       "id": "rb-nl-radio-1-2e96250c",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
+      "status": "working",
+      "metadataKey": "npo",
+      "metadataUrl": "npo-radio-1",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
+      "hasProgram": true,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-nl-radio-10-d227990c",
@@ -327266,14 +322800,14 @@
     },
     {
       "id": "rb-nl-radio-5-f765558b",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
+      "status": "working",
+      "metadataKey": "npo",
+      "metadataUrl": "npo-radio-5",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
+      "hasProgram": true,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-nl-radio-509-hilversum-96468f55",
@@ -327541,17 +323075,6 @@
     },
     {
       "id": "rb-nl-radio-bnt-e36dceb3",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-nl-radio-boven-ij-c84d20ef",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -329058,17 +324581,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-nl-reformatorische-omroep-radio-2-a488aff7",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-nl-reformatorische-omroep-radio-3-ea24b884",
       "status": "stream-only",
       "metadataKey": null,
@@ -329433,17 +324945,6 @@
     },
     {
       "id": "rb-nl-rtv-nof-radio-6b01213e",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-nl-rtv-noord-e9ac3175",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -331006,17 +326507,6 @@
     },
     {
       "id": "rb-nl-westradio-mp3-192kbps-7ace568c",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-nl-westradio-mp3-320kbps-01855155",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -340289,17 +335779,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ph-islamic-radio-filipino-272af0a8",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-ph-islamic-radio-filipino-ec323e9e",
       "status": "stream-only",
       "metadataKey": null,
@@ -341192,17 +336671,6 @@
     },
     {
       "id": "rb-ph-mor-101-9-fm-a90bf48e",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ph-mor-93-9-legazpi-654e8eea",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -346570,17 +342038,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-pl-kiss-online-radio-d6b6a286",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-pl-konin-fm-60118daa",
       "status": "stream-only",
       "metadataKey": null,
@@ -350652,17 +346109,6 @@
     },
     {
       "id": "rb-pl-radio-szczecin-128k-mp3-961b5bb7",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-pl-radio-szczecin-64k-aac-960faea3",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -354875,17 +350321,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-pt-a1-df73b42f",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-pt-abc-portugal-96197766",
       "status": "stream-only",
       "metadataKey": null,
@@ -356361,17 +351796,6 @@
     },
     {
       "id": "rb-pt-radio-clube-de-sintra-9618e5ff",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-pt-radio-clube-foz-do-mondego-77382bc6",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -361277,17 +356701,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ro-golounge-15d9bfdc",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-ro-gorebel-8cfa473d",
       "status": "stream-only",
       "metadataKey": null,
@@ -363037,17 +358450,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ro-radio-dobrogea-dd992c1f",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-ro-radio-domeldo-6b6ed0fb",
       "status": "stream-only",
       "metadataKey": null,
@@ -363258,17 +358660,6 @@
     },
     {
       "id": "rb-ro-radio-etno-vest-timisoara-701c9821",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ro-radio-extrem-live-eab5fe3c",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -366590,17 +361981,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ro-terra-radio-murfatlar-97-5-fm-26af3344",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-ro-terranova-radio-584294a7",
       "status": "stream-only",
       "metadataKey": null,
@@ -369329,17 +364709,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-rs-radio-lola-545f009c",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-rs-radio-lola-domaca-0e0d15ed",
       "status": "stream-only",
       "metadataKey": null,
@@ -371243,6 +366612,39 @@
       "hasProviderCover": false
     },
     {
+      "id": "rb-ru-101-ru-2b60b40c",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-101-ru-30623ca5",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-101-ru-20fa636d",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
       "id": "rb-ru-101-ru-mikhail-boyarsky-977b8452",
       "status": "stream-only",
       "metadataKey": null,
@@ -371288,6 +366690,17 @@
     },
     {
       "id": "rb-ru-101-ru-50-70-020ff018",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-101-ru-69079673",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -371584,6 +366997,28 @@
       "hasProviderCover": false
     },
     {
+      "id": "rb-ru-90-d06c20f1",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-90-3565cd24",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
       "id": "rb-ru-90-s-pop-101-ru-4967f748",
       "status": "stream-only",
       "metadataKey": null,
@@ -371607,17 +367042,6 @@
     },
     {
       "id": "rb-ru-92-0-fm-0170594b",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ru-97557-88f5b9a9",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -372641,6 +368065,17 @@
     },
     {
       "id": "rb-ru-cassiopeia-station-4cd636d5",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-cassiopeia-station-17b9a8f2",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -373828,7 +369263,29 @@
       "hasProviderCover": false
     },
     {
+      "id": "rb-ru-dfm-7f700276",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
       "id": "rb-ru-dfm-105-6-fm-70e30a64",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-dfm-103-2-fm-c749d7ea",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -374027,17 +369484,6 @@
     },
     {
       "id": "rb-ru-dream-pop-radio-caprice-2224a86c",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ru-dream-pop-radio-caprice-aac-48-7392c1c4",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -374312,29 +369758,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ru-europa-plus-128-kbps-96393d3c",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-ru-europa-plus-101-6fm-ecb84995",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ru-europa-plus-128aac-5396ba22",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -374379,17 +369803,6 @@
     },
     {
       "id": "rb-ru-europa-plus-8e6e12f8",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ru-europapplus-fresh-0e48643c",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -375027,17 +370440,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ru-insomnia-307eb1b0",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-ru-instrumental-jazz-518d02e0",
       "status": "stream-only",
       "metadataKey": null,
@@ -375149,17 +370551,6 @@
     },
     {
       "id": "rb-ru-joy-b7e0d449",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ru-joy-hits-54501180",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -376568,6 +371959,17 @@
     },
     {
       "id": "rb-ru-nrj-101-4-fm-1ec5c72d",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-nstation-c673d4f1",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -378052,17 +373454,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ru-radio-blago-041dbcb5",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-ru-radio-cadenazo-07283d76",
       "status": "stream-only",
       "metadataKey": null,
@@ -378779,17 +374170,6 @@
     },
     {
       "id": "rb-ru-radio-caprice-drum-n-bass-bd568faa",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ru-radio-caprice-dub-48-kbps-ddaf5eb3",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -381143,17 +376523,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ru-radio-game-play-9d52c1f2",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-ru-radio-gameplay-387753d6",
       "status": "stream-only",
       "metadataKey": null,
@@ -381243,17 +376612,6 @@
     },
     {
       "id": "rb-ru-radio-jah-8360a966",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ru-radio-jazz-89-1-classic-jazz-963400ea",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -381781,6 +377139,17 @@
       "hasProviderCover": false
     },
     {
+      "id": "rb-ru-radio-orpheus-a3e0ec59",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
       "id": "rb-ru-radio-orthodox-chants-20425c1a",
       "status": "stream-only",
       "metadataKey": null,
@@ -382188,6 +377557,17 @@
       "hasProviderCover": false
     },
     {
+      "id": "rb-ru-radio-record-hq-c724c6db",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
       "id": "rb-ru-radio-record-liquid-funk-c02a069b",
       "status": "stream-only",
       "metadataKey": null,
@@ -382233,17 +377613,6 @@
     },
     {
       "id": "rb-ru-radio-record-megamix-a1c3d110",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ru-radio-record-organic-55569140",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -382519,17 +377888,6 @@
     },
     {
       "id": "rb-ru-radio-ultra-5caa6e2a",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ru-radio-vanya-2b9ea1ed",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -383068,6 +378426,28 @@
       "hasProviderCover": false
     },
     {
+      "id": "rb-ru-relax-fm-78766053",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-relax-fm-38ba7b0a",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
       "id": "rb-ru-relax-instrumental-01497202",
       "status": "stream-only",
       "metadataKey": null,
@@ -383256,39 +378636,6 @@
     },
     {
       "id": "rb-ru-rock-fm-80s-aa943731",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ru-rock-fm-90s-06f0f758",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ru-rock-fm-heavy-ad98405b",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ru-rock-fm-prog-5fbf0b02",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -383519,17 +378866,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ru-royal-radio-98-6-fm-02c28ce6",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-ru-rpi-658bfcc3",
       "status": "stream-only",
       "metadataKey": null,
@@ -383706,17 +379042,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ru-russkoe-radio-53c29beb",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-ru-ruworship-256-147fb750",
       "status": "stream-only",
       "metadataKey": null,
@@ -383729,6 +379054,28 @@
     },
     {
       "id": "rb-ru-ruworship-84aa8dae",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-ruworship-1ae4ad97",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-ruworship-cc724a08",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -383773,17 +379120,6 @@
     },
     {
       "id": "rb-ru-sector-jazz-f6564ec5",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ru-segenswelle-russisch-30fb9c35",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -384048,17 +379384,6 @@
     },
     {
       "id": "rb-ru-spacesynth-ru-online-radio-f4c352e1",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ru-spokoinoe-radio-ru-128k-mp3-54ec7640",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -384422,17 +379747,6 @@
     },
     {
       "id": "rb-ru-tht-music-radio-ac1d7b5c",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ru-trade-electronic-fe0f2c09",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -384949,6 +380263,17 @@
       "hasProviderCover": false
     },
     {
+      "id": "rb-ru-90-d2a178ac",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
       "id": "rb-ru-station-2d6a6dda",
       "status": "stream-only",
       "metadataKey": null,
@@ -385038,6 +380363,17 @@
     },
     {
       "id": "rb-ru-station-10015214",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-fm-7f79ab9a",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -385345,6 +380681,28 @@
       "hasProviderCover": false
     },
     {
+      "id": "rb-ru-93-5-fm-0908b6c9",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-107-8-fm-04dc0fb1",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
       "id": "rb-ru-107-4-fm-234398bb",
       "status": "stream-only",
       "metadataKey": null,
@@ -385401,6 +380759,17 @@
     },
     {
       "id": "rb-ru-station-ca824443",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-91-5-fm-623da267",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -385500,17 +380869,6 @@
     },
     {
       "id": "rb-ru-station-4cb5e25b",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ru-station-718832a5",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -385697,17 +381055,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ru-station-7d2f26fd",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-ru-105-3-fm-8ac2575b",
       "status": "stream-only",
       "metadataKey": null,
@@ -385731,6 +381078,17 @@
     },
     {
       "id": "rb-ru-90-3-fm-79c27c0d",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-90-2-fm-093c5fb3",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -386038,17 +381396,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ru-station-81b64296",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-ru-govorit-moskva-773c08fa",
       "status": "stream-only",
       "metadataKey": null,
@@ -386182,6 +381529,17 @@
     },
     {
       "id": "rb-ru-station-e4d2dcac",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-dfm-aa06a638",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -386368,6 +381726,28 @@
       "hasProviderCover": false
     },
     {
+      "id": "rb-ru-92-0-fm-1d2fb3d8",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-107-0-fm-148ced2e",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
       "id": "rb-ru-fm-6b65778f",
       "status": "stream-only",
       "metadataKey": null,
@@ -386391,17 +381771,6 @@
     },
     {
       "id": "rb-ru-station-37d7c720",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ru-fm-1e707249",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -386555,6 +381924,17 @@
       "hasProviderCover": false
     },
     {
+      "id": "rb-ru-102-3-fm-2683c952",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
       "id": "rb-ru-station-8561e5e5",
       "status": "stream-only",
       "metadataKey": null,
@@ -386566,7 +381946,40 @@
       "hasProviderCover": false
     },
     {
+      "id": "rb-ru-106-7-fm-61eae22c",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-106-2-fm-3075f779",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
       "id": "rb-ru-100-8-fm-6c22c058",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-100-9-fm-ecc7285c",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -386753,6 +382166,17 @@
       "hasProviderCover": false
     },
     {
+      "id": "rb-ru-103-8-fm-54fcae7f",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
       "id": "rb-ru-station-d3af2e99",
       "status": "stream-only",
       "metadataKey": null,
@@ -386841,6 +382265,39 @@
       "hasProviderCover": false
     },
     {
+      "id": "rb-ru-103-2-fm-af21f63e",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-104-2-fm-d0c743e5",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-102-0-fm-72db0375",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
       "id": "rb-ru-100-2-fm-0563b527",
       "status": "stream-only",
       "metadataKey": null,
@@ -386852,7 +382309,40 @@
       "hasProviderCover": false
     },
     {
+      "id": "rb-ru-107-2-fm-4f4d6e2d",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-100-3-fm-56ed89d0",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
       "id": "rb-ru-102-6-fm-2fb4b3f0",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-107-1-fm-0ef395ef",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -386907,7 +382397,29 @@
       "hasProviderCover": false
     },
     {
+      "id": "rb-ru-103-9-fm-9677b6ca",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
       "id": "rb-ru-94-6-fm-7e273a7a",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-105-7-fm-016e9fec",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -386952,6 +382464,17 @@
     },
     {
       "id": "rb-ru-99-9-fm-a14ef0f3",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-105-6-fm-e8800318",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -387424,17 +382947,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ru-station-46bdd0b5",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-ru-station-e6a5c769",
       "status": "stream-only",
       "metadataKey": null,
@@ -387567,6 +383079,28 @@
       "hasProviderCover": false
     },
     {
+      "id": "rb-ru-91-0-fm-4dc527fd",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-92-8-fm-86c81313",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
       "id": "rb-ru-89-8-fm-f97bb313",
       "status": "stream-only",
       "metadataKey": null,
@@ -387601,6 +383135,17 @@
     },
     {
       "id": "rb-ru-99-3-fm-25309dd9",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-88-3-fm-e3b03728",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -387875,6 +383420,17 @@
       "hasProviderCover": false
     },
     {
+      "id": "rb-ru-90-35836e94",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
       "id": "rb-ru-station-b717f737",
       "status": "stream-only",
       "metadataKey": null,
@@ -387909,6 +383465,17 @@
     },
     {
       "id": "rb-ru-fm-72b26174",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-107-4-fm-0e986a11",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -388293,6 +383860,17 @@
       "hasProviderCover": false
     },
     {
+      "id": "rb-ru-102-4-fm-8afdfc21",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
       "id": "rb-ru-99-0-fm-8e78241f",
       "status": "stream-only",
       "metadataKey": null,
@@ -388557,17 +384135,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ru-station-531a592c",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-ru-station-ae109e79",
       "status": "stream-only",
       "metadataKey": null,
@@ -388723,6 +384290,17 @@
     },
     {
       "id": "rb-ru-station-9c14c07a",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-96-0-fm-b5205000",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -389569,28 +385147,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ru-jazz-ca9f6464",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ru-jazz-3d15593b",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-ru-jazz-89-1-256kbps-008647d2",
       "status": "stream-only",
       "metadataKey": null,
@@ -389954,6 +385510,17 @@
       "hasProviderCover": false
     },
     {
+      "id": "rb-ru-98-7-fm-0651cd22",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
       "id": "rb-ru-station-aa36a112",
       "status": "stream-only",
       "metadataKey": null,
@@ -390009,7 +385576,29 @@
       "hasProviderCover": false
     },
     {
+      "id": "rb-ru-105-6-fm-d84470db",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
       "id": "rb-ru-91-6-fm-37771a31",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-88-3-fm-301ad5b2",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -390142,17 +385731,6 @@
     },
     {
       "id": "rb-ru-station-319a9100",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ru-station-096a158b",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -390372,17 +385950,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ru-station-b4ff49c6",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-ru-radio-mayak-9614aa8d",
       "status": "stream-only",
       "metadataKey": null,
@@ -390406,17 +385973,6 @@
     },
     {
       "id": "rb-ru-station-e3645baf",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ru-128-kb-s-fe7328f5",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -390691,6 +386247,17 @@
       "hasProviderCover": false
     },
     {
+      "id": "rb-ru-103-7-fm-4e6bb078",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
       "id": "rb-ru-106-4-fm-cb5829d3",
       "status": "stream-only",
       "metadataKey": null,
@@ -390725,17 +386292,6 @@
     },
     {
       "id": "rb-ru-station-61f8508a",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ru-105-3-fm-3c0869b6",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -390878,6 +386434,50 @@
       "hasProviderCover": false
     },
     {
+      "id": "rb-ru-256kbps-54101383",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-256kbps-59bee85d",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-256kbps-6b340063",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-256kbps-704d705e",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
       "id": "rb-ru-station-065940f3",
       "status": "stream-only",
       "metadataKey": null,
@@ -390933,6 +386533,39 @@
       "hasProviderCover": false
     },
     {
+      "id": "rb-ru-256kbps-52ce11f6",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-256kbps-0399c28b",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-256kbps-f189ddf7",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
       "id": "rb-ru-256kbps-6f755c28",
       "status": "stream-only",
       "metadataKey": null,
@@ -390944,7 +386577,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ru-radio-orpheus-98ef07aa",
+      "id": "rb-ru-256kbps-9be46c30",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -390955,7 +386588,51 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ru-radio-orpheus-64-19378ab5",
+      "id": "rb-ru-256kbps-fa6fded3",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-256kbps-a62cbf9a",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-256kbps-baeb43de",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-256kbps-aeab8a57",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-radio-orpheus-98ef07aa",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -391142,6 +386819,17 @@
       "hasProviderCover": false
     },
     {
+      "id": "rb-ru-103-4-fm-d29ac6ab",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
       "id": "rb-ru-station-8ed16a01",
       "status": "stream-only",
       "metadataKey": null,
@@ -391154,17 +386842,6 @@
     },
     {
       "id": "rb-ru-station-86b43010",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ru-station-ec2adc92",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -391220,28 +386897,6 @@
     },
     {
       "id": "rb-ru-black-rap-f6205c07",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ru-breaks-996cb5ca",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ru-christmas-17e43b79",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -391362,17 +387017,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ru-goa-psy-670c98e3",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-ru-gold-fa350362",
       "status": "stream-only",
       "metadataKey": null,
@@ -391385,17 +387029,6 @@
     },
     {
       "id": "rb-ru-groove-tribal-72cf8197",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ru-hardstyle-644572eb",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -391560,40 +387193,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ru-rock-b5848eac",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-ru-russian-hits-56f5f685",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ru-russian-mix-6ffa5e26",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ru-summer-dance-8b672b47",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -391648,17 +387248,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ru-trancehouse-9ef7bad9",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-ru-trancemission-38faf427",
       "status": "stream-only",
       "metadataKey": null,
@@ -391703,17 +387292,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ru-vip-house-5c9c5075",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-ru-x-mas-party-49cba1c9",
       "status": "stream-only",
       "metadataKey": null,
@@ -391748,17 +387326,6 @@
     },
     {
       "id": "rb-ru-fm-8abb573f",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ru-fm-6127cfeb",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -391824,6 +387391,17 @@
       "hasProviderCover": false
     },
     {
+      "id": "rb-ru-100-9-fm-ee26ca5e",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
       "id": "rb-ru-95-0-fm-53301e87",
       "status": "stream-only",
       "metadataKey": null,
@@ -391836,6 +387414,17 @@
     },
     {
       "id": "rb-ru-station-da2444ae",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-101-5-fm-821f7b48",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -391978,28 +387567,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ru-aac-d5ce45dd",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ru-aac-3424963f",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-ru-radio-russia-9606d076",
       "status": "stream-only",
       "metadataKey": null,
@@ -392023,6 +387590,50 @@
     },
     {
       "id": "rb-ru-station-16ef112b",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-91-6-fm-8ddfd0ef",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-96-0-fm-a428c992",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-90-0-fm-0a38221c",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-106-3-fm-62ce7a75",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -392066,7 +387677,128 @@
       "hasProviderCover": false
     },
     {
+      "id": "rb-ru-91-6-fm-31758931",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-91-6-fm-ba21d9d3",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-91-6-fm-b14d05d0",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-107-4-fm-d2d505bb",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-102-0-fm-4fed5713",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-91-1-fm-1f4abe2a",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-105-2-fm-4574a3cd",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
       "id": "rb-ru-93-5-fm-14ba04c2",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-90-2-fm-7a729e4c",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-99-1-fm-478e120c",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-89-1-fm-25389991",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-106-3-fm-f55b725d",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -392089,6 +387821,17 @@
     },
     {
       "id": "rb-ru-station-0bf01ace",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-station-e7b0a051",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -392243,6 +387986,17 @@
     },
     {
       "id": "rb-ru-station-ce597c0e",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-103-7-fm-5ce05193",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -392495,6 +388249,39 @@
       "hasProviderCover": false
     },
     {
+      "id": "rb-ru-fm-105-6-7583f366",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-103-6-fm-c16ef9c9",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-90-55a1b26d",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
       "id": "rb-ru-station-bd9ed15f",
       "status": "stream-only",
       "metadataKey": null,
@@ -392639,6 +388426,17 @@
     },
     {
       "id": "rb-ru-station-30e3d9f1",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-100-7-fm-c683b7ec",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -392891,6 +388689,17 @@
       "hasProviderCover": false
     },
     {
+      "id": "rb-ru-105-3-fm-d4b93e5d",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
       "id": "rb-ru-102-4-fm-2cdce220",
       "status": "stream-only",
       "metadataKey": null,
@@ -392935,7 +388744,40 @@
       "hasProviderCover": false
     },
     {
+      "id": "rb-ru-106-4-fm-36b7cfbc",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
       "id": "rb-ru-101-2-fm-c8a54457",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-98-6-fm-52cf56e7",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-102-2-fm-9e5dee5b",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -393112,6 +388954,17 @@
     },
     {
       "id": "rb-ru-station-fbacdb66",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-18-9c8224a2",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -393452,6 +389305,17 @@
       "hasProviderCover": false
     },
     {
+      "id": "rb-ru-102-1-fm-63a8787f",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
       "id": "rb-ru-104-8-fm-fe11e0ae",
       "status": "stream-only",
       "metadataKey": null,
@@ -393486,6 +389350,17 @@
     },
     {
       "id": "rb-ru-97-9-fm-1c97985b",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-105-2-fm-b74a0630",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -393640,6 +389515,17 @@
     },
     {
       "id": "rb-ru-station-82343b35",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-europa-plus-dcafe6bd",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -394684,6 +390570,28 @@
       "hasProviderCover": false
     },
     {
+      "id": "rb-ru-101-4-fm-519b02f1",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-ru-102-7-fm-96e597fa",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
       "id": "rb-ru-station-61a2675e",
       "status": "stream-only",
       "metadataKey": null,
@@ -394894,17 +390802,6 @@
     },
     {
       "id": "rb-ru-station-3929ae77",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ru-station-770d3623",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -395829,17 +391726,6 @@
     },
     {
       "id": "rb-sa-radio-disney-ksa-87-7-fm-94f75d0c",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-sa-radio-maria-middle-east-76e40aad",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -401394,17 +397280,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-sk-repete-ab1e278e",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-sk-rock-radio-2d04650f",
       "status": "stream-only",
       "metadataKey": null,
@@ -401791,17 +397666,6 @@
     },
     {
       "id": "rb-sm-radio-san-marino-classic-bd06bffb",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-sm-radio-san-marino-classic-10f93ee3",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -405212,17 +401076,6 @@
     },
     {
       "id": "rb-tr-afn-incirlik-3bd0d78d",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-tr-ahaber-68d94f0b",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -408863,17 +404716,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-tr-radyo-45-lik-1a43c888",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-tr-radyo-45-lik-1970-ler-1980-ler-ve-1990-lar-27dc3e5e",
       "status": "stream-only",
       "metadataKey": null,
@@ -411888,6 +407730,17 @@
       "hasProviderCover": false
     },
     {
+      "id": "rb-tw-asiafm-39619832",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
       "id": "rb-tw-asiafm-ca368d8d",
       "status": "stream-only",
       "metadataKey": null,
@@ -411988,17 +407841,6 @@
     },
     {
       "id": "rb-tw-hit-fm-14569b3b",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-tw-https-www-csbc-com-tw-98e6c0ab",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -412834,17 +408676,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-tw-station-5b444801",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-tw-station-e7370b46",
       "status": "stream-only",
       "metadataKey": null,
@@ -413406,6 +409237,28 @@
       "hasProviderCover": false
     },
     {
+      "id": "rb-tw-fm-94-3-21faf135",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
+      "id": "rb-tw-fm-94-3-7902974d",
+      "status": "stream-only",
+      "metadataKey": null,
+      "metadataUrl": null,
+      "metadataStrategy": "none",
+      "backgroundPollPriority": "never",
+      "hasProgram": false,
+      "hasSchedule": false,
+      "hasProviderCover": false
+    },
+    {
       "id": "rb-tw-fm-93-1-79c96d7f",
       "status": "stream-only",
       "metadataKey": null,
@@ -413506,17 +409359,6 @@
     },
     {
       "id": "rb-tw-station-4a9431fb",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-tw-station-9daf966a",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -414980,17 +410822,6 @@
     },
     {
       "id": "rb-ua-rock-38df9888",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ua-rock-ballads-9dc2bd8c",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -416750,17 +412581,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-ua-station-7081ac4d",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-ua-station-a29d6620",
       "status": "stream-only",
       "metadataKey": null,
@@ -416828,17 +412648,6 @@
     },
     {
       "id": "rb-ug-abdulbasit-abdulsamad-885fd8d2",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ug-104-1-favour-fm-gulu-104-1-fm-mp3-276c2bc0",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -418082,17 +413891,6 @@
     },
     {
       "id": "rb-ug-kyoga-veritas-radio-soroti-91-5-fm-mp3-82b790e8",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-ug-mcf-radio-kampala-98-7-fm-mp3-6a807fd5",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -419874,17 +415672,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-us-100hitz-90-s-hitz-2d57c0e8",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-us-100hitz-90s-alternative-hitz-4ddc509b",
       "status": "stream-only",
       "metadataKey": null,
@@ -419952,17 +415739,6 @@
     },
     {
       "id": "rb-us-100hitz-indie-4366c397",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-us-100hitz-indie-rock-d0cad744",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -420513,17 +416289,6 @@
     },
     {
       "id": "rb-us-102-7-kiis-fm-c76686ca",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-us-102-7-kiis-fm-los-angeles-2e6fabb2",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -421118,17 +416883,6 @@
     },
     {
       "id": "rb-us-104-9-the-river-c248e9ea",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-us-104-9-the-river-aac-6555c763",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -427112,17 +422866,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-us-a-m-ambient-128-kbps-mp3-8501f14b",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-us-aardvark-blues-fm-be3d699a",
       "status": "stream-only",
       "metadataKey": null,
@@ -428102,17 +423845,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-us-altrok-radio-6f8adda6",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-us-altrok-radio-wbjb-nj-47e13e04",
       "status": "stream-only",
       "metadataKey": null,
@@ -428334,17 +424066,6 @@
     },
     {
       "id": "rb-us-ambient-sleeping-pill-961fa288",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-us-ambient-sleeping-pill-128-kbps-mp3-4b4d1308",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -429555,17 +425276,6 @@
     },
     {
       "id": "rb-us-bassdrive-960cc332",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-us-bassdrive-aac-56k-af55bae9",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -431303,17 +427013,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-us-browns-radio-network-726596c0",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-us-brushwood-media-network-76ed8808",
       "status": "stream-only",
       "metadataKey": null,
@@ -432348,17 +428047,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-us-chicago-symphony-orchestra-bb3356db",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-us-chill-lounge-florida-c5983c96",
       "status": "stream-only",
       "metadataKey": null,
@@ -432657,17 +428345,6 @@
     },
     {
       "id": "rb-us-christiancountrygospel-net-976fa379",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-us-christmas-365-santa-s-radio-mp3-24080e23",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -433866,17 +429543,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-us-colorado-public-radio-openair-986cf55e",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-us-comedy-104-radiostorm-c2958dcc",
       "status": "stream-only",
       "metadataKey": null,
@@ -434340,17 +430006,6 @@
     },
     {
       "id": "rb-us-crime-fighter-detectives-b178fbf8",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-us-crime-fighter-detectives-d153e18b",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -436429,17 +432084,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-us-en-familia-radio-740-am-a40de7aa",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-us-epic-classical-study-0ed20c4a",
       "status": "stream-only",
       "metadataKey": null,
@@ -436957,17 +432601,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-us-faith-radio-network-fd19e8c6",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-us-faithful-road-71dd5ab6",
       "status": "stream-only",
       "metadataKey": null,
@@ -437398,17 +433031,6 @@
     },
     {
       "id": "rb-us-folk-alley-4c33c80a",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-us-folk-alley-classic-4448e36a",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -437947,29 +433569,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-us-frisky-classics-http-6f497c5e",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-us-frisky-deep-9612308f",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-us-frisky-deep-http-db8f3c40",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -438585,17 +434185,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-us-got-radio-guitar-genius-c77042da",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-us-gotradio-90s-alternative-738363a2",
       "status": "stream-only",
       "metadataKey": null,
@@ -438817,17 +434406,6 @@
     },
     {
       "id": "rb-us-grace-fm-b71a7d67",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-us-grace-stream-d5399ff4",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -441434,17 +437012,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-us-iriestorm-radio-b077426c",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-us-irosary-radio-7dec776f",
       "status": "stream-only",
       "metadataKey": null,
@@ -441875,17 +437442,6 @@
     },
     {
       "id": "rb-us-jefferson-public-radio-rhythm-and-news-c7f2edb5",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-us-jemp-12d5717b",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -444184,17 +439740,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-us-keol-eastern-oregon-university-00e3831e",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-us-keom-88-5-mesquite-schools-radio-aac-stream-33dc9b2f",
       "status": "stream-only",
       "metadataKey": null,
@@ -444306,14 +439851,14 @@
     },
     {
       "id": "rb-us-kexp-90-3-seattle-wa-6a7508a9",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
+      "status": "working",
+      "metadataKey": "kexp",
+      "metadataUrl": "https://api.kexp.org/v2/plays/?limit=5",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
+      "hasProgram": true,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-us-kexp-90-3-seattle-wa-aac-160k-445cbb3a",
@@ -444449,17 +439994,6 @@
     },
     {
       "id": "rb-us-kfi-937c891b",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-us-kfi-la-5112d8da",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -447946,17 +443480,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-us-kpbs-hd2-classical-san-diego-961e45df",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-us-kpbx-997ed664",
       "status": "stream-only",
       "metadataKey": null,
@@ -448013,17 +443536,6 @@
     },
     {
       "id": "rb-us-kpfa-662f715d",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-us-kpfx-fm-107-9-the-fox-d9ec3be2",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -448408,17 +443920,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-us-krcl-90-9-fm-salt-lake-city-ut-low-960d3428",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-us-krcu-90-9-southeast-public-radio-cape-girard-960f3936",
       "status": "stream-only",
       "metadataKey": null,
@@ -448453,17 +443954,6 @@
     },
     {
       "id": "rb-us-krdo-6106a2a2",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-us-krdo-news-radio-colorado-springs-54a839a3",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -450531,17 +446021,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-us-kvgc-oldies-aac-64-40fc8608",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-us-kvgc-oldies-mp3-128-aec36449",
       "status": "stream-only",
       "metadataKey": null,
@@ -451257,17 +446736,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-us-kxlu-lo-4c974589",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-us-kxly-fm-big-99-9-coyote-country-spokane-wa-96467647",
       "status": "stream-only",
       "metadataKey": null,
@@ -451412,17 +446880,6 @@
     },
     {
       "id": "rb-us-kyse-94-7-la-tricolor-el-paso-tx-96492125",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-us-kysr-98-7-fm-los-angeles-ca-49508135",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -452545,17 +448002,6 @@
     },
     {
       "id": "rb-us-little-raleigh-radio-high-quality-64-kbps-aa-e5da287f",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-us-little-raleigh-radio-legacy-128-kbps-mp3-str-0f330201",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -454249,17 +449695,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-us-mpr-news-aac-48k-9b06dea3",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-us-mpr-radio-heartland-eff2bb93",
       "status": "stream-only",
       "metadataKey": null,
@@ -455504,17 +450939,6 @@
     },
     {
       "id": "rb-us-newsradio-95-wxtk-526255b3",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-us-newsradio-970-wfla-48kbps-51223718",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -458561,17 +453985,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-us-r-a-dio-961473eb",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-us-racer-4bf4b220",
       "status": "stream-only",
       "metadataKey": null,
@@ -459035,17 +454448,6 @@
     },
     {
       "id": "rb-us-radio-calico-0a55298e",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-us-radio-calico-192kpbs-e2f255af",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -460244,29 +455646,7 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-us-radio-paradies-radio-2050-32k-aac-2aa3762c",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-us-radio-paradise-2050-192k-mp3-74b82d3a",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-us-radio-paradise-64k-aac-e7e05200",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -460321,28 +455701,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-us-radio-paradise-global-32k-aac-ca1baf77",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-us-radio-paradise-global-mix-128k-aac-99894c20",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-us-radio-paradise-global-mix-flac-meta-12489c5a",
       "status": "stream-only",
       "metadataKey": null,
@@ -460387,17 +455745,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-us-radio-paradise-main-mix-192-mp3-5677f92c",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-us-radio-paradise-main-mix-24k-aac-962d394d",
       "status": "stream-only",
       "metadataKey": null,
@@ -460410,17 +455757,6 @@
     },
     {
       "id": "rb-us-radio-paradise-main-mix-320k-aac-4aad9a26",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-us-radio-paradise-main-mix-32k-aac-961516d4",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -460465,17 +455801,6 @@
     },
     {
       "id": "rb-us-radio-paradise-mellow-mix-320k-aac-d88c0d24",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-us-radio-paradise-mellow-mix-32k-aac-d3c867ad",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -460541,17 +455866,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-us-radio-paradise-rock-mix-32k-aac-83413791",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-us-radio-paradise-rock-mix-64k-aac-9e54d6fc",
       "status": "stream-only",
       "metadataKey": null,
@@ -460575,17 +455889,6 @@
     },
     {
       "id": "rb-us-radio-paradise-rock-mix-flac-meta-dcee5c2b",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-us-radio-paradise-serenity-fixed-flac-41514a58",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -460641,28 +455944,6 @@
     },
     {
       "id": "rb-us-radio-paradise-world-etc-mix-flac-6263a7a9",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-us-radio-paradiso-main-df380477",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-us-radio-paradiso-rock-eaa1d39b",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -463621,17 +458902,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-us-sharks-audio-network-6e4afd5b",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-us-shine-fm-58f1760e",
       "status": "stream-only",
       "metadataKey": null,
@@ -463666,17 +458936,6 @@
     },
     {
       "id": "rb-us-shoutdrive-dance-music-for-north-america-fro-b294bf46",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-us-shouting-fire-aac-583d4269",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -463863,17 +459122,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-us-smells-like-the-90s-3381946d",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-us-smoky-mountain-radio-755890fc",
       "status": "stream-only",
       "metadataKey": null,
@@ -463996,17 +459244,6 @@
     },
     {
       "id": "rb-us-smooth-jazz-florida-615fe9a1",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-us-smooth-jazz-global-15725b26",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -464711,14 +459948,14 @@
     },
     {
       "id": "rb-us-somafm-drone-zone-128k-mp3-960eb2e9",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
+      "status": "working",
+      "metadataKey": "soma-fm",
+      "metadataUrl": "dronezone",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
       "hasProgram": false,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-us-somafm-drone-zone-256k-mp3-ae7aeb65",
@@ -464854,14 +460091,14 @@
     },
     {
       "id": "rb-us-somafm-groove-salad-128k-mp3-960cf833",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
+      "status": "working",
+      "metadataKey": "soma-fm",
+      "metadataUrl": "groovesalad",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
       "hasProgram": false,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-us-somafm-groove-salad-16k-aac-05c3cfd3",
@@ -464975,14 +460212,14 @@
     },
     {
       "id": "rb-us-somafm-indie-pop-rocks-128k-aac-96394224",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
+      "status": "working",
+      "metadataKey": "soma-fm",
+      "metadataUrl": "indiepop",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
       "hasProgram": false,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-us-somafm-indie-pop-rocks-32k-aac-40d531b3",
@@ -465228,14 +460465,14 @@
     },
     {
       "id": "rb-us-somafm-secret-agent-128k-mp3-960c7c81",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
+      "status": "working",
+      "metadataKey": "soma-fm",
+      "metadataUrl": "secretagent",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
       "hasProgram": false,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-us-somafm-secret-agent-32k-aac-960d68cf",
@@ -465371,14 +460608,14 @@
     },
     {
       "id": "rb-us-somafm-space-station-soma-128k-aac-960d3f6f",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
+      "status": "working",
+      "metadataKey": "soma-fm",
+      "metadataUrl": "spacestation",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
       "hasProgram": false,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-us-somafm-space-station-soma-320k-mp3-05d929e4",
@@ -465591,14 +460828,14 @@
     },
     {
       "id": "rb-us-somafm-underground-80s-128k-mp3-9614b5e5",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
+      "status": "working",
+      "metadataKey": "soma-fm",
+      "metadataUrl": "u80s",
+      "metadataStrategy": "api",
+      "backgroundPollPriority": "normal",
       "hasProgram": false,
       "hasSchedule": false,
-      "hasProviderCover": false
+      "hasProviderCover": true
     },
     {
       "id": "rb-us-somafm-underground-80s-256k-mp3-ed1fb9a0",
@@ -472300,17 +467537,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-us-wctb-cruisin-93-5-222daf08",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-us-wctk-98-1-cat-country-new-bedford-ma-963db308",
       "status": "stream-only",
       "metadataKey": null,
@@ -473268,17 +468494,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-us-wfcr-88-5-npr-classical-amherst-ma-a3e8560c",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-us-wfcr-88-5-new-england-public-radio-amherst-m-9625f0d2",
       "status": "stream-only",
       "metadataKey": null,
@@ -473511,17 +468726,6 @@
     },
     {
       "id": "rb-us-wfmu-91-1-east-orange-nj-9618344a",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-us-wfmu-91-1-east-orange-nj-32k-stream-9644c9cb",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -474358,17 +469562,6 @@
     },
     {
       "id": "rb-us-whro-88-1-fm-wfos-2b892707",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-us-whru-lp-101-5-huntley-community-radio-huntle-961d5d1c",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -477415,17 +472608,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-us-wnyc-93-9-fm-f34ae431",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-us-wnyc-fm-535d3971",
       "status": "stream-only",
       "metadataKey": null,
@@ -477438,17 +472620,6 @@
     },
     {
       "id": "rb-us-wnyc-operavore-3cc5d805",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-us-wnyc-wqxr-a2bd7f10",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -478329,17 +473500,6 @@
     },
     {
       "id": "rb-us-wqcm-94-3-19af2e66",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-us-wqed-pittsburgh-bfc70aae",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -480198,17 +475358,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-us-wtob-eca683a4",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-us-wtob-980-am-ff6292b5",
       "status": "stream-only",
       "metadataKey": null,
@@ -480551,17 +475700,6 @@
     },
     {
       "id": "rb-us-wumb-french-accent-stream-boston-ma-961e81ca",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-us-wumb-l-air-du-temps-d8d1511b",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -480936,17 +476074,6 @@
     },
     {
       "id": "rb-us-wvco-94-9-the-surf-c3c464b3",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-us-wvcr-88-3-siena-college-loudonville-ny-cffc29a2",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,
@@ -482431,17 +477558,6 @@
       "hasProviderCover": false
     },
     {
-      "id": "rb-us-wzeb-power-101-7-e956d215",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
       "id": "rb-us-wzee-104-1-z-104-madison-wi-dadddf8b",
       "status": "stream-only",
       "metadataKey": null,
@@ -483411,17 +478527,6 @@
     },
     {
       "id": "rb-us-z100-whtz-fm-100-3-new-york-56df9f1a",
-      "status": "stream-only",
-      "metadataKey": null,
-      "metadataUrl": null,
-      "metadataStrategy": "none",
-      "backgroundPollPriority": "never",
-      "hasProgram": false,
-      "hasSchedule": false,
-      "hasProviderCover": false
-    },
-    {
-      "id": "rb-us-z100-whtz-fm-100-3-new-york-35d36481",
       "status": "stream-only",
       "metadataKey": null,
       "metadataUrl": null,

--- a/tools/build-ios-local-catalog.mjs
+++ b/tools/build-ios-local-catalog.mjs
@@ -15,13 +15,17 @@
 import { existsSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { parse as parseYaml } from 'yaml';
 import { writeStationCapabilities } from './build-station-capabilities.mjs';
+import { detectFamilies, familyBucketKey } from './lib/station-family.mjs';
+import { nameTokens } from './lib/station-name-signature.mjs';
 
 const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
 const PUBLIC = join(ROOT, 'public');
 const OUT = join(PUBLIC, 'stations-ios-local.json');
 const CAPABILITIES_OUT = join(PUBLIC, 'station-capabilities-ios-local.json');
 const PUBLISHED_CATALOG = join(PUBLIC, 'stations.json');
+const STATIONS_YAML = join(ROOT, 'data', 'stations.yaml');
 const RB_CANDIDATES = join(PUBLIC, 'sources', 'radio-browser-candidates.json');
 const MANUAL_CANDIDATES = join(PUBLIC, 'sources', 'manual-candidates.json');
 const BYTE_PROBES = join(PUBLIC, 'sources', 'radio-browser-byte-probes.json');
@@ -141,6 +145,85 @@ function loadCatalogById() {
   return out;
 }
 
+/**
+ * Map legacy/aliased Radio Browser `stationuuid`s → their curated catalog
+ * station. The uuid/streamUrl matcher in build-sources can only link a candidate
+ * to the catalog when they share a stationuuid or stream URL — so RB records that
+ * pre-date a broadcaster's HTTPS migration or a rename (different uuid, dead old
+ * stream, drifted name) stay orphaned and render iconless here. `akaStationUuids`
+ * in data/stations.yaml declares those legacy ids so this catalog can inherit the
+ * curated station's per-channel art. Source of truth is the YAML (build-catalog
+ * strips the field from the public stations.json).
+ */
+function loadAkaCatalog(catalogById) {
+  const out = new Map();
+  let yamlList;
+  try {
+    yamlList = parseYaml(readFileSync(STATIONS_YAML, 'utf8'));
+  } catch {
+    return out;
+  }
+  if (!Array.isArray(yamlList)) return out;
+  for (const s of yamlList) {
+    if (!Array.isArray(s?.akaStationUuids)) continue;
+    const station = catalogById.get(s.id);
+    if (!station) continue;
+    for (const uuid of s.akaStationUuids) {
+      if (typeof uuid === 'string' && uuid && !out.has(uuid)) out.set(uuid, station);
+    }
+  }
+  return out;
+}
+
+/**
+ * Per detected brand family, a representative "brand" favicon plus the family's
+ * name-token core. Last-resort icon for an RB candidate that belongs to a
+ * broadcaster we curate but matches no specific station and has no usable
+ * favicon of its own — so a name-drifted sibling renders the broadcaster's mark
+ * rather than blank.
+ *
+ * We gate on `detectFamilies` (shared COUNTRY|host AND a shared name-token core),
+ * NOT a bare host bucket: a host alone groups unrelated tenants (facebook.com
+ * pages, platform subdomains) into a bogus "family" and would smear one
+ * station's art across them. Requiring the candidate to also carry the family
+ * core (checked at assignment time) keeps the fallback to true siblings.
+ *
+ * The representative is the family member with the fewest identity tokens (the
+ * one closest to the bare brand name), chosen deterministically.
+ *
+ * @returns {Map<string, Array<{coreTokens: string[], brand: string}>>} bucket → families
+ */
+function buildFamilyBrandIndex(catalogById) {
+  const members = [...catalogById.values()]
+    .filter((s) => cleanFavicon(s.favicon))
+    .map((s) => ({ id: s.id, name: s.name, country: s.country, homepage: s.homepage, favicon: cleanFavicon(s.favicon) }));
+  const byBucket = new Map();
+  for (const fam of detectFamilies(members)) {
+    const favMembers = fam.members.filter((m) => m.favicon);
+    if (favMembers.length < 2) continue;
+    favMembers.sort((a, b) => nameTokens(a.name).length - nameTokens(b.name).length || a.id.localeCompare(b.id));
+    const coreTokens = fam.core.split(' ').filter(Boolean);
+    if (!coreTokens.length) continue;
+    if (!byBucket.has(fam.bucket)) byBucket.set(fam.bucket, []);
+    byBucket.get(fam.bucket).push({ coreTokens, brand: favMembers[0].favicon });
+  }
+  return byBucket;
+}
+
+/**
+ * Brand favicon for a candidate: only when its name carries a curated family's
+ * full core (i.e. it really is a sibling of that brand), not merely its host.
+ */
+function familyBrandFavicon(byBucket, bucket, candidateName) {
+  const families = bucket ? byBucket.get(bucket) : undefined;
+  if (!families) return undefined;
+  const tokens = new Set(nameTokens(candidateName));
+  for (const fam of families) {
+    if (fam.coreTokens.every((t) => tokens.has(t))) return fam.brand;
+  }
+  return undefined;
+}
+
 function dashboardPlayableSource(candidate, byteProbes) {
   if (candidate.matchedCatalogId) return 'imported';
   if (candidate.duplicateOf) return null;
@@ -165,6 +248,8 @@ const manualCandidates = readJson(MANUAL_CANDIDATES, { candidates: [] }).candida
 const rawByUuid = loadRawByUuid();
 const byteProbes = loadByteProbes();
 const catalogById = loadCatalogById();
+const akaCatalog = loadAkaCatalog(catalogById);
+const familyBrand = buildFamilyBrandIndex(catalogById);
 
 const stations = [];
 const seenIds = new Set();
@@ -181,6 +266,11 @@ const counts = {
   httpsStreams: 0,
   skippedMissingRaw: 0,
   skippedNotPlayable: 0,
+  faviconFromCatalog: 0,
+  faviconFromRb: 0,
+  faviconFromAka: 0,
+  faviconFromFamilyBrand: 0,
+  faviconMissing: 0,
 };
 const byCountry = {};
 
@@ -217,13 +307,42 @@ for (const candidate of rbCandidates) {
     counts.skippedNotPlayable++;
     continue;
   }
-  const matchedCatalog = candidate.matchedCatalogId
+  const matchedById = candidate.matchedCatalogId
     ? catalogById.get(candidate.matchedCatalogId)
     : undefined;
+  // Fall back to an `akaStationUuids` alias when the uuid/streamUrl matcher
+  // couldn't link this stale RB record to the curated station it really is.
+  const akaMatch = matchedById ? undefined : akaCatalog.get(candidate.stationuuid);
+  const matchedCatalog = matchedById ?? akaMatch;
   const country = text(candidate.country || raw.countrycode).toUpperCase() || undefined;
-  const favicon = cleanFavicon(matchedCatalog?.favicon)
-    ?? cleanFavicon(raw.favicon || candidate.favicon);
   const homepage = cleanUrl(candidate.homepage || raw.homepage);
+
+  // Favicon resolution tiers: curated/aliased catalog art → raw RB favicon →
+  // curated brand mark for a same-broadcaster orphan → none.
+  let favicon = cleanFavicon(matchedCatalog?.favicon);
+  let faviconSource = favicon ? matchedCatalog.faviconSource || undefined : undefined;
+  let faviconSourceType = favicon ? matchedCatalog.faviconSourceType : undefined;
+  let faviconSourceUrl = favicon ? matchedCatalog.faviconSourceUrl : undefined;
+  let faviconLicense = favicon ? matchedCatalog.faviconLicense : undefined;
+  let faviconOk = favicon ? matchedCatalog.faviconOk : undefined;
+  let faviconTier = favicon ? (akaMatch ? 'aka' : 'catalog') : null;
+  if (!favicon) {
+    const rbFav = cleanFavicon(raw.favicon || candidate.favicon);
+    if (rbFav) {
+      favicon = rbFav;
+      faviconSource = 'radio-browser';
+      faviconTier = 'rb';
+    } else {
+      const bucket = familyBucketKey({ country, homepage });
+      const brand = familyBrandFavicon(familyBrand, bucket, name);
+      if (brand) {
+        favicon = brand;
+        faviconSource = 'catalog-family-brand';
+        faviconTier = 'family-brand';
+      }
+    }
+  }
+
   const station = pruneUndefined({
     id: stableId(candidate, raw),
     name,
@@ -233,11 +352,11 @@ for (const candidate of rbCandidates) {
     country,
     tags: tags(raw.tags),
     favicon,
-    faviconSource: matchedCatalog?.faviconSource || (favicon ? 'radio-browser' : undefined),
-    faviconSourceType: matchedCatalog?.faviconSourceType,
-    faviconSourceUrl: matchedCatalog?.faviconSourceUrl,
-    faviconLicense: matchedCatalog?.faviconLicense,
-    faviconOk: matchedCatalog?.faviconOk,
+    faviconSource,
+    faviconSourceType,
+    faviconSourceUrl,
+    faviconLicense,
+    faviconOk,
     bitrate: Number(raw.bitrate) > 0 ? Number(raw.bitrate) : undefined,
     codec: raw.codec ? text(raw.codec).toUpperCase() : undefined,
     listeners: Number(raw.clickcount) > 0 ? Number(raw.clickcount) : undefined,
@@ -249,7 +368,8 @@ for (const candidate of rbCandidates) {
     stationuuid: candidate.stationuuid,
     changeuuid: raw.changeuuid,
     localPlayableSource: source,
-    localMatchedCatalogId: candidate.matchedCatalogId || undefined,
+    localMatchedCatalogId: candidate.matchedCatalogId || matchedCatalog?.id || undefined,
+    localFaviconVia: faviconTier === 'aka' || faviconTier === 'family-brand' ? faviconTier : undefined,
     localDuplicateOf: candidate.duplicateOf || undefined,
   });
 
@@ -261,6 +381,11 @@ for (const candidate of rbCandidates) {
   if (candidate.duplicateOf) counts.includedDuplicateMatches++;
   if (streamUrl.startsWith('http://')) counts.httpStreams++;
   if (streamUrl.startsWith('https://')) counts.httpsStreams++;
+  if (faviconTier === 'catalog') counts.faviconFromCatalog++;
+  else if (faviconTier === 'aka') counts.faviconFromAka++;
+  else if (faviconTier === 'rb') counts.faviconFromRb++;
+  else if (faviconTier === 'family-brand') counts.faviconFromFamilyBrand++;
+  else counts.faviconMissing++;
 }
 
 for (const candidate of manualCandidates) {
@@ -332,3 +457,7 @@ console.log(`  duplicate source rows skipped: ${counts.skippedDuplicate}`);
 console.log(`  duplicate source rows included via catalog match: ${counts.includedDuplicateMatches}`);
 console.log(`  http streams: ${counts.httpStreams}`);
 console.log(`  https streams: ${counts.httpsStreams}`);
+console.log(
+  `  favicon: catalog=${counts.faviconFromCatalog}, aka=${counts.faviconFromAka}, ` +
+    `rb=${counts.faviconFromRb}, family-brand=${counts.faviconFromFamilyBrand}, missing=${counts.faviconMissing}`,
+);

--- a/tools/check-catalog.mjs
+++ b/tools/check-catalog.mjs
@@ -189,6 +189,49 @@ if (drift) {
   process.exit(2);
 }
 
+// iOS-local catalog freshness. public/stations-ios-local.json is a separate,
+// manually-rebuilt artifact (npm run catalog:ios-local) that mirrors curated
+// favicons into the full Radio-Browser candidate pool. It silently drifts
+// behind the curated catalog — a station gains per-channel art but the matched
+// iOS row keeps no icon — which is exactly how a batch of Radio Gong 96.3 rows
+// shipped iconless. Invariant: every iOS row linked to a curated station
+// (localMatchedCatalogId) must carry a favicon when that curated station has a
+// usable one. Skip silently when the artifact isn't present in the checkout.
+const iosLocalPath = join(root, 'public/stations-ios-local.json');
+if (existsSync(iosLocalPath)) {
+  const curatedFaviconById = new Map();
+  for (const s of jsonStations) {
+    const f = s.favicon;
+    if (typeof f === 'string' && (/^stations\//.test(f) || f.startsWith('https://'))) {
+      curatedFaviconById.set(s.id, f);
+    }
+  }
+  let iosLocal;
+  try {
+    iosLocal = JSON.parse(readFileSync(iosLocalPath, 'utf8'));
+  } catch {
+    fail('public/stations-ios-local.json is not valid JSON — run npm run catalog:ios-local');
+  }
+  const iosStations = Array.isArray(iosLocal) ? iosLocal : iosLocal.stations;
+  const staleIosRows = [];
+  for (const s of iosStations || []) {
+    const curatedId = s.localMatchedCatalogId;
+    if (!curatedId || !curatedFaviconById.has(curatedId)) continue;
+    if (!s.favicon) staleIosRows.push(`${s.id} → ${curatedId}`);
+  }
+  if (staleIosRows.length > 0) {
+    console.error(
+      `${C.bad}check-catalog: ${staleIosRows.length} iOS-local row(s) missing a favicon their curated station has:${C.reset}`,
+    );
+    for (const m of staleIosRows.slice(0, 20)) console.error(`  ${m}`);
+    if (staleIosRows.length > 20) console.error(`  …and ${staleIosRows.length - 20} more`);
+    console.error(
+      `\n  public/stations-ios-local.json is stale. Fix: run ${C.ok}npm run catalog:ios-local${C.reset}${C.bad} and commit it.${C.reset}`,
+    );
+    process.exit(2);
+  }
+}
+
 // Stale-allowlist check: an `httpAllowed: true` row whose stream is
 // now actually HTTPS (e.g. RB upstream upgraded) means the flag should
 // be removed. Warn (don't fail) so curator can clean up.


### PR DESCRIPTION
## Why

We worked on Radio Gong 96.3 per-channel logos yesterday (#458/#461/#462/#464), yet **7 Radio Gong 96.3 rows still had no icon**. This PR is the root-cause fix, not just an icon patch.

The 7 were never in the shipped web catalog — they live in `public/stations-ios-local.json`, the iOS *test* catalog (curated set **+** the full Radio Browser candidate pool). The blanks decomposed into three stacked failures, each fixed here.

## What

**1. Staleness gate (biggest cause).** `catalog:ios-local` is a manual rebuild step, and the artifact had drifted 5 days behind the curated catalog — predating *all* the Gong art. `check-catalog` now **fails** when any iOS-local row linked to a curated station (`localMatchedCatalogId`) lacks a favicon that station actually has. It runs in CI (`deploy.yml`). The drift was **systemic**: the stale artifact had **22** such rows across `90s90s`, `radio-saw`, `radio-7`, and Radio Gong — the whole #462 sweep.

**2. Dedupe link — `akaStationUuids` (exact art).** Our curated Gong channels carry **no `stationuuid`** and use the new addradio streams, so `build-sources`' uuid/streamURL matcher can never link the legacy "München −" RB records (old `nmdn` streams, drifted names). New `akaStationUuids:` YAML field absorbs those stale ids; bound 3 by channel number so the iOS-local catalog inherits the correct per-channel art (Live, Party Gong) / logo (089 Kult). The field is stripped from the public `stations.json` by `build-catalog`'s explicit field list.

**3. Family brand fallback (safety net).** Any RB orphan from a broadcaster we curate **that carries the family's name-token core** (gated by `detectFamilies`, *not* a bare host bucket — which was smearing art across unrelated `facebook.com` / `stream.laut.fm` tenants) now gets the family brand mark instead of blank.

## Result

- **0** Radio Gong 96.3 rows iconless (was 7).
- Favicon tiers: `catalog=23944, aka=3, rb=6167, family-brand=1132` (1,132 orphans across 218 real networks now branded instead of blank).
- `public/stations.json` (shipped catalog) **unchanged**.

## Verification

- `npm run typecheck` ✓
- `npm run check-catalog` ✓ — new gate fires on the stale artifact (22 rows), green on the rebuilt one
- `npm run check-duplicates` ✓ (timestamp-only churn restored)
- `npm run build` ✓
- `npm test -- --run` — **507/507** ✓

## Known limitations (follow-ups filed)

- `akaStationUuids` is resolved only in `build-ios-local`, not yet in `build-sources` — the candidate pool still counts these as unmatched.
- Two non-blank München duplicates (Akustic Covers, Kids) still show RB's generic icon.
- `familyBucketKey`'s aggregator guard misses subdomains (`stream.laut.fm`); the name-core gate masks it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)