### PR TITLE
feat(reports): P3 broken-station fix agent — issue → catalog-fix PR

### DIFF
--- a/.github/workflows/propose-fixes.yml
+++ b/.github/workflows/propose-fixes.yml
@@ -1,0 +1,73 @@
+name: Propose broken-station fixes
+
+# P3 of the broken-station report pipeline (issue #507). Reads the open
+# `broken-station` issues P2 upserts and turns each into a catalog-fix PR:
+# re-probes the stream (swap to a working https replacement, or mark it
+# `status: broken`), clears a dead favicon, or corrects the country when
+# Radio Browser disagrees. Anything it can't fix confidently becomes a
+# research comment on the issue instead of a guessed PR.
+#
+# A human reviews the diff and merges — that is the control point.
+# Merging closes the linked issue (the PR body carries `Closes #N`),
+# which fires resolve-reports.yml → the Worker resolves the reports →
+# the apps' receipt polling notifies the reporters.
+#
+# Daily, an hour after the P2 triage cron, so same-day confirmed issues
+# get a fix PR. The tool dedups against open fix PRs, so a daily cadence
+# never piles up duplicate PRs. Plus manual dispatch with an optional
+# dry run (the recommended safe first run).
+#
+# No Worker secret needed — P3 acts off the GitHub issues, not D1.
+# GITHUB_TOKEN writes the branch, PR, comments, and labels.
+
+on:
+  schedule:
+    - cron: '0 7 * * *' # daily 07:00 UTC (P2 triage runs 06:00)
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Plan only — probe + decide, open nothing'
+        type: boolean
+        default: false
+
+permissions:
+  contents: write # push the fix branch
+  pull-requests: write # open the catalog-fix PR
+  issues: write # research comments + label
+
+concurrency:
+  group: propose-fixes
+  cancel-in-progress: false
+
+jobs:
+  propose:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Ensure the fix label exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh label create broken-station-fix \
+            --description "Automated broken-station catalog fix awaiting review" \
+            --color 1D76DB --force >/dev/null 2>&1 || true
+
+      - name: Propose fixes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          # GITHUB_REPOSITORY / GITHUB_SERVER_URL / GITHUB_RUN_ID are
+          # provided automatically (issue repo + run link).
+        run: |
+          npm run propose-station-fix -- ${{ (github.event_name == 'workflow_dispatch' && inputs.dry_run) && '--dry-run' || '' }} --verbose

--- a/docs/spec/contracts/broken-reports.md
+++ b/docs/spec/contracts/broken-reports.md
@@ -33,6 +33,8 @@ confirmed ────────(issue closed / admin)──────▶ re
 
 - `received → confirmed` is driven by the P2 triage cron (see Triage
   automation); `→ resolved` by the issue-close Action or a manual admin call.
+- The P3 fix agent (see Fix automation) turns a confirmed `broken-station`
+  issue into the catalog-fix PR whose merge closes the issue → resolution.
 - `resolved` is terminal and carries exactly one `resolution`:
   `fixed | removed | not-reproducible`.
 - Nothing un-resolves a report. A still-broken station is a *new* report.
@@ -101,6 +103,34 @@ touches `received`). Response: `{ "ok": true, "confirmed": <n>, "linked": <n> }`
   Resolution = `resolved:fixed | resolved:removed | resolved:not-reproducible`
   label when present, else GitHub's close reason (completed → `fixed`,
   not planned → `not-reproducible`). The station id comes from the body marker.
