### PR TITLE
Broken-station reports P2 — cron prober + auto issue upsert (#507)

### DIFF
--- a/.github/workflows/triage-reports.yml
+++ b/.github/workflows/triage-reports.yml
@@ -1,0 +1,67 @@
+name: Triage broken-station reports
+
+# P2 of the broken-station report pipeline (issue #507). Reads
+# non-resolved reports from the stats Worker, probes each reported
+# station's stream (no-audio / interruptions) or favicon (wrong-logo),
+# and confirms a category when the probe fails OR enough independent
+# reports agree. Confirmed reports upsert ONE `broken-station` GitHub
+# issue per station; the Worker then flips those rows to `confirmed`
+# and stamps the issue number so closing the issue (handled by
+# resolve-reports.yml) resolves the reports and notifies the apps.
+#
+# Daily by default — broken-station reports trickle in, they don't
+# burst — plus manual dispatch with an optional dry run.
+#
+# Required repo secret:
+#   STATS_ADMIN_TOKEN — the Worker's ADMIN_TOKEN (read reports + apply
+#                       confirm/link). Same secret resolve-reports.yml
+#                       uses. GITHUB_TOKEN (auto) writes the issues.
+
+on:
+  schedule:
+    - cron: '0 6 * * *' # daily 06:00 UTC
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Probe + plan only, write nothing'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read # checkout (catalog + tooling)
+  issues: write # upsert broken-station issues
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci
+
+      - name: Ensure issue labels exist
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Pre-create so the issue upsert never 422s on an unknown label.
+          gh label create broken-station --description "User-reported broken station (automated triage)" --color B60205 --force >/dev/null 2>&1 || true
+          for c in no-audio interruptions wrong-station wrong-logo wrong-info other; do
+            gh label create "$c" --description "Broken-station report category" --color D93F0B --force >/dev/null 2>&1 || true
+          done
+
+      - name: Triage reports
+        env:
+          STATS_ADMIN_TOKEN: ${{ secrets.STATS_ADMIN_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+          # GITHUB_REPOSITORY / GITHUB_SERVER_URL / GITHUB_RUN_ID are
+          # provided automatically and used for the issue repo + run link.
+        run: |
+          if [ -z "$STATS_ADMIN_TOKEN" ]; then
+            echo "STATS_ADMIN_TOKEN secret is not set — cannot read reports." >&2
+            exit 1
+          fi
+          npm run triage-reports -- ${{ (github.event_name == 'workflow_dispatch' && inputs.dry_run) && '--dry-run' || '' }} --verbose

--- a/docs/spec/contracts/broken-reports.md
+++ b/docs/spec/contracts/broken-reports.md
@@ -26,11 +26,13 @@ report-sheet UX lives in the companion `rrradio-ios` issue.
 ### Report lifecycle (state machine)
 
 ```
-received ──(probe fail | report threshold; P2)──▶ confirmed
-received ─────────────(issue closed / admin)──────▶ resolved
-confirmed ────────────(issue closed / admin)──────▶ resolved
+received ──(probe fail | report threshold)──▶ confirmed
+received ─────────(issue closed / admin)──────▶ resolved
+confirmed ────────(issue closed / admin)──────▶ resolved
 ```
 
+- `received → confirmed` is driven by the P2 triage cron (see Triage
+  automation); `→ resolved` by the issue-close Action or a manual admin call.
 - `resolved` is terminal and carries exactly one `resolution`:
   `fixed | removed | not-reproducible`.
 - Nothing un-resolves a report. A still-broken station is a *new* report.
@@ -69,15 +71,36 @@ selector — `reportIds` (≤100), `stationId` (optionally scoped by `category`)
 `githubIssue`. Selectors OR-combine; already-resolved rows are never touched.
 Response: `{ "ok": true, "resolved": <n> }`.
 
+### `POST /api/admin/triage-reports` (Bearer `ADMIN_TOKEN`)
+
+Applies one station's automated-triage outcome. Body:
+`{ "stationId", "confirmCategories"?: [...], "githubIssue"?: <int> }` — at least
+one of `confirmCategories` / `githubIssue` required. `confirmCategories` flips
+that station's matching `received` rows to `confirmed`; `githubIssue` stamps the
+issue number on all the station's non-resolved rows. Idempotent (confirm only
+touches `received`). Response: `{ "ok": true, "confirmed": <n>, "linked": <n> }`.
+
 ### Triage automation
 
-- One GitHub issue per station (P2 upserts), labeled `broken-station`, body
-  carrying the marker `<!-- rrradio:station-id=<id> -->`.
-- Closing a `broken-station` issue triggers
-  `.github/workflows/resolve-reports.yml`, which calls the admin endpoint.
+- **Confirmation (P2 cron, daily — `.github/workflows/triage-reports.yml` →
+  `tools/triage-reports.mjs`):** reads non-resolved reports, aggregates by
+  `(station, category)`, and probes the catalog stream (`no-audio`,
+  `interruptions`) or favicon (`wrong-logo`). A category is confirmed when the
+  probe **fails** (stream unreachable / non-audio / favicon 404 or timeout) **or**
+  the independent-report count reaches the threshold (default 3). Non-probe-able
+  categories (`wrong-station`, `wrong-info`, `other`, `unspecified`) are
+  threshold-only.
+- **Issue upsert:** confirmed categories upsert **one** `broken-station` issue
+  per station (matched by the body marker `<!-- rrradio:station-id=<id> -->`),
+  labeled `broken-station` + each confirmed category, body carrying per-category
+  counts, probe evidence, and reporter comments verbatim. User comment text is
+  neutralized so it cannot forge the marker. The issue number is written back via
+  `triage-reports`.
+- **Resolution:** closing a `broken-station` issue triggers
+  `.github/workflows/resolve-reports.yml`, which calls `resolve-reports`.
   Resolution = `resolved:fixed | resolved:removed | resolved:not-reproducible`
   label when present, else GitHub's close reason (completed → `fixed`,
-  not planned → `not-reproducible`).
+  not planned → `not-reproducible`). The station id comes from the body marker.
 
 ## Detail
 
@@ -90,6 +113,7 @@ Response: `{ "ok": true, "resolved": <n> }`.
 | `resolution` | `fixed \| removed \| not-reproducible` | only when resolved | what closed it | — |
 | `resolvedAt` | ISO 8601 UTC | only when resolved | resolution timestamp | — |
 | `github_issue` | int (server-side) | yes | linked triage issue | unset |
+| Report threshold | int (server-side env) | no | independent reports to confirm a non-probe-failed category | 3 (`REPORT_THRESHOLD`) |
 | Receipt store (client) | local list of `{ id, stationId, createdAt }` | yes | what the device polls with | empty |
 | Ingest rate limit | 20 reports / IP / UTC day | no | enforced via daily-salted IP hash, purged next day | — |
 
@@ -180,18 +204,27 @@ integration point.
 
 1. Retention: when (if ever) are resolved/stale `broken_reports` rows purged?
    Receipts of deleted rows read as expired, so purging is client-safe — pick
-   a window (e.g. 180d) in P2.
+   a window (e.g. 180d) in a follow-up.
 2. Should `confirmed` be user-visible ("we reproduced it") or collapsed into
    "in review" until resolution? Spec currently allows either rendering.
