### PR TITLE
feat(logos): broadcaster-API logo harvester (SRG integration layer)

### DIFF
--- a/docs/logo-extraction.md
+++ b/docs/logo-extraction.md
@@ -40,7 +40,7 @@ and whether we can redistribute a bundled copy. They flow through to
 | Value | Set by |
 |---|---|
 | `broadcaster-site` | `scrape-logos` (HTML/manifest image from broadcaster homepage) |
-| `broadcaster-api` | image URL returned by a broadcaster metadata API |
+| `broadcaster-api` | `harvest-logos` (per-channel image URL from a broadcaster metadata API) |
 | `radio-browser` | imported from Radio Browser's favicon field |
 | `wiki` | `wiki-logos` (Wikipedia CC-licensed article image) |
 | `broadcaster` | bundled local PNG hand-curated from the broadcaster |
@@ -216,6 +216,30 @@ YAML insert/replace as `scrape-logos`. Report: `.cache/channel-art-report.json`
 
 After a real run, regenerate and verify exactly as for `scrape-logos` (catalog,
 favicon-variants, check-catalog, check-duplicates, build).
+
+## Broadcaster-API Logos (metadata-API channel art)
+
+When a broadcaster exposes per-channel art through the **same metadata API we
+already call for now-playing** (the SRG SSR integration layer is the proven
+case), `harvest-logos` beats scraping: the URLs are authoritative,
+broadcaster-hosted, and licence-clean, and the station → channel join is exact
+(by the id already in `metadataUrl`). See *Broadcaster-API logos* in
+`docs/operations.md` for the full workflow. In short:
+
+```bash
+npm run harvest-logos                          # missing-only (safe inserts)
+npm run harvest-logos -- --upgrade-generic     # + weak/site-default icons
+npm run harvest-logos -- --include-existing     # forced idempotent re-harvest
+npm run apply-logos -- --in internal/logos/broadcaster-api.json [--replace]
+```
+
+The join + write policy are pure and unit-tested in
+`tools/lib/broadcaster-logos.mjs`; add a broadcaster by adding an adapter there.
+`faviconSource: broadcaster-api`. Prefer this over `scrape-logos` /
+`scrape-channel-art` whenever a metadata API already serves the art. Caveat: the
+SRG `imageUrl` is a 16:9 branded card — busier than a wordmark for the list
+icon, so default policy leaves an existing good logo (e.g. SRF's Commons
+wordmarks) untouched.
 
 ## iOS-local Catalog: Favicon Inheritance
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -124,6 +124,45 @@ homepage is a curation lead: find the live URL (often the broadcaster's own
 programme page — for SRG the integration layer's `timeTableUrl`) and update the
 YAML, then regenerate the catalog.
 
+## Broadcaster-API logos (`harvest-logos`)
+
+Some broadcasters expose an authoritative, broadcaster-hosted, licence-clean
+per-channel logo through the **same metadata API we already call for now-playing
+data** — no scraping, no fragile Wikimedia dependence. `npm run harvest-logos`
+(`tools/harvest-broadcaster-logos.mjs`) codifies that join (#471): for each
+station matching an adapter it fetches the broadcaster's channel list, joins
+station → channel by the id already in `metadataUrl`, and emits an `apply-logos`
+patch (`faviconSource: broadcaster-api`, `faviconLicense: broadcaster`).
+
+First adapter: the **SRG SSR integration layer** (SRF / RTS / RSI / RTR), all
+sharing `il.srf.ch/integrationlayer/2.0/<net>/channelList/radio.json` and keying
+art by the same channel id as our `.../songList/radio/byChannel/<id>.json`. The
+pure join + policy classifier live in `tools/lib/broadcaster-logos.mjs`
+(unit-tested); the CLI only fetches and applies policy.
+
+The tool **never mutates `stations.yaml`** — it writes a patch you review, then
+apply. Write policy chooses which stations enter the patch:
+
+```bash
+npm run harvest-logos                          # default: stations with NO favicon (safe to insert)
+npm run harvest-logos -- --upgrade-generic     # + weak / site-default icons (the generic-shared-icon win)
+npm run harvest-logos -- --include-existing     # every matched station (forced idempotent re-harvest)
+npm run harvest-logos -- --adapter srg --cc CH  # scope to one adapter / country
+npm run harvest-logos -- --only id1,id2         # specific stations
+# review internal/logos/broadcaster-api.json (gitignored), then:
+npm run apply-logos -- --in internal/logos/broadcaster-api.json            # insert (fill missing)
+npm run apply-logos -- --in internal/logos/broadcaster-api.json --replace  # also overwrite existing
+```
+
+It is **idempotent**: `--include-existing` re-derives URLs identical to what's
+already in the catalog for stations already on broadcaster-API art (RTS/RSI),
+and flags them `patch(idempotent)`. Note the SRG `imageUrl` is a 16:9 branded
+card — great for the now-playing destination but busier than a wordmark for the
+list icon, which is why SRF deliberately keeps its clean Commons wordmarks
+(default policy leaves any existing good logo alone). To add a broadcaster, add
+an adapter to `tools/lib/broadcaster-logos.mjs` (`match` / `sources` / `index` /
+`resolve`); the SRG adapter is the template.
+
 ## Adding a station that fits an existing fetcher
 
 Existing fetchers cover Grrif, ORF (any channel via metadataUrl), BR (any channel via metadataUrl), plus generic ICY-over-fetch as fallback.

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "scrape-logos": "node tools/scrape-logos.mjs",
     "scrape-channel-art": "node tools/scrape-channel-art.mjs",
     "apply-logos": "node tools/apply-logos.mjs",
+    "harvest-logos": "node tools/harvest-broadcaster-logos.mjs",
     "wiki-logos": "node tools/wiki-logos.mjs",
     "http-upgrade": "node tools/http-upgrade.mjs",
     "curation-db:init": "node tools/curation-db.mjs init",

--- a/tools/harvest-broadcaster-logos.mjs
+++ b/tools/harvest-broadcaster-logos.mjs
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+/**
+ * Broadcaster-API logo harvester (issue #471).
+ *
+ * Turns the by-hand SRG logo fix (#469/#473) into a repeatable tool. For each
+ * broadcaster with a metadata adapter, fetch the authoritative per-channel
+ * `imageUrl` straight from the broadcaster's own API and emit an `apply-logos`
+ * patch — broadcaster-hosted, licence-clean, deterministic, idempotent. Drives
+ * down the fragile non-free-Wikipedia dependence.
+ *
+ * The join is pure (`tools/lib/broadcaster-logos.mjs`); this CLI only fetches
+ * the source documents, applies the write policy, and writes the patch. It does
+ * NOT mutate `data/stations.yaml` — review the patch, then:
+ *
+ *   npm run apply-logos -- --in internal/logos/broadcaster-api.json            # insert (fill missing)
+ *   npm run apply-logos -- --in internal/logos/broadcaster-api.json --replace  # also overwrite existing
+ *
+ * Write policy (which stations enter the patch):
+ *   default            → stations with NO favicon (safe to insert)
+ *   --upgrade-generic  → + stations on a weak / site-default icon
+ *   --include-existing → every matched station (forced idempotent re-harvest)
+ *
+ *   npm run harvest-logos                          # all adapters, missing only
+ *   npm run harvest-logos -- --adapter srg --cc CH # one adapter / country
+ *   npm run harvest-logos -- --only id1,id2        # specific stations
+ *   npm run harvest-logos -- --include-existing    # re-harvest the whole set
+ *   npm run harvest-logos -- --json                # machine-readable summary
+ *
+ * Reads `data/stations.yaml` (the authoring source the patch is applied back
+ * into). Network-read-only.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parse as parseYaml } from 'yaml';
+
+import { ADAPTERS, POLICY, faviconState, getAdapter, policyIncludes } from './lib/broadcaster-logos.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+const STATIONS = path.join(ROOT, 'data', 'stations.yaml');
+const DEFAULT_OUT = path.join(ROOT, 'internal', 'logos', 'broadcaster-api.json');
+
+const UA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_5) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.1.15';
+const TIMEOUT_MS = 15000;
+
+const args = parseArgs(process.argv.slice(2));
+
+function parseArgs(argv) {
+  const out = { adapter: null, cc: null, only: new Set(), out: DEFAULT_OUT, policy: POLICY.MISSING, json: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--adapter') out.adapter = String(argv[++i] ?? '').toLowerCase();
+    else if (a === '--cc') out.cc = String(argv[++i] ?? '').toUpperCase();
+    else if (a === '--only' || a === '--id')
+      for (const id of (argv[++i] ?? '').split(',').map((s) => s.trim()).filter(Boolean)) out.only.add(id);
+    else if (a === '--out') out.out = path.resolve(ROOT, String(argv[++i] ?? DEFAULT_OUT));
+    else if (a === '--upgrade-generic') out.policy = POLICY.GENERIC;
+    else if (a === '--include-existing' || a === '--all') out.policy = POLICY.ALL;
+    else if (a === '--json') out.json = true;
+    else if (a === '--help' || a === '-h') {
+      console.log(
+        'usage: harvest-broadcaster-logos [--adapter srg] [--cc XX] [--only id,…] [--out path]\n' +
+          '                                [--upgrade-generic | --include-existing] [--json]',
+      );
+      process.exit(0);
+    } else {
+      console.error(`unknown arg: ${a}`);
+      process.exit(2);
+    }
+  }
+  return out;
+}
+
+function loadStations() {
+  const parsed = parseYaml(fs.readFileSync(STATIONS, 'utf8'));
+  if (!Array.isArray(parsed)) {
+    console.error('harvest-broadcaster-logos: stations.yaml is not a list');
+    process.exit(1);
+  }
+  return parsed.filter((s) => s?.id);
+}
+
+function selectStations(all) {
+  let xs = all;
+  if (args.only.size) xs = xs.filter((s) => args.only.has(s.id));
+  if (args.cc) xs = xs.filter((s) => String(s.country ?? '').toUpperCase() === args.cc);
+  return xs;
+}
+
+async function fetchJson(url) {
+  const ctl = new AbortController();
+  const timer = setTimeout(() => ctl.abort(), TIMEOUT_MS);
+  try {
+    const res = await fetch(url, { signal: ctl.signal, redirect: 'follow', headers: { 'User-Agent': UA, Accept: 'application/json,*/*' } });
+    if (!res.ok) return { ok: false, reason: `HTTP ${res.status}` };
+    return { ok: true, json: await res.json() };
+  } catch (err) {
+    return { ok: false, reason: String(err?.message ?? err).slice(0, 80) };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function harvestAdapter(adapter, stations) {
+  const matched = stations.filter((s) => adapter.match(s));
+  if (!matched.length) return { adapter: adapter.name, matched: 0, entries: [], rows: [], fetchErrors: [] };
+
+  // One fetch per source document, indexed per net.
+  const indexByNet = new Map();
+  const fetchErrors = [];
+  for (const { net, url } of adapter.sources(matched)) {
+    const res = await fetchJson(url);
+    if (!res.ok) {
+      fetchErrors.push({ net, url, reason: res.reason });
+      continue;
+    }
+    indexByNet.set(net, adapter.index(net, res.json));
+  }
+
+  const entries = [];
+  const rows = [];
+  for (const s of matched) {
+    const resolved = adapter.resolve(s, indexByNet);
+    const state = faviconState(s);
+    if (!resolved) {
+      rows.push({ id: s.id, state, action: 'unresolved' });
+      continue;
+    }
+    const included = policyIncludes(args.policy, state);
+    const sameAsCurrent = s.favicon === resolved.url;
+    rows.push({
+      id: s.id,
+      state,
+      url: resolved.url,
+      action: included ? (sameAsCurrent ? 'patch(idempotent)' : state === 'missing' ? 'patch(insert)' : 'patch(replace)') : 'hold',
+    });
+    if (included) entries.push(resolved);
+  }
+  return { adapter: adapter.name, matched: matched.length, entries, rows, fetchErrors };
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+
+const adapters = args.adapter ? [getAdapter(args.adapter)].filter(Boolean) : ADAPTERS;
+if (args.adapter && !adapters.length) {
+  console.error(`harvest-broadcaster-logos: unknown adapter "${args.adapter}" (have: ${ADAPTERS.map((a) => a.name).join(', ')})`);
+  process.exit(2);
+}
+
+const stations = selectStations(loadStations());
+const results = [];
+for (const adapter of adapters) results.push(await harvestAdapter(adapter, stations));
+
+const patch = results.flatMap((r) => r.entries);
+
+// De-dupe by id (an adapter resolves each station once, but guard regardless).
+const byId = new Map();
+for (const e of patch) byId.set(e.id, e);
+const finalPatch = [...byId.values()];
+
+fs.mkdirSync(path.dirname(args.out), { recursive: true });
+fs.writeFileSync(args.out, JSON.stringify(finalPatch, null, 2) + '\n');
+
+if (args.json) {
+  console.log(JSON.stringify({ policy: args.policy, out: path.relative(ROOT, args.out), results }, null, 2));
+} else {
+  for (const r of results) {
+    const counts = r.rows.reduce((m, row) => ((m[row.action] = (m[row.action] ?? 0) + 1), m), {});
+    console.log(`\n[${r.adapter}] matched ${r.matched} station(s) · policy=${args.policy}`);
+    for (const e of r.fetchErrors) console.warn(`  ! fetch ${e.net} failed: ${e.reason}`);
+    for (const row of r.rows) {
+      const mark = row.action.startsWith('patch') ? '✓' : row.action === 'hold' ? '·' : '!';
+      console.log(`  ${mark} ${row.id.padEnd(34)} ${row.state.padEnd(8)} ${row.action}${row.url ? '  ' + row.url : ''}`);
+    }
+    console.log(`  → ${Object.entries(counts).map(([k, v]) => `${v} ${k}`).join(', ') || 'nothing'}`);
+  }
+  console.log(`\nwrote ${finalPatch.length} patch entr${finalPatch.length === 1 ? 'y' : 'ies'} → ${path.relative(ROOT, args.out)}`);
+  if (finalPatch.length) {
+    console.log(`apply with:  npm run apply-logos -- --in ${path.relative(ROOT, args.out)}${args.policy === POLICY.MISSING ? '' : ' --replace'}`);
+  }
+}

--- a/tools/lib/broadcaster-logos.mjs
+++ b/tools/lib/broadcaster-logos.mjs
@@ -1,0 +1,157 @@
+/**
+ * Broadcaster-API logo harvesting — pure, network-free core (issue #471).
+ *
+ * Some broadcasters expose an authoritative, broadcaster-hosted, licence-clean
+ * per-channel logo through the very same metadata API we already call for
+ * now-playing data. This module codifies the *join* — station → channel record
+ * → image URL — and the policy classifier, so a thin CLI
+ * (`tools/harvest-broadcaster-logos.mjs`) can fetch the source documents and
+ * emit an `apply-logos` patch without any business logic of its own.
+ *
+ * First adapter: the SRG SSR integration layer (SRF / RTS / RSI / RTR), all of
+ * which share `il.srf.ch/integrationlayer/2.0/<net>/channelList/radio.json` and
+ * key per-channel art by the same id we already store in `metadataUrl`.
+ *
+ * An adapter is `{ name, sources(stations), match(station), index(net, json),
+ * resolve(station, indexByNet) }`:
+ *   - sources(stations) → the channelList documents the CLI must fetch, as
+ *     `[{ net, url }]`, deduped to the nets actually present in the catalog.
+ *   - match(station)    → a truthy key when the station belongs to the adapter.
+ *   - index(net, json)  → Map<channelId, channelRecord> from a fetched document.
+ *   - resolve(...)      → an apply-logos patch entry, or null when unmatched.
+ */
+
+export const SRG_NETS = ['srf', 'rts', 'rsi', 'rtr'];
+
+// `.../integrationlayer/2.0/<net>/songList/radio/byChannel/<channelId>.json`
+const SRG_METADATA_RE =
+  /^https?:\/\/il\.srf\.ch\/integrationlayer\/2\.0\/(srf|rts|rsi|rtr)\/songList\/radio\/byChannel\/([^/]+)\.json$/i;
+
+/** Extract `{ net, channelId }` from an SRG songList metadataUrl, else null. */
+export function parseSrgMetadataUrl(url) {
+  if (typeof url !== 'string') return null;
+  const m = url.match(SRG_METADATA_RE);
+  if (!m) return null;
+  return { net: m[1].toLowerCase(), channelId: m[2] };
+}
+
+/** The channelList document for a net (all per-channel art in one fetch). */
+export function srgChannelListUrl(net) {
+  return `https://il.srf.ch/integrationlayer/2.0/${net}/channelList/radio.json`;
+}
+
+/**
+ * Build `Map<channelId, record>` from a fetched channelList document. Channels
+ * without a usable string `imageUrl` (e.g. podcast placeholders) are dropped so
+ * the join can only ever resolve real art.
+ */
+export function indexSrgChannelList(json) {
+  const list = Array.isArray(json?.channelList) ? json.channelList : [];
+  const out = new Map();
+  for (const c of list) {
+    if (c?.id == null) continue;
+    if (typeof c.imageUrl !== 'string' || !c.imageUrl.trim()) continue;
+    const id = String(c.id);
+    out.set(id, {
+      channelId: id,
+      title: typeof c.title === 'string' ? c.title : '',
+      imageUrl: c.imageUrl.trim(),
+      imageTitle: typeof c.imageTitle === 'string' ? c.imageTitle : '',
+      timeTableUrl: typeof c.timeTableUrl === 'string' ? c.timeTableUrl : '',
+    });
+  }
+  return out;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Policy: is the station's current logo worth replacing?
+// ─────────────────────────────────────────────────────────────────────────
+
+/** faviconSource values that mark a non-specific, replaceable logo. */
+const WEAK_FAVICON_SOURCES = new Set(['radio-browser', 'catalog-family-brand']);
+
+/** URL tails that look like a site-wide default rather than a station mark. */
+const GENERIC_FAVICON_PATH_RE = /\/(favicon(\.ico|[-._][^/]*\.(png|jpe?g|webp|gif))?|apple-touch-icon[^/]*)$/i;
+
+/**
+ * Classify a station's existing logo into the policy tiers the harvester acts
+ * on: `missing` (no favicon at all), `generic` (a weak/site-default icon worth
+ * upgrading), or `good` (a deliberate per-station logo we leave alone unless
+ * forced). Pure — reads only `favicon` / `faviconSource`.
+ */
+export function faviconState(station) {
+  const fav = station?.favicon;
+  if (typeof fav !== 'string' || !fav.trim()) return 'missing';
+  const src = typeof station?.faviconSource === 'string' ? station.faviconSource : '';
+  if (!src || WEAK_FAVICON_SOURCES.has(src)) return 'generic';
+  if (GENERIC_FAVICON_PATH_RE.test(fav)) return 'generic';
+  return 'good';
+}
+
+/** Policy tiers in increasing aggressiveness — the CLI maps a flag to one. */
+export const POLICY = {
+  MISSING: 'missing', // only stations with no favicon
+  GENERIC: 'generic', // + weak / site-default icons
+  ALL: 'all', // every matched station (forced re-harvest)
+};
+
+/** Does `state` fall within the chosen policy's write set? */
+export function policyIncludes(policy, state) {
+  if (policy === POLICY.ALL) return true;
+  if (policy === POLICY.GENERIC) return state === 'missing' || state === 'generic';
+  return state === 'missing';
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// SRG adapter
+// ─────────────────────────────────────────────────────────────────────────
+
+export const srgAdapter = {
+  name: 'srg',
+
+  match(station) {
+    return parseSrgMetadataUrl(station?.metadataUrl ?? '');
+  },
+
+  /** The channelList docs to fetch — only the nets present in `stations`. */
+  sources(stations) {
+    const nets = new Set();
+    for (const s of stations ?? []) {
+      const key = this.match(s);
+      if (key) nets.add(key.net);
+    }
+    return [...nets].sort().map((net) => ({ net, url: srgChannelListUrl(net) }));
+  },
+
+  index(_net, json) {
+    return indexSrgChannelList(json);
+  },
+
+  /**
+   * Resolve an apply-logos patch entry for a station, given `indexByNet`
+   * (`Map<net, Map<channelId, record>>`). Returns null when the station is
+   * not SRG or its channel id isn't in the fetched list.
+   */
+  resolve(station, indexByNet) {
+    const key = this.match(station);
+    if (!key) return null;
+    const rec = indexByNet.get(key.net)?.get(key.channelId);
+    if (!rec) return null;
+    return {
+      id: station.id,
+      url: rec.imageUrl,
+      source: 'broadcaster-api',
+      sourceType: 'cdn',
+      license: 'broadcaster',
+      sourceUrl: srgChannelListUrl(key.net),
+    };
+  },
+};
+
+export const ADAPTERS = [srgAdapter];
+
+/** Look up an adapter by name (case-insensitive), or null. */
+export function getAdapter(name) {
+  const n = String(name ?? '').toLowerCase();
+  return ADAPTERS.find((a) => a.name === n) ?? null;
+}

--- a/tools/lib/broadcaster-logos.test.mjs
+++ b/tools/lib/broadcaster-logos.test.mjs
@@ -1,0 +1,170 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ADAPTERS,
+  POLICY,
+  faviconState,
+  getAdapter,
+  indexSrgChannelList,
+  parseSrgMetadataUrl,
+  policyIncludes,
+  srgAdapter,
+  srgChannelListUrl,
+} from './broadcaster-logos.mjs';
+
+describe('parseSrgMetadataUrl', () => {
+  it('extracts net + hex channel id (SRF/RTS/RTR style)', () => {
+    expect(
+      parseSrgMetadataUrl(
+        'https://il.srf.ch/integrationlayer/2.0/srf/songList/radio/byChannel/69e8ac16-4327-4af4-b873-fd5cd6e895a7.json',
+      ),
+    ).toEqual({ net: 'srf', channelId: '69e8ac16-4327-4af4-b873-fd5cd6e895a7' });
+    expect(
+      parseSrgMetadataUrl(
+        'https://il.srf.ch/integrationlayer/2.0/rts/songList/radio/byChannel/a9e7621504c6959e35c3ecbe7f6bed0446cdf8da.json',
+      ),
+    ).toEqual({ net: 'rts', channelId: 'a9e7621504c6959e35c3ecbe7f6bed0446cdf8da' });
+  });
+
+  it('extracts net + slug channel id (RSI style)', () => {
+    expect(
+      parseSrgMetadataUrl('https://il.srf.ch/integrationlayer/2.0/rsi/songList/radio/byChannel/rete-uno.json'),
+    ).toEqual({ net: 'rsi', channelId: 'rete-uno' });
+  });
+
+  it('rejects non-SRG and malformed urls', () => {
+    expect(parseSrgMetadataUrl('https://api.radiofrance.fr/livemeta/live/1/inter_player')).toBeNull();
+    expect(parseSrgMetadataUrl('https://il.srf.ch/integrationlayer/2.0/xx/songList/radio/byChannel/a.json')).toBeNull();
+    expect(parseSrgMetadataUrl('https://il.srf.ch/integrationlayer/2.0/srf/songList/radio/byChannel/.json')).toBeNull();
+    expect(parseSrgMetadataUrl('')).toBeNull();
+    expect(parseSrgMetadataUrl(null)).toBeNull();
+    expect(parseSrgMetadataUrl(42)).toBeNull();
+  });
+});
+
+describe('srgChannelListUrl', () => {
+  it('builds the per-net channelList endpoint', () => {
+    expect(srgChannelListUrl('rsi')).toBe('https://il.srf.ch/integrationlayer/2.0/rsi/channelList/radio.json');
+  });
+});
+
+describe('indexSrgChannelList', () => {
+  const doc = {
+    channelList: [
+      { id: 'rete-uno', title: 'Rete Uno', imageUrl: 'https://il.rsi.ch/.../rete-uno.png', imageTitle: 'Rete Uno Logo', timeTableUrl: '' },
+      { id: 'rete-due', title: 'Rete Due', imageUrl: '  https://il.rsi.ch/.../rete-due.png  ' },
+      { id: 'podcast', title: 'RSI Podcast', imageUrl: '' }, // no usable art → dropped
+      { id: 'broken', title: 'No image field' }, // missing imageUrl → dropped
+    ],
+  };
+
+  it('keys real channel art by id and trims the url', () => {
+    const idx = indexSrgChannelList(doc);
+    expect(idx.size).toBe(2);
+    expect(idx.get('rete-uno').imageUrl).toBe('https://il.rsi.ch/.../rete-uno.png');
+    expect(idx.get('rete-due').imageUrl).toBe('https://il.rsi.ch/.../rete-due.png');
+    expect(idx.get('rete-uno').timeTableUrl).toBe('');
+  });
+
+  it('drops channels without usable image urls', () => {
+    const idx = indexSrgChannelList(doc);
+    expect(idx.has('podcast')).toBe(false);
+    expect(idx.has('broken')).toBe(false);
+  });
+
+  it('tolerates missing / non-array documents', () => {
+    expect(indexSrgChannelList(null).size).toBe(0);
+    expect(indexSrgChannelList({}).size).toBe(0);
+    expect(indexSrgChannelList({ channelList: 'nope' }).size).toBe(0);
+  });
+});
+
+describe('faviconState', () => {
+  it('flags a station with no favicon as missing', () => {
+    expect(faviconState({})).toBe('missing');
+    expect(faviconState({ favicon: '   ' })).toBe('missing');
+    expect(faviconState({ favicon: 7 })).toBe('missing');
+  });
+
+  it('flags weak sources and site-default paths as generic', () => {
+    expect(faviconState({ favicon: 'https://x/a.png', faviconSource: 'radio-browser' })).toBe('generic');
+    expect(faviconState({ favicon: 'https://x/a.png', faviconSource: 'catalog-family-brand' })).toBe('generic');
+    expect(faviconState({ favicon: 'https://x/a.png' })).toBe('generic'); // no source
+    expect(faviconState({ favicon: 'https://example.com/favicon.ico', faviconSource: 'broadcaster-site' })).toBe('generic');
+    expect(faviconState({ favicon: 'https://example.com/apple-touch-icon-180.png', faviconSource: 'wiki' })).toBe('generic');
+  });
+
+  it('treats deliberate per-station logos as good', () => {
+    expect(faviconState({ favicon: 'https://upload.wikimedia.org/.../Logo_SRF_1.svg.png', faviconSource: 'wiki' })).toBe('good');
+    expect(faviconState({ favicon: 'https://img.rts.ch/articles/2020/image/4kb71i.image', faviconSource: 'broadcaster-api' })).toBe('good');
+    expect(faviconState({ favicon: 'stations/builtin-rtr.png', faviconSource: 'broadcaster-site' })).toBe('good');
+  });
+});
+
+describe('policyIncludes', () => {
+  it('MISSING writes only missing', () => {
+    expect(policyIncludes(POLICY.MISSING, 'missing')).toBe(true);
+    expect(policyIncludes(POLICY.MISSING, 'generic')).toBe(false);
+    expect(policyIncludes(POLICY.MISSING, 'good')).toBe(false);
+  });
+
+  it('GENERIC writes missing + generic', () => {
+    expect(policyIncludes(POLICY.GENERIC, 'missing')).toBe(true);
+    expect(policyIncludes(POLICY.GENERIC, 'generic')).toBe(true);
+    expect(policyIncludes(POLICY.GENERIC, 'good')).toBe(false);
+  });
+
+  it('ALL writes everything', () => {
+    for (const s of ['missing', 'generic', 'good']) expect(policyIncludes(POLICY.ALL, s)).toBe(true);
+  });
+});
+
+describe('srgAdapter', () => {
+  const srf1 = {
+    id: 'builtin-srf-1',
+    metadataUrl: 'https://il.srf.ch/integrationlayer/2.0/srf/songList/radio/byChannel/abc.json',
+  };
+  const reteUno = {
+    id: 'builtin-rsi-rete-uno',
+    metadataUrl: 'https://il.srf.ch/integrationlayer/2.0/rsi/songList/radio/byChannel/rete-uno.json',
+  };
+  const notSrg = { id: 'x', metadataUrl: 'https://api.radiofrance.fr/livemeta/live/1/inter_player' };
+
+  it('is registered and discoverable by name', () => {
+    expect(ADAPTERS).toContain(srgAdapter);
+    expect(getAdapter('SRG')).toBe(srgAdapter);
+    expect(getAdapter('nope')).toBeNull();
+  });
+
+  it('match() identifies SRG stations only', () => {
+    expect(srgAdapter.match(srf1)).toEqual({ net: 'srf', channelId: 'abc' });
+    expect(srgAdapter.match(notSrg)).toBeNull();
+  });
+
+  it('sources() returns one channelList per present net, deduped + sorted', () => {
+    const srf2 = { id: 'b', metadataUrl: 'https://il.srf.ch/integrationlayer/2.0/srf/songList/radio/byChannel/def.json' };
+    const sources = srgAdapter.sources([srf1, srf2, reteUno, notSrg]);
+    expect(sources).toEqual([
+      { net: 'rsi', url: srgChannelListUrl('rsi') },
+      { net: 'srf', url: srgChannelListUrl('srf') },
+    ]);
+  });
+
+  it('resolve() joins channel id → image url into an apply-logos entry', () => {
+    const indexByNet = new Map([
+      ['srf', new Map([['abc', { channelId: 'abc', imageUrl: 'https://download-media.srf.ch/x', title: 'Radio SRF 1' }]])],
+    ]);
+    expect(srgAdapter.resolve(srf1, indexByNet)).toEqual({
+      id: 'builtin-srf-1',
+      url: 'https://download-media.srf.ch/x',
+      source: 'broadcaster-api',
+      sourceType: 'cdn',
+      license: 'broadcaster',
+      sourceUrl: srgChannelListUrl('srf'),
+    });
+  });
+
+  it('resolve() returns null when the channel id is absent or station is not SRG', () => {
+    expect(srgAdapter.resolve(srf1, new Map([['srf', new Map()]]))).toBeNull();
+    expect(srgAdapter.resolve(notSrg, new Map())).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

Turns the by-hand SRG logo fix (#469/#473) into a repeatable tool. For broadcasters that expose per-channel art through the **same metadata API we already call for now-playing data**, harvest the authoritative, broadcaster-hosted, licence-clean `imageUrl` and emit an `apply-logos` patch — no scraping, no fragile Wikimedia dependence.

**Closes #471.**

## How

- **`tools/lib/broadcaster-logos.mjs`** — pure, network-free join + policy core. The SRG adapter (SRF/RTS/RSI/RTR) keys station → channel by the id already stored in `metadataUrl` (`.../songList/radio/byChannel/<id>.json` ↔ `.../channelList/radio.json`). `faviconState()` classifies a station's current logo `missing` / `generic` / `good`, driving a tiered write policy. **18 unit tests.**
- **`tools/harvest-broadcaster-logos.mjs`** — thin CLI: fetch the channelList docs (browser UA), join, apply policy, write the patch. **Never mutates `stations.yaml`** — emits an `apply-logos` JSON you review, then apply.
- Write policy (which stations enter the patch):
  - default → **missing** favicons only (safe inserts)
  - `--upgrade-generic` → + weak / site-default icons (the generic-shared-icon win)
  - `--include-existing` → every matched station (forced idempotent re-harvest)
  - scope with `--adapter` / `--cc` / `--only`
- `npm run harvest-logos`; docs added to `docs/operations.md` + `docs/logo-extraction.md`.

## Why it's correct (and idempotent)

`--include-existing` on today's catalog:

| net | result | meaning |
|---|---|---|
| RTS (4) + RSI (3) | `patch(idempotent)` | harvested URL **exactly equals** the catalog favicon → **the join is proven correct** (re-derives what #473 applied by hand) |
| SRF (6) + RTR (1) | `patch(replace)` | SRG 16:9 card *differs* from the deliberate Commons wordmark / bundled PNG → **correctly held back** by default policy |

Default policy emits **0** entries (all 14 SRG stations already have good logos) — honestly idempotent. The SRG `imageUrl` is a busy 16:9 branded card, so SRF keeps its clean Commons wordmarks for the list icon; the tool's real value is codifying the join for **future** SRG channels and as the template to generalize to other broadcaster metadata APIs.

## Scope

Code + docs only — **no catalog/`stations.json` change** (the SRG set is already fully populated). Same shape as #461.

## Gates

- `npm run typecheck` ✓
- `npx vitest run tools/` → **180 passed** (incl. the new 18) ✓
- `npm run build` ✓
- `apply-logos --dry-run` on the 14-entry patch → 14 valid, 0 invalid ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)