+
+### Fix automation (P3)
+
+- **Fix agent (P3 cron, daily — `.github/workflows/propose-fixes.yml` →
+  `tools/propose-station-fix.mjs`, an hour after the P2 cron):** reads the open
+  `broken-station` issues (the confirmed work queue), parses the station-id
+  marker + category labels, and turns each into a **catalog-fix PR**:
+  - `no-audio` / `interruptions` → re-probe the stream; if dead, find a working
+    **https** replacement (http→https upgrade, then Radio Browser by
+    `stationuuid`, then exact name) and swap `streamUrl` (+ codec/bitrate); if
+    none plays, propose `status: broken` (drops it from the published catalog).
+  - `wrong-logo` → probe the favicon; if 404/error, clear it so the app falls
+    back to a monogram.
+  - `wrong-station` / `wrong-info` → when Radio Browser disagrees on the
+    country, correct it.
+- **Confidence gate:** anything it can't fix confidently — stream recovered,
+  favicon still loads, ambiguous name/tags, free-form `other` — becomes a
+  one-time research comment on the issue (marked `<!-- rrradio:fix-bot -->`)
+  rather than a guessed PR.
+- **Surgical patch:** both `data/stations.yaml` (source) and
+  `public/stations.json` (the artifact deploys serve as-is, audit #65) are
+  edited in place for a minimal diff — no full `npm run catalog` rebuild.
+  `check-catalog` runs before each PR is pushed.
+- **Control point + resolution:** the PR is normal (ready to merge), labeled
+  `broken-station-fix`, its body carries `Closes #<issue>`, and it is deduped
+  one-per-station by the `bot/broken-fix/<id>` branch. A human reviews and
+  merges; merging closes the issue → `resolve-reports.yml` resolves the linked
+  reports. P3 needs no Worker secret — it acts off the GitHub issues, not D1.
 
 ## Detail
 
@@ -219,6 +249,11 @@ integration point.
 - Triage cron (P2): `tools/triage-reports.mjs` (+ `tools/triage-reports.test.mjs`),
   `.github/workflows/triage-reports.yml`; reuses `tools/playable-check.mjs`'s
   `lenientProbe` for the stream probe.
+- Fix agent (P3): `tools/propose-station-fix.mjs` (+ `tools/propose-station-fix.test.mjs`),
+  `.github/workflows/propose-fixes.yml`; surgical-edit helpers
+  `tools/lib/yaml-station-edit.mjs` + `tools/lib/catalog-json-patch.mjs`
+  (each with a `.test.mjs`); reuses `lenientProbe`, `tools/rb-client.mjs`, and
+  `tools/triage-reports.mjs`'s shared probe helpers.
 - Resolution Action: `.github/workflows/resolve-reports.yml`.
 - Privacy rows: [privacy-data-boundaries.md](privacy-data-boundaries.md) rows 4, 15.
 - Pipeline definition: [#507](https://github.com/MarkusSteinbrecher/rrradio/issues/507).
@@ -228,3 +263,12 @@ integration point.
 - No client implements categories/receipts/polling yet, so the user-facing half
   of the loop (the report sheet, the "resolved" notification) is unverified
   end-to-end. Server pipeline (ingest → confirm → issue → resolve) is live.
+- **P3 metadata fixes are narrow:** only a `country` disagreement with Radio
+  Browser is auto-corrected. Name/tags corrections, and re-sourcing a *new*
+  logo (vs. clearing a dead one), are left to a research comment + the
+  `curate-stations`/`curate-logos` skills — they lack a confident automated
+  signal. `wrong-station`/`wrong-info` that manifest as a dead stream are fixed
+  via the stream path.
+- **P3 patches the artifact surgically, not by rebuild:** a `name` change would
+  leave the derived `shortName` in `stations.json` stale until the next
+  catalog-watch rebuild — which is why P3 does not auto-edit `name`.

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "analyze": "node tools/health-probe.mjs",
     "backlog": "node tools/backlog.mjs",
     "triage-reports": "node tools/triage-reports.mjs",
+    "propose-station-fix": "node tools/propose-station-fix.mjs",
     "import-ard": "node tools/import-ard.mjs",
     "backfill-geo": "node tools/backfill-geo.mjs",
     "wire-metadata": "node tools/wire-metadata.mjs",

--- a/tools/lib/catalog-json-patch.mjs
+++ b/tools/lib/catalog-json-patch.mjs
@@ -1,0 +1,93 @@
+/**
+ * Surgical patch of the built catalog artifact (public/stations.json).
+ *
+ * Production serves the committed stations.json as-is — deploys do NOT
+ * re-run build-catalog (audit #65, keep RB fragility out of every push).
+ * So a broken-station fix has to land the change in BOTH data/stations.yaml
+ * (the source) and stations.json (the shipped artifact) for it to reach
+ * users on the next deploy. A full `npm run catalog` rebuild needs a primed
+ * RB cache / network and reflows the whole 31k-row file; instead we mutate
+ * the one affected station object in place and let the caller re-stringify
+ * with the same `JSON.stringify(payload, null, 2)` build-catalog uses, so
+ * the diff stays minimal. The weekly catalog-watch rebuild reconciles any
+ * derived-field drift (e.g. shortName) afterwards.
+ *
+ * Operates on the parsed `stations[]` array — no file I/O here. Used by
+ * tools/propose-station-fix.mjs (issue #507, P3).
+ */
+
+// Fields the fix agent is allowed to mutate in place. Pass-through values
+// (no further derivation) except `name`, whose `shortName` the caller
+// recomputes and passes alongside.
+const PATCHABLE = new Set([
+  'streamUrl',
+  'bitrate',
+  'codec',
+  'country',
+  'tags',
+  'name',
+  'shortName',
+  'stationuuid',
+]);
+
+const FAVICON_FIELDS = [
+  'favicon',
+  'favicons',
+  'faviconSource',
+  'faviconSourceType',
+  'faviconSourceUrl',
+  'faviconLicense',
+  'faviconOk',
+];
+
+export function findStation(stations, stationId) {
+  return stations.find((s) => s && s.id === stationId) ?? null;
+}
+
+/** Shallow value equality good enough for the scalar/array fields we set. */
+function sameValue(a, b) {
+  if (Array.isArray(a) && Array.isArray(b)) {
+    return a.length === b.length && a.every((v, i) => v === b[i]);
+  }
+  return a === b;
+}
+
+/**
+ * Apply scalar/array field changes to one station, in place (preserving
+ * key order for existing keys → minimal diff). Unknown / undefined values
+ * are skipped. Returns { found, changed, applied: string[] }.
+ */
+export function patchStationFields(stations, stationId, changes) {
+  const station = findStation(stations, stationId);
+  if (!station) return { found: false, changed: false, applied: [] };
+  const applied = [];
+  for (const [field, value] of Object.entries(changes ?? {})) {
+    if (value === undefined || !PATCHABLE.has(field)) continue;
+    if (sameValue(station[field], value)) continue;
+    station[field] = value;
+    applied.push(field);
+  }
+  return { found: true, changed: applied.length > 0, applied };
+}
+
+/** Drop every favicon-related field from one station (wrong-logo clear).
+ *  Returns { found, changed }. */
+export function clearFaviconFields(stations, stationId) {
+  const station = findStation(stations, stationId);
+  if (!station) return { found: false, changed: false };
+  let changed = false;
+  for (const f of FAVICON_FIELDS) {
+    if (f in station) {
+      delete station[f];
+      changed = true;
+    }
+  }
+  return { found: true, changed };
+}
+
+/** Remove a station from the published catalog (status → broken / removed).
+ *  Returns { stations, removed } — a new array; caller reassigns. */
+export function removeStation(stations, stationId) {
+  const next = stations.filter((s) => !(s && s.id === stationId));
+  return { stations: next, removed: next.length !== stations.length };
+}

--- a/tools/lib/catalog-json-patch.test.mjs
+++ b/tools/lib/catalog-json-patch.test.mjs
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import {
+  findStation,
+  patchStationFields,
+  clearFaviconFields,
+  removeStation,
+} from './catalog-json-patch.mjs';
+
+const make = () => [
+  {
+    id: 'a-one',
+    name: 'One FM',
+    streamUrl: 'https://a.example/one.mp3',
+    bitrate: 128,
+    codec: 'MP3',
+    tags: ['pop', 'rock'],
+    favicon: 'stations/a-one.png',
+    favicons: { 76: 'favicons/a-one-76.png' },
+    faviconSource: 'broadcaster',
+    shortName: 'One',
+    status: 'working',
+  },
+  { id: 'b-two', name: 'Two FM', streamUrl: 'http://b.example/two', status: 'stream-only' },
+];
+
+describe('patchStationFields', () => {
+  it('sets scalar + array fields in place, preserving key order', () => {
+    const stations = make();
+    const r = patchStationFields(stations, 'a-one', {
+      streamUrl: 'https://a.example/new.aac',
+      codec: 'AAC',
+      tags: ['jazz'],
+    });
+    expect(r).toEqual({ found: true, changed: true, applied: ['streamUrl', 'codec', 'tags'] });
+    const s = findStation(stations, 'a-one');
+    expect(s.streamUrl).toBe('https://a.example/new.aac');
+    expect(s.codec).toBe('AAC');
+    expect(s.tags).toEqual(['jazz']);
+    // key order unchanged (no new keys, no reordering)
+    expect(Object.keys(s)[0]).toBe('id');
+    expect(Object.keys(s)[2]).toBe('streamUrl');
+  });
+  it('skips undefined values and unknown/unpatchable fields', () => {
+    const stations = make();
+    const r = patchStationFields(stations, 'a-one', { codec: undefined, status: 'broken', homepage: 'x' });
+    expect(r.changed).toBe(false);
+    expect(findStation(stations, 'a-one').status).toBe('working');
+  });
+  it('is a no-op when the value already matches', () => {
+    const stations = make();
+    const r = patchStationFields(stations, 'a-one', { codec: 'MP3' });
+    expect(r.changed).toBe(false);
+    expect(r.applied).toEqual([]);
+  });
+  it('reports found=false for unknown id', () => {
+    const r = patchStationFields(make(), 'nope', { codec: 'AAC' });
+    expect(r).toEqual({ found: false, changed: false, applied: [] });
+  });
+});
+
+describe('clearFaviconFields', () => {
+  it('drops every favicon-related field', () => {
+    const stations = make();
+    const r = clearFaviconFields(stations, 'a-one');
+    expect(r).toEqual({ found: true, changed: true });
+    const s = findStation(stations, 'a-one');
+    expect('favicon' in s).toBe(false);
+    expect('favicons' in s).toBe(false);
+    expect('faviconSource' in s).toBe(false);
+    expect(s.name).toBe('One FM'); // untouched
+  });
+  it('is a no-op when there is nothing to clear', () => {
+    const stations = make();
+    const r = clearFaviconFields(stations, 'b-two');
+    expect(r).toEqual({ found: true, changed: false });
+  });
+});
+
+describe('removeStation', () => {
+  it('removes the station and signals removal', () => {
+    const { stations, removed } = removeStation(make(), 'b-two');
+    expect(removed).toBe(true);
+    expect(stations.map((s) => s.id)).toEqual(['a-one']);
+  });
+  it('signals no removal for unknown id', () => {
+    const { stations, removed } = removeStation(make(), 'nope');
+    expect(removed).toBe(false);
+    expect(stations).toHaveLength(2);
+  });
+});

--- a/tools/lib/yaml-station-edit.mjs
+++ b/tools/lib/yaml-station-edit.mjs
@@ -1,0 +1,125 @@
+/**
+ * Surgical, line-based field editor for a single station block in
+ * data/stations.yaml. Companion to yaml-block-favicon.mjs (which handles
+ * favicon stripping); this one sets scalar fields and the `tags` list.
+ *
+ * Why line-based and not structural: stations.yaml is hand-maintained,
+ * carries comments, and has a strict one-pair-per-line shape (enforced by
+ * the catalog gates). Round-tripping the whole document through a YAML
+ * serializer would reflow 31k unrelated rows and blow up the diff. A line
+ * walk keeps the change to exactly the field(s) we touch.
+ *
+ * Used by tools/propose-station-fix.mjs (issue #507, P3) to write a
+ * broken-station fix (stream swap, status: broken, metadata correction)
+ * before opening the catalog-fix PR.
+ */
+
+import { stringify } from 'yaml';
+
+const BLOCK_START_RX = /^- id: (.+)$/;
+
+/** Serialize one scalar (string/number/boolean) the way the catalog
+ *  would, so quoting matches the rest of the file. Rejects values that
+ *  don't fit on one line — none of the fields we edit are multi-line. */
+export function serializeScalar(value) {
+  const out = stringify(value).replace(/\n+$/, '');
+  if (out.includes('\n')) {
+    throw new Error(`refusing to write a multi-line scalar: ${JSON.stringify(value)}`);
+  }
+  return out;
+}
+
+/** Locate a station's block bounds by id. Returns { start, end } line
+ *  indices (inclusive) or null. `end` is the last line before the next
+ *  `- id:` header (or EOF). */
+export function findStationBlock(lines, stationId) {
+  let start = -1;
+  for (let i = 0; i < lines.length; i++) {
+    const m = BLOCK_START_RX.exec(lines[i]);
+    if (!m) continue;
+    if (m[1].trim() === stationId) {
+      start = i;
+      // Find the end: the line before the next `- id:` (or EOF).
+      let end = lines.length - 1;
+      for (let j = i + 1; j < lines.length; j++) {
+        if (BLOCK_START_RX.test(lines[j])) {
+          end = j - 1;
+          break;
+        }
+      }
+      return { start, end };
+    }
+  }
+  return null;
+}
+
+/**
+ * Set a scalar field on one station. Replaces the existing `  field: …`
+ * line in the block, or inserts it right after the `- id:` header when
+ * absent. Returns { text, changed, found } — `found` is whether the
+ * station block exists, `changed` whether the text actually moved.
+ */
+export function setStationScalar(yamlText, stationId, field, value) {
+  const lines = yamlText.split('\n');
+  const block = findStationBlock(lines, stationId);
+  if (!block) return { text: yamlText, changed: false, found: false };
+
+  const fieldRx = new RegExp(`^  ${field}:( |$)`);
+  const newLine = `  ${field}: ${serializeScalar(value)}`;
+
+  for (let i = block.start + 1; i <= block.end; i++) {
+    if (fieldRx.test(lines[i])) {
+      if (lines[i] === newLine) return { text: yamlText, changed: false, found: true };
+      lines[i] = newLine;
+      return { text: lines.join('\n'), changed: true, found: true };
+    }
+  }
+  // Absent — insert right after the `- id:` header.
+  lines.splice(block.start + 1, 0, newLine);
+  return { text: lines.join('\n'), changed: true, found: true };
+}
+
+/**
+ * Replace (or insert) the `tags:` block-style list on one station.
+ * Drops the existing `  tags:` line and its `    - item` children, then
+ * writes the new list. Empty `tags` removes the field entirely.
+ */
+export function setStationTags(yamlText, stationId, tags) {
+  const lines = yamlText.split('\n');
+  const block = findStationBlock(lines, stationId);
+  if (!block) return { text: yamlText, changed: false, found: false };
+
+  // Find the existing tags region: the `  tags:` line plus any
+  // immediately-following 4-space list items.
+  let tagsAt = -1;
+  for (let i = block.start + 1; i <= block.end; i++) {
+    if (/^  tags:( |$)/.test(lines[i])) {
+      tagsAt = i;
+      break;
+    }
+  }
+  let removeStart = tagsAt;
+  let removeCount = 0;
+  if (tagsAt >= 0) {
+    removeCount = 1;
+    for (let j = tagsAt + 1; j <= block.end; j++) {
+      if (/^    - /.test(lines[j])) removeCount++;
+      else break;
+    }
+  }
+
+  const cleaned = (tags ?? []).map((t) => String(t).trim()).filter(Boolean);
+  const newLines = cleaned.length
+    ? ['  tags:', ...cleaned.map((t) => `    - ${serializeScalar(t)}`)]
+    : [];
+
+  if (tagsAt >= 0) {
+    const existing = lines.slice(removeStart, removeStart + removeCount).join('\n');
+    if (existing === newLines.join('\n')) return { text: yamlText, changed: false, found: true };
+    lines.splice(removeStart, removeCount, ...newLines);
+  } else {
+    if (!newLines.length) return { text: yamlText, changed: false, found: true };
+    lines.splice(block.start + 1, 0, ...newLines);
+  }
+  return { text: lines.join('\n'), changed: true, found: true };
+}

--- a/tools/lib/yaml-station-edit.test.mjs
+++ b/tools/lib/yaml-station-edit.test.mjs
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import {
+  serializeScalar,
+  findStationBlock,
+  setStationScalar,
+  setStationTags,
+} from './yaml-station-edit.mjs';
+
+const SAMPLE = `- id: a-one
+  broadcaster: independent
+  name: One FM
+  streamUrl: https://a.example/one.mp3
+  bitrate: 128
+  codec: MP3
+  tags:
+    - pop
+    - rock
+  favicon: stations/a-one.png
+  country: GB
+  status: working
+  # trailing comment about a-one
+- id: b-two
+  broadcaster: independent
+  name: Two FM
+  streamUrl: http://b.example/two
+  status: stream-only
+`;
+
+describe('serializeScalar', () => {
+  it('renders plain strings and numbers without quotes', () => {
+    expect(serializeScalar('working')).toBe('working');
+    expect(serializeScalar('https://x.example/s.aac')).toBe('https://x.example/s.aac');
+    expect(serializeScalar(128)).toBe('128');
+  });
+  it('quotes strings that need it (yaml-lib default = house style)', () => {
+    // Double quotes by default; single only when the value contains a
+    // double-quote — matches how build-catalog already serialized the file.
+    expect(serializeScalar('Radio: FM')).toBe('"Radio: FM"');
+    expect(serializeScalar(' leading')).toBe('" leading"');
+    expect(serializeScalar('"The Mighty" 1290')).toBe('\'"The Mighty" 1290\'');
+  });
+  it('refuses multi-line values', () => {
+    expect(() => serializeScalar('a\nb')).toThrow();
+  });
+});
+
+describe('findStationBlock', () => {
+  it('returns inclusive bounds up to the next id (comments included)', () => {
+    const lines = SAMPLE.split('\n');
+    const a = findStationBlock(lines, 'a-one');
+    expect(lines[a.start]).toBe('- id: a-one');
+    expect(lines[a.end]).toBe('  # trailing comment about a-one');
+    const b = findStationBlock(lines, 'b-two');
+    expect(lines[b.start]).toBe('- id: b-two');
+  });
+  it('returns null for unknown id', () => {
+    expect(findStationBlock(SAMPLE.split('\n'), 'nope')).toBeNull();
+  });
+});
+
+describe('setStationScalar', () => {
+  it('replaces an existing field in place, touching nothing else', () => {
+    const r = setStationScalar(SAMPLE, 'a-one', 'streamUrl', 'https://a.example/new.aac');
+    expect(r.changed).toBe(true);
+    expect(r.text).toContain('  streamUrl: https://a.example/new.aac');
+    expect(r.text).not.toContain('one.mp3');
+    // b-two untouched
+    expect(r.text).toContain('  streamUrl: http://b.example/two');
+    // comment preserved
+    expect(r.text).toContain('  # trailing comment about a-one');
+  });
+  it('inserts an absent field right after the id header', () => {
+    const r = setStationScalar(SAMPLE, 'b-two', 'country', 'IE');
+    expect(r.changed).toBe(true);
+    const lines = r.text.split('\n');
+    const idx = lines.indexOf('- id: b-two');
+    expect(lines[idx + 1]).toBe('  country: IE');
+  });
+  it('is a no-op when the value already matches', () => {
+    const r = setStationScalar(SAMPLE, 'a-one', 'status', 'working');
+    expect(r.changed).toBe(false);
+    expect(r.text).toBe(SAMPLE);
+  });
+  it('flips status to broken on the right block only', () => {
+    const r = setStationScalar(SAMPLE, 'b-two', 'status', 'broken');
+    expect(r.text).toContain('- id: b-two\n  broadcaster: independent\n  name: Two FM\n  streamUrl: http://b.example/two\n  status: broken');
+    expect(r.text).toContain('  status: working'); // a-one unchanged
+  });
+  it('reports found=false for unknown station', () => {
+    const r = setStationScalar(SAMPLE, 'nope', 'status', 'broken');
+    expect(r.found).toBe(false);
+    expect(r.changed).toBe(false);
+  });
+});
+
+describe('setStationTags', () => {
+  it('replaces an existing tag list block', () => {
+    const r = setStationTags(SAMPLE, 'a-one', ['jazz', 'soul']);
+    expect(r.changed).toBe(true);
+    expect(r.text).toContain('  tags:\n    - jazz\n    - soul\n  favicon: stations/a-one.png');
+    expect(r.text).not.toContain('- pop');
+  });
+  it('inserts a tag list when absent', () => {
+    const r = setStationTags(SAMPLE, 'b-two', ['news']);
+    expect(r.changed).toBe(true);
+    const lines = r.text.split('\n');
+    const idx = lines.indexOf('- id: b-two');
+    expect(lines[idx + 1]).toBe('  tags:');
+    expect(lines[idx + 2]).toBe('    - news');
+  });
+  it('removes the tag list when given an empty array', () => {
+    const r = setStationTags(SAMPLE, 'a-one', []);
+    expect(r.changed).toBe(true);
+    expect(r.text).not.toContain('  tags:');
+    expect(r.text).not.toContain('    - pop');
+    expect(r.text).toContain('  favicon: stations/a-one.png');
+  });
+  it('is a no-op when tags already match', () => {
+    const r = setStationTags(SAMPLE, 'a-one', ['pop', 'rock']);
+    expect(r.changed).toBe(false);
+  });
+});

--- a/tools/propose-station-fix.mjs
+++ b/tools/propose-station-fix.mjs
@@ -1,0 +1,705 @@
+#!/usr/bin/env node
+/**
+ * Broken-station fix agent (issue #507, P3).
+ *
+ * The last phase of the report pipeline. P1 ingested reports + receipts,
+ * P2 confirmed them and upserted one `broken-station` GitHub issue per
+ * station. This turns each open issue into a **catalog-fix PR**:
+ *
+ *   - no-audio / interruptions → re-probe the stream; if dead, find a
+ *     working https replacement (http→https upgrade, then Radio Browser
+ *     by stationuuid / exact name) and swap `streamUrl`; if none, propose
+ *     `status: broken` (drops it from the published catalog).
+ *   - wrong-logo → probe the favicon; if dead (404/error), clear it so
+ *     the app falls back to a monogram.
+ *   - wrong-station / wrong-info → when Radio Browser disagrees on the
+ *     country, correct it; otherwise leave a research comment.
+ *
+ * Anything it can't fix confidently (stream recovered, favicon still
+ * loads, ambiguous metadata, free-form `other`) becomes a research
+ * comment on the issue instead of a guessed PR.
+ *
+ * The PR body carries `Closes #<issue>`. A human reviews the diff and
+ * merges — that's the control point. Merging closes the issue, which
+ * fires resolve-reports.yml → the Worker resolves the linked reports →
+ * the apps' receipt polling notifies the reporters.
+ *
+ * Both data/stations.yaml (source) and public/stations.json (the shipped
+ * artifact deploys serve as-is) are patched surgically — no full
+ * `npm run catalog` rebuild — so each PR is a minimal, reviewable diff.
+ * The weekly catalog-watch rebuild reconciles any derived-field drift.
+ *
+ * Pure logic is exported and unit-tested in propose-station-fix.test.mjs;
+ * I/O (probe, Radio Browser, GitHub, git) lives in main().
+ *
+ *   GH_TOKEN            GitHub token: issues + pull-requests write (gh CLI)
+ *   GITHUB_REPOSITORY   owner/repo (default MarkusSteinbrecher/rrradio)
+ *   flags: --dry-run (plan only, no writes/PRs), --verbose,
+ *          --limit N (max stations this run), --station <id> (target one)
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parse as parseYaml } from 'yaml';
+import { lenientProbe } from './playable-check.mjs';
+import { fetchByUuid } from './rb-client.mjs';
+import {
+  sanitizeComment,
+  faviconUrl,
+  streamProbeFailed,
+  faviconProbeFailed,
+} from './triage-reports.mjs';
+import { setStationScalar, setStationTags } from './lib/yaml-station-edit.mjs';
+import { blockFavicons } from './lib/yaml-block-favicon.mjs';
+import {
+  findStation,
+  patchStationFields,
+  clearFaviconFields,
+  removeStation,
+} from './lib/catalog-json-patch.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, '..');
+
+export const KNOWN_CATEGORIES = [
+  'no-audio',
+  'interruptions',
+  'wrong-station',
+  'wrong-logo',
+  'wrong-info',
+  'other',
+  'unspecified',
+];
+
+const STATION_MARKER_RE = /<!-- rrradio:station-id=([A-Za-z0-9._:-]+) -->/;
+const FIX_LABEL = 'broken-station-fix';
+const COMMENT_MARKER = '<!-- rrradio:fix-bot -->';
+// lenientProbe verdicts that mean "plays" — a replacement must hit one.
+const STREAM_PASS = new Set(['ok', 'ok-hls', 'needs-playlist']);
+const RB_BASE = 'https://de1.api.radio-browser.info';
+const DEFAULT_MAX = 25;
+const PROBE_TIMEOUT_MS = 8000;
+const MAX_REPLACEMENT_PROBES = 6;
+
+// ─── pure logic ──────────────────────────────────────────────────────
+
+/** Station id from the issue body marker P2 writes, or null. */
+export function parseStationId(issueBody) {
+  const m = STATION_MARKER_RE.exec(issueBody || '');
+  return m ? m[1] : null;
+}
+
+/** The known report categories carried as issue labels (drops the
+ *  `broken-station` umbrella label and anything unrelated). */
+export function categoriesFromLabels(labels) {
+  const known = new Set(KNOWN_CATEGORIES);
+  return [...new Set(labels || [])].filter((l) => known.has(l));
+}
+
+/** Stable per-station branch name → also the dedup key against open PRs. */
+export function branchName(stationId) {
+  return `bot/broken-fix/${String(stationId).replace(/[^A-Za-z0-9._-]/g, '-').slice(0, 100)}`;
+}
+
+/** A probe verdict that means the stream actually plays. */
+export function streamProbePassed(verdict) {
+  return verdict != null && STREAM_PASS.has(verdict);
+}
+
+/** Radio Browser's comma/semicolon tag string → a small clean tag list. */
+export function normaliseTags(rbTags) {
+  if (!rbTags) return [];
+  return String(rbTags)
+    .split(/[,;]/)
+    .map((t) => t.trim().toLowerCase())
+    .filter(Boolean)
+    .filter((t, i, a) => a.indexOf(t) === i)
+    .slice(0, 6);
+}
+
+export function buildPrTitle(stationName, stationId) {
+  return `Fix broken station: ${stationName} (${stationId})`.slice(0, 120);
+}
+
+function fixLine(fx) {
+  const cats = fx.categories.join(', ');
+  switch (fx.action) {
+    case 'stream-swap':
+      return `- **${cats}** — swap dead stream → \`${fx.url}\`${
+        fx.codec ? ` (${fx.codec}${fx.bitrate ? ` ${fx.bitrate}kbps` : ''})` : ''
+      }`;
+    case 'mark-broken':
+      return `- **${cats}** — \`status: broken\` (removed from the published catalog)`;
+    case 'favicon-clear':
+      return `- **${cats}** — clear dead favicon (app falls back to a monogram)`;
+    case 'metadata':
+      return `- **${cats}** — set \`country: ${fx.country}\``;
+    default:
+      return `- **${cats}** — ${fx.action}`;
+  }
+}
+
+function footer({ generatedAt, runUrl }) {
+  const stamp = [
+    generatedAt ? `Generated ${generatedAt}` : null,
+    runUrl ? `[workflow run](${runUrl})` : null,
+  ]
+    .filter(Boolean)
+    .join(' · ');
+  return stamp ? ['', '---', stamp] : [];
+}
+
+export function buildPrBody(station, fixes, unfixable, { issue, generatedAt, runUrl } = {}) {
+  const lines = [];
+  if (issue) lines.push(`Closes #${issue}`, '');
+  lines.push(`Automated catalog fix for the broken-station report on **${station.name}** (\`${station.id}\`).`);
+  lines.push('');
+  lines.push(
+    '_Generated by the broken-station fix agent (issue #507, P3). A human reviews this diff and merges; merging closes the linked report issue, which notifies the reporters via receipt polling._',
+  );
+  lines.push('', '## Changes');
+  for (const fx of fixes) {
+    lines.push(fixLine(fx));
+    if (fx.evidence) lines.push(`  - ${fx.evidence}`);
+  }
+  if (unfixable.length) {
+    lines.push('', '## Needs human follow-up (not auto-fixed)');
+    for (const u of unfixable) {
+      lines.push(`- **${u.categories.join(', ')}** — ${u.reason}`);
+      if (u.evidence) lines.push(`  - ${u.evidence}`);
+    }
+  }
+  if (fixes.some((f) => f.action === 'mark-broken')) {
+    lines.push('', '> Tip: add the `resolved:removed` label before closing so reporters see "removed" rather than "fixed".');
+  }
+  lines.push(...footer({ generatedAt, runUrl }));
+  return lines.join('\n');
+}
+
+export function buildResearchComment(station, unfixable, { generatedAt, runUrl } = {}) {
+  const lines = [COMMENT_MARKER, ''];
+  lines.push(`**Fix agent — no confident automated fix** for \`${station.id}\`. Findings for a human:`, '');
+  for (const u of unfixable) {
+    lines.push(`- **${u.categories.join(', ')}** — ${u.reason}`);
+    if (u.evidence) lines.push(`  - ${u.evidence}`);
+    if (u.suggest) lines.push(`  - suggested resolution label: \`${u.suggest}\``);
+  }
+  lines.push(...footer({ generatedAt, runUrl }));
+  return lines.join('\n');
+}
+
+// ─── I/O ─────────────────────────────────────────────────────────────
+
+function loadYamlText() {
+  return readFileSync(join(ROOT, 'data/stations.yaml'), 'utf8');
+}
+
+function parseCatalog(yamlText) {
+  const list = parseYaml(yamlText);
+  const byId = new Map();
+  for (const s of Array.isArray(list) ? list : []) if (s && s.id) byId.set(s.id, s);
+  return byId;
+}
+
+function loadJsonPayload() {
+  return JSON.parse(readFileSync(join(ROOT, 'public/stations.json'), 'utf8'));
+}
+
+function withTimeout(ms) {
+  const ctl = new AbortController();
+  const timer = setTimeout(() => ctl.abort(), ms);
+  return { signal: ctl.signal, done: () => clearTimeout(timer) };
+}
+
+async function probeStreamUrl(url) {
+  try {
+    const res = await lenientProbe(url, { allowHttp: true });
+    const verdict = res?.verdict ?? null;
+    return {
+      failed: streamProbeFailed({ verdict, errored: false }),
+      verdict,
+      reason: res?.reason ?? 'inconclusive (redirect/mixed-content)',
+    };
+  } catch (err) {
+    return { failed: true, verdict: null, reason: `connection failed: ${String(err?.message ?? err).slice(0, 160)}` };
+  }
+}
+
+async function probeFaviconUrl(url) {
+  const t = withTimeout(PROBE_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, {
+      method: 'GET',
+      redirect: 'follow',
+      signal: t.signal,
+      headers: { 'User-Agent': 'rrradio-fix/1.0 (+https://rrradio.org)' },
+    });
+    return {
+      failed: faviconProbeFailed({ status: res.status, errored: false }),
+      evidence: `HTTP ${res.status} ${res.headers.get('content-type') ?? ''}`.trim().slice(0, 120),
+    };
+  } catch (err) {
+    return { failed: true, evidence: `fetch failed: ${String(err?.message ?? err).slice(0, 120)}` };
+  } finally {
+    t.done();
+  }
+}
+
+async function rbSearchByName(name) {
+  const params = new URLSearchParams({
+    name,
+    name_exact: 'true',
+    hidebroken: 'true',
+    order: 'clickcount',
+    reverse: 'true',
+    limit: '5',
+  });
+  const t = withTimeout(PROBE_TIMEOUT_MS);
+  try {
+    const res = await fetch(`${RB_BASE}/json/stations/search?${params}`, {
+      headers: { 'User-Agent': 'rrradio-fix/1.0' },
+      signal: t.signal,
+    });
+    if (!res.ok) return [];
+    return (await res.json()) ?? [];
+  } catch {
+    return [];
+  } finally {
+    t.done();
+  }
+}
+
+/** The single best Radio Browser record for a catalog station: prefer
+ *  the bound stationuuid, else the top exact-name hit. Null on miss. */
+async function rbRecord(entry) {
+  if (entry.stationuuid) {
+    try {
+      const recs = await fetchByUuid([entry.stationuuid]);
+      if (recs?.[0]) return recs[0];
+    } catch {
+      /* fall through to name search */
+    }
+  }
+  const list = await rbSearchByName(entry.name);
+  return list[0] ?? null;
+}
+
+/** Find a working https replacement stream for a dead station. Tries an
+ *  http→https upgrade of the current URL, then Radio Browser (by uuid,
+ *  then exact name), probing https candidates until one plays. */
+async function findReplacement(entry) {
+  const seen = new Set([entry.streamUrl]);
+  const candidates = [];
+  const add = (url, extra = {}) => {
+    if (!url || seen.has(url) || !/^https:\/\//i.test(url)) return;
+    seen.add(url);
+    candidates.push({ url, ...extra });
+  };
+
+  if (typeof entry.streamUrl === 'string' && entry.streamUrl.startsWith('http://')) {
+    add('https://' + entry.streamUrl.slice('http://'.length), { source: 'https-upgrade' });
+  }
+  if (entry.stationuuid) {
+    try {
+      const recs = await fetchByUuid([entry.stationuuid]);
+      const rb = recs?.[0];
+      if (rb) add(rb.url_resolved || rb.url, { codec: rb.codec, bitrate: rb.bitrate, source: 'rb-uuid' });
+    } catch {
+      /* ignore RB errors */
+    }
+  }
+  const named = (await rbSearchByName(entry.name))
+    .filter((s) => /^https:\/\//i.test(s.url_resolved || s.url))
+    .sort((a, b) => (b.lastcheckok ?? 0) - (a.lastcheckok ?? 0) || (b.clickcount ?? 0) - (a.clickcount ?? 0));
+  for (const s of named) add(s.url_resolved || s.url, { codec: s.codec, bitrate: s.bitrate, source: 'rb-name' });
+
+  for (const c of candidates.slice(0, MAX_REPLACEMENT_PROBES)) {
+    const p = await probeStreamUrl(c.url);
+    if (streamProbePassed(p.verdict)) {
+      return {
+        url: c.url,
+        codec: c.codec ? String(c.codec).toUpperCase() : undefined,
+        bitrate: c.bitrate && c.bitrate > 0 ? c.bitrate : undefined,
+        verdict: p.verdict,
+        source: c.source,
+      };
+    }
+  }
+  return null;
+}
+
+/**
+ * Inspect one station against its reported categories and return the
+ * planned { fixes, unfixable }. All probing/RB I/O happens here.
+ */
+async function inspectStation(entry, categories, { verbose } = {}) {
+  const catSet = new Set(categories);
+  const fixes = [];
+  const unfixable = [];
+
+  // ── stream (no-audio / interruptions) ──
+  const streamCats = [...catSet].filter((c) => c === 'no-audio' || c === 'interruptions');
+  if (streamCats.length) {
+    const sp = await probeStreamUrl(entry.streamUrl);
+    if (verbose) console.log(`    stream ${entry.streamUrl} → ${sp.failed ? 'DEAD' : 'ok'} (${sp.verdict ?? 'n/a'})`);
+    if (sp.failed) {
+      const repl = await findReplacement(entry);
+      if (repl) {
+        fixes.push({
+          categories: streamCats,
+          action: 'stream-swap',
+          url: repl.url,
+          codec: repl.codec,
+          bitrate: repl.bitrate,
+          evidence: `current stream ${sp.verdict ?? 'failed'} (${sp.reason}); replacement via ${repl.source} probes ${repl.verdict}`,
+        });
+      } else {
+        fixes.push({
+          categories: streamCats,
+          action: 'mark-broken',
+          evidence: `current stream ${sp.verdict ?? 'failed'} (${sp.reason}); no working https replacement found via http-upgrade or Radio Browser`,
+        });
+      }
+    } else {
+      unfixable.push({
+        categories: streamCats,
+        reason: 'stream probes OK now — likely transient or already fixed',
+        evidence: `probe: ${sp.verdict} (${sp.reason})`,
+        suggest: 'resolved:not-reproducible',
+      });
+    }
+  }
+
+  // ── favicon (wrong-logo) ──
+  if (catSet.has('wrong-logo')) {
+    const fav = faviconUrl(entry.favicon);
+    if (!fav) {
+      unfixable.push({
+        categories: ['wrong-logo'],
+        reason: 'no favicon set in the catalog — a logo needs sourcing (curate-logos)',
+        evidence: 'favicon is empty',
+      });
+    } else {
+      const fp = await probeFaviconUrl(fav);
+      if (verbose) console.log(`    favicon ${fav} → ${fp.failed ? 'DEAD' : 'ok'} (${fp.evidence})`);
+      if (fp.failed) {
+        fixes.push({
+          categories: ['wrong-logo'],
+          action: 'favicon-clear',
+          evidence: `favicon ${fav} → ${fp.evidence}; clearing so the app falls back to a monogram`,
+        });
+      } else {
+        unfixable.push({
+          categories: ['wrong-logo'],
+          reason: "favicon loads — can't auto-verify it's the right image",
+          evidence: `favicon ${fav} → ${fp.evidence}`,
+          suggest: 'curate-logos',
+        });
+      }
+    }
+  }
+
+  // ── metadata (wrong-station / wrong-info) ──
+  const metaCats = [...catSet].filter((c) => c === 'wrong-station' || c === 'wrong-info');
+  if (metaCats.length) {
+    const rb = await rbRecord(entry);
+    const catCountry = entry.country ? String(entry.country).toUpperCase() : '';
+    const rbCountry = rb?.countrycode ? String(rb.countrycode).toUpperCase() : '';
+    if (rbCountry && catCountry && rbCountry !== catCountry) {
+      fixes.push({
+        categories: metaCats,
+        action: 'metadata',
+        country: rbCountry,
+        evidence: `Radio Browser lists country ${rbCountry}; catalog has ${catCountry}`,
+      });
+    } else {
+      unfixable.push({
+        categories: metaCats,
+        reason: 'metadata correction needs human judgement (name / tags / country)',
+        evidence: rb
+          ? `RB: name=${JSON.stringify(rb.name)} country=${rbCountry || '?'} tags=${rb.tags || '?'}; catalog: name=${JSON.stringify(entry.name)} country=${catCountry || '?'}`
+          : 'no Radio Browser record matched this station',
+      });
+    }
+  }
+
+  // ── free-form ──
+  const otherCats = [...catSet].filter((c) => c === 'other' || c === 'unspecified');
+  if (otherCats.length) {
+    unfixable.push({
+      categories: otherCats,
+      reason: 'free-form report — needs human review',
+      evidence: 'see the reporter comments in the issue body',
+    });
+  }
+
+  return { fixes, unfixable };
+}
+
+/** Apply the planned fixes to in-memory YAML text + JSON payload copies.
+ *  Returns { yaml, json } ready to write. Pure (exported for tests). */
+export function applyFixes(yamlText, jsonPayload, stationId, fixes) {
+  let yaml = yamlText;
+  const json = structuredClone(jsonPayload);
+  const jsonChanges = {};
+  let unpublish = false;
+  let clearFavicon = false;
+
+  for (const fx of fixes) {
+    if (fx.action === 'stream-swap') {
+      yaml = setStationScalar(yaml, stationId, 'streamUrl', fx.url).text;
+      jsonChanges.streamUrl = fx.url;
+      if (fx.codec) {
+        yaml = setStationScalar(yaml, stationId, 'codec', fx.codec).text;
+        jsonChanges.codec = fx.codec;
+      }
+      if (fx.bitrate) {
+        yaml = setStationScalar(yaml, stationId, 'bitrate', fx.bitrate).text;
+        jsonChanges.bitrate = fx.bitrate;
+      }
+    } else if (fx.action === 'mark-broken') {
+      yaml = setStationScalar(yaml, stationId, 'status', 'broken').text;
+      unpublish = true;
+    } else if (fx.action === 'favicon-clear') {
+      yaml = blockFavicons(yaml, [stationId]).text;
+      clearFavicon = true;
+    } else if (fx.action === 'metadata') {
+      if (fx.country) {
+        yaml = setStationScalar(yaml, stationId, 'country', fx.country).text;
+        jsonChanges.country = fx.country;
+      }
+      if (fx.tags) {
+        yaml = setStationTags(yaml, stationId, fx.tags).text;
+        jsonChanges.tags = fx.tags;
+      }
+    }
+  }
+
+  if (unpublish) {
+    json.stations = removeStation(json.stations, stationId).stations;
+  } else {
+    patchStationFields(json.stations, stationId, jsonChanges);
+    if (clearFavicon) clearFaviconFields(json.stations, stationId);
+  }
+  return { yaml, json };
+}
+
+// ── git / gh shells (only invoked when not in dry-run) ──
+function git(args) {
+  return execFileSync('git', args, { cwd: ROOT, encoding: 'utf8' });
+}
+function gh(args, input) {
+  return execFileSync('gh', args, { cwd: ROOT, encoding: 'utf8', input, maxBuffer: 1 << 26 });
+}
+function ghJson(args) {
+  return JSON.parse(gh(args));
+}
+
+function issueHasFixBotComment(repo, number) {
+  try {
+    const comments = ghJson(['api', `repos/${repo}/issues/${number}/comments`, '--paginate']);
+    return comments.some((c) => (c.body || '').includes(COMMENT_MARKER));
+  } catch {
+    return false;
+  }
+}
+
+function parseArgs(argv) {
+  const out = { dryRun: false, verbose: false, limit: DEFAULT_MAX, station: null };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--dry-run' || a === '-n') out.dryRun = true;
+    else if (a === '--verbose' || a === '-v') out.verbose = true;
+    else if (a === '--limit') out.limit = Math.max(1, Number(argv[++i]) || DEFAULT_MAX);
+    else if (a === '--station') out.station = argv[++i] || null;
+    else if (a === '--help' || a === '-h') {
+      console.log('usage: propose-station-fix [--dry-run] [--verbose] [--limit N] [--station <id>]');
+      process.exit(0);
+    } else {
+      console.error(`propose-station-fix: unknown argument "${a}"`);
+      process.exit(1);
+    }
+  }
+  return out;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const dryRun = args.dryRun || process.env.DRY_RUN === '1';
+  const repo = process.env.GITHUB_REPOSITORY || 'MarkusSteinbrecher/rrradio';
+  const generatedAt = new Date().toISOString().replace(/\.\d+Z$/, 'Z');
+  const runUrl =
+    process.env.GITHUB_SERVER_URL && process.env.GITHUB_RUN_ID
+      ? `${process.env.GITHUB_SERVER_URL}/${repo}/actions/runs/${process.env.GITHUB_RUN_ID}`
+      : null;
+
+  // Open broken-station issues = the confirmed work queue (P2 upserts them).
+  const issues = ghJson([
+    'issue',
+    'list',
+    '--repo',
+    repo,
+    '--label',
+    'broken-station',
+    '--state',
+    'open',
+    '--json',
+    'number,title,body,labels',
+    '--limit',
+    '200',
+  ]);
+
+  // Dedup: skip stations that already have an open fix PR.
+  const openPrHeads = new Set(
+    ghJson(['pr', 'list', '--repo', repo, '--state', 'open', '--json', 'headRefName', '--limit', '200']).map(
+      (p) => p.headRefName,
+    ),
+  );
+
+  const yamlText = loadYamlText();
+  const catalog = parseCatalog(yamlText);
+  const jsonPayload = loadJsonPayload();
+  const base = dryRun ? null : git(['rev-parse', 'HEAD']).trim();
+  // Where to return between stations. On a `schedule` run actions/checkout
+  // leaves a detached HEAD (abbrev-ref → "HEAD"), so fall back to the base
+  // commit rather than trying to check out a ref literally named "HEAD".
+  let startRef = null;
+  if (!dryRun) {
+    const abbrev = git(['rev-parse', '--abbrev-ref', 'HEAD']).trim();
+    startRef = abbrev && abbrev !== 'HEAD' ? abbrev : base;
+  }
+
+  console.log(
+    `propose-fix: ${issues.length} open broken-station issue(s) · ${openPrHeads.size} open PR(s)${dryRun ? ' · DRY RUN' : ''}`,
+  );
+
+  let prs = 0;
+  let comments = 0;
+  let processed = 0;
+
+  for (const issue of issues) {
+    if (processed >= args.limit) {
+      console.warn(`propose-fix: hit --limit ${args.limit}; ${issues.length - processed} issue(s) deferred`);
+      break;
+    }
+    const stationId = parseStationId(issue.body);
+    if (!stationId) {
+      if (args.verbose) console.log(`  #${issue.number}: no station-id marker — skipping`);
+      continue;
+    }
+    if (args.station && stationId !== args.station) continue;
+    const cats = categoriesFromLabels((issue.labels || []).map((l) => l.name));
+    const branch = branchName(stationId);
+    if (openPrHeads.has(branch)) {
+      if (args.verbose) console.log(`  #${issue.number} ${stationId}: open fix PR exists — skipping`);
+      continue;
+    }
+    const entry = catalog.get(stationId);
+    processed += 1;
+
+    if (!entry) {
+      console.log(`  #${issue.number} ${stationId}: not in the bundled catalog (custom/unknown id)`);
+      if (!dryRun && !issueHasFixBotComment(repo, issue.number)) {
+        const body = buildResearchComment(
+          { id: stationId, name: stationId },
+          [{ categories: cats.length ? cats : ['unspecified'], reason: 'station id not found in data/stations.yaml — custom or already removed', evidence: 'nothing to patch' }],
+          { generatedAt, runUrl },
+        );
+        gh(['issue', 'comment', String(issue.number), '--repo', repo, '--body-file', '-'], body);
+        comments += 1;
+      }
+      continue;
+    }
+
+    const { fixes, unfixable } = await inspectStation(entry, cats, { verbose: args.verbose });
+    console.log(
+      `  #${issue.number} ${stationId} [${cats.join(',') || 'none'}] → ${fixes.length} fix(es), ${unfixable.length} for human`,
+    );
+
+    if (fixes.length === 0) {
+      // Nothing actionable — leave a one-time research comment.
+      if (unfixable.length === 0) continue;
+      if (dryRun) {
+        console.log(`  [dry-run] would comment on #${issue.number}: ${unfixable.map((u) => u.reason).join(' | ')}`);
+        comments += 1;
+        continue;
+      }
+      if (issueHasFixBotComment(repo, issue.number)) {
+        if (args.verbose) console.log(`  #${issue.number}: fix-bot comment already present — skipping`);
+        continue;
+      }
+      const body = buildResearchComment(entry, unfixable, { generatedAt, runUrl });
+      gh(['issue', 'comment', String(issue.number), '--repo', repo, '--body-file', '-'], body);
+      comments += 1;
+      continue;
+    }
+
+    const title = buildPrTitle(entry.name, stationId);
+    const body = buildPrBody(entry, fixes, unfixable, { issue: issue.number, generatedAt, runUrl });
+
+    if (dryRun) {
+      console.log(`  [dry-run] would open PR "${title}" (head ${branch})`);
+      for (const fx of fixes) console.log(`            ${fixLine(fx).replace(/^- /, '')}`);
+      prs += 1;
+      continue;
+    }
+
+    // Build the change on a fresh branch off the base commit.
+    git(['checkout', '-B', branch, base]);
+    const { yaml, json } = applyFixes(yamlText, jsonPayload, stationId, fixes);
+    writeFileSync(join(ROOT, 'data/stations.yaml'), yaml);
+    writeFileSync(join(ROOT, 'public/stations.json'), JSON.stringify(json, null, 2) + '\n');
+
+    // Gate the change before pushing — never open a PR that fails check-catalog.
+    try {
+      execFileSync('node', ['tools/check-catalog.mjs'], { cwd: ROOT, stdio: 'pipe' });
+    } catch (err) {
+      console.error(`  #${issue.number} ${stationId}: check-catalog failed — abandoning this fix`);
+      console.error(String(err.stdout || '') + String(err.stderr || ''));
+      git(['checkout', '-f', startRef]);
+      git(['branch', '-D', branch]);
+      continue;
+    }
+
+    git(['add', 'data/stations.yaml', 'public/stations.json']);
+    git(['commit', '-m', `fix(catalog): ${title}\n\nCloses #${issue.number}`]);
+    // Force-push: the branch name is stable per station, so a re-run after
+    // a previous (closed-unmerged) PR overwrites its stale bot branch. Bot
+    // namespace only — never main; the workflow serializes runs.
+    git(['push', '--force', '-u', 'origin', branch]);
+    gh([
+      'pr',
+      'create',
+      '--repo',
+      repo,
+      '--head',
+      branch,
+      '--base',
+      'main',
+      '--title',
+      title,
+      '--body-file',
+      '-',
+      '--label',
+      FIX_LABEL,
+    ], body);
+    prs += 1;
+    console.log(`  #${issue.number} ${stationId}: opened PR on ${branch}`);
+
+    // Restore the working tree for the next iteration.
+    git(['checkout', '-f', startRef]);
+  }
+
+  console.log(
+    `propose-fix done: ${prs} PR(s)${dryRun ? ' (planned)' : ''}, ${comments} comment(s), ${processed} issue(s) processed`,
+  );
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    console.error('propose-station-fix failed:', err?.stack ?? err);
+    process.exit(1);
+  });
+}