+3. The prober stops at stream connect + content-type (the fast, decisive
+   signal); it does not yet read several seconds of audio bytes. Intermittent
+   `interruptions` therefore confirm mostly by threshold. Revisit if byte-level
+   probing proves necessary.
 
 ## Reference
 
 - Worker: `worker/src/reports.ts`, schema `worker/migrations/0001_broken_reports.sql`,
   routes wired in `worker/src/index.ts`, tests `worker/src/reports.test.ts`.
-- Automation: `.github/workflows/resolve-reports.yml`.
+- Triage cron (P2): `tools/triage-reports.mjs` (+ `tools/triage-reports.test.mjs`),
+  `.github/workflows/triage-reports.yml`; reuses `tools/playable-check.mjs`'s
+  `lenientProbe` for the stream probe.
+- Resolution Action: `.github/workflows/resolve-reports.yml`.
 - Privacy rows: [privacy-data-boundaries.md](privacy-data-boundaries.md) rows 4, 15.
 - Pipeline definition: [#507](https://github.com/MarkusSteinbrecher/rrradio/issues/507).
 
 ## Known deviations
 
-- None yet — no client implements categories/receipts as of this writing.
+- No client implements categories/receipts/polling yet, so the user-facing half
+  of the loop (the report sheet, the "resolved" notification) is unverified
+  end-to-end. Server pipeline (ingest → confirm → issue → resolve) is live.

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "curation-db:dedupe-report": "node tools/curation-db.mjs dedupe-report",
     "analyze": "node tools/health-probe.mjs",
     "backlog": "node tools/backlog.mjs",
+    "triage-reports": "node tools/triage-reports.mjs",
     "import-ard": "node tools/import-ard.mjs",
     "backfill-geo": "node tools/backfill-geo.mjs",
     "wire-metadata": "node tools/wire-metadata.mjs",

--- a/tools/triage-reports.mjs
+++ b/tools/triage-reports.mjs
@@ -1,0 +1,469 @@
+#!/usr/bin/env node
+/**
+ * Broken-station report triage (issue #507, P2).
+ *
+ * The cron half of the report pipeline. Reads non-resolved reports from
+ * the stats Worker, aggregates them by (station, category), probes the
+ * stream (no-audio / interruptions) or favicon (wrong-logo), and:
+ *
+ *   - confirms a category when the probe fails OR enough independent
+ *     reports agree (report threshold), and
+ *   - upserts ONE GitHub issue per station (label `broken-station` +
+ *     each confirmed category), then tells the Worker to flip the
+ *     confirmed rows to `confirmed` and stamp the issue number on the
+ *     station's reports so the issue-close Action can resolve them.
+ *
+ * P1 built ingest + receipts + manual resolve; P3 will have a curation
+ * agent propose the catalog-fix PR. This sits in between: it is the
+ * "received → confirmed → an issue exists" step. A human still merges
+ * the fix and closes the issue.
+ *
+ * I/O lives in main(); everything above it is pure and unit-tested in
+ * tools/triage-reports.test.mjs.
+ *
+ *   STATS_ADMIN_TOKEN   Worker admin bearer (required to act)
+ *   GH_TOKEN            GitHub token with issues:write (required to act)
+ *   GITHUB_REPOSITORY   owner/repo (default MarkusSteinbrecher/rrradio)
+ *   STATS_BASE          Worker base URL (default https://stats.rrradio.org)
+ *   REPORT_THRESHOLD    independent-report count to confirm (default 3)
+ *   flags: --dry-run (probe + plan, write nothing), --verbose
+ */
+
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { lenientProbe } from './playable-check.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, '..');
+
+// Probe-able categories → which resource the prober checks. The others
+// (wrong-station, wrong-info, other, unspecified) can't be auto-verified
+// and rely on the report threshold alone.
+export const CATEGORY_PROBE = {
+  'no-audio': 'stream',
+  interruptions: 'stream',
+  'wrong-logo': 'favicon',
+};
+
+// lenientProbe verdicts we treat as "the stream is fine". needs-playlist
+// resolves to a .pls/.m3u the app parses, so it still plays.
+const STREAM_PASS = new Set(['ok', 'ok-hls', 'needs-playlist']);
+// HTTP-parser quirks aren't proof the stream is down — browsers play
+// these — so don't auto-confirm on them.
+const STREAM_INCONCLUSIVE = new Set(['probe-inconclusive']);
+
+const FAVICON_BASE = 'https://rrradio.org/';
+const STATION_MARKER_RE = /<!-- rrradio:station-id=([A-Za-z0-9._:-]+) -->/;
+const DEFAULT_THRESHOLD = 3;
+const COMMENT_MAX = 500;
+const TITLE_MAX = 120;
+// Bound a single run so a flood of distinct stations can't blow the job
+// timeout. Surfaced in the log when hit — never silently truncated.
+const MAX_STATIONS_PER_RUN = 200;
+
+// ─── pure logic ──────────────────────────────────────────────────────
+
+/** Resolve a catalog favicon field to an absolute URL. Absolute http(s)
+ *  URLs pass through; bare paths (`stations/x.png`) hang off rrradio.org;
+ *  empty stays null (nothing to probe). */
+export function faviconUrl(favicon) {
+  if (!favicon || typeof favicon !== 'string') return null;
+  if (/^https?:\/\//i.test(favicon)) return favicon;
+  return FAVICON_BASE + favicon.replace(/^\/+/, '');
+}
+
+/** Stream probe → did it fail? Thrown connection = down; null verdict
+ *  (redirect/mixed-content) and parser-quirk = inconclusive (not a
+ *  fail); pass-set = fine; everything else (broken-*) = down. */
+export function streamProbeFailed({ verdict, errored }) {
+  if (errored) return true;
+  if (verdict == null) return false;
+  if (STREAM_PASS.has(verdict)) return false;
+  if (STREAM_INCONCLUSIVE.has(verdict)) return false;
+  return true;
+}
+
+/** Favicon probe → did it fail? Per the issue: 404 or timeout/network
+ *  error auto-confirms wrong-logo; a present favicon (even if visually
+ *  wrong) can't be auto-judged, so it relies on the threshold. */
+export function faviconProbeFailed({ status, errored }) {
+  if (errored) return true;
+  return status === 404;
+}
+
+/** Confirm a (station, category) group when the probe failed or enough
+ *  independent reports agree. */
+export function decideConfirm({ probeFailed, count, threshold }) {
+  return Boolean(probeFailed) || count >= threshold;
+}
+
+/** Group non-resolved report rows by station, then category. Resolved
+ *  rows are dropped (their issue is closed). Returns a Map keyed by
+ *  stationId. */
+export function aggregate(rows) {
+  const stations = new Map();
+  for (const r of rows) {
+    if (r.status === 'resolved') continue;
+    let st = stations.get(r.stationId);
+    if (!st) {
+      st = {
+        stationId: r.stationId,
+        stationName: r.stationName || r.stationId,
+        streamHost: r.streamHost || '',
+        githubIssue: r.githubIssue ?? null,
+        categories: new Map(),
+      };
+      stations.set(r.stationId, st);
+    }
+    if (r.stationName && !st.stationName) st.stationName = r.stationName;
+    if (r.streamHost && !st.streamHost) st.streamHost = r.streamHost;
+    if (r.githubIssue && !st.githubIssue) st.githubIssue = r.githubIssue;
+
+    let cat = st.categories.get(r.category);
+    if (!cat) {
+      cat = { category: r.category, count: 0, receivedCount: 0, confirmedCount: 0, comments: [] };
+      st.categories.set(r.category, cat);
+    }
+    cat.count += 1;
+    if (r.status === 'confirmed') cat.confirmedCount += 1;
+    else cat.receivedCount += 1;
+    const c = (r.comment || '').trim();
+    if (c) cat.comments.push(c);
+  }
+  return stations;
+}
+
+/** Neutralize user comment text for safe inclusion in a GitHub issue
+ *  body: a comment must not be able to forge the station-id marker the
+ *  resolve Action greps for, nor break out of a fenced block. Zero-width
+ *  spaces defuse the delimiters while staying human-readable. */
+export function sanitizeComment(text) {
+  if (!text) return '';
+  return String(text)
+    .replace(/<!--/g, '<!​--')
+    .replace(/-->/g, '--​>')
+    .replace(/```/g, '`​``')
+    .replace(/[\u0000-\u0008\u000b-\u001f\u007f]/g, '')
+    .slice(0, COMMENT_MAX);
+}
+
+export function stationMarker(stationId) {
+  return `<!-- rrradio:station-id=${stationId} -->`;
+}
+
+export function buildIssueTitle(station) {
+  return `Broken station: ${station.stationName} (${station.stationId})`.slice(0, TITLE_MAX);
+}
+
+export function issueLabels(confirmedCategories) {
+  return ['broken-station', ...new Set(confirmedCategories)];
+}
+
+/** Find the open `broken-station` issue for a station by its body
+ *  marker. Returns the issue object or null. */
+export function findIssueForStation(openIssues, stationId) {
+  for (const issue of openIssues) {
+    const m = STATION_MARKER_RE.exec(issue.body || '');
+    if (m && m[1] === stationId) return issue;
+  }
+  return null;
+}
+
+/**
+ * Decide, for one aggregated station, what to confirm and whether an
+ * issue should exist. `probes` is { stream?: {failed, evidence},
+ * favicon?: {failed, evidence} } gathered by the caller (I/O). Pure.
+ */
+export function planStation(station, probes, { threshold = DEFAULT_THRESHOLD } = {}) {
+  const sections = [];
+  const confirmCategories = []; // received → confirmed this run
+  const labelCategories = []; // every category the (open) issue should carry
+  for (const cat of station.categories.values()) {
+    const kind = CATEGORY_PROBE[cat.category] ?? null;
+    const probe = kind ? probes[kind] ?? null : null;
+    const probeFailed = probe ? probe.failed : false;
+    const willConfirm = decideConfirm({ probeFailed, count: cat.count, threshold });
+    const alreadyConfirmed = cat.confirmedCount > 0;
+    const isActive = willConfirm || alreadyConfirmed;
+    if (!isActive) continue;
+    labelCategories.push(cat.category);
+    if (willConfirm && cat.receivedCount > 0) confirmCategories.push(cat.category);
+    sections.push({
+      category: cat.category,
+      count: cat.count,
+      probeKind: kind,
+      probeEvidence: probe ? probe.evidence : kind ? 'not probed (no catalog entry)' : 'not probe-able',
+      reason: probeFailed ? 'probe failed' : `${cat.count} report(s) ≥ threshold ${threshold}`,
+      comments: cat.comments.map(sanitizeComment).filter(Boolean),
+    });
+  }
+  return { shouldOpenIssue: sections.length > 0, sections, confirmCategories, labelCategories };
+}
+
+export function buildIssueBody(station, plan, { catalogPresent, generatedAt, runUrl } = {}) {
+  const lines = [];
+  lines.push(stationMarker(station.stationId));
+  lines.push('');
+  lines.push(`**Station:** ${station.stationName} · \`${station.stationId}\``);
+  if (station.streamHost) lines.push(`**Stream host:** \`${station.streamHost}\``);
+  if (catalogPresent === false) {
+    lines.push('');
+    lines.push('> ⚠️ Not found in the bundled catalog (custom or unknown id) — stream/logo could not be auto-probed; confirmation is report-threshold only.');
+  }
+  lines.push('');
+  lines.push('_Automated triage — confirmed by stream/favicon probe or report threshold. A human merges the fix and closes this issue with a `resolved:*` label to notify reporters._');
+
+  for (const s of plan.sections) {
+    lines.push('');
+    lines.push(`### ${s.category} — ${s.count} report(s)`);
+    lines.push(`- Confirmed by: ${s.reason}`);
+    if (s.probeKind) lines.push(`- Probe (${s.probeKind}): ${s.probeEvidence}`);
+    if (s.comments.length) {
+      lines.push('- Reporter comments:');
+      for (const c of s.comments) {
+        lines.push(`  > ${c.replace(/\n/g, '\n  > ')}`);
+      }
+    }
+  }
+
+  lines.push('');
+  lines.push('---');
+  const stamp = [
+    generatedAt ? `Last triaged ${generatedAt}` : null,
+    runUrl ? `[workflow run](${runUrl})` : null,
+  ]
+    .filter(Boolean)
+    .join(' · ');
+  if (stamp) lines.push(stamp);
+  return lines.join('\n');
+}
+
+// ─── I/O ─────────────────────────────────────────────────────────────
+
+function loadCatalog() {
+  const data = JSON.parse(readFileSync(join(ROOT, 'public/stations.json'), 'utf8'));
+  const byId = new Map();
+  for (const s of data.stations ?? []) byId.set(s.id, s);
+  return byId;
+}
+
+function withTimeout(ms) {
+  const ctl = new AbortController();
+  const timer = setTimeout(() => ctl.abort(), ms);
+  return { signal: ctl.signal, done: () => clearTimeout(timer) };
+}
+
+async function probeStream(streamUrl, timeoutMs) {
+  try {
+    const res = await lenientProbe(streamUrl, { allowHttp: true });
+    const verdict = res?.verdict ?? null;
+    const failed = streamProbeFailed({ verdict, errored: false });
+    return { failed, evidence: res ? `${verdict}: ${res.reason}`.slice(0, 200) : 'inconclusive (redirect/mixed-content)' };
+  } catch (err) {
+    void timeoutMs;
+    return { failed: true, evidence: `connection failed: ${String(err?.message ?? err).slice(0, 160)}` };
+  }
+}
+
+async function probeFavicon(url, timeoutMs) {
+  const t = withTimeout(timeoutMs);
+  try {
+    const res = await fetch(url, {
+      method: 'GET',
+      redirect: 'follow',
+      signal: t.signal,
+      headers: { 'User-Agent': 'rrradio-triage/1.0 (+https://rrradio.org)' },
+    });
+    return {
+      failed: faviconProbeFailed({ status: res.status, errored: false }),
+      evidence: `HTTP ${res.status} ${res.headers.get('content-type') ?? ''}`.trim().slice(0, 120),
+    };
+  } catch (err) {
+    return { failed: true, evidence: `fetch failed: ${String(err?.message ?? err).slice(0, 120)}` };
+  } finally {
+    t.done();
+  }
+}
+
+async function workerGet(base, token) {
+  const res = await fetch(`${base}/api/broken-reports?limit=500`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error(`worker GET /api/broken-reports: ${res.status}`);
+  const body = await res.json();
+  return body.items ?? [];
+}
+
+async function workerApplyTriage(base, token, payload) {
+  const res = await fetch(`${base}/api/admin/triage-reports`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) throw new Error(`worker POST /api/admin/triage-reports: ${res.status} ${await res.text()}`);
+  return res.json();
+}
+
+function ghApi(repo, token) {
+  const base = `https://api.github.com/repos/${repo}`;
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+    'User-Agent': 'rrradio-triage/1.0',
+  };
+  return {
+    async listOpenBrokenIssues() {
+      const out = [];
+      for (let page = 1; page <= 10; page++) {
+        const res = await fetch(`${base}/issues?labels=broken-station&state=open&per_page=100&page=${page}`, { headers });
+        if (!res.ok) throw new Error(`gh list issues: ${res.status} ${await res.text()}`);
+        const batch = await res.json();
+        // The issues endpoint also returns PRs; drop them.
+        out.push(...batch.filter((i) => !i.pull_request));
+        if (batch.length < 100) break;
+      }
+      return out;
+    },
+    async createIssue({ title, body, labels }) {
+      const res = await fetch(`${base}/issues`, {
+        method: 'POST',
+        headers: { ...headers, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title, body, labels }),
+      });
+      if (!res.ok) throw new Error(`gh create issue: ${res.status} ${await res.text()}`);
+      return res.json();
+    },
+    async updateIssue(number, { title, body, labels }) {
+      const res = await fetch(`${base}/issues/${number}`, {
+        method: 'PATCH',
+        headers: { ...headers, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title, body, labels }),
+      });
+      if (!res.ok) throw new Error(`gh update issue #${number}: ${res.status} ${await res.text()}`);
+      return res.json();
+    },
+  };
+}
+
+function parseArgs(argv) {
+  const out = { dryRun: false, verbose: false };
+  for (const a of argv) {
+    if (a === '--dry-run' || a === '-n') out.dryRun = true;
+    else if (a === '--verbose' || a === '-v') out.verbose = true;
+    else if (a === '--help' || a === '-h') {
+      console.log('usage: triage-reports [--dry-run] [--verbose]');
+      process.exit(0);
+    } else {
+      console.error(`triage-reports: unknown argument "${a}"`);
+      process.exit(1);
+    }
+  }
+  return out;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const dryRun = args.dryRun || process.env.DRY_RUN === '1';
+  const base = process.env.STATS_BASE || 'https://stats.rrradio.org';
+  const adminToken = process.env.STATS_ADMIN_TOKEN || '';
+  const ghToken = process.env.GH_TOKEN || process.env.GITHUB_TOKEN || '';
+  const repo = process.env.GITHUB_REPOSITORY || 'MarkusSteinbrecher/rrradio';
+  const threshold = Math.max(1, Number(process.env.REPORT_THRESHOLD) || DEFAULT_THRESHOLD);
+  const timeoutMs = Math.max(2000, Number(process.env.PROBE_TIMEOUT_MS) || 8000);
+  const generatedAt = new Date().toISOString().replace(/\.\d+Z$/, 'Z');
+  const runUrl =
+    process.env.GITHUB_SERVER_URL && process.env.GITHUB_RUN_ID
+      ? `${process.env.GITHUB_SERVER_URL}/${repo}/actions/runs/${process.env.GITHUB_RUN_ID}`
+      : null;
+
+  if (!adminToken) throw new Error('STATS_ADMIN_TOKEN is required');
+  if (!dryRun && !ghToken) throw new Error('GH_TOKEN is required (or pass --dry-run)');
+
+  const catalog = loadCatalog();
+  const rows = await workerGet(base, adminToken);
+  const stations = aggregate(rows);
+  console.log(
+    `triage: ${rows.length} report row(s) → ${stations.size} station(s) with open reports · threshold ${threshold}${dryRun ? ' · DRY RUN' : ''}`,
+  );
+
+  const gh = ghToken ? ghApi(repo, ghToken) : null;
+  // Dedupe against existing issues only when we'll actually write. In a
+  // dry run we skip the GitHub read entirely and just report intent.
+  const openIssues = !dryRun && gh ? await gh.listOpenBrokenIssues() : [];
+
+  let processed = 0;
+  let confirmedCount = 0;
+  let issuesOpened = 0;
+  let issuesUpdated = 0;
+
+  for (const station of stations.values()) {
+    if (processed >= MAX_STATIONS_PER_RUN) {
+      console.warn(`triage: hit MAX_STATIONS_PER_RUN (${MAX_STATIONS_PER_RUN}); ${stations.size - processed} station(s) deferred to next run`);
+      break;
+    }
+    processed += 1;
+
+    const entry = catalog.get(station.stationId) ?? null;
+    const cats = [...station.categories.keys()];
+    const needStream = cats.some((c) => CATEGORY_PROBE[c] === 'stream');
+    const needFavicon = cats.some((c) => CATEGORY_PROBE[c] === 'favicon');
+    const probes = {};
+    if (needStream && entry?.streamUrl) probes.stream = await probeStream(entry.streamUrl, timeoutMs);
+    const favUrl = entry ? faviconUrl(entry.favicon) : null;
+    if (needFavicon && favUrl) probes.favicon = await probeFavicon(favUrl, timeoutMs);
+
+    const plan = planStation(station, probes, { threshold });
+    if (args.verbose) {
+      console.log(
+        `  ${station.stationId}: ${cats.join(',')} → ${plan.shouldOpenIssue ? `confirm[${plan.labelCategories.join(',')}]` : 'hold (no confirmation yet)'}`,
+      );
+    }
+    if (!plan.shouldOpenIssue) continue;
+
+    const title = buildIssueTitle(station);
+    const body = buildIssueBody(station, plan, { catalogPresent: Boolean(entry), generatedAt, runUrl });
+    const labels = issueLabels(plan.labelCategories);
+
+    if (dryRun) {
+      console.log(`  [dry-run] would upsert issue: ${title} · labels ${labels.join(',')}`);
+      console.log(`  [dry-run] would confirm ${plan.confirmCategories.join(',') || '(none new)'}`);
+      confirmedCount += plan.confirmCategories.length;
+      continue;
+    }
+
+    const existing = findIssueForStation(openIssues, station.stationId);
+    let issueNumber;
+    if (existing) {
+      await gh.updateIssue(existing.number, { title, body, labels });
+      issueNumber = existing.number;
+      issuesUpdated += 1;
+    } else {
+      const created = await gh.createIssue({ title, body, labels });
+      issueNumber = created.number;
+      issuesOpened += 1;
+    }
+
+    const applied = await workerApplyTriage(base, adminToken, {
+      stationId: station.stationId,
+      confirmCategories: plan.confirmCategories,
+      githubIssue: issueNumber,
+    });
+    confirmedCount += applied.confirmed ?? 0;
+    console.log(
+      `  #${issueNumber} ${existing ? 'updated' : 'opened'} for ${station.stationId} · confirmed ${applied.confirmed} · linked ${applied.linked}`,
+    );
+  }
+
+  console.log(
+    `triage done: ${issuesOpened} opened, ${issuesUpdated} updated, ${confirmedCount} report(s) confirmed${dryRun ? ' (dry run — nothing written)' : ''}`,
+  );
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    console.error('triage-reports failed:', err?.stack ?? err);
+    process.exit(1);
+  });
+}

