### PR TITLE
spec: exhaustive iOS reconciliation against d241aa9 — finalize the 26 docs

### DIFF
--- a/docs/spec/COVERAGE.md
+++ b/docs/spec/COVERAGE.md
@@ -20,47 +20,47 @@ a doc. See `STYLE.md` for templates and the reconciliation ritual.
 
 | Doc | Status | Reconciled @ | iOS source of truth |
 |---|---|---|---|
-| catalog-schema | draft | 9336321 | `Shared/Station.swift`, `Models/Catalog.swift`, `Models/StreamQuality.swift` |
-| playback-state-machine | draft | 9336321 | `Player/AudioPlayer.swift`, `Shared/StationPlaybackQueue.swift` |
-| metadata-fetchers | draft | 9336321 | `Player/Metadata/*` |
-| search | draft | 9336321 | `Search/*`, `Models/RadioBrowserClient.swift`, `Resources/stations.fts5.db` |
-| sync-merge | draft | 9336321 | `CloudSync/*` |
-| privacy-data-boundaries | draft | 9336321 | `RegionResolver.swift`, `DashboardView.swift`, `AddStationView.swift`, `Diagnostics.swift` |
-| broken-reports | draft | — | server-side first (`worker/src/reports.ts`); iOS report sheet pending (companion issue to #507) |
-| watch-protocol | draft | 800bb74 | `Shared/WatchRemoteProtocol.swift`, `WatchRemote/*`, `rrradioWatch/*` |
-| localization | draft | 9336321 | `Views/LocaleController.swift`, `Resources/Localizable.xcstrings` |
+| catalog-schema | review | d241aa9 | `Shared/Station.swift`, `Models/Catalog.swift`, `Models/StreamQuality.swift` (`StreamQualityBucket`) |
+| playback-state-machine | review | d241aa9 | `Player/AudioPlayer.swift`, `Shared/StationPlaybackQueue.swift` |
+| metadata-fetchers | review | d241aa9 | `Player/Metadata/*` |
+| search | review | d241aa9 | `Search/*`, `Models/RadioBrowserClient.swift`, `Resources/stations.fts5.db` |
+| sync-merge | review | d241aa9 | `CloudSync/*` |
+| privacy-data-boundaries | review | d241aa9 | `Models/RegionResolver.swift`, `Views/DashboardView.swift`, `Views/AddStationView.swift`, `Diagnostics.swift` |
+| broken-reports | review | d241aa9 | server `worker/src/reports.ts`; iOS `Models/BrokenStationReports.swift`, `Views/BrokenReportResolvedToast.swift`, `Views/NowPlayingView.swift` (report sheet) |
+| watch-protocol | approved | d241aa9 | `Shared/WatchRemoteProtocol.swift`, `WatchRemote/*`, `rrradioWatch/*` |
+| localization | review | d241aa9 | `Views/LocaleController.swift`, `Resources/Localizable.xcstrings` |
 
 ## Features (`features/*`) — observable behavior
 
 | Doc | Status | Reconciled @ | iOS source of truth |
 |---|---|---|---|
-| browse | draft | 9336321 | `Views/FeedPages/BrowsePage.swift`, `BrowseFiltersSheet`, `BrowseSortRow`, `StationMapView.swift` |
-| search | draft | 9336321 | `Search/*`, `Views/FeedPages/BrowsePage.swift` |
-| favorites | draft | 9336321 | `Views/FeedPages/FavoritesPage.swift`, `Views/StationKit.swift`, `Library/Library.swift` |
-| station-lists | draft | 9336321 | `Library/Library.swift`, `Views/FeedPages/*`, `BrowseSelectionDock` |
-| custom-stations | draft | 9336321 | `Views/AddStationView.swift`, `Library/StreamProbe.swift`, `Library/CustomStationBuilder.swift` |
-| now-playing | draft | 9336321 | `Views/NowPlayingView.swift`, `MiniPlayerView`, `Player/Metadata/MusicServiceLinks.swift` |
-| metadata-artwork | draft | 9336321 | `Player/Metadata/*` |
-| sleep-timer | draft | 9336321 | `Player/SleepTimer.swift` |
-| wake-to-radio | draft | 9336321 | `Player/WakeAlarm.swift` |
-| listening-history | draft | 9336321 | `Library/ListeningHistory.swift`, `Views/DashboardView.swift`, `Views/ListeningRaceChart.swift` |
-| watch-remote | draft | 800bb74 | `rrradioWatch/*`, `WatchRemote/PhoneRemoteControlController.swift` |
-| siri-shortcuts | draft | 9336321 | `Shortcuts/*` |
-| first-run-offline | draft | 9336321 | `App.swift`, `Models/Catalog.swift`, `Views/CatalogLoadingSplash.swift` |
-| preferences-diagnostics | draft | 9336321 | `Views/SettingsView.swift`, `ThemeController.swift`, `Player/CarModeController.swift`, `Diagnostics.swift` |
+| browse | review | d241aa9 | `Views/FeedPages/BrowsePage.swift`, `Views/FeedPages/BrowseFiltersSheet.swift`, `BrowseSortRow`, `Views/StationMapView.swift` |
+| search | review | d241aa9 | `Search/*`, `Views/FeedPages/BrowsePage.swift` |
+| favorites | review | d241aa9 | `Views/FeedPages/FavoritesPage.swift`, `Views/StationKit.swift`, `Library/Library.swift` |
+| station-lists | review | d241aa9 | `Library/Library.swift`, `Views/FeedPages/*`, `BrowseSelectionDock` |
+| custom-stations | review | d241aa9 | `Views/AddStationView.swift`, `Library/StreamProbe.swift`, `Library/CustomStationBuilder.swift` |
+| now-playing | review | d241aa9 | `Views/NowPlayingView.swift`, `MiniPlayerView`, `Player/Metadata/MusicServiceLinks.swift` |
+| metadata-artwork | review | d241aa9 | `Player/Metadata/*` |
+| sleep-timer | review | d241aa9 | `Player/SleepTimer.swift` |
+| wake-to-radio | review | d241aa9 | `Player/WakeAlarm.swift` |
+| listening-history | review | d241aa9 | `Library/ListeningHistory.swift`, `Views/DashboardView.swift`, `Views/ListeningRaceChart.swift` |
+| watch-remote | approved | d241aa9 | `rrradioWatch/*`, `WatchRemote/PhoneRemoteControlController.swift` |
+| siri-shortcuts | review | d241aa9 | `Shortcuts/*` |
+| first-run-offline | review | d241aa9 | `App.swift`, `Models/Catalog.swift`, `Views/CatalogLoadingSplash.swift` |
+| preferences-diagnostics | review | d241aa9 | `Views/SettingsView.swift`, `Views/ThemeController.swift`, `Player/CarModeController.swift`, `Diagnostics.swift` |
 
 ## Cross-cutting (`*.md`)
 
 | Doc | Status | Reconciled @ | Notes |
 |---|---|---|---|
-| platforms | draft | 9336321 | links all 8 contracts; adaptive-layout/landscape note still light (now-playing.md owns the split) |
-| playback | draft | 9336321 | links `contracts/playback-state-machine.md` |
-| data-sync | draft | 9336321 | links `contracts/sync-merge.md` + `contracts/privacy-data-boundaries.md` |
+| platforms | review | d241aa9 | links all 9 contracts; adaptive-layout/landscape note still light (now-playing.md owns the split) |
+| playback | review | d241aa9 | links `contracts/playback-state-machine.md` |
+| data-sync | review | d241aa9 | links `contracts/sync-merge.md` + `contracts/privacy-data-boundaries.md` |
 
 ## Meta
 
 | Doc | Status | Notes |
 |---|---|---|
-| README | updated | spec map split (features + contracts tiers), parity rows for the 5 new features, maintenance ritual; parity matrix should be re-verified true-as-of a named commit in Phase 3 |
+| README | updated | spec map split (features + contracts tiers), maintenance ritual; parity matrix re-verified true-as-of iOS `d241aa9` (2026-06-12) + broken-reports row added |
 | STYLE | approved | authoring standard |
 | COVERAGE | living | this file |

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -103,9 +103,11 @@ Canonical implementation references remain in:
 
 ## Platform Parity Matrix
 
-The iOS column is verified against commit `9336321` (2026-05-31). The web and
-Android columns are carried from the prior spec and the Android parity tracker
-and are re-verified by their own teams.
+The iOS column is verified against commit `d241aa9` (2026-06-12), following the
+exhaustive per-doc reconciliation recorded in [COVERAGE.md](COVERAGE.md). The web
+and Android columns are carried from the prior spec and the Android parity
+tracker and are re-verified by their own teams (web/Android finalization is the
+next phase).
 
 | Area | Web | iOS | Android | Spec |
 |---|---|---|---|---|
@@ -131,6 +133,7 @@ and are re-verified by their own teams.
 | Cross-platform account sync | Not planned | Not planned | Not planned for first Android port | [Data and sync](data-sync.md) |
 | Listening history (personal, opt-in, local) | Planned | Reference | Planned | [Listening history](features/listening-history.md) |
 | Diagnostics | Privacy-preserving telemetry | Local opt-in diagnostics | Local opt-in diagnostics | [Preferences and diagnostics](features/preferences-diagnostics.md) |
+| Broken-station reports | Planned | Supported (sheet + receipts) | Planned | [Broken-station reports](contracts/broken-reports.md) |
 | Siri / Shortcuts / Spotlight | Planned | Supported | Planned | [Siri & Shortcuts](features/siri-shortcuts.md) |
 | First-run / offline launch | Runtime/cache dependent | Reference | Partial | [First run & offline](features/first-run-offline.md) |
 | Watch companion | Not applicable | Supported as iPhone remote | Not applicable | [Watch remote](features/watch-remote.md) |

--- a/docs/spec/contracts/broken-reports.md
+++ b/docs/spec/contracts/broken-reports.md
@@ -1,9 +1,9 @@
 # Broken-Station Reports Contract
 
 ```yaml
-status: draft
+status: review
 platforms: [web, ios, android]
-reconciled-against: —   # server-side first; no client ships this yet
+reconciled-against: d241aa9
 ```
 
 ## Purpose
@@ -19,7 +19,8 @@ Who must honor it: every platform that ships the report sheet or receipt
 polling, the `stats.rrradio.org` Worker (`worker/src/reports.ts`), and the
 triage automation (issue-close Action, P2 prober/upserter). Defined by
 [#507](https://github.com/MarkusSteinbrecher/rrradio/issues/507); the iOS
-report-sheet UX lives in the companion `rrradio-ios` issue.
+report-sheet UX is defined by the companion `rrradio-ios#77` and ships the
+sheet, receipt store, polling, and resolved toast.
 
 ## Definition
 
@@ -132,6 +133,51 @@ touches `received`). Response: `{ "ok": true, "confirmed": <n>, "linked": <n> }`
   merges; merging closes the issue → `resolve-reports.yml` resolves the linked
   reports. P3 needs no Worker secret — it acts off the GitHub issues, not D1.
 
+### Client report flow
+
+The user-facing half of the loop — report sheet, receipt, status line,
+resolution notice. Stated as product behavior; each platform renders it in its
+own chrome.
+
+- **Entry:** a "report broken station" control in the now-playing details opens
+  a report sheet for the current station.
+- **Category:** the sheet lists the six categories as a single-select list, none
+  preselected. The category is always an explicit user choice (never
+  auto-classified). Send stays disabled until one is picked.
+- **Comment:** an optional free-text field, plainly labeled as going to the
+  maintainer, hard-capped at 500 chars as the user types. The comment is
+  **required only for `other`** (it carries no signal otherwise); for that
+  category Send stays disabled until the comment is non-empty. Leading/trailing
+  whitespace is trimmed; an empty comment is omitted from the payload.
+- **Send:** posts the report, then dismisses the sheet. Success and failure each
+  surface once (success acknowledgement; failure offers the email fallback —
+  see Failure & fallback). The category is sent; the comment, when present, is
+  sent; neither the comment nor anything user-authored is written to the local
+  diagnostics breadcrumb (only station id/name + category).
+- **Receipt:** when the response carries a `reportId`, the device stores a local
+  receipt — `{ id, stationId, stationName, category, sentAt, status, resolution?,
+  resolvedAt?, seen }` — initial `status = received`. A response without
+  `reportId` is fire-and-forget: no receipt, no follow-up (degraded mode).
+- **Status line:** the now-playing details show the latest receipt for that
+  station and its current state — `received` ("we'll look into it"), `confirmed`
+  ("fix in progress"), or `resolved` with the outcome wording
+  (`fixed` / `removed` / `not-reproducible`).
+- **Polling:** receipts are refreshed opportunistically on app foreground (not on
+  a timer), batching all held ids into one `report-status` call. The merge
+  accepts `{ "reports": [...] }` or a bare array; unknown ids (omitted from a
+  well-formed response) are dropped as expired. Any non-2xx, offline, or
+  decode failure is a silent no-op — the UI never blocks on the poll.
+- **Resolution notice:** the first time polling finds a receipt newly
+  `resolved`, a root-level toast floats above the bottom chrome with the station
+  name and outcome. Tapping it — or letting it sit ~7s — marks the resolution
+  seen and dismisses it for good; the seen flag survives restarts so the toast
+  fires exactly once per resolution. A second resolution restarts its own
+  countdown. The toast yields its slot to a station-removal-undo toast when both
+  want it (an unseen resolution persists; undo does not).
+- **Receipt retention (client):** receipts age out 90 days after sending;
+  a resolved receipt that has been seen lingers 7 days past its resolution (so
+  the status line can still show the outcome), then self-prunes.
+
 ## Detail
 
 | Field | Type | Optional? | Meaning | Default |
@@ -144,8 +190,11 @@ touches `received`). Response: `{ "ok": true, "confirmed": <n>, "linked": <n> }`
 | `resolvedAt` | ISO 8601 UTC | only when resolved | resolution timestamp | — |
 | `github_issue` | int (server-side) | yes | linked triage issue | unset |
 | Report threshold | int (server-side env) | no | independent reports to confirm a non-probe-failed category | 3 (`REPORT_THRESHOLD`) |
-| Receipt store (client) | local list of `{ id, stationId, createdAt }` | yes | what the device polls with | empty |
+| Receipt store (client) | local list of `{ id, stationId, stationName, category, sentAt, status, resolution?, resolvedAt?, seen }` | yes | what the device polls with + renders the status line/toast from | empty |
+| Receipt age-out (client) | 90 days after `sentAt` | no | unconditional prune window | 90d |
+| Resolved-receipt linger (client) | 7 days past `resolvedAt`, once seen | no | keeps the outcome visible briefly, then prunes | 7d |
 | Ingest rate limit | 20 reports / IP / UTC day | no | enforced via daily-salted IP hash, purged next day | — |
+| Status ids per call | int (server-side) | no | receipt ids the status endpoint reads per request; excess ignored | 50 (`STATUS_IDS_MAX`) |
 
 ## Examples
 
@@ -199,7 +248,7 @@ Status poll `…/report-status?ids=7f0c2b9e-…,11111111-1111-4111-8111-11111111
 
 | Condition | Behavior |
 |---|---|
-| POST non-2xx / network failure | Same as today: client surfaces failure once; iOS offers the `mailto:feedback@rrradio.org` fallback. |
+| POST non-2xx / network failure | Client surfaces failure once; iOS offers a `mailto:support@rrradio.org` fallback prefilled with the station name, id, stream URL, and playback state. |
 | 429 (rate limited) | Client shows the generic failure path; no retry-storm. |
 | D1 down, analytics up | `202 { ok: true }` without `reportId` — report counted, no receipt. Client skips storing a receipt. |
 | D1 and analytics both down | `502`; client failure path. |
@@ -217,26 +266,47 @@ Status poll `…/report-status?ids=7f0c2b9e-…,11111111-1111-4111-8111-11111111
 - Store receipts locally only ([privacy contract](privacy-data-boundaries.md)
   rows 4 and 15); never attach them to any other request.
 - Poll opportunistically (app foreground / stats-sheet open), not on a timer;
-  batch all outstanding ids into one call.
-- On `resolved`, inform the user once (e.g. badge/toast "Your FM4 report:
-  fixed"), then drop the receipt.
+  batch all outstanding ids into one call (≤50 ids reach the server per call).
+- On `resolved`, inform the user once (a toast showing the station name and the
+  outcome — "fixed" / "removed" / "couldn't reproduce it"), mark it seen, then
+  let the receipt self-prune.
 
 **Web** — same endpoint; receipts in `localStorage`. Currently sends the
-pre-#507 payload (no category sheet yet); that remains valid.
+pre-#507 payload (no category sheet, no comment) and ignores `reportId`; that
+remains valid (degraded mode — report counted, no follow-up).
 
-**iOS** — report sheet + receipts + polling specced in the companion
-`rrradio-ios` issue; `Diagnostics.swift`'s `BrokenStationReporter` is the
-integration point.
+**iOS** — ships the full flow per the *Client report flow* section: the
+now-playing report sheet (six-category single-select + optional/`other`-required
+comment), the on-foreground receipt poll, the per-station status line, and the
+root resolved-toast. Receipts persist in `UserDefaults`. `BrokenStationReporter`
+is the POST integration point; the comment is hard-capped client-side and never
+enters the diagnostics breadcrumb.
 
 **Android** — same protocol when the port lands; nothing platform-specific.
+
+## Platform Matrix
+
+| Behavior | Web | iOS | Android |
+|---|---|---|---|
+| POST a broken-station report | Supported | Reference | Not planned (port pending) |
+| Category single-select in the report sheet | Not planned (no sheet) | Reference | Planned |
+| Optional comment (`other` requires it) | Not planned | Reference | Planned |
+| Store the `reportId` receipt locally | Not planned | Reference | Planned |
+| Poll `report-status` on foreground | Not planned | Reference | Planned |
+| Per-station status line (received/confirmed/resolved) | Not planned | Reference | Planned |
+| Resolved notification (toast) | Not planned | Reference | Planned |
+| Email fallback on POST failure | Not planned | Supported | Planned |
 
 ## Open questions
 
 1. Retention: when (if ever) are resolved/stale `broken_reports` rows purged?
    Receipts of deleted rows read as expired, so purging is client-safe — pick
    a window (e.g. 180d) in a follow-up.
-2. Should `confirmed` be user-visible ("we reproduced it") or collapsed into
-   "in review" until resolution? Spec currently allows either rendering.
+2. ~~Should `confirmed` be user-visible or collapsed into "in review"?~~
+   Resolved: iOS renders `confirmed` explicitly as "fix in progress" in the
+   per-station status line. The contract still permits other platforms to
+   collapse it into a neutral "in review" state; revisit only if that
+   divergence proves confusing.
 3. The prober stops at stream connect + content-type (the fast, decisive
    signal); it does not yet read several seconds of audio bytes. Intermittent
    `interruptions` therefore confirm mostly by threshold. Revisit if byte-level
@@ -246,6 +316,15 @@ integration point.
 
 - Worker: `worker/src/reports.ts`, schema `worker/migrations/0001_broken_reports.sql`,
   routes wired in `worker/src/index.ts`, tests `worker/src/reports.test.ts`.
+- iOS client: `rrradio/Diagnostics.swift` (`BrokenStationReporter` — POST +
+  payload + `reportId` parse), `rrradio/Models/BrokenStationReports.swift`
+  (`BrokenStationReportCategory`, `BrokenReportReceipt`,
+  `BrokenReportReceiptStore` — persistence, polling, prune), the
+  `BrokenStationReportSheet` + `reportBroken` in `rrradio/Views/NowPlayingView.swift`,
+  the status line in the same file's details block, the root toast
+  `rrradio/Views/BrokenReportResolvedToast.swift` (presented from
+  `rrradio/Views/ContentView.swift`), and the foreground poll in
+  `rrradio/App.swift`.
 - Triage cron (P2): `tools/triage-reports.mjs` (+ `tools/triage-reports.test.mjs`),
   `.github/workflows/triage-reports.yml`; reuses `tools/playable-check.mjs`'s
   `lenientProbe` for the stream probe.
@@ -260,9 +339,16 @@ integration point.
 
 ## Known deviations
 
-- No client implements categories/receipts/polling yet, so the user-facing half
-  of the loop (the report sheet, the "resolved" notification) is unverified
-  end-to-end. Server pipeline (ingest → confirm → issue → resolve) is live.
+- iOS now ships the full client loop (sheet → receipt → poll → resolved toast),
+  so the protocol is exercised end-to-end against the live server pipeline
+  (ingest → confirm → issue → resolve). Web still sends the pre-#507 payload and
+  has no category sheet or receipt UI; Android is unstarted.
+- **iOS does not chunk the status poll to the 50-id server cap:** it sends every
+  held receipt id in one `report-status` call. A device holding >50 live
+  receipts would have the overflow ignored by the server and then dropped
+  client-side as "expired" on that poll. In practice the 90-day age-out and the
+  20-reports/day ingest cap keep the held count far below 50, so this is latent,
+  not user-visible. No audit filed yet.
 - **P3 metadata fixes are narrow:** only a `country` disagreement with Radio
   Browser is auto-corrected. Name/tags corrections, and re-sourcing a *new*
   logo (vs. clearing a dead one), are left to a research comment + the

--- a/docs/spec/contracts/catalog-schema.md
+++ b/docs/spec/contracts/catalog-schema.md
@@ -1,9 +1,9 @@
 # Catalog & Station Schema Contract
 
 ```yaml
-status: draft
+status: review
 platforms: [web, ios, android]
-reconciled-against: 9336321
+reconciled-against: d241aa9
 ```
 
 ## Purpose
@@ -153,6 +153,19 @@ variants** in the catalog. A station has exactly one `streamUrl`. Quality is a
 presentation derivative, not a wire field; platforms SHOULD compute it with the
 same thresholds for parity.
 
+The 1–4 level also collapses to a coarse three-way **quality bucket** that
+drives the Browse quality filter (a multi-select of low / medium / high
+classes):
+
+| Meter level | Bucket |
+|---|---|
+| 1–2 | low |
+| 3 | medium |
+| 4 | high |
+
+The filter UI is iOS-only today; the bucket boundaries are part of the same
+derived model and SHOULD match wherever a platform exposes a quality filter.
+
 ## Examples
 
 ### Minimal valid station
@@ -230,7 +243,7 @@ else `name` is shown. A standalone station, or a family's bare prefix (plain
 ```json
 {
   "$schema": "https://rrradio.org/schemas/stations.json",
-  "stations": [ /* … 17,103 stations … */ ]
+  "stations": [ /* … tens of thousands of stations … */ ]
 }
 ```
 
@@ -355,15 +368,20 @@ iOS source read for this contract:
   load-order ladder (cache → bundled `stations.json.lzfse` → network),
   `decompressLZFSE`, `orderForBrowse` (featured-first), search-index
   validation scheduling, canonical/base/cache URLs.
-- `rrradio/Models/StreamQuality.swift` — `streamQualityLevel` /
-  `streamQualityMeter` (the derived 1–4 quality meter).
 - `rrradio/Search/SearchIndex.swift` — bundled `stations.fts5.db` schema
   (`stations_fts`, `stations_meta`), `SearchIndexCatalogValidation`
   (10% divergence threshold).
 - `rrradio/Views/StationKit.swift` — `stationHasProgramInfo` (the
   `hasScheduleData` gate + transitional fallback).
-- Resources: `rrradio/Resources/stations.json.lzfse` (bundled snapshot, 17,103
-  stations), `rrradio/Resources/stations.fts5.db` (bundled FTS index).
+- `rrradio/Models/StreamQuality.swift` — `streamQualityLevel` /
+  `streamQualityMeter` (the derived 1–4 quality meter) plus
+  `StreamQualityBucket` / `streamQualityBucket(forLevel:)` (the coarse
+  low/medium/high bucket that drives the Browse quality filter).
+- `rrradio/Views/FeedPages/BrowseFiltersSheet.swift` — the Browse quality
+  filter UI consuming `StreamQualityBucket`.
+- Resources: `rrradio/Resources/stations.json.lzfse` (bundled snapshot, ~24,300
+  stations at this commit), `rrradio/Resources/stations.fts5.db` (bundled FTS
+  index).
 
 ## Known deviations
 

--- a/docs/spec/contracts/localization.md
+++ b/docs/spec/contracts/localization.md
@@ -1,9 +1,9 @@
 # Localization Contract
 
 ```yaml
-status: draft
+status: review
 platforms: [web, ios, android]
-reconciled-against: 9336321
+reconciled-against: d241aa9
 ```
 
 ## Purpose
@@ -15,8 +15,8 @@ The invariant has three parts every platform must honor:
 
 1. **A shared key registry** — one canonical set of string-key names. A key
    names a slot in the UI, never an English literal.
-2. **A fixed supported-language set** — `en`, `de`, `fr`, `es`. `en` is the
-   source language and the universal fallback.
+2. **A fixed supported-language set** — `en`, `de`, `fr`, `es`, `it`, `ru`.
+   `en` is the source language and the universal fallback.
 3. **A deterministic lookup + fallback rule** — given a key and a resolved
    language, every platform resolves the same value, and falls back the same
    way when a translation is missing.
@@ -44,21 +44,27 @@ syncs (see [Data and sync](../data-sync.md)).
 ### Language resolution
 
 ```
-choice ∈ { system, en, de, fr, es }            (user preference)
-rawCode = choice == system ? OS-language : choice-code
+choice ∈ { system, english, german, french, spanish, italian, russian }   (user preference)
+rawCode = choice == system ? OS-language : choice-code   // english→"en", german→"de", … russian→"ru"
 resolvedLanguage =
     rawCode startsWith "de" → "de"
     rawCode startsWith "fr" → "fr"
     rawCode startsWith "es" → "es"
+    rawCode startsWith "it" → "it"
+    rawCode startsWith "ru" → "ru"
     otherwise               → "en"
 ```
 
 - The user picks a **choice**, not a raw locale. `system` follows the OS UI
-  language; the four explicit choices pin a language regardless of OS.
-- Resolution collapses any regional variant to one of the four base codes by
+  language; the six explicit choices pin a language regardless of OS.
+- The choice is a named token (`english`, `german`, …), not the ISO code. The
+  code is derived from the choice (`english → en`, `russian → ru`) and only the
+  code is collapsed below.
+- Resolution collapses any regional variant to one of the six base codes by
   prefix; anything unrecognized resolves to `en`.
 - The choice is persisted and re-applied on launch. The resolved language is
-  recomputed live when the OS language changes *and* the choice is `system`.
+  recomputed live when the OS language changes *and* the choice is `system`
+  (and a `locale` diagnostic note records the new code).
 
 ### Lookup algebra
 
@@ -85,18 +91,28 @@ then substitute {count} → formatted count
 
 ### Plural categories
 
-The contract uses a **two-category CLDR subset** sufficient for the four
-shipped languages:
+The category set is the CLDR cardinal subset `one`/`few`/`many`/`other`. Each
+language uses only the categories its rule can produce:
 
 ```
 pluralCategory(count, lang):
-    lang == "fr" → (count == 0 || count == 1) ? one : other   // FR: 0 and 1 are singular
-    otherwise    → (count == 1)               ? one : other   // EN/DE/ES: only 1 is singular
+    lang == "fr" →
+        (count == 0 || count == 1) ? one : other            // FR: 0 and 1 are singular
+    lang == "ru" →                                           // RU integer cardinals
+        (count%10 == 1 && count%100 != 11)               ? one
+        (count%10 ∈ 2..4 && count%100 ∉ 12..14)          ? few
+        otherwise                                          → many
+    otherwise →
+        (count == 1) ? one : other                          // EN/DE/ES/IT: only 1 is singular
 ```
 
-This is a deliberate subset of full CLDR (no `zero`/`two`/`few`/`many`). It is
-correct for `en`/`de`/`fr`/`es` only. See Open questions before adding a
-language with richer plural rules (Polish, Russian, Arabic, Czech, …).
+- `en`/`de`/`es`/`it` and `fr` only ever resolve to `one` or `other`; their
+  tables carry only those two categories.
+- `ru` resolves to `one`/`few`/`many`; its table carries those three (its
+  `other` slot is fraction-only and unreachable for integer counts, so it is
+  the table fallback, not a produced category).
+- The set omits `zero`/`two`. Adding a language whose CLDR rule needs `two`
+  (or that uses `other` for integers) requires extending `pluralCategory`.
 
 ## Detail
 
@@ -105,13 +121,16 @@ language with richer plural rules (Polish, Russian, Arabic, Czech, …).
 | State | Type | Optional? | Meaning | Default |
 |---|---|---|---|---|
 | `system` | choice | — | Follow the OS UI language; resolved code recomputed on OS-language change. | yes (default) |
-| `en` | choice | — | Force English. | — |
-| `de` | choice | — | Force German. | — |
-| `fr` | choice | — | Force French. | — |
-| `es` | choice | — | Force Spanish. | — |
+| `english` | choice | — | Force English (code `en`). | — |
+| `german` | choice | — | Force German (code `de`). | — |
+| `french` | choice | — | Force French (code `fr`). | — |
+| `spanish` | choice | — | Force Spanish (code `es`). | — |
+| `italian` | choice | — | Force Italian (code `it`). | — |
+| `russian` | choice | — | Force Russian (code `ru`). | — |
 
-- Persisted as the choice token (`system` / `en` / `de` / `fr` / `es`), not the
-  resolved code, so a `system` user keeps following the OS after a relaunch.
+- Persisted as the choice token (`system` / `english` / `german` / `french` /
+  `spanish` / `italian` / `russian`), not the resolved code, so a `system` user
+  keeps following the OS after a relaunch.
 - The choice is a syncable preference (see [Data and sync](../data-sync.md));
   the resolved code and any OS-language change are never synced.
 
@@ -121,7 +140,7 @@ language with richer plural rules (Polish, Russian, Arabic, Czech, …).
 |---|---|---|---|---|
 | key | identifier | no | Stable slot name; identical across platforms. | — |
 | `en` value | string | no | Source-language text; also the fallback value. | — |
-| `de`/`fr`/`es` value | string | no (full cardinality) | Translated text. | — |
+| `de`/`fr`/`es`/`it`/`ru` value | string | no (full cardinality) | Translated text. | — |
 | `{placeholder}` tokens | inline | yes | Named substitutions filled at render. Unfilled tokens are left literal. | left intact |
 
 ### Plural key entry
@@ -131,7 +150,8 @@ language with richer plural rules (Polish, Russian, Arabic, Czech, …).
 | key | identifier | no | Stable plural slot name. | — |
 | `one` value | string | no | Singular-category template; contains `{count}`. | — |
 | `other` value | string | no | Plural-category template; contains `{count}`. | — |
-| per language | one/other pair | no (full cardinality) | Each supported language carries both categories. | — |
+| `few`/`many` value | string | only where the rule produces it (currently `ru`) | CLDR `few`/`many` templates; contain `{count}`. | — |
+| per language | category templates | no (full cardinality) | Each supported language carries at minimum `one` + `other`; `ru` additionally carries `few` + `many`. | — |
 
 ### Plural keys (registry)
 
@@ -139,7 +159,8 @@ The plural namespace is small and fixed; every entry is a count-prefixed noun:
 
 `broadcastsCount` · `stationsCount` · `favoritesCount` · `listsCount` ·
 `customStationsCount` · `recentsCount` · `catalogStationsLoaded` ·
-`cloudSyncRestored` · `cloudSyncSynced` · `cloudSyncPushed`.
+`cloudSyncRestored` · `cloudSyncSynced` · `cloudSyncPushed` ·
+`stationsRemovedToast` · `deleteListStationsKept`.
 
 ## Examples
 
@@ -169,24 +190,31 @@ text(.listenOnService, { }, "en")                     = "Listen on {service}"   
 Plural entry and rendering (key `broadcastsCount`):
 
 ```
-broadcastsCount.one  → en:"{count} broadcast"   de:"{count} Sendung"   fr:"{count} émission"   es:"{count} programa"
-broadcastsCount.other→ en:"{count} broadcasts"  de:"{count} Sendungen" fr:"{count} émissions" es:"{count} programas"
+broadcastsCount.one  → en:"{count} broadcast"   de:"{count} Sendung"   fr:"{count} émission"   es:"{count} programa"   it:"{count} trasmissione"   ru:"{count} передача"
+broadcastsCount.other→ en:"{count} broadcasts"  de:"{count} Sendungen" fr:"{count} émissions" es:"{count} programas"  it:"{count} trasmissioni"  ru:"{count} передачи"
+broadcastsCount.few  → ru:"{count} передачи"     // RU only
+broadcastsCount.many → ru:"{count} передач"      // RU only
 
 text(.broadcastsCount, count:0, "en") = "0 broadcasts"   // EN: 0 → other
 text(.broadcastsCount, count:1, "en") = "1 broadcast"
 text(.broadcastsCount, count:0, "fr") = "0 émission"     // FR: 0 → one
 text(.broadcastsCount, count:2, "fr") = "2 émissions"
 text(.broadcastsCount, count:0, "de") = "0 Sendungen"
+text(.broadcastsCount, count:1, "ru") = "1 передача"     // RU: 1,21,31… → one (not 11)
+text(.broadcastsCount, count:2, "ru") = "2 передачи"     // RU: 2-4,22-24… → few (not 12-14)
+text(.broadcastsCount, count:5, "ru") = "5 передач"      // RU: 0,5-20,11-14… → many
+text(.broadcastsCount, count:11, "ru") = "11 передач"    // RU: 11 → many (not one)
 text(.broadcastsCount, count:3, "xx") = "3 broadcasts"   // unknown lang → en + other
 ```
 
 ## Versioning & evolution
 
-- **Adding a key**: add it to the registry with all four language values in the
-  same change. A key with fewer than four values violates full cardinality.
+- **Adding a key**: add it to the registry with all six language values in the
+  same change. A key with fewer than six values violates full cardinality.
 - **Adding a language**: extend the language set, supply every singular and
   plural value, and extend `pluralCategory` if the language needs categories
-  beyond `one`/`other`. Until then it falls back to `en` per the lookup rule.
+  beyond `one`/`other`/`few`/`many`. Until the choice and prefix-collapse rule
+  recognize its code it falls back to `en` per the lookup rule.
 - **Renaming a key**: a breaking change to the cross-platform registry; rename
   in lockstep on every platform. There is no alias layer.
 - **The registry has no version field today** (see Open questions). Platforms
@@ -220,7 +248,7 @@ key name) is a visible defect, not a crash.
 **All platforms**
 
 - Use the same key registry: identical key names, identical language set
-  (`en`/`de`/`fr`/`es`), identical lookup and plural algebra above.
+  (`en`/`de`/`fr`/`es`/`it`/`ru`), identical lookup and plural algebra above.
 - Enforce full cardinality: every supported language carries every singular and
   plural key. This MUST be a build-time or test-time gate, not a manual review.
 - Never ship a raw English literal to a non-English locale. Every user-visible
@@ -235,11 +263,18 @@ key name) is a visible defect, not a crash.
 
 **iOS** (reference)
 
-- Choice set: `system`, `en`, `de`, `fr`, `es`; persisted in UserDefaults.
-- Language choice participates in CloudKit preference sync; the resolved code
-  and OS-language changes do not sync.
+- Choice set: `system`, `english`, `german`, `french`, `spanish`, `italian`,
+  `russian`; persisted in UserDefaults as the choice token (not the code).
+- Language choice participates in CloudKit preference sync, carried as the same
+  choice token; the resolved code and OS-language changes do not sync. A
+  cloud-applied choice that equals the local one is a silent no-op.
 - Re-render is driven by the resolved language code being part of the view
   identity / snapshot token.
+- **Time formatting is independent of the language choice.** Time pickers and
+  time labels (e.g. the wake alarm) follow the device 24-Hour Time setting, not
+  the chosen app language: an English-language user on a 24-hour device sees
+  24-hour times, never AM/PM (issue #57). Only the hour cycle is grafted from
+  the device onto the app language; the rest of the locale stays language-only.
 
 **Web**
 
@@ -258,12 +293,13 @@ key name) is a visible defect, not a crash.
 | Behavior | Web | iOS | Android |
 |---|---|---|---|
 | Shared key registry | Supported | Reference | Planned |
-| Supported language set (en/de/fr/es) | Supported | Reference | Planned |
+| Supported language set (en/de/fr/es/it/ru) | Supported | Reference | Planned |
 | Full-cardinality enforcement | Supported | Supported (test-gated) | Planned |
 | `en` fallback on missing key | Supported | Supported | Planned |
-| Two-category plural (`one`/`other`) | Supported | Supported | Planned |
+| CLDR plural (`one`/`few`/`many`/`other`) | Supported | Supported | Planned |
 | `{placeholder}` substitution | Supported | Supported | Planned |
 | `system` follows OS language | Supported | Supported | Planned |
+| Time format follows device 24-Hour setting | Supported | Supported | Planned |
 | Language choice cloud sync | Not planned | Supported | Not planned |
 
 ## Open questions
@@ -272,11 +308,14 @@ key name) is a visible defect, not a crash.
   marker. A shared registry consumed by three platforms eventually needs a
   version (or content hash) so a platform can detect that it is reading a newer
   key set than it understands. Decide whether to add one and where it lives.
-- **Two-category plural ceiling.** The algebra hard-codes `one`/`other` and a
-  French-only `0→one` rule. Any future language with `zero`/`two`/`few`/`many`
-  (Polish, Russian, Arabic, …) needs the category set widened *and* every plural
-  key re-authored. Recommended: adopt full CLDR plural categories and a
-  per-language category function before the fifth language lands.
+- **Plural rules are per-language hard-codes, not a general CLDR engine.** The
+  category set is `one`/`few`/`many`/`other`, but `pluralCategory` switches on
+  the language string with bespoke arithmetic per case (a French `0→one` rule, a
+  Russian mod-10/mod-100 rule, an `else` of `1→one`). It still omits `zero` and
+  `two`, so a language needing those (Polish, Arabic, Welsh, …) requires both a
+  new category and a new hand-written branch, plus re-authoring every plural key
+  to carry the added categories. Recommended: replace the per-language switch
+  with a data-driven CLDR plural-rules table before the next language lands.
 - **Single source-of-truth registry across platforms.** Today each platform
   owns its own copy of the key/value tables. Recommended: a single
   platform-neutral registry (e.g. one canonical catalog file or a generated
@@ -294,17 +333,22 @@ key name) is a visible defect, not a crash.
 ## Reference
 
 - `rrradio-ios/rrradio/Views/LocaleController.swift` — `LocaleController`
-  (`Choice` enum, persistence, resolution, `text(_:)` / `text(_:_:)` /
-  `text(_:count:)` overloads), the `L10nKey` and `L10nPluralKey` registries,
-  the `L10nPluralCategory` set, and the `L10n` lookup/fallback engine.
+  (`Choice` enum incl. `italian`/`russian`, persistence, resolution, `text(_:)`
+  / `text(_:_:)` / `text(_:count:)` overloads, `timeLocale` 24-hour grafting),
+  the `L10nKey` and `L10nPluralKey` registries, the `L10nPluralCategory` set
+  (`one`/`few`/`many`/`other`), and the `L10n` lookup/fallback engine
+  (incl. `pluralCategory(forCount:language:)` per-language rules).
 - `rrradio-ios/rrradio/Resources/Localizable.xcstrings` — the iOS source of
-  truth for translated values (Xcode string catalog; plural keys stored as flat
-  `key.one` / `key.other` composites).
+  truth for translated values (Xcode string catalog; six localizations; plural
+  keys stored as flat `key.one` / `key.few` / `key.many` / `key.other`
+  composites and re-assembled at load).
 - `rrradio-ios/rrradioTests/LocaleControllerTests.swift` — the cardinality,
-  no-EN-copy-paste, plural-rule, and choice round-trip gates.
+  no-EN-copy-paste, plural-rule (incl. the Russian one/few/many cases), and
+  choice round-trip gates.
 - `rrradio-ios/rrradio/CloudSync/CloudSyncSnapshot.swift`,
-  `CloudSync/CloudSyncController.swift`, `CloudSync/CloudSyncStore.swift` — the
-  language choice as a synced preference (`locale` field).
+  `CloudSync/SettingsBackup.swift`, `CloudSync/CloudSyncController.swift`,
+  `CloudSync/CloudSyncStore.swift` — the language choice as a synced preference
+  (`locale` field, carrying the choice token).
 
 ## Known deviations
 
@@ -320,7 +364,8 @@ key name) is a visible defect, not a crash.
   LocaleController audit (`…-slice26.md`, findings LC1/LC2/LC11/LC12) recorded
   ~70 missing keys, two keys shipping raw English to DE/FR/ES, and nine
   diacritic typos. The localization sweep (Phase A) has since landed full
-  cardinality (every `L10nKey` and `L10nPluralKey` carries all four languages)
+  cardinality (every `L10nKey` carries all six languages, and every
+  `L10nPluralKey` carries `one`/`other` per language plus `few`/`many` for `ru`)
   and the LC13 lint gates; treat the audit findings as the historical record of
   intent, not current state.
 - **Cross-surface hardcoded English.** Multiple surfaces injected raw English

--- a/docs/spec/contracts/metadata-fetchers.md
+++ b/docs/spec/contracts/metadata-fetchers.md
@@ -1,9 +1,9 @@
 # Metadata Fetchers Contract
 
 ```yaml
-status: draft
+status: review
 platforms: [web, ios, android]
-reconciled-against: 9336321
+reconciled-against: d241aa9
 ```
 
 ## Purpose
@@ -55,7 +55,7 @@ that callers run layers two transport fallbacks and a cover-art enrichment step:
 
 1. Resolved fetcher = primary registry fetcher **unless** `status == "icy-only"`
    (in which case the registry is skipped here and ICY runs as the explicit
-   step 3). If the resolved fetcher returns non-nil → use it.
+   step 2). If the resolved fetcher returns non-nil → use it.
 2. Else if `status == "icy-only"` → run generic ICY scrape.
 3. Else if `streamUrl` path extension is `m3u8` → run HLS timed-metadata
    (ID3) scrape.
@@ -112,9 +112,9 @@ upper-cased (see *Known deviations* M6).
 | `swiss-radio` | Radio Swiss (Classic/Jazz/Pop) | `metadataUrl` direct | JSON | title=`channel.playingnow.current.metadata.title`, artist=`.artist` (**no** title-case) | empty title |
 | `srr` | SRR live (program) | `metadataUrl` = `"{url}#{stationKey}"` | JSON | program-only: `raw`/`programName`=station `title`, `programSubtitle`=`schedule` | bad split / empty title |
 | `mr` | MR (XML name) | `metadataUrl` direct | XML | `<Name>` → split on ` - ` into artist/title (title-cased); single-part → title only | empty `<Name>` |
-| `br-radioplayer` | BR Radioplayer | `metadataUrl` via Worker proxy | JSON (lenient) | current track (time-windowed; else first): title=`title`, artist=`interpret`; falls back to current broadcast `headline`/`broadcastSeriesName` as program | no track and no broadcast headline |
+| `br-radioplayer` | BR Radioplayer | `metadataUrl` via Worker proxy | JSON (lenient) | current track (time-windowed; else first): title=`title`, artist=`interpret`; when the track has no artist, also surfaces the current broadcast `headline` as `programName` and `broadcastSeriesName` (when ≠ headline) as `programSubtitle`; with no track, falls back to broadcast `headline`/`broadcastSeriesName` as program-only | no track and no broadcast headline |
 | `bbc` | BBC | `{worker}/api/public/bbc/play/{service}` (`service`=last path of `metadataUrl`) | JSON | program-only: module `id=="live_play_area"` first item → `programName`=`titles.primary`, `programSubtitle`=`titles.secondary` | empty primary title |
-| `hr` | HR (program + ICY) | `metadataUrl` via Worker proxy (program); ICY in parallel | JSON + ICY | **ICY wins if present**; else current broadcast (time-windowed): `programName`=`title`, `programSubtitle`=`mit {hosts.name}` | no ICY and no current title |
+| `hr` | HR (program + ICY) | `metadataUrl` via Worker proxy (program); ICY in parallel | JSON + ICY | **ICY wins if present**; else current broadcast (`currentBroadcast==true`, else time-windowed): `programName`=`title`, `programSubtitle`=`mit {hosts.name}` | no ICY and no current title |
 | `antenne` | ANTENNE | `metadataUrl` = `"{apiUrl}#{mountpoint}"`; apiUrl via Worker proxy | JSON | matched mount, `class=="Music"`: title=`title`, artist=`artist` (title-cased) | non-Music class, empty title |
 | `grrif` | GRRIF | fixed `https://www.grrif.ch/live/covers.json` + cache-bust `_` (no `metadataUrl`) | JSON (array) | **last** entry: title=`Title`, artist=`Artist` (title-cased), cover=`URLCover` (skips `…/default.jpg`) | empty title |
 | `rb-bremen` | Radio Bremen | `metadataUrl` via Worker proxy | JSON | program-only: `programName`=`currentBroadcast.title`, `programSubtitle`=`.titleAddon` | empty title |
@@ -153,7 +153,12 @@ Cover resolution is **ordered**; the first non-nil wins:
    `/50x50/`, or the SRG `cdne-satr-prd-rsp-covers` `50/` path).
 2. **Station favicon** — the catalog `favicon` is the station-art source
    (per [`../features/metadata-artwork.md`](../features/metadata-artwork.md)).
-3. **iTunes Search** — `https://itunes.apple.com/search?term={artist title}&entity=song&limit=5&media=music`;
+   *Platform note:* on iOS this favicon fallback feeds the **system media
+   surface** (lock screen / Control Center artwork = provider cover ?? favicon);
+   the in-app now-playing artwork instead falls back to the animated rrradio
+   dot-matrix logo when no provider/iTunes cover resolves.
+3. **iTunes Search** — `https://itunes.apple.com/search?term={artist title}&entity=song&limit=5&media=music`
+   (`term` = `artist` + space + `title`, truncated to 100 chars);
    best match's `artworkUrl100` upgraded to `600x600bb`. Requires title ≥ 3
    chars and not `-`/`—`. Result cached (64-entry LRU).
 4. **MusicBrainz / Cover Art Archive** — *not implemented on iOS* (web-only step
@@ -165,9 +170,14 @@ Cover resolution is **ordered**; the first non-nil wins:
 
 The same iTunes call returns `{hit, cover, appleMusicUrl}`:
 
-- `hit` (`resultCount > 0`) gates the **music-service buttons** — Apple Music /
+- `hit` is a **genuine artist/title match**, not raw `resultCount`: a hit
+  requires the best result's title (and, when metadata carries one, its artist)
+  to corroborate the query — with no artist, the iTunes track title must
+  *contain* the full query title. There is deliberately **no** "take the top
+  result" fallback. `hit` gates the **music-service buttons** — Apple Music /
   Spotify / YouTube Music links surface only when iTunes confirms the title is a
-  real searchable track (suppresses station IDs / news headlines).
+  real searchable track (suppresses station IDs / news headlines that iTunes
+  fuzzy-matches to unrelated songs).
 - `appleMusicUrl` (`trackViewUrl`) deep-links the Apple Music button to the
   exact song; Spotify/YouTube Music stay on search URLs.
 - Transport errors return `.miss` **without caching** (lets the next poll
@@ -285,12 +295,17 @@ iTunes high-res upgrade:
 | Program schedule (ORF/FM4) | MUST | MUST | Partial (ORF current-program; full grids planned) |
 | Lyrics: LRCLIB → Lyrics.ovh | MUST | MUST | Planned |
 | Coarse-only failure diagnostics (no title/artist/URL) | MUST | MUST | MUST |
-| Honor `metadataStrategy: none` / `backgroundPollPriority: never` (no stream open) | MUST | MUST | MUST |
+| Honor `metadataStrategy: none` / `backgroundPollPriority: never` (no stream open) | MUST | Planned (fields not yet in catalog/iOS) | MUST |
 
-All platforms additionally MUST honor the capability hint layer
-(`metadataStrategy`, `backgroundPollPriority`, `hasProgram`/`hasSchedule`/
-`hasProviderCover`) defined in
-[`../features/metadata-artwork.md`](../features/metadata-artwork.md).
+The capability hint layer (`metadataStrategy`, `backgroundPollPriority`,
+`hasProgram`/`hasSchedule`/`hasProviderCover`) defined in
+[`../features/metadata-artwork.md`](../features/metadata-artwork.md) is the
+**forward-looking shared design**: once the catalog publishes those fields, all
+platforms MUST honor them. As of the reconciled commit none of these fields
+exist on the iOS `Station` model — only `hasScheduleData` is present, and even
+it is not yet consulted (routing still hardcodes the ORF/FM4 host check; see
+*Open questions*). iOS therefore polls every published station on its standard
+cadence regardless of strategy/priority hints.
 
 ## Open questions
 
@@ -366,5 +381,10 @@ Resolved (recorded for traceability, not current deviations):
   `0x27`); **fixed** in PR3 (commit `0dcb233`) as a streaming state machine.
 - **M2** — MDR `startdate` used GMT instead of the broadcaster's Berlin day;
   **fixed** — the fetcher now injects `Europe/Berlin` `yyyyMMdd`.
+- **M3** — the lyrics cache was unbounded (grew for the app's lifetime);
+  **fixed** in PR5 — it is now a 256-entry FIFO cache (matches the lyrics-lookup
+  description above). *(The slice-6 audit table still lists M3 as Open; the fix
+  shipped under the execution-plan label "slice 6 M9", a numbering skew vs the
+  audit table where M9 is the Lyrics.ovh `+`-charset bug, which remains open.)*
 - **2026-05-18 #2.J** — `FavoriteNowPlayingStore.stop()` not cancelling in-flight
   fetches; **fixed**.

--- a/docs/spec/contracts/playback-state-machine.md
+++ b/docs/spec/contracts/playback-state-machine.md
@@ -1,9 +1,9 @@
 # Playback State Machine Contract
 
 ```yaml
-status: draft
+status: review
 platforms: [web, ios, android]
-reconciled-against: 9336321
+reconciled-against: d241aa9
 ```
 
 ## Purpose
@@ -158,8 +158,20 @@ Stepping to a different station calls `play` on it (rebuild, `loading`).
 ### Audio-session + media-control contract
 
 - **Session category:** playback (continues in background; mixes per platform
-  background-audio entitlement). Activated on configure; deactivated on `stop`,
-  on interruption-began, and on keep-alive stop when nothing follows.
+  background-audio entitlement). The category is set **dormant** at startup —
+  configured but not activated — so an idle app never registers as the system
+  Now Playing app or shows an empty lock-screen card.
+- **Lazy activation:** the session is activated only when audible work begins:
+  on `play`, on `resume`, and when the wake keep-alive starts.
+- **Deactivation:** the session is released (with notify-others-on-deactivation)
+  whenever nothing is playing — on `stop`, on interruption-began, when
+  now-playing is cleared (no `current` station) and no wake keep-alive is
+  running, and when the wake keep-alive stops with the player idle. A user
+  `pause` keeps the session active so resume from the lock screen is instant.
+- **Wake keep-alive (iOS-only):** a near-silent looped tone can hold the audio
+  session alive while the app waits to start playback at a scheduled wake time;
+  starting `play` tears it down and starts the real stream. It supports the
+  wake-to-radio alarm and is not part of the cross-platform state machine.
 - **Now-playing info published** (see Detail) so the lock screen / system surface
   shows station identity, current track, live-stream flag, playback rate, queue
   position, and artwork.
@@ -212,7 +224,7 @@ the `NowPlayingMetadata` struct produced in
 | Field | Type | Value | When |
 |---|---|---|---|
 | Title | string | Station name; `"<station> - <program>"` when a program name is known; sleep-timer suffix `" - Sleep in <n>m"` appended when armed. | always when station selected |
-| Artist (subtitle) | string | `"<artist> - <title>"` for music tracks; else state label (`Standby`/`Loading`/`Live`/`Paused`/`Error`) or country code. | always |
+| Artist (subtitle) | string | `"<artist> - <title>"` for music tracks (or bare `<title>` when no artist); else a per-state label — `Loading` / `Live` / `Paused` / `Error` (and, in the defensive `idle`-with-station branch, the station's uppercased country code or `Standby`). | when a station is selected |
 | Media type | enum | audio | always |
 | Is live stream | bool | true | always |
 | Playback rate | number | 1.0 when state == `playing`, else 0.0 | always |
@@ -387,7 +399,9 @@ reactivate session, resume; state → playing
   retry scheduler (`scheduleStreamRetry`, `rebuildCurrentStreamItem`,
   `scheduleHealthyPlaybackRetryResetIfNeeded`), backoff
   (`defaultStreamRetryDelayNanoseconds`), session handling
-  (`configureAudioSession`/`deactivateAudioSession`, interruption / route-change /
+  (`prepareAudioSessionCategory` dormant-at-init, `configureAudioSession`/
+  `deactivateAudioSession`, `clearNowPlaying`, `startWakeKeepAlive`/
+  `stopWakeKeepAlive`, interruption / route-change /
   media-services-reset handlers), remote commands (`wireRemoteCommands`,
   `updateRemoteStationCommandAvailability`), now-playing (`updateNowPlaying`,
   `nowPlayingPlaybackState`), auto-reconnect
@@ -401,11 +415,14 @@ reactivate session, resume; state → playing
 
 ## Known deviations
 
-- **Audio session not deactivated on stop/pause/teardown (slice 5 A2).** Shipped
-  iOS code historically left `AVAudioSession` active across `pause()`,
-  `stopWakeKeepAlive()`, and `teardownPlayer()`; only interruption-began and (now)
-  `stop()` deactivate. The contract intends the session to be released when nothing
-  is playing. See
-  `rrradio-ios/internal/audit/2026-05-25-ios-code-review-slice5.md` (A2) and the
-  remediation in `rrradio-ios/internal/audit/2026-05-25-fixes-prioritized.md`
-  (PR 3); the Now Playing close path is the slice 24 N6 surface of the same gap.
+- **Audio session deactivation (slice 5 A2 / slice 24 N6) — largely remediated.**
+  The audit flagged that shipped iOS code left `AVAudioSession` active across every
+  stop path; only interruption-began deactivated. At the reconciled commit this is
+  mostly fixed: `stop`, the now-playing-cleared path, and wake-keep-alive stop (when
+  idle) now deactivate, so the slice 24 N6 close-player surface releases the session.
+  `pause` still deliberately keeps the session active (fast lock-screen resume —
+  defensible per the audit), and `teardownPlayer` does not itself deactivate but is
+  only reached from callers that do. See
+  `rrradio-ios/internal/audit/2026-05-25-ios-code-review-slice5.md` (A2),
+  `…-slice24.md` (N6), and the remediation plan in
+  `rrradio-ios/internal/audit/2026-05-25-fixes-prioritized.md` (PR 3).

--- a/docs/spec/contracts/privacy-data-boundaries.md
+++ b/docs/spec/contracts/privacy-data-boundaries.md
@@ -1,9 +1,9 @@
 # Privacy & Data Boundaries Contract
 
 ```yaml
-status: draft
+status: review
 platforms: [web, ios, android]
-reconciled-against: 9336321
+reconciled-against: d241aa9
 ```
 
 ## Purpose
@@ -67,27 +67,37 @@ every rule.
 ### Diagnostics rule block
 
 - Default OFF; the user must explicitly enable "Collect Diagnostics".
-- Capped: 100 events / 14 days (iOS), then pruned oldest-first.
-- Disabling clears the local store immediately.
-- Allowed categories only: playback lifecycle, stream-retry category, network
-  availability, metadata-fetch category, cloud-sync availability (iOS), local
-  persistence. (Full list in
+- Two local stores, both gated by the single opt-in switch:
+  - **Breadcrumb events** — capped 100 events / 14 days (iOS), pruned
+    oldest-first.
+  - **MetricKit reports** — crash/hang reports the OS hands the app; capped 6
+    reports / 14 days, each call stack truncated to 6000 chars.
+- Disabling clears both local stores immediately.
+- Allowed breadcrumb categories only: playback lifecycle, stream-retry category,
+  network availability, metadata-fetch category, cloud-sync availability (iOS),
+  local persistence, MetricKit-report breadcrumb. (Full list in
   [`../features/preferences-diagnostics.md`](../features/preferences-diagnostics.md).)
-- MUST NOT contain: stack traces, search queries, full stream/homepage URLs,
-  custom-station URLs, track titles, artist names, long-lived user IDs.
-- Write-time: detail values are host-reduced (`URL → host`) and length-capped.
-- Export-time: a sensitive-key allow-list is dropped and any residual URL/host
-  is regex-redacted to `[url]` / `[host]`.
+- Breadcrumb events MUST NOT contain: stack traces, search queries, full
+  stream/homepage URLs, custom-station URLs, track titles, artist names,
+  long-lived user IDs.
+- Write-time: breadcrumb detail values are host-reduced (`URL → host`) and
+  length-capped (120 chars).
+- Export-time: breadcrumbs have a sensitive-key allow-list dropped and any
+  residual URL/host regex-redacted to `[url]` / `[host]`.
+- MetricKit report bodies are exported verbatim (own-app binary frames + offsets
+  only — no URLs/PII), bypassing the host/URL regex that would mangle them; they
+  are still opt-in-gated, capped, and cleared on disable like everything else.
 - Diagnostics never auto-upload. They leave the device only when the user
-  invokes the Share/Copy action, and only the redacted form.
+  invokes the Share/Copy action, and only the redacted (breadcrumb) / verbatim
+  (MetricKit) form described above.
 
-### Outbound data matrix (reconciled-against `9336321`)
+### Outbound data matrix (reconciled-against `d241aa9`)
 
 | # | Endpoint | What is sent | When | Opt-in? | rrradio-operated? | Retention intent |
 |---|---|---|---|---|---|---|
 | 1 | `https://rrradio.org/stations.json` | nothing but the GET (+ IP via TCP) | on launch / catalog refresh | No (core function) | Yes | none app-side; OS cache |
 | 2 | `https://stats.rrradio.org/api/public/region` | nothing in body; IP read at the edge for `CF-IPCountry` | first launch + every cold launch past the 24h region cache | No (silent) | Yes (subdomain — see Open Qs) | aggregate/none intended; edge logs at CF |
-| 3 | `https://stats.rrradio.org/api/public/top-stations`, `/totals`, `/locations` | nothing in body (+ IP via TCP); `?days=7`, `?limit=…` | every time the Stats sheet opens | No (silent on open) | Yes (subdomain) | public aggregate; edge logs |
+| 3 | `https://stats.rrradio.org/api/public/top-stations`, `/totals`, `/locations` | nothing in body (+ IP via TCP); `?days=7`, plus `?limit=25` (top-stations) / `?limit=50` (locations) | every time the Stats sheet opens (three GETs in parallel) | No (silent on open) | Yes (subdomain) | public aggregate; edge logs |
 | 4 | `https://stats.rrradio.org/api/public/report-broken` | `stationId`, `stationName`, `streamHost`, `platform=ios`, `appVersion`, `reason` (≤160 chars of player state), `source=manual`, `category` (user-chosen breakage class), `comment` (**user-authored text**, ≤500 chars, optional) (+ IP) | user taps "Report broken station" | **Yes** (explicit tap; comment is explicit typed input) | Yes (subdomain) | broken-station triage store (D1, no reporter identity; comments verbatim — see [broken-reports](broken-reports.md)). IP used only for a daily-salted rate-limit hash, purged next day |
 | 5 | `https://stats.rrradio.org/api/public/proxy?url=<stream/metadata URL>` | the station's stream/metadata URL as a query param (+ IP) | metadata poll for stations routed through the CORS/ICY proxy | No (core function) | Yes (subdomain) | none intended; edge logs |
 | 6 | `https://stats.rrradio.org/api/public/bbc/play/<service>` | BBC service id (+ IP) | metadata poll for BBC stations | No (core function) | Yes (subdomain) | none intended |
@@ -97,9 +107,9 @@ every rule.
 | 10 | `https://{de1,at1,nl1}.api.radio-browser.info/json/stations/search` | **the user's typed search query**, plus tag/country filters; `User-Agent` carries app name+version (request shape owned by [`search.md`](search.md) §Radio Browser API) | live station search beyond the bundled catalog | No (core function) | No (Radio Browser) | none app-side |
 | 11 | Station favicon / cover-art image hosts (broadcaster + RB-hosted URLs) | nothing identifying; the image URL (+ IP) | rendering station/track art | No (core function) | No (third party) | byte-budgeted `URLCache` |
 | 12 | Music-service deep links: `music.apple.com/search`, `open.spotify.com/search`, `music.youtube.com/search`, `music.apple.com/.../album/...` | search term or Apple-track URL **opened in the external app/browser** — not a background request | user taps a music-service button on Now Playing | **Yes** (explicit tap) | No (third party) | n/a (handoff) |
-| 13 | `mailto:feedback@rrradio.org` (Add Station catalog submission; broken-station email fallback) | station name + stream URL + the user's own email return address — composed in the OS Mail app, **sent only if the user taps Send** | user submits a catalog request, or emails a broken-station report after the HTTP path fails | **Yes** (explicit send) | Yes (first-party inbox) | maintainer inbox |
+| 13 | `mailto:support@rrradio.org` (Add Station catalog submission; broken-station email fallback) | station name + stream URL + the user's own email return address — composed in the OS Mail app, **sent only if the user taps Send** | user submits a catalog request, or emails a broken-station report after the HTTP path fails | **Yes** (explicit send) | Yes (first-party inbox) | maintainer inbox |
 | 14 | iCloud / CloudKit (iOS only) | favorites, station lists, custom stations, preferences — in the **user's own** private database | when iCloud sync is enabled | per-user iCloud (system) | n/a (Apple, user-owned) | until user disables/removes; recents, history, diagnostics, one-shot intents NOT synced |
-| 15 | `https://stats.rrradio.org/api/public/report-status?ids=…` | the device's locally-stored report receipt tokens (random, Worker-minted — see [broken-reports](broken-reports.md)) (+ IP) | app polls while unresolved receipts exist (foreground / stats-sheet open, batched) | follows from row 4's explicit report | Yes (subdomain) | none intended; receipts dropped client-side once resolved/expired |
+| 15 | `https://stats.rrradio.org/api/public/report-status?ids=…` | the device's locally-stored report receipt tokens (random, Worker-minted — see [broken-reports](broken-reports.md)), comma-joined in one batched GET (+ IP) | app polls while unresolved receipts are held — on foreground (scene-active, debounced) | follows from row 4's explicit report | Yes (subdomain) | none intended; receipts dropped client-side once resolved/expired or aged out |
 
 Rows 2–6 and 15 are the **IP-bearing, rrradio-operated** flows that drive the
 App Store privacy-label question (see Open questions).
@@ -113,11 +123,17 @@ App Store privacy-label question (see Open questions).
 | Region resolution outcome | `unfetched` / `unknown` / `known(CC)` | no | Drives geo-badge UX | `unfetched` |
 | `isAvailable` semantics | fail-open | no | Unknown region ⇒ treat station as available | fail-open |
 | Diagnostics enabled (`rrradio.diagnostics.enabled.v1`) | bool | no | Master opt-in switch | `false` |
+| Diagnostics events store (`rrradio.diagnostics.events.v1`) | UserDefaults JSON | yes | Breadcrumb ring buffer | empty / removed when OFF |
 | Diagnostics event cap | int | no | Ring-buffer size | 100 |
-| Diagnostics max age | duration | no | Time-based prune | 14 days |
+| Diagnostics max age | duration | no | Time-based prune (events + reports) | 14 days |
 | Diagnostics detail value cap | int | no | Per-value truncation | 120 chars |
-| Diagnostics export redaction | sensitive-key drop + URL/host regex | no | Strips host/url/station keys + inline URLs on export | always-on at export |
+| MetricKit reports store (`rrradio.diagnostics.reports.v1`) | UserDefaults JSON | yes | Crash/hang call stacks | empty / removed when OFF |
+| MetricKit report cap | int | no | Reports ring-buffer size | 6 |
+| MetricKit report detail cap | int | no | Per-report call-stack truncation | 6000 chars |
+| Diagnostics export redaction | sensitive-key drop + URL/host regex | no | Strips host/url/station keys + inline URLs on breadcrumb export (MetricKit bodies verbatim) | always-on at export |
 | Broken-report `reason` cap | int | no | Player-state error prefix length | 160 chars |
+| Broken-report `comment` cap | int | no | User-authored comment length (optional) | 500 chars |
+| Report receipts store (`BrokenStationReports`) | UserDefaults JSON | yes | Worker-minted tokens polled via row 15 | empty; dropped when resolved/expired |
 | Catalog cache | Caches file | yes | Last `stations.json` payload | OS-managed lifetime |
 | Listening history | local file, opt-in | yes | Station (and optional track) sessions | OFF; 90d when on; never synced |
 | Analytics SDK (iOS/Android) | none | n/a | No telemetry library is linked | absent |
@@ -136,8 +152,9 @@ Region resolution response body (row 2):
 
 `null` country ⇒ state becomes `unknown`, user treated as fail-open available.
 
-Broken-station report body (row 4), exactly as built — `category` and
-`comment` only when the report sheet (post-#507 clients) supplies them:
+Broken-station report body (row 4), exactly as built — `category` is always
+present (the user picks one in the report sheet); `comment` only when the user
+typed non-empty text (trimmed, ≤500 chars):
 
 ```json
 {
@@ -166,7 +183,7 @@ https://itunes.apple.com/search?term=Radiohead%20Reckoner&entity=song&limit=5&me
 Catalog-submission mailto (row 13), reconciled destination:
 
 ```
-mailto:feedback@rrradio.org?subject=rrradio%20catalog%20station%20request
+mailto:support@rrradio.org?subject=rrradio%20catalog%20station%20request
 &body=Please%20consider%20adding%20this%20station...%0AName:%20...%0AStream%20URL:%20https://...
 ```
 
@@ -199,10 +216,11 @@ Diagnostics export line (always redacted form):
 
 | Input / condition | Behavior |
 |---|---|
-| Region endpoint unreachable / non-200 / `null` | Region stays previous value; cache NOT updated; next launch retries; user treated as available (fail-open). |
+| Region endpoint unreachable / non-200 / decode error | Region stays previous value; cache NOT updated; next launch retries; user treated as available (fail-open). |
+| Region 200 with `null` country (Tor / anycast / unknown IP) | State becomes `unknown`; cache IS written (empty value + fresh timestamp), so no retry for 24h; user treated as available (fail-open). |
 | Region payload malformed (bad CC) | Normalizes to `unknown`; fail-open. |
 | Stats endpoints unreachable | Each fetch returns empty; Stats sheet renders "no data" (indistinguishable from a genuinely empty week — see Known deviations DH4). |
-| Broken-report non-2xx | Surfaces as a single failure; iOS offers the `mailto:feedback@rrradio.org` fallback (row 13). No idempotency key sent (see deviation D2). |
+| Broken-report non-2xx | Surfaces as a single failure; iOS offers the `mailto:support@rrradio.org` fallback (row 13). No idempotency key sent (see deviation D2). |
 | Metadata/proxy/broadcaster API fails | Track metadata silently absent; playback continues; only a coarse diagnostic category is recorded. |
 | iTunes/lyrics fails | Cover-art falls back to station favicon; lyrics pane stays hidden; transient errors are not cached. |
 | Search endpoint fails | Falls back across RB mirrors; on total failure, search shows bundled-catalog results only. |
@@ -224,9 +242,10 @@ Diagnostics export line (always redacted form):
 
 - Ships **no** analytics SDK; rows 2–6 and 15 are the only rrradio-operated
   calls and MUST point at the first-party domain (no `*.workers.dev`).
-- Diagnostics off by default, capped (100/14d), redacted on export, cleared on
-  disable; never auto-uploaded.
-- mailto destinations MUST be a first-party inbox (`feedback@rrradio.org`),
+- Diagnostics off by default, capped (100 breadcrumbs + 6 MetricKit reports /
+  14d), redacted on breadcrumb export, cleared on disable; never auto-uploaded.
+  MetricKit reports carry only own-app stack frames (no URLs/PII).
+- mailto destinations MUST be a first-party inbox (`support@rrradio.org`),
   never a developer-personal address.
 - Region resolution fails open; never blocks playback on an unknown IP.
 - CloudKit uses the user's private database only; recents, listening history,
@@ -243,6 +262,22 @@ Diagnostics export line (always redacted form):
 - Region/stats flows, if implemented, use the first-party boundary and fail
   open.
 - Library data stays local; no track/query content to analytics.
+
+## Platform Matrix
+
+| Behavior | Web | iOS | Android |
+|---|---|---|---|
+| No account / no app-minted user ID | Supported | Reference | Planned |
+| No analytics SDK linked | Not planned (GoatCounter only) | Reference | Planned |
+| First-party telemetry anonymous + aggregate (GoatCounter) | Reference | Not planned (no SDK) | Planned |
+| All rrradio-operated calls under `rrradio.org` | Supported | Reference | Planned |
+| Region/GeoIP resolution, fail-open, 24h cache | Supported | Reference | Planned |
+| Diagnostics opt-in, capped, redacted on export, cleared on disable | Planned | Reference | Planned |
+| MetricKit crash/hang reports (own-app frames, opt-in) | Not planned | Reference | Not planned |
+| Broken-station report (anonymous POST + receipt polling) | Supported | Reference | Planned |
+| Library data local-first; never sent to analytics | Supported | Reference | Planned |
+| CloudKit sync to user's own private DB | Not planned | Reference | Not planned (Apple-only) |
+| mailto destinations → first-party inbox only | Supported | Reference | Planned |
 
 ## Open questions
 
@@ -261,9 +296,10 @@ Diagnostics export line (always redacted form):
    cache. Confirm this cadence is acceptable for the privacy label and consider
    widening the TTL or removing the auto-refresh on launch.
 3. **Stats-sheet consent.** Row 3 sends three GETs on every Stats-sheet open
-   with no consent; the parallel Listening-History screen claims "nothing is
-   sent." Reconcile the two privacy claims (deviation DH5) — either disclose the
-   Stats fetch in-screen or make it explicit.
+   with no consent; sibling Settings copy frames the app as on-device ("History
+   stays on this device", "Nothing is sent automatically"). Reconcile the two
+   privacy claims (deviation DH5) — either disclose the Stats fetch in-screen or
+   make it explicit.
 4. **Proxy URL exposure (row 5).** The metadata proxy forwards the station's
    stream/metadata URL as a query param to the first-party Worker. Confirm the
    Worker does not log these URLs against the requesting IP, or document the
@@ -282,9 +318,10 @@ iOS source the contract was reconciled against:
 
 - `rrradio/Models/RegionResolver.swift` — region/GeoIP resolution, `WorkerAPI.base = "https://stats.rrradio.org"`, 24h cache, fail-open.
 - `rrradio/Views/DashboardView.swift` — Stats sheet GETs to `/api/public/{top-stations,totals,locations}`.
-- `rrradio/Diagnostics.swift` — local opt-in ring buffer, redacted export, sensitive-key allow-list, and `BrokenStationReporter` POST to `/api/public/report-broken`.
-- `rrradio/Views/AddStationView.swift` — `catalogSubmissionMailURL` → `mailto:feedback@rrradio.org`.
-- `rrradio/Views/NowPlayingView.swift` — broken-station `mailto:feedback@rrradio.org` fallback; music-service deep links.
+- `rrradio/Diagnostics.swift` — local opt-in ring buffer (100 events / 14d, 120-char detail cap), write-time host-reduction, redacted export (sensitive-key allow-list + URL/host regex), and `BrokenStationReporter` POST to `/api/public/report-broken` (with `category` + optional `comment` ≤500 chars; returns `reportId`).
+- `rrradio/Models/BrokenStationReports.swift` — receipt store; `/api/public/report-status?ids=…` polling (row 15), driven by the foreground refresh in `rrradio/App.swift`.
+- `rrradio/Views/AddStationView.swift` — `catalogSubmissionMailURL` → `mailto:support@rrradio.org`.
+- `rrradio/Views/NowPlayingView.swift` — broken-station `mailto:support@rrradio.org` fallback; music-service deep links.
 - `rrradio/Player/Metadata/DirectMetadataFetchers.swift` — `/api/public/proxy`, `/api/public/bbc`, broadcaster APIs (laut.fm, ffh, radioeins, grrif).
 - `rrradio/Player/Metadata/CoverArtFetcher.swift` — `itunes.apple.com/search` (artist+title).
 - `rrradio/Player/Metadata/LyricsFetcher.swift` — LRCLIB + Lyrics.ovh (artist+title).
@@ -297,13 +334,15 @@ iOS source the contract was reconciled against:
 
 ## Known deviations
 
-- **Developer-personal infrastructure exposure — RESOLVED at `9336321`.** Five
-  production paths previously routed user data (IP, station IDs, stream hosts,
-  user email return address) to a developer-personal Cloudflare Workers
-  subdomain (`stats.rrradio.org`) and personal Gmail
+- **Developer-personal infrastructure exposure — RESOLVED (verified at `d241aa9`).**
+  Five production paths previously routed user data (IP, station IDs, stream
+  hosts, user email return address) to a developer-personal Cloudflare Workers
+  subdomain (`rrradio-stats.markussteinbrecher.workers.dev`) and personal Gmail
   (`redsukramst@gmail.com`). Migrated to `stats.rrradio.org` and
-  `feedback@rrradio.org` by commit `2cd5cff` ("PR2: privacy boundary"). The
-  contract above states the corrected intent; the original findings:
+  `support@rrradio.org` by commit `2cd5cff` ("PR2: privacy boundary"); all
+  iOS endpoints at `d241aa9` route through `WorkerAPI.base =
+  https://stats.rrradio.org` and every mailto targets `support@rrradio.org`.
+  The contract above states the corrected intent; the original findings:
   - `rrradio-ios/internal/audit/2026-05-25-ios-code-review-slice11.md` (M3/M4 — RegionResolver region endpoint, IP exposure).
   - `rrradio-ios/internal/audit/2026-05-25-ios-code-review-slice20.md` (D1 — BrokenStationReporter endpoint; D3 — `recentSummary` text-selection bypassing redaction; D2 — no idempotency on report).
   - `rrradio-ios/internal/audit/2026-05-25-ios-code-review-slice22.md` (AS2 — AddStation mailto → personal Gmail).
@@ -313,6 +352,8 @@ iOS source the contract was reconciled against:
 - **Stats-sheet silent fetch with no failure distinction (DH4)** —
   `rrradio-ios/internal/audit/2026-05-25-ios-code-review-slice23.md`. A failed
   stats fetch is rendered identically to a genuinely empty week.
-- **Diagnostics on-screen text-selection bypasses export redaction (D3)** —
-  `rrradio-ios/internal/audit/2026-05-25-ios-code-review-slice20.md`. The
-  contract intent is that anything copyable matches the redacted export.
+- **Diagnostics on-screen text-selection vs. export redaction (D3) — RESOLVED at
+  `d241aa9`** — `rrradio-ios/internal/audit/2026-05-25-ios-code-review-slice20.md`.
+  The contract intent is that anything copyable matches the redacted export; the
+  on-screen inline summary now renders the same redacted variant the Copy/Share
+  action exports, so a Copy of selected text no longer leaks unredacted detail.

--- a/docs/spec/contracts/search.md
+++ b/docs/spec/contracts/search.md
@@ -1,9 +1,9 @@
 # Search Contract
 
 ```yaml
-status: draft
+status: review
 platforms: [web, ios, android]
-reconciled-against: 9336321
+reconciled-against: d241aa9
 ```
 
 ## Purpose
@@ -86,7 +86,10 @@ produce the result list; the community tier is appended.
 - **Tier 1′ (substring fallback):** when the index failed to open or query
   threw, OR divergence > 10%, the entire local match is a substring scan over
   `unique(catalog + custom + RadioBrowser)` using `stationMatches`. No FTS
-  ranking; preserves input order.
+  ranking; preserves input order. The divergence decision is **re-evaluated
+  whenever the catalog's station-ID set changes** (async, off-main): if a later
+  catalog state converges back under 10%, FTS is re-enabled and an active search
+  re-runs through Tier 1.
 - **Tier 2 (FTS-miss safety net):** with FTS active, a substring scan runs ONLY
   over catalog stations the FTS index did NOT return (`!ftsHitIDs.contains(id)`)
   — i.e. stations added to the live catalog since the bundled DB was built.
@@ -136,7 +139,7 @@ This is the network analogue of normalizer (B): it gives Radio Browser's
 | Mirror order | last-successful host first, else seed order; failover advances on bad status or error |
 | Search path | `/json/stations/search` |
 | Stats path | `/json/stats` (→ `{ "stations": Int }`) |
-| Region path | `/api/public/region` on the rrradio-stats Worker (NOT Radio Browser) — see operations.md |
+| Region path | `/api/public/region` on the rrradio-stats Worker (`https://stats.rrradio.org`, NOT Radio Browser) — see operations.md |
 | `User-Agent` | `rrradio-ios/<CFBundleShortVersionString>` (platform-specific UA string) |
 | Page size | 60 (client default); the Browse paginator requests 50 |
 
@@ -309,9 +312,11 @@ prefix, country/codec uppercasing, `schemaVersion` ride-along — owned by
   bm25 weights are the schema contract; a client reading a DB with a different
   column set must fall back to substring search.
 - **Divergence guard:** when the bundled index drifts > 10% from the live
-  catalog (`maximumDivergenceRatio`), the client abandons FTS for the session
-  and uses substring search — so a stale bundle degrades gracefully instead of
-  hiding new stations.
+  catalog (`maximumDivergenceRatio`), the client abandons FTS and uses substring
+  search — so a stale bundle degrades gracefully instead of hiding new stations.
+  The guard re-evaluates on every catalog station-ID change and can re-enable
+  FTS if the catalog later converges back under the threshold; it is not a
+  one-way latch for the session.
 - **Radio Browser API is external and unversioned.** Treat unknown JSON fields
   as ignorable; only the fields in the mapping table are consumed. New mirrors
   or a different host list is a client-config change, not a contract break.
@@ -325,7 +330,7 @@ prefix, country/codec uppercasing, `schemaVersion` ride-along — owned by
 | Empty / whitespace query | Search is a no-op; Browse shows the filtered catalog, RB paginator reset, no network call. |
 | FTS DB missing at launch | `bundled()` returns nil; all queries use substring fallback (Tier 1′). Diagnostic `search/fts unavailable` recorded. |
 | FTS query throws mid-session | Caught; that query falls back to substring over `unique(catalog+custom+RB)`. Diagnostic `search/fts failed`. |
-| FTS index diverged > 10% | Client uses substring fallback for the session. |
+| FTS index diverged > 10% | Client uses substring fallback; diagnostic `search/fts stale disabled` recorded. The guard re-evaluates on each catalog-ID change and re-enables FTS if drift falls back under 10%. A non-zero divergence still under the threshold keeps the index and logs `search/fts stale but usable`. |
 | Empty FTS MATCH (no alnum tokens) | Zero FTS hits, no error; substring tiers still run. |
 | Radio Browser mirror returns non-2xx or errors | Failover to next mirror after a jittered backoff (`75ms · 2^attempt + 0..75ms`, attempt clamped 0–4). |
 | All Radio Browser mirrors fail | Search throws upstream; the paginator catches it and sets `hasMore = false`. **No error UI or retry surfaces** — see Known deviations. |
@@ -415,11 +420,16 @@ iOS source (the only place iOS mechanics are named):
   a geo-gated station universally available. Adjacent to search via the
   result-visibility path. See
   `internal/audit/2026-05-25-ios-code-review-slice11.md` (M2).
-- **Region endpoint on a developer-personal Worker subdomain** — the visitor-
-  country resolver (and other telemetry) routes user IPs to
-  `*.markussteinbrecher.workers.dev`. See
-  `internal/audit/2026-05-25-ios-code-review-slice11.md` (M3/M4) and the
-  privacy-boundary summary in `internal/audit/2026-05-25-audit-handover.md`.
+- **Region endpoint sends the visitor IP to the rrradio-stats Worker** — the
+  visitor-country resolver (and other telemetry) routes user IPs through the
+  rrradio-stats Worker so Cloudflare's edge can echo `CF-IPCountry`; the IP-
+  disclosure surface remains. At d241aa9 the Worker base is the production
+  `https://stats.rrradio.org`, NOT the developer-personal
+  `*.markussteinbrecher.workers.dev` subdomain the audit still describes — the
+  host moved since the audit was filed. See
+  `internal/audit/2026-05-25-ios-code-review-slice11.md` (M3/M4, now partly
+  stale on the host) and the privacy-boundary summary in
+  `internal/audit/2026-05-25-audit-handover.md`.
 - No malformed-JSON *silent-fail* exists in the search path: `JSONDecoder`
   failures in `RadioBrowserClient.search` throw and propagate to the
   failover/paginator (which then hits the silent B6 gap above), rather than

--- a/docs/spec/contracts/sync-merge.md
+++ b/docs/spec/contracts/sync-merge.md
@@ -1,8 +1,8 @@
 # Library Sync & Merge Contract
 ```yaml
-status: draft
+status: review
 platforms: [ios]
-reconciled-against: 9336321
+reconciled-against: d241aa9
 ```
 
 ## Purpose
@@ -19,6 +19,13 @@ the same state without losing user data. This is an **iOS-only** sync path.
   semantics when they merge a user-initiated **backup file** into the live
   library. See [data-sync.md](../data-sync.md) for the data-class privacy
   boundaries (what may and must not sync) — this contract does not restate them.
+- iOS also ships a **settings backup file** (a versioned JSON document holding
+  the same favorites / custom stations / station lists / preferences the cloud
+  snapshot carries, **but never listening history** — backups are made to be
+  shared outside the sandbox). It works with iCloud sync off. **Restore replaces**
+  the live library wholesale (the backup's index flags are authoritative — it is
+  a replace, not the union merge), then pushes the restored state to iCloud like
+  any local edit. See Backup file below.
 - Cross-platform account sync is **not planned**. A future shared backend
   requires its own ADR (tracked in [data-sync.md](../data-sync.md) §Future
   Cross-Platform Sync). This contract is the iOS reference and the local-merge
@@ -41,6 +48,7 @@ authoritative id ordering.
 | `StationList` | `station-list-<sha256(listId)>` | one station-list blob |
 | `StationListsIndex` | `station-lists-index` (singleton) | authoritative station-list ids |
 | `Preferences` | `preferences` (singleton) | all synced preference fields |
+| `ListeningHistory` | `listening-history` (singleton) | one blob of all shared closed listening-history sessions |
 | `SyncState` | `sync-state` (singleton) | `resetAt` deletion tombstone |
 
 - Per-entry record id = `"<prefix>-" + hex(SHA256(utf8(id)))`. Hashing keeps long
@@ -68,10 +76,16 @@ requests that arrive mid-cycle are coalesced and re-fired in `finishSync`.
    - If remote is empty AND local has no user payload AND no pending preferences
      push, end `emptyRemote` (nothing written).
    - Else `merged = CloudSyncMerge.merged(local, remote, preferLocalPreferences)`,
-     apply merged to live state, then `save(localSnapshot())` (ratify the merge
-     back to cloud). End `synced` (local had payload) or `restored` (it did not).
-2. **Push** (`pushLocalSnapshot`) — a debounced write of the local snapshot only.
-   Triggered by a local library/preferences change. End `pushed`.
+     apply merged to live state, then save the (bounded — see Listening-history
+     bounds) local snapshot back to cloud to ratify the merge. End `synced`
+     (local had payload) or `restored` (it did not).
+   - Applying merged state to live also reconciles the player: a station blob
+     changed on another device replaces that station everywhere it appears in
+     the active playback queue, and a station removed on another device is
+     removed from the active queue.
+2. **Push** (`pushLocalSnapshot`) — a debounced write of the local snapshot only
+   (listening history bounded for upload first). Triggered by a local library /
+   preferences / listening-history change. End `pushed`.
 
 ### Merge algebra (`CloudSyncMerge.merged`)
 
@@ -84,13 +98,30 @@ snapshot.
 | **Custom stations** | Authoritative-remote when `remote.hasCustomStationsIndex`: result = remote list + unresolved-id local fallbacks. Otherwise union by id with **remote-wins on collision** (`mergeStations`), local-only appended. |
 | **Station lists** | Authoritative-remote when `remote.hasStationListsIndex`: result = remote list + unresolved-id local fallbacks. Otherwise union by id with **remote-wins (remote first, then local-only)**. |
 | **Preferences** | All-or-nothing block. `useRemotePreferences = remote.hasPreferences && !preferLocalPreferences`. When true, every preference field takes the remote value; when false, every field keeps local. (One exception: `sleepTimerDefaultMinutes` takes remote only if `remote > 0`.) `preferLocalPreferences` is set when this device has a queued, not-yet-pushed local preference edit. |
+| **Listening history** | Union of both devices' **closed** sessions, keyed by `station id + whole-second start` (a session's local record id — a per-device random UUID — is ignored). Local wins on a key collision (it may carry back-filled artwork). **Open (in-flight) sessions are never shared.** Result is sorted chronological ascending. The union is idempotent — re-merging the same sets never duplicates. Unconditional (not gated by `useRemotePreferences`). |
 | **Index flags** | `hasFavoritesOrder/hasCustomStationsIndex/hasStationListsIndex/hasPreferences` in merged output = local OR remote (sticky). |
 | **`favoritesOrder`** in merged output | = `remote.favoritesOrder` verbatim. |
 | **`resetAt`** in merged output | = `remote.resetAt`. |
 
-Recents / listening-history records / diagnostics / active wake intents are
-**absent from the snapshot entirely** — they have no field, so they are never
-synced (enforced structurally, not by filter). See [data-sync.md](../data-sync.md).
+Recents / diagnostics / active wake intents are **absent from the snapshot
+entirely** — they have no field, so they are never synced (enforced
+structurally, not by filter). **Listening-history records do sync** (see the
+Listening-history rules below); they are the one privacy-sensitive class carried
+in the snapshot. The opt-in preference gates whether new sessions are *recorded*,
+not whether already-recorded sessions sync — any closed sessions still present
+upload regardless of the current toggle. See [data-sync.md](../data-sync.md).
+
+### Listening history (cross-device sessions)
+
+- Only **closed** sessions sync; the active (open) session never leaves the
+  device. They travel as **one shared blob record** (`listening-history`), not
+  one record per session.
+- Pull merges the remote blob into local with the union rule above. The blob is
+  re-written on push only when its content actually changed (UUID-insensitive
+  comparison) so a steady state doesn't re-save every cycle and bounce silent
+  pushes between devices.
+- The synced *records* are distinct from the three listening-history *preference*
+  fields (enabled / level / retention), which sync in the Preferences block.
 
 ### Push timing
 
@@ -101,6 +132,19 @@ synced (enforced structurally, not by filter). See [data-sync.md](../data-sync.m
 | Backoff | exponential `base × 2^(attempt-1)`, capped 60 s | Per-attempt deferred-push delay. |
 | Max retries | 3 | After which the pending push is **suspended** (kept dirty, retried on next external trigger), not dropped. |
 
+### Listening-history upload bounds
+
+The shared listening-history blob is trimmed **for upload only** (local storage
+keeps everything per the user's retention setting). Before each push:
+
+| Cap | Value | Meaning |
+|---|---|---|
+| Retention window | per `listeningHistoryRetention` | Sessions older than the cutoff are excluded from the upload. |
+| Max records | 2000 | Hard ceiling independent of retention so `forever` can't grow the blob without bound; keeps the most-recent. |
+| Max encoded bytes | 800 000 | Safety net under CloudKit's ~1 MB per-record limit; oldest sessions dropped until the encoded blob fits. |
+
+Dropped-session counts are logged to diagnostics; nothing local is touched.
+
 ### Silent push (`CKDatabaseSubscription`)
 
 - A single `CKDatabaseSubscription` id `rrradio.private-db-changes.v1` is
@@ -109,6 +153,12 @@ synced (enforced structurally, not by filter). See [data-sync.md](../data-sync.m
   no badge, no sound). It only wakes the app to pull.
 - On delivery the app calls `handleRemoteChangeNotification` → `refreshFromCloud`
   (coalesced if a sync is already running).
+- The subscription's existence is **verified server-side once per app session**
+  (and re-attempted on each foreground refresh until it succeeds). The check
+  deliberately does **not** trust any persisted "installed" flag: CloudKit
+  Development and Production are separate databases, and a flag would survive the
+  dev→prod transition and skip creating the Production subscription. The
+  existence check is idempotent and cheap, so it self-heals across environments.
 
 ## Detail
 
@@ -142,8 +192,10 @@ synced (enforced structurally, not by filter). See [data-sync.md](../data-sync.m
 | `aiBlurbsEnabled` | Bool | `false` | AI station blurbs. |
 
 Note: the active wake **intent** is not synced; only the wake *preferences*
-above sync. Listening-history *records* never sync — only the three history
-*preference* fields above. (See [data-sync.md](../data-sync.md).)
+above sync. The three listening-history *preference* fields above (enabled /
+level / retention) sync here; the history *records* themselves sync separately
+through the `ListeningHistory` blob (see Listening history above), not in this
+Preferences block. (See [data-sync.md](../data-sync.md).)
 
 ### Per-entry / index records
 
@@ -155,6 +207,7 @@ above sync. Listening-history *records* never sync — only the three history
 | `FavoritesOrder` | `stationIds` (String array) | Authoritative order. |
 | `CustomStationsIndex` | `stationIds` (String array) | Authoritative membership. |
 | `StationListsIndex` | `listIds` (String array) | Authoritative membership. |
+| `ListeningHistory` | `records` (Data, ISO-8601 JSON array), `updatedAt` (Date), `count` (Int) | One shared blob of all closed sessions. Empty set → record deleted; unchanged content → not re-written. |
 | `SyncState` | `resetAt` (Date) | Deletion tombstone for "remove all cloud data". |
 
 ### Local sync flags (`UserDefaults`)
@@ -164,7 +217,26 @@ above sync. Listening-history *records* never sync — only the three history
 | `rrradio.icloudSync.enabled.v1` | Sync on/off (defaults **on** at first launch). |
 | `rrradio.icloudSync.pendingPreferencesPush.v1` | A local preference edit awaits push → forces `preferLocalPreferences` on next merge. |
 | `rrradio.icloudSync.resetAcknowledgedAt.v1` | Last `resetAt` this device has honored. |
-| `rrradio.icloudSync.subscriptionInstalled.v1` | Subscription install confirmed locally. |
+
+### Backup file (iOS, on-disk)
+
+A versioned JSON document the user can export, share, and restore independently
+of iCloud (works with sync off — it reads/writes local state only).
+
+| Field | Meaning |
+|---|---|
+| `version` | Current **1**; reading rejects any file with `version > 1` with a "made with a newer version" message rather than half-decoding. |
+| `exportedAt`, `appVersion` | Provenance stamps. |
+| `favorites`, `customStations`, `stationLists`, `preferences` | Same data the cloud snapshot carries. **Listening history is deliberately omitted.** |
+
+- Export reads the current local snapshot; suggested file name
+  `rrradio-settings-<yyyy-MM-dd>.json`.
+- Restore decodes the file, **replaces** favorites / custom stations / station
+  lists / preferences live (the backup's index flags are authoritative — restore
+  replaces, it does not union), then schedules one push so the restored state
+  propagates to iCloud when sync is on.
+- A malformed (non-backup) file fails with "this is not a rrradio settings
+  backup."
 
 ## Examples
 
@@ -214,14 +286,26 @@ remote.hasPreferences = true, preferLocalPreferences = false
    (except sleepTimerDefaultMinutes, which takes remote only if remote > 0)
 ```
 
+### Listening-history merge (union by station+second, local-wins, open dropped)
+
+```
+local:  [ {st:"fip",  start:100, artwork:"A"}, {st:"soma", start:300, OPEN} ]
+remote: [ {st:"fip",  start:100, artwork:nil}, {st:"byte", start:200} ]
+merged: [ {st:"fip",  start:100, artwork:"A"},      # local wins on key collision
+          {st:"byte", start:200} ]                  # remote-only session added
+        # soma@300 is open → never shared; result sorted by start ascending
+```
+
 ### Reset tombstone
 
 ```
 removeAllCloudData():
   save SyncState{resetAt: now}; delete all Favorite/CustomStation/StationList
-  + the three index records + Preferences.
+  + the three index records + Preferences + the ListeningHistory blob;
+  clear local listening history; end removedCloudData.
 Other device on next refresh: resetAt > resetAcknowledgedAt and no payload
-  beyond the tombstone => apply empty locally, acknowledge resetAt, end resetApplied.
+  beyond the tombstone => apply empty locally, clear local listening history,
+  acknowledge resetAt, end resetApplied.
 ```
 
 ## Versioning & evolution
@@ -240,8 +324,14 @@ Other device on next refresh: resetAt > resetAcknowledgedAt and no payload
 - The subscription id carries a `.v1` suffix; bumping it forces re-creation
   against a new configuration.
 - Migration policy: no automatic blob migration exists. The "save back the merge"
-  step (`save(localSnapshot())`) re-encodes any decodable blob with the current
-  encoder, which heals stale-but-decodable records opportunistically.
+  step (re-saving the bounded local snapshot) re-encodes any decodable blob with
+  the current encoder, which heals stale-but-decodable records opportunistically.
+- The `ListeningHistory` blob carries no `schemaVersion`; it round-trips through
+  `ListeningHistoryRecord` `Codable` (ISO-8601 dates). Two devices that
+  independently logged the same session hold different local record ids but
+  identical content; the change-detection that gates a re-write is
+  **id-insensitive**, so the blob does not ping-pong as each device re-asserts
+  its own ids.
 
 ## Failure & fallback
 
@@ -258,6 +348,8 @@ Other device on next refresh: resetAt > resetAcknowledgedAt and no payload
 | Retryable push error (CloudKit transient, partial-modify) | Exponential backoff, max 3 retries, then suspended (kept dirty). |
 | Non-retryable push error (`notAuthenticated`, `permissionFailure`, `quotaExceeded`, unavailable, fetch error) | No retry; pending push suspended; surfaces as `failed`. |
 | Stale `resetAt` tombstone with payload still present | Tombstone ignored, acknowledged, sync continues (treats it as a superseded reset). |
+| Listening-history blob missing or fails to decode | Treated as **no remote sessions** (empty), not a wipe; the local union is additive, so local sessions survive. |
+| Listening-history blob exceeds caps (count / encoded bytes / retention) | Trimmed for upload oldest-first (see Listening-history upload bounds); **local storage keeps everything**; dropped count logged. |
 | Concurrent request during a running cycle | Coalesced: a pending reset, pending remote-refresh, or pending push is re-fired once the current cycle finishes (`finishSync`). |
 
 All errors are sanitized before surfacing: no stack traces, no PII; record names
@@ -268,9 +360,9 @@ and CKError codes only.
 | # | Web | iOS | Android |
 |---|---|---|---|
 | 1 | Local-only; no CloudKit, no account, no automatic cross-device sync. | Implements the full CloudKit sync above. | Local-only; no CloudKit, no account. |
-| 2 | When importing a backup file, merge with the **same algebra**: favorites/custom/list union by id with the imported copy winning on collision; preferences applied as a block. | Honor the merge algebra exactly so two iOS devices converge. | Same backup-import merge algebra as web. |
+| 2 | When importing a backup file, merge with the **same algebra**: favorites/custom/list union by id with the imported copy winning on collision; preferences applied as a block. | Honor the cloud merge algebra exactly so two iOS devices converge. (Note: iOS **backup-file restore replaces** rather than unions — see Open questions.) | Same backup-import merge algebra as web. |
 | 3 | Never require cloud to function. | Degrade to local-only when iCloud is unavailable; no feature blocks on it. | Never require cloud to function. |
-| 4 | Treat recents, listening-history records, diagnostics, and active wake intent as non-syncable (export must exclude them per [data-sync.md](../data-sync.md)). | Same exclusions, enforced structurally (absent from snapshot). | Same exclusions. |
+| 4 | Treat recents, diagnostics, and active wake intent as non-syncable; **backup/export files must exclude listening-history records** per [data-sync.md](../data-sync.md). | Recents / diagnostics / active wake intent absent from snapshot (structural). Listening-history **records** sync to iCloud (one shared blob) but are **excluded from the exported backup file**. | Same exclusions; no record-level history sync (local-only). |
 | 5 | Decode failure on import must not wipe surviving local entries — keep local on un-decodable id. | Keep local copy for unresolved ids; never let a single bad blob wipe or stall. | Decode failure on import must not wipe surviving local entries. |
 | 6 | Provide a user-initiated "remove all" only over local/backup data. | Provide "remove all iCloud data" via the `resetAt` tombstone; other devices honor it. | Provide "remove all" over local data. |
 
@@ -293,6 +385,20 @@ and CKError codes only.
 3. Does a future shared backend (web/Android account sync) reuse this record
    schema, or define its own wire format? Deferred to the cross-platform sync
    ADR in [data-sync.md](../data-sync.md).
+4. **Listening-history sync vs. the data-sync privacy boundary.**
+   [data-sync.md](../data-sync.md) currently states listening history "does not
+   sync" and lists listening-history *records* among non-syncable classes. At
+   d241aa9 iOS **does** sync closed listening-history records to the user's own
+   private CloudKit database (never to a backup file, never to a shared/third
+   party). data-sync.md should be reconciled to draw the boundary as
+   *private-iCloud-sync-allowed, backup-export-excluded* for history records.
+5. **Backup-restore semantics diverge from the contract's backup-import rule.**
+   Platform obligation #2 says a backup import should **union** (imported copy
+   wins on id collision). iOS's own backup restore instead **replaces** the live
+   library wholesale (the backup's index flags are authoritative). "Restore a
+   backup" arguably *should* replace, but web/Android are told to union — the two
+   should be reconciled to one cross-platform intent (replace-on-restore vs.
+   union-on-import).
 
 ## Reference
 
@@ -305,16 +411,22 @@ and CKError codes only.
 - `rrradio/CloudSync/CloudSyncStore.swift` — `CloudSyncStoring`, `CloudKitSyncStore`
   (record types/names, save plan, fetch, subscription), `CloudSyncPreferencesSchema`,
   the unavailable/partial/fetch error types.
-- `rrradio/CloudSync/CloudSyncSnapshot.swift` — `CloudSyncSnapshot` schema and the
+- `rrradio/CloudSync/CloudSyncSnapshot.swift` — `CloudSyncSnapshot` schema, the
   `CloudSyncMerge` algebra (`mergeFavorites`/`mergeStations`/`mergeStationLists`/
-  `preservingUnresolved`).
+  `mergeListeningHistory`/`preservingUnresolved`), and the listening-history
+  upload bounds (`boundingListeningHistoryForUpload`, `ListeningHistorySyncBounds`).
+- `rrradio/CloudSync/SettingsBackup.swift` — the on-disk backup file: schema,
+  version gate, encode/decode, suggested file name; restore replaces live state.
+- `rrradio/Library/ListeningHistory.swift` — `syncableRecords` /
+  `mergeSyncedRecords` / `clear`, and `ListeningHistorySyncCoding` (the
+  `dedupKey` and id-insensitive `contentEqual` used by the shared blob).
 
 ## Known deviations
 
 - **C1 — decode-failure → authoritative-index → data-loss cascade (Fixed).**
   Index records are authoritative, so a per-entry blob that failed to decode
   used to be dropped via `compactMap`, the merge overwrote local with the empty/
-  partial array, and `save(localSnapshot())` ratified the wipe back to CloudKit
+  partial array, and the post-merge save-back ratified the wipe to CloudKit
   — propagating data loss to every paired device. Resolved in two steps: a
   fail-closed throw (`079b773`), then the current unresolved-id +
   `preservingUnresolved` keep-local design (`f03b34f`). See
@@ -332,5 +444,12 @@ and CKError codes only.
   ones. See slice10 §C7 (proposed fix in Open questions #2).
 - **C10 — `updateAvailability` runs twice per logical sync cycle (Open, low).**
   See slice10 §C10.
-- **C11 — subscription existence check round-trips on every cold launch even
-  when the local installed-flag is set (Open, low).** See slice10 §C11.
+- **C11 — subscription existence check round-trips on launch (Superseded /
+  intentional).** slice10 §C11 proposed short-circuiting the existence check on a
+  persisted "installed" flag. At d241aa9 that flag is **removed**: the check is
+  now done **once per app session** (in-memory flag), retried on each foreground
+  refresh until it succeeds, and deliberately does **not** trust any persisted
+  flag — a persisted flag would survive the dev→prod CloudKit transition and
+  cause a device to skip creating the Production subscription (issue #57). The
+  per-session round-trip is now intended behavior, not a deviation. See slice10
+  §C11 for the original (now-rejected) recommendation.

--- a/docs/spec/contracts/watch-protocol.md
+++ b/docs/spec/contracts/watch-protocol.md
@@ -1,9 +1,9 @@
 # Watch Remote Protocol Contract
 
 ```yaml
-status: draft
+status: approved
 platforms: [ios]
-reconciled-against: 800bb74
+reconciled-against: d241aa9
 ```
 
 The Apple Watch companion is an iPhone *remote*, not an independent player. It

--- a/docs/spec/data-sync.md
+++ b/docs/spec/data-sync.md
@@ -1,9 +1,26 @@
 # Data And Sync Specification
 
+```yaml
+status: review
+platforms: [web, ios, android]
+reconciled-against: d241aa9
+```
+
+## Purpose
+
 rrradio has no cross-platform account system today. Each platform owns its
 local user data. The web app supports user-initiated backup export/import as a
 manual sync/transfer mechanism for selected library data. iOS additionally
-offers private iCloud/CloudKit sync between the user's Apple devices.
+ships a versioned settings backup file (export and import) and private
+iCloud/CloudKit sync between the user's Apple devices.
+
+This spec defines the **data classes** and **per-platform storage/privacy
+boundaries** — what may and must not leave the device, and by which path. The
+CloudKit record schema, merge algebra, push timing, and on-disk backup file
+format are pinned in [sync-merge](contracts/sync-merge.md); the cross-platform
+privacy invariant (every outbound byte, enumerated) is pinned in
+[privacy & data boundaries](contracts/privacy-data-boundaries.md). This spec
+does not restate either; it links to them.
 
 ## Data Classes
 
@@ -13,64 +30,97 @@ offers private iCloud/CloudKit sync between the user's Apple devices.
 | Recents | Recently played stations, capped. | Private local activity. |
 | Station lists | Named station collections. | Private user library. |
 | Custom stations | User-entered streams and labels. | Private user content. |
-| Preferences | Theme, language, landing page, display modes, timer defaults. | Private settings. |
+| Preferences | Theme, accent, language, landing page, display modes, timer/wake/car defaults, music-service deep-link toggles, AI-blurb toggle, history settings. | Private settings. |
 | Wake state | One armed wake-to-radio intent. | Private local intent. |
-| Listening history | Optional playback history. | Private local activity. |
+| Listening history | Optional playback-session history. | Private local activity. |
 | Diagnostics | Optional operational events. | Private support data. |
 | Catalog cache | Published station catalog. | Public app data. |
+| Region cache | Cached GeoIP country for geo-restriction badging. | Private local cache. |
 | Backup file | User-exported snapshot for manual transfer. | Private user library. |
 
 ## Platform Behavior
 
 | Data | Web | iOS | Android |
 |---|---|---|---|
-| Favorites | `localStorage`, export/import supported. | Local UserDefaults plus optional CloudKit sync. | Local DataStore. |
+| Favorites | `localStorage`, export/import supported. | Local plus optional CloudKit sync; export/import supported. | Local DataStore. |
 | Recents | `localStorage`, capped. | Local-only, capped. | Local DataStore, capped. |
-| Station lists | Not planned for current web. | Local plus optional CloudKit sync. | Local DataStore. |
-| Custom stations | `localStorage`, export/import supported. | Local plus optional CloudKit sync. | Local DataStore. |
-| Preferences | Local browser preferences. | Local plus optional CloudKit sync for selected preferences. | Local-only for first port. |
-| Wake state | Local-only, one armed wake. | Local-only for active wake; selected wake preferences may sync. | Local-only. |
-| Listening history | Not part of current web storage contract. | Local-only, opt-in, retention-controlled. | Local-only, off by default, opt-in. |
+| Station lists | Not planned for current web. | Local plus optional CloudKit sync; export/import supported. | Local DataStore. |
+| Custom stations | `localStorage`, export/import supported. | Local plus optional CloudKit sync; export/import supported. | Local DataStore. |
+| Preferences | Local browser preferences. | Local plus optional CloudKit sync for the synced preference set; export/import supported. | Local-only for first port. |
+| Wake state | Local-only, one armed wake. | Local-only for the active wake intent; wake default-time, notification, and keep-alive preferences sync. | Local-only. |
+| Listening history | Not part of current web storage contract. | Local-only, opt-in, retention-controlled; closed sessions sync to the user's own iCloud (never to the backup file). | Local-only, off by default, opt-in. |
 | Diagnostics | Anonymous production events only. | Local opt-in diagnostic log. | Local opt-in diagnostic log, capped and exportable. |
 | Catalog cache | Browser/runtime cache. | Disk cache and bundled index fallback. | Cache-backed catalog loading; optional search index is deferred. |
-| Backup file | Manual export/import for favorites and custom stations. | Planned/optional import path if needed. | Manual export/import for library data and preferences. |
+| Region cache | `localStorage`, 24h. | Local UserDefaults, 24h, fail-open. | Local cache if implemented. |
+| Backup file | Manual export/import for favorites and custom stations. | Versioned JSON export and import (favorites, custom stations, station lists, preferences; no listening history). | Manual export/import for library data and preferences. |
 
 ## iCloud And CloudKit
 
 iCloud/CloudKit is an iOS-only feature. The record types, merge algebra,
-conflict rules, and decode-isolation are pinned in
-[sync-merge](contracts/sync-merge.md); the privacy classification of what may and
-may not leave the device is
+conflict rules, push/retry timing, silent-push subscription, and
+decode-isolation are pinned in [sync-merge](contracts/sync-merge.md); the
+privacy classification of what may and may not leave the device is
 [privacy & data boundaries](contracts/privacy-data-boundaries.md).
 
-The iOS app may sync:
+- iCloud sync defaults **on** at first launch and can be turned off in Settings.
+- Sync targets the user's **own** private CloudKit database — not an
+  rrradio-operated store. No data is shared with rrradio or any third party.
+- When CloudKit is unavailable (signed out, restricted, unsigned/simulator
+  build, offline), iOS stays local-only. No user-facing feature may require
+  iCloud to function.
+- The user can remove all synced data from iCloud from Settings; a tombstone
+  propagates the removal to the user's other paired devices.
+
+The iOS app syncs:
 
 - Favorites.
 - Favorite order.
 - Station lists.
 - Custom stations.
+- Closed listening-history sessions (to the user's own iCloud only; see the
+  boundary note below).
 - Theme and accent preferences.
 - Language preference.
-- Landing page preference.
-- Favorites display mode preferences.
+- Landing-page preference, plus the pinned landing station and landing list IDs.
+- Favorites display-mode preferences (selected mode, ordered set, visible set).
 - Sleep timer default.
-- Wake default-time and notification preferences.
-- Car mode preferences.
-- Listening-history preferences.
+- Wake default-time, notification, and keep-alive preferences.
+- Car mode preferences (automatic and manual).
+- Listening-history preferences (enabled, level, retention).
+- Music-service deep-link toggles (Apple Music, Spotify, YouTube Music).
+- AI station-blurb toggle.
 
 The iOS app must not sync:
 
 - Recents.
-- Listening-history records.
 - Diagnostics.
-- One-shot active wake intents.
+- The one-shot **active** wake intent (only wake *preferences* sync).
 - Raw playback errors.
 - Search queries.
-- Track titles or artist names from listening history unless a future explicit
-  user-facing sync feature is approved.
 
-When CloudKit is unavailable, iOS stays local-only. No user-facing feature may
-require iCloud to function.
+These five are **structurally absent** from the sync snapshot — there is no
+field to carry them — so they can never be synced.
+
+### Listening-history boundary
+
+Listening-history *records* are private but **do sync to the user's own
+iCloud** as a single shared blob of closed sessions, so a user sees one history
+across their Apple devices. This sync is strictly bounded:
+
+- Only **closed** sessions travel; the active (in-flight) session never leaves
+  the device.
+- The blob lives only in the user's **own** private CloudKit database — never
+  in an exported backup file, never to any rrradio-operated or third-party
+  endpoint.
+- The opt-in preference gates whether new sessions are *recorded*, not whether
+  already-recorded sessions sync; any closed sessions still present upload
+  regardless of the current toggle.
+- The uploaded blob is trimmed for transport (retention window, record count,
+  encoded-byte caps) — local storage keeps everything. See
+  [sync-merge](contracts/sync-merge.md) §Listening-history upload bounds.
+
+The three listening-history *preference* fields (enabled / level / retention)
+sync in the preferences block, separately from the records.
 
 ## Web
 
@@ -85,6 +135,25 @@ export/import:
 - The backup file is the user-controlled sync/transfer mechanism.
 - Current backup scope is favorites and custom stations.
 - Clearing site data clears the local library.
+
+## iOS Settings Backup File
+
+iOS ships a versioned JSON settings backup, independent of iCloud (it reads and
+writes local state only and works with sync off). The file format, version
+gate, and restore semantics are pinned in [sync-merge](contracts/sync-merge.md)
+§Backup file.
+
+- **Export** writes the current local snapshot (favorites, custom stations,
+  station lists, preferences) to a JSON file shared via the OS share sheet;
+  suggested file name `rrradio-settings-<yyyy-MM-dd>.json`.
+- **Import (restore)** decodes a chosen file and **replaces** favorites, custom
+  stations, station lists, and preferences with the backup's contents, then
+  pushes the restored state to iCloud like any local edit (when sync is on).
+- Listening history is deliberately excluded from the backup file — backups are
+  made to be shared and saved outside the app sandbox, and history is private.
+- A file made by a newer app version (a higher schema version) is rejected with
+  a clear "made with a newer version" message; a non-backup file is rejected
+  with "this is not a rrradio settings backup."
 
 ## Android
 
@@ -149,3 +218,62 @@ A future sync ADR must decide:
 Until that ADR exists, web and Android have no automatic account/cloud sync.
 Web still has manual file export/import, and iOS CloudKit sync remains
 Apple-device-only.
+
+## Platform Matrix
+
+| Behavior | Web | iOS | Android |
+|---|---|---|---|
+| Library data local-first, private by default | Supported | Reference | Planned |
+| Optional cloud sync to the user's own account | Not planned | Reference | Not planned (Apple-only) |
+| iCloud sync defaults on, removable from Settings | Not planned | Reference | Not planned |
+| Sync degrades to local-only when account unavailable | Not planned | Reference | Not planned |
+| Listening-history records sync to user's own iCloud only | Not planned | Reference | Not planned |
+| Listening-history records excluded from backup file | Supported (no history) | Reference | Supported |
+| Recents / diagnostics / active wake intent never synced | Supported | Reference | Planned |
+| Versioned settings backup export | Partial (favorites + custom only) | Reference | Planned |
+| Settings backup import (restore replaces live library) | Partial (import merges) | Reference | Planned |
+| Region/GeoIP cache, 24h, fail-open | Supported | Reference | Planned |
+| Catalog cache with bundled fallback | Supported | Reference | Partial |
+
+## Open questions
+
+1. **Backup restore vs. import semantics.** iOS backup restore **replaces** the
+   live library wholesale; web/Android backup import **merges** by id (imported
+   copy wins on collision). These should be reconciled to one cross-platform
+   intent (replace-on-restore vs. union-on-import). Tracked in
+   [sync-merge](contracts/sync-merge.md) §Open questions.
+2. **Backup scope parity.** Web exports only favorites and custom stations; iOS
+   and Android also carry station lists and preferences. Decide the canonical
+   backup scope across platforms.
+3. **Future shared backend.** Whether a future account-based cross-platform sync
+   reuses the iOS record schema or defines its own wire format is deferred to
+   the cross-platform sync ADR above.
+
+## Reference
+
+iOS source (the only place iOS mechanics are named):
+
+- `rrradio/CloudSync/CloudSyncController.swift` — sync enable/disable (default on),
+  pull/merge/push cycle, settings-backup encode/restore, remove-all-cloud-data.
+- `rrradio/CloudSync/CloudSyncStore.swift` — CloudKit record types/names, save
+  plan, fetch, silent-push subscription, container `iCloud.ios.rrradio.org`.
+- `rrradio/CloudSync/CloudSyncSnapshot.swift` — the synced snapshot schema, the
+  merge algebra, and listening-history upload bounds.
+- `rrradio/CloudSync/SettingsBackup.swift` — the on-disk backup file schema,
+  version gate, encode/decode, suggested file name.
+- `rrradio/Views/SettingsView.swift` — iCloud toggle, remove-all-cloud-data,
+  backup export (share sheet) and import (file importer) UI.
+- `rrradio/Models/RegionResolver.swift` — GeoIP region cache
+  (`rrradio.region.v1`, 24h, fail-open) for geo-restriction badging.
+
+The CloudKit record schema, merge algebra, push timing, and backup file format
+are specified in [sync-merge](contracts/sync-merge.md); the outbound-data
+boundary (including the region cache and the iCloud row) in
+[privacy & data boundaries](contracts/privacy-data-boundaries.md).
+
+## Known deviations
+
+- The decode-failure → data-loss cascade in the CloudKit merge and the binary
+  pending-preferences flag are tracked in [sync-merge](contracts/sync-merge.md)
+  §Known deviations (slice10 §C1 fixed, §C7 open). This spec states the intended
+  data-class boundaries; the contract owns the merge-level deviations.

--- a/docs/spec/features/browse.md
+++ b/docs/spec/features/browse.md
@@ -1,18 +1,21 @@
 # Browse Specification
 
 ```yaml
-status: draft
+status: review
 platforms: [web, ios, android]
-reconciled-against: 9336321
+reconciled-against: d241aa9
 ```
 
 ## Purpose
 
-Browse is the catalog discovery surface: the "all stations" view where a user
-finds something to play. It renders the shared catalog, folds live community
-results into an active search, narrows by genre / country / news, sorts the
-un-queried catalog, supports building a station list from multiple picks, and
-offers a map view for geographic exploration. The search *field* mechanics
+Browse is the catalog discovery surface: the place a user finds something to
+play. It opens on a **discovery landing** (genre chips, country chips, a
+"Browse all" rail, and an editorial "Featured" rail) and only drops into the
+flat result list once the user searches, taps a chip, applies a filter, or
+chooses "Browse all". The result list renders the shared catalog, folds live
+community results into an active search, narrows by genre / country / news /
+stream-quality, sorts the un-queried catalog, and supports building a station
+list (or extending Favorites) from multiple picks. The search *field* mechanics
 (normalization, tier precedence, Radio Browser API) live in
 [search](search.md) and [features/search](search.md); this spec links to them
 and does not re-derive them.
@@ -20,21 +23,30 @@ and does not re-derive them.
 ## Entry points
 
 - The Browse tab in the bottom navigation (default landing page unless the user
-  set another).
+  set another). Browse opens on its **discovery landing**, not the flat list.
 - Tapping the inline rrradio logo on any tab routes to the Browse tab (logo as a
   "go home" affordance); on Browse itself it re-selects the tab and resets
   scroll.
-- A "+" / "add stations" affordance on a station-list detail page or the library
-  home jumps into Browse in multi-select mode targeting that list (see
-  [station-lists](station-lists.md)).
+- A "+" / "add stations" affordance elsewhere enters Browse in multi-select
+  mode targeting a destination: a station-list detail page or the library home
+  targets that **list** (see [station-lists](station-lists.md)); the Favorites
+  page targets **Favorites** (picks are added to favorites, then routed back to
+  the Favorites tab); "create new" from the library home seeds a draft name with
+  no target list yet.
 - Deep links / Shortcuts that open a station resolve through the catalog Browse
   consumes.
+
+Browse reaches the **result list** from the discovery landing by: typing a
+search, tapping a genre / country chip, tapping a section's "See all ›" then
+applying a filter, or tapping the "Browse all" header. A back chevron (or a
+rightward swipe) returns to discovery.
 
 ## Layout
 
 Top to bottom:
 
-1. **Top control row** (collapses on scroll-down, expands on scroll-to-top):
+1. **Top control row** (single combined row; collapses on scroll-down, expands
+   on scroll-to-top — Browse has no separate brand row):
    - rrradio **logo button** (left) — go home / re-select Browse.
    - **Search field** (capsule) — magnifier icon, placeholder "Search all…",
      inline clear (✕) button when non-empty. Field behavior in
@@ -42,28 +54,41 @@ Top to bottom:
    - **Filter button** — funnel icon; shows an accent dot when any filter is
      active.
    - **Settings button** — gear icon; opens the settings sheet.
-2. **Sort row** — three columns:
-   - Left: **alphabet sort** control aligned over the row artwork column.
-   - Center: **result-count label** (numeric; hidden while multi-select is
-     active so the dock can use the center).
-   - Right: **"+" add-to-list** control opening the add-list popup.
+2. **Second row** — depends on mode:
+   - **Discovery landing:** no second row (just a small spacer); the sort /
+     count / add-list controls "belong with results", so they are suppressed.
+   - **Results:** the **sort row**, three columns — left: a **back-to-discovery
+     chevron** (over the artwork column) then the **alphabet sort** control
+     (aligned over the name column); center: the **result-count label**
+     (numeric); right: a **"+" add-to-list** control opening the add-list popup.
+   - **Multi-select:** the **selection bar** takes this slot (directly under the
+     search field, accent-tinted) — step strip, cancel (✕), "Adding to <name>"
+     label + selection-count badge, and a labeled "Add N" save button.
 3. **Top nav rule** — hairline divider; the boundary above which chrome stays
    sharp when a popup blurs the content below.
 4. **Content area** — one of:
-   - Station list/grid of rows, each row showing logo (favicon), name,
-     country/tag context, a stream-quality meter, a favorite heart, and current
-     /playing indicators. Rows render `featured`-first then catalog order; an
-     active query replaces this with relevance order.
-   - Empty-state view (search vs. catalog variants).
+   - **Discovery landing** (default, no query / filter / multi-select): a
+     "Browse by genre" chip carousel, a "Browse by country" chip carousel, a
+     "Browse all" header (catalog count) over a horizontal logo rail previewing
+     the full list, then a hairline and an editorial "Featured" rail of
+     highlight cards. Carousels scroll horizontally; the landing itself does not
+     scroll the nav away when it fits.
+   - **Result list/grid** of rows, each row showing logo (favicon), name,
+     country/tag context, a favorite heart, and current/playing indicators (no
+     stream-quality meter — see Row layout). An optional **filter-summary
+     header** above the first row spells out the active genre/country/quality
+     filter. Rows render `featured`-first then catalog order; an active query
+     replaces this with relevance order. Wide layouts (iPad / iPhone landscape)
+     lay rows out as a multi-column grid.
+   - **Empty-state view** (search vs. catalog variants).
    - A trailing **load-more** spinner when more local pages or community results
      remain.
-5. **Multi-select dock** (only while composing a list) — cancel (✕), list-name
-   label + selection-count badge, save (✓). Sits above the bottom chrome; the
-   mini-player is hidden while it is up.
-6. **Popup overlays** (transient, centered, over a blurred content backdrop):
-   filter popup, add-list popup, and a press-and-hold station-info preview.
-7. **Map view** (separate surface) — a sheet with a header, an interactive map,
-   and a scrollable country list (see Map section).
+5. **Popup overlays** (transient, centered, over a blurred content backdrop):
+   filter popup, add-list popup, and a press-and-hold station-info preview. The
+   mini-player is hidden while the selection bar is up.
+6. **Map view** (separate surface) — a sheet with a header, an interactive map,
+   and a scrollable country list (see Map section). Defined but **not wired into
+   Browse on iOS at d241aa9** (no entry point — see Open questions).
 
 ### Row layout (per station)
 
@@ -72,20 +97,25 @@ Top to bottom:
 | Favicon | Station logo, or a placeholder when absent. |
 | Name | Display name (one line). |
 | Context | Country / tag signal. |
-| Quality meter | Filled bars 1–4 derived from `codec`+`bitrate` ([catalog-schema](../contracts/catalog-schema.md)); passive indicator in Browse (not tappable). |
 | Favorite heart | Toggles favorite; hidden in multi-select. |
 | Current/playing badge | Marks the current station and whether it is playing. |
-| Selection bubble | Replaces play/favorite affordances while multi-select is active. |
+| Geo-restriction badge | Stations whose curated `availableIn` excludes the visitor's region render dimmed and badged ([catalog-schema](../contracts/catalog-schema.md)). |
+| Selection bubble | Replaces play/favorite affordances while multi-select is active; "already-in-list" rows render inert and out of the selection. |
+
+The stream-quality meter is **not** shown on Browse rows — the row's only tap
+target is "play this station"; the codec/bitrate detail stays reachable from the
+press-and-hold station-info preview.
 
 ## States
 
 | State | What shows | Actionable |
 |---|---|---|
-| **Loading (cold)** | Catalog resolves cache → bundled snapshot → network ([catalog-schema](../contracts/catalog-schema.md)); the first source renders immediately. | Rows are tappable as soon as any source renders. |
-| **Loaded (no query, no filter)** | Full catalog, `featured`-first, capped to the visible window (first 25 rows), load-more grows it. | Play, favorite, info-hold, sort, filter, multi-select. |
-| **Loaded (filtered)** | Catalog narrowed by country/genre/news; count reflects the filtered set. | Same; filter dot lit. |
+| **Loading (cold)** | Catalog resolves cache → bundled snapshot → network ([catalog-schema](../contracts/catalog-schema.md)); the first source renders immediately. | Discovery chips / rail populate as catalog counts land; rows are tappable as soon as any source renders. |
+| **Discovery (no query, no filter, not multi-select)** | Genre + country chips (catalog match counts, "See all ›"), the "Browse all" header + logo rail, and the "Featured" rail. Chips/rails appear only when non-empty; the "Browse all" header is always present. | Tap a chip → filter into results; "See all ›" → open filter sheet on that section; "Browse all" → full unfiltered list; tap/play a highlight; search to leave discovery. |
+| **Loaded (no query, no filter — "Browse all")** | Full catalog, `featured`-first, capped to the visible window (first 25 rows), load-more grows it. | Play, favorite, info-hold, sort, filter, multi-select, back-to-discovery. |
+| **Loaded (filtered)** | Catalog narrowed by country/genre/news/quality; count reflects the filtered set; a filter-summary header spells out the active filter. | Same; filter dot lit; back chevron returns to discovery. |
 | **Loaded (query active)** | Local matches (relevance order) then community results appended as the user pages; sort suppressed. | Play, favorite, info-hold, multi-select; load-more pages local then Radio Browser. |
-| **Empty (query)** | "No stations found" + "try a different search" with a magnifier glyph. | Clear search to return to catalog. |
+| **Empty (query)** | "No stations found" + "try a different search" with a magnifier glyph. | Clear search to return to discovery (or the filtered list if a filter is still active). |
 | **Empty (catalog)** | Catalog empty title + "no rows" description. | Retry occurs via the catalog refresh ladder; nothing in-view to tap. |
 | **Partial** | Local results render while community results stream in behind the load-more spinner. | All loaded rows actionable; spinner is non-interactive. |
 | **Error (catalog refresh fails, data already shown)** | Stays in loaded state on cache/bundled data; no error chrome. | Normal. |
@@ -99,39 +129,61 @@ Top to bottom:
 | Tap logo | On another tab | Route to Browse tab | — |
 | Tap logo | Already on Browse | Re-select tab | Scroll to top, chrome re-expands |
 | Tap settings gear | — | Open settings sheet | — |
-| Type in search field | — | Debounced 180 ms, then query updates | Resets visible window to 25; (re)issues community search; recomputes results off-main |
+| Tap a genre chip | Discovery | Apply that single genre as the filter, drop into results | Leaves discovery; filter dot lit |
+| Tap a country chip | Discovery | Apply that single country as the filter, drop into results | Leaves discovery; filter dot lit |
+| Tap "See all ›" (genre/country header) | Discovery | Open filter popup with that section pre-expanded | — |
+| Tap "Browse all" header / a logo on its rail | Discovery | Drop into the full, unfiltered list (no filter applied) | Leaves discovery; back chevron returns |
+| Tap / play a highlight card | Discovery | Play that station | Pushes to recents if catalog; queues the current visible window for skip-next |
+| Tap back chevron | Results (search/chip/filter, not multi-select) | Clear search + filter + browse-all, return to discovery | — |
+| Swipe right over the result list | Results, back chevron shown | Same as back chevron (return to discovery) | Vertical scroll untouched; multi-select excluded |
+| Type in search field | — | Debounced 180 ms, then query updates | Leaves discovery; resets visible window to 25; (re)issues community search; recomputes results off-main |
 | Submit search (return) | — | Commit query immediately, bypassing debounce | Dismisses keyboard |
-| Tap clear (✕) in field | Field non-empty | Clears text and query | Community paginator reset; catalog re-shows |
+| Tap clear (✕) in field | Field non-empty | Clears text and query | Community paginator reset; discovery re-shows (if no filter) |
 | Tap filter funnel | — | Open filter popup over blurred content | — |
 | Tap outside filter popup | Popup open | Dismiss without applying | Draft discarded |
-| Expand a filter section | Filter popup open | Reveal genres (news + genre rows) or countries (search + rows) | — |
-| Toggle a genre / news / country row | Filter popup open | Toggle membership in the draft; section badge updates | — |
+| Expand a filter section | Filter popup open | Reveal genres (news + genre rows), countries (search + rows), or quality (low/medium/high rows) | — |
+| Toggle a genre / news / country / quality row | Filter popup open | Toggle membership in the draft; section badge + live match count update | — |
 | Type in country search | Country section expanded | Filters country rows; selected countries pinned to top | — |
-| Tap ✓ (apply) | Filter popup open | Apply draft filter, close popup | Resets window; re-issues community search with first genre/country; recomputes |
-| Tap trash (clear) | Draft non-empty | Reset draft to no filter (still must Apply) | — |
+| Tap apply ("Show N stations") | Filter popup open, ≥1 match | Apply draft filter, close popup | Resets window; re-issues community search with first genre/country; recomputes |
+| (Apply while 0 matches) | Draft matches nothing | Apply button disabled | — |
+| Tap "Clear" | Draft non-empty | Reset draft to no filter (still must Apply) | — |
 | Tap ✕ (cancel) in popup | Filter popup open | Close, discard draft | — |
 | Tap alphabet sort | No active query | Cycle off → A→Z → Z→A → off | Resets window; recomputes order |
 | (Sort while query active) | Query active | Sort suppressed; relevance order kept | — |
-| Tap "+" add-to-list | — | Open add-list popup (Create new / pick existing) | — |
-| Pick "Create new" + name | Add-list popup | Enter multi-select, no target list, dock seeded with name | Mini-player hidden; count label hidden |
-| Pick existing list | Add-list popup | Enter multi-select targeting that list, dock seeded with its name | Same |
+| Tap "+" add-to-list | Results | Open add-list popup (Create new / pick existing) | — |
+| Pick "Create new" + name | Add-list popup | Enter multi-select, no target list, bar seeded with name | Mini-player hidden; count label hidden |
+| Pick existing list | Add-list popup | Enter multi-select targeting that list, bar seeded with its name | Same |
+| Enter from a list / "create new" / Favorites "+" | (external entry) | Enter multi-select; clears search/filter/sort; seeds target + name (Favorites seeds the page title) | Same |
 | Tap a row (multi-select off) | Loaded | Play station | Pushes to recents if it is a catalog station; queues the visible window for skip-next |
-| Tap a row (multi-select on) | Multi-select active | Toggle selection (tap order preserved) | Dock count updates |
+| Tap a row (multi-select on) | Multi-select active | Toggle selection (tap order preserved); already-in-list rows inert | Selection count updates |
 | Tap favorite heart | Multi-select off | Toggle favorite | Library mutation; sync per [data-sync](../data-sync.md) |
 | Press-and-hold a row | Multi-select off | Show station-info preview overlay while held | Releasing dismisses it |
-| Tap dock ✓ (save) | ≥1 selected AND name non-empty | Append to target list, or append to a name-matched list, or create a new one | Leaves multi-select; opens the destination list in Library |
-| Tap dock ✕ (cancel) | Multi-select active | Discard selection, leave multi-select | Mini-player returns |
+| Tap "Add N" (save) | ≥1 selected AND name non-empty | Favorites target → add picks to Favorites, route to Favorites tab; else append to target/name-matched list, else create a new one | Leaves multi-select; opens the destination in Library / Favorites |
+| Tap ✕ (cancel) in selection bar | Multi-select active | Discard selection, leave multi-select | Mini-player returns |
 | Scroll to load-more spinner | More local pages remain | Grow visible window by 25 | — |
 | Scroll to load-more spinner | Local exhausted, query active | Fetch next community page (50 rows) | Network call per [search](search.md) |
-| Open map | (map surface entered) | Show map sheet | — |
 | Pinch / pan map | Map open | Re-clusters: country pins when zoomed out, station pins under ~7° latitude span, logo pins under ~2.5° with ≤35 stations | Recomputes visible pins (cap 70) |
 | Tap country pin / country row | Map open | Select that country, recenter map on it | Drives the bound `selectedCountry` |
 | Tap "All countries" | Map open | Clear country selection, recenter to world | — |
 | Tap a station pin | Map open (pins shown) | Open that station and dismiss the map | Plays / routes to the station |
-| Backgrounding / tab switch away | — | Cancel debounce + filter tasks, reset community paginator, dismiss info preview | — |
+| Backgrounding / tab switch away | — | Cancel debounce + filter + discovery-count tasks, reset community paginator, dismiss info preview | — |
 
 ## Business rules
 
+- **Discovery gate:** the discovery landing shows only when the search is empty,
+  no filter is active, the page is not mid-multi-select, and "Browse all" has not
+  been tapped. Any of those drops into the result list. Genre/country chips and
+  the Featured rail render only when non-empty; the "Browse all" header is always
+  present so the full list is reachable without first applying a filter.
+- **Discovery counts:** per-genre and per-country catalog match counts are
+  computed off-main (the genre scan compiles a regex per station), recomputed on
+  catalog revision; chips sort by count desc with a stable id/code tiebreak.
+  Country chips cap at 20; highlight cards cap at 8; the "Browse all" logo rail
+  caps at 30 stations carrying real artwork. Chip counts ≥ 1000 abbreviate
+  ("1.4k", "17k").
+- **Highlights:** the editorial "Featured" feed loads lazily from the highlights
+  store; entries whose `stationId` isn't in the catalog are dropped, deduped by
+  station; an all-unavailable feed hides the rail.
 - **Search debounce:** 180 ms after the last keystroke; Submit commits
   immediately.
 - **Visible window (paging):** renders the first 25 of the result set; each
@@ -156,27 +208,54 @@ Top to bottom:
 - **Community page size:** the Browse paginator requests 50 rows per page (the
   client default is 60); tier ordering, dedupe, and the country-code
   short-circuit are owned by [search](search.md).
+- **Filter matching:** within a dimension, membership is OR (any selected genre
+  matches, any selected country matches, any selected quality class matches);
+  across dimensions it is AND (a row must satisfy genre AND country AND news AND
+  quality). News and genres compose; the news toggle is an additional AND
+  predicate.
+- **Quality classes:** the quality filter is multi-select Low / Medium / High
+  buckets mapped from the station's derived `codec`+`bitrate` level (levels 1–2 =
+  Low, 3 = Medium, 4 = High; unknown codec/bitrate scores level 1 → Low). Empty
+  means quality is not filtered.
 - **Filter → community mapping:** the first sorted selected genre's `rbTag`
   (else `news` when only the news toggle is on) and the first sorted selected
-  country code are passed to the community search.
+  country code are passed to the community search. The quality filter is local
+  only — it is not forwarded to Radio Browser.
+- **Filter apply gate:** the filter popup's apply button is labeled with the live
+  match count ("Show N stations") and is disabled when the draft matches zero
+  stations; the count is recomputed only when the draft changes (typing in the
+  country search does not rescan).
 - **Result count label** equals the merged local+community result count (the
   community hits are already merged into the result set, so they are not
   double-counted). Hidden while multi-select is active.
-- **Multi-select save resolution:** save targets the requested list if present;
-  else a list whose name case-insensitively matches the typed name; else creates
-  a new list. Save requires ≥1 station and a non-empty trimmed name. Selection is
-  stored as full `Station` values (not just IDs) so picks made under an earlier
-  query survive into the save even when no longer in the visible pool. Selection
-  persists across page swipes within Browse.
+- **Multi-select save resolution:** a Favorites target adds the picks to
+  Favorites and returns to the Favorites tab (no list name involved). Otherwise
+  save targets the requested list if present; else a list whose name
+  case-insensitively matches the typed name; else creates a new list. List saves
+  require ≥1 station and a non-empty trimmed name. Selection is stored as full
+  `Station` values (not just IDs) so picks made under an earlier query survive
+  into the save even when no longer in the visible pool. Selection persists
+  across page swipes within Browse. Rows already in the target list / Favorites
+  render inert and stay out of the new-additions selection.
 - **Filter sections:** genres = a news toggle plus the fixed `genres` taxonomy;
   countries = the catalog's available 2-letter country codes, device region
-  pinned first, currently-selected pinned to top while searching.
+  pinned first, currently-selected pinned to top while searching; quality =
+  Low / Medium / High classes.
 - **Map clustering thresholds:** station pins appear when the visible latitude
   span < 7°; logo pins (favicon) when span < 2.5° and ≤35 visible stations;
   otherwise country-aggregate pins. Visible station pins capped at 70; map shows
   up to 100 country pins and the country list up to 80 rows. Country aggregation
   requires a valid `geo` and a 2-letter country; rows sort by station count
   desc, then country display name.
+- **Filter-summary header:** when a filter is active, a header above the first
+  row spells out the applied filter — genres (catalog display order), then News,
+  then countries (localized, sorted), then the minimum stream-quality classes.
+  The sort row keeps only the numeric count.
+- **Back to discovery:** the back chevron / rightward swipe is available whenever
+  results are on screen because of a search or filter, except in multi-select
+  (the selection bar owns the exit there). It clears search + filter + the
+  browse-all flag. The swipe reads as "back" past ~56 pt travel or a far-enough
+  predicted fling, and only when predominantly horizontal-rightward.
 - **Recents:** playing a *catalog* station pushes it to recents; community /
   custom stations do not (see [favorites](favorites.md)).
 
@@ -214,8 +293,15 @@ Top to bottom:
   cache/bundled data; no error chrome.
 - **Custom-station changes / catalog revision changes** trigger a recompute so
   the visible set stays consistent.
-- **Backgrounding / leaving Browse:** debounce + filter tasks cancel, the
-  community paginator resets, and any info preview is dismissed.
+- **Backgrounding / leaving Browse:** debounce + filter + discovery-count tasks
+  cancel, the community paginator resets, and any info preview is dismissed.
+- **Discovery counts cancellable:** the off-main genre/country count pass polls
+  cancellation every 1024 stations; a catalog refresh supersedes the prior pass.
+  Counts are skipped while a search is active (production first-appears empty).
+- **Map not reachable from Browse (iOS):** the map surface compiles and works
+  standalone but has no entry point wired into Browse at d241aa9, so its
+  interactions below are dormant on iOS until a presenter is added (Open
+  questions).
 - **Map with no `geo` data:** stations without valid `geo` are absent from pins
   and country aggregates; the country list simply omits them.
 - **Geo-restricted rows:** stations with `availableIn` are dimmed and badged for
@@ -228,17 +314,27 @@ Top to bottom:
   labeled "clear search".
 - Filter button carries a label ("filters") and a value reflecting whether
   filters are active ("no filters active" / "filters active").
+- Back-to-discovery chevron labeled "back to discovery".
+- Discovery chips are single elements labeled "<name>, <n> stations"; section
+  "See all ›" exposes its plain label; the "Browse all" row is a button labeled
+  "browse all" with an "all stations" hint; the logo rail is hidden from
+  VoiceOver (the header is the accessible route).
+- Highlight cards are single buttons labeled badge + station + genres.
 - Alphabet sort's label states the *next* action ("sort ascending" / "sort
   descending" / "clear alphabetic sort").
-- Add-to-list "+" labeled "add to list"; dock buttons labeled "cancel" / "save".
-- Filter popup: cancel = "cancel", clear = "clear filters", apply = "done";
-  selected picker rows expose the selected trait.
+- Add-to-list "+" labeled "add to list"; selection-bar buttons labeled "cancel"
+  and the live "Add N" save label; the filter-summary header reads "filters
+  active" + the summary.
+- Filter popup: cancel = "cancel", clear = "clear filters", apply = the live
+  match-count label ("Show N stations"); selected picker rows expose the selected
+  trait; quality meter graphics are hidden from VoiceOver.
 - Load-more spinner labeled "loading".
-- Map pins expose readable labels ("Open <station>", "<country>, <n> stations").
+- Map pins expose readable labels ("Open <station>", "<country>, <n> stations") —
+  currently as literal English text, not localized (see Known deviations).
 - Dynamic Type: row text and the filter picker rows scale; the picker label
   rows shrink minimally before truncating. Count label and badges use a
   monospaced numeric style.
-- Focus order follows top control row → sort row → result rows → dock.
+- Focus order follows top control row → sort / selection row → result rows.
 
 ## Localization
 
@@ -247,16 +343,25 @@ Strings this surface owns (keys, not literals):
 - Search: `searchAll` (placeholder), `clearSearch`.
 - Sort: `sortAscending`, `sortDescending`, `clearAlphabeticSort`.
 - Filters: `browseFiltersA11y`, `noFiltersActive`, `filtersActive`,
-  `createFilter`, `clearFilters`, `genre`, `country`, `news`, `searchCountries`.
-- Add-to-list / dock: `addToList`, `cancel`, `save`, `done`.
+  `createFilter`, `clear`, `clearFilters`, `genre`, `country`, `news`,
+  `searchCountries`, `rowQuality`, `qualityLow`, `qualityMedium`, `qualityHigh`,
+  `showMatchingStations` / `showMatchingStationsOne`.
+- Discovery: `browseByGenre`, `browseByCountry`, `seeAll`, `browseAll`,
+  `allStations`, `featured`, `backToDiscovery`.
+- Add-to-list / selection bar: `addToList`, `cancel`, `addingTo`, `addCount`,
+  `selectStations`, `done`.
+- Count: `stationsCount` (pluralized — `.one` / `.other` / locale variants).
 - Empty states: `noStationsFound`, `trySearch`, `catalogEmpty`, `catalogNoRows`.
 - Chrome: `browse`, `goHome`, `settings`, `loading`.
-- Map: `map`, `allCountries`; country names rendered via the OS locale's
-  region display names; flag emoji derived from the code.
+- Map: `map`; country names rendered via the OS locale's region display names;
+  flag emoji derived from the code. (The map's "All countries", "Open
+  <station>", and "<n> stations" labels are hardcoded English at d241aa9 even
+  though `allCountries` exists — see Known deviations.)
 
-Plural / parameter needs: the result-count label and country-station counts are
-numeric and need locale-aware number formatting; the map's "<n> stations" and
-country-row counts are pluralizable.
+Plural / parameter needs: `stationsCount`, the chip counts, and the country-row
+counts are numeric and need locale-aware number formatting; `addCount` /
+`showMatchingStations` take a count parameter; the result-count label and the
+map's "<n> stations" are pluralizable.
 
 ## Platform Matrix
 
@@ -264,17 +369,23 @@ country-row counts are pluralizable.
 |---|---|---|---|
 | Curated catalog | Supported. | Supported. | Supported. |
 | Large Radio Browser-backed catalog | Supported. | Supported with bundled index/cache behavior. | Supported with cache-backed loading. |
+| Discovery landing (genre/country chips + Featured rail + Browse all) | Supported. | Supported. | Planned. |
 | Search normalization | Supported. | Reference native behavior. | Supported. |
 | Country filter | Supported. | Supported with native picker rows. | Supported. |
 | Genre/tag filter | Supported. | Supported. | Supported. |
 | News filter toggle | Supported. | Supported. | Supported. |
+| Stream-quality (Low/Medium/High) filter | Supported. | Supported (multi-select buckets). | Planned. |
+| Filter apply gated on live match count | Supported. | Supported. | Planned. |
 | Searchable country picker with selected-pinned-to-top | Supported. | Supported. | Supported. |
-| Map browse | Supported with web map asset. | Supported with MapKit. | Planned with native map, provider TBD. |
+| Back-to-discovery chevron + swipe | Supported. | Supported. | Planned. |
+| Map browse | Supported with web map asset. | Surface built (MapKit) but no Browse entry point wired at d241aa9. | Planned with native map, provider TBD. |
 | Add several stations to a station list | Not planned for current web. | Supported from Browse. | Supported. |
-| Multi-select dock (name + count + save) | Not planned for current web. | Supported. | Supported. |
+| Add several stations to Favorites | Not planned for current web. | Supported (Favorites "+" target). | Planned. |
+| Multi-select selection bar (name + count + save) | Not planned for current web. | Supported (top, under the search field). | Supported. |
 | Sort controls | Supported. | Reference native behavior. | Supported for name, quality, and favorite-state sorting. |
 | Alphabet sort cycle (off/A–Z/Z–A) in the sort row | Supported. | Reference native behavior. | Supported. |
-| Quality / favorite-state sort | Supported. | Supported in the sort model. | Supported. |
+| Quality / favorite-state sort | Supported. | In the sort model; not exposed by the Browse sort row's single control. | Supported. |
+| Stream-quality meter on Browse rows | Supported. | Hidden in Browse (reachable from the info preview). | Per platform. |
 | Featured-first catalog ordering | Supported. | Supported. | Partial. |
 | Result-count label | Supported. | Supported. | Supported. |
 | Visible-window paging (load more) | Supported. | Supported (25-row pages). | Supported. |
@@ -291,9 +402,10 @@ country-row counts are pluralizable.
   Whether those should get dedicated controls in the sort row (and whether all
   platforms expose the same sort set) is unresolved. The matrix records them as
   product-supported behaviors regardless of which control exposes them.
-- The map view exists as a self-contained surface; its exact entry point on iOS
-  (which control opens it) should be confirmed at reconciliation and stated in
-  Entry points.
+- The map view is built as a self-contained MapKit surface but has **no entry
+  point wired into Browse on iOS at d241aa9** — no control opens it. Whether the
+  map ships as a Browse affordance (and which control opens it) is an unresolved
+  product decision; until then its interactions are dormant on iOS.
 - Community-result re-ranking against the query (vs. votes-only order) is an
   open product call carried in [search](search.md).
 - No enforced minimum/maximum query length aside from the country-filter
@@ -303,30 +415,39 @@ country-row counts are pluralizable.
 
 iOS source (the only place iOS mechanics are named):
 
-- `rrradio/Views/FeedPages/BrowsePage.swift` — the page: top row, search field
-  (180 ms debounce), sort suppression under query, off-main cancellable filter
-  pipeline, 25-row visible window, 5000-row local cap, load-more, multi-select
-  entry, play/recents.
-- `rrradio/Views/FeedPages/BrowseFiltersSheet.swift` — genre/news/country filter
-  popup, country search, selected-pinned ordering, apply/clear/cancel.
-- `rrradio/Views/FeedPages/BrowseSortRow.swift` — alphabet sort cycle, count
-  label, add-to-list "+".
-- `rrradio/Views/FeedPages/BrowseSelectionDock.swift` — multi-select dock
-  (cancel / name+count / save) and save-enabled rule.
+- `rrradio/Views/FeedPages/BrowsePage.swift` — the page: combined top row,
+  search field (180 ms debounce), discovery gate + chip/count computation,
+  sort suppression under query, off-main cancellable filter pipeline, 25-row
+  visible window, 5000-row local cap, load-more, filter-summary header,
+  back-to-discovery chevron/swipe, multi-select entry (list / create-new /
+  Favorites), play/recents, quality-meter suppression on rows.
+- `rrradio/Views/FeedPages/BrowseFiltersSheet.swift` — genre/news/country/quality
+  filter popup, country search, selected-pinned ordering, live match-count apply
+  gate, clear/cancel, quality meter graphics.
+- `rrradio/Views/FeedPages/BrowseSortRow.swift` — back-to-discovery chevron,
+  alphabet sort cycle, count label, add-to-list "+".
+- `rrradio/Views/FeedPages/BrowseSelectionDock.swift` — top selection bar
+  (cancel / "Adding to <name>" + count / "Add N") and save-enabled rule.
+- `rrradio/Views/FeedPages/BrowseDiscoveryView.swift` — discovery surface: genre
+  / country chips, "Browse all" header + logo rail, Featured highlights rail,
+  count abbreviation (`BrowseDiscoveryFormat`).
 - `rrradio/Views/FeedPages/State/BrowseSelectionState.swift` — selection model
-  (full-Station storage, tap order, save target).
+  (full-Station storage, tap order, list / favorites target).
 - `rrradio/Views/FeedPages/State/RadioBrowserPaginator.swift` — community
-  pagination (50-row pages), `hasMore`, reset.
+  pagination (50-row pages), `hasMore`, reset, short-query country short-circuit.
 - `rrradio/Views/StationMapView.swift` / `rrradio/Views/StationMapData.swift` —
-  map clustering thresholds, country aggregation, pins, country list.
-- `Shared/StationFeed.swift` — `BrowseFilter`, `BrowseSort`, playback-queue
-  source matrix.
+  map clustering thresholds, country aggregation, pins, country list. (Built but
+  not presented from Browse at d241aa9.)
+- `Shared/StationFeed.swift` — `BrowseFilter` (incl. `qualityBuckets`),
+  `BrowseSort`, playback-queue source matrix.
+- `rrradio/Models/StreamQuality.swift` — `StreamQualityBucket`,
+  `streamQualityBucket(forLevel:)`, `streamQualityLevel`.
 - `rrradio/Library/Feeds/BrowseFeed.swift` — feed wiring, `sorted(_:by:)`
   comparators.
 - `rrradio/Search/StationFilters.swift` — `genres` taxonomy + `rbTag`,
-  `availableCountries`, genre matching.
-- `rrradio/Search/CatalogStationSearch.swift` — `matchesBrowseFilters`,
-  `indexedStations` tier orchestration.
+  `availableCountries`, genre matching (text + `\bfunk\b` regex).
+- `rrradio/Search/CatalogStationSearch.swift` — `matchesBrowseFilters`
+  (OR-within / AND-across, quality), `indexedStations` tier orchestration.
 - `rrradio/Models/Catalog.swift` — `browseOrdered` / `orderForBrowse`
   (featured-first) and the load-order ladder.
 
@@ -342,3 +463,9 @@ iOS source (the only place iOS mechanics are named):
 - **`availableIn` fail-open on all-invalid input** silently makes a geo-gated
   Browse row universally available — see
   `rrradio-ios/internal/audit/2026-05-25-ios-code-review-slice11.md` (M2).
+- **Map labels are hardcoded English** — the map's "All countries", "Open
+  <station>", and "<n> stations" strings bypass localization even though an
+  `allCountries` key exists. The map is also a **dead surface** (no Browse entry
+  point) at d241aa9 (slice 17 calls it out as such). Not yet captured in a
+  dedicated audit entry; the intent is full localization + a real entry point
+  (Open questions).

--- a/docs/spec/features/custom-stations.md
+++ b/docs/spec/features/custom-stations.md
@@ -1,9 +1,9 @@
 # Custom Stations Specification
 
 ```yaml
-status: draft
+status: review
 platforms: [web, ios, android]
-reconciled-against: 9336321
+reconciled-against: d241aa9
 ```
 
 ## Purpose
@@ -31,9 +31,10 @@ explicit catalog-submission email.
 Top to bottom, the Add Station surface is a form:
 
 1. **Name field** — single-line text input, placeholder "Name". Auto-capitalizes
-   words.
+   words. Keyboard "next" action moves focus to the Stream URL field.
 2. **Stream URL field** — single-line text input, placeholder "https://". URL
-   keyboard, no autocapitalization, no autocorrect.
+   keyboard, no autocapitalization, no autocorrect. Keyboard "done" action
+   dismisses the keyboard.
 3. **Stream-check status line** — appears only while checking or on failure:
    - Checking: a spinner + "Checking stream..."
    - Failed: the failure reason in red (e.g. "Stream URL must use https://.",
@@ -49,14 +50,15 @@ Top to bottom, the Add Station surface is a form:
      the current form differs from the last save; label flips to "Saved" after a
      successful save.
 5. **"Already in catalog" section** — appears when the entered URL matches one or
-   more published catalog stations. Lists up to 4 matching catalog station rows,
-   each playable and favoritable in place (so the user adds the catalog station
+   more published catalog stations. Lists up to 4 matching catalog station rows
+   (the app's standard station row, rendered full-width inside the form), each
+   playable and favoritable in place (so the user adds the catalog station
    instead of a private duplicate).
 6. **"Send to rrradio.org catalog" section** — appears when the stream check has
    passed and the URL is *not* already in the catalog. A "Send to rrradio.org
-   catalog" button (paperplane icon) with footer: "Opens Mail with a prefilled
-   catalog request. Your configured Mail account sends it; rrradio cannot read
-   your iCloud email address."
+   catalog" button (paperplane icon, full-width label) with footer: "Opens Mail
+   with a prefilled catalog request. Your configured Mail account sends it;
+   rrradio cannot read your iCloud email address."
 7. **"Already added" section** — appears when the URL matches a station already
    in the user's own library (custom / favorites / recents) but no catalog
    match exists. Lists up to 4 matching entries (name + monospaced URL).
@@ -65,6 +67,9 @@ Top to bottom, the Add Station surface is a form:
 9. **"Added stations" section** — the user's existing custom stations. Each row
    shows a local artwork glyph, the station name, the stream host (monospaced),
    an **edit** (pencil) button, and a **delete** (trash) button.
+
+The keyboard dismisses two ways: any scroll drag dismisses it immediately, and a
+tap anywhere outside the fields and controls unfocuses.
 
 ## States
 
@@ -87,13 +92,16 @@ prior async stream check; the label flip to "Saved" is the only saved-state cue.
 |---|---|---|---|
 | Type in Name field | — | Clears the saved-state cue (SAVE re-enables if stream is playable); clears the name-required red highlight once non-empty. | None. |
 | Type in Stream URL field | — | Clears saved-state cue; schedules a debounced stream check (450 ms) and a debounced catalog-duplicate check (200 ms). | Cancels any in-flight check. |
+| Keyboard "next" from Name field | Name field focused | Moves focus to the Stream URL field. | None. |
+| Keyboard "done" from Stream URL field | Stream URL field focused | Dismisses the keyboard. | None. |
+| Scroll-drag / tap outside fields | Keyboard up | Dismisses the keyboard (drag) / unfocuses (tap); child controls win hit-testing, so taps on rows/buttons act normally. | None. |
 | Stream-URL normalization | URL entered without scheme, or with stacked `https://https://…`, or `http://` after `https://` | Field is rewritten to a single canonical `https://host…`. Bare host gets `https://` prepended; a leading `http://` is left as-is (so it later fails the https-only guard with a clear message). | Re-triggers the check after the writeback (adds latency — see Known deviations). |
 | CLEAR | Form has name or URL text | Empties both fields, resets error/highlight/edit-target, sets check state to idle, cancels the in-flight check. | Does **not** stop a running test-stream playback. |
 | Tap test-stream (play) | Stream check passed; not already testing this URL | Plays the entered stream through the main player under a synthetic `custom-test-<uuid>` station id named by the entered name (or "Test station"). | Starts audio; mini-player shows the test station. |
 | Tap test-stream (pause) | The entered URL is the currently-playing test stream | Toggles/stops the test playback. | Stops/pauses audio. |
 | Tap SAVE | Stream check passed and form differs from last save | Builds a `custom-` station (or updates the one being edited) and adds it to the library auto-favorited; replaces any existing copies of that id across player/library; marks the form "Saved". | Persists custom + favorites stores; syncs to iCloud if enabled. |
 | Tap SAVE with empty/blank name | Stream check passed, name blank | Save aborts; the Name placeholder turns red (required-field highlight); no error row. | None. |
-| Tap "Send to rrradio.org catalog" | Stream check passed, URL not a catalog duplicate | Opens the OS Mail composer prefilled to `feedback@rrradio.org` with the station name + canonical URL in the body. Sent only if the user taps Send in Mail. | Hands off to Mail; nothing sent in-app. |
+| Tap "Send to rrradio.org catalog" | Stream check passed, URL not a catalog duplicate | Opens the OS Mail composer prefilled to `support@rrradio.org` with the station name + canonical URL in the body. Sent only if the user taps Send in Mail. | Hands off to Mail; nothing sent in-app. |
 | Tap a play control on an "Already in catalog" row | A catalog match is shown | Plays that catalog station. | Becomes the current station. |
 | Tap favorite on an "Already in catalog" row | A catalog match is shown | Adds that catalog station to favorites (the intended alternative to creating a duplicate). | Persists favorites; iCloud sync if enabled. |
 | Tap edit (pencil) on an Added-stations row | Row is a saved custom station | Loads that station into the form (name + URL), sets the edit target, marks the check state playable **without re-probing**. | Cancels in-flight check. |
@@ -146,8 +154,10 @@ prior async stream check; the label flip to "Saved" is the only saved-state cue.
 - **Save eligibility.** SAVE is enabled only when the check is `playable` and the
   current form (edit-target id + trimmed name + canonical URL) differs from the
   last saved signature; re-pressing without a change is a no-op ("Saved").
-- **Auto-favorite on save.** Saving a custom station inserts it at the top of
-  favorites; custom stations are kept as favorites.
+- **Auto-favorite on save.** Saving a custom station appends it to the end of
+  the custom-stations list and to favorites; custom stations are always kept as
+  favorites (a normalization pass re-adds any custom station missing from
+  favorites).
 - **Optional metadata on build.** The builder also accepts optional homepage
   (must be valid `http`/`https`), 2-letter uppercase country code, and
   comma-separated lowercase tags — validated and rejected with specific messages
@@ -165,7 +175,7 @@ prior async stream check; the label flip to "Saved" is the only saved-state cue.
 - [privacy-data-boundaries](../contracts/privacy-data-boundaries.md) — custom
   stream URLs are private user-entered data: never sent to analytics/telemetry,
   excluded from diagnostics export, and leave the device only via the user's own
-  iCloud (row 14) or the explicit catalog-submission `mailto:feedback@rrradio.org`
+  iCloud (row 14) or the explicit catalog-submission `mailto:support@rrradio.org`
   (row 13).
 
 ## Edge cases
@@ -299,8 +309,10 @@ iOS source read for this spec:
 
 - `rrradio/Views/AddStationView.swift` — the Add Station form, field validation,
   debounced stream check + catalog-duplicate scan, save/test/clear/edit/delete
-  flows, `StreamCheckState`, `normalizedHTTPSStreamURLString`,
-  `catalogSubmissionMailURL`.
+  flows, keyboard-dismiss (`scrollDismissesKeyboard` + tap-to-unfocus) and
+  next/done submit-label focus order, `StreamCheckState`,
+  `normalizedHTTPSStreamURLString`, `catalogSubmissionMailURL`
+  (→ `mailto:support@rrradio.org`).
 - `rrradio/Library/StreamProbe.swift` — `probeStreamURL` (ranged HEAD-like probe,
   3-redirect cap, 8 s timeout), `responseLooksLikeAudioStream` (ICY +
   content-type allow-list), `isPublicHTTPSStreamURL` and the SSRF/DNS-rebind
@@ -315,6 +327,9 @@ iOS source read for this spec:
 - `rrradio/Library/Library.swift` — `addCustom` (auto-favorite, replace copies),
   `removeCustom` (purge from custom/favorites/recents/lists),
   `replaceStationEverywhere`, `customStations`, `isCustom`.
+- `rrradio/Player/AudioPlayer.swift` — `replaceStationEverywhere` (swaps the
+  saved station into the live player/queue) and `removeStationFromActiveQueue`
+  (pulls a deleted custom station from the active queue).
 - `rrradio/Views/SettingsView.swift` — the Settings tab strip hosting the
   `AddStationContentView` "Add Station" tab.
 
@@ -341,8 +356,8 @@ Shipped iOS code that diverges from the intent above is tracked in
   station sets the check state to `playable` unconditionally, so a stream that
   has since gone offline can be re-saved without a fresh reachability warning.
   (`internal/audit/2026-05-25-ios-code-review-slice22.md` §AS7)
-- **AS2 — catalog-submission `mailto:` (RESOLVED at `9336321`).** The submission
-  destination previously hardcoded a developer-personal Gmail address; migrated
-  to `feedback@rrradio.org`. Intent is the first-party inbox (see
+- **AS2 — catalog-submission `mailto:` (RESOLVED).** The submission destination
+  previously hardcoded a developer-personal Gmail address; migrated to the
+  first-party inbox `support@rrradio.org`. Intent is the first-party inbox (see
   [privacy-data-boundaries](../contracts/privacy-data-boundaries.md) row 13).
   (`internal/audit/2026-05-25-ios-code-review-slice22.md` §AS2)

--- a/docs/spec/features/favorites.md
+++ b/docs/spec/features/favorites.md
@@ -1,9 +1,9 @@
 # Favorites Specification
 
 ```yaml
-status: draft
+status: review
 platforms: [web, ios, android]
-reconciled-against: 9336321
+reconciled-against: d241aa9
 ```
 
 ## Purpose
@@ -93,9 +93,9 @@ Three presentations, switchable in place (no teardown):
 | Tap a row / tile / icon | Not in delete mode | Plays the station with a **favorites** queue (catalog-fallback search uses a **browse** queue). | Pushes a recent (catalog stations only); selection haptic on reorder commits elsewhere. |
 | Tap a row / tile / icon | In delete mode | Exits delete mode (no play). | — |
 | Tap heart on a row (list, where shown) | Station is favorite | Removes from favorites. For a **custom** station, deletes the custom station from the library. | Persists; row animates out. |
-| Tap heart on a row | Station not favorite | Adds to favorites at the top. | Persists. |
-| Long-press a row / tile / icon (~0.36 s) | List/tiles: long-press also drives the info preview; any mode | Enters **delete mode**: app icons jiggle, minus badges appear on every cell; the chrome trash toggle engages. | Snappy 0.16 s animation. |
-| Tap a minus badge | In delete mode | Removes that favorite (custom station deleted; see above). | Persists; cell animates out. |
+| Tap heart on a row | Station not favorite | Adds to favorites at the **tail** (end of the page). | Persists. |
+| Long-press a row / tile / icon (~0.35 s) | Any mode; in **list** mode a ~0.36 s hold also drives the info preview | Enters **delete mode**: app icons jiggle, minus badges appear on every cell; the chrome trash toggle engages. | Snappy 0.16 s animation. |
+| Tap a minus badge | In delete mode | Removes that favorite (custom station deleted; see above). | Persists; cell animates out; an **undo toast** offers to restore the station to its original index across every store the removal touched. |
 | Drag a cell onto another | Not searching, not in catalog-fallback, ≥1 favorite | Reorders favorites; the dragged cell moves through the grid, throttled so fine adjustments pass but the array isn't thrashed. | New order persisted on drop; selection haptic. |
 | Release a long-press without moving | In delete mode | Stays in delete mode (lets the user tap a minus or drag) — matches iPhone Home. | — |
 | Tap empty background | In delete mode | Exits delete mode. | — |
@@ -112,16 +112,25 @@ Three presentations, switchable in place (no teardown):
 
 ## Business rules
 
-- **Add at top.** A newly favorited station is inserted at index 0; re-adding an
-  existing favorite only refreshes its stored snapshot in place.
+- **Add at tail.** A newly favorited station is appended to the end of the list;
+  re-adding an existing favorite only refreshes its stored snapshot in place (no
+  re-order). This mirrors the sync-merge "extras trail the authoritative order"
+  rule — local-only and re-asserted custom favorites both land at the tail.
 - **Stable user order.** Favorites keep a user-defined order; reorder rewrites it and
   persists immediately. Reorder is disabled while searching or showing the catalog
   fallback.
 - **Custom stations are always favorites.** Creating a custom station adds it to
-  favorites; on load the library re-asserts that every custom station is present in
-  favorites. Un-favoriting a custom station **deletes** the custom station (and
-  removes it from recents and all lists). Un-favoriting a catalog station only
-  removes the favorite — it never deletes anything else.
+  favorites (at the tail); on load — and after a cloud-sync apply — the library
+  re-asserts that every custom station is present in favorites, appending any
+  missing ones at the tail. Un-favoriting a custom station **deletes** the custom
+  station (and removes it from recents and all lists). Un-favoriting a catalog
+  station only removes the favorite — it never deletes anything else.
+- **Removal is undoable.** Removing a favorite via the minus badge (and removing a
+  recent) records a removal snapshot and surfaces an undo toast; undo re-inserts the
+  station at the **exact index** it held in every store the removal cleared
+  (favorites, recents, custom stations, and any lists for a cascaded custom-station
+  delete). Indices are clamped and any store that re-acquired the station in the
+  meantime is skipped.
 - **Favorites as playback queue.** Playing from Favorites builds a queue with source
   `favorites`; previous/next then step through the favorites order (circular). The
   catalog-fallback search path uses a `browse` queue so skip walks the catalog
@@ -133,8 +142,10 @@ Three presentations, switchable in place (no teardown):
 - **Recents cap.** iOS keeps the most recent **12** stations; older entries fall off
   the tail. (Web/Android cap and any time-window dedupe are governed by their own
   storage — see Open questions.)
-- **Recents are read-only.** No reorder, no swipe-delete; the library trims its own
-  tail.
+- **Recents has no reorder.** The library trims its own tail, so order is not
+  user-mutable. Recents *does* support removal: a per-row delete (delete-mode minus
+  badge, with undo) plus a "delete all" affordance clear individual entries or the
+  whole list. Removing a recent persists locally only (recents are non-syncable).
 - **Now-playing metadata** for list/tiles polls every **60 s**; the currently-playing
   row prefers the live player snapshot over the poll. App mode never polls.
 - **Display-mode restore** happens before first render; at least one mode is always
@@ -251,11 +262,17 @@ stream-quality message. See [localization](../contracts/localization.md).
 - `rrradio/Views/StationKit.swift` — `FavoritesDisplayMode` (order/visibility/selection
   normalization), `FavoriteJiggleModifier`, delete badge, list row / tile / app-icon
   views, drop delegates.
-- `rrradio/Library/Library.swift` — favorites/recents/custom/list stores: add/remove,
-  `toggleFavorite`, `reorderFavorites`, `pushRecent` / `pushRecentIfCatalogStation`,
-  `recentsLimit = 12`, catalog reconciliation, cloud-sync apply, quarantine-on-decode.
+- `rrradio/Library/Library.swift` — favorites/recents/custom/list stores: add/remove
+  (tail append via `addFavorite` / `toggleFavorite`), `reorderFavorites`,
+  `pushRecent` / `pushRecentIfCatalogStation`, `removeRecent` / `clearRecents`,
+  `removeFavoriteForUndo` / `removeRecentForUndo` / `restore` (undo), `recentsLimit = 12`,
+  `ensureCustomStationsAreFavorites` (tail re-assert), catalog reconciliation,
+  cloud-sync apply, quarantine-on-decode.
+- `rrradio/Views/StationRemovalUndo.swift` — `StationRemovalUndoController`: records a
+  removal and exposes the undo toast that restores the station to its original index.
 - `rrradio/Library/Feeds/FavoritesFeed.swift`, `RecentsFeed.swift` — feed capabilities
-  and queue source bindings.
+  (Favorites: reorder/remove/multi-mode/long-press-info; Recents: remove + long-press
+  info, no reorder) and queue source bindings.
 - `rrradio/Views/FeedPages/LibraryChrome.swift` — display-mode pill, search field,
   delete-mode toggle, title/placeholder per selection.
 - `rrradio/Views/SettingsView.swift` — Favorites display-mode order/visibility config.

--- a/docs/spec/features/first-run-offline.md
+++ b/docs/spec/features/first-run-offline.md
@@ -1,9 +1,9 @@
 # First Run & Offline Specification
 
 ```yaml
-status: draft
+status: review
 platforms: [web, ios, android]
-reconciled-against: 9336321
+reconciled-against: d241aa9
 ```
 
 ## Purpose
@@ -39,8 +39,11 @@ on the worst launch (cold install, airplane mode), not just the best one.
 A full-screen overlay shown over the (already-laid-out) app until the launch
 hand-off completes, top to bottom:
 
-- **App logo** — centered, rounded square, ~96 pt. Decorative (hidden from
-  assistive tech as an element; the group carries the label).
+- **Animated brand mark** — centered, an animated dot-matrix equalizer that
+  spells the `rrr` logo (live-signal motion on a ~4.4 s loop), accent-tinted,
+  ~150 × 99 pt. With Reduce Motion it renders the static fully-formed `rrr`
+  instead of the animation. Decorative (hidden from assistive tech as an
+  element; the group carries the label).
 - **Progress indicator** — indeterminate spinner, accent-tinted.
 - **Status line** — "Tuning…", medium-weight, muted ink.
 - Background uses the resolved theme background; the whole group fades out as
@@ -86,7 +89,7 @@ whatever surface the user was on, with the cached catalog browsable underneath.
 | Launch app (cold, no cache) | First install / cleared cache | Bundled snapshot decodes → catalog `loaded` from bundle; splash held ~1.5 s | Diagnostics `catalog/bundled fallback loaded`; `loadedFromBundle = true`; network refresh attempted |
 | Launch app while offline | No connectivity at launch | Cache or bundled snapshot renders; network step fails; catalog stays `loaded` (or `failed` only if nothing rendered) | Diagnostic `catalog/network failed`; `lastRefreshError` set |
 | Splash hand-off completes | Catalog settled + grace elapsed | Splash crossfades out (0.28 s) revealing the app | `hasCompletedLaunchHandoff = true` |
-| Return to foreground | App becomes active | Foreground refresh fires (catalog `refreshIfStale` + cloud pull), throttled ≥2 s between runs | Diagnostics; catalog refresh skipped if last network refresh < 6 h ago |
+| Return to foreground | App becomes active | Foreground refresh fires (catalog `refreshIfStale` + cloud pull + broken-report receipt sync), throttled ≥2 s between runs | Diagnostics; catalog refresh skipped if last network refresh < 6 h ago; `lastSync` persisted on a successful network refresh |
 | Tap a cached station while offline | Station already in cached catalog | Playback attempt proceeds; a new stream needs network and surfaces a playback error (see [playback](../playback.md)) | — |
 | Connectivity restored | Was offline; a stream had auto-stopped on the drop | If the player armed auto-resume on the drop, the current station reconnects automatically | Auto-resume fires once; offline flags cleared |
 | Connectivity lost mid-stream | Playing | Stream stops; offline phrase shows; player may arm auto-resume-on-restore | `wasOffline = true` |
@@ -100,8 +103,8 @@ whatever surface the user was on, with the cached catalog browsable underneath.
   [catalog-schema load-order ladder](../contracts/catalog-schema.md). This spec
   does not restate decode rules.
 - **Bundled snapshot** is an LZFSE-compressed copy of `stations.json` shipped in
-  the app (~1.4 MB compressed, ~9 MB raw, 17,103 stations at this commit). Used
-  **only** when the disk cache is empty (first install / cold cache).
+  the app (~2.7 MB compressed, ~17.7 MB raw, 24,320 stations at this commit).
+  Used **only** when the disk cache is empty (first install / cold cache).
 - **Network refresh is always attempted** on load, even after cache/bundled
   render. On HTTP 2xx it overwrites cache + in-memory roster; on failure the
   already-rendered roster stays and the catalog remains in a loaded state.
@@ -170,9 +173,10 @@ whatever surface the user was on, with the cached catalog browsable underneath.
 
 ## Accessibility
 
-- **Splash:** the logo/spinner/text are combined into a single accessibility
-  element labeled "Tuning…"; the logo image is individually hidden so assistive
-  tech announces one concise label, not three.
+- **Splash:** the brand mark/spinner/text are combined into a single
+  accessibility element labeled "Tuning…"; the animated brand mark is
+  individually hidden so assistive tech announces one concise label, not three.
+  The animation honors Reduce Motion (static `rrr`, no timeline).
 - **Offline indicator:** the `wifi.slash` glyph is paired with a text phrase
   ("No internet connection" / "Connection required") so the state is not
   color/icon-only; assistive tech reads the phrase.
@@ -187,7 +191,7 @@ whatever surface the user was on, with the cached catalog browsable underneath.
 ## Localization
 
 Strings owned by this surface (source language English; localized to de, es,
-fr):
+fr, it, ru):
 
 | Key | English value | Used by |
 |---|---|---|
@@ -209,7 +213,7 @@ fr):
 | Behavior | Web | iOS | Android |
 |---|---|---|---|
 | Cold launch shows real stations without waiting on network | Runtime/cache dependent | Reference (disk cache → bundled snapshot → network) | Cache-backed load; bundled snapshot is porting work |
-| Bundled catalog snapshot for first-run / cold cache | Not applicable (server-rendered/runtime cache) | Supported (`stations.json.lzfse`, 17,103 stations) | Planned (bundled snapshot porting work) |
+| Bundled catalog snapshot for first-run / cold cache | Not applicable (server-rendered/runtime cache) | Supported (`stations.json.lzfse`, 24,320 stations) | Planned (bundled snapshot porting work) |
 | Persisted disk cache of last network payload | Browser/runtime cache | Supported (Caches dir) | Partial (cache-backed load) |
 | Always-attempt network refresh after first paint, upgrade in place | Supported | Reference | Partial |
 | Branded launch splash with hand-off grace | Not applicable | Supported | Platform-specific |
@@ -240,17 +244,21 @@ fr):
 
 iOS source read for this spec:
 
-- `rrradio/App.swift` — `AppRootView` launch hand-off (`launchHandoff` task,
-  `showsCatalogSplash`, `completeLaunchHandoff` grace selection on
-  `catalog.loadedFromBundle`), `ForegroundRefreshCoordinator` (2 s throttle),
-  scene-phase foreground refresh, `handleNetworkChange` auto-resume-on-restore.
+- `rrradio/App.swift` — `AppRootView` launch hand-off (`.task` running
+  `catalog.loadIfNeeded` then `completeLaunchHandoff`, `showsCatalogSplash`,
+  grace selection on `catalog.loadedFromBundle`), `ForegroundRefreshCoordinator`
+  (2 s throttle), scene-phase foreground refresh (catalog + cloud + broken-report
+  receipts), `handleNetworkChange` auto-resume-on-restore.
 - `rrradio/Models/Catalog.swift` — `load(force:)` ladder (disk cache → bundled
   `stations.json.lzfse` → network), `readCache`, `readBundledFallback`,
   `loadBundledStations`/`decompressLZFSE`, `refreshIfStale` (6 h interval),
-  `lastRefreshError`, `loadedFromBundle`, atomic decode, no-op-refresh skip,
-  search-index validation scheduling.
+  `lastRefreshError`, `loadedFromBundle`, `lastSync` (persisted last successful
+  sync), atomic decode, no-op-refresh skip, search-index validation scheduling.
 - `rrradio/Views/CatalogLoadingSplash.swift` — splash layout, "Tuning…" label,
-  combined accessibility element.
+  combined accessibility element, theme-background fill.
+- `rrradio/Views/DotMatrixLogoView.swift` — the animated dot-matrix `rrr` brand
+  mark on the splash (30 Hz `Canvas`, ~4.4 s seeded loop; static `rrr` under
+  Reduce Motion).
 - `rrradio/NetworkMonitor.swift` — `NetworkSnapshot` (`isOffline`, `shortPhrase`,
   `detailPhrase`), the connectivity `Phrase` set, `NWPathMonitor` wiring.
 - `rrradio/Views/MiniPlayerView.swift`, `rrradio/Views/NowPlayingView.swift` —

--- a/docs/spec/features/listening-history.md
+++ b/docs/spec/features/listening-history.md
@@ -1,8 +1,8 @@
 # Listening History Specification
 ```yaml
-status: draft
+status: review
 platforms: [web, ios, android]
-reconciled-against: 9336321
+reconciled-against: d241aa9
 ```
 
 ## Purpose
@@ -10,11 +10,14 @@ reconciled-against: 9336321
 Listening History gives the user a private, on-device record of what they
 actually listened to — which stations, for how long, from which countries, and
 (optionally) which tracks — surfaced as a personal stats dashboard: top stations,
-a "most listened" animated race chart, minutes-by-day bars, country totals, and
-recent tracks. It is opt-in, local-only, never synced and never sent anywhere,
-and exportable as CSV. It is distinct from the community **Stats / Dashboard**
-sheet, which shows aggregate *catalog-wide* listener/station numbers fetched from
-the rrradio Worker.
+a "most listened" animated race chart, minutes-by-day bars, country totals,
+recent sessions, and recent tracks. It is opt-in, on-device, never sent to any
+analytics endpoint, and exportable as CSV. Its records are kept locally and
+(iOS, when iCloud sync is on) mirrored to the user's *own* private iCloud so the
+history follows them across their devices — the data never leaves the user's
+control. It is distinct from the community **Stats / Dashboard** sheet, which
+shows aggregate *catalog-wide* listener/station numbers fetched from the rrradio
+Worker.
 
 This spec covers the user's **personal** listening history. The community Stats
 sheet is described under [Preferences and diagnostics](preferences-diagnostics.md)
@@ -23,69 +26,90 @@ rows 2–3.
 
 ## Entry points
 
-- **Settings → Listening tab.** Settings sheet has a horizontal tab strip
-  (Settings · About · Add station · Listening); the Listening tab is the history
-  dashboard. Reachable by tapping the tab or horizontal swipe.
-- **Settings → Settings tab → "Listening history" section.** Holds the master
-  toggle, and when on: an "Open Listening dashboard" link (jumps to the Listening
-  tab), the granularity rows, and the retention rows.
-- The dashboard surface is never reached if the feature is off — it instead shows
-  an enable prompt.
+- **Settings → History tab.** Settings sheet has a horizontal tab strip; the
+  History tab is the history dashboard. Reachable by tapping the tab or
+  horizontal page-swipe.
+- **Settings → Settings tab → "Listening history" section.** Holds the
+  tracking control (a single tri-state: Off / Stations / + Tracks), and when on:
+  an "Open History" link (jumps to the History tab) and the retention row.
+- The dashboard surface is always reachable; when the feature is off it shows an
+  enable card instead of the dashboard.
 
 ## Layout
 
-Listening dashboard (Listening tab), top to bottom:
+Listening dashboard (History tab), top to bottom:
 
 - **Title** "Listening history" with subtitle "Stored on your phone only".
 - **Send/export button** (envelope icon), top-right. Opens a mail composer with a
   CSV attachment, or a share sheet if mail is unavailable.
 - **Range segmented control**: `7 days` · `30 days` · `All`. Default `30 days`.
-- **When enabled, with data in range:**
+- **When enabled, with sessions in range:**
   - **Stat tiles row** (three): `Time` (total listening, e.g. `3h 12m`),
     `Sessions` (count), `Stations` (distinct count).
   - **"Most listened" section** — the animated race chart (see below).
-  - **"Minutes by day" section** — vertical day bars across the range, with first
-    and last day labels.
-  - **"Countries" section** — rows of country + session count (`12x`) + total
+  - **"Minutes by day" section** — bar chart across the range (see below).
+  - **"Countries" section** — rows of country code + session count (`12x`) + total
     duration.
+  - **"Recent sessions" section** — only when at least one qualifying session
+    exists; rows of station name + when it started (`Jun 5, 18:52`) + that
+    session's duration. Newest first.
   - **"Recent tracks" section** — only when granularity is Stations + tracks and
     tracks exist; rows of `Artist - Title` + station name + last-played date.
   - **"Clear listening history" button** (destructive, trash icon).
-- **When enabled, no data in range:** an empty card "No listening sessions in this
-  range yet." plus the Clear button.
+- **When enabled, no sessions in range:** an empty card "No listening sessions in
+  this range yet." plus the Clear button. (A loading card — spinner +
+  "Loading…" — shows briefly while the aggregation computes the first frame.)
 - **When disabled:** an enable card (icon, "Listening history is off", explanatory
-  detail, "Enable" button). No dashboard, no clear.
+  detail, "Enable" button). No dashboard sections, no clear. The title, subtitle,
+  export button, and range control still render above it.
 
 Race chart (`Most listened`):
 
 - Header row: first-snapshot date, **Play/Pause** pill, last-snapshot date.
 - **Scrubber slider** spanning all daily snapshots (a flat line when only one).
 - Center label: the currently displayed snapshot date.
-- **Ranked bars 1–10**: rank number, station favicon, a horizontal bar whose width
-  is the station's cumulative share, station name + country flag + share %, and a
-  trailing cumulative-minutes value. Empty ranks render as blank rows so the chart
-  height is stable at 10 rows.
+- **Ranked bars** (up to 10): rank number, station favicon, a horizontal bar whose
+  width is proportional to that station's cumulative seconds vs the leader, station
+  name + country flag, and a trailing cumulative-minutes value (`12m`). Each station
+  keeps one stable colour for the whole race; the rank-1 station carries a small
+  crown badge on its favicon.
+- Row count is the deepest any snapshot ever reaches, capped at 10 — short
+  histories don't pad out empty rows.
 
-Settings → Listening history section (when enabled):
+"Minutes by day" chart:
 
-- **"Listening history" toggle** ("Record what you listen to" detail) — master
-  opt-in.
-- **"Open Listening dashboard"** link.
-- **Granularity rows** (single-select): "Stations only" (station, country, start
-  time, duration) · "Stations + tracks" (also artist + title when published).
-- **Retention rows** (single-select): `30 days` · `90 days` · `1 year` · `Forever`.
+- **Readout line** (top): the active bucket's date (or week range) and its total
+  duration; a "Peak day" badge marks the busiest bucket. With no bucket active it
+  shows the empty-range message.
+- **Bars**: one bar per calendar day for short ranges; above ~7 weeks it groups
+  into one bar per ISO week. The peak bucket is fully accented; the selected bucket
+  is outlined; zero-listening buckets render as a muted stub.
+- **First/last labels** under the bars mark the window's start and end.
+
+Settings → Listening history section:
+
+- **Tracking control** — one tri-state capsule group: `Off` · `Stations` ·
+  `+ Tracks`, with a one-line detail describing the current choice. This single
+  control replaces the former master toggle plus granularity rows; `Off` disables
+  recording, `Stations` records station/country/time/duration, `+ Tracks` also
+  records artist + title when published.
+- **When enabled** (a grouped panel below the control):
+  - **"Open History"** link ("Review your local listening stats.") — jumps to the
+    History tab.
+  - **"Keep history" retention dropdown** — a menu of `30 days` · `90 days` ·
+    `1 year` · `Forever`, with a detail line that changes for Forever.
 
 ## States
 
 | State | What shows | Actionable |
 |---|---|---|
-| Disabled | Enable card | "Enable" button; range control + export are present but yield empty/no data |
+| Disabled | Title/subtitle, export button, range control, then the Enable card | "Enable" button; export still works (CSV from any records on disk); range control inert |
 | Enabled, loading | Loading card ("Loading…") with spinner | Range control |
-| Enabled, empty (no sessions in range) | Empty card; zeroed implied | Range control, export (empty CSV header only), Clear |
-| Enabled, loaded | Full dashboard (tiles, race, day bars, countries, optional tracks) | Range control, race play/scrub, export, Clear |
+| Enabled, empty (no sessions in range) | Empty card "No listening sessions in this range yet." | Range control, export, Clear |
+| Enabled, loaded | Stat tiles + sections (race, minutes-by-day, countries, recent sessions, optional tracks) | Range control, race play/scrub, day-bar tap, export, Clear |
 | Race: no snapshots in range | "No listening history in this range." inside the section | Range control |
-| Offline | Fully functional — all data is local; no network needed | Everything (export/share use OS apps) |
-| Error | No error state: persistence failures are recorded as a local diagnostic and surface as missing/empty data, not an error screen | — |
+| Offline | Fully functional — all data is local; no network needed | Everything (export/share use OS apps; favicon back-fill skips the network leg) |
+| Error | No error state: persistence/back-fill failures are recorded as a local diagnostic and surface as missing/empty data, not an error screen | — |
 
 The dashboard recomputes (shows loading, then loaded) whenever the range, the
 record count, the enabled flag, or the granularity changes.
@@ -94,27 +118,30 @@ record count, the enabled flag, or the granularity changes.
 
 | Control / gesture | Precondition | Result | Side effects |
 |---|---|---|---|
-| Tap Listening tab / swipe to it | Settings open | Shows the dashboard or enable card | Triggers an aggregation pass |
-| Tap "Enable" (disabled card) | Disabled | Enables history; dashboard appears (empty until sessions accrue) | Persists opt-in; marks preferences dirty for sync; closes any active session if just disabled |
-| Toggle "Listening history" off (Settings) | Enabled | Disables recording | Closes the active session immediately at now; marks preferences dirty |
-| Tap "Open Listening dashboard" | Enabled | Switches Settings to the Listening tab | — |
-| Tap a granularity row | Enabled | Sets Stations-only or Stations+tracks | Switching to Stations-only **strips** all stored artist/title from existing records and re-saves; marks preferences dirty |
-| Tap a retention row | Enabled | Sets 30d / 90d / 1y / Forever | Immediately prunes closed records older than the window; re-saves; marks preferences dirty |
-| Change range control | Always | Re-scopes tiles/race/day-bars/countries/tracks to 7d / 30d / All | Recomputes aggregation off the main thread |
-| Race Play | ≥2 snapshots | Animates rank bars from first to last day; if at end, restarts from day 0 | Periodic advance (~80ms tick) |
-| Race Pause | Playing | Freezes at current snapshot | Cancels the advance task |
+| Tap History tab / page-swipe to it | Settings open | Shows the dashboard or enable card | Triggers an aggregation pass and a station-artwork back-fill |
+| Tap "Enable" (disabled card) | Disabled | Enables history; dashboard appears (empty until sessions accrue) | Persists opt-in; marks preferences dirty for sync |
+| Set tracking control to `Off` (Settings) | Enabled | Disables recording | Closes the active session immediately at now; marks preferences dirty |
+| Set tracking control to `Stations` | Any | Enables history at Stations-only | Switching down from + Tracks **strips** all stored artist/title from existing records and re-saves; marks preferences dirty |
+| Set tracking control to `+ Tracks` | Any | Enables history at Stations + tracks | Marks preferences dirty |
+| Tap "Open History" | Enabled | Switches Settings to the History tab | — |
+| Pick a retention value (dropdown) | Enabled | Sets 30d / 90d / 1y / Forever | Immediately prunes closed records older than the window; re-saves; marks preferences dirty |
+| Change range control | Always | Re-scopes tiles/race/day-bars/countries/sessions/tracks to 7d / 30d / All | Recomputes aggregation off the main thread |
+| Race Play | ≥2 snapshots | Smoothly animates standings from first to last day, easing between snapshots; if at the end, restarts from day 0 | ~60 fps advance; total run scales with snapshot count, clamped to 14–36s |
+| Race Pause | Playing | Freezes at current position | Cancels the advance task |
 | Drag race scrubber | ≥2 snapshots | Jumps to that day's snapshot | Stops any running playback |
+| Tap a day/week bar | ≥1 bar | Selects that bucket; readout shows its date (or week range) and total; tapping again deselects | — |
 | Tap envelope (Send) | Always | Mail composer with CSV attachment, or share sheet if mail unavailable | Builds CSV from **all** records (ignores range), newest-first |
 | Send mail / Share | Composer/sheet open | User-initiated CSV leaves device only if they Send/Share | CSV attachment named `rrradio-listening-history-<YYYY-MM-DD>.csv` |
 | Tap "Clear listening history" | Enabled | Confirmation dialog | — |
-| Confirm Clear | Dialog shown | Deletes **all** records (every range) | Clears active session; re-saves empty file |
+| Confirm Clear | Dialog shown | Deletes **all** records (every range) | Clears active session; re-saves empty file; signals sync (empties the shared iCloud blob) |
 | Start playing a station | History enabled | Opens a new session for that station | Closes any prior open session at now; appended record persisted |
 | Resume same station | Open session, same station | Keeps the session; refreshes the lifecycle timestamp | No new record |
-| Resume a different station / play new station | Enabled | Closes prior session, opens a new one | — |
-| Pause / stop playback | Open session | Closes the session at now; computes duration | Prunes if under 5s; persists |
-| New track metadata arrives | Enabled, Stations+tracks, open session | Stores latest artist/title on the open session | Persisted only when artist/title actually change |
-| App backgrounded while playing | Open session | Session stays open; a 30s heartbeat keeps the lifecycle timestamp fresh | — |
-| App relaunch with an open (crashed/killed) session | On launch | The stale open session is closed at the last-known lifecycle timestamp (or session start if none) | Pruned if under 5s; retention applied; persisted |
+| Resume a different station / play new station | Enabled | Closes prior session, opens a new one | Closing the prior session signals sync |
+| Pause / stop playback | Open session | Closes the session at now; computes duration | Prunes if under 5s; persists; signals sync |
+| New track metadata arrives | Enabled, + Tracks, open session | Stores latest artist/title on the open session | Persisted only when artist/title actually change |
+| App backgrounded while playing | Open session | Session stays open; a ~30s heartbeat refreshes the lifecycle timestamp **and persists the open record's elapsed duration** | — |
+| App relaunch with an open (crashed/killed) session | On launch | The stale open session is closed at the furthest-reaching of its last-persisted progress and the lifecycle timestamp, clamped to launch | Pruned if under 5s; retention applied; persisted |
+| iCloud sync delivers another device's sessions | iCloud sync on | Closed sessions from other devices are unioned into the local store | Additive only (never deletes local); de-duped; records older than retention skipped; no push echoed back |
 
 ## Business rules
 
@@ -127,31 +154,58 @@ record count, the enabled flag, or the granularity changes.
   duration in aggregation = `now − startedAt`.
 - **Granularity.**
   - Stations-only stores: station id, station name, country, start time, end time,
-    duration.
-  - Stations+tracks additionally stores the latest artist/title published while
+    duration, and (for display + merging) the station's favicon and stream URL
+    captured at play time.
+  - Stations + tracks additionally stores the latest artist/title published while
     that session was open (one pair per session — last write wins).
   - Switching to Stations-only erases artist/title from history retroactively.
+- **Station merging.** For all dashboard aggregates (top stations, station count,
+  countries, race chart), catalog duplicates of one broadcaster are merged:
+  records group by case/diacritic-folded station name + country, and any groups
+  that share a stream URL are further unioned into one station. Merging only ever
+  combines, never splits — a missing or odd stream URL can't fragment a group. The
+  merged row's favicon and concrete station id come from its most-listened variant.
+- **Artwork back-fill.** Records that predate the stored favicon/stream-URL fields
+  are back-filled on demand from local sources (catalog + favorites/recents/custom)
+  first, then a bounded one-shot Radio Browser re-fetch for aged-out `rb-…`
+  stations. Back-fill only fills nil values (never overwrites) and converges.
 - **Retention** prunes *closed* records whose start is older than the window
   (30 / 90 / 365 days); Forever = no time prune. Open sessions are never pruned by
   retention. Default retention: **90 days**. Pruning runs on session start, session
   close, retention change, and launch.
 - **Top stations:** ranked by total seconds desc, tie-break by case/diacritic-folded
-  station name then id; top **12** kept in the summary.
+  merged station name then id; top **12** kept in the summary.
 - **Top countries:** ranked by total seconds desc, tie-break by country code; top
   **8** kept. Missing country normalizes to `??`. Country codes uppercased.
+- **Recent sessions** (visible dashboard section): newest **20** sessions whose
+  duration is **≥60s**, so a few-second channel-surf doesn't bury the sessions the
+  user sat through. The ≥60s filter applies only to this list — every aggregate
+  (tiles, race, day bars, countries) still counts all sessions ≥5s.
 - **Recent tracks:** newest **20**, only sessions that carry a track title.
-- **Recent sessions:** newest **12** (in the summary model).
 - **Race chart:** one cumulative snapshot per calendar day in range, top **10**
   stations per snapshot, capped to the most recent **366** days; pre-window days
   fold their totals into the starting baseline so cumulative shares stay correct.
-  Share = station seconds ÷ all-station seconds that day.
+  Bar length is the station's seconds ÷ the leader's seconds that day.
 - **Day bars:** one bar per calendar day across the range, capped to **366** days;
-  empty days render a 3pt stub.
+  empty days render a small stub. Above ~7 weeks (49 days) of buckets the chart
+  groups into one bar per ISO week. The busiest bucket is flagged as the peak.
 - **Day boundaries** use the user's local Gregorian calendar (what the user calls
   "today").
-- **Lifecycle heartbeat:** a 30-second periodic observer refreshes the last-known
-  lifecycle timestamp while audio plays, so a crash recovery can close the session
-  near where playback actually stopped.
+- **Duration formatting** is compact and scales: `m` under an hour, `Hh Mm` under a
+  day, and `Dd Hh` once a total crosses 24h (so cumulative totals stay legible).
+  Per-session durations under a minute render as whole seconds (`42s`).
+- **Lifecycle heartbeat:** a ~30-second periodic observer (while audio plays, and
+  on scene transitions) refreshes the last-known lifecycle timestamp **and persists
+  the open record's elapsed duration** (monotonic, `endedAt` stays nil), so a crash
+  recovery can close the session near where playback actually stopped and an
+  app-kill loses at most one tick.
+- **Cross-device sync (iOS, iCloud on).** Closed sessions sync to the user's own
+  private iCloud as one shared blob; merges are an additive union keyed by
+  `station id + whole-second start` (local wins on a key collision). Open sessions
+  are never shared. The upload is bounded — within the retention window, newest
+  **2000** sessions, trimmed oldest-first to stay under the per-record byte cap —
+  while local storage keeps everything. Records are **excluded from the
+  backup/export file**. See [sync-merge](../contracts/sync-merge.md).
 - **Export** serializes every record (CSV header `id, station_id, station_name,
   country, started_at, ended_at, duration_seconds, track_artist, track_title`),
   sorted newest-first, ISO-8601 timestamps, integer seconds.
@@ -159,20 +213,25 @@ record count, the enabled flag, or the granularity changes.
 ## Data dependencies
 
 - [privacy-data-boundaries](../contracts/privacy-data-boundaries.md) — listening
-  history is the local, opt-in, never-auto-uploaded store (matrix "Listening
-  history" row; boundary rule 2). The CSV export (row 13-style user-initiated
-  hand-off) leaves the device only on explicit Send/Share. Track titles/artists
-  in history never reach any counting endpoint.
-- [sync-merge](../contracts/sync-merge.md) — history **records are excluded from
-  the sync snapshot entirely** (never synced, enforced structurally). Only the
-  three *preference* fields sync: `listeningHistoryEnabled`,
-  `listeningHistoryLevel`, `listeningHistoryRetention`.
+  history is the local, opt-in store; it is never sent to any analytics endpoint.
+  The CSV export leaves the device only on explicit Send/Share. Track
+  titles/artists in history never reach any counting endpoint. (iOS additionally
+  mirrors closed records to the user's *own* private iCloud when sync is on — see
+  below.)
+- [sync-merge](../contracts/sync-merge.md) — on iOS with iCloud sync on, **closed**
+  history records DO sync, as one shared blob, union-merged across the user's
+  devices and bounded for upload; open sessions never sync, and the records are
+  excluded from the exported backup file. The three *preference* fields
+  (`listeningHistoryEnabled`, `listeningHistoryLevel`, `listeningHistoryRetention`)
+  sync separately as preferences.
 
 ## Edge cases
 
 - **Crash / force-quit with an open session.** On next launch the open record is
-  closed at `min(last-known-lifecycle-timestamp, launch)`, floored at session
-  start; then pruned if under 5s. No phantom multi-day session.
+  closed at the later of its last-persisted progress (heartbeat-written elapsed
+  duration) and the global lifecycle timestamp, clamped to launch and floored at
+  session start; then pruned if under 5s. The progress floor means a long session
+  survives even if the heartbeat went stale. No phantom multi-day session.
 - **Clock skew / `endedAt < startedAt`.** Duration clamps to 0 → pruned by the 5s
   rule.
 - **Corrupt history file.** On decode failure the file is quarantined to
@@ -191,8 +250,17 @@ record count, the enabled flag, or the granularity changes.
 - **Old on-disk layout (newest-first).** Sorted ascending on read; self-heals on
   next save.
 - **Cloud sync flips a history preference remotely.** Applied without re-triggering
-  a local sync push (avoids a feedback loop); records themselves never arrive over
-  sync.
+  a local sync push (avoids a feedback loop).
+- **Cloud sync delivers records from another device.** Closed sessions are unioned
+  additively into the local store (never deleting a local record), de-duped by
+  `station id + whole-second start`, and any older than the local retention window
+  are skipped. The resulting save is suppressed from echoing a push back out, so
+  repeated syncs converge without duplicates or churn. A missing or undecodable
+  remote blob is treated as "no remote sessions", not a wipe.
+- **Missing station artwork on old records.** Records written before favicon/stream
+  fields existed render with initials until back-fill resolves a logo; the Radio
+  Browser re-fetch is attempted once per station id per session, so a failure
+  doesn't hammer the mirrors.
 
 ## Accessibility
 
@@ -203,17 +271,20 @@ record count, the enabled flag, or the granularity changes.
 - Dynamic Type: tile and metric values use minimum-scale-factor down-scaling
   (~0.75) and single-line clamping so large text stays legible without truncation
   loss; titles down-scale to ~0.82.
-- Day bars and race bars are decorative-over-text; the numeric values
-  (minutes/percent) accompany each bar so meaning does not rely on bar length
-  alone.
-- Race Play/Pause is a labeled control; scrubbing is a standard slider.
+- Day/week bars are decorative-over-text; each bar is an accessibility element
+  labeled with its date and duration, and the numeric total accompanies the chart
+  readout so meaning never relies on bar length alone. Race bars likewise carry a
+  trailing minutes value.
+- Race Play/Pause is a labeled control; scrubbing is a standard slider. The rank-1
+  crown is decorative (rank is conveyed by row order and the leading rank number).
 
 ## Localization
 
-This surface owns:
+The **dashboard surface** is fully localized and owns:
 
 - Section/title strings: "Listening history", "Stored on your phone only",
-  "Most listened", "Minutes by day", "Countries", "Recent tracks".
+  "Most listened", "Minutes by day", "Countries", "Recent sessions",
+  "Recent tracks", "Peak day".
 - Stat tile labels: "Time", "Sessions", "Stations".
 - Range labels: "7 days", "30 days", "All".
 - Enable/disabled card: "Listening history is off" + enable detail + "Enable".
@@ -225,19 +296,19 @@ This surface owns:
   body message, "Share listening history", "Export history", send-history a11y
   label.
 - Race controls: "Play", "Pause".
-- Settings rows: "Record what you listen to" + detail; "Stations only" /
-  "Stations + tracks" + details; retention titles/details.
+- Tab label: "History".
 
 Parameter/plural needs:
 
 - Mail subject takes a `date` parameter.
-- Retention detail interpolates the window phrase ("Keep local history for …").
-- Country rows show a session multiplier (`12x`) and durations (`3h 12m`, `45m`) —
-  duration formatting needs hour/minute composition; consider plural forms per
-  locale.
-- Several Settings strings (dashboard link, granularity rows, retention phrasing)
-  are currently hard-coded English literals (see Open questions / Known
-  deviations).
+- Country rows show a session multiplier (`12x`) and durations (`3h 12m`, `45m`,
+  `2d 3h`) — duration formatting composes seconds/minutes/hours/days; consider
+  plural forms per locale.
+- The **Settings listening-history section** strings are **not yet localized** —
+  the tri-state labels ("Off", "Stations", "+ Tracks") and their detail lines,
+  "Open History" + "Review your local listening stats.", "Keep history" + its
+  detail lines, and the retention menu titles ("30 days" / "90 days" / "1 year" /
+  "Forever") are hard-coded English literals (see Open questions).
 
 ## Platform Matrix
 
@@ -250,12 +321,15 @@ Parameter/plural needs:
 | Retention windows (30d/90d/1y/Forever) | Planned | Supported | Planned |
 | Range scope (7d/30d/All) | Planned | Supported | Planned |
 | Top stations / countries / recent tracks | Planned | Supported | Planned |
+| Recent sessions list (≥60s, newest 20) | Planned | Supported | Planned |
+| Station merge by name+country / stream URL | Planned | Supported | Planned |
 | Race chart (animated, 366-day cap) | Planned | Supported | Planned |
-| Minutes-by-day bars | Planned | Supported | Planned |
+| Minutes-by-day bars (weekly grouping, peak, tap-select) | Planned | Supported | Planned |
 | CSV export (mail / share) | Supported (export per [data-sync.md](../data-sync.md)) | Supported | Planned |
-| Records excluded from cloud sync | n/a (local-only) | Supported | n/a (local-only) |
+| Closed records synced to user's own iCloud (bounded, union-merge) | n/a | Supported | n/a |
+| Open sessions never synced; records excluded from backup-export | n/a | Supported | n/a |
 | History preferences synced (3 fields) | Not planned | Supported | Not planned |
-| Never auto-uploaded / no analytics | Supported | Supported | Planned |
+| Never sent to analytics endpoints | Supported | Supported | Planned |
 
 ## Open questions
 
@@ -267,7 +341,16 @@ Parameter/plural needs:
   question 3). Tracked under Known deviations.
 - Should the CSV export honor the selected range instead of always exporting all
   records?
-- Several Settings/dashboard strings are hard-coded English (not localized).
+- The **Settings** listening-history section strings (tri-state labels + details,
+  "Open History", retention row) are still hard-coded English while the dashboard
+  is fully localized — finish localizing the Settings rows.
+- **Privacy boundary wording:** history records now sync to the user's own private
+  iCloud, yet the dashboard subtitle says "Stored on your phone only" and the
+  disabled-card copy says "Nothing is sent to rrradio.org." Both are technically
+  true (the data stays user-owned; nothing reaches rrradio servers) but the
+  "your phone only" phrasing predates cross-device sync — reconcile with
+  [privacy-data-boundaries](../contracts/privacy-data-boundaries.md) Open
+  question 4.
 - Cross-platform: define whether web/Android persist history at all, or only ship
   the export/backup-merge path defined in [data-sync.md](../data-sync.md).
 
@@ -275,29 +358,38 @@ Parameter/plural needs:
 
 iOS source read for this spec:
 
-- `rrradio/Library/ListeningHistory.swift` — record model, session lifecycle
-  (start/resume/close), track update, retention/pruning, crash-recovery close,
-  CSV export, corrupt-file quarantine; `ListeningHistoryAggregation` (summary,
-  race snapshots, scoping, day boundaries, caps).
-- `rrradio/Views/ListeningHistoryView.swift` — the Listening dashboard: range
-  control, stat tiles, sections, day bars, clear flow, mail/share export.
+- `rrradio/Library/ListeningHistory.swift` — record model (incl. favicon/stream
+  fields), session lifecycle (start/resume/close), track update, heartbeat
+  (`tickActiveSession`), retention/pruning, crash-recovery close, artwork
+  back-fill, CSV export, corrupt-file quarantine; `ListeningHistoryAggregation`
+  (summary, race snapshots, station merging, scoping, day boundaries, caps);
+  `ListeningHistorySyncCoding` (cross-device dedup/encoding).
+- `rrradio/Views/ListeningHistoryView.swift` — the History dashboard
+  (`ListeningHistoryPageView`): range control, stat tiles, sections, recent
+  sessions, mail/share export, artwork back-fill; `MinutesByDayChart` (day/week
+  bars, peak, tap-select); `ListeningDashboardData` (recent-sessions ≥60s filter).
 - `rrradio/Views/ListeningRaceChart.swift` — the animated race chart, play/scrub,
-  interpolation, top-10 rows.
+  eased interpolation, stable per-station colours, crown, up-to-10 rows.
 - `rrradio/Views/DashboardView.swift` — the *community* Stats sheet (Worker
   fetches); referenced to distinguish it from personal history.
-- `rrradio/Views/SettingsView.swift` — Listening tab plumbing, the Settings
-  history section (toggle, dashboard link, granularity, retention).
+- `rrradio/Views/SettingsView.swift` — History tab plumbing, the Settings
+  listening-history section (tri-state tracking control, "Open History" link,
+  retention dropdown).
 - `rrradio/Player/AudioPlayer.swift` — wires play/resume/pause/stop and metadata
-  to session start/resume/close/track-update; 30s lifecycle heartbeat observer.
+  to session start/resume/close/track-update; ~30s lifecycle heartbeat observer.
 - `rrradio/App.swift` — owns the `ListeningHistory` instance; injects it into the
-  player.
+  player; fires `tickActiveSession` on scene transitions.
+- `rrradio/CloudSync/CloudSyncSnapshot.swift`, `CloudSyncController.swift` —
+  cross-device record sync: `syncableRecords`, `mergeSyncedRecords`,
+  `boundingListeningHistoryForUpload`, `ListeningHistorySyncBounds` (issue #58).
 
 ## Known deviations
 
 - **DH5 — privacy-posture inconsistency ("nothing is sent" vs. silent stats
   fetch).** The personal dashboard's "Stored on your phone only" copy sits beside
   the community Stats sheet, which fires silent Worker GETs on open. Personal
-  history genuinely sends nothing; the Stats sheet does. See
+  history sends nothing to rrradio/analytics (its only off-device path is the
+  user's own private iCloud); the Stats sheet hits the developer Worker. See
   `rrradio-ios/internal/audit/2026-05-25-ios-code-review-slice23.md` (DH5) and
   [privacy-data-boundaries](../contracts/privacy-data-boundaries.md) Known
   deviations / Open question 3. The spec states the intended boundary (history is

--- a/docs/spec/features/metadata-artwork.md
+++ b/docs/spec/features/metadata-artwork.md
@@ -1,18 +1,18 @@
 # Metadata And Artwork Specification
 
 ```yaml
-status: draft
+status: review
 platforms: [web, ios, android]
-reconciled-against: 9336321
+reconciled-against: d241aa9
 ```
 
 ## Purpose
 
 Metadata turns a live stream into a useful radio experience: the user sees the
-current artist and title, an album cover (or the station logo when no cover is
-known), the current program and its day schedule for wired broadcasters, lyrics
-when a match is found, and one-tap links to the song on Apple Music / Spotify /
-YouTube Music. The product contract is the catalog's broadcaster metadata fields
+current artist and title, an album cover (or a brand/station placeholder when no
+cover is known), the current program and its day schedule for wired broadcasters,
+lyrics when a match is found, and one-tap links to the song on Apple Music /
+Spotify / YouTube Music. The product contract is the catalog's broadcaster metadata fields
 and capability hints, not any one platform's implementation. The fetcher routing,
 per-broadcaster request/parse rules, cover-art fallback chain, lyrics lookup, and
 program-schedule fetch are pinned formally in
@@ -23,9 +23,9 @@ the mechanics.
 ## Entry points
 
 - **Now Playing** ([now-playing](now-playing.md)) — the primary surface: artwork,
-  artist/title, program name, the Program and Lyrics panes, and the music-service
-  rail all render here. Reached from the mini-player, station rows, and platform
-  launch surfaces.
+  artist/title, program name, the `Schedule` and `Lyrics` panes, and the
+  music-service rail all render here. Reached from the mini-player, station rows,
+  and platform launch surfaces.
 - **System media surface** — lock screen / Control Center / CarPlay receive the
   same now-playing text and a downscaled cover (or station logo) via the
   now-playing-info mapping in
@@ -41,9 +41,16 @@ the mechanics.
 Top to bottom on Now Playing (portrait); the landscape/iPad split moves the same
 elements into an artwork column + program/lyrics column.
 
+- **Station header** — the station logo (favicon) chip plus the station name; the
+  favorite and close controls. The favicon chip falls back to the station's
+  initials plate.
+- **Header / page title** — `Now Playing`.
 - **Artwork** — square cover image. Shows the resolved track cover when known;
-  otherwise the station logo (favicon); otherwise a generated placeholder from
-  the station name.
+  otherwise an animated brand placeholder (the dot-matrix "rrr" mark — animated
+  while playing, static otherwise). The in-app Now Playing artwork does **not**
+  fall back to the favicon; the favicon is the station-header chip, the
+  station-row/mini-player art, and the lock-screen artwork fallback (see *Business
+  rules*).
 - **Track title** — the current track title, or a state phrase (`Connecting`,
   `Playback error`, `Live stream`) when no title, or an offline phrase when the
   network is down.
@@ -52,16 +59,19 @@ elements into an artwork column + program/lyrics column.
 - **Program name** — a small uppercased caption under the track block when the
   broadcaster reports a current program (talk/news stations and wired
   broadcasters).
-- **Pane tabs** — Now / Program / Lyrics. Program and Lyrics tabs are present only
-  when their pane has data (see *States*).
-- **Now pane** — the artwork + track block (described above).
-- **Program pane** — current program name + subtitle, then a "Today" schedule list
+- **Pane tabs** — `Album` / `Schedule` / `Lyrics`. The `Schedule` and `Lyrics`
+  tabs are present only when their pane has data (see *States*). The active tab
+  carries an accent underline that slides between tabs.
+- **Album pane** — the artwork + track block (described above).
+- **Schedule pane** — current program name + subtitle, then a "Today" schedule list
   of broadcasts with start time, title, subtitle, and a "Live" badge on the
   on-air row. Each row is tappable to set a wake alarm.
 - **Lyrics pane** — scrollable, selectable lyrics text plus a "Lyrics source:
   {provider}" attribution link.
 - **Music-service rail** — Apple Music / Spotify / YouTube Music buttons, shown
-  only after the track is verified as a real song (see *Business rules*).
+  only after the track is verified as a real song (see *Business rules*). Reserves
+  a steady height (caption + button row) so switching to the Lyrics pane — where
+  the rail is hidden — does not shift the transport below it.
 - **Stream-info strip / details** — expandable codec, bitrate, country, stream
   URL, metadata source, and a report-broken-station action.
 
@@ -69,15 +79,15 @@ elements into an artwork column + program/lyrics column.
 
 | State | What shows | Actionable |
 |---|---|---|
-| **No track yet (loaded, talk/instrumental)** | Station logo as artwork; title = `Live stream`; subtitle = station name. No music-service rail. | Playback, favorite, sleep/wake controls. |
+| **No track yet (loaded, talk/instrumental)** | Dot-matrix placeholder as artwork; title = `Live stream`; subtitle = station name. No music-service rail. | Playback, favorite, sleep/wake controls. |
 | **Loading metadata** | Prior values retained (poller keeps last good value); title shows `Connecting` only when there is no title and the player is connecting. | All transport controls. |
-| **Loaded (track known)** | Cover (track or logo), title, artist; Program tab if program/schedule present; Lyrics tab if lyrics found; music-service rail once verified. | All panes; music-service links; schedule rows tappable. |
-| **Cover resolving** | Logo shown immediately; upgrades in place to the track cover when the lookup returns (no spinner over the art). | — |
-| **Schedule loading** | Program pane shows a spinner while the day grid loads; program name/subtitle may already be shown. | Pane is visible. |
-| **No schedule** | Program pane shows `No schedule available` (when a program name exists but no grid). | — |
-| **Lyrics not found / instrumental** | Lyrics tab is absent (pane only appears on a non-empty hit). | — |
-| **Verification miss (news/talk/station ID)** | Music-service rail hidden; cover stays on logo. | — |
-| **Error** | Title = `Playback error`; subtitle = the error message; artwork = logo. | Retry via play/pause; report-broken. |
+| **Loaded (track known)** | Cover (track) or placeholder, title, artist; `Schedule` tab if program/schedule present; `Lyrics` tab if lyrics found; music-service rail once verified. | All panes; music-service links; schedule rows tappable. |
+| **Cover resolving** | Placeholder shown immediately; upgrades in place to the track cover when the lookup returns (no spinner over the art). | — |
+| **Schedule loading** | `Schedule` tab appears as soon as a schedule load starts; the pane shows a spinner while the day grid loads; program name/subtitle may already be shown. | Pane is visible. |
+| **No schedule** | Schedule pane shows `No schedule available` (when a program name exists but no grid, or the grid load failed). | — |
+| **Lyrics not found / instrumental** | `Lyrics` tab is absent (pane only appears on a non-empty hit). | — |
+| **Verification miss (news/talk/station ID)** | Music-service rail hidden; cover stays on the placeholder. | — |
+| **Error** | Title = `Playback error`; subtitle = the error message; artwork = placeholder. | Retry via play/pause; report-broken. |
 | **Offline** | Title = network phrase (e.g. "No internet connection"); subtitle = station name; offline tint. No fetches issued. | Controls reflect offline. |
 
 ## Interactions
@@ -85,16 +95,16 @@ elements into an artwork column + program/lyrics column.
 | Control / gesture | Precondition | Result | Side effects |
 |---|---|---|---|
 | Open Now Playing | A station is current | Metadata, artwork, program, lyrics surfaces render with the latest polled values | Schedule load begins for ORF/FM4 |
-| Swipe / tap pane tab → Program | Program data present | Shows program name + Today schedule; auto-scrolls to the live broadcast | Recomputes live-row highlight on a 30 s tick |
-| Swipe / tap pane tab → Lyrics | Lyrics found for the track | Shows lyrics text + source link | — |
-| Tap a music-service button | Track verified (iTunes confirms it is a real song) and that service enabled | Opens the song in Apple Music (deep link when available) / a Spotify search / a YouTube Music search | No track text sent to telemetry |
+| Swipe / tap pane tab → `Schedule` | Program data present (program name, a loaded grid, or a load in flight) | Shows program name + Today schedule; auto-scrolls to the live broadcast | Recomputes live-row highlight on a 30 s tick |
+| Swipe / tap pane tab → `Lyrics` | Lyrics found for the track | Shows lyrics text + source link | — |
+| Tap a music-service button | Track verified (iTunes confirms it is a real song) and that service enabled | Opens the song in Apple Music (deep link to the exact song via the iTunes `trackViewUrl` when present, else an Apple Music search) / a Spotify search / a YouTube Music search | No track text sent to telemetry |
 | Tap a schedule row | ORF/FM4 schedule loaded | Opens the wake-alarm sheet pre-filled with that broadcast's start time and title | — |
 | Tap "Lyrics source: …" link | Lyrics loaded with a source | Opens the lyrics provider's site | — |
 | Track changes (new now-playing) | Poll or in-band metadata returns a different title | Title/artist/cover/program update; lyrics + verification + cover lookups re-run for the new track | History updates current track; lock screen refreshes |
 | Station changes | User switches station | All track/program/schedule/lyrics/verification fields clear immediately, then re-poll | In-flight fetches cancelled |
 | 30 s poll tick | Playing, station has a fetcher | Re-fetches now-playing; updates only if the station is still current | Coarse diagnostic on failure |
 | Background / foreground | App backgrounded | Poll cadence continues per `backgroundPollPriority`; foreground in-band (timed) metadata path is iOS-only | — |
-| Sleep timer armed | Lock screen visible | Lock-screen title appends "Sleep in {N}m"; refreshes every 30 s | — |
+| Sleep timer armed | Lock screen visible | Lock-screen title appends "Sleep in {N}m" and the system artwork gains a yellow moon badge in its lower corner; both refresh every 30 s | — |
 
 ## Business rules
 
@@ -102,13 +112,18 @@ elements into an artwork column + program/lyrics column.
   exists for the current station; one in-flight fetch at a time (a new tick is
   skipped if the prior is still running). See
   [metadata-fetchers](../contracts/metadata-fetchers.md).
-- **Artwork fallback order (observable):** resolved track cover → station logo
-  (favicon) → generated name placeholder. The cover only *upgrades* the logo when
-  a non-nil, non-low-res result arrives; a good provider cover is never
-  downgraded. Full chain (provider → favicon → iTunes → …) is in
+- **In-app Now Playing artwork (observable):** resolved track cover → animated
+  dot-matrix "rrr" placeholder. The in-app surface does **not** substitute the
+  favicon for missing cover art (the favicon is the station-header chip and the
+  station-row/mini-player art). The cover only *upgrades* the placeholder when a
+  non-nil, non-low-res result arrives; a good provider cover is never downgraded.
+  Full provider chain (provider → iTunes → …, including the favicon step the web
+  client uses) is in
   [metadata-fetchers](../contracts/metadata-fetchers.md#cover-art-fallback-chain).
-- **Cover never blocks:** the logo renders immediately; the cover swaps in when
-  resolved. No spinner over the artwork.
+- **iTunes cover upgrade resolution:** a 100×100 iTunes artwork URL is rewritten to
+  600×600 before it becomes the in-app cover.
+- **Cover never blocks:** the placeholder renders immediately; the cover swaps in
+  when resolved. No spinner over the artwork.
 - **Music-service rail gating:** buttons appear **only** when iTunes Search
   confirms the title resolves to a real song (`hit`). While the lookup is
   in-flight, or after a confirmed miss, the rail stays hidden — this suppresses
@@ -121,13 +136,30 @@ elements into an artwork column + program/lyrics column.
   on station change). Distinction between `nil` and error is in
   [metadata-fetchers](../contracts/metadata-fetchers.md#null-vs-error-uniform-across-all-fetchers).
 - **Program schedule scope:** the day schedule is wired for **ORF/FM4 only** today;
-  other broadcasters may report a current *program name* without a grid.
-- **Lock-screen artwork cap:** the system cover is downscaled to a **512×512**
-  bounds (never the multi-MB original); the same source image powers the in-app
-  artwork.
+  other broadcasters may report a current *program name* without a grid. The
+  `Schedule` tab appears as soon as a schedule load begins (not only once a grid
+  has arrived).
+- **Lock-screen text mapping:** the system surface does **not** mirror the in-app
+  layout. The lock-screen *title* is the station name (with `— {program}` appended
+  when a program is known, and `— Sleep in {N}m` when the sleep timer is armed); the
+  lock-screen *artist/subtitle* carries the track (`{artist} — {title}`, or the
+  title alone, or a state phrase like `Live`/`Paused`/`Loading`/`Error`/country when
+  no track is known). Mapping detail is in
+  [playback-state-machine](../contracts/playback-state-machine.md).
+- **Lock-screen artwork cap:** the lock-screen source image is fetched bounded to
+  **≤512 px** on its longest side and **≤5 MB** (never the multi-MB original), and
+  is sourced from the resolved track cover when present, else the station favicon.
+  The in-app artwork is driven separately by the 600×600 cover URL.
 - **Lyrics lookup:** runs only when both artist and title are non-empty; result
   (including "not found") is cached so the same track does not re-query. Order and
   caches in [metadata-fetchers](../contracts/metadata-fetchers.md#lyrics-lookup).
+- **Station-row now-playing previews (iOS):** Browse/Favorites rows show a live
+  now-playing line for stations that have a fetcher, on a separate **~60 s** poll
+  scoped to the **visible rows plus a prefetch margin** (never the whole feed).
+  Fetch attempts are debounced past a scroll fling, negative results are cached so a
+  station that returned nothing is not re-tapped within the interval, and ICY rows
+  open the audio stream to read metadata — so the visible-row scope is a
+  privacy/bandwidth bound, not just an optimization.
 
 ## Data dependencies
 
@@ -168,8 +200,8 @@ elements into an artwork column + program/lyrics column.
   user has switched stations is discarded (the result is dropped unless the
   station is still current).
 - **Provider returns a low-res cover:** the low-res provider cover is skipped and
-  the chain continues to iTunes; the logo holds meanwhile. Low-res detection
-  patterns are in
+  the chain continues to iTunes; the in-app placeholder holds meanwhile. Low-res
+  detection patterns are in
   [metadata-fetchers](../contracts/metadata-fetchers.md#cover-art-fallback-chain).
 - **Talk/news titles:** verification miss → no music-service rail, no lyrics tab;
   program name still shows for wired broadcasters.
@@ -178,7 +210,7 @@ elements into an artwork column + program/lyrics column.
   poller, not a substitute.
 - **Offline:** no fetches; the surface shows network phrasing and an offline tint,
   retaining the last station identity.
-- **Schedule fetch failure:** the Program pane falls back to `No schedule
+- **Schedule fetch failure:** the Schedule pane falls back to `No schedule
   available`; a current program name (if any) still shows.
 - **Lyrics provider down / instrumental track:** the Lyrics tab is simply absent;
   an instrumental result is cached as a definitive "no lyrics".
@@ -188,11 +220,11 @@ elements into an artwork column + program/lyrics column.
 
 ## Accessibility
 
-- Pane tabs expose labels "Now" / "Program" / "Lyrics"; the selected tab is
-  emphasized.
-- Music-service buttons expose per-service accessibility labels (e.g. "Open in
-  Apple Music"); the brand mark image is hidden from VoiceOver so the label is not
-  duplicated.
+- Pane tabs expose labels `Album` / `Schedule` / `Lyrics`; the selected tab is
+  emphasized (carries the `.isSelected` trait).
+- Music-service buttons expose per-service accessibility labels — "Listen on Apple
+  Music", "Listen on Spotify", "Search on YouTube Music"; the brand mark image is
+  hidden from VoiceOver so the label is not duplicated.
 - Lyrics text is selectable (copy) and read as body text; the source link is a
   focusable link.
 - Track title/subtitle scale down (minimum scale factor) rather than truncating so
@@ -205,20 +237,24 @@ elements into an artwork column + program/lyrics column.
 
 This surface owns the following user-visible strings:
 
-- Pane labels: `Now`, `Program`, `Lyrics`; header `Now Playing`.
-- State phrases: `Connecting`, `Live stream`, `Playback error`, `No station`,
-  `No schedule available`.
-- Schedule chrome: the day header label and broadcast-count caption.
+- Pane labels: `Album`, `Schedule`, `Lyrics`; header `Now Playing`.
+- State phrases: `Connecting`, `Live stream`, `Playback error`, `No schedule
+  available`.
+- Schedule chrome: `Today` day label and the broadcast-count caption.
 - Plural/parameter needs: the schedule broadcast count needs a plural rule; the
-  lock-screen "Sleep in {N}m" and "Lyrics source: {provider}" strings are
-  parameterized.
+  lock-screen "Sleep in {N}m" and the "Lyrics source: {provider}" attribution
+  (intended key `Lyrics by {source}`) are parameterized.
 - Track artist/title/program text is **provider data**, never localized.
 
-Known un-localized literals in shipped iOS (English hard-coded): the schedule
-"Live" badge, "Today", the "{n} broadcasts" caption, "Lyrics source:" prefix,
-the lock-screen `Connecting`/`Live`/`Paused`/`Error` and `"Sleep in …"` text, and
-the schedule `Untitled` placeholder (see *Known deviations* M12). These are
-localization gaps, not intended behavior.
+`Now Playing`, `Album`, `Schedule`, `Lyrics`, `Today`, `Program`, `Open in`, and
+`No schedule available` are keyed in `Localizable.xcstrings` today. Known
+un-localized literals still hard-coded in shipped iOS: the schedule "Live" badge,
+the "{n} broadcasts" caption, the "Lyrics source:" attribution prefix (despite the
+keyed `Lyrics by {source}` string existing — see *Known deviations*), the
+`trackTitle` state phrases `Connecting`/`Live stream`/`Playback error`, the
+lock-screen subtitle phrases `Standby`/`Loading`/`Live`/`Paused`/`Error` and the
+`"Sleep in …"` text, and the schedule `Untitled` placeholder (see *Known
+deviations* M12). These are localization gaps, not intended behavior.
 
 ## Platform Matrix
 
@@ -231,7 +267,7 @@ localization gaps, not intended behavior.
 | Track cover art | Supported. | Supported. | Partial; broadcaster covers plus iTunes cover fallback are supported for fetched tracks. |
 | Lyrics lookup | Supported. | Planned/partial native parity. | Planned. |
 | Music-service links (verified-gated) | Supported. | Supported (Apple Music deep link, Spotify/YT Music search). | Planned. |
-| Lock-screen / media-surface cover (downscaled) | Supported where browser allows. | Supported (512×512 cap). | Partial. |
+| Lock-screen / media-surface cover (downscaled) | Supported where browser allows. | Supported (≤512 px / ≤5 MB cap; sleep-timer moon badge). | Partial. |
 | Last-good retention on poll miss/fail | Supported. | Supported. | Partial. |
 
 ## Privacy Rules
@@ -254,33 +290,57 @@ before marking the station as fully parity-supported on native platforms.
   [metadata-fetchers](../contracts/metadata-fetchers.md#open-questions).)
 - **Schedule capability source of truth:** schedule is still ORF/FM4-hardcoded;
   the `hasScheduleData` catalog field is the forward path once populated.
-- **Lyrics on native:** iOS lyrics lookup is implemented but the lyrics surface is
-  marked planned/partial parity in the cross-platform matrix — confirm the
-  intended native rollout.
+- **Lyrics on native:** iOS lyrics lookup and the Lyrics pane are implemented, yet
+  the lyrics surface is still marked planned/partial parity in the cross-platform
+  matrix — confirm the intended native rollout / update the matrix.
+- **In-app artwork fallback parity:** iOS Now Playing falls back to the dot-matrix
+  brand mark rather than the favicon, while the favicon is the documented
+  station-art source for rows and the lock screen. Should the favicon-as-art rule
+  also apply to the in-app Now Playing surface, or is the brand placeholder the
+  intended cross-platform fallback there?
 - **Localization of schedule/lock-screen literals** (see *Localization*) — when do
-  the hard-coded English strings get keyed?
+  the remaining hard-coded English strings (`Live` badge, "{n} broadcasts",
+  state phrases, `Untitled`, the `Lyrics source:` prefix) get keyed?
 
 ## Reference
 
 iOS source (the only place iOS mechanics are named):
 
 - `rrradio/Player/Metadata/NowPlayingMetadata.swift` — `NowPlayingMetadata` output
-  struct + `metadataFetcher(for:)` registry router.
+  struct + `metadataFetcher(for:)` registry router (keyed on `station.metadata` /
+  `metadataUrl`, with an `icy-only` fallback).
 - `rrradio/Player/Metadata/MetadataPoller.swift` — 30 s poll loop, single in-flight
-  fetch, coarse failure diagnostics.
+  fetch, generation guard, coarse failure diagnostics (`onUpdate` is not called on
+  error or on a `nil` result, so the last good value is retained).
 - `rrradio/Player/Metadata/CoverArtFetcher.swift` — iTunes Search
-  (`searchITunes`/`lookupCoverArt`/`verifyTrack`), low-res detection, high-res
-  upgrade, 64-entry LRU cache, music-service verification signal.
+  (`searchITunes`/`lookupCoverArt`/`verifyTrack`), `pickBestCoverArtMatch` genuine
+  artist/title match, low-res detection, 100×100→600×600 high-res upgrade, 64-entry
+  LRU cache, `appleMusicUrl` deep link, music-service verification signal.
 - `rrradio/Player/Metadata/LyricsFetcher.swift` — LRCLIB → Lyrics.ovh, LRC parse,
-  256-entry FIFO cache.
+  instrumental short-circuit, 256-entry FIFO cache.
+- `rrradio/Player/Metadata/ScheduleFetcher.swift` — `scheduleFetcher(for:)` (ORF/FM4
+  only), ORF `/broadcasts` day grid, `cleanScheduleTitle` (`Untitled` fallback).
 - `rrradio/Player/Metadata/MusicServiceLinks.swift` — Apple Music / Spotify /
-  YouTube Music link builder, badge-lockup vs icon, per-service enable keys.
-- `rrradio/Player/AudioPlayer.swift` — applies polled + in-band timed metadata,
-  drives lyrics/verification/cover lookups per track, schedule load, and the
-  512×512 lock-screen artwork.
-- `rrradio/Views/NowPlayingView.swift` — Now/Program/Lyrics panes, artwork (`cover
-  ?? favicon`), program schedule list + live badge, music-service rail gate
-  (`nowPlayingTrackVerified == true`), offline phrasing.
+  YouTube Music registry + link builder, badge-lockup vs icon, per-service enable
+  keys (default ON), accessibility labels.
+- `rrradio/Player/Metadata/FavoriteNowPlayingStore.swift` — station-row now-playing
+  previews; ~60 s visible-row poll with debounce, negative caching, and a 400-entry
+  cap.
+- `rrradio/Player/Metadata/DirectMetadataFetchers.swift`,
+  `OrfMetadataFetcher.swift`, `IcyMetadataFetcher.swift`, `MetadataHelpers.swift` —
+  the broadcaster-specific fetchers and shared JSON/HTML helpers (`bestOrfImage`,
+  `metadataStripHTML`).
+- `rrradio/Player/AudioPlayer.swift` — applies polled + in-band timed metadata
+  (`applyTimedMetadataTitle` splits `Artist - Title`), drives
+  lyrics/verification/cover lookups per track, schedule load, lock-screen
+  title/subtitle mapping, and the ≤512 px / ≤5 MB lock-screen artwork
+  (`makeLockScreenArtwork` + sleep-timer moon badge).
+- `rrradio/Views/NowPlayingView.swift` — `Album`/`Schedule`/`Lyrics` panes,
+  `ArtworkView` (cover → `DotMatrixLogoView` placeholder, no favicon fallback),
+  program schedule list + live badge, music-service rail gate
+  (`nowPlayingTrackVerified == true`, hidden on the Lyrics pane), offline phrasing.
+- `rrradio/Views/StationKit.swift` — `FaviconView` / station-row art and the
+  initials-plate favicon fallback.
 - Contract: [metadata-fetchers](../contracts/metadata-fetchers.md) (full fetcher,
   cover, lyrics, schedule, and music-link mechanics).
 
@@ -295,8 +355,14 @@ under `rrradio-ios/internal/audit/2026-05-25-ios-code-review-slice6.md`.
 
 Behavior-surface notes from those:
 
-- **M8** — the oversized-ORF-image bug can briefly fetch a multi-MB asset for the
-  in-app artwork before the 512×512 lock-screen downscale, against the
-  "cover never blocks" intent.
+- **M8** — the oversized-ORF-image bug (`bestOrfImage` picks the largest available
+  version) can fetch a multi-MB asset on the lock-screen artwork path before it is
+  downsampled to the ≤512 px / ≤5 MB cap — wasted bandwidth against the "cover never
+  blocks" intent.
 - **M12** — blank schedule titles render the English literal `Untitled` rather than
   a localized placeholder, contradicting *Localization*.
+
+Additional behavior-surface localization gap (not yet in the audit; flagged for a
+human, see *Open questions*): the Lyrics-pane attribution renders the hard-coded
+`Lyrics source: {name}` even though a localized `Lyrics by {source}` string is
+already keyed in `Localizable.xcstrings`. The intent is the localized string.

--- a/docs/spec/features/now-playing.md
+++ b/docs/spec/features/now-playing.md
@@ -1,9 +1,9 @@
 # Now Playing Specification
 
 ```yaml
-status: draft
+status: review
 platforms: [web, ios, android]
-reconciled-against: 9336321
+reconciled-against: d241aa9
 ```
 
 ## Purpose
@@ -38,8 +38,8 @@ Fixed-height bar (88 pt on iOS), left to right:
   device is offline. A small list badge overlays the favicon when playback is
   driven by a station-list queue.
 - **Metadata lines** (stacked, flexing to fill):
-  - Station name + country flag emoji; a calendar glyph appears when program info
-    exists. When offline, this line becomes a short "no internet" label instead.
+  - Station name + country flag emoji. When offline, this line becomes a short
+    "no internet" label instead.
   - Track line `"<artist> - <title>"` (or title alone) when a track is resolved.
   - Program line `"<program> . <subtitle>"` when present; otherwise, if no track,
     a state line (`Standby` / `Loading` / `Live` / `Paused` / error phrase) with a
@@ -47,9 +47,11 @@ Fixed-height bar (88 pt on iOS), left to right:
 - **Sleep-timer glyph** (`moon.zzz.fill`) when a sleep timer is armed.
 - **Album artwork thumbnail** (64 pt) when a track cover art URL resolves and the
   device is online.
-- **Trailing control** — play/pause toggle (44 pt). It is replaced by a red close
-  ("✕") button while the close prompt is showing, or by a static offline glyph
-  when there is no station and the device is offline.
+- **Trailing control** — play/pause toggle (44 pt). It becomes a static offline
+  glyph when there is no current station and the device is offline.
+- **Swipe-to-close zone** — a red close ("✕") zone sits behind the card, revealed
+  by swiping the card left (see Interactions). The card content slides over a
+  pinned bar surface; only the content moves, never the page behind it.
 
 ### Full Now Playing (portrait / compact width)
 
@@ -60,43 +62,68 @@ Top to bottom:
   and dismisses.
 - **Station block** — station favicon (38 pt), station name (large), and a
   heart favorite toggle.
-- **Divider**, then a **pane tab strip**: Now (artwork) / Program (calendar) /
-  Lyrics (quote). Program and Lyrics tabs are enabled only when that data exists.
+- **Divider**, then a **pane tab strip** of uppercase text labels: Album /
+  Schedule / Lyrics, with a short accent underline that slides to the active tab.
+  Schedule and Lyrics tabs appear only when that data exists (Album is always
+  present); a station with neither shows a single Album tab.
 - **Paged pane content** (swipeable):
-  - **Now pane** — large artwork (220 pt: track cover, else station favicon),
-    track title, artist subtitle, and an uppercase program-name caption when known.
-  - **Program pane** — program header (name + subtitle), then today's broadcast
+  - **Album (Now) pane** — large artwork (220 pt: track cover, else the
+    dot-matrix `rrr` fallback — see Artwork fallback below), track title, artist
+    subtitle, and an uppercase program-name caption when known.
+  - **Schedule pane** — program header (name + subtitle), then today's broadcast
     list with start times; the live broadcast is highlighted and tagged "Live".
+    Shows a loading spinner while the schedule fetches and a "no schedule" line
+    when the day has no broadcasts.
   - **Lyrics pane** — track header, scrollable lyrics text (selectable), and a
     "Lyrics source: <name>" attribution link.
 - **Music-service rail** — Apple Music / Spotify / YouTube Music buttons (hidden
   on the Lyrics pane and until the track is verified as a real song).
 - **Expandable station details** — collapsed by default behind a status strip
   chevron; expands to show website link, stream URL, country, format
-  (codec/bitrate/quality), genres, metadata source, and a "Report broken station"
-  action.
+  (codec/bitrate/quality), genres, metadata source, a "Report broken station"
+  action, and — when a prior report exists for this station — its current
+  resolution status (received / confirmed / resolved).
 - **Stream-info status strip** — a tappable line `"<state> . <codec> . <bitrate>"`
-  with a status dot; the chevron toggles the details panel.
+  with a status dot; the chevron (up when collapsed, down when expanded) toggles
+  the details panel.
 - **Controls block** — wake-alarm button (left), previous-station, play/pause
   (large, 64 pt), next-station, sleep-timer button (right). Wake and sleep
   buttons carry a countdown chip when armed.
 
+### Artwork fallback (all full-view layouts)
+
+When there is no resolved track cover (no URL, or the image fails to load) the
+artwork frame shows an animated dot-matrix `rrr` logo instead of the station
+favicon. It animates (a live-signal equalizer that resolves into the `rrr`
+wordmark) while the station is playing and renders the static fully-formed `rrr`
+when paused or idle. Reduce Motion forces the static render regardless of state.
+The fallback sits directly on the page surface (no card chrome); a loaded cover
+keeps its card, stroke, and shadow. (The mini-player album thumbnail is cover-art
+only — it never shows the dot-matrix fallback.)
+
 ### Full Now Playing (landscape / iPad split)
 
-Branch work introduces a width-driven split layout selected when the surface is
-wider than tall (so iPad landscape and portrait full-screen both get it; the
-choice keys off surface aspect, not the vertical size class):
+A width-driven multi-column layout is selected when the surface is wider than
+tall (so iPad landscape and portrait full-screen both get it; the choice keys off
+surface aspect, not the vertical size class):
 
-- **Top station bar** — dismiss chevron, station favicon, station name (flexes),
-  inline music-service buttons, favorite toggle, close "✕".
-- **Left artwork column** — artwork (sized to the column), track title, artist,
-  program caption; vertically centered.
-- **Right pane column** — Program / Lyrics tab strip (only when either exists) and
-  the corresponding scrollable pane. When neither exists, the right column shows a
-  details list (stream, country, format, genres) under the track text.
+- **Top station bar** — dismiss chevron, station favicon, centered station name
+  (overlaid, scales to fit), favorite toggle, close "✕". No music-service buttons
+  here (they moved into the album column).
+- **Columns** — up to three equal-width columns, each under a static uppercase
+  section header (Album / Schedule / Lyrics), separated by full-height hairlines:
+  - **Album column** — artwork (capped, sized to the column; dot-matrix fallback
+    when no cover), then track title, artist, and program caption, with the
+    music-service "Open in" row anchored at the column's bottom.
+  - **Schedule column** — today's broadcast list; appears only when program data
+    exists. Always on-screen, so it follows the live broadcast unconditionally.
+  - **Lyrics column** — track header + scrollable lyrics; appears only when lyrics
+    exist.
+  - With no program and no lyrics the row collapses to a single centered album
+    column; with one present it is two columns.
 - **Bottom bar** — the expandable details panel (height-capped, scrolls up over
-  the pane instead of pushing the transport), the stream-info status strip, then
-  the transport row: wake, previous, play/pause (52 pt), next, sleep.
+  the columns instead of pushing the transport), the stream-info status strip,
+  then the transport row: wake, previous, play/pause (52 pt), next, sleep.
 
 ### Full Now Playing (car mode)
 
@@ -114,10 +141,10 @@ When car mode is active the layout is replaced by a large-touch-target variant:
 | State | Mini-player | Full Now Playing |
 |---|---|---|
 | **empty** (idle, no station) | Favicon placeholder; metadata blank; play/pause disabled; tap does nothing. | Reached only if opened with no station: blank station name, "Live stream" placeholder, controls disabled. |
-| **loading** | State line "Loading"; play/pause disabled; track/cover suppressed. | Artwork = station favicon; title "Connecting"; play button shows animated loading dots and is disabled. |
-| **loaded / playing** | Track + program lines; pulsing dot; play→pause; cover thumbnail when resolved. | Full artwork/track/program; transport enabled; status dot accent-tinted; "LIVE". |
-| **paused** | State line "Paused"; pause→play. | Same layout; play button shows play glyph; status "PAUSED". |
-| **partial** (station, no track metadata) | Station name + state line; no track line; calendar glyph if program exists. | Artwork = favicon; title "Live stream"; subtitle = station name; music-service rail hidden; Program/Lyrics tabs disabled if no data. |
+| **loading** | State line "Loading"; play/pause disabled; track/cover suppressed. | Artwork = dot-matrix `rrr` fallback; title "Connecting"; play button shows animated loading dots and is disabled. |
+| **loaded / playing** | Track + program lines; pulsing dot; play→pause; cover thumbnail when resolved. | Track cover when resolved, else animated dot-matrix `rrr`; track/program shown; transport enabled; status dot accent-tinted; "LIVE". |
+| **paused** | State line "Paused"; pause→play. | Same layout; dot-matrix fallback (if no cover) is static; play button shows play glyph; status "PAUSED". |
+| **partial** (station, no track metadata) | Station name + program line if program exists, else state line; no track line. | Artwork = dot-matrix `rrr` fallback; title "Live stream"; subtitle = station name; music-service rail hidden; Schedule/Lyrics tabs absent if no data. |
 | **error** | State line = shortened error phrase (country phrase trimmed before em-dash). | Title "Playback error"; subtitle = error message; controls remain (play retries). |
 | **offline** | Offline glyph + short "no internet" label; track/program lines suppressed; cover hidden. | Track text becomes offline phrase in a warm tint; subtitle = station name; status strip shows "no internet / offline / no stream". |
 
@@ -129,25 +156,27 @@ wake entry (sleep/wake also reachable while armed even with no current station).
 | Control / gesture | Precondition | Result | Side effects |
 |---|---|---|---|
 | Tap mini-player | A station is current; no close prompt showing | Presents full Now Playing | Sheet (iPhone) or full-screen (iPad) per idiom |
-| Tap mini-player while close prompt shown | Close prompt visible | Dismisses the close prompt | No navigation |
-| Long-press mini-player (≥0.45 s) | A station is current | Shows the red close prompt on the trailing control | Light haptic |
+| Tap mini-player while close prompt shown | Close prompt visible (card resting open) | Springs the card back and dismisses the close prompt | No navigation |
+| Swipe mini-player left to the reveal rest | A station is current | Rests the card open, revealing the red close zone (close prompt) | Light haptic on rest |
+| Swipe mini-player left past the auto-close threshold (or fling) | A station is current | Stops playback and slides the card off-screen | Rigid haptic when armed; medium haptic on close; player → idle |
 | Tap mini-player play/pause | Station current, not loading | Toggles play/pause | Per [playback-state-machine](../contracts/playback-state-machine.md) |
-| Tap mini-player close "✕" | Close prompt visible | Stops playback, dismisses Now Playing if open | Player → idle; prompt cleared |
-| Station identity changes | Mini-player visible | Auto-dismisses any open close prompt | — |
+| Tap revealed mini-player close "✕" | Close zone revealed | Stops playback, dismisses Now Playing if open | Player → idle; card reset |
+| Station identity changes | Mini-player visible | Auto-dismisses any open close prompt and resets the card | — |
 | Tap header down-chevron | Now Playing presented as sheet | Dismisses Now Playing | Playback continues |
 | Tap header / station-bar "✕" | Now Playing open | Stops playback and dismisses | Player → idle |
 | Tap favorite heart | A station is current | Toggles favorite; glyph fills / empties | Writes library; iCloud sync per [sync-merge](../contracts/sync-merge.md) |
 | Tap play/pause (full) | Station current, not loading | Toggles play/pause | Loading shows dots; disabled while loading |
 | Tap previous-station | Active queue has >1 station | Steps to previous station (circular) | Rebuilds source; see queue rules |
 | Tap next-station | Active queue has >1 station | Steps to next station (circular) | As above |
-| Swipe pane / tap pane tab | Target pane enabled | Switches Now / Program / Lyrics | Program pane auto-scrolls to the live broadcast |
-| Tap a program-schedule row | A station is current | Opens the wake-alarm sheet preset to that broadcast's start time + title | Notifications default ON for the preset |
+| Swipe pane / tap pane tab | Target pane present | Switches Album / Schedule / Lyrics | Schedule pane auto-scrolls to the live broadcast |
+| Tap a program-schedule row | A station is current OR a wake alarm is armed | Opens the wake-alarm sheet preset to that broadcast's start time + title | Notifications default ON for the preset |
 | Tap wake-alarm button | Station current OR wake armed | Opens wake-alarm sheet | See [wake-to-radio](wake-to-radio.md) |
 | Tap sleep-timer button | Station current OR sleep armed | Opens sleep-timer sheet | See [sleep-timer](sleep-timer.md) |
 | Tap a music-service button | Track verified as a real song; service enabled | Opens that service (Apple Music deep-link when available; else search) | External app/URL; never sent to telemetry |
 | Tap status strip / chevron | — | Expands / collapses station details panel | Transport keeps its bottom anchor |
 | Tap website / stream link rows | Row present | Opens the URL externally | — |
-| Tap "Report broken station" | A station is current; not already reporting | Sends a broken-station report; shows sent/failed alert; offers an email fallback on failure | Coarse diagnostic recorded locally |
+| Tap "Report broken station" | A station is current; not already reporting | Opens the broken-station report sheet (category picker + optional/required comment) | — |
+| Submit the report sheet | A category is selected (and a comment when that category requires one) | Sends the report; shows a sent/failed alert; offers an email fallback on failure | Coarse diagnostic recorded locally; a receipt is stored when the worker returns an id |
 | Tap car-mode `car.fill` | Car mode active | Confirmation dialog → turning off disables manual + automatic car mode | — |
 | Station change while reporting | A report is in flight | Cancels the report; clears its status | — |
 | Background / dismiss view | — | Cancels any in-flight broken-station report | Playback unaffected |
@@ -155,8 +184,16 @@ wake entry (sleep/wake also reachable while armed even with no current station).
 ## Business rules
 
 - **Mini-player height** 88 pt; favicon 46 pt; album thumb 64 pt; controls 44 pt.
-- **Long-press threshold** for the close prompt: 0.45 s; the prompt auto-clears
-  when the station identity changes.
+- **Mini-player close gesture**: swipe the card left. Releasing past the reveal
+  threshold rests the card open with the red close zone exposed (the close
+  prompt); a release/fling past the auto-close threshold (~half the bar width)
+  closes it automatically. Only the card content slides; the bar surface stays
+  pinned so the page behind it never shifts. The close prompt auto-clears (and the
+  card resets) when the station identity changes.
+- **Artwork fallback**: with no resolved track cover, the artwork frame shows the
+  dot-matrix `rrr` logo — animated while playing, static `rrr` when paused/idle,
+  and static under Reduce Motion. Applies to portrait, landscape, and car-mode
+  full views; not the mini-player thumbnail (cover-art only).
 - **Music-service buttons render only when the track is verified** as a real
   searchable song (iTunes Search confirmed a hit). In-flight or confirmed-miss →
   buttons hidden, so users are never sent to empty search results. See the iTunes
@@ -165,10 +202,19 @@ wake entry (sleep/wake also reachable while armed even with no current station).
   per-app enable toggle (default ON). Apple Music uses a deep link to the exact
   song when iTunes returned a `trackViewUrl`; Spotify and YouTube Music use search
   URLs. URL shapes are owned by [metadata-fetchers](../contracts/metadata-fetchers.md).
-- **Program schedule** shows today's broadcasts; the live broadcast (`start ≤ now
-  < end`) is highlighted and tagged "Live". The live row is recomputed on a 30 s
-  tick and only re-rendered on a boundary crossing. The pane auto-scrolls to the
-  live row on open and on boundary change. Schedule is ORF/FM4-only today.
+- **Program schedule** (Schedule pane) shows today's broadcasts; the live
+  broadcast (`start ≤ now < end`) is highlighted and tagged "Live". The live row
+  is recomputed on a 30 s tick and only re-rendered on a boundary crossing. The
+  pane auto-scrolls to the live row on open and on boundary change. Schedule is
+  ORF/FM4-only today.
+- **Broken-station report** is a two-step flow: the details-panel action opens a
+  report sheet, the user picks one of six categories (no audio / interruptions /
+  wrong station / wrong logo / wrong info / other) plus an optional comment, then
+  submits. Some categories require a comment before Send is enabled; the comment
+  is length-capped. After a successful submit that returns a report id, a
+  persistent receipt for that station is stored and its lifecycle status
+  (received → confirmed → resolved as fixed / removed / not reproducible) shows
+  under the report row.
 - **Program-only sources** show a program name caption but no music-service rail
   (no artist/title to search).
 - **Genres** in the details panel: at most 5 tags, dot-joined. **Format**:
@@ -211,9 +257,10 @@ wake entry (sleep/wake also reachable while armed even with no current station).
   auto-reconnect only from loading/playing/error (never from paused/idle).
 - **Track verified false / pending** — music-service rail stays hidden; no empty
   search results.
-- **Program data races** — switching away from Program/Lyrics when its data
-  disappears falls back to the Now pane (or the remaining enabled pane in the
-  landscape split).
+- **Program/lyrics data races** — when Schedule or Lyrics data disappears while
+  that pane is active, the portrait view falls back to the Album pane and the tab
+  is removed; in the landscape split the corresponding column is dropped and the
+  row recollapses to the remaining columns.
 - **Broken-station report races** — an in-flight report is cancelled on station
   change or view dismissal; every exit path clears the in-flight flag so the
   button never gets stuck disabled.
@@ -230,10 +277,12 @@ wake entry (sleep/wake also reachable while armed even with no current station).
 
 - Every control carries a screen-reader label: dismiss, close, favorite
   (add/remove), play/pause, previous/next station, wake to radio, sleep timer,
-  pane tabs (Now / Program / Lyrics), and each music-service button ("Listen on
-  Apple Music", "Listen on Spotify", "Search on YouTube Music").
-- Mini-player labels: play/pause, close mini-player, sleep-timer-active glyph,
-  program/calendar glyph, "playing from list" badge; the offline glyph is hidden
+  pane tabs (Album / Schedule / Lyrics, with the active tab marked selected), and
+  each music-service button ("Listen on Apple Music", "Listen on Spotify", "Search
+  on YouTube Music").
+- Mini-player labels: play/pause, close mini-player (also exposed as an
+  accessibility action on the card so the swipe close has a non-gesture path),
+  sleep-timer-active glyph, "playing from list" badge; the offline glyph is hidden
   from the reader (the offline state is conveyed by the text label).
 - Brand marks are decorative (hidden); the button's text/label carries the name.
 - Text uses `minimumScaleFactor` so long station/track names shrink rather than
@@ -246,11 +295,13 @@ wake entry (sleep/wake also reachable while armed even with no current station).
 ## Localization
 
 - This surface owns: NOW PLAYING eyebrow, transport/secondary-control labels,
-  pane labels (Now / Program / Lyrics), status labels (Standby / Loading / Live /
-  Paused / playback-error / no-internet phrases), details-row labels (Website /
-  Stream / Country / Format / Genres / Metadata), the broken-station report
-  states (report / sending / sent / failed) and its alert copy, car-mode labels,
-  and the "playing from list" badge.
+  pane / column labels (Album / Schedule / Lyrics), status labels (Standby /
+  Loading / Live / Paused / playback-error / no-internet phrases), details-row
+  labels (Website / Stream / Country / Format / Genres / Metadata), the
+  broken-station report states (report / sending / sent / failed) plus its sheet
+  copy (prompt, six category labels, required/optional comment prompts, send) and
+  receipt-status strings, its alert copy, car-mode labels, and the "playing from
+  list" badge.
 - Music-service accessibility labels are currently English (localization rewrite
   tracked as a deferred slice).
 - Plural/parameter needs: broadcast count ("N broadcasts"), countdown chips for
@@ -264,7 +315,7 @@ wake entry (sleep/wake also reachable while armed even with no current station).
 |---|---|---|---|
 | Destination view | Supported. | Reference. | Supported for the core playback surface; secondary panels remain planned. |
 | Mini-player handoff | Supported. | Supported. | Supported. |
-| Mini-player long-press close prompt | Platform-specific (no equivalent gesture). | Supported. | Planned. |
+| Mini-player swipe-to-close | Platform-specific (no equivalent gesture). | Supported. | Planned. |
 | Track metadata | Supported. | Reference. | Partial; basic ICY metadata exists. |
 | Cover art fallback | Supported. | Reference. | Partial; station artwork fallback exists, track cover art is deferred. |
 | Previous/next station controls | Supported. | Reference. | Supported for active playback queues. |
@@ -298,14 +349,23 @@ and media controls.
 ## Reference
 
 - `rrradio/Views/NowPlayingView.swift` — full destination view: portrait
-  (`regularBody`), landscape/iPad split (`landscapeBody`), car mode
-  (`carModeBody`), pane tabs + paged content, music-service rail, station-detail
-  panel, transport controls, the embedded `WakeAlarmView` / `SleepTimerView`
-  sheets, `ArtworkView`, and `nowPlayingPresentation` (sheet vs. full-screen by
-  idiom).
+  (`regularBody`), landscape/iPad multi-column split (`landscapeBody` /
+  `landscapeAlbumColumn` / `landscapeProgramColumn` / `landscapeLyricsColumn`),
+  car mode (`carModeBody`), the Album/Schedule/Lyrics text `modeTabBar` + paged
+  content, music-service rail, station-detail panel and the embedded
+  `BrokenStationReportSheet` (category picker + comment), receipt status display,
+  transport controls, the embedded `WakeAlarmView` / `SleepTimerView` sheets,
+  `ArtworkView`, and `nowPlayingPresentation` (sheet vs. full-screen by idiom).
+- `rrradio/Views/DotMatrixLogoView.swift` — the animated `rrr` dot-matrix used as
+  the no-cover artwork fallback (animated while playing, static otherwise / under
+  Reduce Motion).
 - `rrradio/Views/MiniPlayerView.swift` — persistent bottom strip, tap-to-expand,
-  long-press close prompt (`MiniPlayerClosePromptState`), offline affordances,
-  station-list badge, and the `miniPlayerSurface` chrome.
+  swipe-to-close gesture + revealed close zone (`MiniPlayerClosePromptState`,
+  reveal/auto-close thresholds, haptics), offline affordances, station-list badge,
+  and the `miniPlayerSurface` chrome.
+- `rrradio/Models/BrokenStationReports.swift` — `BrokenStationReportCategory`
+  (six categories), the report receipt and its `received`/`confirmed`/`resolved`
+  lifecycle, and `BrokenReportReceiptStore`.
 - `rrradio/Player/Metadata/MusicServiceLinks.swift` — `MusicServiceRegistry`
   (Apple Music / Spotify / YouTube Music), per-service toggles, badge-lockup
   rendering, and the search / Apple-Music deep-link URL builders.

--- a/docs/spec/features/preferences-diagnostics.md
+++ b/docs/spec/features/preferences-diagnostics.md
@@ -1,9 +1,9 @@
 # Preferences And Diagnostics Specification
 
 ```yaml
-status: draft
+status: review
 platforms: [web, ios, android]
-reconciled-against: 9336321
+reconciled-against: d241aa9
 ```
 
 ## Purpose
@@ -21,10 +21,11 @@ share. Both surfaces sit behind one Settings sheet and never require an account.
 - A horizontal tab strip switches between four pages: **Preferences**, **About**,
   **Upload** (Add Station), **History** (Listening dashboard). Swiping the page
   horizontally lands on the same page the tab strip selects.
-- The **Open Listening dashboard** row inside Listening History jumps to the
-  History tab.
+- The **Open History** row inside Listening History jumps to the History tab.
 - A denied-wake-notification warning row deep-links to the OS Settings app.
 - The cloud-sync **iPhone Settings** button deep-links to the OS iCloud settings.
+- The diagnostics-preview **expand** corner button opens the full diagnostics log
+  in a full-screen viewer. *(iOS.)*
 
 ## Layout
 
@@ -34,33 +35,40 @@ Settings sheet, top to bottom:
 - **Tab strip** — Preferences · About · Upload · History (uppercase, mono).
 - **Preferences page** (scrolling), sections in order:
   1. **Theme** — three-way segmented pill: System · Light · Dark (icon + label).
-  2. **Color** — accent row (palette icon, current hex or "Classic", color swatch,
-     chevron → picker sheet) and a **Standard** reset row (checkmark when no custom
-     accent; disabled when already standard).
-  3. **iCloud Sync** — master sync toggle ("Sync library and settings with iCloud")
-     with a live status detail line; **Sync now** + **iPhone Settings** buttons;
-     destructive **Remove all iCloud data** row. *(iOS only.)*
-  4. **Catalog** — station-catalog row (count + freshness detail), optional inline
-     refresh-error line, **Refresh** button.
-  5. **Landing page** — radio list of launch targets: Browse, Library, Favorites,
-     each user station list, Recents, Play a station. Selecting "Play a station"
-     reveals a station picker (use-current shortcut, search field, up to 8 matches).
-  6. **Library views** — per-display-mode rows (List / Tiles / App) with up/down
-     reorder buttons and a show/hide toggle each.
-  7. **Default Library view** — radio list over the currently visible display modes.
-  8. **Timer defaults** — default wake time (time picker), wake-notification toggle,
-     optional notifications-denied warning row, default sleep duration (picker).
-  9. **Car mode** — Automatic car mode toggle (shows current audio route), Manual
-     car mode toggle (shows active/inactive). *(iOS.)*
-  10. **Music services** — one toggle per registered service (Apple Music, Spotify,
-      YouTube Music) controlling whether its Now Playing deep-link is offered.
-  11. **Listening History** — tracking toggle; when on: dashboard link, granularity
-      rows (Stations only / Stations + tracks), retention rows (30 days / 90 days /
-      1 year / Forever).
-  12. **Apple Intelligence** — AI station-blurbs toggle. *(iOS 26+ only.)*
-  13. **Language** — radio list: System, English, Deutsch, Français, Español.
-  14. **Diagnostics** — Collect-Diagnostics toggle, redacted recent-events preview,
-      Copy / Share / Clear buttons.
+  2. **Color** — two-segment pill: **Standard** (swatch of the appearance's adaptive
+     default) · **Custom** (filled swatch when set, dashed ring when not). Tapping
+     Standard resets the accent for the current appearance; tapping Custom opens the
+     color-picker overlay. Accent is scoped to the active appearance (light/dark
+     edited independently).
+  3. **iCloud Sync** — master sync toggle ("Sync with iCloud") with a live status
+     detail line; **Sync now** + **iPhone Settings** buttons; a **Backup** / **Restore**
+     local-file pair (export/import a JSON backup; works with sync off; history not
+     included); destructive **Remove all iCloud data** row. *(iOS only.)*
+  4. **Catalog** — station-catalog row (count + freshness/last-sync detail), optional
+     inline refresh-error line, **Refresh** button.
+  5. **Landing page** — radio list of launch targets: Browse, Favorites, a combined
+     **Library** row (its trailing dropdown picks Home, any user station list, or
+     Recents), and Play a station. Selecting "Play a station" reveals a station
+     picker (use-current shortcut, search field, up to 8 matches).
+  6. **Library views** — per-display-mode rows (List / Tiles / App): tap a visible
+     row to make it the default (DEFAULT badge), up/down reorder buttons, and a
+     show/hide toggle each. The former separate "Default Library view" section is
+     folded in here.
+  7. **Timer defaults** — default wake time (time picker), wake-notification toggle,
+     optional notifications-denied warning row, default sleep duration (hh:mm dial).
+  8. **Car mode** — single tri-state pill: **Auto** (activate on a car-like route) ·
+     **Always** (manual override) · **Off**. *(iOS.)*
+  9. **Music services** — one toggle per registered service (Apple Music, Spotify,
+     YouTube Music) controlling whether its Now Playing deep-link is offered.
+  10. **Listening History** — tri-state pill (Off · Stations · + Tracks) with a
+      detail line; when tracking is on: **Open History** link and a **Keep history**
+      retention dropdown (30 days / 90 days / 1 year / Forever).
+  11. **Apple Intelligence** — AI station-blurbs toggle. *(iOS 26+ only.)*
+  12. **Language** — single dropdown row showing the current choice; the menu lists
+      System, English, Deutsch, Français, Español, Italiano, Русский.
+  13. **Diagnostics** — Collect-Diagnostics toggle, redacted recent-events preview
+      with an **expand** corner button (opens the full log full-screen), Copy /
+      Share / Clear buttons.
 - **About page** — app/privacy disclosure copy and links (owned by `about` surface).
 - **Upload page** — Add Station (owned by [custom-stations](custom-stations.md)).
 - **History page** — Listening dashboard (owned by [favorites](favorites.md) /
@@ -71,7 +79,7 @@ Settings sheet, top to bottom:
 | State | What shows | Actionable |
 |---|---|---|
 | Loaded (default) | All preference sections rendered with current values; each selection shows a checkmark / filled control. | Every control. |
-| Catalog idle/loaded | Detail: "N stations loaded. The app checks for updates occasionally." | Refresh. |
+| Catalog idle/loaded | Detail: "N stations loaded." + last-sync time; checked occasionally when the app becomes active. | Refresh. |
 | Catalog loading / refreshing | Detail: "Refreshing station list…" / "Loading station list…"; Refresh button disabled. | — |
 | Catalog failed | Inline error line ("Could not refresh: …") + Refresh button. | Refresh (retry). |
 | Cloud sync off | Detail: "Off for this device. Existing iCloud data is kept for other devices."; Sync-now and Remove rows disabled. | Enable toggle. |
@@ -81,9 +89,9 @@ Settings sheet, top to bottom:
 | Cloud sync removed / reset applied | Detail confirms removal/reset. | — |
 | Diagnostics off | Preview: "Diagnostics collection is off."; Copy/Share disabled. | Enable toggle. |
 | Diagnostics on, empty | Preview: "No diagnostic events yet."; Copy/Share/Clear disabled. | — |
-| Diagnostics on, has events | Preview shows the last 6 redacted events. | Copy, Share, Clear. |
-| Listening history off | Only the tracking toggle is shown. | Enable toggle. |
-| Listening history on | Dashboard link + granularity + retention rows revealed. | All rows. |
+| Diagnostics on, has events | Preview shows the last 6 redacted events; expand opens the full redacted log. | Copy, Share, Clear, Expand. |
+| Listening history off | Only the tracking pill + its detail line are shown. | Tracking pill. |
+| Listening history on | Open-History link + retention dropdown revealed. | Tracking pill, link, retention. |
 | Offline | Preferences fully editable (local). Catalog refresh and Sync-now fail and surface their error/empty state; library data stays intact. | All local controls; network actions degrade. |
 
 ## Interactions
@@ -93,42 +101,45 @@ Settings sheet, top to bottom:
 | Tap tab (Preferences/About/Upload/History) | — | Switches page | — |
 | Swipe page horizontally | — | Switches page; tab strip follows | — |
 | Tap Theme segment (System/Light/Dark) | — | Sets theme; app recolors live | Persists; pushes preference to cloud |
-| Tap accent row | — | Opens accent picker sheet | Seeds picker with current accent |
-| Pick color in picker / type hex / Accept | Hex valid | Applies accent; closes sheet | Persists; pushes to cloud |
-| Type invalid hex + Accept | Hex invalid | No-op (accept blocked); error haptic; hex field refocused | Inline "Use #RRGGBB" hint shown |
-| Tap Standard (reset accent) | Custom accent set | Resets to classic accent | Persists; pushes to cloud |
+| Tap **Custom** (accent) | — | Opens accent picker overlay for the current appearance | Seeds picker with the current appearance's accent |
+| Pick color in picker / enter hex / Apply | Hex valid | Applies accent to the current appearance; closes overlay | Persists; pushes to cloud |
+| Enter invalid hex + Apply | Hex invalid | No-op (Apply disabled/greyed); error haptic; hex field refocused | — |
+| Tap **Standard** (accent) | Custom accent set for this appearance | Resets that appearance back to the adaptive default | Persists; pushes to cloud |
 | Toggle iCloud Sync on/off | — | Enables/disables sync for this device | On: pull+merge+push; off: stops syncing, keeps remote data |
 | Tap **Sync now** | Sync on, not already syncing | Pull + merge + push cycle | Detail updates with result |
 | Tap **iPhone Settings** | — | Opens OS iCloud settings | Leaves app |
+| Tap **Backup** | — | Encodes a JSON settings backup and opens the OS share sheet | Local-only; history excluded |
+| Tap **Restore** → Choose file | — | Confirmation alert → file importer → replaces favorites, lists, custom stations, and preferences from the backup | Result alert reports success/failure |
 | Tap **Remove all iCloud data** → Remove | Sync on, not syncing | Confirmation alert → wipes the user's cloud snapshot via tombstone | Other devices honor the reset on next sync |
-| Tap **Refresh** (catalog) | Not already refreshing | Re-fetches `stations.json` | Updates count/freshness or error line |
-| Tap landing-page row | — | Sets launch target | Persists; pushes to cloud |
+| Tap **Refresh** (catalog) | Not already refreshing | Re-fetches `stations.json` | Updates count/freshness or inline error line |
+| Tap landing-page row (Browse / Favorites / Play a station) | — | Sets launch target | Persists; pushes to cloud |
+| Tap the **Library** landing row | — | Sets landing to whatever the row's dropdown shows | Persists; pushes to cloud |
+| Pick from the Library landing dropdown | — | Sets landing to Home, a station list, or Recents | Persists; pushes to cloud |
 | Tap "Play a station" | — | Reveals station picker; pre-selects current/first preferred station | Persists choice; pushes to cloud |
 | Type in landing-station search | Picker open | Filters station pool (debounced ~200 ms, off main thread); shows ≤8 matches | — |
-| Tap "Use current station" | A station is playing | Pins the playing station as launch target | Persists; pushes to cloud |
-| Tap a landing-station match | — | Pins that station; sets landing to "Play a station" | Persists; pushes to cloud |
+| Tap "Use current station" | A station is playing, none picked yet | Pins the playing station as launch target | Persists; pushes to cloud |
+| Tap a landing-station match | — | Pins that station; sets landing to "Play a station"; collapses the suggestion list | Persists; pushes to cloud |
+| Tap a visible library-view row | Mode is visible | Sets it as the default display mode (DEFAULT badge) | Persists; pushes to cloud |
 | Tap library-view ▲/▼ | Not at edge | Reorders the display mode | Persists order + visible set; pushes to cloud |
 | Toggle library-view visibility | ≥1 mode stays visible | Shows/hides that mode in Library | Persists; pushes to cloud; may renormalize default mode |
-| Tap Default-Library-view row | Mode is visible | Sets the default display mode | Persists; pushes to cloud |
 | Change default wake time | — | Sets wake default | Persists; pushes to cloud |
 | Toggle wake notification | — | Opt in/out of wake notification | Persists; pushes to cloud; may request OS permission |
 | Tap notifications-denied warning | Permission denied | Opens OS Settings | Leaves app |
-| Change default sleep duration | — | Sets sleep default (from the timer cycle set) | Persists; pushes to cloud |
-| Toggle Automatic car mode | — | Enables/disables route-based car mode | Persists; pushes to cloud |
-| Toggle Manual car mode | — | Forces car mode on/off | Persists; pushes to cloud |
+| Change default sleep duration | — | Sets sleep default via the hh:mm dial (clamped to ≥1 min) | Persists; pushes to cloud |
+| Tap Car-mode segment (Auto/Always/Off) | — | Sets route-based / forced-on / off | Persists; pushes to cloud |
 | Toggle a Music service | — | Shows/hides that service's Now Playing deep-link | Persists; pushes to cloud |
-| Toggle Listening-history tracking | — | Enables/disables local history; reveals/hides sub-rows | Persists; pushes to cloud |
-| Tap **Open Listening dashboard** | History on | Jumps to History tab | — |
-| Tap granularity row | History on | Sets Stations-only or Stations+tracks | Persists; pushes to cloud |
-| Tap retention row | History on | Sets 30d / 90d / 1y / Forever | Persists; pushes to cloud |
+| Tap History segment (Off/Stations/+Tracks) | — | Enables/disables history and sets its level; reveals/hides sub-rows | Persists; pushes to cloud |
+| Tap **Open History** | History on | Jumps to History tab | — |
+| Pick from the Keep-history dropdown | History on | Sets 30d / 90d / 1y / Forever | Persists; pushes to cloud |
 | Toggle AI station blurbs | iOS 26+ | Enables/disables AI blurbs | Persists; pushes to cloud |
-| Tap language row | — | Sets language choice; UI re-renders | Persists; pushes to cloud |
+| Pick from the Language dropdown | — | Sets language choice; UI re-renders | Persists; pushes to cloud |
 | Toggle Collect Diagnostics | — | Enables/disables local diagnostics | Disable clears the local store immediately |
-| Long-press recent-events preview → Copy | — | Copies the selected (redacted) preview text | See deviation D3/ST3 |
+| Long-press recent-events preview → Copy | — | Copies the selected (already redacted) preview text | Matches the redacted export |
+| Tap diagnostics **expand** corner button | — | Opens the full redacted log full-screen | — |
 | Tap **Copy** (diagnostics) | On + events exist | Copies redacted export to clipboard | Button reads "Copied"; records a "copied" event |
 | Tap **Share** (diagnostics) | On + events exist | Opens OS share sheet with redacted export | Records a "share opened" event |
-| Tap **Clear** (diagnostics) | Events exist | Empties the local diagnostics store | Resets Copy/Share state |
-| System: audio route change | Automatic car mode on | Re-evaluates car-like route → toggles active state | Updates route label |
+| Tap **Clear** (diagnostics) | Events exist | Confirmation alert → empties the local diagnostics store | Resets Copy/Share state |
+| System: audio route change | Automatic car mode on | Re-evaluates car-like route → toggles active state | Updates the detected-route flag |
 | System: OS language change | Language choice = System | Recomputes resolved language; re-renders | Records a locale diagnostic note |
 | System: remote cloud change | Sync on | Silent push wakes a pull+merge | Applies merged preferences live |
 
@@ -136,44 +147,65 @@ Settings sheet, top to bottom:
 
 - **Theme** choices: `system` (default) · `light` · `dark`. Persisted as the
   choice token, re-applied on launch.
-- **Accent** stored as a normalized 6-digit hex (`#RRGGBB`) or the sentinel
-  `classic`. Classic resolves dynamically: yellow `#FFFF00` in dark, green
-  `#00A040` in light. Legacy preset names (`blue`/`rose`/`violet`) migrate to hex.
-  3-digit hex expands to 6; invalid input is rejected.
-- **Language** choices: `system` (default) · `en` · `de` · `fr` · `es`. Resolution
-  collapses regional variants by prefix; unrecognized → `en`. Full rules in
-  [localization](../contracts/localization.md).
-- **Landing page** targets: Browse (default) · Library · Favorites · a named
-  station list · Recents · a pinned station. Station-list and pinned-station ids
-  are stored separately; "Play a station" requires a resolvable station id.
+- **Accent** is per-appearance: a light side and a dark side, each either a
+  normalized 6-digit hex (`#RRGGBB`) or the sentinel `classic`. Stored as one token
+  when both sides match, otherwise a `light/dark` composite. Classic resolves to
+  green `#00A040` in light and yellow `#FFFF00` in dark. Editing in light/dark mode
+  changes only that appearance's side; Standard resets only that side. Legacy preset
+  names (`blue`/`rose`/`violet`) migrate to hex; 3-digit hex expands to 6; invalid
+  input is rejected.
+- **Language** choices: `system` (default) · `en` · `de` · `fr` · `es` · `it` ·
+  `ru`. Resolution collapses regional variants by prefix; unrecognized → `en`. Full
+  rules in [localization](../contracts/localization.md).
+- **Landing page** targets: Browse (default) · Library home · Favorites · a named
+  station list · Recents · a pinned station. The Library home / station-list /
+  Recents targets share one row whose dropdown picks among them. Station-list and
+  pinned-station ids are stored separately; "Play a station" requires a resolvable
+  station id.
 - **Library views**: display modes are List / Tiles / App. At least one mode must
-  stay visible; the default mode is renormalized to a visible mode when its
-  current default is hidden. Order and visible-set are persisted as raw strings.
-- **Sleep default** is chosen from the timer's positive cycle minutes. **Wake
-  default** time is `HH:mm` (24h stored). See [sleep-timer](sleep-timer.md) and
-  [wake-to-radio](wake-to-radio.md) for the timers themselves.
+  stay visible; the default mode is renormalized to a visible mode when its current
+  default is hidden. Order and visible-set are persisted as raw strings. The default
+  mode is chosen by tapping a visible row in the same section.
+- **Sleep default** is set with an `hh:mm` dial (any duration 0:01–23:59, clamped to
+  a 1-minute floor), stored as minutes. **Wake default** time is `HH:mm` (24h
+  stored). Both dials follow the device's 24-/12-hour setting where applicable. See
+  [sleep-timer](sleep-timer.md) and [wake-to-radio](wake-to-radio.md) for the timers
+  themselves.
 - **Car mode** is active when manual is on, or when automatic is on and a car-like
   audio route is detected (CarPlay/`carAudio` port, or a Bluetooth/USB output whose
   name matches a known car/brand hint). Automatic defaults **on**; manual **off**.
+  Surfaced as one tri-state control: Auto (automatic on) · Always (manual on) · Off.
 - **Music services**: each registered service has an offered/hidden toggle; all
   three ship default **on**. A new registry service automatically gets a toggle.
-- **Listening history** is **off by default**, granularity defaults to
-  Stations-only, retention defaults to 90 days. Track-level granularity stores
-  artist/title only when the station publishes them. History never syncs.
+- **Listening history** is **off by default**, level defaults to Stations-only,
+  retention defaults to 90 days. Track-level granularity stores artist/title only
+  when the station publishes them. The enabled/level/retention preferences sync, and
+  closed history sessions **sync** across the user's devices as an additive union;
+  the active/open session is never uploaded.
 - **Diagnostics** are **off by default**. Cap: **100 events / 14 days**, pruned
   oldest-first. Per-detail value capped at **120 chars**; URLs reduced to host at
-  write time. Export prepends app version, device model/OS, locale, collection
-  state, then redacted events. Disabling **immediately clears** the store. The
-  recent-events preview shows the last **6** events.
+  write time. MetricKit crash/hang **reports** are captured separately (cap **6**,
+  body ≤ **6000 chars**): they leave a one-line breadcrumb in the event stream and
+  append their verbatim call stack to the export. Export prepends app version, device
+  model/OS, locale, collection state, then redacted events, then any reports.
+  Disabling **immediately clears** both stores. The recent-events preview shows the
+  last **6** events, redacted (so selecting/copying it matches the export); an expand
+  button opens the full redacted log.
 - **Catalog refresh** re-fetches `https://rrradio.org/stations.json`; the catalog
-  also loads on launch and is checked occasionally when the app becomes active.
-- **Synced preferences** (iOS): theme, accent, locale, sleep default, landing page
-  (+ station/list ids), favorites display mode/order/visible, wake default time,
-  wake-notifications, wake keep-alive, car-mode auto/manual, listening-history
-  enabled/level/retention, the three music-service toggles, and AI blurbs.
-  **Not synced**: recents, listening-history records, diagnostics, active wake
-  intent. Authoritative field list and merge rule in
-  [sync-merge](../contracts/sync-merge.md).
+  also loads on launch and is checked occasionally when the app becomes active. A
+  failed refresh keeps any cached stations on screen and surfaces an inline error
+  line; the last successful sync time is shown.
+- **Settings backup** (iOS) writes/reads a local JSON file (share sheet / file
+  importer) of favorites, station lists, custom stations, and preferences. It works
+  with iCloud sync off and **excludes** listening history; restoring replaces those
+  categories with the backup's contents.
+- **Synced preferences** (iOS): theme, accent (per-appearance), locale, sleep
+  default, landing page (+ station/list ids), favorites display mode/order/visible,
+  wake default time, wake-notifications, wake keep-alive, car-mode auto/manual,
+  listening-history enabled/level/retention (and closed listening-history records),
+  the three music-service toggles, and AI blurbs. **Not synced**: recents,
+  diagnostics, the active/open listening session, active wake intent. Authoritative
+  field list and merge rule in [sync-merge](../contracts/sync-merge.md).
 
 ## Data dependencies
 
@@ -198,15 +230,23 @@ Settings sheet, top to bottom:
 - **Pending-preferences flag.** A queued local preference edit makes *all* local
   preference fields authoritative on the next merge (binary flag — see Known
   deviations C7).
-- **Catalog refresh failure.** Surfaces as an inline error line; the "Refreshing"
-  label can flip back to a stale count without an explicit error toast (deviation
-  ST7).
-- **Invalid hex entry.** Accept is blocked with an error haptic and inline hint;
-  no accent change is committed.
+- **Catalog refresh failure.** Cached stations stay on screen; the failure surfaces
+  as an inline error line (the count detail can still read the stale total alongside
+  it — deviation ST7).
+- **Invalid hex entry.** The picker's Apply control is disabled/greyed; tapping it
+  fires an error haptic and refocuses the hex field; no accent change is committed.
 - **Wake-notification permission denied.** A warning row appears linking to OS
   Settings; the toggle reflects the denied state.
-- **Diagnostics disabled.** `record(…)` becomes a no-op, the store is removed, and
-  export reports "collection off".
+- **Diagnostics disabled.** `record(…)` becomes a no-op, both the event and report
+  stores are removed, and export reports "collection off".
+- **MetricKit report captured.** A crash/hang report adds a one-line breadcrumb to
+  the events and stores the verbatim call stack (≤6000 chars) in a separate
+  6-deep store; the call stack is exported verbatim (no host/URL redaction) since it
+  carries only the user's own app frames.
+- **Settings backup restore.** Reads a security-scoped file; a malformed or
+  incompatible file fails with a "Backup failed" alert and no data change; a valid
+  file replaces favorites, lists, custom stations, and preferences and reports the
+  restored counts.
 - **Huge landing-station search.** The pool includes the full catalog (~17k); the
   filter is debounced and run off the main thread, displaying ≤8 rows (historical
   main-thread/no-debounce shape flagged in ST2; current code debounces ~200 ms and
@@ -217,31 +257,38 @@ Settings sheet, top to bottom:
 
 ## Accessibility
 
-- Theme segments expose label + selected/not-selected value + `isSelected` trait.
-- Accent-picker Accept/Cancel carry explicit labels; the picker disables alpha and
-  the eyedropper (iOS 26+).
-- Radio rows (landing, language, granularity, retention, default view) show a
-  checkmark for the active choice; the row is the tap target.
-- Library-view visibility toggles read only their pill state and lack a spoken
-  "what is toggled" context outside the visual row (gap ST16).
-- Dynamic Type: theme-segment labels shrink (min scale ~0.82); detail/title text
-  uses fixed point sizes — large accessibility sizes can truncate multi-line
-  detail copy (lineLimit caps of 2–8).
+- Theme, Color, Car-mode, and History segments expose label + selected/not-selected
+  value + `isSelected` trait.
+- Accent-picker Apply/Cancel carry explicit labels; the picker (Apple's system color
+  picker) disables alpha and the eyedropper (iOS 26+).
+- Landing rows show a checkmark for the active choice; the row is the tap target. The
+  Library landing, language, and retention dropdowns expose an accessibility label +
+  value (the current selection).
+- Library-view rows expose the default choice as a label + selected value +
+  `isSelected` trait; the per-mode visibility toggle reads only its pill state and
+  lacks a spoken "what is toggled" context outside the visual row (gap ST16).
+- The diagnostics expand button carries an explicit "Expand diagnostics log" label.
+- Dynamic Type: segment labels shrink (min scale ~0.82); detail/title text uses
+  fixed point sizes — large accessibility sizes can truncate multi-line detail copy
+  (lineLimit caps of 2–8).
 - Destructive **Remove all iCloud data** uses the system destructive role (red);
   the confirmation alert is the irreversible cross-device wipe gate.
 
 ## Localization
 
 This surface owns its section titles and row copy: Theme/Color/iCloud Sync/Catalog/
-Landing page/Library views/Default Library view/Timer defaults/Car mode/Music
-services/Listening History/Apple Intelligence/Language/Diagnostics, plus all
-cloud-sync state sentences, catalog state messages, the diagnostics labels
-(Collect/Copy/Copied/Share/Clear), accent labels (Accent/Classic/Standard/Hex),
-the Remove-iCloud alert title/message/buttons, and the four tab titles. Language
-row display names (System/English/Deutsch/Français/Español) are intentionally
-self-localized. Count-bearing copy (favorites/lists/stations/retention) needs
-plural keys, not hand-rolled `1 ? "x" : "xs"` strings. Full rules and the registry
-in [localization](../contracts/localization.md).
+Landing page/Library views/Timer defaults/Car mode/Music services/Listening History/
+Apple Intelligence/Language/Diagnostics, plus all cloud-sync state sentences, catalog
+state messages, the diagnostics labels (Collect/Copy/Copied/Share/Clear), accent
+labels (Standard/Custom), the Remove-iCloud alert title/message/buttons, and the four
+tab titles, plus the
+settings-backup copy (Backup/Restore buttons, restore-confirm + result alerts) and
+the diagnostics expand label. Language menu display names
+(System/English/Deutsch/Français/Español/Italiano/Русский) are intentionally
+self-localized. Count-bearing copy (favorites/lists/stations/retention) needs plural
+keys, not hand-rolled `1 ? "x" : "xs"` strings. Many of these strings still ship raw
+English (deviation ST4–ST6). Full rules and the registry in
+[localization](../contracts/localization.md).
 
 ## Platform Matrix
 
@@ -267,15 +314,16 @@ in [localization](../contracts/localization.md).
 | Station history | Not part of current web contract beyond recents. | Supported as opt-in listening history. | Supported as local opt-in history. |
 | Track-level history | Not planned for current web. | Supported only when user selects it. | Gated behind explicit opt-in; metadata-recording expansion remains future polish. |
 | Retention controls | Supported where exposed. | Supported (30d/90d/1y/Forever; default 90d). | Partial; bounded default, controls TBD. |
-| Sync | Not planned. | Not synced. | Not planned. |
+| Sync | Not planned. | Supported (closed sessions union across devices via iCloud). | Not planned. |
 
 ### Diagnostics
 
 | Behavior | Web | iOS | Android |
 |---|---|---|---|
 | Anonymous aggregate telemetry | Supported through GoatCounter. | Not the native support surface. | Not planned for first port. |
-| Local diagnostics | Not primary web contract. | Supported, opt-in, capped, exportable. | Supported, opt-in, capped, exportable. |
-| Redacted export / clear-on-disable | Supported where exposed. | Supported. | Supported. |
+| Local diagnostics | Not primary web contract. | Supported, opt-in, capped, exportable, with full-log viewer. | Supported, opt-in, capped, exportable. |
+| MetricKit crash/hang reports | Not applicable. | Supported (capped, call stack exported verbatim). | Not planned for first port. |
+| Redacted export / clear-on-disable | Supported where exposed. | Supported (preview also redacted). | Supported. |
 | Broken-station report | Supported. | Supported where implemented. | Supported through the shared anonymous report endpoint. |
 
 ### Cloud sync & car mode
@@ -284,34 +332,44 @@ in [localization](../contracts/localization.md).
 |---|---|---|---|
 | iCloud/CloudKit library+preferences sync | Not planned. | Supported (own private DB). | Not applicable. |
 | Sync status / Sync now / Remove all | Not applicable. | Supported. | Not applicable. |
-| Car mode preferences | Browser/OS dependent. | Supported (auto route detect + manual). | Partial media controls; Android Auto TBD. |
+| Local settings backup file (export/import) | Not planned. | Supported (JSON; works with sync off; excludes history). | Not planned. |
+| Car mode preferences | Browser/OS dependent. | Supported (tri-state: auto route detect / always / off). | Partial media controls; Android Auto TBD. |
 
 ## Open questions
 
 - **C7 — binary pending-preferences flag.** One queued preference edit makes every
   local preference field authoritative on the next merge; per-field dirty-tracking
   is proposed. See [sync-merge](../contracts/sync-merge.md) Open questions.
-- **Device-local vs synced clarity.** Now that the music-service and AI-blurbs
-  toggles do sync, no preference is silently device-local; confirm this is the
-  intended end state versus an explicit "(this device)" affordance for any future
-  device-local toggle.
+- **Device-local vs synced clarity.** No preference is silently device-local now,
+  and closed listening-history sessions sync too; confirm this is the intended end
+  state versus an explicit "(this device)" affordance, given the History UI still
+  frames history as "stays on this device."
 - **Catalog-refresh error surfacing.** Whether a failed refresh should raise an
   explicit toast rather than only an inline line that a stale count can mask (ST7).
 
 ## Reference
 
 - `rrradio/Views/SettingsView.swift` — the Settings sheet, all preference sections,
-  cloud-sync/catalog/diagnostics blocks, accent picker, landing-station picker.
-- `rrradio/Views/ThemeController.swift` — theme choice + accent normalization,
-  classic-accent resolution, legacy-preset migration, hex parsing.
-- `rrradio/Views/LocaleController.swift` — language choice, resolution, the
-  `L10nKey`/`L10nPluralKey` registries and `L10n` lookup engine.
+  cloud-sync/backup/catalog/diagnostics blocks, accent-picker overlay, the
+  Library/language/retention dropdowns, the tri-state car-mode/history controls, the
+  landing-station picker, and the full-screen diagnostics-log viewer.
+- `rrradio/Views/ThemeController.swift` — theme choice + per-appearance accent
+  (light/dark side tokens, composite storage), classic-accent resolution,
+  legacy-preset migration, hex parsing.
+- `rrradio/Views/LocaleController.swift` — language choice (incl. it/ru), resolution,
+  the `L10nKey`/`L10nPluralKey` registries and `L10n` lookup engine.
 - `rrradio/Views/LandingPreference.swift` — `LandingPage` enum + storage keys.
 - `rrradio/Player/CarModeController.swift` — auto/manual car mode, route detection,
   car-like-output heuristics.
-- `rrradio/Diagnostics.swift` — local ring buffer (100/14d), write-time host
-  reduction, redacted export with sensitive-key allow-list, share/copy draft, and
-  `BrokenStationReporter`.
+- `rrradio/Library/ListeningHistory.swift` — enabled/level/retention, record store,
+  retention pruning, and `syncableRecords()` / `mergeSyncedRecords()` for the
+  cross-device record union.
+- `rrradio/CloudSync/CloudSyncController.swift`, `CloudSyncSnapshot.swift`,
+  `SettingsBackup.swift` — the synced-preferences snapshot, merge wiring, and the
+  local settings-backup encode/restore.
+- `rrradio/Diagnostics.swift` — local ring buffer (100/14d) plus a separate MetricKit
+  report store (6 / 6000 chars), write-time host reduction, redacted export with
+  sensitive-key allow-list, share/copy draft, and `BrokenStationReporter`.
 
 ## Known deviations
 
@@ -320,11 +378,12 @@ in [localization](../contracts/localization.md).
   sync snapshot. Now wired through a cloud-synced binding and present in the
   `Preferences` record. Historical finding:
   `rrradio-ios/internal/audit/2026-05-25-ios-code-review-slice25.md` (ST1).
-- **ST3 / D3 — diagnostics preview text-selection bypasses redaction.** The
-  on-screen recent-events preview is selectable; the contract intent is that
-  anything copyable matches the redacted export.
+- **ST3 / D3 — diagnostics preview text-selection bypassed redaction (RESOLVED).**
+  The on-screen recent-events preview is still selectable, but it now renders the
+  redacted variant, so anything copied out of it matches the redacted export — the
+  contract intent. Historical findings:
   `rrradio-ios/internal/audit/2026-05-25-ios-code-review-slice20.md` (D3),
-  `…-slice25.md` (ST3); also flagged in
+  `…-slice25.md` (ST3); also referenced in
   [privacy-data-boundaries](../contracts/privacy-data-boundaries.md) Known deviations.
 - **ST4–ST6 / LC3 — untranslated Settings strings + hand-rolled plurals.** ~50
   Settings strings ship raw English even where keys exist (section titles, all
@@ -335,15 +394,20 @@ in [localization](../contracts/localization.md).
   plurals. `rrradio-ios/internal/audit/2026-05-25-ios-code-review-slice25.md`
   (ST4–ST6), `…-slice26.md` (LC3); cross-referenced in
   [localization](../contracts/localization.md) Known deviations.
-- **ST7 — catalog refresh errors silently disappear.** A failed refresh can flip
-  back to a stale "N stations loaded" without an explicit error indication.
+- **ST7 — catalog refresh errors could go stale (partially mitigated).** A failed
+  refresh now keeps cached stations on screen and surfaces a dedicated inline error
+  line (`lastRefreshError`), but the count detail can still read a stale "N stations
+  loaded" alongside it rather than an explicit error toast.
   `rrradio-ios/internal/audit/2026-05-25-ios-code-review-slice25.md` (ST7).
 - **ST2 — landing-station search filtered ~17k catalog on the main thread (largely
   mitigated).** Original finding had no debounce and ran on the main thread; current
   code debounces ~200 ms and detaches the filter.
   `rrradio-ios/internal/audit/2026-05-25-ios-code-review-slice25.md` (ST2).
-- **ST10 / ST16 — accent-accept silent no-op on invalid hex; labeled-but-empty
-  visibility toggle lacks VoiceOver context.**
+- **ST10 / ST16 — accent Apply on invalid hex; labeled-but-empty visibility toggle
+  lacks VoiceOver context.** On invalid hex the Apply control is disabled/greyed and
+  tapping it fires an error haptic + refocuses the field, but there is no inline
+  textual hint near the control. The library-view visibility toggle still reads only
+  its pill state.
   `rrradio-ios/internal/audit/2026-05-25-ios-code-review-slice25.md` (ST10, ST16).
 - **C7 — binary pending-preferences flag locks all preferences on merge.**
   `rrradio-ios/internal/audit/2026-05-25-ios-code-review-slice10.md` (C7); see

--- a/docs/spec/features/search.md
+++ b/docs/spec/features/search.md
@@ -1,9 +1,9 @@
 # Search Specification
 
 ```yaml
-status: draft
+status: review
 platforms: [web, ios, android]
-reconciled-against: 9336321
+reconciled-against: d241aa9
 ```
 
 ## Purpose
@@ -81,6 +81,7 @@ Top to bottom, the search-relevant elements of the Browse surface:
 | Tap a result row | — | Plays that station; queues the currently visible window | Catalog stations push to recents |
 | Long-press a result row | Not in multi-select | Shows station info preview overlay | Released → preview dismisses |
 | Change country/genre/news filter | — | Query result set re-filters; Radio Browser re-fetches with derived tag/country | Display window resets |
+| Change stream-quality filter (low/medium/high buckets) | — | Query result set re-filters to matching buckets across every tier (local + community); Radio Browser query is *not* re-derived from it | Display window resets |
 | Enter multi-select / receive list-selection request | — | Search is cleared, filters reset (browse-owned) | — |
 | Leave Browse page | — | Debounce + filter tasks cancelled; Radio Browser paginator reset; info preview dismissed | Query lost on return |
 
@@ -106,10 +107,17 @@ Top to bottom, the search-relevant elements of the Browse surface:
   broad query doesn't pull the entire catalog into memory.
 - **Visible window paging: 25 rows.** The list renders only the first 25 results,
   growing by 25 each load-more hit before falling through to Radio Browser.
+- **Active browse filters gate every search tier.** Country, genre, news, and
+  stream-quality (low/medium/high buckets) filters are applied to FTS hits, the
+  substring safety net, custom + Radio Browser side matches, and the substring
+  fallback alike — a result must satisfy the filter on every path. A station with
+  unknown codec/bitrate scores the lowest quality bucket.
 - **Radio Browser fires only while a query is active**, and is suppressed when a
   country filter is active and the query is ≤2 normalized characters (contract:
   country-code short-circuit). It is a "more results" extension, never ambient
-  catalog enrichment.
+  catalog enrichment. Only the genre (or news) and country filters derive the
+  Radio Browser tag/country params; the quality filter narrows the merged result
+  set but is never sent to Radio Browser.
 - **Radio Browser page size: 50** (Browse paginator). Pagination stops when a
   page returns empty or a fetch fails.
 - The **count label** reflects the merged local+community total already in the
@@ -198,6 +206,7 @@ This surface owns four strings:
 | Query-active suppresses alphabet/quality/favorite sort | Required | Reference | Required |
 | Radio Browser community results appended on load-more | Supported | Reference | Supported with cache-backed loading |
 | Country-filter + ≤2-char-query suppresses RB call | Required | Reference | Required |
+| Stream-quality (low/medium/high) filter gates every search tier | Supported | Reference | Supported |
 | Visible-window paging then RB pagination | Supported | Reference (25 then 50) | Supported |
 | Clear button resets field + query + RB paginator | Supported | Reference | Supported |
 | No-results unavailable view with guidance text | Supported | Reference | Supported |
@@ -229,11 +238,14 @@ iOS source (the only place iOS mechanics are named):
 - `rrradio/Search/Search.swift` — `normalizeForSearch`, `stationMatches`,
   `stationSearchSurface` (the searchable surface).
 - `rrradio/Search/CatalogStationSearch.swift` — tier orchestration
-  (`indexedStations`), FTS-miss safety net, filter gating, dedupe by id.
+  (`indexedStations`), FTS-miss safety net, `matchesBrowseFilters`
+  (country/genre/news/quality gating on every tier), dedupe by id.
 - `rrradio/Search/SearchIndex.swift` — bundled FTS5 open/query, ranking,
   divergence validation.
 - `rrradio/Search/StationFilters.swift` — genre `rbTag` mapping used to derive
   the Radio Browser tag param, country helpers.
+- `Shared/StationFeed.swift` — `BrowseFilter` (country/genre/news +
+  `qualityBuckets`), the filter object every search tier is gated by.
 - `rrradio/Views/FeedPages/State/RadioBrowserPaginator.swift` — pagination,
   cancellation key, `canonicalQuery` country-code short-circuit, silent failure.
 - `rrradio/Views/FeedPages/State/FeedPageState.swift` — `searchText` vs committed

--- a/docs/spec/features/siri-shortcuts.md
+++ b/docs/spec/features/siri-shortcuts.md
@@ -1,22 +1,25 @@
 # Siri & Shortcuts Specification
 
 ```yaml
-status: draft
+status: review
 platforms: [ios]
-reconciled-against: 9336321
+reconciled-against: d241aa9
 ```
 
 ## Purpose
 
 Lets a user control rrradio hands-free, without touching the app. iOS exposes a
 set of App Intents that Siri, the Shortcuts app, and Spotlight can run: start a
-named station, resume the last station, and run transport commands
-(pause / resume / stop / next / previous) and a favorite toggle on the live
-stream. Stations surface as first-class, searchable system entities so a user
-can say "Play Grrif in rrradio", run a shortcut, or tap a Spotlight result and
-hear audio with no manual navigation. This surface is iOS-only; web and Android
-reach the same product value through their own OS equivalents (PWA / Web Share
-Target, Android App Actions / Assistant), which are not yet built.
+named station, play a named station list, resume the last station, run transport
+commands (pause / resume / stop / next / previous), toggle a favorite, arm a
+sleep timer or wake alarm, and ask what's playing. Stations and station lists
+surface as first-class, searchable system entities so a user can say "Play Grrif
+in rrradio", run a shortcut, or tap a Spotlight result and hear audio with no
+manual navigation. Query intents (What's Playing, Set Sleep Timer) speak a Siri
+answer drawn from a persisted now-playing snapshot, so they work even when the
+app is asleep. This surface is iOS-only; web and Android reach the same product
+value through their own OS equivalents (PWA / Web Share Target, Android App
+Actions / Assistant), which are not yet built.
 
 ## Entry points
 
@@ -27,13 +30,16 @@ Target, Android App Actions / Assistant), which are not yet built.
 - **Spotlight search** — each known station is indexed as a searchable item;
   tapping a result runs the Play Station intent for that station.
 - **Siri Suggestions / Shortcuts gallery** — the app's shortcuts are offered as
-  suggested actions; up to 25 stations are surfaced as suggested entities.
+  suggested actions; up to 25 stations and all of the user's station lists are
+  surfaced as suggested entities.
 - **Action Button / Back Tap / Lock Screen / Control Center widgets** — any iOS
   surface that can run an App Intent or Shortcut runs these the same way.
 
 These intents are NOT a visible in-app screen. They are a system-level surface;
-their only in-app consequence is playback / library state changing and the Now
-Playing destination appearing after a launch.
+their in-app consequences are playback / library / timer state changing and the
+Now Playing destination appearing after a launch. Two intents (What's Playing,
+Set Sleep Timer) produce only a spoken Siri answer and change nothing on a
+sleeping app.
 
 ## Layout
 
@@ -42,12 +48,13 @@ system UI, populated by the app's intent and entity definitions:
 
 | Surface | What shows |
 |---|---|
-| Shortcuts action list | One row per intent: short title + system glyph (radio, dot.radiowaves.left.and.right, pause.fill, play.fill, stop.fill, forward.fill, backward.fill, heart). |
-| Action parameter summary | Human sentence, e.g. "Play [Station]", "Pause rrradio", "Toggle favorite on [Station]". |
+| Shortcuts action list | One row per intent: short title + system glyph (radio, dot.radiowaves.left.and.right, pause.fill, play.fill, list.star, forward.fill, backward.fill, music.note, moon.zzz, alarm). |
+| Action parameter summary | Human sentence, e.g. "Play [Station]", "Play list [List]", "Pause rrradio", "Toggle favorite on [Station]", "Set a sleep timer for [Minutes] minutes", "Wake to [Station] at [Time]", "Get what's playing in rrradio". |
 | Station picker (parameterized intents) | A searchable list of station entities; each row shows station name (title) and a subtitle. |
+| Station list picker (Play Station List) | A searchable list of station-list entities; each row shows list name (title) and "N stations" subtitle. |
 | Station entity subtitle | `broadcaster · country` when both known and differ; else broadcaster, else country, else nothing. |
-| Spotlight result | Station name (title + display name), description = broadcaster else country, artist = broadcaster, audio content type. |
-| Siri response | System confirmation that the intent ran; for app-opening intents the app launches to Now Playing. |
+| Spotlight result | Station name (title + display name), description = broadcaster else country, artist = broadcaster, content sources = country, audio content type. |
+| Siri response | System confirmation that the intent ran; query intents speak a dialog ("Playing [track] on [station].", "Sleep timer set for N minutes.", "Nothing is playing in rrradio right now."); for app-opening intents the app launches to Now Playing. |
 
 ## States
 
@@ -56,86 +63,142 @@ of running one.
 
 | State | What happens | Actionable |
 |---|---|---|
-| Resolved + app launches | Play / Play Last open the app, route to the resolved station, start playback, surface Now Playing after a short delay. | Full app UI. |
-| Resolved, app already running | Transport / favorite intents (which do not open the app) wake the running app via one shared request; it applies the action in place. | Existing UI. |
-| Station picker, no query | Up to 25 suggested stations (favorites → recents → custom → catalog order) are listed for selection. | Pick a station. |
+| Resolved + app launches | Play / Play Station List / Play Last / Set Wake Alarm open the app, route to the resolved station (or list head), start playback (Wake Alarm arms, no playback), surface Now Playing after a short delay. | Full app UI. |
+| Resolved, app already running | Transport / favorite / sleep-timer intents (which do not open the app) wake the running app via one shared request; it applies the action in place. | Existing UI. |
+| Query intent (What's Playing / Set Sleep Timer) | Reads the persisted now-playing snapshot and speaks a Siri dialog; arms the timer only if the snapshot says something is playing. No app launch, no screen. | None (spoken only). |
+| Station picker, no query | Up to 25 suggested stations (favorites → recents → custom → cached catalog → bundled order) are listed for selection. | Pick a station. |
 | Station picker, query typed | Up to 25 stations whose name contains the query (case-insensitive) are listed. | Pick a station; refine query. |
+| Station-list picker | Every station list the user owns is listed (no cap); empty-query lists all, a query filters by case-insensitive name substring. | Pick a list. |
 | Empty roster (cold, no catalog) | Picker / suggestions resolve from whatever local sources exist; with none, the bundled snapshot still provides stations. An unresolvable id is a no-op. | None until catalog loads. |
-| Unresolved station id | The intent posts the request, but on consume the id matches no known station: silently dropped, no playback, no error dialog. | None. |
+| Unresolved station / list id | The intent posts the request, but on consume the id matches nothing known: silently dropped, no playback, no error dialog. | None. |
 | Transport intent, app not running | The action is recorded and no-ops on the next launch (it is not replayed as a stale command). | None. |
+| Timed intent (sleep / wake) consumed late | If more than 60 s passed between firing and consume, the request is dropped rather than armed against the wrong moment. | None. |
 | Play Last, no recents | No station resolves; no playback starts. | None. |
 
 ## Interactions
 
 | Control / gesture | Precondition | Result | Side effects |
 |---|---|---|---|
-| Run "Play Station" (pick / phrase with station) | Station resolves to a known id | App opens, plays that station, shows Now Playing after ~300 ms | Pending play-station id stored; `intentPlaybackRequested` posted; recents updated by playback |
+| Run "Play Station" (pick / phrase with station) | Station resolves to a known id | App opens, plays that station with the library queue it belongs to, shows Now Playing after ~300 ms | Pending play-station id stored; `intentPlaybackRequested` posted; recent pushed if catalog station |
+| Run "Play Station List" / "Play list X" | List resolves and has ≥1 station | App opens, plays the list's first station inside the full station-list queue, shows Now Playing | Pending list id stored; recent pushed for the head station |
 | Run "Play Last Station" / "Start rrradio" | A recent exists | App opens, plays most-recent station, shows Now Playing | Pending play-last flag set; play-station id cleared |
 | Run "Pause" | App reachable; stream audible | Running app pauses in place; station stays selected | Pending action `pause`; does NOT open app |
 | Run "Resume" | App reachable; paused/error | Running app resumes the current station | Pending action `resume`; does NOT open app |
 | Run "Stop" | App reachable; station selected | Running app stops: clears station, queue, metadata; goes idle | Pending action `stop`; does NOT open app |
 | Run "Next Station" | App reachable; steppable queue (>1) | App steps forward (circular) and plays the next station | Pending action `nextStation`; no app open |
 | Run "Previous Station" | App reachable; steppable queue (>1) | App steps backward (circular) and plays the previous station | Pending action `previousStation`; no app open |
-| Run "Toggle Favorite" (pick / phrase with station) | Station resolves to a known id | Adds station to favorites, or removes it if already saved | Pending action `toggleFavorite` + station id; library mutated; no app open |
+| Run "Toggle Favorite Station" (pick) | Station resolves to a known id | Adds station to favorites, or removes it if already saved | Pending action `toggleFavorite` + station id; library mutated; no app open |
+| Run "Set Sleep Timer" (1–720 min) | Snapshot says something is playing | Running app arms a sleep timer that pauses playback after N minutes; Siri says "Sleep timer set for N minutes." | Pending minutes + timestamp stored; no app open; dropped if not consumed within 60 s |
+| Run "Set Sleep Timer", nothing playing | Snapshot absent or `isPlaying` false | No timer armed; Siri says "Nothing is playing in rrradio right now." | None |
+| Run "Set Wake Alarm" (station + time) | Station resolves to a known id | App opens and arms a wake alarm for the time-of-day of the picked time on that station | Pending station id + "HH:mm" time + timestamp stored; dropped if not consumed within 60 s |
+| Run "What's Playing" | — | Siri speaks the current station and track, or "Nothing is playing…" if the snapshot is absent / not playing | None; no app open |
 | Type in station picker | Parameterized intent | Filters to ≤25 stations whose name contains the text (case-insensitive) | None |
+| Type in station-list picker | Play Station List | Filters all lists by case-insensitive name substring (no cap) | None |
 | Tap a Spotlight station result | Station indexed | Runs Play Station for that station id | Same as Play Station |
-| Siri disambiguation prompt | Phrase resolves to multiple stations | iOS asks the user to choose from matching entities before running | None until chosen |
+| Siri disambiguation prompt | Phrase resolves to multiple entities | iOS asks the user to choose from matching stations / lists before running | None until chosen |
 | App enters foreground / catalog refreshes | A pending intent/transport request exists | App drains the pending request(s) and applies them | Pending keys cleared on consume |
 
 ## Business rules
 
-- **Intent set (8):** Play Station, Play Last Station, Pause, Resume, Stop,
-  Next Station, Previous Station, Toggle Favorite Station.
-- **App-opening intents (2):** Play Station and Play Last Station open the app.
-  All transport and favorite intents do NOT open the app — they target an
-  already-running session.
-- **Single wake channel:** every intent records its intent (id and/or action)
-  to a pending store and posts one shared `intentPlaybackRequested` request; the
-  running app inspects the store to decide what to do. Play / Play Last route
-  through the station-consume path; everything else through the
-  transport-action path.
-- **At most one outcome per drain:** a single consume call returns one play
-  outcome and one transport outcome, so a play + transport request arriving in
-  rapid succession does not double-fire.
-- **Transport intents are fire-and-no-op-if-dead:** if the app is not running,
-  the recorded action is applied (or ignored) on the next launch rather than
-  resurrecting playback from a cold start. Only Play / Play Last cold-start
-  audio.
-- **Station resolution roster** (de-duplicated by id, first occurrence wins,
-  order preserved): favorites → recents → custom stations → cached catalog →
-  bundled catalog snapshot. The play-consume path additionally unions the
-  intent-supplied candidate entities with this local roster.
+- **Intent set (12):** Play Station, Play Station List, Play Last Station,
+  Pause, Resume, Stop, Next Station, Previous Station, Toggle Favorite Station,
+  Set Sleep Timer, Set Wake Alarm, What's Playing.
+- **App-opening intents (4):** Play Station, Play Station List, Play Last
+  Station, and Set Wake Alarm open the app. All transport, favorite, sleep-timer,
+  and query intents do NOT open the app — they target an already-running session
+  or just speak an answer.
+- **Single wake channel:** every intent records its intent (id, list, action,
+  or timer payload) to a pending store and posts one shared
+  `intentPlaybackRequested` request; the running app inspects the store to decide
+  what to do. Play / Play Last route through the station-consume path; the list,
+  sleep-timer, wake-alarm, and transport/favorite paths each have their own
+  consume.
+- **At most one outcome per drain:** a single transport consume returns one
+  action, so a play + transport request arriving in rapid succession does not
+  double-fire.
+- **Transport / sleep-timer intents are fire-and-no-op-if-dead:** if the app is
+  not running, the recorded action is applied (or ignored) on the next launch
+  rather than resurrecting playback from a cold start. Only Play / Play Station
+  List / Play Last / Set Wake Alarm cold-start or open the app.
+- **Two distinct rosters:**
+  - **Entity resolution** (pickers, suggestions, Spotlight) draws from, in
+    order: favorites → recents → custom stations → cached catalog → bundled
+    catalog snapshot.
+  - **Consume-side id resolution** (Play / Toggle Favorite / Wake Alarm) draws
+    from: catalog browse order → favorites → recents → custom stations →
+    station-list members, unioned with the intent-supplied candidate entities.
+  - Both de-duplicate by id, first occurrence wins, order preserved.
 - **Play Last** resolves to the first entry of recents.
-- **Picker / search limits:** entity query and suggested-entity lists return at
-  most **25** stations. An empty query returns the first 25 of the local roster;
-  a non-empty query filters by case-insensitive name substring, then takes 25.
+- **Queue carried on Siri play:** a station played by intent inherits the queue
+  of wherever it lives in the library — favorites, else the first station list
+  containing it, else recents — so "Next Station" steps somewhere sensible after
+  a voice launch. A catalog-only station saved nowhere stays a single-item queue.
+  Play Station List always plays inside the full list queue.
+- **Picker / search limits:** station entity query and suggested-entity lists
+  return at most **25** stations. An empty query returns the first 25 of the
+  roster; a non-empty query filters by case-insensitive name substring, then
+  takes 25. Station-list query and suggestions are **uncapped** (users own few
+  lists, and every list name must be speakable in the parameterized phrase).
+- **Timed-request expiry (60 s):** sleep-timer and wake-alarm requests stamp the
+  time they were fired; on consume, anything older than 60 s is dropped. Arming a
+  bedtime sleep timer against the next morning's stream would be actively wrong,
+  unlike a stale Pause (a harmless no-op).
+- **Sleep-timer / What's-Playing honesty gate:** both read the persisted
+  now-playing snapshot. With nothing playing, Set Sleep Timer arms nothing and
+  What's Playing reports nothing — Siri never claims success against silence.
 - **Spotlight indexing:** each station entity is indexed once when iOS indexes
   the entity set (the entity is an `IndexedEntity`), as audio content with
-  keywords `[name, "radio", "rrradio", broadcaster?, country?]`.
-- **Activity type:** the app advertises the `org.rrradio.playStation` user
-  activity type for handoff/indexing of the play action.
-- **Entity subtitle rule:** `broadcaster · country` when both present and
-  unequal; else broadcaster, else country, else title-only.
+  keywords `[name, "radio", "rrradio", broadcaster?, country?]` and content
+  sources `[country?]`.
+- **Activity donation:** every in-app play donates an `org.rrradio.playStation`
+  user activity (per-station persistent id, eligible for search + prediction) so
+  the played station becomes Spotlight/Siri-predictable.
+- **Entity subtitle rule:** stations show `broadcaster · country` when both
+  present and unequal; else broadcaster, else country, else title-only. Station
+  lists show "N stations".
 - **Toggle Favorite** is idempotent per state: present ⇒ remove; absent ⇒ add.
+- **Wake-alarm time** is stored as a wall-clock "HH:mm" string; only the
+  time-of-day of the picked date matters — the next occurrence resolves at arm
+  time.
+- **Zero-setup phrases (Apple caps App Shortcuts at 10):** ten intents ship
+  spoken phrases — Play Last ("Play last station…", "Start…"), Play Station
+  ("Play [Station]…"), Play Station List ("Play list [List]…", "Play my [List]
+  list…"), Pause, Resume, Next ("Next station…", "Skip to next…"), Previous
+  ("Previous station…", "Skip back…"), What's Playing ("What's playing…", "What
+  song is this…"), Set Sleep Timer ("Set a … sleep timer"), Set Wake Alarm
+  ("Wake me up with …"). **Stop** and **Toggle Favorite Station** deliberately
+  carry no phrases (Pause covers the live-stream-stop utterance; "toggle favorite
+  on X" reads awkwardly) but stay fully usable from the Shortcuts app. Every
+  phrase interpolates the localized app name; parameterized phrases interpolate
+  the station / list entity.
 
 ## Data dependencies
 
 - [playback-state-machine](../contracts/playback-state-machine.md) — Play /
-  Play Last drive `play(station)` (→ `loading`); Pause → `pause()`; Resume →
-  `resume()`; Stop → `stop()` (→ `idle`, clears station/queue/metadata); Next /
-  Previous map to circular queue stepping (forward / backward), gated on a
-  steppable queue (>1 station). The intents are command sources into this
-  machine; they do not redefine any transition.
+  Play Station List / Play Last drive `play(station, queue:)` (→ `loading`);
+  Pause → `pause()`; Resume → `resume()`; Stop → `stop()` (→ `idle`, clears
+  station/queue/metadata); Next / Previous map to circular queue stepping
+  (forward / backward), gated on a steppable queue (>1 station). The intents are
+  command sources into this machine; they do not redefine any transition.
 - [catalog-schema](../contracts/catalog-schema.md) — station entities are built
   from `Station` records (`id`, `name`, `broadcaster`, `country`); resolution
-  uses the same local-roster sources and the cache → bundled snapshot fallback
-  ladder defined there. Reserved id prefixes (`custom-`, `rb-`) flow through
-  unchanged.
+  uses the local-roster sources and the cache → bundled snapshot fallback ladder
+  defined there. Reserved id prefixes (`custom-`, `rb-`) flow through unchanged.
+  Station-list entities are built from the user's saved station lists (id, name,
+  member count).
+- Sleep Timer and Wake Alarm are local timing surfaces, not cross-platform
+  contracts; the intents are command sources into them and inherit their arming
+  / firing rules. What's Playing reads the same now-playing data published to the
+  lock screen, persisted as a snapshot so it survives the app process sleeping.
 
 ## Edge cases
 
-- **Unknown station id on consume:** dropped silently; no playback, no alert.
+- **Unknown station / list id on consume:** dropped silently; no playback, no
+  alert. A pending play-station id and a pending play-list id each survive until
+  a matching entry shows up, so a cold launch that consumes before the library
+  loads doesn't drop the ask.
 - **Play Last with empty recents:** no station resolves; no-op.
+- **Play Station List with an empty list:** no head station; no playback.
 - **Transport intent with no station selected / single-station queue:** Next /
   Previous no-op on an empty or single-station queue (per the state machine's
   stepping precondition); Pause / Resume / Stop on `idle` are no-ops or stop is
@@ -146,6 +209,15 @@ of running one.
 - **App killed between firing a transport intent and consuming it:** the action
   is not replayed as a stale auto-play; transport requests are designed for an
   already-running session.
+- **Sleep timer / wake alarm consumed >60 s late:** dropped, so a request the
+  user spoke at bedtime never arms against the next morning's session.
+- **Set Sleep Timer / What's Playing on a sleeping app:** answered from the
+  persisted snapshot without launching; if nothing is playing, Siri says so and
+  no timer is armed.
+- **Force-quit (swipe-kill) while playing:** the snapshot can be left with a
+  stale `isPlaying: true`, so What's Playing may describe the last station once
+  after a kill. Every regular pause/stop rewrites the snapshot (a `nil` save
+  always writes through), correcting it. See *Known deviations*.
 - **Rapid sequence (cold launch):** landing-preference, wake-alarm, and intent
   requests can fire near-simultaneously; the Now Playing presentation is
   debounced (~300 ms, single sheet) and each pending request is drained once.
@@ -155,17 +227,20 @@ of running one.
 - **Duplicate ids across sources:** de-duplicated by id with first-source-wins,
   so a favorited catalog station resolves once.
 - **Stations without broadcaster/country (test seeds, some community streams):**
-  entity subtitle falls back gracefully; Spotlight description/keywords omit the
-  missing fields.
+  entity subtitle falls back gracefully; Spotlight description/keywords/content
+  sources omit the missing fields.
 
 ## Accessibility
 
 - Intent titles, parameter summaries, and short titles are spoken by Siri and
   read by VoiceOver in the Shortcuts app verbatim ("Play Station", "Pause
-  rrradio", "Toggle favorite on …").
-- Station entities expose a display title (name) and subtitle
-  (broadcaster · country) that VoiceOver reads in the picker and Siri reads back
-  during disambiguation.
+  rrradio", "Toggle favorite on …", "Set a sleep timer for N minutes").
+- Query intents (What's Playing, Set Sleep Timer) speak a full-sentence Siri
+  answer, voicing the now-playing station/track or confirming the timer — a
+  hands-free, eyes-free report for users who can't look at the screen.
+- Station and station-list entities expose a display title (name) and subtitle
+  (broadcaster · country, or "N stations") that VoiceOver reads in the picker and
+  Siri reads back during disambiguation.
 - The surface is voice-first by design — it requires no on-screen interaction,
   serving users who cannot or prefer not to navigate the app UI.
 - Dynamic Type, contrast, and focus order are owned by the system Shortcuts /
@@ -177,12 +252,17 @@ of running one.
 
 - This surface owns these system-facing strings: each intent's **title**,
   **description**, **parameter summary**, **short title**, the **entity type
-  display name** ("Station"), and the **invocation phrases**.
+  display names** ("Station", "Station List"), the **query-intent dialogs**
+  (What's Playing / Set Sleep Timer answers, the "Nothing is playing…" guard),
+  and the **invocation phrases**.
 - Phrases interpolate the localized application name (`\(.applicationName)`) and,
-  where parameterized, the station entity (`\(\.$station)`).
-- Station names, broadcaster, and country values are catalog data, not localized
-  by this surface.
-- No plural forms are required (no counts in any string).
+  where parameterized, the station or station-list entity, the minutes count, or
+  the time.
+- Station names, broadcaster, country values, list names, and track metadata are
+  catalog / library / stream data, not localized by this surface.
+- Counts appear in the station-list subtitle ("N stations"), the sleep-timer
+  summary/dialog ("N minutes"), and the wake-alarm time — candidates for plural
+  forms when those strings are translated.
 - All strings are defined as localizable resources (`LocalizedStringResource` /
   `IntentDescription`); shipped string catalogs determine which locales are
   actually translated.
@@ -193,51 +273,78 @@ of running one.
 |---|---|---|---|
 | Voice-assistant playback control | Planned (Web Speech / PWA) | Supported | Planned (Assistant / App Actions) |
 | OS shortcut actions (Play / transport / favorite) | Planned | Supported | Planned (App Actions) |
-| Station entity resolution + disambiguation | Not applicable | Supported | Planned |
+| Play a named station list by voice | Not applicable | Supported | Planned |
+| Set sleep timer / wake alarm by voice | Not applicable | Supported | Planned |
+| Spoken "What's playing" answer | Not applicable | Supported | Planned |
+| Station / station-list entity resolution + disambiguation | Not applicable | Supported | Planned |
 | System search indexing of stations (Spotlight) | Browser-dependent | Supported | Planned (App Search / Slices) |
-| Suggested shortcuts / entities (≤25) | Not applicable | Supported | Planned |
-| Transport intents target a running session only | Not applicable | Supported | Planned |
-| Localized invocation phrases | Not applicable | Supported | Planned |
+| Suggested shortcuts / entities (≤25 stations, all lists) | Not applicable | Supported | Planned |
+| Transport / sleep-timer intents target a running session only | Not applicable | Supported | Planned |
+| Timed-request expiry (stale sleep/wake dropped) | Not applicable | Supported | Planned |
+| Localized invocation phrases (≤10 App Shortcuts) | Not applicable | Supported | Planned |
 
 ## Open questions
 
 - Whether transport intents should optionally cold-start the app (today only
-  Play / Play Last do) for a "Pause" said to a stopped app.
+  Play / Play Station List / Play Last / Set Wake Alarm open it) for a "Pause"
+  said to a stopped app.
 - Whether Spotlight results should support deep-linking into Browse / a station
   detail rather than always starting playback.
-- Whether to add intents for Sleep Timer, Wake to Radio, or playing a named
-  station list, beyond the current single-station set.
-- Picker/search caps (25) and the name-substring-only match are not yet pinned
-  as a cross-platform contract; web/Android equivalents are unspecified.
+- Whether the 60 s timed-request lifetime and the swipe-kill stale-snapshot
+  window warrant tightening (e.g. clearing the snapshot on a scene-disconnect).
+- Picker/search caps (25 stations; uncapped lists) and the name-substring-only
+  match are not yet pinned as a cross-platform contract; web/Android equivalents
+  are unspecified.
 
 ## Reference
 
-- `rrradio/Shortcuts/PlayStationIntent.swift` — the 8 `AppIntent`s
-  (`PlayStationIntent`, `PlayLastStationIntent`, `PauseRrradioIntent`,
-  `ResumeRrradioIntent`, `StopRrradioIntent`, `NextStationIntent`,
-  `PreviousStationIntent`, `ToggleFavoriteStationIntent`), their titles /
-  descriptions / parameter summaries / `openAppWhenRun`, and the
-  `RrradioShortcuts` `AppShortcutsProvider` (phrases + short titles + glyphs).
+- `rrradio/Shortcuts/PlayStationIntent.swift` — the 12 `AppIntent`s
+  (`PlayStationIntent`, `PlayStationListIntent`, `PlayLastStationIntent`,
+  `PauseRrradioIntent`, `ResumeRrradioIntent`, `StopRrradioIntent`,
+  `NextStationIntent`, `PreviousStationIntent`, `ToggleFavoriteStationIntent`,
+  `SetSleepTimerIntent`, `SetWakeAlarmIntent`, `WhatsPlayingIntent`), their
+  titles / descriptions / parameter summaries / `openAppWhenRun` / query-intent
+  `ProvidesDialog`, and the `RrradioShortcuts` `AppShortcutsProvider` (10 phrase
+  slots + short titles + glyphs; Stop and Toggle Favorite have no phrases).
 - `rrradio/Shortcuts/StationEntity.swift` — `StationEntity` (`AppEntity`,
   `IndexedEntity`): display representation, Spotlight `attributeSet`; and
   `StationEntityQuery` (`EntityStringQuery`): `entities(for:)`,
   `entities(matching:)` (≤25, case-insensitive name contains),
   `suggestedEntities()` (≤25), and `localStations()` roster assembly +
   de-duplication.
+- `rrradio/Shortcuts/StationListEntity.swift` — `StationListEntity` (`AppEntity`)
+  with "N stations" subtitle, and `StationListEntityQuery` (`EntityStringQuery`,
+  uncapped, reads `Library.readStationLists`).
 - `rrradio/Shortcuts/IntentPlaybackRequest.swift` — `IntentPlaybackAction`
-  enum, the pending-store keys, `requestPlay` / `requestPlayLastStation` /
-  `requestTransportAction` / `requestToggleFavorite`, the
-  `intentPlaybackRequested` notification, and `consumePendingStation` /
-  `consumePendingTransportAction`.
+  enum, the pending-store keys, `timedRequestLifetime` (60 s),
+  `requestPlay` / `requestPlayLastStation` / `requestPlayStationList` /
+  `requestTransportAction` / `requestToggleFavorite` / `requestSetSleepTimer` /
+  `requestArmWakeAlarm`, the `intentPlaybackRequested` notification,
+  `consumePendingStation` / `consumePendingTransportAction` /
+  `consumePendingStationList` / `consumePendingSleepTimerMinutes` /
+  `consumePendingWakeAlarm`, the `playbackQueue(for:…)` library-queue resolver,
+  and `IntentNowPlayingSnapshot` (the persisted lock-screen mirror).
 - `rrradio/Views/AppRouter.swift` — `consumePendingIntentPlayback`,
   `consumePendingIntentTransportAction`, `IntentTransportOutcome`,
-  `playableStations` roster.
+  `consumePendingIntentStationList`, `consumePendingIntentSleepTimerMinutes`,
+  `consumePendingIntentWakeAlarm`, and the `playableStations` consume-side roster.
 - `rrradio/Views/ContentView.swift` — `playPendingIntentStationIfPossible`,
   `applyPendingIntentTransportActionIfPossible`, the `intentPlaybackRequested`
   observer, and `showNowPlayingSoon` debounce.
+- `rrradio/Player/AudioPlayer.swift` — `donatePlaybackActivity` (the
+  `org.rrradio.playStation` `NSUserActivity` donation) and
+  `persistIntentNowPlayingSnapshot` (writes the snapshot that query intents read).
 - `project.yml` — `NSUserActivityTypes: [org.rrradio.playStation]`.
 
 ## Known deviations
 
-None recorded. File any divergence between shipped intent behavior and this
-intent under `rrradio-ios/internal/audit/` and link it here.
+- **Stale now-playing snapshot after a swipe-kill.** A force-quit while playing
+  can leave the persisted snapshot with `isPlaying: true`, so What's Playing may
+  describe the last station once after the kill before the next play/stop
+  rewrites it. The intent is that the snapshot always reflects live playback;
+  this gap is acknowledged in the implementation (a code comment in
+  `IntentPlaybackRequest.swift`) but not yet in a formal `rrradio-ios/internal/audit/`
+  entry. File one if it warrants a fix and link it here.
+
+Otherwise none recorded. File any divergence between shipped intent behavior and
+this intent under `rrradio-ios/internal/audit/` and link it here.

--- a/docs/spec/features/sleep-timer.md
+++ b/docs/spec/features/sleep-timer.md
@@ -1,9 +1,9 @@
 # Sleep Timer Specification
 
 ```yaml
-status: draft
+status: review
 platforms: [web, ios, android]
-reconciled-against: 9336321
+reconciled-against: d241aa9
 ```
 
 ## Purpose
@@ -21,8 +21,8 @@ cancelled at any time.
   small chip on the icon shows the armed duration.
 - **Sleep-timer sheet** — the surface where the timer is set, changed, or
   cancelled.
-- **Settings** — a "Default sleep timer" row sets the duration the sheet starts
-  pre-filled with; it does not arm the timer.
+- **Settings** — a "Default sleep timer" row (under "Timer defaults") sets the
+  duration the sheet starts pre-filled with; it does not arm the timer.
 - **Mini player** — read-only: shows a moon indicator when the timer is armed;
   tapping the mini player opens Now Playing (not the sheet directly).
 - **Lock screen / system media surface** — read-only: the now-playing title
@@ -33,41 +33,48 @@ cancelled at any time.
 
 ### Now Playing moon control
 
-- Round 44pt control in the secondary transport row.
+- Round 44pt control in the secondary transport row (beside the wake-alarm
+  control, next to previous / next).
 - Glyph: `moon.zzz` (off) / `moon.zzz.fill` (armed), accent-tinted when armed.
-- Chip badge (armed only): the remaining-time-at-arming as `H:MM` (e.g. `0:30`,
-  `1:30`), monospaced, accent capsule, top-trailing.
+- Chip badge (armed only): the armed duration as `H:MM` (e.g. `0:30`, `1:30`),
+  monospaced, accent capsule, top-trailing.
 - Disabled when no station is selected AND the timer is not already armed.
 
 ### Sleep-timer sheet (top to bottom)
 
-1. Moon icon, large; filled + accent when armed.
-2. Title "Sleep timer". When armed, an accent countdown capsule next to it shows
-   remaining time as `H:MM` (uppercased, monospaced), refreshing on a cadence.
-3. Subtitle line:
-   - Armed → "Playback pauses when the timer ends".
-   - Idle with a station → "Set a sleep timer for &lt;station name&gt;".
-   - Idle with no station → "Play a station first".
-4. Duration picker — a wheel hour:minute picker, pre-filled with the armed
-   duration (when armed) or the default duration (when idle).
-5. Action button — "Set" (idle) or "Unset" (armed). Disabled when idle AND no
-   station is selected.
-6. Helper text "Play a station first" — shown only when no station is selected
-   and the timer is not armed.
-7. Close affordance (top-trailing).
+1. **Header row** — centered moon glyph (`moon.zzz` off / `moon.zzz.fill` +
+   accent armed) and the "Sleep timer" title (station-name size), closed by a
+   hairline rule that runs edge to edge. When armed, an accent countdown capsule
+   rides the trailing edge of the header (uppercased, monospaced `H:MM`),
+   refreshing on a cadence; it sits in an overlay so it never pulls the centered
+   title off-center.
+2. **Duration wheel** — a two-component hours:minutes wheel (not a wall-clock
+   time picker), floated to roughly mid-sheet. Bare numbers on the wheels with
+   the unit labels ("h" / "min") fixed in the selection band. Pre-filled with the
+   armed duration (when armed) or the default duration (when idle).
+3. **Helper text "Play a station first"** — directly under the wheel; visible
+   only when no station is selected and the timer is not armed (otherwise
+   transparent, holding its layout space).
+4. **Footer button pair** — centered group: an x-to-close button (left) and the
+   confirm button (right), "Set" (idle) or "Unset" (armed). The confirm button
+   is disabled (and dimmed) when idle AND no station is selected. There is no
+   subtitle line and no separate top-trailing close.
 
 ### Settings default row
 
-- Moon icon, "Default sleep timer" label, current default shown as `H:MM`.
-- Trailing picker offering the preset durations (30, 60, 90 minutes).
+- Moon icon, "Default sleep timer" label, with the subtitle "Set the time to
+  sleep in hh:mm" (the dial reads as a duration, not a time of day).
+- Trailing compact time picker pinned to a 24-hour locale, covering any duration
+  in `0:01`–`23:59`. Free-form — it is not limited to the cycle presets. `0:00`
+  is clamped up to one minute.
 
 ## States
 
 | State | What shows | Actionable |
 |---|---|---|
-| Off, station selected | Moon outline, no chip; sheet shows default duration, "Set" enabled | Set a timer |
-| Off, no station | Moon outline, control disabled; sheet shows "Play a station first", "Set" disabled | Nothing until a station plays |
-| Armed | Filled moon + duration chip; sheet shows countdown + "Unset" | Change duration (re-Set) or Unset |
+| Off, station selected | Moon outline, no chip; sheet pre-fills default duration, "Set" enabled | Set a timer |
+| Off, no station | Moon outline, control disabled; sheet shows "Play a station first" hint, "Set" disabled | Nothing until a station plays |
+| Armed | Filled moon + duration chip; sheet header shows live countdown capsule + "Unset" | Unset (then re-open + Set to change duration) |
 | Counting down | Countdown decreases on the lock screen and in the open sheet | Change or cancel |
 | Fired (zero reached) | Timer clears to off; playback is paused; station stays selected | Re-arm; resume playback manually |
 
@@ -86,21 +93,24 @@ cases for how an already-paused or error state interacts.
 | Tap "Set" | Idle AND station selected | Arms the timer for the staged minutes (min 1); schedules the pause; closes sheet | Computes fire time; publishes "Sleep in <n>m" to lock screen; shows chip + filled moon |
 | Tap "Set" | Idle AND no station | No-op (button disabled) | None |
 | Tap "Unset" | Armed | Cancels the pending pause; closes sheet | Clears fire time; clears lock-screen suffix/badge; chip + filled moon removed |
-| Re-Set while armed | Armed | Replaces the previous timer with the new duration | Old pending pause cancelled; new fire time scheduled |
-| Cycle to next preset | (code affordance, web parity) | Steps off → 30 → 60 → 90 → off | Re-arms / cancels accordingly |
+| Re-Set while armed | Armed | Tapping "Unset" while armed cancels; to change the duration, Unset then Set again with the new wheel value | Old pending pause cancelled; a fresh Set schedules a new fire time |
+| Cycle to next preset | (code affordance only) | Steps off → 30 → 60 → 90 → off | iOS exposes no UI for this; the sheet uses the free-form wheel. Web parity affordance only — unwired on iOS |
 | Timer reaches zero | Armed | Playback pauses; timer clears to off | Calls pause on the player; station, queue, metadata retained; lock screen suffix/badge cleared |
-| Change default (Settings) | — | Persists the default duration; future sheet opens pre-fill to it | Synced to iCloud where available; does not arm or change an active timer |
+| Change default (Settings) | — | Persists the default duration (free-form, clamped ≥ 1 min); future sheet opens pre-fill to it | Synced to iCloud where available; does not arm or change an active timer |
 | Close sheet without Set/Unset | Sheet open | Dismisses; no change to the timer | None |
 | Tap mini-player moon | n/a (indicator only) | n/a — opening the mini player navigates to Now Playing | None |
 | App backgrounded while armed | Armed | Countdown continues; fires while backgrounded if the session stays eligible | Lock-screen suffix refreshes on a cadence |
 
 ## Business rules
 
-- **Preset cycle durations:** off, 30, 60, 90 minutes. The cycle never includes
-  a 15-minute preset on iOS (see Open questions for web parity).
-- **Settings default presets:** 30, 60, 90 minutes (the nonzero cycle values).
-- **Default duration:** seeded to **30 minutes** on first run; persisted locally
-  and synced via iCloud where available.
+- **Preset cycle durations:** off, 30, 60, 90 minutes. The cycle is the model's
+  `cycle()` step set; on iOS no UI invokes it (see Interactions). It never
+  includes a 15-minute preset (see Open questions for web parity).
+- **Settings default duration:** free-form. The Settings row accepts any
+  `0:01`–`23:59` duration via a 24-hour time picker — it is *not* limited to the
+  cycle presets. `0:00` is clamped up to one minute.
+- **Default duration seed:** **30 minutes** on first run; persisted locally under
+  `rrradio.sleep.defaultMinutes.v1` and synced via iCloud where available.
 - **Free-form duration (iOS sheet):** the wheel picker accepts any hours:minutes
   value; the armed duration is clamped to a **minimum of 1 minute**.
 - **Changing the timer replaces the previous timer** — there is never more than
@@ -138,10 +148,12 @@ cases for how an already-paused or error state interacts.
 - **No station when "Set" is reached:** prevented — the action is disabled and a
   "Play a station first" hint shows.
 - **Station changed after arming:** the timer is independent of which station is
-  selected; it pauses whatever is current when it fires. (The arming subtitle
-  named a station, but the pending pause is not bound to it.)
-- **Re-arm during countdown:** the prior pending pause is cancelled atomically;
-  exactly one pause is scheduled.
+  selected; it pauses whatever is current when it fires. The pending pause is not
+  bound to a specific station.
+- **Re-arm during countdown:** any new `set(minutes:)` invalidates the prior
+  timer atomically before scheduling the next, so exactly one pause is ever
+  pending. (Via the iOS sheet, an armed timer's confirm button reads "Unset";
+  changing the duration is Unset then Set, not a single in-place re-arm.)
 - **Backgrounding / lock:** countdown continues; firing while backgrounded
   depends on the OS keeping the audio session eligible (iOS: supported while the
   session remains active; web/Android: OS/browser dependent — see Matrix).
@@ -157,11 +169,11 @@ cases for how an already-paused or error state interacts.
 - Moon control carries the localized "Sleep timer" label; armed/off state is
   conveyed by the filled/outline glyph and the duration chip.
 - Mini-player armed indicator carries the "Sleep timer active" label.
-- Action button reads "Set" / "Unset"; subtitle text is plain readable copy.
+- Footer buttons carry "Close" and "Set" / "Unset" accessibility labels.
 - Countdown text is monospaced for stable width; should be exposed as remaining
   time to assistive tech, not just visually.
-- Sheet content scales with Dynamic Type; the wheel picker uses the system
-  picker (native VoiceOver support).
+- Sheet content scales with Dynamic Type; the title scales down to fit; the
+  duration wheel uses the system picker control (native VoiceOver support).
 - Helper "Play a station first" hint communicates why "Set" is disabled.
 
 ## Localization
@@ -170,16 +182,27 @@ This surface owns:
 
 - `sleepTimer` — "Sleep timer" (control + sheet title).
 - `defaultSleep` — "Default sleep timer" (Settings row).
-- `set` — "Set"; `unset` — "Unset" (action button).
-- `playStationFirst` — "Play a station first" (disabled hint + subtitle).
+- `set` — "Set"; `unset` — "Unset" (confirm button).
+- `close` — "Close" (footer x-to-close a11y label).
+- `playStationFirst` — "Play a station first" (disabled hint under the wheel).
 - `sleepTimerActive` — "Sleep timer active" (mini-player a11y label).
-- `sleepTimerMessage` — "Stop playback after a delay." (description).
+- `hoursShort` — "h"; `minutesShort` — "min" (duration-wheel unit labels).
+
+Catalog strings present but **not currently rendered** by this surface (the
+restructured sheet dropped its subtitle line):
+
+- `sleepTimerMessage` — "Stop playback after a delay." (description copy).
 - `sleepTimerForStation` — "Sleep timer for {name}" (parameterized by station
   name).
 
+Hard-coded English copy (not yet localized keys):
+
+- The Settings subtitle "Set the time to sleep in hh:mm".
+- The lock-screen "Sleep in <n>m" title suffix.
+
 Parameter/plural needs:
 
-- `{name}` parameter in `sleepTimerForStation`.
+- `{name}` parameter in `sleepTimerForStation` (string defined; unused today).
 - "Sleep in <n>m" lock-screen suffix and `H:MM` countdown are numeric-formatted,
   not full localized plural strings today (see Open questions).
 
@@ -187,8 +210,8 @@ Parameter/plural needs:
 
 | Behavior | Web | iOS | Android |
 |---|---|---|---|
-| Timer cycle | Supported. | Reference. | Supported. |
-| Preset durations | 15/30/60/90 (web). | 30/60/90 cycle; free-form via picker. | 30/60/90. |
+| Timer cycle | Supported. | Model only (no UI invokes `cycle()`). | Supported. |
+| Preset / free-form durations | 15/30/60/90 presets (web). | Free-form via wheel (sheet) and 24h picker (Settings default); cycle presets unwired. | 30/60/90. |
 | Visible remaining time | Supported where UI exposes it. | Supported (control chip + sheet countdown + lock screen). | Partial. |
 | Background firing | Browser/OS dependent. | Supported while app/session remains eligible. | Planned through service/alarm design. |
 | Wake interaction | Silent-bed behavior. | Keep-alive aware. | To be designed with Android wake flow. |
@@ -203,12 +226,18 @@ behavior with the app backgrounded and the media notification active.
 ## Open questions
 
 - **15-minute preset parity.** The web app offers a 15-minute cycle option; the
-  iOS cycle is 30/60/90 only. iOS users can still reach 15 minutes via the
-  free-form wheel picker, but the *preset cycle* differs. Decide whether the
-  cycle set is a hard cross-platform contract.
-- **Free-form vs. preset entry.** iOS surfaces an arbitrary hours:minutes picker
-  in the sheet, while web/Android lean on preset taps. Should arbitrary
-  durations be a shared capability or an iOS-only affordance?
+  iOS `cycle()` set is 30/60/90 only (and no iOS UI invokes it). iOS users reach
+  any duration, 15 included, via the free-form wheel. Decide whether the cycle
+  set is a hard cross-platform contract.
+- **Free-form vs. preset entry.** iOS surfaces an arbitrary hours:minutes wheel
+  in the sheet *and* a free-form 24h picker for the Settings default, while
+  web/Android lean on preset taps. Should arbitrary durations be a shared
+  capability or an iOS-only affordance?
+- **Dropped sheet subtitle copy.** The `sleepTimerForStation` ("Sleep timer for
+  {name}") and `sleepTimerMessage` ("Stop playback after a delay.") strings are
+  still in the catalog but no longer rendered after the sheet restructure (the
+  subtitle line was removed). Decide whether to retire the strings or restore a
+  description line.
 - **Localized countdown formatting.** The "Sleep in <n>m" suffix and `H:MM`
   countdown are numeric formats, not full localized plural strings; promote to
   proper plural/format rules if a locale needs them.
@@ -220,30 +249,48 @@ behavior with the app backgrounded and the media notification active.
 
 - `rrradio-ios/rrradio/Player/SleepTimer.swift` — `cycleMinutes`
   `[0, 30, 60, 90]`, `defaultMinutesKey` (`rrradio.sleep.defaultMinutes.v1`,
-  fallback 30), `set(minutes:onFire:)`, `cycle(onFire:)`, `cancel()`,
-  `fire(onFire:)` (pauses + clears), `chipText`, `countdownText(at:)`,
-  `applyCloudSyncDefaultMinutes`.
+  `fallbackDefaultMinutes` 30), `set(minutes:onFire:)`, `cycle(onFire:)` (no UI
+  caller), `cancel()`, `fire(onFire:)` (pauses + clears), `setDefaultMinutes`,
+  `applyCloudSyncDefaultMinutes`, `chipText` (armed `H:MM`),
+  `countdownText(at:)` (live remaining; "now" at/after zero), `format`.
 - `rrradio-ios/rrradio/Views/NowPlayingView.swift` — `sleepControlButton`,
-  `roundControlButton` chip rendering, `SleepTimerView` sheet (wheel
-  `DatePicker`, Set/Unset, `TimelineView` 30s countdown, `targetLine`,
-  `minutes(from:)` clamp).
-- `rrradio-ios/rrradio/Views/MiniPlayerView.swift` — armed moon indicator.
-- `rrradio-ios/rrradio/Views/SettingsView.swift` — `sleepDefaultRow` default
-  picker, `@AppStorage(SleepTimer.defaultMinutesKey)`.
+  `roundControlButton` 44pt + chip rendering, `SleepTimerView` sheet:
+  `sheetHeader` (centered moon + title, edge-to-edge hairline rule, trailing
+  countdown capsule overlay, `TimelineView(.periodic by: 30)`), `durationWheel`
+  (`DurationWheelPicker` + `DurationWheelUnitLabels`), `footerButtons`
+  (x-to-close + Set/Unset, `max(1, …)` clamp), `canConfirm`.
+- `rrradio-ios/rrradio/Views/MiniPlayerView.swift` — armed `moon.zzz.fill`
+  indicator.
+- `rrradio-ios/rrradio/Views/SettingsView.swift` — `sleepDefaultRow`
+  (compact `DatePicker` pinned to `de_DE` 24h locale, ≥ 1 min clamp) under the
+  "Timer defaults" section, `@AppStorage(SleepTimer.defaultMinutesKey)`.
 - `rrradio-ios/rrradio/Player/AudioPlayer.swift` — `setLockScreenSleepTimer`,
-  `lockScreenSleepTimerText` ("<n>m"), `scheduleLockScreenSleepTimerRefresh`
-  (30s), now-playing title suffix and artwork sleep badge.
-- `rrradio-ios/rrradio/App.swift` — wiring of `onStateChanged` →
-  `setLockScreenSleepTimer`, sheet `onFire` → `player.pause()`.
+  `lockScreenSleepTimerText` ("<n>m"), `lockScreenTitle` ("… - Sleep in <n>m"
+  suffix), `scheduleLockScreenSleepTimerRefresh` (30s), `renderLockScreenArtwork`
+  (`moon.zzz.fill` accent badge while armed).
+- `rrradio-ios/rrradio/App.swift` — wiring of `sleepTimer.onStateChanged` →
+  `player.setLockScreenSleepTimer(firesAt:)`, sheet `onFire` → `player.pause()`.
 - `rrradio-ios/rrradio/CloudSync/*` — `sleepTimerDefaultMinutes` snapshot field
-  and `applyCloudSyncDefaultMinutes` sync.
-- `rrradio-ios/rrradioTests/SleepTimerTests.swift` — cycle, set-zero-cancels,
-  fire-clears-and-pauses behavior.
+  (`CloudSyncSnapshot`, `SettingsBackup`, `CloudSyncStore`) and
+  `applyCloudSyncDefaultMinutes` apply path in `CloudSyncController`.
+- `rrradio-ios/rrradioTests/SleepTimerTests.swift` — starts-disarmed,
+  cycle-uses-web-durations, set-zero-cancels, state-change-callback,
+  fire-clears-and-pauses.
 
 ## Known deviations
 
-- None recorded. (If the audio session is not deactivated on a sleep-timer
-  pause, that is governed by the playback session deviation in
+- **`cycle()` skips presets after a custom default.** The intent is a stable
+  off → 30 → 60 → 90 → off cycle. The shipped `cycle()` first jumps from off to
+  the *current default* and then walks the array, so a non-30 default makes the
+  30-minute step (and others) unreachable. Latent today — no iOS UI invokes
+  `cycle()` — but documented at
+  `rrradio-ios/internal/audit/2026-05-25-ios-code-review-slice4.md` (S2).
+- **Armed-chip `H:MM` reads as a clock time.** The chip/countdown format
+  (`0:30`, `1:30`) is duration-shaped but visually ambiguous with wall-clock
+  time; flagged Medium at
+  `rrradio-ios/internal/audit/2026-05-25-ios-code-review-slice4.md` (S1).
+- If the audio session is not deactivated on a sleep-timer pause, that is
+  governed by the playback session deviation in
   [playback-state-machine](../contracts/playback-state-machine.md) "Known
   deviations" — `rrradio-ios/internal/audit/2026-05-25-ios-code-review-slice5.md`
-  — not a sleep-timer-specific bug.)
+  — not a sleep-timer-specific bug.

--- a/docs/spec/features/station-lists.md
+++ b/docs/spec/features/station-lists.md
@@ -1,8 +1,8 @@
 # Station Lists Specification
 ```yaml
-status: draft
+status: review
 platforms: [web, ios, android]
-reconciled-against: 9336321
+reconciled-against: d241aa9
 ```
 
 ## Purpose
@@ -16,17 +16,22 @@ through that list.
 ## Entry points
 
 - **Library Home** — every list appears as its own card in the library navigator,
-  beside the Recents and Favorites cards.
+  above the pinned Recents card. (Favorites is a separate bottom-nav tab, not a
+  Home card.)
 - **Library page swiper** — each list is a swipeable page in the library
   page sequence (Home · lists · Recents); a tuner-style status bar shows the
-  current list's title with its neighbours hinted to either side.
-- **Create from Browse** — the "+" affordance on the Browse sort row opens an
-  add-or-create-list popup; choosing "Create list" enters Browse multi-select to
-  compose a new list.
-- **Create from library chrome** — the "+" accessory in the library status bar
-  (when not already inside a list) opens a create-list name prompt.
+  current list's title with its neighbours hinted to either side. Favorites is
+  reached only via its own tab and sits out of this sequence.
+- **Create from Browse** — the "+" affordance on the Browse sort row opens the
+  add-or-create-list popup; choosing "Create list" + a name enters Browse
+  multi-select to compose the list. The list is created only on save, with the
+  picked stations.
+- **Create from library chrome** — the "+" accessory in the Home status bar opens
+  the same add-or-create-list popup (the create-list row plus the existing lists).
+  Choosing "Create list" + a name routes into Browse multi-select; the list is
+  created only on save. There is no empty-list creation path.
 - **Add to existing list** — the "+" accessory while viewing a list, or picking an
-  existing list in the Browse add-list popup, enters Browse multi-select targeting
+  existing list in the add-or-create popup, enters Browse multi-select targeting
   that list.
 - **Open a list** — tap a list card on Library Home, or swipe to its page.
 - **Pinned launch** — a list may be pinned as the launch landing surface (see
@@ -36,20 +41,28 @@ through that list.
 ## Layout
 
 ### Library Home — list card
-- One card per list, in user order, after the Recents and Favorites cards.
+- One card per list, in user order, above a single pinned Recents card. (No
+  Favorites card — Favorites is its own tab.)
 - Shows the list name, a strip of station favicons (empty hint when the list has
-  no stations), a play control, and a current-list indicator when this list is the
-  active playback queue.
+  no stations), a play control (disabled/dimmed when the list is empty), and a
+  now-playing indicator when this list is the active, on-air playback queue.
 - Tapping a station favicon opens the list and plays that station queued against
   the list.
-- In delete mode the card shows a remove control; tapping it deletes the whole
-  list.
+- In edit (delete) mode the card swaps its play control for two trailing badges:
+  a rename (pencil) badge and a remove (minus) badge. Tapping rename opens a
+  rename alert; tapping remove deletes the whole list (with a confirmation for
+  non-empty lists — see Interactions). The Recents card is dimmed and locked
+  (not reorderable, renamable, or removable) while edit mode is active.
 
 ### List detail page (top to bottom)
 - **Library chrome** (shared, fixed above the page): brand/logo row with a
-  collapsible search field and a settings gear; a status bar with a back-to-home
-  arrow, the list title (uppercased, tuner scale beneath), a leading search icon,
-  a trailing "+" add-stations icon, and a trash delete-mode toggle; a divider rule.
+  collapsible search field, a display-mode pill (list / tiles / app), and a
+  settings gear; a status bar with a back-to-home arrow, the list title
+  (uppercased, monospaced, tuner scale of neighbour titles to either side), a
+  leading search icon, a trailing "+" add-stations icon, and a trash
+  delete-mode toggle (shown only when the list is non-empty); a divider rule.
+  The list-detail page has no rename affordance — rename lives on the Home card
+  in edit mode.
 - **Station rows/cells**: one row per station in the list, in list order. List
   detail uses the quiet card row — station name + country flag only, no tag line,
   no signal bars, no favorite heart, no stream-quality control. List, tiles, and
@@ -61,25 +74,35 @@ through that list.
   glass icon, "No stations found", and "Try a station name, country code, or tag."
 
 ### Browse multi-select dock (while composing a list)
-- A bar pinned above the bottom chrome: a cancel control (x), the draft list name
-  (or target list name) with a selection-count badge, and a save control (checkmark).
-- Save is disabled until at least one station is selected and the name is non-empty.
+- An accent-tinted bar pinned at the **top** of Browse, directly under the search
+  field (not in the bottom chrome). Carries a two-step progress strip (step 1
+  "Add list" done, step 2 "Pick stations" active) above an action row: a cancel
+  control (x), an "Adding to {name}" label with a live selection-count badge, and
+  a primary that reads "Add N" once stations are picked or a disabled "Select
+  stations" prompt while the selection is empty.
+- Save is disabled until at least one station is selected and the name is non-empty
+  (Favorites-target mode seeds the name with the Favorites title so its save gates
+  only on the selection).
 
-### Add-or-create-list popup (from Browse "+")
-- A card titled "Add or create list" with a "Create list" row that morphs into a
-  focused name field when selected, followed by one row per existing list (accent
-  checkmark on the selected target), and cancel (x) / confirm (checkmark) footer
-  controls. Confirm is disabled until a target is valid (non-empty new name, or a
-  picked existing list).
+### Add-or-create-list popup (from the Browse "+" or the Home "+")
+- A card opened by a two-step progress strip (step 1 "Add list" active, step 2
+  "Pick stations" upcoming). A "Create list" row morphs into a focused name field
+  when selected; when its drafted name collides case-insensitively with an
+  existing list an inline "Name already in use" warning appears and confirm is
+  blocked. Below it, one row per existing list (accent checkmark on the selected
+  target). Footer: a cancel (x) control and a labeled "Pick stations →" advance.
+- The advance is disabled until a target is valid (non-empty, non-duplicate new
+  name, or a picked existing list). Confirming does not finish — it advances to
+  step 2 (Browse multi-select); a new list is created only on save in step 2.
 
 ## States
 
 | State | What shows | Actionable |
 |---|---|---|
-| **Empty (no lists)** | No list cards on Library Home; only Recents/Favorites cards. Trash/delete-mode is unavailable. | Create a list from Browse "+" or the chrome "+". |
+| **Empty (no lists)** | No list cards on Library Home; only the pinned Recents card. Trash/delete-mode is unavailable. | Create a list from the Browse "+" or the Home "+". |
 | **Empty (list has no stations)** | Unavailable view: "Empty station list" + "Add stations from Browse to build this list." | "+" add-stations, search, delete-mode auto-unavailable (nothing to remove). |
 | **Loading** | Lists render immediately from local storage on launch; no spinner. Station blobs render before the catalog refreshes from network. | Full interaction; rows reconcile in place when the catalog arrives. |
-| **Loaded** | List cards on Home; list detail shows its stations in order. | Play, reorder, remove, add, delete, rename (model-level), search. |
+| **Loaded** | List cards on Home; list detail shows its stations in order. | Play, reorder, remove (undoable), add, delete (confirmed), rename (Home card edit mode), search. |
 | **Partial (search active, some matches)** | Filtered subset of the list's stations. | Play / open the visible matches. |
 | **No matches (search active)** | "No stations found" view. | Clear the search to restore the full list. |
 | **Offline** | Lists and their station blobs render from local storage; play attempts stream as usual. | Full library interaction; playback subject to network. |
@@ -88,29 +111,33 @@ through that list.
 
 | Control / gesture | Precondition | Result | Side effects |
 |---|---|---|---|
-| Tap "+" on Browse sort row | On Browse | Opens add-or-create-list popup | — |
-| Select "Create list" + type name + confirm | Popup open | Enters Browse multi-select with that name seeded in the dock | Dismisses search focus |
-| Pick an existing list + confirm | Popup open | Enters Browse multi-select targeting that list (name = list name) | — |
+| Tap "+" on Browse sort row | On Browse | Opens the add-or-create-list popup | — |
+| Tap "+" in Home status bar | On Library Home | Opens the same add-or-create-list popup as a centered floating card with a backdrop | — |
+| Select "Create list" + type name + advance | Popup open | Routes into Browse multi-select with that name seeded in the dock; the list is not created yet | Clears Browse search/filter/sort; switches to Browse tab |
+| Pick an existing list + advance | Popup open | Routes into Browse multi-select targeting that list (name = list name) | Switches to Browse tab |
+| Type a name colliding with an existing list | Create-list row active | Shows "Name already in use"; advance disabled | — |
 | Tap a Browse row in multi-select | Multi-select active | Toggles the station into the selection (tap order preserved) | Selection-count badge updates |
-| Tap save (checkmark) in dock | ≥1 selected and name non-empty | Saves: appends to target list, or folds into an existing list whose name matches case-insensitively, or creates a new list with the selected stations | Exits multi-select; opens the destination list; switches to Library tab |
-| Tap cancel (x) in dock | Multi-select active | Discards the selection and name | Exits multi-select |
-| Tap "+" in library chrome (not in a list) | On a library page | Opens a create-list name prompt | — |
-| Confirm create-list prompt | Name non-empty (trimmed) | Creates an empty list and opens it | Empty/whitespace name rejected (Confirm disabled) |
+| Tap "Add N" in dock | ≥1 selected and name non-empty | Saves: appends to the explicit target list, or folds into an existing list whose name matches case-insensitively, or creates a new list with the selected stations | Exits multi-select; opens the destination list; switches to Library tab |
+| Tap cancel (x) in dock | Multi-select active | Discards the selection and name; no list is created | Exits multi-select |
 | Tap "+" in chrome while viewing a list | On a list detail page | Enters Browse multi-select targeting this list | Switches to Browse tab |
-| Tap a list card on Home | Not in delete mode | Opens the list detail page | — |
-| Swipe horizontally on a list page | Not in delete mode | Moves to the neighbouring library page | — |
+| Tap a list card on Home | Not in edit mode | Opens the list detail page | — |
+| Tap a list card on Home | In edit mode | Exits edit mode (does not navigate) | — |
+| Swipe horizontally on a list page | No drag in flight | Moves to the neighbouring library page | Resting edit (jiggle) state exits on the page change |
 | Tap a station row/cell | Not in delete/reorder | Plays the station; list becomes the active playback queue | Pushes to recents if it is a catalog (non-custom) station |
 | Tap play on a list card | List non-empty | Plays the first station, queued against the list | Pushes to recents if catalog station |
-| Tap a favicon in a list card | — | Opens the list and plays that station queued against the list | Switches to Library; pushes recents if catalog station |
-| Long-press a row/cell | List supports reorder/remove | Enters delete mode (per-row remove badges, jiggle on icon grid) | Drives shared chrome delete state |
-| Tap trash icon in status bar | Delete-mode available (list non-empty) | Toggles delete mode | Swiping to another page exits delete mode |
-| Tap a row's remove badge | In delete mode | Removes that station from the list | Removing the last station auto-exits delete mode |
-| Tap delete badge on a list card (Home) | Home delete mode | Deletes the whole list | Deleting the last list exits delete mode |
-| Tap outside badges / background | In delete mode | Exits delete mode | — |
-| Drag a row to a new position | Reorder enabled | Reorders stations within the list; persists new order | Selection haptic on drop; scroll disabled mid-drag |
+| Tap a favicon in a list card | Not in edit mode | Opens the list and plays that station queued against the list | Switches to Library; pushes recents if catalog station |
+| Long-press a row/cell or Home card | Feed supports reorder/remove (Home: ≥1 list) | Enters edit mode (per-row remove badges, Home cards also get a rename badge; jiggle on icon grid) and, when reorderable, begins the drag | Drives shared chrome delete state |
+| Tap trash icon in status bar | Delete-mode available (list non-empty; Home has ≥1 list) | Toggles edit mode | Swiping to another page exits edit mode |
+| Tap a row's remove badge | In edit mode | Removes that station from the list; raises an undo toast | Removing the last station auto-exits edit mode |
+| Tap a Home card's rename (pencil) badge | Home edit mode | Opens a rename alert seeded with the list name; confirming renames (empty/whitespace blocked) | — |
+| Tap a Home card's remove (minus) badge | Home edit mode | Empty list deletes immediately; a non-empty list raises a destructive confirmation dialog ("Delete '{name}'?") before deleting | Deleting the last list exits edit mode |
+| Tap Undo in the removal toast | Toast visible | Restores the whole removal batch to each station's original index | Toast dismisses |
+| Tap outside badges / background | In edit mode | Exits edit mode | — |
+| Drag a row to a new position | Reorder enabled | Reorders stations within the list; persists new order (no-order-change is a no-op) | Selection haptic on drop; scroll + page-swiper locked mid-drag |
+| Drag a list card on Home | ≥2 lists and no active search | Reorders whole lists; persists new order; Recents stays pinned at the tail | Selection haptic on drop; scroll + page-swiper locked mid-drag |
 | Skip next / previous (lock screen, in-app) | Playing from a list | Steps to the next/previous station in the list, wrapping circularly | Queue identity tied to the list id |
 | Pull to refresh on a list page | List non-empty | One-shot now-playing metadata fetch for the list's stations | Merges results into per-row metadata cache |
-| Type in the chrome search field | List detail or Recents | Filters the visible list (180 ms debounce) | Filter shared across library pages |
+| Type in the chrome search field | On a library page | Filters the visible content: list-detail / Recents rows by station match (180 ms debounce); Home cards by list title or member-station name | Filter shared (one query) across library pages |
 | App backgrounded mid-edit | Any | List state already persisted on each mutation | iCloud push debounced (see sync) |
 
 ## Business rules
@@ -120,10 +147,19 @@ through that list.
 - **Name**: created/renamed names are trimmed of surrounding whitespace; an empty or
   whitespace-only name is refused (create returns nothing, rename returns false). UI
   confirm controls disable on empty trimmed input so the refusal is a safety net.
+  Rename to the unchanged name is a no-op (no persistence write).
+- **Duplicate names (create)**: the create-list popup blocks a new name that matches
+  an existing list case-insensitively (after trim) and shows an inline warning. This
+  guard is on the create path only; the save-from-Browse fold still merges a matching
+  name into the existing list.
 - **Identity**: each list gets a stable UUID id at creation; renames keep the id.
 - **Ordering**: lists keep user order; stations keep user order within a list.
   Reorder operations that don't change the order are no-ops (no persistence write).
-- **Save-from-Browse folding**: an explicit target list always wins; otherwise a
+  Home list-reorder needs ≥2 lists and no active search; Recents is never part of
+  the reorderable set (it trails as a pinned card).
+- **Save-from-Browse folding**: a Favorites target (the Favorites-page "+") wins
+  first — selected stations are added to Favorites and the user returns to the
+  Favorites tab. Otherwise an explicit target list wins; otherwise a
   case-insensitive name match against an existing list appends to it; otherwise a
   new list is created. Selected stations are added in tap order.
 - **Playback queue**: playing from a list sets the active queue to `source =
@@ -134,6 +170,14 @@ through that list.
   custom (user-created) stations are not pushed.
 - **Limits**: no fixed cap on list count or stations per list. Recents (a sibling
   surface) caps at 12; lists do not.
+- **Station-removal undo**: removing stations via the edit-mode badge is recoverable
+  rather than re-confirmed. Removals coalesce into one batch behind a single
+  "Removed … · Undo" toast; Undo restores every station in the batch to its original
+  index. The toast auto-dismisses after 5 s (15 s under VoiceOver).
+- **List-delete confirmation**: deleting a whole list is the one badge action that is
+  confirmed, not undoable — an empty list deletes immediately, a non-empty list
+  prompts a destructive dialog first, because it destroys curated membership + order
+  and propagates to every device via CloudKit.
 - **Cross-store consistency**: deleting a custom station removes it from every list
   (and favorites and recents) automatically.
 - **Catalog reconciliation**: persisted station blobs in lists are healed in place to
@@ -158,15 +202,18 @@ through that list.
   key and an empty list set is returned rather than overwriting the original; per
   sync, a single bad list blob never wipes or stalls the rest (keep-local on
   unresolved id).
-- **Save with empty selection or empty name**: save is refused (dock save disabled);
-  no list is created or mutated.
+- **Save with empty selection or empty name**: save is refused (dock "Add N" primary
+  disabled); no list is created or mutated. A create-flow brand-new list is created
+  only on save, so backing out of step 2 never leaves an empty list behind.
 - **Re-adding a selected station already in the target list**: replaces the blob,
   no duplicate row.
 - **Removing the last station while in delete mode**: delete mode auto-exits so the
   page isn't stranded in an empty edit state.
 - **Deleting the last list**: Home delete mode auto-exits.
-- **Reorder during root horizontal swipe**: the page-swiper is suppressed in delete
-  mode so a drag can't double as a page change.
+- **Reorder during root horizontal swipe**: the page-swiper locks its selection only
+  while a card/row drag is actually in flight, so a drag can't double as a page
+  change. A swipe in the resting jiggle (edit) state is allowed and exits edit mode
+  on the page change.
 - **Huge lists**: list detail filters synchronously per keystroke on the main thread;
   this is safe only for small library-sized lists, not catalog-scale feeds.
 - **Persistence failure**: a write error is recorded as a sanitized diagnostic
@@ -176,15 +223,19 @@ through that list.
 
 ## Accessibility
 
-- Remove badge: "Remove {name} from list".
+- Row remove badge: "Remove {name} from list".
+- Home card edit badges: "Rename {name}" (pencil), "Remove {name}" (minus).
+- Home card itself: "Show stations in {name}" (non-empty) / "{name}, empty list".
 - Add-stations / create controls: "Add stations to list", "Create list",
-  "Add or create list".
+  "Add stations to favorites".
 - Status-bar controls: back-to-home "Show Library pages", delete toggle "Enter
   delete mode".
-- List status bar announces the page as title + position in the swipe sequence
-  ("{title}, page {index} of {total}").
-- Empty list announced as "{name}, empty list".
-- Dock controls labeled cancel / save; popup confirm labeled done.
+- List status bar announces a page in the swipe sequence as title + position
+  ("{title}, page {index} of {total}"); Favorites (out of the sequence) announces
+  just its title.
+- Removal undo toast posts a VoiceOver announcement on appear and on each added
+  removal; its action is labeled "Undo".
+- Dock controls labeled cancel / "Add N"; popup advance labeled "Pick stations".
 - Search field, clear button, and display-mode pills carry labels.
 - Names and titles support Dynamic Type; the uppercased title scales down before
   truncating from the middle. Station names wrap to two lines in icon mode.
@@ -196,19 +247,29 @@ Strings this surface owns:
 
 - `stationLists` ("Station Lists") — fallback list title / library label.
 - `stationListsHint` ("Create a list to collect stations outside favorites.").
-- `createStationList` ("Create list"), `stationListName` ("List name").
-- `addOrCreateList` ("Add or create list"), `addStationsToList` ("Add stations to
-  list").
+- `createStationList` ("Create list"), `stationListName` ("List name"),
+  `renameList` ("Rename list"), `listNameInUse` ("Name already in use").
+- `addStationsToList` ("Add stations to list"), `addStationsToFavorites` ("Add
+  stations to favorites"), `addStationList` ("Add list") / `pickStations` ("Pick
+  stations") — the popup/dock two-step labels.
 - `emptyStationList` ("Empty station list"), `emptyStationListHint` ("Add stations
-  from Browse to build this list.").
+  from Browse to build this list."), `emptyList` ("Empty list") — the Home card hint.
 - `noStationsFound` ("No stations found"), `trySearch` ("Try a station name, country
   code, or tag.").
+- `deleteListTitle` ("Delete “{name}”?"), `deleteListStationsKept`
+  (plural: "The station in it stays available in Browse." / "Its {count} stations
+  stay available in Browse.").
+- `stationRemovedToast` ("Removed {name}"), `stationsRemovedToast` (plural:
+  "{count} station(s) removed"), `undo` ("Undo").
 - `removeFromList` — parameterized on `{name}` ("Remove {name} from list").
-- `stationListEmptyA11y` — parameterized on `{name}` ("{name}, empty list").
+- `showStationsIn` ("Show stations in {name}"),
+  `stationListEmptyA11y` — parameterized on `{name}` ("{name}, empty list").
 - `statusBarPageA11y` — parameterized on `{title}`, `{index}`, `{total}`.
 
-Parameter needs: `{name}` (station/list name), `{title}`/`{index}`/`{total}` (page
-position). No plural categories required today (count badge is a bare numeral).
+Parameter needs: `{name}` (station/list name), `{count}` (removed/kept station
+count), `{title}`/`{index}`/`{total}` (page position). Plural categories are
+required for `stationsRemovedToast` and `deleteListStationsKept` (count-driven
+copy); the dock selection-count badge remains a bare numeral.
 
 ## Platform Matrix
 
@@ -216,11 +277,11 @@ position). No plural categories required today (count badge is a bare numeral).
 |---|---|---|---|
 | Station-list overview | Not planned for current web. | Reference. | Supported. |
 | Create/delete list | Not planned for current web. | Supported. | Supported. |
-| Rename list | Not planned for current web. | Supported (model + edit-state; see Open questions on chrome affordance). | Supported. |
+| Rename list | Not planned for current web. | Supported (Home card edit-mode pencil → rename alert). | Supported. |
 | Create from Browse multi-select | Not planned for current web. | Supported (popup name entry + selection dock). | Supported. |
 | Add stations from Browse | Not planned for current web. | Supported. | Supported. |
-| Remove stations from a list | Not planned for current web. | Supported. | Supported. |
-| Reorder lists | Not planned for current web. | Supported. | Supported with up/down controls. |
+| Remove stations from a list | Not planned for current web. | Supported (with undo toast). | Supported. |
+| Reorder lists | Not planned for current web. | Supported (interactive drag on Home; Recents pinned). | Supported with up/down controls. |
 | Reorder stations inside a list | Not planned for current web. | Supported (interactive drag). | Supported with up/down controls. |
 | Play list as queue | Not planned for current web. | Supported (circular skip). | Supported. |
 | Empty-list guidance | Not planned for current web. | Supported ("Add stations from Browse…"). | Supported. |
@@ -237,42 +298,51 @@ too heavy.
 
 ## Open questions
 
-1. **Rename affordance on iOS.** The rename mutation (`renameStationList`) and a
-   per-page rename edit-state exist and are tested, but the current shared library
-   chrome surfaces only create (name prompt), add-stations, and delete — no live
-   rename control on the list detail page. Where should rename live (tap the title?
-   a long-press menu?) and does Home need an inline rename too?
+1. **Rename on the list-detail page.** Rename now ships as a Home card edit-mode
+   pencil badge, resolving where the primary affordance lives. A per-list rename
+   edit-state still exists but is unwired on the detail page itself — should the
+   detail page also offer rename (tap the title?), or is the Home card the only
+   intended entry point?
 2. **List/station caps.** No cap exists today; should very large lists get a cap or
    off-main filtering like Browse?
-3. **List-level reorder on iOS.** Lists reorder is marked Supported, but the live
-   surface for dragging whole lists vs. the Android up/down controls is unconfirmed
-   in the read sources.
 
 ## Reference
 
 - `rrradio/Library/Library.swift` — `StationList` model; create/rename/delete/reorder
   lists, add/remove/reorder stations, uniqueness, name trimming, decode quarantine,
-  catalog reconciliation, cross-store custom-station removal, cloud-sync apply.
+  catalog reconciliation, cross-store custom-station removal, removal-undo records
+  (`StationRemoval`, `restore`), cloud-sync apply. `recentsLimit = 12`.
 - `Shared/StationFeed.swift` — `StationFeed` protocol, `FeedID.stationList`,
   `FeedCapabilities`, playback-queue source matrix.
 - `Shared/StationPlaybackQueue.swift` — circular skip-next/previous, queue identity,
   remove/replace-in-queue.
+- `rrradio/Views/LibraryListSelection.swift` — page-swipe ordering
+  (`orderedSelections`: Home · user lists · Recents; Favorites excluded).
 - `rrradio/Library/Feeds/StationListFeed.swift` — the list feed (resolves by id,
   capabilities: reorder/remove/rename/delete/long-press info).
 - `rrradio/Views/FeedPages/StationFeedPage.swift` — list detail renderer: rows/tiles/
   icons, delete badges, reorder, search, empty / no-match states, pull-to-refresh.
-- `rrradio/Views/FeedPages/LibraryHomePage.swift` — list cards, play, delete a list.
+- `rrradio/Views/FeedPages/LibraryHomePage.swift` — list cards (interactive
+  drag-reorder, pinned Recents), play, rename alert, delete-confirmation dialog.
 - `rrradio/Views/FeedPages/LibraryChrome.swift` / `LibraryPageStatusBar.swift` —
-  create prompt, add-stations "+", delete-mode toggle, status bar / tuner scale.
-- `rrradio/Views/FeedPages/AddListPopupCard.swift` — add-or-create-list picker.
+  add-or-create "+" (Home), add-stations "+", Favorites "+", delete-mode toggle,
+  status bar / tuner scale.
+- `rrradio/Views/FeedPages/AddListPopupCard.swift` /
+  `AddListStepStrip.swift` — add-or-create-list picker with the two-step strip and
+  duplicate-name guard.
 - `rrradio/Views/FeedPages/BrowseSelectionDock.swift` /
-  `State/BrowseSelectionState.swift` — Browse multi-select dock and selection model.
-- `rrradio/Views/FeedPages/BrowsePage.swift` — multi-select entry + save folding
-  logic.
+  `State/BrowseSelectionState.swift` — top-pinned Browse multi-select dock and
+  selection model (incl. Favorites-target mode).
+- `rrradio/Views/FeedPages/BrowsePage.swift` /
+  `BrowseStationListSelectionRequest.swift` — multi-select entry, save folding +
+  Favorites-target logic.
 - `rrradio/Views/FeedPages/State/StationListEditState.swift` — per-list delete /
-  rename edit state.
+  rename edit state (rename draft unwired on the detail page).
+- `rrradio/Views/StationKit.swift` — `StationListCard` (rename/delete badges) and
+  `LibrarySelectionCard` (Recents card).
+- `rrradio/Views/StationRemovalUndo.swift` — removal-undo controller + toast.
 - `rrradio/Views/ContentView.swift` — list page wiring (remove/reorder callbacks,
-  add-stations request).
+  add-stations request, create-list popup host, undo-toast host).
 
 ## Known deviations
 

--- a/docs/spec/features/wake-to-radio.md
+++ b/docs/spec/features/wake-to-radio.md
@@ -1,9 +1,9 @@
 # Wake To Radio Specification
 
 ```yaml
-status: draft
+status: review
 platforms: [web, ios, android]
-reconciled-against: 9336321
+reconciled-against: d241aa9
 ```
 
 ## Purpose
@@ -24,55 +24,73 @@ setup guidance and platform-limit prose; this spec does not duplicate it.
 - **Program schedule on Now Playing** — tapping a scheduled broadcast opens the
   wake sheet pre-filled (preset) with that broadcast's station, start time, and
   program name as the alarm title, with the notification toggle on by default.
-- **Settings** — three persistent preference rows (default wake time, Lock Screen
-  notification toggle) seed the next alarm but do not arm one.
+- **Settings** — two persistent wake preference rows (default wake time, Lock Screen
+  notification toggle) seed the next alarm but do not arm one; a denied-permission
+  warning row appears under them only while an alarm is armed with the notification
+  preference on and OS permission denied. Keep-audio-alive has no Settings row — it
+  lives only in the wake sheet, even though its default is part of preference sync.
 - **Notification tap** — tapping the fired wake notification re-enters the app and
   drives the notification → playback flow (see Interactions).
-- **Shortcuts / Siri (iOS)** — "Play Station" and "Play Last Station" App Intents
-  let a user build a Time-of-Day Personal Automation that starts a station on a
-  schedule. This is a parallel path, independent of the in-app alarm.
+- **Shortcuts / Siri (iOS)** — three App Intents reach this feature:
+  - "Set Wake Alarm" (station + time) arms the in-app alarm directly, opening the
+    app; it stores only the time-of-day, so "tomorrow" resolves at arm time.
+  - "Play Station" and "Play Last Station" let a user build a Time-of-Day Personal
+    Automation that starts a station on a schedule — a parallel path that plays
+    immediately rather than arming the alarm.
 
 ## Layout
 
 The wake sheet, top to bottom:
 
-- **Close button** — top-trailing `xmark`; dismisses the sheet without changing the
-  alarm.
-- **Header** — alarm glyph (filled + accent when armed); title "Wake to radio";
-  when armed, a live countdown capsule ("IN 7H 20M") that ticks every 30s.
-- **Station identity card** — favicon, station name, and (when set) the alarm
-  title/program line for the wake target. When no station is resolvable, shows
-  "Play a station first" instead.
-- **Time wheel** — hour/minute picker. Defaults to the preset time, else the
-  current alarm time, else the saved default wake time.
+- **Header** — a centered title row: alarm glyph (filled + accent when armed) plus
+  the title "Wake to", closed by a full-width hairline rule. When armed, a live
+  countdown capsule ("IN 7H 20M") rides the trailing edge of the row and ticks every
+  30s without pulling the title off-center. The header stays pinned; the rest of the
+  sheet scrolls under it.
+- **Station identity line** — directly under the rule, a centered favicon + station
+  name for the wake target. When no station is resolvable, shows "Play a station
+  first" instead. (The alarm title/program name is carried on the alarm but is not
+  shown on this line; it surfaces in the notification body.)
+- **Time wheel** — hour/minute picker (follows the device 24-hour setting, not the
+  app language). Defaults to the preset time, else the current alarm time, else the
+  saved default wake time.
 - **Lock Screen notification toggle** — with detail copy. Disabled while an alarm
   is armed (unless the sheet is editing that armed alarm).
 - **Notification-denied warning** (conditional) — shown only when the notification
   toggle is on and OS permission is denied: a bell-slash icon, a warning line, and
   an "Open Settings" button that deep-links to the app's system settings.
 - **Keep-audio-alive toggle** — with detail copy. Disabled while an alarm is armed.
-- **Action button** — "SET" when no alarm (or editing one); "UNSET" when armed and
-  unchanged. While armed it shows a subtitle (the new time when editing, else
-  "<time> · in <countdown>"). Disabled when setting but no station resolves.
-- **Hint** — accent footnote: keep rrradio running and enable keep-alive for the
-  best chance of autoplay.
+- **Footer button pair** — a centered `xmark` capsule (dismiss without changing the
+  alarm) beside the action button. The action button reads "SET" when no alarm (or
+  editing one) and "UNSET" when armed and unchanged; it carries no subtitle. The SET
+  state is disabled (dimmed) when no station resolves; UNSET is always available.
 
-The wake target station chips show the armed time on the Now Playing wake button
-while armed.
+The Now Playing wake button shows the armed time as a small accent chip while armed
+(`alarm.fill` glyph + time); the chip is decorative and is not exposed as an
+accessibility value.
 
 ## States
 
 | State | What shows | Actionable |
 |---|---|---|
 | Disarmed, station playing | Sheet pre-fills station + default/last time; SET enabled. | Set an alarm. |
-| Disarmed, nothing playing | Station card shows "Play a station first"; SET disabled. | Pick time/toggles only; cannot set. |
-| Armed | Header countdown capsule; button reads UNSET with `<time> · in <countdown>`; toggles locked. | Unset; edit (changing time/station/title flips to SET). |
-| Editing an armed alarm | Button flips back to SET with the new time as subtitle; toggles re-enabled. | Re-arm with new values. |
-| Notification permission denied | Denied-warning block under the notification toggle (only while toggle on). | Open Settings. |
-| Fired (alarm reached) | Alarm disarms itself; if the app is alive it switches to the station; Now Playing surfaces shortly after. | Normal playback. |
+| Disarmed, nothing playing | Station line shows "Play a station first"; SET disabled. | Pick time/toggles only; cannot set. |
+| Armed | Header countdown capsule; button reads UNSET (no subtitle); toggles locked; lock-screen Live Activity glances the station + fire time. | Unset; edit (changing time/station/title flips to SET). |
+| Editing an armed alarm | Button flips back to SET; toggles re-enabled. | Re-arm with new values. |
+| Notification permission denied | Denied-warning block under the notification toggle (only while toggle on and alarm armed); same warning row appears in Settings. | Open Settings. |
+| Fired (alarm reached) | Alarm disarms itself; Live Activity ends; if the app is alive it switches to the station; Now Playing surfaces shortly after. | Normal playback. |
 | Missed (app was suspended/asleep) | The fired local notification is the cue; on next launch a stale alarm is cleared (see deviations). | Tap notification to start; or re-arm. |
 
 There is at most **one** active wake intent at a time.
+
+While armed, a dedicated lock-screen / Dynamic Island **Live Activity** glances the
+alarm independent of current playback: an alarm glyph, the wake station name, the
+fire time, and a relative countdown, themed in the app's effective accent/surface
+colors. It is a glanceable surface only — the alarm still fires via the in-app timer,
+keep-alive, and scheduled notification, so the activity expiring (e.g. iOS's ~12 h
+Live Activity lifetime cap on an alarm set far ahead) never affects whether the alarm
+goes off. It updates on re-arm and ends on disarm/fire; if Live Activities are
+disabled or starting one fails, the alarm is unaffected.
 
 ## Interactions
 
@@ -90,8 +108,9 @@ There is at most **one** active wake intent at a time.
 | Alarm time reached, app alive | Armed | Timer fires: disarms, stops keep-alive, plays the station | Diagnostic "timer fired"; Now Playing surfaces |
 | App launch / foreground with pending fire | `firesAt` already passed but within grace | Fires immediately on activate | — |
 | Tap fired notification | Notification delivered | Queues the station id; on next active app pass, fires the armed alarm (or plays the station directly if no longer armed) | Now Playing surfaces |
-| Pause playback while armed (keep-alive off) | Armed, keep-alive off, warning not suppressed | One-time alert: alarm may not auto-play; offers "Don't show again" | Suppress flag persisted on dismiss-with-don't-show |
-| Run "Play Station" / "Play Last Station" intent | App launchable by iOS | Queues a playback request; app foregrounds and plays | Independent of in-app alarm |
+| Pause playback while armed (keep-alive off) | Armed, keep-alive off, warning not suppressed | One-time alert: alarm may not auto-play; offers "Don't show again" + "OK" | Suppress flag persisted on dismiss-with-don't-show |
+| Run "Set Wake Alarm" intent (station + time) | App launchable by iOS | Queues an arm request (time-of-day only); app foregrounds and arms the in-app alarm | Independent of the notification-tap path; resolves the station against everything playable; stale requests past the intent lifetime are dropped |
+| Run "Play Station" / "Play Last Station" intent | App launchable by iOS | Queues a playback request; app foregrounds and plays | Plays immediately; does not arm an alarm |
 
 ## Business rules
 
@@ -118,7 +137,10 @@ There is at most **one** active wake intent at a time.
   the project privacy boundary — no full private stream URLs leak. Diagnostics are
   local opt-in.
 - **Preference sync:** default time, notification-enabled, and keep-alive-enabled
-  are part of the cloud-sync snapshot (see Known deviations for the keep-alive gap).
+  are all part of the cloud-sync snapshot; changing any of the three (via its
+  setter or the wake sheet) pushes to sync, and applying a remote snapshot suppresses
+  the re-push. The armed alarm itself (station, time, title) is device-local — only
+  the three defaults sync.
 
 ## Data dependencies
 
@@ -166,36 +188,45 @@ There is at most **one** active wake intent at a time.
 
 ## Accessibility
 
-- Wake button carries the localized "Wake to radio" label; armed state adds the
-  time as a value.
-- Close button has an explicit "Close" accessibility label.
+- Wake button carries the localized "Wake to radio" label; the armed-time chip is a
+  visual badge only and is not exposed as an accessibility value.
+- Footer close button has an explicit "Close" accessibility label; the action button
+  is labeled "Set"/"Unset" to match its state.
 - Toggles expose title + detail text; the denied warning is readable as a labeled
   block with an "Open Settings" action.
-- Station name and title use `minimumScaleFactor` so they scale rather than
+- Header title and station name use `minimumScaleFactor` so they scale rather than
   truncate under large Dynamic Type.
 - Countdown capsule updates on a 30s timeline; it is decorative relative to the
   primary time, which remains the source of truth.
+- The wake Live Activity collapses to a single element labeled "Alarm set for
+  <station>"; its alarm glyph is hidden from VoiceOver.
 
 ## Localization
 
 This surface owns these strings (English reference values):
 
-- `wakeToRadio` — "Wake to radio"
+- `wakeTo` — "Wake to" (wake-sheet header title)
+- `wakeToRadio` — "Wake to radio" (Now Playing wake button label)
 - `wakeTime` — "Wake time"
-- `defaultWake` — "Default wake time"
-- `wakeHint` — autoplay/keep-alive guidance footnote
+- `defaultWake` — "Default wake time" (Settings row)
 - `wakeNotification` — "Lock Screen notification"
 - `wakeNotificationDetail` — "Shows a wake alert at the set time. Program alarms turn this on by default."
 - `wakeNotificationsDeniedWarning` — denied-permission warning
 - `wakeKeepAlive` — "Keep audio alive until wake"
 - `wakeKeepAliveDetail` — near-silent-sound + battery explanation
 - `wakePauseWarningTitle` / `wakePauseWarningMessage` — pause-while-armed alert
-- `unsetWakeAlarm` — "Unset wake alarm"
 - `playStationFirst` — "Play a station first"
 - `set` / `unset`, `openSettings`, `dontShowAgain`, `close`, `ok` (shared)
 
-Notification body interpolates station name and time; localization must keep the
-station/time parameters. No plural forms required (countdown uses compact "Hh Mm"
+`wakeHint` (autoplay/keep-alive footnote) and `unsetWakeAlarm` remain defined but
+are no longer rendered after the sheet restructure; the keep-alive guidance now lives
+in `wakeKeepAliveDetail`.
+
+Notification body interpolates station name and time, with a separate body when an
+alarm title is set; localization must keep the station/time parameters. The Live
+Activity strings ("Alarm", "Alarm set for <station>") and the App Intent titles
+("Set Wake Alarm", "Play Station", "Play Last Station") are not yet part of the
+localized string table. No plural forms required (countdown uses compact "Hh Mm"
 formatting; "now"/"soon" are special-cased).
 
 ## Platform Matrix
@@ -210,10 +241,11 @@ formatting; "now"/"soon" are special-cased).
 | Program-schedule preset arming | Where schedules exist. | Supported. | Planned. |
 | DST-safe next-fire resolution | Required. | Supported. | Required. |
 | Pause-while-armed warning | TBD. | Supported (once per alarm, keep-alive off). | TBD. |
-| Shortcuts/automation | Not applicable. | Supported through App Intents/Shortcuts. | Not applicable. |
+| Lock-screen wake Live Activity | Not applicable. | Supported (glanceable; independent of playback). | TBD. |
+| Shortcuts/automation | Not applicable. | Supported (Set Wake Alarm arms; Play Station / Play Last Station play). | Not applicable. |
 | Exact alarm | Not available. | Not available to third-party app in this sense. | Open decision; may require permission. |
 | Survives force quit | No. | No. | No reliable guarantee. |
-| Preference cloud sync | Not planned. | Supported for time + notify (keep-alive gap, W6). | Not applicable. |
+| Preference cloud sync | Not planned. | Supported for time + notify + keep-alive. | Not applicable. |
 
 ## Web
 
@@ -229,7 +261,9 @@ iOS is the current reference behavior:
 - In-app wake alarm with a runloop-`.common` timer (survives scroll).
 - Near-silent keep-alive option (default on).
 - One-shot local notification fallback.
-- App Intents / Shortcuts actions "Play Station" and "Play Last Station".
+- Lock-screen / Dynamic Island Live Activity while armed (glanceable only).
+- App Intents / Shortcuts actions "Set Wake Alarm" (arms the alarm), "Play Station",
+  and "Play Last Station" (play immediately).
 
 See [Wake to radio on iOS](../../wake-to-radio.md) for setup and limits.
 
@@ -263,36 +297,48 @@ stations are the launch scope.
 
 iOS source files (the only place iOS mechanics are named):
 
-- `rrradio-ios/rrradio/Player/WakeAlarm.swift` — `WakeAlarm` (`arm`, `disarm`,
+- `rrradio/Player/WakeAlarm.swift` — `WakeAlarm` (`arm`, `disarm`,
   `activate`, `fire`, `fireFromNotification`, `nextFireDate` DST-safe resolution,
-  `formatCountdown`, keep-alive/notification preference `didSet`s, stale-grace
-  restore in `init`, `shouldShowPauseWarning`/`suppressPauseWarning`,
-  `requestNotificationAuthorizationIfNeeded`, `applyCloudSyncPreferences`);
+  `formatCountdown`, keep-alive/notification preference `didSet`s that push prefs,
+  stale-grace restore in `init`, `shouldShowPauseWarning`/`suppressPauseWarning`,
+  `requestNotificationAuthorizationIfNeeded`, `applyCloudSyncPreferences`,
+  `shouldShowNotificationPermissionWarning`, `chipText`);
   `WakeAlarmNotification` (payload, category, `requestPlayback`, pending-station id);
   `LocalWakeAlarmNotifier` (`UNCalendarNotificationTrigger`, authorization).
-- `rrradio-ios/rrradio/Player/AudioPlayer.swift` — `startWakeKeepAlive`/
-  `stopWakeKeepAlive`, `keepAliveWavData` (near-silent looped WAV), session
+- `rrradio/Player/AudioPlayer.swift` — `startWakeKeepAlive`/
+  `stopWakeKeepAlive` (deactivates the session when idle and nothing follows),
+  `keepAliveWavData` (near-silent looped WAV, volume 0.001), session
   configure/deactivate.
-- `rrradio-ios/rrradio/Views/NowPlayingView.swift` — `WakeAlarmView` sheet,
-  `WakeAlarmPreset`, wake button, station identity, countdown, pause warning trigger.
-- `rrradio-ios/rrradio/Views/ContentView.swift` — `activate`, `syncWakeKeepAlive`,
-  `playPendingWakeAlarmNotificationIfPossible`, pause-warning alert.
-- `rrradio-ios/rrradio/Views/AppRouter.swift` — `consumePendingWakeNotification`,
-  `WakeNotificationOutcome`.
-- `rrradio-ios/rrradio/App.swift` — `AppDelegate` `UNUserNotificationCenterDelegate`
-  (`willPresent`, `didReceive`), category registration.
-- `rrradio-ios/rrradio/Shortcuts/PlayStationIntent.swift`,
-  `IntentPlaybackRequest.swift` — "Play Station" / "Play Last Station" App Intents.
-- `rrradio-ios/rrradio/CloudSync/CloudSyncSnapshot.swift` — `wakeDefaultTime`,
+- `rrradio/Player/WakeAlarmLiveActivityController.swift` — `sync`/`end`, re-adopts a
+  surviving activity on launch.
+- `Shared/WakeAlarmActivityAttributes.swift` — Live Activity `ContentState`
+  (station, `firesAt`, themed colors).
+- `rrradioWidget/WakeAlarmLiveActivity.swift` — lock-screen + Dynamic Island
+  presentation.
+- `rrradio/Views/NowPlayingView.swift` — `WakeAlarmView` sheet (`sheetHeader`,
+  `stationLine`, footer SET/UNSET + close pair), `WakeAlarmPreset`,
+  `WakeAlarmSheet`, wake button + armed chip, countdown.
+- `rrradio/Views/ContentView.swift` — `activate`, `syncWakeKeepAlive`,
+  `syncWakeLiveActivity`, `playPendingWakeAlarmNotificationIfPossible`,
+  `consumePendingIntentWakeAlarm` arming, pause-warning trigger + alert.
+- `rrradio/Views/AppRouter.swift` — `consumePendingWakeNotification`,
+  `WakeNotificationOutcome`, `consumePendingIntentWakeAlarm`.
+- `rrradio/App.swift` — `AppDelegate` `UNUserNotificationCenterDelegate`
+  (`willPresent` → banner+sound, `didReceive` → `requestPlayback`), category
+  registration.
+- `rrradio/Shortcuts/PlayStationIntent.swift` — `SetWakeAlarmIntent`,
+  `PlayStationIntent`, `PlayLastStationIntent`; `IntentPlaybackRequest.swift` —
+  `requestArmWakeAlarm` / `consumePendingWakeAlarm` (time-of-day, stale-drop).
+- `rrradio/CloudSync/CloudSyncSnapshot.swift` — `wakeDefaultTime`,
   `wakeNotificationsEnabled`, `wakeKeepAliveEnabled`.
-- `rrradio-ios/rrradio/Views/SettingsView.swift` — default-time row, notification
-  row, denied warning.
+- `rrradio/Views/SettingsView.swift` — default-time row, notification
+  row, conditional denied-warning row.
 
 ## Known deviations
 
 These record shipped iOS code that does not match the intended behavior above; the
 spec states intent, the audit owns the bug. See
-`rrradio-ios/internal/audit/2026-05-25-ios-code-review-slice3.md`:
+`internal/audit/2026-05-25-ios-code-review-slice3.md`:
 
 - **W1 (High):** notification-tap handler *queues* playback (consumed on the next
   active app pass) rather than starting it directly; a sound-only, untapped banner
@@ -304,10 +350,6 @@ spec states intent, the audit owns the bug. See
   (non-idempotent getter).
 - **W4 (Medium):** DST resolution is fixed but the chosen `firesAt` is not logged,
   so a silently-shifted firing is hard to diagnose.
-- **W5 (Medium):** a direct write to `notificationsEnabled` bypasses the cloud-sync
-  push that the explicit setter performs.
-- **W6 (Medium):** keep-alive-enabled is read into the snapshot but its direct setter
-  is not consistently synced across devices.
 - **W10 (Low):** the notification trigger is constructed without a pinned timezone;
   travel mid-arm fires at the new local time matching the original components.
 - **W11 (Low):** when no notification preference is stored, the default splits on
@@ -315,7 +357,11 @@ spec states intent, the audit owns the bug. See
   branch.
 - **W12 (Medium):** the denied-permission warning only renders while
   `isArmed && notificationsEnabled && notificationPermissionDenied`; denying after
-  arming then disarming loses the warning surface.
-- Related session/keep-alive teardown gap: see
-  `rrradio-ios/internal/audit/2026-05-25-ios-code-review-slice5.md` (A2) — the audio
-  session is not always deactivated when keep-alive stops and nothing follows.
+  arming then disarming loses the in-sheet warning surface (the Settings warning row
+  shares the same predicate).
+
+Resolved since the audit (code now matches intent at d241aa9, no longer deviations):
+W5 (the `notificationsEnabled` `didSet` now pushes the cloud-sync change, guarded by
+the apply-from-sync flag); W6 (keep-alive is in the cloud-sync snapshot and its
+`didSet` pushes); and the slice5 (A2) keep-alive teardown gap (`stopWakeKeepAlive`
+deactivates the audio session when the player is idle and nothing follows).

--- a/docs/spec/features/watch-remote.md
+++ b/docs/spec/features/watch-remote.md
@@ -1,9 +1,9 @@
 # Watch Remote Specification
 
 ```yaml
-status: draft
+status: approved
 platforms: [ios]
-reconciled-against: 800bb74
+reconciled-against: d241aa9
 ```
 
 ## Purpose
@@ -144,7 +144,9 @@ dimmed with no current station.
   than falling back to favorites.
 - **Primary action resolution** (play/pause button and double-tap on the Player):
   pause if the watch believes playback is live → resume if a current station exists
-  but is paused → else play the first list → else play the first favorite.
+  but is paused → else play the first **non-empty** list → else play the first
+  favorite. (An empty first list is skipped — the resolver requires it to hold
+  ≥1 station before starting it.)
 - **"Playing" includes loading.** The play/pause button shows the pause icon while
   the iPhone is loading, so it never flickers to "play" during buffering.
 - **Stepping availability** (watch enable check): active queue has >1 station, OR

--- a/docs/spec/platforms.md
+++ b/docs/spec/platforms.md
@@ -1,5 +1,11 @@
 # Platform Specification
 
+```yaml
+status: review
+platforms: [web, ios, android]
+reconciled-against: d241aa9
+```
+
 rrradio has one product contract and multiple platform implementations. Shared
 behavior should remain recognizable across web, iOS, and Android, while each
 platform uses native playback, storage, and OS integration.
@@ -23,10 +29,15 @@ The formal, field-level cross-platform invariants live in
 - A platform may cache the catalog, but cache refresh must never require an app
   release when the published JSON changes.
 - User-entered stream URLs must be treated as private user data.
+- Local library data is private and stays on device unless a platform offers an
+  explicit cloud or file-transfer path; the record types, merge algebra, and
+  decode isolation for cross-device sync are [sync-merge](contracts/sync-merge.md).
 - Telemetry and diagnostics must avoid stack traces, search queries, stream
   URLs, track titles, artist names, and arbitrary user-entered strings; the full
   data-boundary matrix is
   [privacy & data boundaries](contracts/privacy-data-boundaries.md).
+- User and automated broken-station reports follow a single server-side contract
+  shared by all platforms: [broken-reports](contracts/broken-reports.md).
 - Playback states, retry, and queue stepping are
   [playback-state-machine](contracts/playback-state-machine.md); the watch remote
   wire format is [watch-protocol](contracts/watch-protocol.md); the localization
@@ -66,11 +77,15 @@ Current implementation shape:
 - Background audio capability.
 - MPNowPlayingInfoCenter and MPRemoteCommandCenter for lock-screen,
   Bluetooth, and AirPods controls.
+- Native CarPlay template surface (Favorites, Recents, Lists, Browse-by-country)
+  plus the system now-playing screen, separate from the in-app car mode.
+- App Intents, Siri, Spotlight, and Shortcuts for station playback.
 - UserDefaults-backed local library.
 - CloudKit private database sync for supported library and preference data.
 - watchOS companion app that remotely controls iPhone playback.
 - Native map, wake alarm, sleep timer, local diagnostics, listening history,
   theme/language/landing preferences, and station lists.
+- Wake-alarm Live Activity (lock screen and Dynamic Island) for an armed wake.
 
 Platform constraints:
 
@@ -121,3 +136,47 @@ Android-specific open decisions:
 - Whether the Android catalog search needs a bundled index or can start with an
   in-memory matcher.
 - Whether watch/companion surfaces are out of scope or future Wear OS work.
+
+## Platform Matrix
+
+The canonical, per-behavior parity matrix lives in
+[README](README.md#platform-parity-matrix); the rows below capture only the
+platform-shape differences this doc asserts, using the README status legend.
+
+| Behavior | Web | iOS | Android |
+|---|---|---|---|
+| Native playback engine | Supported (`HTMLAudioElement` + `hls.js`) | Reference (AVFoundation) | Supported (Media3/ExoPlayer) |
+| Lock-screen / media controls | Supported where browser allows | Reference | Partial |
+| Background audio | Partial | Reference | Partial |
+| Cloud library sync | Not planned | Supported (CloudKit, iOS-only) | Not applicable |
+| Manual export/import | Supported (favorites, custom stations) | Planned/optional | Supported (library + preferences) |
+| Watch companion remote | Not applicable | Supported | Not applicable |
+| CarPlay / vehicle template surface | Browser/OS dependent | Supported | Android Auto TBD |
+| Siri / Shortcuts / Spotlight | Planned | Supported | Planned |
+| Wake-to-radio | Partial, browser-limited | Reference, iOS-limited | Planned, Android-limited |
+| Local diagnostics opt-in | Anonymous production events only | Supported | Supported |
+
+## Reference
+
+iOS source (read-only mirror) for the cross-cutting platform claims above:
+
+- App entry and scene wiring — `rrradio/App.swift`, `rrradio/Views/AppRouter.swift`.
+- Playback, lock-screen, and background audio — `rrradio/Player/AudioPlayer.swift`.
+- CarPlay template surface — `rrradio/CarPlay/CarPlayController.swift`,
+  `rrradio/CarPlay/CarPlaySceneDelegate.swift`; in-app car mode —
+  `rrradio/Player/CarModeController.swift`.
+- CloudKit sync — `rrradio/CloudSync/CloudSyncStore.swift`,
+  `CloudSyncController.swift`, `CloudSyncSnapshot.swift`.
+- Watch remote — `Shared/WatchRemoteProtocol.swift`,
+  `rrradio/WatchRemote/PhoneRemoteControlController.swift`, `rrradioWatch/`.
+- App Intents / Siri / Spotlight — `rrradio/Shortcuts/`.
+- Localization catalog — `rrradio/Resources/Localizable.xcstrings`.
+- Project generation and target/scene configuration — `project.yml` (xcodegen).
+
+Per-behavior depth lives in the linked feature and contract specs; this doc only
+summarizes the platform split.
+
+## Known deviations
+
+None tracked for the cross-platform claims in this doc. Per-feature deviations
+are linked from the individual feature and contract specs.

--- a/docs/spec/playback.md
+++ b/docs/spec/playback.md
@@ -1,5 +1,11 @@
 # Playback Specification
 
+```yaml
+status: review
+platforms: [web, ios, android]
+reconciled-against: d241aa9
+```
+
 Playback is the core product surface. Every platform should prioritize reliable
 start, pause, resume, stop, retry, and media-control behavior over decorative
 UI differences.
@@ -13,16 +19,20 @@ behavioral summary; the contract is authoritative for exact states and limits.
 
 - A station row starts playback for that station.
 - Starting a new station replaces the current audio source in place.
-- Pause keeps the current station selected.
-- Resume restarts the current station.
-- Stop clears active playback unless a platform-specific wake flow needs a
-  silent keep-alive source.
+- Pause keeps the current station selected and the session active for fast resume.
+- Resume on a paused station unpauses in place; resume on a failed/errored station
+  rebuilds the source from scratch (manual retry).
+- Stop clears active playback and the active queue unless a platform-specific wake
+  flow needs a silent keep-alive source.
 - The mini-player appears after playback starts or when an offline state needs
   a product-level surface.
 - The current station should stay visible across list, favorite, and Now
   Playing surfaces.
 - Station stepping from media controls should use the active playback queue
   where one exists, then fall back to favorites where appropriate.
+- A station the broadcaster region-locks (curated availability excludes the
+  listener's region) surfaces a friendly region-locked message and is treated as
+  a permanent failure — no retry.
 
 ## Stream Support
 
@@ -30,8 +40,8 @@ behavioral summary; the contract is authoritative for exact states and limits.
 |---|---|---|---|
 | MP3 | `HTMLAudioElement` | AVPlayer | Media3/ExoPlayer |
 | AAC | `HTMLAudioElement` | AVPlayer | Media3/ExoPlayer |
-| HLS | Safari native, `hls.js` elsewhere | AVPlayer | Media3/ExoPlayer |
-| Playlist redirects | Parse or resolve before playback where needed. | Resolve through player/fetcher support where needed. | Resolves plain `.m3u` / `.pls` before MediaItem playback; HLS `.m3u8` remains native. |
+| HLS | Safari native, `hls.js` elsewhere | AVPlayer native (`.m3u8`) | Media3/ExoPlayer |
+| Playlist redirects | Parse or resolve before playback where needed. | Catalog ships the resolved stream URL; the player streams it directly and does not parse `.pls` / `.m3u` at playback time. | Resolves plain `.m3u` / `.pls` before MediaItem playback; HLS `.m3u8` remains native. |
 
 Only HTTPS streams publish by default. Catalog exceptions require the
 `httpAllowed` escape hatch documented in [Operations](../operations.md).
@@ -42,16 +52,22 @@ All platforms must handle transient stream failure:
 
 - Detect error, stalled, disconnected, and route/interruption states.
 - Retry by rebuilding the media source, not only by calling play again.
+- Cap automatic retries (≤3 per station session) and back off between attempts;
+  never spin a tight retry loop.
 - Keep errors privacy-preserving in telemetry or diagnostics.
-- Avoid tight retry loops.
-- Surface offline state at product level when the device loses connectivity.
+- Surface offline state at product level when the device loses connectivity, and
+  auto-reconnect the current station once connectivity returns — but only when
+  playback was active (playing, loading, or errored), never when the user had
+  paused or nothing was selected.
+- Region-locked stations do not retry; the friendly region message is preserved.
 
 Platform notes:
 
 - Web must treat `HTMLAudioElement` as unreliable after some failures and
   rebuild source state.
-- iOS should keep AVPlayer item rebuilding and audio-session interruption
-  handling as native reference behavior.
+- iOS keeps AVPlayer item rebuilding, audio-session interruption handling,
+  output-route-loss pause, and media-services-reset recovery as native reference
+  behavior; a connectivity monitor drives the network-restore auto-reconnect.
 - Android should use Media3 player error callbacks and rebuild the MediaItem or
   player item when required.
 
@@ -62,8 +78,12 @@ Platform notes:
 | Lock screen | Media Session API where supported. | MPNowPlayingInfoCenter. | Media3 media session notification. |
 | Headphones/Bluetooth | Browser/OS dependent. | MPRemoteCommandCenter. | Media session transport controls. |
 | Background playback | Browser/OS dependent. | Background audio entitlement. | Foreground media service. |
-| Vehicle controls | Browser/OS dependent. | Media controls, CarPlay behavior through system surfaces. | Media controls; Android Auto is an explicit open decision. |
-| Watch companion | Not applicable. | watchOS remote controls iPhone playback. | Wear OS out of scope for first Android port. |
+| Vehicle controls | Browser/OS dependent. | In-app big-button car mode on a car audio route; native CarPlay app (Favorites / Recents / Lists / Browse-by-country + system Now Playing) implemented behind a dev build, pending Apple's CarPlay-audio entitlement. | Media controls; Android Auto is an explicit open decision. |
+| Watch companion | Not applicable. | watchOS app remote-controls iPhone playback (mirrors player state, steps stations, plays favorites/lists). | Wear OS out of scope for first Android port. |
+
+Media-control surfaces expose play, pause, toggle, and previous/next (station
+step); previous/next is enabled only when the active queue holds more than one
+station. Live streams disable seek / skip-by-time controls.
 
 ## Queue Rules
 
@@ -73,6 +93,10 @@ Platform notes:
 - Station-list playback uses the selected station list as the queue.
 - Recents playback uses the visible recents order.
 - If a station is launched outside a known list, it is a single-station queue.
+- Stations are de-duplicated by id (first occurrence wins, order preserved);
+  stepping is circular within the queue.
+- Removing the last station from the active queue clears the queue but keeps the
+  current station playing; stepping then becomes unavailable.
 - Previous/next media controls should not jump to unrelated catalog stations
   when the user is in a curated list or station list.
 
@@ -82,4 +106,60 @@ Platform notes:
   and metadata parsing.
 - Browser tests cover cold boot and visible controls.
 - Native real-device testing is required for background audio, lock-screen
-  controls, interruptions, Bluetooth, and wake-to-radio.
+  controls, interruptions, Bluetooth, CarPlay, and wake-to-radio.
+
+## Platform Matrix
+
+Status words per the [README](README.md) status legend.
+
+| Behavior | Web | iOS | Android |
+|---|---|---|---|
+| Start / pause / resume / stop | Supported. | Reference. | Supported. |
+| Source rebuild on new station | Supported. | Reference. | Supported. |
+| Automatic retry (≤3, backoff) | Supported. | Reference. | Supported. |
+| Geo-restriction = permanent (no retry) | Supported. | Reference. | Supported. |
+| Network-restore auto-reconnect | Supported. | Reference. | Supported. |
+| Lock-screen / system now-playing | Partial (browser-dependent). | Reference. | Supported. |
+| Headphone / Bluetooth transport | Partial (browser-dependent). | Reference. | Supported. |
+| Background playback | Partial. | Reference. | Supported. |
+| Active playback queue + circular stepping | Supported. | Reference. | Supported. |
+| In-app car mode | Not applicable. | Supported. | Not planned. |
+| Native vehicle integration | Not applicable. | Partial; CarPlay app implemented, entitlement-gated (issue #51). | Planned (Android Auto is an open decision). |
+| Watch companion remote | Not applicable. | Supported. | Not applicable. |
+| Wake-to-radio keep-alive | Not applicable. | Supported (iOS-only). | Not planned. |
+
+## Open questions
+
+- Listener-selectable stream quality (`best` / `data` / `low`) — no platform
+  ships a tier selector; see [playback-state-machine](contracts/playback-state-machine.md).
+- Android Auto support for the first Android port.
+- Whether to deactivate the audio session on a long pause vs. keeping it active
+  for instant resume — see Known deviations.
+
+## Reference
+
+- iOS player: `rrradio-ios/rrradio/Player/AudioPlayer.swift` — state machine,
+  retry scheduler, audio-session + remote-command wiring, now-playing info,
+  network-restore reconnect (`reconnectCurrentAfterConnectivityRestored`).
+- iOS queue model: `rrradio-ios/Shared/StationPlaybackQueue.swift`.
+- iOS connectivity: `rrradio-ios/rrradio/NetworkMonitor.swift`, with the
+  network-change handler in `rrradio-ios/rrradio/App.swift`.
+- iOS CarPlay: `rrradio-ios/rrradio/CarPlay/CarPlayController.swift`,
+  `rrradio-ios/rrradio/CarPlay/CarPlaySceneDelegate.swift` (entitlement-gated via
+  the `rrradio-CarPlay` dev scheme, issue #51); in-app car mode in
+  `rrradio-ios/rrradio/Player/CarModeController.swift`.
+- iOS watch remote: `rrradio-ios/Shared/WatchRemoteProtocol.swift`,
+  `rrradio-ios/rrradioWatch/WatchRemoteModel.swift`,
+  `rrradio-ios/rrradio/WatchRemote/PhoneRemoteControlController.swift`.
+- The exact states, transitions, retry numbers, queue fields, now-playing
+  fields, and remote-command mapping are in
+  [playback-state-machine](contracts/playback-state-machine.md).
+
+## Known deviations
+
+- Audio-session deactivation on close paths was historically incomplete; largely
+  remediated at the reconciled commit (pause still deliberately keeps the session
+  active for fast resume). See the Known deviations section of
+  [playback-state-machine](contracts/playback-state-machine.md) and
+  `rrradio-ios/internal/audit/2026-05-25-ios-code-review-slice5.md` (A2),
+  `…-slice24.md` (N6).


### PR DESCRIPTION
Full exhaustive re-read of the product spec against **iOS main `d241aa9`** (2026-06-12), one agent per doc. Follows #508 (which landed the watch reconciliation + the `/spec/` site generator on `main`).

## What changed
- **26 docs reconciled** against the real iOS source of truth. Stamps bumped `draft → review`; `watch-protocol` + `watch-remote` re-verified **approved** (already reconciled in #508).
- `COVERAGE.md` + the `README.md` parity matrix retargeted to `d241aa9`; **broken-reports** parity row added; moved iOS file paths corrected.
- Generator builds all 28 pages; 327 intra-spec links resolve. No code touched — docs only.

## Status ladder
24 docs are `review`, not `approved`, by design: the pass reconciled content and bumped `reconciled-against`, but **promotion to `approved` is the human gate**. Reviewing/merging this PR is that sign-off. Per STYLE, suspected **code bugs were flagged, not encoded** — the spec states intent.

## Notable drift captured
| Doc | What the reconcile added |
|---|---|
| broken-reports | The now-shipped iOS report sheet (categories, comment, receipts, foreground polling, resolved toast) on top of the server contract — was reconciled `—` |
| catalog-schema / browse | Low/Medium/High stream-quality buckets + the Browse quality filter |
| playback-state-machine | Lazy audio-session activation (dormant at init) + wake keep-alive tone; session released when nothing plays |
| localization | Russian as the 6th app language |
| listening-history / privacy / sync | Closed records now sync to the user's **private iCloud** (#58) |
| platforms | iOS **native CarPlay** surface (#51) replaces media-session-only |

## Decisions for review (the high-signal ones)
51 deviations + 82 open questions were surfaced. The ones that are genuine product calls:

1. **⚠️ Privacy-label release blocker** (`privacy-data-boundaries`): the Stats sheet fires 3 silent IP-bearing GETs on open while sibling Settings copy says "History stays on this device / nothing is sent automatically." Rows 2–6 + 15 of the privacy matrix are IP-bearing and rrradio-operated — the App Store / Play privacy label must declare them (or the calls be gated/removed) before any TestFlight/Play build ships.
2. **Listening-history copy vs. iCloud sync** (`listening-history`, `preferences-diagnostics`, `privacy-data-boundaries`, `sync-merge`, `data-sync`): closed records now sync to the user's own private iCloud (#58), but five surfaces still say "on your phone only." Data stays user-owned (never reaches rrradio), but the copy understates cross-device travel — needs a copy/intent decision.
3. **Backup restore conflict** (`sync-merge` ↔ `data-sync`): iOS **replaces** the library wholesale on restore; the contract tells web/Android to **union** on import. Pick one canonical cross-platform intent.
4. **Web parity overstatements** the pass flagged for the upcoming web phase: web has **no i18n module** in `src/` yet `localization` marks web "Supported"; Favorites changed to **add-at-tail** on iOS (sync-merge parity) while web still adds at top.
5. **Dead / unwired iOS surfaces**: `StationMapView` is fully built but has **no entry point**; `SleepTimer.cycle()` is unwired (and can't reach the 30/60 step after a non-default); watch `toggle` is never sent; list-detail rename is built but unwired.
6. **Newly-flagged latent bugs (no audit yet)**: SR (Saarländischer Rundfunk) fetcher reads `.values.first` from an unordered dict (non-deterministic now-playing); iOS doesn't chunk the report-status poll to the server's 50-id cap.

## Follow-ups (not in this PR)
- **iOS audit housekeeping**: several `internal/audit/*` entries are stale at `d241aa9` (slice3 W5/W6 fixed-but-Open, slice6 M3 lyrics-cache shipped, slice11 region host now `stats.rrradio.org`, queued rename-list premise false). These belong in rrradio-ios.
- **Mirror refresh**: run `rrradio-ios/scripts/sync-spec.sh` against iOS `main` after this merges (the iOS repo is mid-flight on a feature branch right now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)