### PR TITLE
logos: family propagation + exact-brand File: scoring (#478, code-only)

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -192,6 +192,27 @@ free equivalent (that's *why* the en upload is non-free) and need `scrape-logos`
 against the broadcaster site instead. Pure matching/scoring logic lives in
 `tools/lib/nonfree-migration.mjs` (unit-tested).
 
+**Family propagation (`--propagate`, #478).** Stations sharing one non-free en
+file share the same artwork, so when a sibling resolves a Commons logo the tool
+can reuse it for the rest (entries tagged `_via: family` + `_seed`/`_tier`):
+
+```bash
+npm run migrate-nonfree-logos -- --propagate                  # same-country only (safe)
+npm run migrate-nonfree-logos -- --propagate --cross-country  # + cross-country (review-first)
+```
+
+Two guards: a shared brand token (`sharesBrandToken`) and the country `_tier`.
+`same-country` (within-country sub-channels/regionals) is the safe default;
+`cross-country` is **flagged for mandatory review** because a generic name
+("Kiss", "Gold", "Magic") is shared by *unrelated* stations across countries —
+only a true network (NRJ) is legitimately cross-country, and even then a wrong
+seed propagates to every sibling (the NRJ seed has mis-resolved to a neighbour
+brand before). In practice the yield is small: the genuinely-safe same-country
+sub-channel groups (KCRW, Mirchi, KSFR…) have **no** free Commons logo to seed
+from — those belong to the `scrape-logos` track. The companion `scoreFileHit`
+fix (prefer an exact brand token over a sub-brand) is the broadly useful part:
+it stops the File: search from picking e.g. *NRJ Junior* for *NRJ*.
+
 ## Adding a station that fits an existing fetcher
 
 Existing fetchers cover Grrif, ORF (any channel via metadataUrl), BR (any channel via metadataUrl), plus generic ICY-over-fetch as fallback.

--- a/tools/lib/nonfree-migration.mjs
+++ b/tools/lib/nonfree-migration.mjs
@@ -95,10 +95,39 @@ export function scoreFileHit(title, stationName) {
   let s = formatScore;
   if (/logo/i.test(t)) s += 5;
   if (r === n || r === `logo ${n}` || r === `${n} logo`) s += 5;
+  // Token-level exactness: strongly reward the station name appearing as WHOLE
+  // tokens (lets a logo-less exact match like "NRJ Radio.png" clear the bar),
+  // and penalize a sub-brand token that merely *contains* a station token, so
+  // "NRJ Radio" beats "NRJJunior" for the station "NRJ" (#478). The radio-
+  // subject gate above still guards against off-topic exact-name files.
+  const rootToks = new Set(r.split(' ').filter(Boolean));
+  const nameToks = n.split(' ').filter(Boolean);
+  if (nameToks.length && nameToks.every((tok) => rootToks.has(tok))) s += 5;
+  if (nameToks.some((tok) => [...rootToks].some((rt) => rt !== tok && rt.includes(tok)))) s -= 4;
   return s;
 }
 
 export const FILE_HIT_MIN_SCORE = 8;
+
+// Generic tokens that carry no brand identity — ignored when comparing two
+// station names for a shared brand (#478 family propagation).
+const BRAND_STOPWORDS = new Set([
+  'radio', 'fm', 'am', 'the', 'station', 'hd', 'dab', 'hits', 'music',
+]);
+
+/** True if two station names share a significant (non-generic, non-numeric)
+ *  token — the brand guard for propagating one sibling's logo to another. */
+export function sharesBrandToken(nameA, nameB) {
+  const toks = (name) =>
+    new Set(
+      normalizeTitle(name)
+        .split(' ')
+        .filter((tok) => tok && !BRAND_STOPWORDS.has(tok) && !/^\d+$/.test(tok)),
+    );
+  const a = toks(nameA);
+  for (const tok of toks(nameB)) if (a.has(tok)) return true;
+  return false;
+}
 
 /** Extract the underlying File: name from a Commons upload URL (handles the
  *  /thumb/x/xx/<File>/NNNpx-<File> form). Returns null if not a Commons URL. */
@@ -107,6 +136,29 @@ export function commonsFileName(commonsUrl) {
     /\/wikipedia\/commons\/(?:thumb\/)?[0-9a-f]\/[0-9a-f]{2}\/([^/?]+)/i,
   );
   return m ? decodeURIComponent(m[1]) : null;
+}
+
+/** Extract the underlying File: name from a non-free /wikipedia/en/ upload URL.
+ *  Stations sharing one en file share the same (non-free) artwork — this is the
+ *  family-grouping key for propagation (#478). Returns null for non-en URLs. */
+export function enWikiFileName(url) {
+  const m = String(url).match(
+    /\/wikipedia\/en\/(?:thumb\/)?[0-9a-f]\/[0-9a-f]{2}\/([^/?]+)/i,
+  );
+  return m ? decodeURIComponent(m[1]) : null;
+}
+
+/** Country relationship between a resolved seed and a sibling sharing its
+ *  non-free file. `same-country` is safe to auto-propagate (within-country
+ *  sub-channels / regionals); `cross-country` needs review — a generic name
+ *  ("Kiss", "Gold") is shared by UNRELATED stations across countries, while a
+ *  real network (NRJ) is legitimately cross-country. Missing country → treat as
+ *  cross-country (the conservative side). */
+export function propagationTier(seedCountry, siblingCountry) {
+  const a = String(seedCountry || '').toUpperCase().trim();
+  const b = String(siblingCountry || '').toUpperCase().trim();
+  if (!a || !b) return 'cross-country';
+  return a === b ? 'same-country' : 'cross-country';
 }
 
 /** Normalize a Commons imageinfo `extmetadata` block to a short faviconLicense

--- a/tools/lib/nonfree-migration.test.mjs
+++ b/tools/lib/nonfree-migration.test.mjs
@@ -9,6 +9,9 @@ import {
   FILE_HIT_MIN_SCORE,
   commonsFileName,
   normalizeLicense,
+  enWikiFileName,
+  propagationTier,
+  sharesBrandToken,
 } from './nonfree-migration.mjs';
 
 describe('langsForCountry', () => {
@@ -83,6 +86,49 @@ describe('scoreFileHit', () => {
     expect(scoreFileHit('File:Some report.pdf', 'Jazz Radio')).toBe(-1); // not an image
     expect(scoreFileHit('File:Jazz Radio photo.png', 'Beat')).toBe(-1); // name not contained
     expect(scoreFileHit('File:DR P6 Beat 2017 logo.png', 'DR P6 BEAT')).toBe(-1); // no radio word anywhere
+  });
+  it('prefers the exact brand over a sub-brand (#478: NRJ over NRJ Junior)', () => {
+    const main = scoreFileHit('File:Logo NRJ 2016 radio.png', 'NRJ');
+    const junior = scoreFileHit('File:Logo NRJJunior radio 2014.png', 'NRJ');
+    expect(main).toBeGreaterThan(junior);
+  });
+  it('lets a logo-less exact-brand + radio file clear the threshold (NRJ Radio.png)', () => {
+    expect(scoreFileHit('File:NRJ Radio.png', 'NRJ')).toBeGreaterThanOrEqual(FILE_HIT_MIN_SCORE);
+  });
+});
+
+describe('enWikiFileName', () => {
+  it('extracts the shared file from non-free en uploads (thumb + direct)', () => {
+    expect(enWikiFileName('https://upload.wikimedia.org/wikipedia/en/thumb/d/d7/DR_P1_logo_2020.svg/330px-DR_P1_logo_2020.svg.png')).toBe('DR_P1_logo_2020.svg');
+    expect(enWikiFileName('https://upload.wikimedia.org/wikipedia/en/8/8a/Nash_FM_Orange_Logo.jpeg')).toBe('Nash_FM_Orange_Logo.jpeg');
+  });
+  it('returns null for Commons (free) URLs', () => {
+    expect(enWikiFileName('https://upload.wikimedia.org/wikipedia/commons/3/3d/DR_P1_2017_logo.png')).toBe(null);
+  });
+});
+
+describe('propagationTier', () => {
+  it('is same-country only when both countries match', () => {
+    expect(propagationTier('US', 'US')).toBe('same-country');
+    expect(propagationTier('us', 'US')).toBe('same-country');
+    expect(propagationTier('SE', 'BG')).toBe('cross-country'); // NRJ across countries
+    expect(propagationTier('CA', 'ES')).toBe('cross-country'); // unrelated Kiss stations
+  });
+  it('treats a missing country as cross-country (conservative)', () => {
+    expect(propagationTier('US', '')).toBe('cross-country');
+    expect(propagationTier(undefined, 'US')).toBe('cross-country');
+  });
+});
+
+describe('sharesBrandToken', () => {
+  it('matches real brand siblings, ignoring generic tokens', () => {
+    expect(sharesBrandToken('NRJ Sweden', 'Energy NRJ')).toBe(true);
+    expect(sharesBrandToken('KCRW 88.9 FM', 'KCRW Eclectic 24')).toBe(true);
+    expect(sharesBrandToken('Mirchi Top 20', 'Mirchi Love')).toBe(true);
+  });
+  it('does not match on generic words alone', () => {
+    expect(sharesBrandToken('Jazz Radio', 'Smooth Radio')).toBe(false); // only "radio" shared
+    expect(sharesBrandToken('Magic 99.5', 'Gold FM')).toBe(false);
   });
 });
 

--- a/tools/migrate-nonfree-logos.mjs
+++ b/tools/migrate-nonfree-logos.mjs
@@ -23,6 +23,14 @@
  *   node tools/migrate-nonfree-logos.mjs --limit 30       # validation slice
  *   node tools/migrate-nonfree-logos.mjs --concurrency 6  # default 6
  *   node tools/migrate-nonfree-logos.mjs --out <path>     # default internal/logos/nonfree-migration.json
+ *
+ * Family propagation (#478) — reuse one sibling's resolved Commons logo for the
+ * others sharing its non-free en file (they share the same artwork):
+ *   node tools/migrate-nonfree-logos.mjs --propagate               # same-country only (safe)
+ *   node tools/migrate-nonfree-logos.mjs --propagate --cross-country  # + cross-country (review-first: NRJ yes, Kiss no)
+ * Propagated entries are tagged `_via: family` + `_seed`/`_tier`; cross-country
+ * ones are listed for mandatory review (a generic name like "Kiss"/"Gold" is
+ * shared by UNRELATED stations across countries).
  */
 
 import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
@@ -41,6 +49,9 @@ import {
   FILE_HIT_MIN_SCORE,
   commonsFileName,
   normalizeLicense,
+  enWikiFileName,
+  propagationTier,
+  sharesBrandToken,
 } from './lib/nonfree-migration.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -59,6 +70,13 @@ const LIMIT = Number(argVal('--limit', Infinity));
 const CONCURRENCY = Math.max(1, Math.min(12, Number(argVal('--concurrency', 6))));
 const OUT_ARG = argVal('--out', 'internal/logos/nonfree-migration.json');
 const OUT_PATH = isAbsolute(OUT_ARG) ? OUT_ARG : join(root, OUT_ARG);
+// Family propagation (#478): reuse one sibling's resolved Commons logo for the
+// other stations sharing its non-free en file. `--propagate` does the safe
+// same-country subset (within-country sub-channels/regionals); add
+// `--cross-country` to also surface cross-country members (real networks like
+// NRJ — but also unrelated same-name stations, so they're flagged review-first).
+const PROPAGATE = argFlag('--propagate');
+const CROSS_COUNTRY = argFlag('--cross-country');
 
 const FETCH_TIMEOUT_MS = 12000;
 const UA =
@@ -283,16 +301,76 @@ await runPool(
   CONCURRENCY,
 );
 
+// ─── family propagation (#478) ─────────────────────────────────────
+// Stations sharing one non-free en file share the same artwork. When a sibling
+// resolved a free Commons logo, reuse it for the others in the group — guarded
+// by a shared brand token and the country tier (same-country auto;
+// cross-country only with --cross-country, and flagged for review because a
+// generic name like "Kiss"/"Gold" is shared by UNRELATED stations).
+const propagationReview = [];
+if (PROPAGATE) {
+  const seedEntryById = new Map(patch.map((e) => [e.id, e])); // original per-station resolutions only
+  const groups = new Map();
+  for (const s of targets) {
+    const f = enWikiFileName(s.favicon);
+    if (!f) continue;
+    if (!groups.has(f)) groups.set(f, []);
+    groups.get(f).push(s);
+  }
+  for (const members of groups.values()) {
+    if (members.length < 2) continue;
+    const seeds = members.filter((m) => seedEntryById.has(m.id));
+    const unresolved = members.filter((m) => !seedEntryById.has(m.id));
+    if (!seeds.length || !unresolved.length) continue;
+    for (const sib of unresolved) {
+      let chosen = null;
+      for (const seed of seeds) {
+        if (!sharesBrandToken(seed.name, sib.name)) continue;
+        const tier = propagationTier(seed.country, sib.country);
+        if (tier === 'cross-country' && !CROSS_COUNTRY) continue;
+        chosen = { seed, tier };
+        break;
+      }
+      if (!chosen) continue;
+      const seedEntry = seedEntryById.get(chosen.seed.id);
+      const entry = {
+        id: sib.id,
+        url: seedEntry.url,
+        source: 'wiki',
+        sourceUrl: seedEntry.sourceUrl,
+        _via: 'family',
+        _seed: chosen.seed.id,
+        _seedVia: seedEntry._via,
+        _tier: chosen.tier,
+        _name: sib.name,
+      };
+      if (seedEntry.license) entry.license = seedEntry.license;
+      patch.push(entry);
+      const mi = misses.findIndex((m) => m.id === sib.id);
+      if (mi >= 0) misses.splice(mi, 1);
+      if (chosen.tier === 'cross-country') {
+        propagationReview.push(`${sib.id} ← ${chosen.seed.id} [${chosen.seed.country}→${sib.country}]`);
+      }
+      console.log(`[prop ${chosen.tier}] ${sib.id}  ← ${chosen.seed.id}  ${seedEntry.url}`);
+    }
+  }
+}
+
 patch.sort((a, b) => a.id.localeCompare(b.id));
 mkdirSync(dirname(OUT_PATH), { recursive: true });
 writeFileSync(OUT_PATH, JSON.stringify(patch, null, 2) + '\n');
 
 const viaArticle = patch.filter((e) => e._via === 'article').length;
-const viaFile = patch.length - viaArticle;
+const viaFile = patch.filter((e) => e._via === 'file').length;
+const viaFamily = patch.filter((e) => e._via === 'family').length;
 console.log('');
-console.log(`resolved: ${patch.length}/${targets.length}  (article: ${viaArticle}, file: ${viaFile}, miss: ${misses.length}, no-licence: ${noLicense.length})`);
+console.log(`resolved: ${patch.length}/${targets.length}  (article: ${viaArticle}, file: ${viaFile}, family: ${viaFamily}, miss: ${misses.length}, no-licence: ${noLicense.length})`);
 console.log(`patch → ${OUT_PATH}`);
-console.log(`  ⚠ review the ${viaFile} _via:file entr${viaFile === 1 ? 'y' : 'ies'} by hand — they can match a same-named sibling station.`);
+if (viaFile) console.log(`  ⚠ review the ${viaFile} _via:file entr${viaFile === 1 ? 'y' : 'ies'} by hand — they can match a same-named sibling station.`);
+if (propagationReview.length) {
+  console.log(`  ⚠ ${propagationReview.length} CROSS-COUNTRY propagation(s) — REVIEW EACH (real network vs same-name collision):`);
+  for (const r of propagationReview) console.log(`    ${r}`);
+}
 if (noLicense.length) {
   console.log(`  ⚠ ${noLicense.length} resolved without a Commons licence (written without faviconLicense):`);
   for (const n of noLicense.slice(0, 20)) console.log(`    ${n.id} (raw: ${n.raw || 'none'})`);


### PR DESCRIPTION
Follow-up to #477 (now merged). Extends `migrate-nonfree-logos` with the family-propagation enhancement from #478. **Code-only — no catalog change; nothing migrated via propagation yet.**

## Family propagation — `--propagate`
Stations sharing one non-free `wikipedia/en` file share the same artwork, so when a sibling resolves a free Commons logo the tool reuses it for the rest (entries tagged `_via: family` + `_seed`/`_tier`). Two guards:
- **`sharesBrandToken`** — seed and sibling must share a non-generic name token.
- **country `_tier`** (`propagationTier`) — `same-country` is the safe default (within-country sub-channels/regionals); `cross-country` requires `--cross-country` **and is flagged for mandatory review**, because a generic name ("Kiss", "Gold", "Magic") is shared by *unrelated* stations across countries.

New pure helpers `enWikiFileName` / `propagationTier` / `sharesBrandToken` (+8 vitest; 26 lib / 209 tools total).

## `scoreFileHit` fix (the broadly useful part)
The File: search now rewards the station name appearing as **whole tokens** (+5 — lets a logo-less exact match like `NRJ Radio.png` clear the bar) and penalizes a **sub-brand** token that merely contains a station token (−4). So it stops picking *NRJ Junior* for *NRJ*. Only raises the existing file-path winners (no regression); the radio-subject gate still guards off-topic exact-name files.

## Honest yield note (documented in operations.md)
Propagation's practical yield on this catalog is **small**:
- The genuinely-safe same-country sub-channel groups (KCRW, Mirchi, KSFR, KMOJ — all checked) have **no** free Commons logo to seed from → they belong to the `scrape-logos` track (#478 track 1).
- The one real cross-country network (NRJ ×5) is review-gated for good reason: in testing the `nrj` seed mis-resolved on live Wikipedia data to a neighbour brand and propagation faithfully spread it to all 4 siblings — **all flagged REVIEW**. The safety net works; it just shows why cross-country never auto-applies.

The durable win here is the exact-brand scoring fix. The recommended path for the remaining 205 non-free logos is the broadcaster-site scrape sweep (#478 track 1).

Refs #478.

🤖 Generated with [Claude Code](https://claude.com/claude-code)