--- a/tools/triage-reports.test.mjs
+++ b/tools/triage-reports.test.mjs
@@ -1,0 +1,268 @@
+import { describe, expect, it } from 'vitest';
+import {
+  faviconUrl,
+  streamProbeFailed,
+  faviconProbeFailed,
+  decideConfirm,
+  aggregate,
+  sanitizeComment,
+  stationMarker,
+  buildIssueTitle,
+  buildIssueBody,
+  issueLabels,
+  findIssueForStation,
+  planStation,
+} from './triage-reports.mjs';
+
+// The exact marker regex the resolve-reports.yml workflow greps with.
+// Kept in lockstep here so the injection test proves the real defense.
+const WORKFLOW_MARKER_RE = /<!-- rrradio:station-id=([A-Za-z0-9._:-]+) -->/g;
+
+function row(over = {}) {
+  return {
+    id: over.id ?? 'r' + Math.random().toString(36).slice(2),
+    stationId: 'builtin-fm4',
+    stationName: 'FM4',
+    streamHost: 'stream.fm4.example',
+    category: 'no-audio',
+    comment: '',
+    status: 'received',
+    githubIssue: null,
+    ...over,
+  };
+}
+
+describe('faviconUrl', () => {
+  it('passes absolute http(s) through', () => {
+    expect(faviconUrl('https://oe1.orf.at/x.png')).toBe('https://oe1.orf.at/x.png');
+  });
+  it('hangs relative paths off rrradio.org', () => {
+    expect(faviconUrl('stations/grrif.png')).toBe('https://rrradio.org/stations/grrif.png');
+    expect(faviconUrl('/stations/grrif.png')).toBe('https://rrradio.org/stations/grrif.png');
+  });
+  it('returns null for empty/missing', () => {
+    expect(faviconUrl('')).toBeNull();
+    expect(faviconUrl(undefined)).toBeNull();
+  });
+});
+
+describe('streamProbeFailed', () => {
+  it('treats a thrown connection as down', () => {
+    expect(streamProbeFailed({ verdict: null, errored: true })).toBe(true);
+  });
+  it('treats null verdict (redirect/mixed-content) as inconclusive, not down', () => {
+    expect(streamProbeFailed({ verdict: null, errored: false })).toBe(false);
+  });
+  it('passes ok / ok-hls / needs-playlist', () => {
+    for (const v of ['ok', 'ok-hls', 'needs-playlist']) {
+      expect(streamProbeFailed({ verdict: v, errored: false })).toBe(false);
+    }
+  });
+  it('does not auto-confirm on parser-quirk', () => {
+    expect(streamProbeFailed({ verdict: 'probe-inconclusive', errored: false })).toBe(false);
+  });
+  it('treats broken-* verdicts as down', () => {
+    for (const v of ['broken-4xx', 'broken-5xx', 'broken-dns', 'broken-format', 'broken-tls']) {
+      expect(streamProbeFailed({ verdict: v, errored: false })).toBe(true);
+    }
+  });
+});
+
+describe('faviconProbeFailed', () => {
+  it('fails on 404 or network error, passes otherwise', () => {
+    expect(faviconProbeFailed({ status: 404, errored: false })).toBe(true);
+    expect(faviconProbeFailed({ status: 0, errored: true })).toBe(true);
+    expect(faviconProbeFailed({ status: 200, errored: false })).toBe(false);
+    // A present-but-maybe-wrong favicon (403/500) is not auto-confirmed.
+    expect(faviconProbeFailed({ status: 403, errored: false })).toBe(false);
+  });
+});
+
+describe('decideConfirm', () => {
+  it('confirms on probe failure regardless of count', () => {
+    expect(decideConfirm({ probeFailed: true, count: 1, threshold: 3 })).toBe(true);
+  });
+  it('confirms when count reaches threshold', () => {
+    expect(decideConfirm({ probeFailed: false, count: 3, threshold: 3 })).toBe(true);
+    expect(decideConfirm({ probeFailed: false, count: 2, threshold: 3 })).toBe(false);
+  });
+});
+
+describe('aggregate', () => {
+  it('groups by station then category, dropping resolved rows', () => {
+    const stations = aggregate([
+      row({ category: 'no-audio', comment: 'silent', status: 'received' }),
+      row({ category: 'no-audio', comment: 'still dead', status: 'confirmed' }),
+      row({ category: 'wrong-logo', status: 'received' }),
+      row({ stationId: 'swr3', stationName: 'SWR3', category: 'no-audio' }),
+      row({ category: 'no-audio', status: 'resolved' }), // dropped
+    ]);
+    expect([...stations.keys()].sort()).toEqual(['builtin-fm4', 'swr3']);
+    const fm4 = stations.get('builtin-fm4');
+    const audio = fm4.categories.get('no-audio');
+    expect(audio.count).toBe(2);
+    expect(audio.receivedCount).toBe(1);
+    expect(audio.confirmedCount).toBe(1);
+    expect(audio.comments).toEqual(['silent', 'still dead']);
+    expect(fm4.categories.get('wrong-logo').count).toBe(1);
+  });
+
+  it('picks up a linked github issue from any row', () => {
+    const stations = aggregate([row(), row({ githubIssue: 712 })]);
+    expect(stations.get('builtin-fm4').githubIssue).toBe(712);
+  });
+});
+
+describe('sanitizeComment', () => {
+  it('caps at 500 chars and strips control characters', () => {
+    const out = sanitizeComment('a\u0000\u0007b\tc\n' + 'x'.repeat(600));
+    expect(out.startsWith('ab\tc\n')).toBe(true);
+    expect(out.length).toBe(500);
+  });
+  it('defuses an embedded station-id marker so it cannot forge resolution', () => {
+    const evil = sanitizeComment('please fix <!-- rrradio:station-id=victim -->');
+    WORKFLOW_MARKER_RE.lastIndex = 0;
+    expect(WORKFLOW_MARKER_RE.test(evil)).toBe(false);
+  });
+  it('defuses fenced-code breakouts', () => {
+    expect(sanitizeComment('```js\nbad')).not.toContain('```');
+  });
+});
+
+describe('buildIssueBody marker safety', () => {
+  it('keeps the real station marker as the first marker even with a malicious comment', () => {
+    const station = {
+      stationId: 'builtin-fm4',
+      stationName: 'FM4',
+      streamHost: 'stream.fm4.example',
+      categories: new Map(),
+    };
+    const plan = {
+      sections: [
+        {
+          category: 'no-audio',
+          count: 1,
+          probeKind: 'stream',
+          probeEvidence: 'broken-dns: ...',
+          reason: 'probe failed',
+          comments: [sanitizeComment('<!-- rrradio:station-id=victim -->')],
+        },
+      ],
+    };
+    const body = buildIssueBody(station, plan, { catalogPresent: true });
+    WORKFLOW_MARKER_RE.lastIndex = 0;
+    const first = WORKFLOW_MARKER_RE.exec(body);
+    expect(first[1]).toBe('builtin-fm4');
+    // And there is exactly one valid marker in the whole body.
+    WORKFLOW_MARKER_RE.lastIndex = 0;
+    const all = body.match(WORKFLOW_MARKER_RE);
+    expect(all).toHaveLength(1);
+  });
+
+  it('places the marker on the first line', () => {
+    const station = { stationId: 'x', stationName: 'X', streamHost: '', categories: new Map() };
+    const body = buildIssueBody(station, { sections: [] }, {});
+    expect(body.split('\n')[0]).toBe(stationMarker('x'));
+  });
+});
+
+describe('issue helpers', () => {
+  it('builds a title and labels', () => {
+    expect(buildIssueTitle({ stationName: 'FM4', stationId: 'builtin-fm4' })).toBe(
+      'Broken station: FM4 (builtin-fm4)',
+    );
+    expect(issueLabels(['no-audio', 'no-audio', 'wrong-logo'])).toEqual([
+      'broken-station',
+      'no-audio',
+      'wrong-logo',
+    ]);
+  });
+
+  it('finds an existing issue by station marker', () => {
+    const issues = [
+      { number: 1, body: 'unrelated' },
+      { number: 2, body: `header\n${stationMarker('builtin-fm4')}\nbody` },
+    ];
+    expect(findIssueForStation(issues, 'builtin-fm4').number).toBe(2);
+    expect(findIssueForStation(issues, 'nope')).toBeNull();
+  });
+});
+
+describe('planStation', () => {
+  function station(categories) {
+    const map = new Map();
+    for (const [category, c] of Object.entries(categories)) {
+      map.set(category, {
+        category,
+        count: c.count ?? c.received + (c.confirmed ?? 0),
+        receivedCount: c.received ?? 0,
+        confirmedCount: c.confirmed ?? 0,
+        comments: c.comments ?? [],
+      });
+    }
+    return { stationId: 'builtin-fm4', stationName: 'FM4', streamHost: '', categories: map };
+  }
+
+  it('confirms a probe-failed category even with a single report', () => {
+    const plan = planStation(
+      station({ 'no-audio': { received: 1 } }),
+      { stream: { failed: true, evidence: 'broken-dns' } },
+      { threshold: 3 },
+    );
+    expect(plan.shouldOpenIssue).toBe(true);
+    expect(plan.confirmCategories).toEqual(['no-audio']);
+    expect(plan.labelCategories).toEqual(['no-audio']);
+  });
+
+  it('holds a probe-passing category below threshold (no issue)', () => {
+    const plan = planStation(
+      station({ 'no-audio': { received: 1 } }),
+      { stream: { failed: false, evidence: 'ok' } },
+      { threshold: 3 },
+    );
+    expect(plan.shouldOpenIssue).toBe(false);
+    expect(plan.confirmCategories).toEqual([]);
+  });
+
+  it('confirms a probe-passing category once it reaches threshold', () => {
+    const plan = planStation(
+      station({ 'no-audio': { received: 3 } }),
+      { stream: { failed: false, evidence: 'ok' } },
+      { threshold: 3 },
+    );
+    expect(plan.shouldOpenIssue).toBe(true);
+    expect(plan.confirmCategories).toEqual(['no-audio']);
+  });
+
+  it('keeps an already-confirmed category in the issue even when the probe now passes', () => {
+    const plan = planStation(
+      station({ 'no-audio': { received: 0, confirmed: 2 } }),
+      { stream: { failed: false, evidence: 'ok' } },
+      { threshold: 3 },
+    );
+    expect(plan.shouldOpenIssue).toBe(true);
+    expect(plan.labelCategories).toEqual(['no-audio']);
+    // Nothing new to confirm (no received rows left).
+    expect(plan.confirmCategories).toEqual([]);
+  });
+
+  it('confirms non-probe-able categories by threshold only', () => {
+    const belowThreshold = planStation(station({ 'wrong-info': { received: 2 } }), {}, { threshold: 3 });
+    expect(belowThreshold.shouldOpenIssue).toBe(false);
+    const atThreshold = planStation(station({ 'wrong-info': { received: 3 } }), {}, { threshold: 3 });
+    expect(atThreshold.shouldOpenIssue).toBe(true);
+    expect(atThreshold.confirmCategories).toEqual(['wrong-info']);
+  });
+
+  it('only lists categories with received rows in confirmCategories', () => {
+    // 4 confirmed + 0 received, probe still failing → active, but nothing
+    // new to flip received→confirmed.
+    const plan = planStation(
+      station({ 'no-audio': { received: 0, confirmed: 4 } }),
+      { stream: { failed: true, evidence: 'broken-dns' } },
+      { threshold: 3 },
+    );
+    expect(plan.labelCategories).toEqual(['no-audio']);
+    expect(plan.confirmCategories).toEqual([]);
+  });
+});