--- a/tools/propose-station-fix.test.mjs
+++ b/tools/propose-station-fix.test.mjs
@@ -1,0 +1,165 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parse as parseYaml } from 'yaml';
+import {
+  parseStationId,
+  categoriesFromLabels,
+  branchName,
+  streamProbePassed,
+  normaliseTags,
+  buildPrTitle,
+  buildPrBody,
+  buildResearchComment,
+  applyFixes,
+} from './propose-station-fix.mjs';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const PUBLISHABLE = new Set(['working', 'stream-only', 'icy-only']);
+
+describe('parseStationId', () => {
+  it('reads the station-id marker P2 writes', () => {
+    expect(parseStationId('<!-- rrradio:station-id=builtin-grrif -->\n\nbody')).toBe('builtin-grrif');
+    expect(parseStationId('text\n<!-- rrradio:station-id=de.br-b1 -->')).toBe('de.br-b1');
+  });
+  it('returns null when absent', () => {
+    expect(parseStationId('no marker here')).toBeNull();
+    expect(parseStationId('')).toBeNull();
+    expect(parseStationId(null)).toBeNull();
+  });
+  it('does not match a zero-width-space defused marker (injection guard)', () => {
+    // P2 neutralizes reporter comments by inserting a ZWSP after `<!`.
+    expect(parseStationId('<!​-- rrradio:station-id=evil -->')).toBeNull();
+  });
+});
+
+describe('categoriesFromLabels', () => {
+  it('keeps known categories, drops the umbrella + noise labels', () => {
+    expect(categoriesFromLabels(['broken-station', 'no-audio', 'wrong-logo', 'enhancement'])).toEqual([
+      'no-audio',
+      'wrong-logo',
+    ]);
+  });
+  it('dedups and tolerates empty', () => {
+    expect(categoriesFromLabels(['no-audio', 'no-audio'])).toEqual(['no-audio']);
+    expect(categoriesFromLabels([])).toEqual([]);
+    expect(categoriesFromLabels(undefined)).toEqual([]);
+  });
+});
+
+describe('branchName', () => {
+  it('is a stable per-station bot branch', () => {
+    expect(branchName('builtin-grrif')).toBe('bot/broken-fix/builtin-grrif');
+  });
+  it('sanitizes ids with odd characters', () => {
+    expect(branchName('rb:abc/def 1')).toBe('bot/broken-fix/rb-abc-def-1');
+  });
+});
+
+describe('streamProbePassed', () => {
+  it('passes only on play-able verdicts', () => {
+    expect(streamProbePassed('ok')).toBe(true);
+    expect(streamProbePassed('ok-hls')).toBe(true);
+    expect(streamProbePassed('needs-playlist')).toBe(true);
+    expect(streamProbePassed('broken-format')).toBe(false);
+    expect(streamProbePassed(null)).toBe(false);
+  });
+});
+
+describe('normaliseTags', () => {
+  it('splits, lowercases, dedups, and caps at 6', () => {
+    expect(normaliseTags('Rock, Pop; rock,Jazz')).toEqual(['rock', 'pop', 'jazz']);
+    expect(normaliseTags('')).toEqual([]);
+    expect(normaliseTags(null)).toEqual([]);
+  });
+});
+
+describe('buildPrTitle', () => {
+  it('names the station and id', () => {
+    expect(buildPrTitle('One FM', 'a-one')).toBe('Fix broken station: One FM (a-one)');
+  });
+});
+
+const station = { id: 'a-one', name: 'One FM' };
+
+describe('buildPrBody', () => {
+  it('leads with Closes #N and lists each fix with evidence', () => {
+    const body = buildPrBody(
+      station,
+      [
+        { categories: ['no-audio'], action: 'stream-swap', url: 'https://x/s.aac', codec: 'AAC', bitrate: 128, evidence: 'dead → x probes ok' },
+        { categories: ['wrong-logo'], action: 'favicon-clear', evidence: 'favicon 404' },
+      ],
+      [{ categories: ['wrong-info'], reason: 'needs human', evidence: 'RB diff' }],
+      { issue: 42, generatedAt: '2026-06-13T00:00:00Z' },
+    );
+    expect(body).toMatch(/^Closes #42/);
+    expect(body).toContain('swap dead stream → `https://x/s.aac` (AAC 128kbps)');
+    expect(body).toContain('clear dead favicon');
+    expect(body).toContain('## Needs human follow-up');
+    expect(body).toContain('needs human');
+  });
+  it('adds the removed-label tip when a station is marked broken', () => {
+    const body = buildPrBody(station, [{ categories: ['no-audio'], action: 'mark-broken', evidence: 'dead, no replacement' }], [], { issue: 7 });
+    expect(body).toContain('status: broken');
+    expect(body).toContain('resolved:removed');
+  });
+});
+
+describe('buildResearchComment', () => {
+  it('carries the idempotency marker and the findings', () => {
+    const c = buildResearchComment(station, [
+      { categories: ['no-audio'], reason: 'probes OK now', evidence: 'verdict ok', suggest: 'resolved:not-reproducible' },
+    ]);
+    expect(c).toMatch(/^<!-- rrradio:fix-bot -->/);
+    expect(c).toContain('no confident automated fix');
+    expect(c).toContain('probes OK now');
+    expect(c).toContain('`resolved:not-reproducible`');
+  });
+});
+
+// Integration: surgical edits against the REAL catalog must keep
+// stations.json consistent with stations.yaml the way check-catalog
+// verifies (publishable id-set + count). No disk writes. Parsing the
+// 31k-row YAML is slow, so each case re-parses the edited YAML at most
+// once and the block runs with a generous timeout.
+describe('applyFixes (real catalog consistency)', () => {
+  const yamlText = readFileSync(join(ROOT, 'data/stations.yaml'), 'utf8');
+  const jsonPayload = JSON.parse(readFileSync(join(ROOT, 'public/stations.json'), 'utf8'));
+  const yamlList = parseYaml(yamlText);
+  const target = yamlList.find((s) => s && PUBLISHABLE.has(s.status) && s.streamUrl);
+  const baselinePub = new Set(yamlList.filter((s) => s && PUBLISHABLE.has(s.status)).map((s) => s.id));
+
+  const publishableIds = (text) =>
+    new Set(parseYaml(text).filter((s) => s && PUBLISHABLE.has(s.status)).map((s) => s.id));
+  const jsonIds = (payload) => new Set(payload.stations.map((s) => s.id));
+  const sorted = (set) => [...set].sort();
+
+  it('a stream-swap keeps both sides in sync (same ids, same count)', () => {
+    const fix = [{ categories: ['no-audio'], action: 'stream-swap', url: 'https://example.test/replacement.aac', codec: 'AAC', bitrate: 128 }];
+    const { yaml, json } = applyFixes(yamlText, jsonPayload, target.id, fix);
+    expect(yaml).toContain('  streamUrl: https://example.test/replacement.aac');
+    expect(json.stations.find((s) => s.id === target.id).streamUrl).toBe('https://example.test/replacement.aac');
+    // check-catalog invariant: edited publishable YAML ids === JSON ids === baseline
+    expect(sorted(publishableIds(yaml))).toEqual(sorted(jsonIds(json)));
+    expect(sorted(jsonIds(json))).toEqual(sorted(baselinePub));
+    expect(json.$schema).toBe(jsonPayload.$schema); // payload shape preserved
+  }, 30000);
+
+  it('a mark-broken removes the station from BOTH sides', () => {
+    const fix = [{ categories: ['no-audio'], action: 'mark-broken' }];
+    const { yaml, json } = applyFixes(yamlText, jsonPayload, target.id, fix);
+    const editedPub = publishableIds(yaml);
+    expect(editedPub.has(target.id)).toBe(false);
+    expect(jsonIds(json).has(target.id)).toBe(false);
+    expect(sorted(editedPub)).toEqual(sorted(jsonIds(json)));
+    expect(json.stations.length).toBe(jsonPayload.stations.length - 1);
+  }, 30000);
+
+  it('does not mutate the caller-supplied payload', () => {
+    const before = jsonPayload.stations.length;
+    applyFixes(yamlText, jsonPayload, target.id, [{ categories: ['no-audio'], action: 'mark-broken' }]);
+    expect(jsonPayload.stations.length).toBe(before);
+  }, 30000);
+});

--- a/worker/README.md
+++ b/worker/README.md
@@ -189,6 +189,18 @@ the issue number. Needs the `STATS_ADMIN_TOKEN` repo secret; the
 issues are written with the workflow's built-in `GITHUB_TOKEN`. The
 full protocol lives in `../docs/spec/contracts/broken-reports.md`.
 
+### Automated fix PRs (P3 cron)
+
+`.github/workflows/propose-fixes.yml` runs daily (07:00 UTC, an hour
+after triage; also `workflow_dispatch` with `dry_run`). It runs
+`tools/propose-station-fix.mjs`, which reads the open `broken-station`
+issues, re-probes each station, and opens a catalog-fix PR — swapping a
+dead stream for a working https replacement (Radio Browser lookup) or
+marking it `broken`, clearing a dead favicon, or correcting the country
+— with `Closes #<issue>` in the body. A human merges (the control
+point), which closes the issue and triggers the resolve Action above.
+It acts off the GitHub issues, not D1, so it needs **no Worker secret**.
+
 ### Resolving reports via issue close
 
 `.github/workflows/resolve-reports.yml` fires when an issue labeled


### PR DESCRIPTION
Final phase of the broken-station report pipeline (#507). P1 ingested reports + receipts, P2 confirmed them and upserted one `broken-station` issue per station. **P3 turns each open issue into a ready-to-merge catalog-fix PR** — the human merge is the control point, and a `Closes #<issue>` keyword (the per-station report issue, not this umbrella) fires `resolve-reports.yml` on merge, which notifies the reporters.

Scope confirmed with the sponsor: **ready-to-merge PRs**, reading **open `broken-station` issues** (not D1), handling **all three fix categories**.

## What it does

`tools/propose-station-fix.mjs` reads the open `broken-station` issues, parses the station-id marker + category labels, re-probes, and per category:

- **no-audio / interruptions** → re-probe the stream; if dead, find a working **https** replacement (http→https upgrade, then Radio Browser by `stationuuid`, then exact name) and swap `streamUrl` (+ codec/bitrate); if none plays, propose `status: broken` (drops it from the published catalog).
- **wrong-logo** → probe the favicon; if 404/error, clear it so the app falls back to a monogram.
- **wrong-station / wrong-info** → correct the `country` when Radio Browser disagrees.

**Confidence gate:** anything it can't fix confidently — stream recovered, favicon still loads, ambiguous name/tags, free-form `other` — becomes a one-time research comment (`<!-- rrradio:fix-bot -->`) instead of a guessed PR.

## How it stays safe / minimal

- Patches **both** `data/stations.yaml` (source) and `public/stations.json` (the artifact deploys serve as-is, audit #65) **surgically** — no full `npm run catalog` rebuild — so each PR is a minimal, reviewable diff. New line-based helpers `tools/lib/yaml-station-edit.mjs` + `tools/lib/catalog-json-patch.mjs`.
- Runs `check-catalog` before each PR is pushed; abandons the fix if it fails.
- Deduped one-PR-per-station by the `bot/broken-fix/<id>` branch.
- Acts off GitHub issues, not D1 → **no Worker secret needed**.

## Workflow

`.github/workflows/propose-fixes.yml` — daily 07:00 UTC (an hour after the P2 triage cron) + `workflow_dispatch` with `dry_run`. Permissions: contents/PR/issues write; `GITHUB_TOKEN` only.

**Recommended safe first run:** Actions → "Propose broken-station fixes" → `dry_run ✓` (plans, opens nothing) — same pattern as P2.

## Deviations (documented in the contract)

- Metadata auto-fix is narrow: only a `country` disagreement with Radio Browser. Name/tags corrections and re-sourcing a *new* logo are left to a research comment + the `curate-stations`/`curate-logos` skills (no confident automated signal). `name` is deliberately not auto-edited because the derived `shortName` in the artifact would go stale until the next catalog-watch rebuild.

## Verification

- typecheck ✓ · **661 web tests (+38)** ✓ · 70 worker tests ✓ · build ✓ · check-catalog (31460↔match) ✓
- New tests: yaml-station-edit (14), catalog-json-patch (8), propose-station-fix (16, incl. real-catalog surgical-edit consistency: a swap preserves the publishable id-set/count, a mark-broken removes the station from both sides).
- Live read-only smoke: probe + Radio Browser replacement search + plan decision exercised against a real dead-then-recovered station (`us-wbru`) — correctly resolved to a research comment ("probes OK now → not-reproducible"), demonstrating restraint with no false PR.

## Tracking

Completes the **P3** phase of #507 (the back-end + automation half — P1/P2/P3 all shipped). Left intentionally **without** an auto-close keyword for the umbrella so the sponsor can verify the live pipeline (safe first `dry_run`) before closing the umbrella. The iOS report sheet is the separate companion issue in `rrradio-ios`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

