### PR TITLE
feat(catalog): homepage-liveness gate (check-homepages)

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -95,6 +95,35 @@ See `docs/curation-checklist.md` for the full per-activity playbook. The standar
 4. If broadcaster has a metadata API but no fetcher yet — add one in `src/builtins.ts` AND a discoverer in `tools/wire-metadata.mjs` (so future channels of the same family auto-wire).
 5. Bump status from `stream-only` → `icy-only` (ICY-only metadata) or `working` (full per-broadcaster fetcher with logo).
 
+## Homepage liveness (`check-homepages`)
+
+A dead `homepage:` breaks twice: the link is broken for users, and it silently
+disables `scrape-logos`, which derives a broadcaster logo *from* the homepage.
+`check-catalog` only validates URL *syntax*, so dead homepages sail through (the
+SRF family had all six `/audio/<slug>` homepages 404-ing — #469/#470).
+
+`npm run check-homepages` fetches each publishable station's homepage (deduped
+by URL, ~18.5k unique), follows redirects with a real browser User-Agent, and
+classifies the result: `ok` · `dead` (4xx — actionable, breaks scraping) ·
+`blocked` (401/403/429 — auth/geo/rate, page may be fine) · `server-error` (5xx)
+· `error` (DNS/TLS/timeout). It is a **periodic/curation gate, not a per-build
+CI check** — a full run is a real network job. Non-blocking by default;
+`--strict` exits non-zero when any homepage is `dead`.
+
+```bash
+npm run check-homepages -- --cc CH            # one country (171 stations)
+npm run check-homepages -- --cc DE --strict   # gate a country in CI/curation
+npm run check-homepages -- --only id1,id2     # specific stations
+npm run check-homepages -- --limit 500        # quick sample
+npm run check-homepages -- --force            # ignore cache, recheck all
+```
+
+Results cache to `.cache/homepage-status.json` (gitignored); rows younger than
+`--stale-days` (default 7) are reused, so country batches are resumable. A `dead`
+homepage is a curation lead: find the live URL (often the broadcaster's own
+programme page — for SRG the integration layer's `timeTableUrl`) and update the
+YAML, then regenerate the catalog.
+
 ## Adding a station that fits an existing fetcher
 
 Existing fetchers cover Grrif, ORF (any channel via metadataUrl), BR (any channel via metadataUrl), plus generic ICY-over-fetch as fallback.

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "check-duplicates": "node tools/check-duplicates.mjs",
     "detect-families": "node tools/detect-families.mjs",
     "check-catalog": "node tools/check-catalog.mjs",
+    "check-homepages": "node tools/check-homepages.mjs",
     "build-sources": "node tools/build-sources.mjs",
     "auto-curate": "node tools/auto-curate.mjs",
     "import-playable": "node tools/import-playable-candidates.mjs",

--- a/tools/check-homepages.mjs
+++ b/tools/check-homepages.mjs
@@ -1,0 +1,247 @@
+#!/usr/bin/env node
+/**
+ * Homepage liveness gate (issue #470).
+ *
+ * `check-catalog.mjs` validates that `homepage` is a syntactically valid
+ * http(s) URL, but never fetches it — so a dead homepage sails through. That
+ * bites twice: the link is broken for users, and it silently disables
+ * `scrape-logos`, which derives a broadcaster logo *from* the homepage. The
+ * SRF family (#469) had all six `/audio/<slug>` homepages 404-ing for exactly
+ * this reason.
+ *
+ * This tool fetches each publishable station's homepage (deduped by URL),
+ * follows redirects with a real browser User-Agent, and classifies the result.
+ * It is a PERIODIC / CURATION gate, not a per-build CI check: ~18.5k unique
+ * homepages means a full run is a real network job. Non-blocking by default;
+ * `--strict` exits non-zero when any homepage is genuinely dead (4xx).
+ *
+ *   npm run check-homepages -- --cc CH            # one country
+ *   npm run check-homepages -- --only id1,id2     # specific stations
+ *   npm run check-homepages -- --cc DE --strict   # gate a country
+ *   npm run check-homepages -- --limit 500        # quick sample
+ *   npm run check-homepages -- --force            # ignore cache, recheck all
+ *
+ * Reads `public/stations.json`. Caches results in `.cache/homepage-status.json`
+ * (gitignored); cached rows younger than `--stale-days` (default 7) are reused.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { CLASS, STRICT_FAIL, classifyStatus, classifyError, isRetryable } from './lib/homepage-status.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+const CATALOG = path.join(ROOT, 'public', 'stations.json');
+const CACHE_DIR = path.join(ROOT, '.cache');
+const OUT = path.join(CACHE_DIR, 'homepage-status.json');
+
+const UA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_5) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.1.15';
+
+const RETRIES = 2; // extra attempts on transient failures (5xx / timeout / 429)
+
+const args = parseArgs(process.argv.slice(2));
+
+function parseArgs(argv) {
+  const out = {
+    cc: null,
+    only: new Set(),
+    limit: 0,
+    concurrency: 16,
+    timeout: 10000,
+    staleDays: 7,
+    cache: true,
+    strict: false,
+    json: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--cc') out.cc = String(argv[++i] ?? '').toUpperCase();
+    else if (a === '--only' || a === '--id') for (const id of (argv[++i] ?? '').split(',').map((s) => s.trim()).filter(Boolean)) out.only.add(id);
+    else if (a === '--limit') out.limit = Number(argv[++i]) || 0;
+    else if (a === '--concurrency') out.concurrency = Math.max(1, Number(argv[++i]) || 16);
+    else if (a === '--timeout') out.timeout = Math.max(1000, Number(argv[++i]) || 10000);
+    else if (a === '--stale-days') out.staleDays = Math.max(0, Number(argv[++i]) || 0);
+    else if (a === '--no-cache' || a === '--force') out.cache = false;
+    else if (a === '--strict') out.strict = true;
+    else if (a === '--json') out.json = true;
+    else if (a === '--help' || a === '-h') {
+      console.log('usage: check-homepages [--cc XX] [--only id,…] [--limit N] [--concurrency N] [--timeout MS] [--stale-days N] [--no-cache|--force] [--strict] [--json]');
+      process.exit(0);
+    } else {
+      console.error(`unknown arg: ${a}`);
+      process.exit(2);
+    }
+  }
+  return out;
+}
+
+function loadCatalog() {
+  const raw = JSON.parse(fs.readFileSync(CATALOG, 'utf8'));
+  return raw.stations ?? [];
+}
+
+function loadCache() {
+  if (!args.cache || !fs.existsSync(OUT)) return new Map();
+  try {
+    const raw = JSON.parse(fs.readFileSync(OUT, 'utf8'));
+    const map = new Map();
+    for (const [url, row] of Object.entries(raw.urls ?? {})) map.set(url, row);
+    return map;
+  } catch {
+    return new Map();
+  }
+}
+
+function isFresh(row, nowMs) {
+  if (!row?.checkedAt) return false;
+  const age = nowMs - Date.parse(row.checkedAt);
+  return Number.isFinite(age) && age >= 0 && age < args.staleDays * 86400_000;
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function probeUrl(url) {
+  for (let attempt = 0; ; attempt++) {
+    const ctl = new AbortController();
+    const timer = setTimeout(() => ctl.abort(), args.timeout);
+    try {
+      const res = await fetch(url, {
+        method: 'GET',
+        redirect: 'follow',
+        signal: ctl.signal,
+        headers: { 'User-Agent': UA, Accept: 'text/html,application/xhtml+xml,*/*' },
+      });
+      clearTimeout(timer);
+      try { await res.body?.cancel(); } catch { /* already consumed */ }
+      const klass = classifyStatus(res.status);
+      if (isRetryable(klass, res.status) && attempt < RETRIES) {
+        await sleep(300 * (attempt + 1) + Math.floor(Math.random() * 200));
+        continue;
+      }
+      const row = { status: res.status, class: klass, checkedAt: new Date().toISOString() };
+      if (res.redirected && res.url && res.url !== url) row.finalUrl = res.url;
+      return row;
+    } catch (e) {
+      clearTimeout(timer);
+      const reason = classifyError(e);
+      if (attempt < RETRIES) {
+        await sleep(300 * (attempt + 1) + Math.floor(Math.random() * 200));
+        continue;
+      }
+      return { status: 0, class: CLASS.ERROR, reason, checkedAt: new Date().toISOString() };
+    }
+  }
+}
+
+async function runPool(items, worker, concurrency) {
+  let next = 0;
+  let done = 0;
+  const total = items.length;
+  const lanes = Array.from({ length: Math.min(concurrency, total) }, async () => {
+    while (true) {
+      const i = next++;
+      if (i >= total) return;
+      await worker(items[i], i);
+      done++;
+      if (done % 25 === 0 || done === total) process.stderr.write(`\r  checked ${done}/${total}`);
+    }
+  });
+  await Promise.all(lanes);
+  if (total) process.stderr.write('\n');
+}
+
+function pad(s, n) {
+  s = String(s);
+  return s.length >= n ? s : s + ' '.repeat(n - s.length);
+}
+
+async function main() {
+  const catalog = loadCatalog();
+  const cache = loadCache();
+  const nowMs = Date.now();
+
+  let stations = catalog.filter((s) => s.homepage);
+  if (args.cc) stations = stations.filter((s) => (s.country ?? '').toUpperCase() === args.cc);
+  if (args.only.size) stations = stations.filter((s) => args.only.has(s.id));
+  if (args.limit > 0) stations = stations.slice(0, args.limit);
+
+  // Dedupe: one probe per unique homepage URL, mapped back to every station.
+  const byUrl = new Map();
+  for (const s of stations) {
+    if (!byUrl.has(s.homepage)) byUrl.set(s.homepage, []);
+    byUrl.get(s.homepage).push(s);
+  }
+  const urls = [...byUrl.keys()];
+
+  const results = new Map(); // url -> row
+  const toProbe = [];
+  for (const url of urls) {
+    const cached = cache.get(url);
+    if (isFresh(cached, nowMs)) results.set(url, cached);
+    else toProbe.push(url);
+  }
+
+  console.log(
+    `check-homepages: ${stations.length} station(s) · ${urls.length} unique homepage(s) · ` +
+      `${results.size} cached · ${toProbe.length} to probe` +
+      (args.cc ? ` · cc=${args.cc}` : '') + (args.strict ? ' · STRICT' : ''),
+  );
+
+  await runPool(toProbe, async (url) => { results.set(url, await probeUrl(url)); }, args.concurrency);
+
+  // Build station-level rows + class tallies.
+  const stationRows = [];
+  const classCounts = {};
+  const deadByCountry = {};
+  for (const s of stations) {
+    const r = results.get(s.homepage);
+    if (!r) continue;
+    classCounts[r.class] = (classCounts[r.class] ?? 0) + 1;
+    const row = { id: s.id, name: s.name, country: s.country ?? '', homepage: s.homepage, status: r.status, class: r.class };
+    if (r.reason) row.reason = r.reason;
+    if (r.finalUrl) row.finalUrl = r.finalUrl;
+    stationRows.push(row);
+    if (r.class === CLASS.DEAD) deadByCountry[row.country] = (deadByCountry[row.country] ?? 0) + 1;
+  }
+
+  // Persist a fresh cache (merge: keep untouched cached URLs so big runs are
+  // resumable across country batches) plus a curation-facing stations list.
+  const urlsOut = {};
+  for (const [url, row] of cache) urlsOut[url] = row; // carry over prior runs
+  for (const [url, row] of results) urlsOut[url] = row; // overwrite with this run
+  fs.mkdirSync(CACHE_DIR, { recursive: true });
+  fs.writeFileSync(
+    OUT,
+    JSON.stringify({ generatedAt: new Date().toISOString(), staleDays: args.staleDays, stations: stationRows, urls: urlsOut }, null, 2),
+  );
+
+  if (args.json) {
+    console.log(JSON.stringify(stationRows.filter((r) => r.class !== CLASS.OK), null, 2));
+  } else {
+    const order = [CLASS.OK, CLASS.DEAD, CLASS.BLOCKED, CLASS.SERVER_ERROR, CLASS.ERROR, CLASS.REDIRECT];
+    console.log('  ' + order.filter((c) => classCounts[c]).map((c) => `${c} ${classCounts[c]}`).join(' · '));
+
+    const dead = stationRows.filter((r) => r.class === CLASS.DEAD).sort((a, b) => (a.country + a.id).localeCompare(b.country + b.id));
+    if (dead.length) {
+      console.log(`\n  DEAD homepages (${dead.length}) — these break logo scraping:`);
+      for (const r of dead.slice(0, 60)) {
+        console.log(`    ${pad(r.country, 3)} ${pad(r.id, 34)} ${r.status}  ${r.homepage}`);
+      }
+      if (dead.length > 60) console.log(`    …and ${dead.length - 60} more (see .cache/homepage-status.json)`);
+      const topCc = Object.entries(deadByCountry).sort((a, b) => b[1] - a[1]).slice(0, 12);
+      if (topCc.length > 1) console.log('\n  dead by country: ' + topCc.map(([c, n]) => `${c}:${n}`).join(' '));
+    }
+    console.log(`\n  report → ${path.relative(ROOT, OUT)}`);
+  }
+
+  const strictFails = stationRows.filter((r) => STRICT_FAIL.has(r.class)).length;
+  if (args.strict && strictFails > 0) {
+    console.error(`check-homepages: ${strictFails} dead homepage(s) — strict gate failed`);
+    process.exit(1);
+  }
+}
+
+main().catch((err) => { console.error(err); process.exit(1); });