--- a/worker/README.md
+++ b/worker/README.md
@@ -66,6 +66,7 @@ call per hour regardless of traffic.
 | `/api/everything` | one call returns totals + stations + favorites + errors + reports + tabs + genres + locations + browsers + systems. Sequential internally with 300 ms sleeps to stay under GC's 4 req/s limit. |
 | `/api/broken-reports` | recent D1 report rows for triage: `{ items: [{ id, stationId, …, category, comment, status, resolution, githubIssue }], total }`. `?status=received\|confirmed\|resolved`, `?limit=N` (1–500, default 200). no-store. |
 | `/api/admin/resolve-reports` (POST) | body: `{ resolution: fixed\|removed\|not-reproducible }` + at least one of `reportIds` (≤100), `stationId` (+ optional `category`), `githubIssue`. Marks matching open reports resolved, stamps the issue number, returns `{ ok, resolved: n }`. Called by `.github/workflows/resolve-reports.yml` when a `broken-station` issue closes. |
+| `/api/admin/triage-reports` (POST) | body: `{ stationId }` + at least one of `confirmCategories` (string[]), `githubIssue` (int). Flips that station's matching `received` rows to `confirmed` and stamps the issue number on its non-resolved rows. Returns `{ ok, confirmed: n, linked: n }`. Called by the P2 triage cron (`.github/workflows/triage-reports.yml` → `tools/triage-reports.mjs`). |
 
 All GoatCounter-backed admin endpoints accept `?days=N` (1–90, default
 7) and cache 5 min at the Cloudflare edge; the D1-backed report
