### PR TITLE
ci: bump actions off Node 20 ahead of the June 16 runner default flip

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -15,12 +15,12 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "17"
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: "8.11.1"
       - name: Unit tests

--- a/.github/workflows/catalog-watch.yml
+++ b/.github/workflows/catalog-watch.yml
@@ -27,7 +27,7 @@ jobs:
     # job used to die at the 6 h ceiling when the probes were sequential.
     timeout-minutes: 330
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
           # Same pin as deploy.yml. A hardcoded node 22 here kept failing

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -34,7 +34,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,7 @@ jobs:
   web:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
@@ -58,7 +58,7 @@ jobs:
         with:
           path: dist
       # Persist dist for the e2e job so we don't rebuild.
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist
@@ -80,7 +80,7 @@ jobs:
       image: mcr.microsoft.com/playwright:v1.59.1-noble
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       # setup-node still pins Node 24 (overriding the image's bundled
       # Node) so `npm ci` keeps working against the npm-11 lockfile.
       - uses: actions/setup-node@v6
@@ -88,7 +88,7 @@ jobs:
           node-version-file: .nvmrc
           cache: npm
       - run: npm ci
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist
@@ -96,7 +96,7 @@ jobs:
       # $PLAYWRIGHT_BROWSERS_PATH (/ms-playwright) for playwright 1.59.1.
       - name: Smoke tests
         run: npm run test:e2e
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: playwright-report
@@ -110,7 +110,7 @@ jobs:
   worker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
@@ -139,7 +139,7 @@ jobs:
   catalog:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc

--- a/.github/workflows/error-watch.yml
+++ b/.github/workflows/error-watch.yml
@@ -37,7 +37,7 @@ jobs:
   watch:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Fetch errors from worker
         id: fetch

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -22,7 +22,7 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc


### PR DESCRIPTION
## Summary

Every CI run currently warns that `actions/checkout@v4`, `upload-artifact@v4`, and `download-artifact@v4` run on Node 20, which GitHub forces to Node 24 on **June 16th, 2026** (and removes from runners September 16th). This bumps all flagged actions to their current majors across the six workflows:

| Action | From | To |
|---|---|---|
| `actions/checkout` | v4 | v6 |
| `actions/upload-artifact` | v4 | v7 |
| `actions/download-artifact` | v4 | v8 |
| `gradle/actions/setup-gradle` | v4 | v6 |

Compatibility checked against the release notes: download-artifact's v5 breaking change applies only to downloads **by artifact ID** (deploy.yml downloads by `name: dist`); v8's no-auto-unzip applies only to direct-upload files; checkout/upload-artifact majors are Node 24 runtime migrations. The e2e job runs in the `mcr.microsoft.com/playwright:v1.59.1-noble` container, which supports Node 24 runner externals. `setup-node@v6`, `configure-pages@v6`, `deploy-pages@v5`, `upload-pages-artifact@v5`, and `setup-java@v5` were already current.

## Test plan

- [x] All `uses:` lines verified against `gh api .../releases/latest`
- [ ] Merge exercises the deploy workflow end to end (checkout, artifact hand-off web→e2e, Pages deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)