--- a/tools/lib/homepage-status.mjs
+++ b/tools/lib/homepage-status.mjs
@@ -1,0 +1,79 @@
+/**
+ * Pure classification of a homepage liveness probe into an actionable class.
+ *
+ * Split out from `tools/check-homepages.mjs` so the decision logic — the part
+ * worth getting right — is unit-tested without touching the network.
+ *
+ * Classes:
+ *   ok            final response 2xx (after following redirects)
+ *   dead          4xx that means "this page is gone / wrong" — 404, 410, 400,
+ *                 and other 4xx. THIS is the actionable signal: a dead homepage
+ *                 silently disables logo scraping (see #469/#470).
+ *   blocked       401 / 403 / 429 — auth-walled, geo-gated, or rate-limited.
+ *                 The page may well be fine for a real browser; not actionable
+ *                 on its own, so `--strict` does not fail on it.
+ *   server-error  5xx after retries — upstream is broken, but transiently maybe.
+ *   error         network-level failure (DNS, TLS, timeout, refused).
+ *   redirect      3xx surfaced to the caller (only when redirects aren't
+ *                 followed; the tool follows them, so this is mostly for tests).
+ */
+
+export const CLASS = Object.freeze({
+  OK: 'ok',
+  DEAD: 'dead',
+  BLOCKED: 'blocked',
+  SERVER_ERROR: 'server-error',
+  ERROR: 'error',
+  REDIRECT: 'redirect',
+});
+
+// Classes `--strict` treats as a gate failure. Only genuinely-dead pages —
+// not rate-limited, auth-walled, or transiently 5xx ones — block a strict run.
+export const STRICT_FAIL = Object.freeze(new Set([CLASS.DEAD]));
+
+/**
+ * Map an HTTP status code to a class.
+ * @param {number} status final status code (after redirects)
+ * @returns {string} one of CLASS.*
+ */
+export function classifyStatus(status) {
+  if (!Number.isFinite(status) || status <= 0) return CLASS.ERROR;
+  if (status >= 200 && status < 300) return CLASS.OK;
+  if (status >= 300 && status < 400) return CLASS.REDIRECT;
+  if (status === 401 || status === 403 || status === 429) return CLASS.BLOCKED;
+  if (status >= 400 && status < 500) return CLASS.DEAD;
+  if (status >= 500) return CLASS.SERVER_ERROR;
+  return CLASS.ERROR;
+}
+
+/**
+ * Normalise a thrown fetch error into a short, stable reason token so report
+ * rows are groupable (`timeout`, `dns`, `tls`, `refused`, `aborted`, `network`).
+ * @param {unknown} err
+ * @returns {string}
+ */
+export function classifyError(err) {
+  const msg = String(err?.message ?? err ?? '').toLowerCase();
+  const cause = String(err?.cause?.code ?? err?.cause?.message ?? '').toLowerCase();
+  const hay = `${msg} ${cause}`;
+  if (hay.includes('timeout') || hay.includes('timed out') || err?.name === 'TimeoutError') return 'timeout';
+  if (hay.includes('abort')) return 'timeout';
+  if (hay.includes('enotfound') || hay.includes('eai_again') || hay.includes('getaddrinfo') || hay.includes('dns')) return 'dns';
+  if (hay.includes('certificate') || hay.includes('tls') || hay.includes('ssl') || hay.includes('cert')) return 'tls';
+  if (hay.includes('econnrefused') || hay.includes('refused')) return 'refused';
+  if (hay.includes('econnreset') || hay.includes('reset')) return 'reset';
+  return 'network';
+}
+
+/**
+ * Whether a class/status pair is worth retrying — transient failures only.
+ * @param {string} klass one of CLASS.*
+ * @param {number} [status]
+ * @returns {boolean}
+ */
+export function isRetryable(klass, status) {
+  if (klass === CLASS.SERVER_ERROR) return true;
+  if (klass === CLASS.ERROR) return true; // timeout / reset / transient DNS
+  if (klass === CLASS.BLOCKED && status === 429) return true; // rate-limited
+  return false;
+}