@@ -173,6 +174,20 @@ Inspect live reports without the dashboard:
 curl -s -H "Authorization: Bearer $ADMIN_TOKEN" \
   'https://stats.rrradio.org/api/broken-reports?status=received' | jq .
 ```
+
+### Automated triage (P2 cron)
+
+`.github/workflows/triage-reports.yml` runs daily (06:00 UTC; also
+`workflow_dispatch` with an optional `dry_run`). It runs
+`tools/triage-reports.mjs`, which reads non-resolved reports from this
+Worker, probes each reported station's stream (`no-audio` /
+`interruptions`) or favicon (`wrong-logo`), confirms a category when
+the probe fails or enough independent reports agree (threshold,
+default 3), upserts one `broken-station` GitHub issue per station, and
+POSTs `/api/admin/triage-reports` to flip the confirmed rows and link
+the issue number. Needs the `STATS_ADMIN_TOKEN` repo secret; the
+issues are written with the workflow's built-in `GITHUB_TOKEN`. The
+full protocol lives in `../docs/spec/contracts/broken-reports.md`.
 
 ### Resolving reports via issue close
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -43,6 +43,7 @@ import {
   handleReportBroken,
   handleReportStatus,
   handleResolveReports,
+  handleTriageReports,
 } from './reports';
 
 export type { Env } from './env';
@@ -722,10 +723,18 @@ export default {
       }
     }
 
-    // The one POST admin route. Token-guarded like the GET routes; the
-    // caller is the issue-close GitHub Action (or a human with curl),
-    // not the browser dashboard, so it sits outside the GET-only gate.
-    if (url.pathname === '/api/admin/resolve-reports') {
+    // POST admin routes. Token-guarded like the GET routes; the callers
+    // are the triage/issue-close GitHub Actions (or a human with curl),
+    // not the browser dashboard, so they sit outside the GET-only gate.
+    const adminPost: Record<
+      string,
+      (req: Request, env: Env, headers: Record<string, string>) => Promise<Response>
+    > = {
+      '/api/admin/resolve-reports': handleResolveReports,
+      '/api/admin/triage-reports': handleTriageReports,
+    };
+    const adminPostHandler = adminPost[url.pathname];
+    if (adminPostHandler) {
       if (req.method !== 'POST') {
         return noStoreJsonResponse({ error: 'method not allowed' }, 405, cors);
       }
@@ -734,7 +743,7 @@ export default {
         return noStoreJsonResponse({ error: 'unauthorized' }, 401, cors);
       }
       try {
-        return await handleResolveReports(req, env, cors);
+        return await adminPostHandler(req, env, cors);
       } catch (err) {
         return noStoreJsonResponse(
           { error: 'fetch failed', message: err instanceof Error ? err.message : String(err) },

--- a/worker/src/reports.test.ts
+++ b/worker/src/reports.test.ts
@@ -69,6 +69,14 @@ function resolveReports(body: Record<string, unknown>, token = 'admin-token'): P
   });
 }
 
+function triageReports(body: Record<string, unknown>, token = 'admin-token'): Promise<Response> {
+  return call('/api/admin/triage-reports', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    body: JSON.stringify(body),
+  });
+}
+
 describe('report ingest (POST /api/public/report-broken)', () => {
   it('stores category + comment in D1 and returns a receipt id', async () => {
     const id = await seedReport({
@@ -253,6 +261,80 @@ describe('admin resolve (POST /api/admin/resolve-reports)', () => {
     const res = await resolveReports({ resolution: 'removed', githubIssue: 511 });
     expect(await json(res)).toEqual({ ok: true, resolved: 1 });
     expect(db.reports.get(second)?.status).toBe('resolved');
+  });
+});
+
+describe('admin triage apply (POST /api/admin/triage-reports)', () => {
+  it('requires the admin bearer token', async () => {
+    const res = await triageReports({ stationId: 'fm4', confirmCategories: ['no-audio'] }, 'wrong');
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects non-POST with 405', async () => {
+    const res = await call('/api/admin/triage-reports', {
+      headers: { Authorization: 'Bearer admin-token' },
+    });
+    expect(res.status).toBe(405);
+  });
+
+  it('rejects a body with neither confirmCategories nor githubIssue', async () => {
+    expect((await triageReports({ stationId: 'fm4' })).status).toBe(400);
+    expect((await triageReports({ confirmCategories: ['no-audio'] })).status).toBe(400);
+  });
+
+  it('confirms only the named categories received rows, and links the issue station-wide', async () => {
+    const audio = await seedReport({ category: 'no-audio' });
+    const audio2 = await seedReport({ category: 'no-audio' });
+    const logo = await seedReport({ category: 'wrong-logo' });
+    const other = await seedReport({ stationId: 'swr3', category: 'no-audio' });
+
+    const res = await triageReports({
+      stationId: 'fm4',
+      confirmCategories: ['no-audio'],
+      githubIssue: 600,
+    });
+    expect(res.status).toBe(200);
+    // Two no-audio rows confirmed; all three fm4 rows linked to the issue.
+    expect(await json(res)).toEqual({ ok: true, confirmed: 2, linked: 3 });
+
+    expect(db.reports.get(audio)).toMatchObject({ status: 'confirmed', github_issue: 600 });
+    expect(db.reports.get(audio2)).toMatchObject({ status: 'confirmed', github_issue: 600 });
+    // wrong-logo not in confirmCategories → still received, but linked.
+    expect(db.reports.get(logo)).toMatchObject({ status: 'received', github_issue: 600 });
+    // Different station untouched.
+    expect(db.reports.get(other)).toMatchObject({ status: 'received', github_issue: null });
+  });
+
+  it('is idempotent in effect — re-running confirms nothing new, link stays put', async () => {
+    const id = await seedReport({ category: 'no-audio' });
+    await triageReports({ stationId: 'fm4', confirmCategories: ['no-audio'], githubIssue: 601 });
+    const again = await triageReports({
+      stationId: 'fm4',
+      confirmCategories: ['no-audio'],
+      githubIssue: 601,
+    });
+    // Already confirmed → 0 newly confirmed. `linked` counts rows MATCHING
+    // the link (SQLite reports those regardless of whether the value
+    // changed), so it stays 1 — the row's issue link is unchanged at 601.
+    expect(await json(again)).toEqual({ ok: true, confirmed: 0, linked: 1 });
+    expect(db.reports.get(id)).toMatchObject({ status: 'confirmed', github_issue: 601 });
+  });
+
+  it('drops unknown categories and dedupes', async () => {
+    await seedReport({ category: 'no-audio' });
+    const res = await triageReports({
+      stationId: 'fm4',
+      confirmCategories: ['no-audio', 'no-audio', 'not-a-category'],
+    });
+    expect(await json(res)).toEqual({ ok: true, confirmed: 1, linked: 0 });
+  });
+
+  it('never touches resolved rows when linking', async () => {
+    const id = await seedReport({ category: 'no-audio' });
+    await resolveReports({ resolution: 'fixed', reportIds: [id] });
+    const res = await triageReports({ stationId: 'fm4', githubIssue: 602 });
+    expect(await json(res)).toEqual({ ok: true, confirmed: 0, linked: 0 });
+    expect(db.reports.get(id)?.github_issue).toBeNull();
   });
 });
 

--- a/worker/src/reports.ts
+++ b/worker/src/reports.ts
@@ -61,6 +61,10 @@ export const SQL = {
     "UPDATE broken_reports SET status = 'resolved', resolution = ?, resolved_at = ?, github_issue = COALESCE(?, github_issue) WHERE station_id = ? AND category = ? AND status != 'resolved'",
   resolveByIssue:
     "UPDATE broken_reports SET status = 'resolved', resolution = ?, resolved_at = ?, github_issue = COALESCE(?, github_issue) WHERE github_issue = ? AND status != 'resolved'",
+  confirmByStationCategory:
+    "UPDATE broken_reports SET status = 'confirmed' WHERE station_id = ? AND category = ? AND status = 'received'",
+  linkByStation:
+    "UPDATE broken_reports SET github_issue = ? WHERE station_id = ? AND status != 'resolved'",
   selectRecent:
     'SELECT id, station_id, station_name, stream_host, category, comment, platform, app_version, reason, status, resolution, created_at, resolved_at, github_issue FROM broken_reports ORDER BY created_at DESC LIMIT ?',
   selectRecentByStatus:
@@ -375,6 +379,76 @@ export async function handleResolveReports(
   const results = await env.DB.batch(stmts);
   const resolved = results.reduce((sum, r) => sum + (r.meta?.changes ?? 0), 0);
   return noStoreJsonResponse({ ok: true, resolved }, 200, headers);
+}
+
+/** POST /api/admin/triage-reports — apply one station's automated-triage
+ *  outcome (P2 cron). `confirmCategories` flips that station's matching
+ *  `received` rows to `confirmed` (probe failed or report threshold met);
+ *  `githubIssue` stamps the upserted issue number on all the station's
+ *  non-resolved rows so the issue-close Action can later resolve them.
+ *  Idempotent: confirm only touches `received` rows, and re-linking the
+ *  same issue is a no-op change-wise. Called by the triage GitHub Action. */
+export async function handleTriageReports(
+  req: Request,
+  env: Env,
+  headers: Record<string, string>,
+): Promise<Response> {
+  const raw = await req.text();
+  if (raw.length > 16384) {
+    return noStoreJsonResponse({ error: 'payload too large' }, 413, headers);
+  }
+  let body: unknown;
+  try {
+    body = JSON.parse(raw);
+  } catch {
+    return noStoreJsonResponse({ error: 'invalid json' }, 400, headers);
+  }
+  const data = body && typeof body === 'object' ? (body as Record<string, unknown>) : {};
+
+  const stationId = cleanToken(data.stationId, '');
+  if (!stationId) {
+    return noStoreJsonResponse({ error: 'stationId required' }, 400, headers);
+  }
+
+  // Only known categories; dedupe so a single category can't be double-
+  // counted in the confirmed total.
+  const confirmCategories = Array.isArray(data.confirmCategories)
+    ? [
+        ...new Set(
+          data.confirmCategories
+            .map((c) => cleanToken(c, '', 24))
+            .filter((c) => (CATEGORIES as readonly string[]).includes(c)),
+        ),
+      ]
+    : [];
+  const githubIssue =
+    typeof data.githubIssue === 'number' && Number.isInteger(data.githubIssue) && data.githubIssue > 0
+      ? data.githubIssue
+      : null;
+
+  if (confirmCategories.length === 0 && !githubIssue) {
+    return noStoreJsonResponse(
+      { error: 'at least one of confirmCategories, githubIssue required' },
+      400,
+      headers,
+    );
+  }
+
+  // Fixed statements only (one per category + an optional link) so the
+  // test D1 keeps dispatching on statement identity.
+  const confirmStmts = confirmCategories.map((cat) =>
+    env.DB.prepare(SQL.confirmByStationCategory).bind(stationId, cat),
+  );
+  const linkStmt = githubIssue
+    ? env.DB.prepare(SQL.linkByStation).bind(githubIssue, stationId)
+    : null;
+
+  const results = await env.DB.batch([...confirmStmts, ...(linkStmt ? [linkStmt] : [])]);
+  const confirmed = results
+    .slice(0, confirmStmts.length)
+    .reduce((sum, r) => sum + (r.meta?.changes ?? 0), 0);
+  const linked = linkStmt ? (results[results.length - 1]?.meta?.changes ?? 0) : 0;
+  return noStoreJsonResponse({ ok: true, confirmed, linked }, 200, headers);
 }
 
 /** GET /api/broken-reports — recent report rows for manual triage

--- a/worker/src/test-d1.ts
+++ b/worker/src/test-d1.ts
@@ -163,6 +163,30 @@ export class FakeStatement {
         return result([], changes);
       }
 
+      case SQL.confirmByStationCategory: {
+        const [stationId, category] = b as string[];
+        let changes = 0;
+        for (const row of db.reports.values()) {
+          if (row.station_id === stationId && row.category === category && row.status === 'received') {
+            row.status = 'confirmed';
+            changes++;
+          }
+        }
+        return result([], changes);
+      }
+
+      case SQL.linkByStation: {
+        const [ghIssue, stationId] = b as [number, string];
+        let changes = 0;
+        for (const row of db.reports.values()) {
+          if (row.station_id === stationId && row.status !== 'resolved') {
+            row.github_issue = ghIssue;
+            changes++;
+          }
+        }
+        return result([], changes);
+      }
+
       case SQL.selectRecent:
       case SQL.selectRecentByStatus: {
         const byStatus = this.sql === SQL.selectRecentByStatus;


### PR DESCRIPTION
## What

Phase 2 of #507 — the automated middle of the report pipeline. P1 shipped ingest → receipt → manual resolve; this adds **received → confirmed → one GitHub issue per station**, so reports stop sitting inertly in D1 and become actionable tracking issues. P1's `resolve-reports.yml` already closes the loop (issue close → reports resolved → apps notified).

### Worker — one new admin endpoint
`POST /api/admin/triage-reports` (Bearer `ADMIN_TOKEN`): per station, flips matching `received` rows to `confirmed` (`confirmCategories`) and stamps the upserted issue number on the station's non-resolved rows (`githubIssue`). Idempotent; fixed SQL only, so the in-memory test D1 keeps dispatching on statement identity. Mirrors the existing resolve handler. **+6 tests (70 worker tests pass).**

### Triage cron — `tools/triage-reports.mjs` + `.github/workflows/triage-reports.yml`
- Reads non-resolved reports from the Worker, aggregates by `(station, category)`, and probes the catalog stream (`no-audio`/`interruptions`, via `playable-check.mjs`'s `lenientProbe`) or favicon (`wrong-logo`).
- **Confirms** a category when the probe **fails** (stream unreachable / non-audio / favicon 404|timeout) **or** the independent-report count reaches the threshold (default 3, `REPORT_THRESHOLD`). Non-probe-able categories (`wrong-station`, `wrong-info`, `other`, `unspecified`) are threshold-only.
- **Upserts one `broken-station` issue per station** (matched by a `<!-- rrradio:station-id=<id> -->` body marker), labeled `broken-station` + each confirmed category, body carrying per-category counts, probe evidence, and reporter comments verbatim — then POSTs `triage-reports` to confirm + link.
- **Security:** user comment text is neutralized (zero-width-space defuse of `<!--`/`-->`/fences) so a malicious comment can't forge the station-id marker the resolve Action greps for. Unit-tested, including the injection case.
- Daily cron (06:00 UTC) + `workflow_dispatch` with a `dry_run` input.

### Verification
- Root suite **623 pass** (incl. 26 new triage unit tests: probe-decision mapping, aggregation, comment sanitization + marker-injection defense, issue-body/label building, the confirm/hold/threshold matrix). Worker **70 pass**. `typecheck`, `build`, `check-catalog` green.
- **Live integration check:** probed grrif's real stream (`ok`) and favicon (`200`) — so the existing live test report (grrif, no-audio, 1 report, threshold 3, stream up) correctly **stays `received` with no issue**, demonstrating the hold logic rather than a false confirm.

## Setup / dependency

- Needs the **`STATS_ADMIN_TOKEN`** repo secret (the Worker's `ADMIN_TOKEN`) — the same secret `resolve-reports.yml` already needs. Issues are written with the built-in `GITHUB_TOKEN`. Until it's set, the workflow fails fast with a clear message.
- Safe first run: trigger **Actions → “Triage broken-station reports” → Run workflow → dry_run ✓** to see the probe + plan with nothing written.

## Out of scope

- **P3:** the curation agent that proposes the catalog-fix PR (swap stream / favicon / remove entry). This PR stops at "a human-actionable issue exists"; the human still fixes + closes.
- Client work (iOS report sheet + receipts + polling) — companion `rrradio-ios` issue.

Part of #507.

🤖 Generated with [Claude Code](https://claude.com/claude-code)