### PR TITLE
Worker: broken-station report pipeline P1 — receipts, status API, manual resolve

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -12,7 +12,9 @@ name: Deploy Worker
 #
 # Required repo secret:
 #   CLOUDFLARE_API_TOKEN — token with "Edit Cloudflare Workers" scope
-#                          for this account. Set under
+#                          PLUS the "D1: Edit" permission (the broken-
+#                          reports pipeline applies D1 migrations before
+#                          deploying). Set under
 #                          Settings → Secrets and variables → Actions.
 #
 # Worker secrets (GOATCOUNTER_TOKEN, ADMIN_TOKEN) are stored on the
@@ -52,6 +54,14 @@ jobs:
       - name: Test
         working-directory: worker
         run: npm test
+
+      # Idempotent — already-applied migrations are skipped. Runs before
+      # deploy so new Worker code never sees an old schema.
+      - name: Apply D1 migrations
+        working-directory: worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: npx wrangler d1 migrations apply rrradio-reports --remote
 
       - name: Deploy to Cloudflare
         working-directory: worker

--- a/.github/workflows/resolve-reports.yml
+++ b/.github/workflows/resolve-reports.yml
@@ -1,0 +1,77 @@
+name: Resolve Broken-Station Reports
+
+# When a `broken-station` issue is closed, tell the stats Worker so the
+# D1 report rows for that station flip to `resolved` and the apps'
+# receipt polling can inform the reporters (issue #507, P1).
+#
+# Resolution comes from a `resolved:*` label on the issue; without one
+# it falls back on GitHub's close reason (completed → fixed,
+# not planned → not-reproducible).
+#
+# The station id is read from a marker in the issue body:
+#   <!-- rrradio:station-id=<id> -->
+# The P2 auto-upserter writes this marker; hand-filed issues should
+# include it too. Without it the resolve still matches any reports
+# already linked to this issue number in D1.
+#
+# Required repo secret:
+#   STATS_ADMIN_TOKEN — the Worker's ADMIN_TOKEN (the same value set
+#                       with `wrangler secret put ADMIN_TOKEN`).
+
+on:
+  issues:
+    types: [closed]
+
+permissions: {}
+
+jobs:
+  resolve:
+    if: contains(github.event.issue.labels.*.name, 'broken-station')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark linked reports resolved
+        env:
+          ADMIN_TOKEN: ${{ secrets.STATS_ADMIN_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          LABELS: ${{ join(github.event.issue.labels.*.name, ',') }}
+          STATE_REASON: ${{ github.event.issue.state_reason }}
+        run: |
+          set -euo pipefail
+          if [ -z "$ADMIN_TOKEN" ]; then
+            echo "STATS_ADMIN_TOKEN secret is not set" >&2
+            exit 1
+          fi
+
+          # Resolution: explicit label wins, else GitHub's close reason.
+          resolution=""
+          case ",$LABELS," in
+            *",resolved:fixed,"*)            resolution="fixed" ;;
+            *",resolved:removed,"*)          resolution="removed" ;;
+            *",resolved:not-reproducible,"*) resolution="not-reproducible" ;;
+          esac
+          if [ -z "$resolution" ]; then
+            case "$STATE_REASON" in
+              not_planned) resolution="not-reproducible" ;;
+              *)           resolution="fixed" ;;
+            esac
+          fi
+
+          # Station id from the body marker, if present.
+          station_id=$(printf '%s' "$ISSUE_BODY" \
+            | grep -oE '<!-- rrradio:station-id=[A-Za-z0-9._:-]+ -->' \
+            | head -n1 \
+            | sed -E 's/^<!-- rrradio:station-id=([A-Za-z0-9._:-]+) -->$/\1/' || true)
+
+          payload=$(jq -nc \
+            --arg resolution "$resolution" \
+            --arg stationId "$station_id" \
+            --argjson issue "$ISSUE_NUMBER" \
+            '{resolution: $resolution, githubIssue: $issue}
+             + (if $stationId != "" then {stationId: $stationId} else {} end)')
+
+          echo "Resolving reports for issue #$ISSUE_NUMBER: $payload"
+          curl -fsS -X POST 'https://stats.rrradio.org/api/admin/resolve-reports' \
+            -H "Authorization: Bearer $ADMIN_TOKEN" \
+            -H 'Content-Type: application/json' \
+            -d "$payload"

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -339,7 +339,7 @@ Privacy-friendly pageview + event analytics. No cookies, no consent banner, no u
 | `pause: <station name>` | state goes playing → paused (same station) |
 | `resume: <station name>` | state goes paused → loading (same station) |
 | `error: <station name>` | state enters error; title field carries the error message; deduped while error persists |
-| `report-broken: <station name>` | user taps "Report broken station"; title carries station id, stream host, platform, app version, and current playback reason when available |
+| `report-broken: <station name>` | user taps "Report broken station"; title carries station id, stream host, platform, app version, category, and current playback reason when available. The GC event mirrors the primary record in the Worker's D1 `broken_reports` table (receipts + status pipeline — `docs/spec/contracts/broken-reports.md`); the user's comment stays in D1 and never reaches GC |
 | `favorite: <station name>` | user adds a favorite |
 | `unfavorite: <station name>` | user removes a favorite |
 | `add-custom-station` | user submits the Add sheet |

--- a/docs/spec/COVERAGE.md
+++ b/docs/spec/COVERAGE.md
@@ -26,6 +26,7 @@ a doc. See `STYLE.md` for templates and the reconciliation ritual.
 | search | draft | 9336321 | `Search/*`, `Models/RadioBrowserClient.swift`, `Resources/stations.fts5.db` |
 | sync-merge | draft | 9336321 | `CloudSync/*` |
 | privacy-data-boundaries | draft | 9336321 | `RegionResolver.swift`, `DashboardView.swift`, `AddStationView.swift`, `Diagnostics.swift` |
+| broken-reports | draft | — | server-side first (`worker/src/reports.ts`); iOS report sheet pending (companion issue to #507) |
 | watch-protocol | draft | 9336321 | `Shared/WatchRemoteProtocol.swift`, `WatchRemote/*`, `rrradioWatch/*` |
 | localization | draft | 9336321 | `Views/LocaleController.swift`, `Resources/Localizable.xcstrings` |
 

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -54,6 +54,7 @@ mechanics into web or Android without an explicit platform note.
 - [Search](contracts/search.md)
 - [Library sync & merge](contracts/sync-merge.md)
 - [Privacy & data boundaries](contracts/privacy-data-boundaries.md)
+- [Broken-station reports](contracts/broken-reports.md)
 - [Watch remote protocol](contracts/watch-protocol.md)
 - [Localization](contracts/localization.md)
 

--- a/docs/spec/contracts/broken-reports.md
+++ b/docs/spec/contracts/broken-reports.md
@@ -1,0 +1,197 @@
+# Broken-Station Reports Contract
+
+```yaml
+status: draft
+platforms: [web, ios, android]
+reconciled-against: —   # server-side first; no client ships this yet
+```
+
+## Purpose
+
+Pins the cross-platform protocol for reporting a broken station and learning
+what happened to the report. A user reports a station with a **category** and
+optional **comment**, receives an anonymous **receipt id**, and is later
+informed — via app polling — when the report is resolved. No account, no
+reporter identity: the receipt token, held only by the reporting device, is
+the entire relationship.
+
+Who must honor it: every platform that ships the report sheet or receipt
+polling, the `stats.rrradio.org` Worker (`worker/src/reports.ts`), and the
+triage automation (issue-close Action, P2 prober/upserter). Defined by
+[#507](https://github.com/MarkusSteinbrecher/rrradio/issues/507); the iOS
+report-sheet UX lives in the companion `rrradio-ios` issue.
+
+## Definition
+
+### Report lifecycle (state machine)
+
+```
+received ──(probe fail | report threshold; P2)──▶ confirmed
+received ─────────────(issue closed / admin)──────▶ resolved
+confirmed ────────────(issue closed / admin)──────▶ resolved
+```
+
+- `resolved` is terminal and carries exactly one `resolution`:
+  `fixed | removed | not-reproducible`.
+- Nothing un-resolves a report. A still-broken station is a *new* report.
+
+### `POST /api/public/report-broken` (extended, backward-compatible)
+
+Request body (JSON, ≤4096 bytes; pre-#507 fields unchanged):
+
+- `stationId` (required), `stationName`, `streamHost`, `platform`,
+  `appVersion`, `reason`, `source` — as before.
+- `category` — one of `no-audio | interruptions | wrong-station | wrong-logo |
+  wrong-info | other`. Absent or unrecognized → stored as `unspecified`, so
+  old clients keep working unchanged.
+- `comment` — optional plain text, ≤500 chars. Control characters (except
+  newline) are stripped on ingest; rendering surfaces escape at the output
+  edge. Never forwarded to analytics.
+
+Response: `202` with `{ "ok": true, "reportId": "<token>" }`. The token is a
+crypto-random UUID minted by the Worker. Clients built before receipts MUST
+tolerate the extra field; clients built after MUST tolerate a missing
+`reportId` (degraded mode — report recorded, no receipt).
+
+### `GET /api/public/report-status?ids=a,b,c`
+
+- `ids`: comma-separated receipt tokens, ≤50 per call; malformed ids are
+  ignored.
+- Response `200`: `{ "reports": [{ "id", "status", "resolution"?,
+  "resolvedAt"? }] }` — `resolution`/`resolvedAt` only when resolved.
+- Unknown ids are **omitted**; the client treats an omitted id as expired and
+  drops the receipt locally.
+
+### `POST /api/admin/resolve-reports` (Bearer `ADMIN_TOKEN`)
+
+Body: `{ "resolution": "fixed|removed|not-reproducible" }` plus at least one
+selector — `reportIds` (≤100), `stationId` (optionally scoped by `category`),
+`githubIssue`. Selectors OR-combine; already-resolved rows are never touched.
+Response: `{ "ok": true, "resolved": <n> }`.
+
+### Triage automation
+
+- One GitHub issue per station (P2 upserts), labeled `broken-station`, body
+  carrying the marker `<!-- rrradio:station-id=<id> -->`.
+- Closing a `broken-station` issue triggers
+  `.github/workflows/resolve-reports.yml`, which calls the admin endpoint.
+  Resolution = `resolved:fixed | resolved:removed | resolved:not-reproducible`
+  label when present, else GitHub's close reason (completed → `fixed`,
+  not planned → `not-reproducible`).
+
+## Detail
+
+| Field | Type | Optional? | Meaning | Default |
+|---|---|---|---|---|
+| `category` | enum (6 values) | yes | user's classification of the breakage | `unspecified` |
+| `comment` | string ≤500 | yes | user-authored free text, plain text only | `''` |
+| `reportId` | UUID string | server-minted | anonymous receipt; sole link between device and report | — |
+| `status` | `received \| confirmed \| resolved` | no | lifecycle state | `received` |
+| `resolution` | `fixed \| removed \| not-reproducible` | only when resolved | what closed it | — |
+| `resolvedAt` | ISO 8601 UTC | only when resolved | resolution timestamp | — |
+| `github_issue` | int (server-side) | yes | linked triage issue | unset |
+| Receipt store (client) | local list of `{ id, stationId, createdAt }` | yes | what the device polls with | empty |
+| Ingest rate limit | 20 reports / IP / UTC day | no | enforced via daily-salted IP hash, purged next day | — |
+
+## Examples
+
+Request (new client):
+
+```json
+{
+  "stationId": "builtin-fm4",
+  "stationName": "FM4",
+  "streamHost": "orffm4shoutcast.sf.apa.at",
+  "platform": "ios",
+  "appVersion": "1.2 (57)",
+  "reason": "stream failed: HTTP 403",
+  "source": "manual",
+  "category": "no-audio",
+  "comment": "Plays a second of audio, then silence."
+}
+```
+
+Response: `{ "ok": true, "reportId": "7f0c2b9e-4a1d-4e7b-9c3a-2d8f5e6a1b0c" }`
+
+Status poll `…/report-status?ids=7f0c2b9e-…,11111111-1111-4111-8111-111111111111`:
+
+```json
+{
+  "reports": [
+    {
+      "id": "7f0c2b9e-4a1d-4e7b-9c3a-2d8f5e6a1b0c",
+      "status": "resolved",
+      "resolution": "fixed",
+      "resolvedAt": "2026-06-14T09:12:33.000Z"
+    }
+  ]
+}
+```
+
+(The second id is unknown → omitted → client expires that receipt.)
+
+## Versioning & evolution
+
+- `category` values are append-only; servers map unknown values to
+  `unspecified`, so clients may ship new categories before the Worker knows
+  them (they degrade to `unspecified`, never error).
+- `status`/`resolution` values are append-only; clients MUST render unknown
+  values as a neutral "in review" state rather than failing.
+- Receipt ids carry no version; treat them as opaque tokens.
+- P2 adds server-side transitions to `confirmed` (stream/favicon prober) and
+  the issue upsert — no client-visible protocol change.
+
+## Failure & fallback
+
+| Condition | Behavior |
+|---|---|
+| POST non-2xx / network failure | Same as today: client surfaces failure once; iOS offers the `mailto:feedback@rrradio.org` fallback. |
+| 429 (rate limited) | Client shows the generic failure path; no retry-storm. |
+| D1 down, analytics up | `202 { ok: true }` without `reportId` — report counted, no receipt. Client skips storing a receipt. |
+| D1 and analytics both down | `502`; client failure path. |
+| Status poll fails / non-200 | Keep receipts, retry next poll window. Never block UI on the poll. |
+| Receipt unknown (omitted from response) | Treat as expired; drop the receipt silently. |
+| Issue closed without station marker or linked rows | Action still calls the endpoint; `resolved: 0` — harmless. |
+
+## Platform obligations
+
+**All platforms**
+
+- Send `category` from an explicit user choice; never auto-classify.
+- The comment field is optional, plainly labeled as going to the maintainer,
+  and capped at 500 chars client-side.
+- Store receipts locally only ([privacy contract](privacy-data-boundaries.md)
+  rows 4 and 15); never attach them to any other request.
+- Poll opportunistically (app foreground / stats-sheet open), not on a timer;
+  batch all outstanding ids into one call.
+- On `resolved`, inform the user once (e.g. badge/toast "Your FM4 report:
+  fixed"), then drop the receipt.
+
+**Web** — same endpoint; receipts in `localStorage`. Currently sends the
+pre-#507 payload (no category sheet yet); that remains valid.
+
+**iOS** — report sheet + receipts + polling specced in the companion
+`rrradio-ios` issue; `Diagnostics.swift`'s `BrokenStationReporter` is the
+integration point.
+
+**Android** — same protocol when the port lands; nothing platform-specific.
+
+## Open questions
+
+1. Retention: when (if ever) are resolved/stale `broken_reports` rows purged?
+   Receipts of deleted rows read as expired, so purging is client-safe — pick
+   a window (e.g. 180d) in P2.
+2. Should `confirmed` be user-visible ("we reproduced it") or collapsed into
+   "in review" until resolution? Spec currently allows either rendering.
+
+## Reference
+
+- Worker: `worker/src/reports.ts`, schema `worker/migrations/0001_broken_reports.sql`,
+  routes wired in `worker/src/index.ts`, tests `worker/src/reports.test.ts`.
+- Automation: `.github/workflows/resolve-reports.yml`.
+- Privacy rows: [privacy-data-boundaries.md](privacy-data-boundaries.md) rows 4, 15.
+- Pipeline definition: [#507](https://github.com/MarkusSteinbrecher/rrradio/issues/507).
+
+## Known deviations
+
+- None yet — no client implements categories/receipts as of this writing.

--- a/docs/spec/contracts/privacy-data-boundaries.md
+++ b/docs/spec/contracts/privacy-data-boundaries.md
@@ -88,7 +88,7 @@ every rule.
 | 1 | `https://rrradio.org/stations.json` | nothing but the GET (+ IP via TCP) | on launch / catalog refresh | No (core function) | Yes | none app-side; OS cache |
 | 2 | `https://stats.rrradio.org/api/public/region` | nothing in body; IP read at the edge for `CF-IPCountry` | first launch + every cold launch past the 24h region cache | No (silent) | Yes (subdomain — see Open Qs) | aggregate/none intended; edge logs at CF |
 | 3 | `https://stats.rrradio.org/api/public/top-stations`, `/totals`, `/locations` | nothing in body (+ IP via TCP); `?days=7`, `?limit=…` | every time the Stats sheet opens | No (silent on open) | Yes (subdomain) | public aggregate; edge logs |
-| 4 | `https://stats.rrradio.org/api/public/report-broken` | `stationId`, `stationName`, `streamHost`, `platform=ios`, `appVersion`, `reason` (≤160 chars of player state), `source=manual` (+ IP) | user taps "Report broken station" | **Yes** (explicit tap) | Yes (subdomain) | broken-station triage |
+| 4 | `https://stats.rrradio.org/api/public/report-broken` | `stationId`, `stationName`, `streamHost`, `platform=ios`, `appVersion`, `reason` (≤160 chars of player state), `source=manual`, `category` (user-chosen breakage class), `comment` (**user-authored text**, ≤500 chars, optional) (+ IP) | user taps "Report broken station" | **Yes** (explicit tap; comment is explicit typed input) | Yes (subdomain) | broken-station triage store (D1, no reporter identity; comments verbatim — see [broken-reports](broken-reports.md)). IP used only for a daily-salted rate-limit hash, purged next day |
 | 5 | `https://stats.rrradio.org/api/public/proxy?url=<stream/metadata URL>` | the station's stream/metadata URL as a query param (+ IP) | metadata poll for stations routed through the CORS/ICY proxy | No (core function) | Yes (subdomain) | none intended; edge logs |
 | 6 | `https://stats.rrradio.org/api/public/bbc/play/<service>` | BBC service id (+ IP) | metadata poll for BBC stations | No (core function) | Yes (subdomain) | none intended |
 | 7 | Broadcaster metadata APIs (e.g. `audioapi.orf.at`, `api.laut.fm`, `www.ffh.de`, `www.radioeins.de`, `www.grrif.ch`) | nothing identifying; the station's own now-playing endpoint (+ IP) | metadata poll while that station plays | No (core function) | No (third party) | none app-side |
@@ -99,8 +99,9 @@ every rule.
 | 12 | Music-service deep links: `music.apple.com/search`, `open.spotify.com/search`, `music.youtube.com/search`, `music.apple.com/.../album/...` | search term or Apple-track URL **opened in the external app/browser** — not a background request | user taps a music-service button on Now Playing | **Yes** (explicit tap) | No (third party) | n/a (handoff) |
 | 13 | `mailto:feedback@rrradio.org` (Add Station catalog submission; broken-station email fallback) | station name + stream URL + the user's own email return address — composed in the OS Mail app, **sent only if the user taps Send** | user submits a catalog request, or emails a broken-station report after the HTTP path fails | **Yes** (explicit send) | Yes (first-party inbox) | maintainer inbox |
 | 14 | iCloud / CloudKit (iOS only) | favorites, station lists, custom stations, preferences — in the **user's own** private database | when iCloud sync is enabled | per-user iCloud (system) | n/a (Apple, user-owned) | until user disables/removes; recents, history, diagnostics, one-shot intents NOT synced |
+| 15 | `https://stats.rrradio.org/api/public/report-status?ids=…` | the device's locally-stored report receipt tokens (random, Worker-minted — see [broken-reports](broken-reports.md)) (+ IP) | app polls while unresolved receipts exist (foreground / stats-sheet open, batched) | follows from row 4's explicit report | Yes (subdomain) | none intended; receipts dropped client-side once resolved/expired |
 
-Rows 2–6 are the **IP-bearing, rrradio-operated** flows that drive the
+Rows 2–6 and 15 are the **IP-bearing, rrradio-operated** flows that drive the
 App Store privacy-label question (see Open questions).
 
 ## Detail
@@ -135,7 +136,8 @@ Region resolution response body (row 2):
 
 `null` country ⇒ state becomes `unknown`, user treated as fail-open available.
 
-Broken-station report body (row 4), exactly as built:
+Broken-station report body (row 4), exactly as built — `category` and
+`comment` only when the report sheet (post-#507 clients) supplies them:
 
 ```json
 {
@@ -145,9 +147,14 @@ Broken-station report body (row 4), exactly as built:
   "platform": "ios",
   "appVersion": "1.0 (42)",
   "reason": "stream failed: HTTP 403",
-  "source": "manual"
+  "source": "manual",
+  "category": "no-audio",
+  "comment": "Plays a second of audio, then silence."
 }
 ```
+
+The Worker answers with `{ "ok": true, "reportId": "<random token>" }`; the
+token is stored locally and polled via row 15.
 
 iTunes cover-art / verify request (row 8) — note artist+title leave the device,
 which is allowed (functional, not analytic):
@@ -184,8 +191,9 @@ Diagnostics export line (always redacted form):
 - **New telemetry events** (web) follow the GoatCounter rule in
   [`../operations.md`](../../operations.md): coarse lifecycle/error events only,
   never per-poll, never query/track content.
-- **Privacy-label drift**: any change to rows 2–6 (the IP-bearing first-party
-  flows) requires re-checking the store privacy disclosures before release.
+- **Privacy-label drift**: any change to rows 2–6 or 15 (the IP-bearing
+  first-party flows) requires re-checking the store privacy disclosures before
+  release.
 
 ## Failure & fallback
 
@@ -214,8 +222,8 @@ Diagnostics export line (always redacted form):
 
 **iOS** (reference)
 
-- Ships **no** analytics SDK; rows 2–6 are the only rrradio-operated calls and
-  MUST point at the first-party domain (no `*.workers.dev`).
+- Ships **no** analytics SDK; rows 2–6 and 15 are the only rrradio-operated
+  calls and MUST point at the first-party domain (no `*.workers.dev`).
 - Diagnostics off by default, capped (100/14d), redacted on export, cleared on
   disable; never auto-uploaded.
 - mailto destinations MUST be a first-party inbox (`feedback@rrradio.org`),
@@ -239,8 +247,9 @@ Diagnostics export line (always redacted form):
 ## Open questions
 
 1. **Productionize vs. disclose `stats.rrradio.org` (RELEASE BLOCKER for the
-   store privacy label).** Rows 2–6 are IP-bearing, fire silently (2, 3, 5, 6)
-   or on explicit tap (4), and qualify as "data linked to the user" under store
+   store privacy label).** Rows 2–6 and 15 are IP-bearing, fire silently
+   (2, 3, 5, 6), on explicit tap (4), or as a consequence of an explicit tap
+   (15), and qualify as "data linked to the user" under store
    privacy definitions. Decide and execute one of: (a) keep `stats.rrradio.org`
    and fully declare the IP/region/stats/report flows in the App Store and Play
    Store privacy labels; (b) gate the silent calls behind first-use consent;

--- a/worker/README.md
+++ b/worker/README.md
@@ -1,6 +1,6 @@
 # rrradio-stats Worker
 
-Cloudflare Worker that solves three problems for the rrradio app:
+Cloudflare Worker that solves four problems for the rrradio app:
 
 1. **GoatCounter token shielding** — the admin dashboard at
    `https://<host>/rrradio/dashboard.html` reads aggregated stats
@@ -15,9 +15,14 @@ Cloudflare Worker that solves three problems for the rrradio app:
    `Origin` header that isn't a `bbc.co.uk` subdomain. The
    `/api/public/bbc/...` routes spoof the right `Origin` server-side
    so the browser can consume the data.
+4. **Broken-station reports** (issue #507) — anonymous user reports
+   with a category and optional comment land in a D1 table, the
+   reporter gets a random receipt id, and the apps poll
+   `/api/public/report-status` to learn when a report is resolved.
+   Protocol contract: `../docs/spec/contracts/broken-reports.md`.
 
-The Worker is single-file (`src/index.ts`, ~460 lines). All responses
-are JSON. All endpoints accept GET. All errors have shape
+Routing lives in `src/index.ts`; the report pipeline in
+`src/reports.ts`. All responses are JSON. All errors have shape
 `{ error: string, message?: string, status?: number }`.
 
 ---
@@ -35,6 +40,8 @@ are JSON. All endpoints accept GET. All errors have shape
 | `/api/public/proxy` | `url=<encoded>` | Forwarded JSON body of the upstream URL, **only** if the URL matches the allowlist (else 403) | 1 m |
 | `/api/public/bbc/schedule/<service>` | `service` is the BBC station slug (e.g. `bbc_world_service`) | Forwarded `rms.api.bbc.co.uk` schedule JSON | 10 m |
 | `/api/public/bbc/play/<service>` | same | Forwarded `rms.api.bbc.co.uk` now-playing JSON | 1 m |
+| `/api/public/report-broken` (POST) | body: `stationId` (required), `stationName`, `streamHost`, `platform`, `appVersion`, `reason`, `source`, `category` (`no-audio\|interruptions\|wrong-station\|wrong-logo\|wrong-info\|other`, else `unspecified`), `comment` (≤500 chars) | `202 { ok, reportId }` — row in D1 `broken_reports`; `reportId` is the anonymous receipt token. Rate-limited 20/IP/day (daily-salted hash, purged next day). Old payloads without category/comment stay valid. | no-store |
+| `/api/public/report-status` | `ids=<receipt,receipt,…>` (≤50) | `{ reports: [{ id, status, resolution?, resolvedAt? }] }` — `status` ∈ received/confirmed/resolved. Unknown ids omitted (client treats as expired). | no-store |
 
 `days` is clamped to `[1, 90]`. The public top-stations endpoint backs
 both `tools/candidates.mjs` (curation surfacing) and the in-app stats
@@ -57,9 +64,12 @@ call per hour regardless of traffic.
 | `/api/systems` | top 10 OS shares (GC `/stats/systems`) |
 | `/api/debug` | raw upstream `/stats/total` body — surfaces which fields this GC account/version actually exposes |
 | `/api/everything` | one call returns totals + stations + favorites + errors + reports + tabs + genres + locations + browsers + systems. Sequential internally with 300 ms sleeps to stay under GC's 4 req/s limit. |
+| `/api/broken-reports` | recent D1 report rows for triage: `{ items: [{ id, stationId, …, category, comment, status, resolution, githubIssue }], total }`. `?status=received\|confirmed\|resolved`, `?limit=N` (1–500, default 200). no-store. |
+| `/api/admin/resolve-reports` (POST) | body: `{ resolution: fixed\|removed\|not-reproducible }` + at least one of `reportIds` (≤100), `stationId` (+ optional `category`), `githubIssue`. Marks matching open reports resolved, stamps the issue number, returns `{ ok, resolved: n }`. Called by `.github/workflows/resolve-reports.yml` when a `broken-station` issue closes. |
 
-All admin endpoints accept `?days=N` (1–90, default 7). All responses
-cache 5 min at the Cloudflare edge.
+All GoatCounter-backed admin endpoints accept `?days=N` (1–90, default
+7) and cache 5 min at the Cloudflare edge; the D1-backed report
+endpoints are no-store.
 
 ---
 
@@ -133,6 +143,45 @@ https://dash.cloudflare.com/profile/api-tokens with the
 **Edit Cloudflare Workers** template (account-scoped). The
 `GOATCOUNTER_TOKEN` and `ADMIN_TOKEN` secrets stay on Cloudflare's
 side via `wrangler secret put` — the workflow does not touch them.
+
+---
+
+## D1: the broken-reports database
+
+The report pipeline stores rows in a D1 database (`rrradio-reports`,
+binding `DB`, schema under `migrations/`). One-time setup:
+
+```sh
+cd worker
+npx wrangler d1 create rrradio-reports
+# paste the printed database_id over the placeholder in wrangler.toml
+npx wrangler d1 migrations apply rrradio-reports --remote
+```
+
+After that, CI applies pending migrations on every deploy
+(idempotent step in `.github/workflows/deploy-worker.yml`) — note the
+`CLOUDFLARE_API_TOKEN` repo secret needs the **D1: Edit** permission in
+addition to the Workers template. For local dev, `wrangler dev`
+provisions a local sqlite copy; apply migrations to it with the same
+command minus `--remote`.
+
+Inspect live reports without the dashboard:
+
+```sh
+curl -s -H "Authorization: Bearer $ADMIN_TOKEN" \
+  'https://stats.rrradio.org/api/broken-reports?status=received' | jq .
+```
+
+### Resolving reports via issue close
+
+`.github/workflows/resolve-reports.yml` fires when an issue labeled
+`broken-station` is closed. It picks the resolution from a
+`resolved:fixed` / `resolved:removed` / `resolved:not-reproducible`
+label (falling back on the close reason: completed → fixed, not
+planned → not-reproducible), pulls the station id from a
+`<!-- rrradio:station-id=<id> -->` marker in the issue body, and POSTs
+`/api/admin/resolve-reports`. It needs the `STATS_ADMIN_TOKEN` repo
+secret set to the Worker's `ADMIN_TOKEN` value.
 
 ---
 
@@ -238,11 +287,18 @@ are different code paths so the logs disambiguate them.
 
 ```
 worker/
-  src/index.ts          — single-file Worker. ~460 lines.
+  src/index.ts          — routing + GoatCounter/proxy/BBC endpoints.
                           Public routes: /api/public/...
                           Admin routes: /api/...
                           Allowlist: const ALLOW = [...]
-  wrangler.toml         — non-secret config (GC site, allowed origin)
+  src/reports.ts        — broken-station report pipeline (D1 ingest,
+                          receipt polling, resolve, triage list)
+  src/env.ts            — Env bindings interface
+  src/respond.ts        — shared JSON response helpers
+  src/test-d1.ts        — in-memory D1 stand-in for tests
+  migrations/           — D1 schema migrations (broken_reports)
+  wrangler.toml         — non-secret config (GC site, allowed origin,
+                          D1 binding)
   .dev.vars             — local-dev secrets (gitignored)
   README.md             — this file
 ```

--- a/worker/README.md
+++ b/worker/README.md
@@ -149,16 +149,18 @@ side via `wrangler secret put` — the workflow does not touch them.
 ## D1: the broken-reports database
 
 The report pipeline stores rows in a D1 database (`rrradio-reports`,
-binding `DB`, schema under `migrations/`). One-time setup:
+binding `DB`, schema under `migrations/`). The database is provisioned
+(2026-06-12, region EEUR; id in `wrangler.toml`) — recreating it from
+scratch would be:
 
 ```sh
 cd worker
 npx wrangler d1 create rrradio-reports
-# paste the printed database_id over the placeholder in wrangler.toml
+# paste the printed database_id into wrangler.toml
 npx wrangler d1 migrations apply rrradio-reports --remote
 ```
 
-After that, CI applies pending migrations on every deploy
+CI applies pending migrations on every deploy
 (idempotent step in `.github/workflows/deploy-worker.yml`) — note the
 `CLOUDFLARE_API_TOKEN` repo secret needs the **D1: Edit** permission in
 addition to the Workers template. For local dev, `wrangler dev`

--- a/worker/migrations/0001_broken_reports.sql
+++ b/worker/migrations/0001_broken_reports.sql
@@ -1,0 +1,38 @@
+-- Broken-station report pipeline (issue #507, P1).
+--
+-- One row per report. The `id` is the anonymous receipt token returned
+-- to the reporting client; it is random and unguessable, and it is the
+-- only handle the reporter ever holds — no reporter identity is stored.
+-- Aggregation ("N people reported no-audio for station X") is a
+-- GROUP BY (station_id, category) over these rows.
+CREATE TABLE broken_reports (
+  id           TEXT PRIMARY KEY,            -- receipt token (crypto-random)
+  station_id   TEXT NOT NULL,
+  station_name TEXT NOT NULL,
+  stream_host  TEXT NOT NULL DEFAULT '',
+  category     TEXT NOT NULL DEFAULT 'unspecified',
+  comment      TEXT NOT NULL DEFAULT '',
+  platform     TEXT NOT NULL DEFAULT 'unknown',
+  app_version  TEXT NOT NULL DEFAULT '',
+  reason       TEXT NOT NULL DEFAULT '',
+  status       TEXT NOT NULL DEFAULT 'received',  -- received | confirmed | resolved
+  resolution   TEXT,                              -- fixed | removed | not-reproducible
+  created_at   TEXT NOT NULL,                     -- ISO 8601 UTC
+  resolved_at  TEXT,
+  github_issue INTEGER                            -- linked issue in MarkusSteinbrecher/rrradio
+);
+
+CREATE INDEX idx_broken_reports_station_category ON broken_reports (station_id, category);
+CREATE INDEX idx_broken_reports_status ON broken_reports (status);
+CREATE INDEX idx_broken_reports_github_issue ON broken_reports (github_issue);
+
+-- Ingest rate limiting. Keyed by a daily-salted SHA-256 of the client
+-- IP — not reversible without the salt, not linkable across days, and
+-- rows for previous days are purged on the next ingest. This table is
+-- rate-limit state only; it is never joined against broken_reports.
+CREATE TABLE report_rate (
+  ip_hash TEXT NOT NULL,
+  day     TEXT NOT NULL,                          -- YYYY-MM-DD UTC
+  count   INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (ip_hash, day)
+);

--- a/worker/src/env.ts
+++ b/worker/src/env.ts
@@ -1,0 +1,12 @@
+/**
+ * Worker bindings. Vars come from wrangler.toml [vars]; secrets
+ * (GOATCOUNTER_TOKEN, ADMIN_TOKEN) via `wrangler secret put`; DB is
+ * the D1 database declared in [[d1_databases]].
+ */
+export interface Env {
+  GOATCOUNTER_SITE: string;
+  GOATCOUNTER_TOKEN: string;
+  ADMIN_TOKEN: string;
+  ALLOWED_ORIGIN: string;
+  DB: D1Database;
+}

--- a/worker/src/index.test.ts
+++ b/worker/src/index.test.ts
@@ -8,13 +8,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import worker from './index';
 import type { Env } from './index';
+import { FakeD1 } from './test-d1';
 
-const ENV: Env = {
-  GOATCOUNTER_SITE: 'test.goatcounter.com',
-  GOATCOUNTER_TOKEN: 'gc-token',
-  ADMIN_TOKEN: 'admin-token',
-  ALLOWED_ORIGIN: 'https://rrradio.org',
-};
+// Rebuilt per test (beforeEach) so every test gets an empty D1.
+let db: FakeD1;
+let ENV: Env;
 
 interface UpstreamCall {
   url: string;
@@ -73,6 +71,14 @@ async function json<T = Record<string, unknown>>(res: Response): Promise<T> {
 }
 
 beforeEach(() => {
+  db = new FakeD1();
+  ENV = {
+    GOATCOUNTER_SITE: 'test.goatcounter.com',
+    GOATCOUNTER_TOKEN: 'gc-token',
+    ADMIN_TOKEN: 'admin-token',
+    ALLOWED_ORIGIN: 'https://rrradio.org',
+    DB: db.asD1(),
+  };
   // Default: fail any upstream fetch unless the test explicitly stubs.
   stubFetch(async (c) => {
     throw new Error(`Unstubbed upstream fetch: ${c.url}`);
@@ -348,7 +354,12 @@ describe('public endpoints', () => {
     expect(url.searchParams.get('e')).toBe('1');
     expect(url.searchParams.get('t')).toContain('station=fm4');
     expect(url.searchParams.get('t')).toContain('host=example.com');
+    expect(url.searchParams.get('t')).toContain('category=unspecified');
     expect(url.searchParams.get('t')).not.toContain('token=private');
+    // The D1 row is the primary record; its id is the receipt token.
+    const body = await json<{ ok: boolean; reportId: string }>(res);
+    expect(body.ok).toBe(true);
+    expect(db.reports.get(body.reportId)?.station_id).toBe('fm4');
   });
 
   it('POST /api/public/report-broken rejects missing station id', async () => {

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -15,7 +15,10 @@
  *   /api/favorites     — most-favorited stations (filter: "favorite: ")
  *
  * Public endpoints:
- *   POST /api/public/report-broken — anonymous structured station report
+ *   POST /api/public/report-broken — anonymous structured station report;
+ *                                    stored in D1, returns a receipt id
+ *   GET  /api/public/report-status — per-receipt report status polling
+ *                                    (?ids=a,b,c — see src/reports.ts)
  *   GET  /api/public/poll          — native-app interest poll tallies,
  *                                    all-time (filter: "vote: ")
  *   GET  /api/public/dashboard     — totals + top stations + locations
@@ -24,18 +27,26 @@
  *                                    consistent snapshot. Plays/locations
  *                                    follow ?days=N; poll is all-time.
  *
+ * Report triage (Bearer ADMIN_TOKEN, see src/reports.ts):
+ *   GET  /api/broken-reports        — recent report rows from D1
+ *   POST /api/admin/resolve-reports — mark reports resolved (called by
+ *                                     the issue-close GitHub Action)
+ *
  * Range: ?days=N (1–90, default 7). Response cached 5 min in the
  * Cloudflare edge cache to be a polite GC API consumer.
  */
 
-export interface Env {
-  GOATCOUNTER_SITE: string;
-  GOATCOUNTER_TOKEN: string;
-  ADMIN_TOKEN: string;
-  ALLOWED_ORIGIN: string;
-}
+import type { Env } from './env';
+import { jsonResponse, noStoreJsonResponse } from './respond';
+import {
+  handleAdminReportsList,
+  handleReportBroken,
+  handleReportStatus,
+  handleResolveReports,
+} from './reports';
 
-const CACHE_TTL_S = 300;
+export type { Env } from './env';
+
 /** Public endpoints cache 5 min at the edge. Short enough that the
  *  numbers visibly track what GoatCounter's own dashboard shows; long
  *  enough that we stay polite to GC's 4 req/s rate limit even under
@@ -112,31 +123,6 @@ function corsHeaders(origin: string, allowed: string): Record<string, string> {
     'Access-Control-Max-Age': '86400',
     Vary: 'Origin',
   };
-}
-
-function jsonResponse(body: unknown, status: number, headers: Record<string, string>): Response {
-  // Cache only successful responses; errors should be retryable
-  // immediately, not pinned at the edge for 5 minutes.
-  const cacheControl = status >= 200 && status < 400 ? `public, max-age=${CACHE_TTL_S}` : 'no-store';
-  return new Response(JSON.stringify(body, null, 2), {
-    status,
-    headers: {
-      'Content-Type': 'application/json; charset=utf-8',
-      'Cache-Control': cacheControl,
-      ...headers,
-    },
-  });
-}
-
-function noStoreJsonResponse(body: unknown, status: number, headers: Record<string, string>): Response {
-  return new Response(JSON.stringify(body, null, 2), {
-    status,
-    headers: {
-      'Content-Type': 'application/json; charset=utf-8',
-      'Cache-Control': 'no-store',
-      ...headers,
-    },
-  });
 }
 
 // 8s per upstream call. GoatCounter is normally <1s; anything slower is
@@ -328,88 +314,6 @@ function emptyList(days: number): ListResponse {
   return { items: [], total: 0, range_days: days };
 }
 
-function cleanField(value: unknown, max = 120): string {
-  if (typeof value !== 'string') return '';
-  return value.replace(/\s+/g, ' ').trim().slice(0, max);
-}
-
-function cleanHost(value: unknown): string {
-  if (typeof value !== 'string') return '';
-  try {
-    return new URL(value).host.slice(0, 120);
-  } catch {
-    return cleanField(value, 120);
-  }
-}
-
-function cleanReportedHost(data: Record<string, unknown>): string {
-  const host = cleanToken(data.streamHost, '', 120);
-  if (host) return host;
-  // Backward compatibility for older clients. New clients send only
-  // streamHost so query strings never reach this Worker.
-  return cleanHost(data.streamUrl);
-}
-
-function cleanToken(value: unknown, fallback: string, max = 40): string {
-  const cleaned = cleanField(value, max).replace(/[^a-z0-9._:-]/gi, '-');
-  return cleaned || fallback;
-}
-
-async function recordGoatCounterEvent(path: string, title: string, env: Env): Promise<void> {
-  const params = new URLSearchParams({
-    p: path,
-    t: title,
-    e: '1',
-  });
-  const res = await fetch(`https://${env.GOATCOUNTER_SITE}/count?${params}`, {
-    headers: {
-      'User-Agent': 'rrradio-stats/1.0 (+https://rrradio.org)',
-      Accept: 'image/gif,*/*',
-    },
-  });
-  if (!res.ok) {
-    throw new Error(`goatcounter count failed: ${res.status}`);
-  }
-}
-
-async function reportBrokenStation(req: Request, env: Env, headers: Record<string, string>): Promise<Response> {
-  const raw = await req.text();
-  if (raw.length > 4096) {
-    return noStoreJsonResponse({ error: 'payload too large' }, 413, headers);
-  }
-
-  let body: unknown;
-  try {
-    body = JSON.parse(raw);
-  } catch {
-    return noStoreJsonResponse({ error: 'invalid json' }, 400, headers);
-  }
-  const data = body && typeof body === 'object' ? (body as Record<string, unknown>) : {};
-  const stationId = cleanToken(data.stationId, '');
-  if (!stationId) {
-    return noStoreJsonResponse({ error: 'stationId required' }, 400, headers);
-  }
-
-  const stationName = cleanField(data.stationName, 90) || stationId;
-  const streamHost = cleanReportedHost(data);
-  const platform = cleanToken(data.platform, 'unknown', 24);
-  const appVersion = cleanField(data.appVersion, 48);
-  const reason = cleanField(data.reason, 160);
-  const source = cleanToken(data.source, 'manual', 24);
-
-  const title = [
-    `station=${stationId}`,
-    streamHost ? `host=${streamHost}` : '',
-    `platform=${platform}`,
-    appVersion ? `app=${appVersion}` : '',
-    reason ? `reason=${reason}` : '',
-    `source=${source}`,
-  ].filter(Boolean).join(' · ');
-
-  await recordGoatCounterEvent(`report-broken: ${stationName}`, title, env);
-  return noStoreJsonResponse({ ok: true }, 202, headers);
-}
-
 /** Generic /stats/<group> reader. Used for browsers, systems, sizes,
  *  locations (country), toprefs, etc. */
 async function fetchStatGroup(
@@ -458,11 +362,15 @@ export default {
           if (req.method !== 'POST') {
             return noStoreJsonResponse({ error: 'method not allowed' }, 405, publicCors);
           }
-          return await reportBrokenStation(req, env, publicCors);
+          return await handleReportBroken(req, env, publicCors);
         }
 
         if (req.method !== 'GET') {
           return jsonResponse({ error: 'method not allowed' }, 405, publicCors);
+        }
+
+        if (url.pathname === '/api/public/report-status') {
+          return await handleReportStatus(url, env, publicCors);
         }
 
         if (url.pathname === '/api/public/top-stations') {
@@ -814,6 +722,28 @@ export default {
       }
     }
 
+    // The one POST admin route. Token-guarded like the GET routes; the
+    // caller is the issue-close GitHub Action (or a human with curl),
+    // not the browser dashboard, so it sits outside the GET-only gate.
+    if (url.pathname === '/api/admin/resolve-reports') {
+      if (req.method !== 'POST') {
+        return noStoreJsonResponse({ error: 'method not allowed' }, 405, cors);
+      }
+      const bearer = req.headers.get('Authorization');
+      if (!env.ADMIN_TOKEN || bearer !== `Bearer ${env.ADMIN_TOKEN}`) {
+        return noStoreJsonResponse({ error: 'unauthorized' }, 401, cors);
+      }
+      try {
+        return await handleResolveReports(req, env, cors);
+      } catch (err) {
+        return noStoreJsonResponse(
+          { error: 'fetch failed', message: err instanceof Error ? err.message : String(err) },
+          502,
+          cors,
+        );
+      }
+    }
+
     if (req.method !== 'GET') {
       return jsonResponse({ error: 'method not allowed' }, 405, cors);
     }
@@ -821,6 +751,20 @@ export default {
     const auth = req.headers.get('Authorization');
     if (!env.ADMIN_TOKEN || auth !== `Bearer ${env.ADMIN_TOKEN}`) {
       return jsonResponse({ error: 'unauthorized' }, 401, cors);
+    }
+
+    // Report triage reads come from D1, not GoatCounter, and want live
+    // state — handled outside the cached GC switch below.
+    if (url.pathname === '/api/broken-reports') {
+      try {
+        return await handleAdminReportsList(url, env, cors);
+      } catch (err) {
+        return noStoreJsonResponse(
+          { error: 'fetch failed', message: err instanceof Error ? err.message : String(err) },
+          502,
+          cors,
+        );
+      }
     }
 
     try {

--- a/worker/src/reports.test.ts
+++ b/worker/src/reports.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Broken-station report pipeline tests (issue #507, P1): D1-backed
+ * ingest with receipt ids, anonymous status polling, per-IP rate
+ * limiting, and the admin resolve + triage-list endpoints. D1 is the
+ * in-memory FakeD1; GoatCounter is a `globalThis.fetch` stub like the
+ * rest of the worker suite.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import worker from './index';
+import type { Env } from './index';
+import { FakeD1 } from './test-d1';
+
+let db: FakeD1;
+let env: Env;
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+beforeEach(() => {
+  db = new FakeD1();
+  env = {
+    GOATCOUNTER_SITE: 'test.goatcounter.com',
+    GOATCOUNTER_TOKEN: 'gc-token',
+    ADMIN_TOKEN: 'admin-token',
+    ALLOWED_ORIGIN: 'https://rrradio.org',
+    DB: db.asD1(),
+  };
+  // GoatCounter accepts everything unless a test overrides.
+  vi.stubGlobal('fetch', vi.fn(async () => new Response(null, { status: 204 })));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+function call(path: string, init: RequestInit = {}): Promise<Response> {
+  return worker.fetch(new Request(`https://worker.test${path}`, init), env);
+}
+
+async function json<T = Record<string, unknown>>(res: Response): Promise<T> {
+  return (await res.json()) as T;
+}
+
+function report(
+  body: Record<string, unknown>,
+  headers: Record<string, string> = {},
+): Promise<Response> {
+  return call('/api/public/report-broken', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+/** Ingest one report and return its receipt id. */
+async function seedReport(over: Record<string, unknown> = {}): Promise<string> {
+  const res = await report({ stationId: 'fm4', stationName: 'FM4', ...over });
+  expect(res.status).toBe(202);
+  const body = await json<{ reportId: string }>(res);
+  expect(body.reportId).toMatch(UUID_RE);
+  return body.reportId;
+}
+
+function resolveReports(body: Record<string, unknown>, token = 'admin-token'): Promise<Response> {
+  return call('/api/admin/resolve-reports', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('report ingest (POST /api/public/report-broken)', () => {
+  it('stores category + comment in D1 and returns a receipt id', async () => {
+    const id = await seedReport({
+      category: 'no-audio',
+      comment: 'Silent since Tuesday morning.',
+      platform: 'ios',
+    });
+    const row = db.reports.get(id);
+    expect(row).toMatchObject({
+      station_id: 'fm4',
+      station_name: 'FM4',
+      category: 'no-audio',
+      comment: 'Silent since Tuesday morning.',
+      platform: 'ios',
+      status: 'received',
+      resolution: null,
+      github_issue: null,
+    });
+    expect(row?.created_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('keeps the GoatCounter event, with category but never the comment', async () => {
+    await seedReport({ category: 'wrong-logo', comment: 'top secret user text' });
+    const gc = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls;
+    expect(gc).toHaveLength(1);
+    const url = new URL(String(gc[0][0]));
+    expect(url.pathname).toBe('/count');
+    expect(url.searchParams.get('t')).toContain('category=wrong-logo');
+    expect(String(url)).not.toContain('secret');
+  });
+
+  it('maps absent or unrecognized categories to "unspecified" (old clients)', async () => {
+    const plain = await seedReport({}); // pre-category payload
+    expect(db.reports.get(plain)?.category).toBe('unspecified');
+    const junk = await seedReport({ category: 'definitely-not-a-category' });
+    expect(db.reports.get(junk)?.category).toBe('unspecified');
+  });
+
+  it('strips control characters from the comment and caps it at 500 chars', async () => {
+    const id = await seedReport({
+      comment: 'line one\u0000\u0007\nline two\t!' + 'x'.repeat(600),
+    });
+    const stored = db.reports.get(id)?.comment ?? '';
+    expect(stored.startsWith('line one\nline two!')).toBe(true);
+    expect(stored.length).toBe(500);
+    expect(stored).not.toContain('\u0007');
+  });
+
+  it('rate-limits the 21st report from the same IP within a day', async () => {
+    const ip = { 'CF-Connecting-IP': '203.0.113.7' };
+    for (let i = 0; i < 20; i++) {
+      const res = await report({ stationId: `s${i}` }, ip);
+      expect(res.status).toBe(202);
+    }
+    const blocked = await report({ stationId: 'one-too-many' }, ip);
+    expect(blocked.status).toBe(429);
+    expect((await json(blocked)).error).toBe('rate limited');
+    // A different IP is unaffected.
+    const other = await report({ stationId: 'fine' }, { 'CF-Connecting-IP': '198.51.100.9' });
+    expect(other.status).toBe(202);
+  });
+
+  it('still returns the receipt when GoatCounter is down (D1 is primary)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => {
+      throw new Error('GC down');
+    }));
+    const res = await report({ stationId: 'fm4' });
+    expect(res.status).toBe(202);
+    const body = await json<{ ok: boolean; reportId: string }>(res);
+    expect(body.reportId).toMatch(UUID_RE);
+    expect(db.reports.size).toBe(1);
+  });
+
+  it('falls back to the old receipt-less 202 when D1 is down but GC works', async () => {
+    db.failInserts = true;
+    const res = await report({ stationId: 'fm4' });
+    expect(res.status).toBe(202);
+    const body = await json<{ ok: boolean; reportId?: string }>(res);
+    expect(body.ok).toBe(true);
+    expect(body.reportId).toBeUndefined();
+  });
+
+  it('returns 502 when both D1 and GoatCounter fail', async () => {
+    db.failInserts = true;
+    vi.stubGlobal('fetch', vi.fn(async () => {
+      throw new Error('GC down');
+    }));
+    const res = await report({ stationId: 'fm4' });
+    expect(res.status).toBe(502);
+  });
+});
+
+describe('receipt polling (GET /api/public/report-status)', () => {
+  it('returns status per known id and omits unknown ids', async () => {
+    const id = await seedReport({ category: 'no-audio' });
+    const ghost = '00000000-0000-4000-8000-000000000000';
+    const res = await call(`/api/public/report-status?ids=${id},${ghost}`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Cache-Control')).toBe('no-store');
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('*');
+    const body = await json<{ reports: Array<Record<string, unknown>> }>(res);
+    expect(body.reports).toEqual([{ id, status: 'received' }]);
+  });
+
+  it('includes resolution + resolvedAt once resolved', async () => {
+    const id = await seedReport({});
+    await resolveReports({ resolution: 'fixed', reportIds: [id] });
+    const res = await call(`/api/public/report-status?ids=${id}`);
+    const body = await json<{ reports: Array<Record<string, unknown>> }>(res);
+    expect(body.reports).toHaveLength(1);
+    expect(body.reports[0]).toMatchObject({ id, status: 'resolved', resolution: 'fixed' });
+    expect(String(body.reports[0].resolvedAt)).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('ignores malformed ids and empty queries', async () => {
+    for (const q of ['', '?ids=', "?ids=1'%3BDROP%20TABLE--,not-a-uuid"]) {
+      const res = await call(`/api/public/report-status${q}`);
+      expect(res.status).toBe(200);
+      expect((await json<{ reports: unknown[] }>(res)).reports).toEqual([]);
+    }
+  });
+});
+
+describe('admin resolve (POST /api/admin/resolve-reports)', () => {
+  it('requires the admin bearer token', async () => {
+    const res = await resolveReports({ resolution: 'fixed', stationId: 'fm4' }, 'wrong');
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects non-POST with 405', async () => {
+    const res = await call('/api/admin/resolve-reports', {
+      headers: { Authorization: 'Bearer admin-token' },
+    });
+    expect(res.status).toBe(405);
+  });
+
+  it('rejects an unknown resolution and a selector-less body with 400', async () => {
+    expect((await resolveReports({ resolution: 'wontfix', stationId: 'fm4' })).status).toBe(400);
+    expect((await resolveReports({ resolution: 'fixed' })).status).toBe(400);
+  });
+
+  it('resolves all open reports for a station and stamps the issue number', async () => {
+    const a = await seedReport({ category: 'no-audio' });
+    const b = await seedReport({ category: 'interruptions' });
+    const other = await seedReport({ stationId: 'swr3' });
+
+    const res = await resolveReports({ resolution: 'fixed', stationId: 'fm4', githubIssue: 510 });
+    expect(res.status).toBe(200);
+    expect(await json(res)).toEqual({ ok: true, resolved: 2 });
+
+    for (const id of [a, b]) {
+      expect(db.reports.get(id)).toMatchObject({
+        status: 'resolved',
+        resolution: 'fixed',
+        github_issue: 510,
+      });
+    }
+    expect(db.reports.get(other)?.status).toBe('received');
+
+    // Idempotent: a second close resolves nothing new.
+    const again = await resolveReports({ resolution: 'fixed', stationId: 'fm4', githubIssue: 510 });
+    expect(await json(again)).toEqual({ ok: true, resolved: 0 });
+  });
+
+  it('scopes to a category when one is given', async () => {
+    const logo = await seedReport({ category: 'wrong-logo' });
+    const audio = await seedReport({ category: 'no-audio' });
+    await resolveReports({ resolution: 'fixed', stationId: 'fm4', category: 'wrong-logo' });
+    expect(db.reports.get(logo)?.status).toBe('resolved');
+    expect(db.reports.get(audio)?.status).toBe('received');
+  });
+
+  it('resolves by linked github issue (P2 upsert linkage)', async () => {
+    const id = await seedReport({});
+    // Link the row to an issue first (as the P2 upserter will), then
+    // resolve by issue number alone.
+    await resolveReports({ resolution: 'removed', reportIds: [id], githubIssue: 511 });
+    const second = await seedReport({});
+    const row = db.reports.get(second);
+    if (row) row.github_issue = 511;
+    if (row) row.status = 'confirmed';
+    const res = await resolveReports({ resolution: 'removed', githubIssue: 511 });
+    expect(await json(res)).toEqual({ ok: true, resolved: 1 });
+    expect(db.reports.get(second)?.status).toBe('resolved');
+  });
+});
+
+describe('admin triage list (GET /api/broken-reports)', () => {
+  it('requires auth', async () => {
+    const res = await call('/api/broken-reports');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns rows with camelCase fields, filterable by status', async () => {
+    const a = await seedReport({ category: 'no-audio', comment: 'dead air' });
+    const b = await seedReport({ stationId: 'swr3', category: 'wrong-logo' });
+    await resolveReports({ resolution: 'fixed', reportIds: [b] });
+
+    const all = await call('/api/broken-reports', {
+      headers: { Authorization: 'Bearer admin-token' },
+    });
+    expect(all.status).toBe(200);
+    expect(all.headers.get('Cache-Control')).toBe('no-store');
+    const allBody = await json<{ items: Array<Record<string, unknown>>; total: number }>(all);
+    expect(allBody.total).toBe(2);
+    expect(allBody.items.map((i) => i.id)).toContain(a);
+    const rowA = allBody.items.find((i) => i.id === a);
+    expect(rowA).toMatchObject({
+      stationId: 'fm4',
+      category: 'no-audio',
+      comment: 'dead air',
+      status: 'received',
+    });
+
+    const open = await call('/api/broken-reports?status=received', {
+      headers: { Authorization: 'Bearer admin-token' },
+    });
+    const openBody = await json<{ items: Array<Record<string, unknown>> }>(open);
+    expect(openBody.items.map((i) => i.id)).toEqual([a]);
+
+    const bad = await call('/api/broken-reports?status=nonsense', {
+      headers: { Authorization: 'Bearer admin-token' },
+    });
+    expect(bad.status).toBe(400);
+  });
+});

--- a/worker/src/reports.ts
+++ b/worker/src/reports.ts
@@ -1,0 +1,421 @@
+/**
+ * Broken-station report pipeline (issue #507, P1).
+ *
+ * Reports land in the D1 `broken_reports` table; the row id doubles as
+ * the anonymous receipt token the client polls with. The GoatCounter
+ * event the old endpoint emitted is kept (best-effort) so the existing
+ * admin dashboard keeps working, but D1 is the primary record.
+ *
+ *   POST /api/public/report-broken   — ingest, returns { ok, reportId }
+ *   GET  /api/public/report-status   — receipt polling (?ids=a,b,c)
+ *   POST /api/admin/resolve-reports  — mark reports resolved (Bearer ADMIN_TOKEN)
+ *   GET  /api/broken-reports         — recent rows for triage (Bearer ADMIN_TOKEN)
+ *
+ * Lifecycle: received → confirmed (P2 prober / report threshold)
+ * → resolved (fixed | removed | not-reproducible). P1 ships ingest,
+ * polling, and resolve; nothing here moves rows to `confirmed` yet.
+ */
+
+import type { Env } from './env';
+import { noStoreJsonResponse } from './respond';
+
+export const CATEGORIES = [
+  'no-audio',
+  'interruptions',
+  'wrong-station',
+  'wrong-logo',
+  'wrong-info',
+  'other',
+] as const;
+
+export const RESOLUTIONS = ['fixed', 'removed', 'not-reproducible'] as const;
+export type Resolution = (typeof RESOLUTIONS)[number];
+
+const REPORT_STATUSES = ['received', 'confirmed', 'resolved'] as const;
+
+const COMMENT_MAX = 500;
+/** Per-IP ingest cap. Generous for a human (you'd have to report 20
+ *  stations in a day) but stops scripted flooding. */
+const RATE_LIMIT_PER_DAY = 20;
+const STATUS_IDS_MAX = 50;
+const RESOLVE_IDS_MAX = 100;
+
+/**
+ * Statements as named constants so the test suite's fake D1 dispatches
+ * on statement identity instead of parsing SQL. Receipt ids never go
+ * through string interpolation — always bound parameters.
+ */
+export const SQL = {
+  insertReport:
+    "INSERT INTO broken_reports (id, station_id, station_name, stream_host, category, comment, platform, app_version, reason, status, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'received', ?)",
+  upsertRate:
+    'INSERT INTO report_rate (ip_hash, day, count) VALUES (?, ?, 1) ON CONFLICT (ip_hash, day) DO UPDATE SET count = count + 1 RETURNING count',
+  purgeRate: 'DELETE FROM report_rate WHERE day < ?',
+  selectStatus:
+    'SELECT id, status, resolution, resolved_at FROM broken_reports WHERE id = ?',
+  resolveById:
+    "UPDATE broken_reports SET status = 'resolved', resolution = ?, resolved_at = ?, github_issue = COALESCE(?, github_issue) WHERE id = ? AND status != 'resolved'",
+  resolveByStation:
+    "UPDATE broken_reports SET status = 'resolved', resolution = ?, resolved_at = ?, github_issue = COALESCE(?, github_issue) WHERE station_id = ? AND status != 'resolved'",
+  resolveByStationCategory:
+    "UPDATE broken_reports SET status = 'resolved', resolution = ?, resolved_at = ?, github_issue = COALESCE(?, github_issue) WHERE station_id = ? AND category = ? AND status != 'resolved'",
+  resolveByIssue:
+    "UPDATE broken_reports SET status = 'resolved', resolution = ?, resolved_at = ?, github_issue = COALESCE(?, github_issue) WHERE github_issue = ? AND status != 'resolved'",
+  selectRecent:
+    'SELECT id, station_id, station_name, stream_host, category, comment, platform, app_version, reason, status, resolution, created_at, resolved_at, github_issue FROM broken_reports ORDER BY created_at DESC LIMIT ?',
+  selectRecentByStatus:
+    'SELECT id, station_id, station_name, stream_host, category, comment, platform, app_version, reason, status, resolution, created_at, resolved_at, github_issue FROM broken_reports WHERE status = ? ORDER BY created_at DESC LIMIT ?',
+} as const;
+
+interface StatusRow {
+  id: string;
+  status: string;
+  resolution: string | null;
+  resolved_at: string | null;
+}
+
+interface ReportRow extends StatusRow {
+  station_id: string;
+  station_name: string;
+  stream_host: string;
+  category: string;
+  comment: string;
+  platform: string;
+  app_version: string;
+  reason: string;
+  created_at: string;
+  github_issue: number | null;
+}
+
+function cleanField(value: unknown, max = 120): string {
+  if (typeof value !== 'string') return '';
+  return value.replace(/\s+/g, ' ').trim().slice(0, max);
+}
+
+function cleanHost(value: unknown): string {
+  if (typeof value !== 'string') return '';
+  try {
+    return new URL(value).host.slice(0, 120);
+  } catch {
+    return cleanField(value, 120);
+  }
+}
+
+function cleanReportedHost(data: Record<string, unknown>): string {
+  const host = cleanToken(data.streamHost, '', 120);
+  if (host) return host;
+  // Backward compatibility for older clients. New clients send only
+  // streamHost so query strings never reach this Worker.
+  return cleanHost(data.streamUrl);
+}
+
+function cleanToken(value: unknown, fallback: string, max = 40): string {
+  const cleaned = cleanField(value, max).replace(/[^a-z0-9._:-]/gi, '-');
+  return cleaned || fallback;
+}
+
+/** User-authored free text. Newlines survive; other control characters
+ *  are stripped, runs of spaces collapse, length capped. Stored as
+ *  plain text — anything rendering it (GitHub issue bodies in P2)
+ *  escapes at the output edge. */
+function cleanComment(value: unknown): string {
+  if (typeof value !== 'string') return '';
+  return value
+    .replace(/[\u0000-\u0009\u000b-\u001f\u007f]/g, '')
+    .replace(/ {2,}/g, ' ')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim()
+    .slice(0, COMMENT_MAX);
+}
+
+function parseCategory(value: unknown): string {
+  // Absent or unrecognized → 'unspecified' so pre-category clients
+  // keep working unchanged.
+  const raw = cleanToken(value, '', 24);
+  return (CATEGORIES as readonly string[]).includes(raw) ? raw : 'unspecified';
+}
+
+const RECEIPT_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function parseReceiptIds(raw: string, max: number): string[] {
+  const ids = raw
+    .split(',')
+    .map((s) => s.trim().toLowerCase())
+    .filter((s) => RECEIPT_RE.test(s));
+  return [...new Set(ids)].slice(0, max);
+}
+
+async function sha256Hex(input: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(input));
+  return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+async function recordGoatCounterEvent(path: string, title: string, env: Env): Promise<void> {
+  const params = new URLSearchParams({
+    p: path,
+    t: title,
+    e: '1',
+  });
+  const res = await fetch(`https://${env.GOATCOUNTER_SITE}/count?${params}`, {
+    headers: {
+      'User-Agent': 'rrradio-stats/1.0 (+https://rrradio.org)',
+      Accept: 'image/gif,*/*',
+    },
+  });
+  if (!res.ok) {
+    throw new Error(`goatcounter count failed: ${res.status}`);
+  }
+}
+
+/** True when this IP already spent its daily report budget. Fail-open:
+ *  a D1 hiccup must not block a legitimate report. The hash is salted
+ *  with the day + a server secret so the stored key is neither
+ *  reversible nor linkable across days. */
+async function isRateLimited(req: Request, env: Env): Promise<boolean> {
+  const ip = req.headers.get('CF-Connecting-IP') ?? '';
+  if (!ip) return false;
+  try {
+    const day = new Date().toISOString().slice(0, 10);
+    const ipHash = await sha256Hex(`${day}:${ip}:${env.ADMIN_TOKEN}`);
+    const row = await env.DB.prepare(SQL.upsertRate)
+      .bind(ipHash, day)
+      .first<{ count: number }>();
+    await env.DB.prepare(SQL.purgeRate).bind(day).run();
+    return (row?.count ?? 0) > RATE_LIMIT_PER_DAY;
+  } catch (err) {
+    console.error('[report-rate]', err instanceof Error ? err.message : String(err));
+    return false;
+  }
+}
+
+export async function handleReportBroken(
+  req: Request,
+  env: Env,
+  headers: Record<string, string>,
+): Promise<Response> {
+  const raw = await req.text();
+  if (raw.length > 4096) {
+    return noStoreJsonResponse({ error: 'payload too large' }, 413, headers);
+  }
+
+  let body: unknown;
+  try {
+    body = JSON.parse(raw);
+  } catch {
+    return noStoreJsonResponse({ error: 'invalid json' }, 400, headers);
+  }
+  const data = body && typeof body === 'object' ? (body as Record<string, unknown>) : {};
+  const stationId = cleanToken(data.stationId, '');
+  if (!stationId) {
+    return noStoreJsonResponse({ error: 'stationId required' }, 400, headers);
+  }
+
+  if (await isRateLimited(req, env)) {
+    return noStoreJsonResponse({ error: 'rate limited' }, 429, headers);
+  }
+
+  const stationName = cleanField(data.stationName, 90) || stationId;
+  const streamHost = cleanReportedHost(data);
+  const platform = cleanToken(data.platform, 'unknown', 24);
+  const appVersion = cleanField(data.appVersion, 48);
+  const reason = cleanField(data.reason, 160);
+  const source = cleanToken(data.source, 'manual', 24);
+  const category = parseCategory(data.category);
+  const comment = cleanComment(data.comment);
+
+  // D1 is the primary record; the receipt only exists if the row does.
+  let reportId: string | null = crypto.randomUUID();
+  try {
+    await env.DB.prepare(SQL.insertReport)
+      .bind(
+        reportId,
+        stationId,
+        stationName,
+        streamHost,
+        category,
+        comment,
+        platform,
+        appVersion,
+        reason,
+        new Date().toISOString(),
+      )
+      .run();
+  } catch (err) {
+    console.error('[report-insert]', err instanceof Error ? err.message : String(err));
+    reportId = null;
+  }
+
+  // Keep the GoatCounter event so the existing admin dashboard's
+  // reports card keeps working. Best-effort: the comment never goes to
+  // GC (user-authored text stays in D1), and a GC failure doesn't fail
+  // the report as long as the D1 row landed.
+  const title = [
+    `station=${stationId}`,
+    streamHost ? `host=${streamHost}` : '',
+    `platform=${platform}`,
+    appVersion ? `app=${appVersion}` : '',
+    `category=${category}`,
+    reason ? `reason=${reason}` : '',
+    `source=${source}`,
+  ]
+    .filter(Boolean)
+    .join(' · ');
+  let gcOk = true;
+  try {
+    await recordGoatCounterEvent(`report-broken: ${stationName}`, title, env);
+  } catch (err) {
+    gcOk = false;
+    console.error('[report-gc]', err instanceof Error ? err.message : String(err));
+  }
+
+  if (!reportId && !gcOk) {
+    // Both stores failed — don't pretend the report landed.
+    return noStoreJsonResponse({ error: 'store failed' }, 502, headers);
+  }
+  return noStoreJsonResponse(reportId ? { ok: true, reportId } : { ok: true }, 202, headers);
+}
+
+/** GET /api/public/report-status?ids=a,b,c — anonymous receipt polling.
+ *  Unknown ids are omitted (client treats as expired). no-store: a
+ *  resolution must be visible on the next poll, and receipts are
+ *  per-reporter anyway. */
+export async function handleReportStatus(
+  url: URL,
+  env: Env,
+  headers: Record<string, string>,
+): Promise<Response> {
+  const ids = parseReceiptIds(url.searchParams.get('ids') ?? '', STATUS_IDS_MAX);
+  if (ids.length === 0) {
+    return noStoreJsonResponse({ reports: [] }, 200, headers);
+  }
+  const results = await env.DB.batch<StatusRow>(
+    ids.map((id) => env.DB.prepare(SQL.selectStatus).bind(id)),
+  );
+  const reports = results
+    .flatMap((r) => r.results ?? [])
+    .map((row) => ({
+      id: row.id,
+      status: row.status,
+      ...(row.resolution ? { resolution: row.resolution } : {}),
+      ...(row.resolved_at ? { resolvedAt: row.resolved_at } : {}),
+    }));
+  return noStoreJsonResponse({ reports }, 200, headers);
+}
+
+/** POST /api/admin/resolve-reports — mark reports resolved. Selectors
+ *  (reportIds, stationId [+ category], githubIssue) are OR-combined;
+ *  at least one is required. Already-resolved rows are never touched,
+ *  so overlapping selectors don't double-count. Called by the
+ *  issue-close GitHub Action and by hand. */
+export async function handleResolveReports(
+  req: Request,
+  env: Env,
+  headers: Record<string, string>,
+): Promise<Response> {
+  const raw = await req.text();
+  if (raw.length > 16384) {
+    return noStoreJsonResponse({ error: 'payload too large' }, 413, headers);
+  }
+  let body: unknown;
+  try {
+    body = JSON.parse(raw);
+  } catch {
+    return noStoreJsonResponse({ error: 'invalid json' }, 400, headers);
+  }
+  const data = body && typeof body === 'object' ? (body as Record<string, unknown>) : {};
+
+  const resolution = cleanToken(data.resolution, '', 24);
+  if (!(RESOLUTIONS as readonly string[]).includes(resolution)) {
+    return noStoreJsonResponse(
+      { error: `resolution must be one of: ${RESOLUTIONS.join(', ')}` },
+      400,
+      headers,
+    );
+  }
+
+  const reportIds = Array.isArray(data.reportIds)
+    ? parseReceiptIds(data.reportIds.filter((v) => typeof v === 'string').join(','), RESOLVE_IDS_MAX)
+    : [];
+  const stationId = cleanToken(data.stationId, '');
+  const category = cleanToken(data.category, '', 24);
+  const githubIssue =
+    typeof data.githubIssue === 'number' && Number.isInteger(data.githubIssue) && data.githubIssue > 0
+      ? data.githubIssue
+      : null;
+
+  if (reportIds.length === 0 && !stationId && !githubIssue) {
+    return noStoreJsonResponse(
+      { error: 'at least one of reportIds, stationId, githubIssue required' },
+      400,
+      headers,
+    );
+  }
+
+  const resolvedAt = new Date().toISOString();
+  const stmts: D1PreparedStatement[] = reportIds.map((id) =>
+    env.DB.prepare(SQL.resolveById).bind(resolution, resolvedAt, githubIssue, id),
+  );
+  if (stationId && category) {
+    stmts.push(
+      env.DB.prepare(SQL.resolveByStationCategory).bind(
+        resolution,
+        resolvedAt,
+        githubIssue,
+        stationId,
+        category,
+      ),
+    );
+  } else if (stationId) {
+    stmts.push(env.DB.prepare(SQL.resolveByStation).bind(resolution, resolvedAt, githubIssue, stationId));
+  }
+  if (githubIssue) {
+    stmts.push(env.DB.prepare(SQL.resolveByIssue).bind(resolution, resolvedAt, githubIssue, githubIssue));
+  }
+
+  const results = await env.DB.batch(stmts);
+  const resolved = results.reduce((sum, r) => sum + (r.meta?.changes ?? 0), 0);
+  return noStoreJsonResponse({ ok: true, resolved }, 200, headers);
+}
+
+/** GET /api/broken-reports — recent report rows for manual triage
+ *  (admin dashboard / curl). Optional ?status=received|confirmed|resolved,
+ *  ?limit=N (1–500, default 200). no-store: triage wants live state,
+ *  not a 5-minute-old snapshot. */
+export async function handleAdminReportsList(
+  url: URL,
+  env: Env,
+  headers: Record<string, string>,
+): Promise<Response> {
+  const statusFilter = url.searchParams.get('status') ?? '';
+  if (statusFilter && !(REPORT_STATUSES as readonly string[]).includes(statusFilter)) {
+    return noStoreJsonResponse(
+      { error: `status must be one of: ${REPORT_STATUSES.join(', ')}` },
+      400,
+      headers,
+    );
+  }
+  const limit = Math.min(500, Math.max(1, Number(url.searchParams.get('limit')) || 200));
+
+  const stmt = statusFilter
+    ? env.DB.prepare(SQL.selectRecentByStatus).bind(statusFilter, limit)
+    : env.DB.prepare(SQL.selectRecent).bind(limit);
+  const { results } = await stmt.all<ReportRow>();
+
+  const items = (results ?? []).map((row) => ({
+    id: row.id,
+    stationId: row.station_id,
+    stationName: row.station_name,
+    streamHost: row.stream_host,
+    category: row.category,
+    comment: row.comment,
+    platform: row.platform,
+    appVersion: row.app_version,
+    reason: row.reason,
+    status: row.status,
+    resolution: row.resolution,
+    createdAt: row.created_at,
+    resolvedAt: row.resolved_at,
+    githubIssue: row.github_issue,
+  }));
+  return noStoreJsonResponse({ items, total: items.length }, 200, headers);
+}

--- a/worker/src/respond.ts
+++ b/worker/src/respond.ts
@@ -1,0 +1,26 @@
+export const CACHE_TTL_S = 300;
+
+export function jsonResponse(body: unknown, status: number, headers: Record<string, string>): Response {
+  // Cache only successful responses; errors should be retryable
+  // immediately, not pinned at the edge for 5 minutes.
+  const cacheControl = status >= 200 && status < 400 ? `public, max-age=${CACHE_TTL_S}` : 'no-store';
+  return new Response(JSON.stringify(body, null, 2), {
+    status,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Cache-Control': cacheControl,
+      ...headers,
+    },
+  });
+}
+
+export function noStoreJsonResponse(body: unknown, status: number, headers: Record<string, string>): Response {
+  return new Response(JSON.stringify(body, null, 2), {
+    status,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Cache-Control': 'no-store',
+      ...headers,
+    },
+  });
+}

--- a/worker/src/test-d1.ts
+++ b/worker/src/test-d1.ts
@@ -1,0 +1,182 @@
+/**
+ * Minimal in-memory D1 stand-in for the worker tests. Dispatches on
+ * statement identity — the SQL constants exported from reports.ts —
+ * so an edited statement fails loudly here instead of silently
+ * matching a stale string pattern. Test-only; never imported from the
+ * deployed entry point.
+ */
+import { SQL } from './reports';
+
+export interface FakeReportRow {
+  id: string;
+  station_id: string;
+  station_name: string;
+  stream_host: string;
+  category: string;
+  comment: string;
+  platform: string;
+  app_version: string;
+  reason: string;
+  status: string;
+  resolution: string | null;
+  created_at: string;
+  resolved_at: string | null;
+  github_issue: number | null;
+}
+
+interface FakeResult {
+  results: unknown[];
+  success: true;
+  meta: { changes: number };
+}
+
+export class FakeD1 {
+  reports = new Map<string, FakeReportRow>();
+  /** `${ip_hash}|${day}` → count */
+  rate = new Map<string, number>();
+  /** Simulates a D1 outage on the report INSERT path. */
+  failInserts = false;
+
+  prepare(sql: string): FakeStatement {
+    return new FakeStatement(this, sql);
+  }
+
+  async batch(stmts: FakeStatement[]): Promise<FakeResult[]> {
+    const out: FakeResult[] = [];
+    for (const s of stmts) out.push(await s.run());
+    return out;
+  }
+
+  asD1(): D1Database {
+    return this as unknown as D1Database;
+  }
+}
+
+export class FakeStatement {
+  private binds: unknown[] = [];
+
+  constructor(
+    private readonly db: FakeD1,
+    private readonly sql: string,
+  ) {}
+
+  bind(...args: unknown[]): this {
+    this.binds = args;
+    return this;
+  }
+
+  async first<T>(): Promise<T | null> {
+    const { results } = await this.run();
+    return (results[0] as T) ?? null;
+  }
+
+  async all(): Promise<FakeResult> {
+    return this.run();
+  }
+
+  async run(): Promise<FakeResult> {
+    const db = this.db;
+    const b = this.binds;
+    const result = (results: unknown[] = [], changes = 0): FakeResult => ({
+      results,
+      success: true,
+      meta: { changes },
+    });
+
+    switch (this.sql) {
+      case SQL.insertReport: {
+        if (db.failInserts) throw new Error('D1 unavailable');
+        const [id, stationId, stationName, streamHost, category, comment, platform, appVersion, reason, createdAt] =
+          b as string[];
+        db.reports.set(id, {
+          id,
+          station_id: stationId,
+          station_name: stationName,
+          stream_host: streamHost,
+          category,
+          comment,
+          platform,
+          app_version: appVersion,
+          reason,
+          status: 'received',
+          resolution: null,
+          created_at: createdAt,
+          resolved_at: null,
+          github_issue: null,
+        });
+        return result([], 1);
+      }
+
+      case SQL.upsertRate: {
+        const [hash, day] = b as string[];
+        const key = `${hash}|${day}`;
+        const count = (db.rate.get(key) ?? 0) + 1;
+        db.rate.set(key, count);
+        return result([{ count }], 1);
+      }
+
+      case SQL.purgeRate: {
+        const [day] = b as string[];
+        let changes = 0;
+        for (const key of [...db.rate.keys()]) {
+          if (key.split('|')[1] < day) {
+            db.rate.delete(key);
+            changes++;
+          }
+        }
+        return result([], changes);
+      }
+
+      case SQL.selectStatus: {
+        const [id] = b as string[];
+        const row = db.reports.get(id);
+        return result(
+          row
+            ? [{ id: row.id, status: row.status, resolution: row.resolution, resolved_at: row.resolved_at }]
+            : [],
+        );
+      }
+
+      case SQL.resolveById:
+      case SQL.resolveByStation:
+      case SQL.resolveByStationCategory:
+      case SQL.resolveByIssue: {
+        const [resolution, resolvedAt, ghIssue, ...rest] = b as [string, string, number | null, ...unknown[]];
+        const matches = (row: FakeReportRow): boolean => {
+          if (row.status === 'resolved') return false;
+          if (this.sql === SQL.resolveById) return row.id === rest[0];
+          if (this.sql === SQL.resolveByStation) return row.station_id === rest[0];
+          if (this.sql === SQL.resolveByStationCategory) {
+            return row.station_id === rest[0] && row.category === rest[1];
+          }
+          return row.github_issue === rest[0];
+        };
+        let changes = 0;
+        for (const row of db.reports.values()) {
+          if (!matches(row)) continue;
+          row.status = 'resolved';
+          row.resolution = resolution;
+          row.resolved_at = resolvedAt;
+          row.github_issue = ghIssue ?? row.github_issue;
+          changes++;
+        }
+        return result([], changes);
+      }
+
+      case SQL.selectRecent:
+      case SQL.selectRecentByStatus: {
+        const byStatus = this.sql === SQL.selectRecentByStatus;
+        const status = byStatus ? (b[0] as string) : null;
+        const limit = (byStatus ? b[1] : b[0]) as number;
+        const rows = [...db.reports.values()]
+          .filter((r) => !status || r.status === status)
+          .sort((a, z) => z.created_at.localeCompare(a.created_at))
+          .slice(0, limit);
+        return result(rows.map((r) => ({ ...r })));
+      }
+
+      default:
+        throw new Error(`FakeD1: unrecognized statement: ${this.sql}`);
+    }
+  }
+}

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -18,3 +18,16 @@ routes = [
 [vars]
 GOATCOUNTER_SITE = "markussteinbrecher.goatcounter.com"
 ALLOWED_ORIGIN  = "https://rrradio.org"
+
+# Broken-station reports (issue #507). ONE-TIME SETUP: create the
+# database and paste the id it prints over the placeholder below —
+#   npx wrangler d1 create rrradio-reports
+# then apply the schema:
+#   npx wrangler d1 migrations apply rrradio-reports --remote
+# `wrangler dev` provisions a local sqlite copy automatically (apply
+# migrations locally with the same command minus --remote).
+[[d1_databases]]
+binding = "DB"
+database_name = "rrradio-reports"
+database_id = "REPLACE_WITH_D1_DATABASE_ID"
+migrations_dir = "migrations"

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -19,15 +19,12 @@ routes = [
 GOATCOUNTER_SITE = "markussteinbrecher.goatcounter.com"
 ALLOWED_ORIGIN  = "https://rrradio.org"
 
-# Broken-station reports (issue #507). ONE-TIME SETUP: create the
-# database and paste the id it prints over the placeholder below —
-#   npx wrangler d1 create rrradio-reports
-# then apply the schema:
-#   npx wrangler d1 migrations apply rrradio-reports --remote
-# `wrangler dev` provisions a local sqlite copy automatically (apply
-# migrations locally with the same command minus --remote).
+# Broken-station reports (issue #507). Schema lives in migrations/;
+# CI applies pending migrations before every deploy, and `wrangler dev`
+# provisions a local sqlite copy automatically (apply migrations to it
+# with `npx wrangler d1 migrations apply rrradio-reports` minus --remote).
 [[d1_databases]]
 binding = "DB"
 database_name = "rrradio-reports"
-database_id = "REPLACE_WITH_D1_DATABASE_ID"
+database_id = "3617b3fa-9ff7-4cc2-b38f-3140850cba15"
 migrations_dir = "migrations"


### PR DESCRIPTION
## What

Phase 1 of #507 — the Worker/back-end half of the broken-station report pipeline.

**Protocol** (contract: `docs/spec/contracts/broken-reports.md`)
- `POST /api/public/report-broken` extended **backward-compatibly**: new `category` (`no-audio | interruptions | wrong-station | wrong-logo | wrong-info | other`, absent/unknown → `unspecified`) and `comment` (≤500 chars, control chars stripped on ingest, never forwarded to GoatCounter). Response becomes `202 { ok, reportId }` — the receipt token is a crypto-random UUID, the only handle the reporter holds.
- `GET /api/public/report-status?ids=a,b,c` (new) — per id `{ id, status, resolution?, resolvedAt? }`; unknown ids omitted so clients expire stale receipts.
- `POST /api/admin/resolve-reports` (Bearer `ADMIN_TOKEN`) — selectors `reportIds` / `stationId` (+ optional `category`) / `githubIssue` OR-combine; already-resolved rows untouched, so it's idempotent; stamps `github_issue` on resolved rows.
- `GET /api/broken-reports` (admin) — recent D1 rows for manual triage (`?status=`, `?limit=`).

**Storage** — D1 `broken_reports` per the issue's schema (`worker/migrations/0001_broken_reports.sql`). No reporter identity: rate limiting (20/IP/UTC-day) uses a daily-salted SHA-256 of the IP in a separate table, purged the next day, and fails open on D1 hiccups. If D1 is down but GoatCounter is up, ingest degrades to the old receipt-less `202 { ok }`.

**Automation** — `.github/workflows/resolve-reports.yml`: closing an issue labeled `broken-station` resolves its reports. Resolution = `resolved:fixed` / `resolved:removed` / `resolved:not-reproducible` label, else GitHub close reason (completed → fixed, not planned → not-reproducible). Station id read from an `<!-- rrradio:station-id=<id> -->` body marker (the convention the P2 upserter will write).

**Spec** — new contract doc; privacy matrix row 4 extended (category + comment + rate-limit hash note) and new row 15 for the status poll; the "rows 2–6" privacy-label references updated; ops telemetry table updated.

**Code** — worker split into `reports.ts` / `env.ts` / `respond.ts` (index.ts routes). Tests: 19 new cases against an in-memory D1 fake that dispatches on exported SQL-statement identity (no SQL string matching). 63/63 pass, typecheck clean, `wrangler deploy --dry-run` builds with the binding.

## One-time setup

1. ~~Create the D1 database and wire its id into `wrangler.toml`~~ ✅ **Done** — `rrradio-reports` created 2026-06-12 (region EEUR), id committed, migration `0001_broken_reports.sql` applied remotely and schema verified.
2. ⚠️ Add the **D1: Edit** permission to the `CLOUDFLARE_API_TOKEN` repo secret's CF token (the deploy workflow now runs `wrangler d1 migrations apply` before deploy — without it the post-merge deploy fails).
3. ⚠️ Set the `STATS_ADMIN_TOKEN` repo secret to the Worker's `ADMIN_TOKEN` value (used by the issue-close Action; only needed by the time the first `broken-station` issue closes).

## Out of scope (later phases of #507)

- P2: cron prober + auto GitHub-issue upsert (nothing moves rows to `confirmed` yet).
- P3: curation agent proposing fix PRs.
- Client work (iOS report sheet + receipts + polling) lives in the companion rrradio-ios issue; the web client keeps sending the pre-category payload, which remains valid.

Part of #507.

🤖 Generated with [Claude Code](https://claude.com/claude-code)