--- a/tools/lib/homepage-status.test.mjs
+++ b/tools/lib/homepage-status.test.mjs
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { CLASS, STRICT_FAIL, classifyStatus, classifyError, isRetryable } from './homepage-status.mjs';
+
+describe('classifyStatus', () => {
+  it('treats 2xx as ok', () => {
+    for (const s of [200, 201, 204, 226]) expect(classifyStatus(s)).toBe(CLASS.OK);
+  });
+
+  it('treats 3xx as redirect (only surfaced when not following)', () => {
+    for (const s of [301, 302, 307, 308]) expect(classifyStatus(s)).toBe(CLASS.REDIRECT);
+  });
+
+  it('treats 404 / 410 / 400 and other 4xx as dead — the actionable signal', () => {
+    for (const s of [400, 404, 410, 451, 418]) expect(classifyStatus(s)).toBe(CLASS.DEAD);
+  });
+
+  it('treats 401 / 403 / 429 as blocked, not dead', () => {
+    for (const s of [401, 403, 429]) expect(classifyStatus(s)).toBe(CLASS.BLOCKED);
+  });
+
+  it('treats 5xx as server-error', () => {
+    for (const s of [500, 502, 503, 504]) expect(classifyStatus(s)).toBe(CLASS.SERVER_ERROR);
+  });
+
+  it('treats nonsense codes as error', () => {
+    for (const s of [0, -1, NaN, undefined]) expect(classifyStatus(s)).toBe(CLASS.ERROR);
+  });
+});
+
+describe('STRICT_FAIL', () => {
+  it('fails strict only on dead — not blocked / server-error / error', () => {
+    expect(STRICT_FAIL.has(CLASS.DEAD)).toBe(true);
+    expect(STRICT_FAIL.has(CLASS.BLOCKED)).toBe(false);
+    expect(STRICT_FAIL.has(CLASS.SERVER_ERROR)).toBe(false);
+    expect(STRICT_FAIL.has(CLASS.ERROR)).toBe(false);
+    expect(STRICT_FAIL.has(CLASS.OK)).toBe(false);
+  });
+});
+
+describe('classifyError', () => {
+  it('detects timeouts and aborts', () => {
+    expect(classifyError({ name: 'TimeoutError', message: 'The operation timed out' })).toBe('timeout');
+    expect(classifyError(new Error('This operation was aborted'))).toBe('timeout');
+  });
+
+  it('detects DNS failures', () => {
+    expect(classifyError({ message: 'fetch failed', cause: { code: 'ENOTFOUND' } })).toBe('dns');
+    expect(classifyError(new Error('getaddrinfo EAI_AGAIN example.com'))).toBe('dns');
+  });
+
+  it('detects TLS and connection errors', () => {
+    expect(classifyError(new Error('unable to verify the first certificate'))).toBe('tls');
+    expect(classifyError({ message: 'fetch failed', cause: { code: 'ECONNREFUSED' } })).toBe('refused');
+    expect(classifyError({ message: 'fetch failed', cause: { code: 'ECONNRESET' } })).toBe('reset');
+  });
+
+  it('falls back to network for anything unrecognised', () => {
+    expect(classifyError(new Error('something weird'))).toBe('network');
+    expect(classifyError(null)).toBe('network');
+  });
+});
+
+describe('isRetryable', () => {
+  it('retries server errors, network errors, and 429', () => {
+    expect(isRetryable(CLASS.SERVER_ERROR)).toBe(true);
+    expect(isRetryable(CLASS.ERROR)).toBe(true);
+    expect(isRetryable(CLASS.BLOCKED, 429)).toBe(true);
+  });
+
+  it('does not retry dead, ok, or non-429 blocked', () => {
+    expect(isRetryable(CLASS.DEAD, 404)).toBe(false);
+    expect(isRetryable(CLASS.OK, 200)).toBe(false);
+    expect(isRetryable(CLASS.BLOCKED, 403)).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #470 (Phase 3 of the clean-station-process effort started in #469).

## Problem

`check-catalog` validates that `homepage` is a *syntactically* valid URL, but never fetches it — so dead homepages sail through. They break twice: the link is dead for users, and a dead homepage **silently disables `scrape-logos`**, which derives a broadcaster logo *from* the homepage. The SRF family (#469) had all six `/audio/<slug>` homepages 404-ing for exactly this reason.

## What this adds

`npm run check-homepages` — fetches each publishable station's homepage (deduped by URL → ~18.5k unique), follows redirects with a real browser User-Agent, and classifies:

| class | meaning | `--strict` fails? |
|---|---|---|
| `ok` | 2xx after redirects | no |
| **`dead`** | 4xx (404/410/400/…) — actionable, breaks scraping | **yes** |
| `blocked` | 401/403/429 — auth/geo/rate, page may be fine | no |
| `server-error` | 5xx after retries | no |
| `error` | DNS/TLS/timeout | no |

It is a **periodic/curation gate, not a per-build CI check** (a full run is a real network job), so it lives as a standalone tool rather than inside the offline `check-catalog`. Non-blocking by default; `--strict` exits non-zero on any dead homepage.

**Scope flags:** `--cc`, `--only`/`--id`, `--limit`, `--concurrency`, `--timeout`, `--stale-days`, `--no-cache`/`--force`, `--strict`, `--json`. Results cache to gitignored `.cache/homepage-status.json` (rows younger than `--stale-days`, default 7, are reused → country batches are resumable).

## Design

- Classification core is a **pure, unit-tested lib** (`tools/lib/homepage-status.mjs` + `.test.mjs`, 13 tests) matching the repo's `image-header.mjs` convention — the part worth getting right is tested without the network.
- Dedupe by URL; one probe maps back to every station sharing the homepage.
- Browser UA + GET (body cancelled after headers) + follow redirects + AbortController timeout + bounded retries on transient (5xx/timeout/429).

## Demonstrated (CH, 171 stations)

```
ok 145 · dead 12 · blocked 9 · server-error 1 · error 4
```
The dead set includes **all RTS and RSI siblings** (404) — confirming the #473 hypothesis — plus `ch-radio-bern1`, `ch-energy-basel`, `ch-my105-x-mas-radio-aac`, `ch-radio-32-goldies`, `ch-diks`. `--strict` returns exit 1 on this set, exit 0 on the (now-fixed) SRF set.

## Verification
`npm test -- --run tools/` → 162 passed (incl. 13 new) · `git diff --check` clean. No generated artifacts touched (report is gitignored).

## Follow-up
These dead CH homepages are now curation leads for #473 (RTS/RSI) and a general homepage sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)