### PR TITLE
spec: reconcile the Web parity column against web main (dfc848467)

### DIFF
--- a/docs/spec/COVERAGE.md
+++ b/docs/spec/COVERAGE.md
@@ -57,10 +57,32 @@ a doc. See `STYLE.md` for templates and the reconciliation ritual.
 | playback | review | d241aa9 | links `contracts/playback-state-machine.md` |
 | data-sync | review | d241aa9 | links `contracts/sync-merge.md` + `contracts/privacy-data-boundaries.md` |
 
+## Web reconciliation
+
+The **Web** column of every doc's Platform Matrix was verified against web `main`
+(`dfc848467`, 2026-06-13) — one agent per doc reading the actual `src/`
+implementation. 113 Web matrix cells were corrected; the web app is a focused
+subset of the finalized product intent. Web source of truth per area: catalog
+`src/builtins.ts` `src/stations.ts`; playback `src/player.ts`; metadata
+`src/fetchers.ts` `src/metadata.ts` `src/coverArt.ts` `src/lyrics.ts`; search
+`src/radioBrowser.ts` `src/main.ts`; storage/backup `src/storage.ts`
+`src/backup.ts`; privacy/telemetry `src/telemetry.ts` `src/errors.ts`
+`src/region.ts`; reports `src/reportBroken.ts`; render `src/render-*.ts`
+`src/np-*.ts`.
+
+Surfaces the web app does **not** implement (all now honest in the matrices):
+FTS search index (substring only), cross-platform playback queue (favorites-only
+skip), automatic retry budget/backoff, i18n (English-only, no key registry),
+personal listening history, named station lists, a Settings sheet, custom-station
+probe/dup-check/edit, offline/PWA support, and the broken-report receipt
+lifecycle (fire-and-forget POST only). The reconciliation did **not** edit the
+product-intent body, iOS/Android cells, or stamps — only Web cells + web notes.
+The Android column is unverified pending its own phase.
+
 ## Meta
 
 | Doc | Status | Notes |
 |---|---|---|
-| README | updated | spec map split (features + contracts tiers), maintenance ritual; parity matrix re-verified true-as-of iOS `d241aa9` (2026-06-12) + broken-reports row added |
+| README | updated | spec map split (features + contracts tiers), maintenance ritual; parity matrix iOS column @ `d241aa9` + **Web column @ web `dfc848467`** + broken-reports & localization rows |
 | STYLE | approved | authoring standard |
 | COVERAGE | living | this file |

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -103,39 +103,41 @@ Canonical implementation references remain in:
 
 ## Platform Parity Matrix
 
-The iOS column is verified against commit `d241aa9` (2026-06-12), following the
-exhaustive per-doc reconciliation recorded in [COVERAGE.md](COVERAGE.md). The web
-and Android columns are carried from the prior spec and the Android parity
-tracker and are re-verified by their own teams (web/Android finalization is the
-next phase).
+The iOS column is verified against iOS commit `d241aa9` (2026-06-12) and the
+**Web** column against web `main` (`dfc848467`, 2026-06-13), following the
+exhaustive per-doc reconciliation recorded in [COVERAGE.md](COVERAGE.md). Each
+doc's own Platform Matrix carries the cell-level detail; this table is the
+coarse summary. The Android column is still carried from the prior spec and the
+Android parity tracker (Android finalization is the next phase).
 
 | Area | Web | iOS | Android | Spec |
 |---|---|---|---|---|
-| Shared catalog | Supported | Supported | Supported | [Platforms](platforms.md), [Browse](features/browse.md) |
+| Shared catalog | Partial (per-station skip decode; drops several fields) | Supported | Supported | [Platforms](platforms.md), [Browse](features/browse.md) |
 | Stream playback | Supported | Reference | Supported | [Playback](playback.md) |
 | Background audio | Partial | Reference | Partial | [Playback](playback.md) |
 | Lock-screen/media controls | Supported where browser allows | Reference | Partial | [Playback](playback.md) |
-| Browse/search/filter | Supported | Reference | Supported | [Browse](features/browse.md) |
-| Search field | Supported | Reference | Supported | [Search](features/search.md) |
+| Browse/search/filter | Partial (no discovery landing, sort, or quality filter) | Reference | Supported | [Browse](features/browse.md) |
+| Search field | Partial (substring only; no FTS index) | Reference | Supported | [Search](features/search.md) |
 | Map browse | Supported | Supported | Planned | [Browse](features/browse.md) |
 | Favorites | Supported | Reference | Supported | [Favorites](features/favorites.md) |
-| Favorites display modes | Partial | Reference | Partial | [Favorites](features/favorites.md) |
+| Favorites display modes | Not planned for current web (list only) | Reference | Partial | [Favorites](features/favorites.md) |
 | Recents | Supported | Supported | Supported | [Favorites](features/favorites.md) |
 | Station lists | Not planned for current web | Reference | Partial | [Station lists](features/station-lists.md) |
-| Custom stations | Supported | Reference | Supported | [Custom stations](features/custom-stations.md) |
+| Custom stations | Partial (no probe, dup-check, edit, or auto-favorite) | Reference | Supported | [Custom stations](features/custom-stations.md) |
 | Metadata and cover art | Supported | Reference | Partial | [Metadata and artwork](features/metadata-artwork.md) |
 | Program schedules | Supported for wired broadcasters | Supported for wired broadcasters | Planned | [Now Playing](features/now-playing.md) |
 | Lyrics | Supported on web | Planned/partial on native | Planned | [Now Playing](features/now-playing.md) |
-| Sleep timer | Supported | Reference | Partial | [Sleep timer](features/sleep-timer.md) |
+| Sleep timer | Partial (15/30/60 cycle; no countdown or default) | Reference | Partial | [Sleep timer](features/sleep-timer.md) |
 | Wake to radio | Partial, browser-limited | Reference, iOS-limited | Planned, Android-limited | [Wake to radio](features/wake-to-radio.md) |
 | iCloud/CloudKit sync | Not planned | Supported | Not applicable | [Data and sync](data-sync.md) |
 | Manual file export/import | Supported for favorites and custom stations | Planned/optional | Supported for Android library backup | [Data and sync](data-sync.md) |
 | Cross-platform account sync | Not planned | Not planned | Not planned for first Android port | [Data and sync](data-sync.md) |
 | Listening history (personal, opt-in, local) | Planned | Reference | Planned | [Listening history](features/listening-history.md) |
 | Diagnostics | Privacy-preserving telemetry | Local opt-in diagnostics | Local opt-in diagnostics | [Preferences and diagnostics](features/preferences-diagnostics.md) |
-| Broken-station reports | Planned | Supported (sheet + receipts) | Planned | [Broken-station reports](contracts/broken-reports.md) |
+| Localization / languages | Not planned (English-only; no i18n) | Supported (6 languages) | Planned | [Localization](contracts/localization.md) |
+| Broken-station reports | Partial (fire-and-forget POST; no receipts/category/comment) | Supported (sheet + receipts) | Planned | [Broken-station reports](contracts/broken-reports.md) |
 | Siri / Shortcuts / Spotlight | Planned | Supported | Planned | [Siri & Shortcuts](features/siri-shortcuts.md) |
-| First-run / offline launch | Runtime/cache dependent | Reference | Partial | [First run & offline](features/first-run-offline.md) |
+| First-run / offline launch | Online-only (boot fetch; no offline/PWA) | Reference | Partial | [First run & offline](features/first-run-offline.md) |
 | Watch companion | Not applicable | Supported as iPhone remote | Not applicable | [Watch remote](features/watch-remote.md) |
 | Car mode / vehicle surfaces | Browser/OS dependent | Supported in app, CarPlay controls via media session | Partial media controls; Android Auto TBD | [Preferences and diagnostics](features/preferences-diagnostics.md) |
 

--- a/docs/spec/contracts/broken-reports.md
+++ b/docs/spec/contracts/broken-reports.md
@@ -271,9 +271,12 @@ Status poll `…/report-status?ids=7f0c2b9e-…,11111111-1111-4111-8111-11111111
   outcome — "fixed" / "removed" / "couldn't reproduce it"), mark it seen, then
   let the receipt self-prune.
 
-**Web** — same endpoint; receipts in `localStorage`. Currently sends the
-pre-#507 payload (no category sheet, no comment) and ignores `reportId`; that
-remains valid (degraded mode — report counted, no follow-up).
+**Web** — same endpoint. Currently sends the pre-#507 payload (no category
+sheet, no comment) from a single "Broken station" button in the now-playing
+details, and ignores the response body (`reportId` is never read); no receipt
+is stored, so there is no status line, polling, resolved toast, or email
+fallback. That remains valid (degraded mode — report counted, no follow-up).
+If web later adopts the receipt loop, receipts live in `localStorage`.
 
 **iOS** — ships the full flow per the *Client report flow* section: the
 now-playing report sheet (six-category single-select + optional/`other`-required

--- a/docs/spec/contracts/catalog-schema.md
+++ b/docs/spec/contracts/catalog-schema.md
@@ -303,15 +303,15 @@ restate them.
 | Obligation | Web | iOS | Android |
 |---|---|---|---|
 | Decode the envelope reading only `stations`; ignore `$schema` and unknown keys | Supported | Supported | Supported |
-| Enforce required (`id`, `name`, `streamUrl`) / optional field rules with the documented defaults | Supported | Supported | Cache-backed catalog load; field-rule parity is porting work |
+| Enforce required (`id`, `name`, `streamUrl`) / optional field rules with the documented defaults | Partial — required-field rejection only, per-station skip (not atomic), drops several optional fields | Supported | Cache-backed catalog load; field-rule parity is porting work |
 | Treat new optional fields as forward-compatible (never fail on unknown shape) | Supported | Supported | Supported |
-| Honor the `status` taxonomy (`working`/`icy-only`/`stream-only`) and its capability mapping | Supported | Supported | Partial |
+| Honor the `status` taxonomy (`working`/`icy-only`/`stream-only`) and its capability mapping | Partial — reads the three values for row capability badges; no `station-capabilities.json` strategy/poll-priority mapping | Supported | Partial |
 | Honor `availableIn` (dim/badge + geo-restricted error mapping) | Supported | Supported | Planned |
-| `featured`-first Browse ordering | Supported | Supported | Partial |
-| Quality meter from `codec`+`bitrate` with the documented 1–4 thresholds | Supported | Supported | Partial |
+| `featured`-first Browse ordering | Not planned — Browse home orders by play-count then catalog order; `featured` is not decoded | Supported | Partial |
+| Quality meter from `codec`+`bitrate` with the documented 1–4 thresholds | Not planned — renders `codec`+`bitrate` as a plain text label (e.g. "MP3 · 192 kbps"); no derived 1–4 meter or quality bucket | Supported | Partial |
 | Load-order ladder: cache → bundled snapshot → network refresh | Browser/runtime cache | Disk cache + bundled `stations.json.lzfse` + network | Cache-backed load; bundled snapshot is porting work |
 | Bundled full-text search index with divergence guard (rule in [search](search.md)) | Runtime | Bundled `stations.fts5.db` + divergence guard | Optional search index deferred |
-| Reserve `custom-` / `rb-` id prefixes against catalog collisions | Supported | Supported | Supported |
+| Reserve `custom-` / `rb-` id prefixes against catalog collisions | Partial — mints `custom-` for user stations; Radio Browser imports keep the bare `stationuuid` (no `rb-` prefix) | Supported | Supported |
 
 The bundled snapshot and FTS index are platform-local accelerations, not part
 of the wire contract — but every platform that ships them MUST keep them

--- a/docs/spec/contracts/localization.md
+++ b/docs/spec/contracts/localization.md
@@ -278,9 +278,14 @@ key name) is a visible defect, not a crash.
 
 **Web**
 
-- Honor the same registry and fallback; language is browser/content dependent
-  (see [Preferences and diagnostics](../features/preferences-diagnostics.md)).
-- `system` maps to the browser UI language; no cloud sync of the choice.
+- The web app ships no localization layer today: there is no key registry, no
+  language choice, and no plural engine. Every user-visible string is a
+  hardcoded English literal, so the registry/fallback/plural obligations above
+  are **not implemented** on web (see the matrix).
+- Language is effectively English-only. There is no `system`/language preference
+  and no cloud sync of a choice; the only locale-aware behavior is incidental
+  browser formatting (`Intl.DisplayNames` for country names, `toLocaleTimeString`
+  for schedule times), which follows the browser locale, not an in-app choice.
 
 **Android**
 
@@ -292,14 +297,14 @@ key name) is a visible defect, not a crash.
 
 | Behavior | Web | iOS | Android |
 |---|---|---|---|
-| Shared key registry | Supported | Reference | Planned |
-| Supported language set (en/de/fr/es/it/ru) | Supported | Reference | Planned |
-| Full-cardinality enforcement | Supported | Supported (test-gated) | Planned |
-| `en` fallback on missing key | Supported | Supported | Planned |
-| CLDR plural (`one`/`few`/`many`/`other`) | Supported | Supported | Planned |
-| `{placeholder}` substitution | Supported | Supported | Planned |
-| `system` follows OS language | Supported | Supported | Planned |
-| Time format follows device 24-Hour setting | Supported | Supported | Planned |
+| Shared key registry | Not planned | Reference | Planned |
+| Supported language set (en/de/fr/es/it/ru) | Not planned (English-only) | Reference | Planned |
+| Full-cardinality enforcement | Not planned | Supported (test-gated) | Planned |
+| `en` fallback on missing key | Not planned | Supported | Planned |
+| CLDR plural (`one`/`few`/`many`/`other`) | Not planned | Supported | Planned |
+| `{placeholder}` substitution | Not planned | Supported | Planned |
+| `system` follows OS language | Not planned | Supported | Planned |
+| Time format follows device 24-Hour setting | Partial (browser-locale, no in-app choice) | Supported | Planned |
 | Language choice cloud sync | Not planned | Supported | Not planned |
 
 ## Open questions

--- a/docs/spec/contracts/metadata-fetchers.md
+++ b/docs/spec/contracts/metadata-fetchers.md
@@ -161,10 +161,12 @@ Cover resolution is **ordered**; the first non-nil wins:
    (`term` = `artist` + space + `title`, truncated to 100 chars);
    best match's `artworkUrl100` upgraded to `600x600bb`. Requires title ≥ 3
    chars and not `-`/`—`. Result cached (64-entry LRU).
-4. **MusicBrainz / Cover Art Archive** — *not implemented on iOS* (web-only step
-   in the shared chain; see *Platform obligations*).
-5. **Spotify** — *not implemented on iOS as a cover source*; iOS only links out
-   to Spotify search (see music-service links below).
+4. **MusicBrainz / Cover Art Archive** — *not implemented on iOS, and not
+   implemented on web either* (a forward-looking enrichment step in the shared
+   chain that no shipped platform currently runs; see *Platform obligations* and
+   *Open questions*).
+5. **Spotify** — *not implemented as a cover source on any platform*; both web
+   and iOS only link out to Spotify search (see music-service links below).
 
 ### iTunes Search dual role
 
@@ -290,12 +292,12 @@ iTunes high-res upgrade:
 | Same routing order (ORF → FM4 rewrite → keyed → ICY) | MUST | MUST | MUST |
 | Same per-source field mapping & null-vs-error | MUST | MUST | Partial (Grrif + ORF/FM4 native; rest planned) |
 | Generic ICY `StreamTitle` via `icy-metaint` | MUST (where CORS/proxy allows) | MUST | Partial (basic parser exists) |
-| HLS ID3 timed-metadata scrape | SHOULD | MUST | Planned |
-| Cover chain: provider → favicon → iTunes (+ MusicBrainz/Spotify) | MUST (full chain incl. MusicBrainz) | provider → favicon → iTunes only | Partial (provider + iTunes) |
+| HLS ID3 timed-metadata scrape | Planned (not implemented) | MUST | Planned |
+| Cover chain: provider → favicon → iTunes (+ MusicBrainz/Spotify) | Partial (provider/iTunes → favicon; no MusicBrainz, no Spotify cover) | provider → favicon → iTunes only | Partial (provider + iTunes) |
 | Program schedule (ORF/FM4) | MUST | MUST | Partial (ORF current-program; full grids planned) |
 | Lyrics: LRCLIB → Lyrics.ovh | MUST | MUST | Planned |
 | Coarse-only failure diagnostics (no title/artist/URL) | MUST | MUST | MUST |
-| Honor `metadataStrategy: none` / `backgroundPollPriority: never` (no stream open) | MUST | Planned (fields not yet in catalog/iOS) | MUST |
+| Honor `metadataStrategy: none` / `backgroundPollPriority: never` (no stream open) | Planned (fields not yet in catalog/web) | Planned (fields not yet in catalog/iOS) | MUST |
 
 The capability hint layer (`metadataStrategy`, `backgroundPollPriority`,
 `hasProgram`/`hasSchedule`/`hasProviderCover`) defined in
@@ -310,8 +312,10 @@ cadence regardless of strategy/priority hints.
 ## Open questions
 
 - **MusicBrainz / Cover Art Archive step**: the shared cover chain names it, but
-  iOS does not implement it. Is it a required platform obligation or a web-only
-  enhancement? (Marked web-only above pending decision.)
+  no shipped platform implements it — not iOS and not web (web's cover chain is
+  provider/iTunes cover → station favicon, with no MusicBrainz lookup). Is it a
+  required platform obligation or a future enhancement? (Marked as implemented
+  nowhere above, pending decision.)
 - **Schedule capability source of truth**: routing still hardcodes ORF/FM4. The
   catalog `hasScheduleData` field exists (iOS prep landed) but the catalog has
   not yet populated it; once published, routing should consult it instead of the

--- a/docs/spec/contracts/playback-state-machine.md
+++ b/docs/spec/contracts/playback-state-machine.md
@@ -346,15 +346,34 @@ reactivate session, resume; state → playing
 
 ### Web
 
-- Expose the five states (or an equivalent enum) and the listed transitions.
-- Treat `HTMLAudioElement` as unreliable after failure: **rebuild the source**,
-  do not only re-call play (per [Playback](../playback.md) Recovery).
-- Apply the same retry budget (≤3) and avoid tight retry loops.
-- Use the Media Session API where supported to publish the now-playing fields and
-  to wire play/pause/previous/next; previous/next only when the queue is steppable.
-- Honor the queue model (browse/favorites/recents/stationList/single), circular
-  stepping, and the "no jump to unrelated stations" rule.
-- Geo-restricted streams: surface the friendly message, do not retry.
+- Exposes the five states (`idle`/`loading`/`playing`/`paused`/`error`) as a
+  flat enum. It honors the user-driven transitions (play/pause/toggle/stop) and
+  the play-rebuild rule, but does **not** implement the system-event transitions
+  (audio interruption, output-route lost, media-services reset) or the
+  network-restored auto-reconnect predicate — those are iOS/native concerns.
+- Treats `HTMLAudioElement` as unreliable after failure: **rebuilds the source**,
+  does not only re-call play (per [Playback](../playback.md) Recovery). Every
+  `play()` tears down and rebuilds; live streams are never resumed in place.
+- **Planned: the automatic retry budget/backoff is not yet implemented.** Web
+  recovery today is (a) a stall **watchdog** — if `currentTime` stops advancing
+  for ~8s it forces one fresh rebuild — and (b) surfacing the `<audio>` `error`
+  event as `error(message)`. There is no attempt counter, no `min(30, 2^…)`
+  backoff curve, and no healthy-reset timer. The ≤3-budget exponential-backoff
+  reconnect is deferred (see the `Phase 4` note in `src/player.ts`).
+- Uses the Media Session API where supported to wire play/pause/previous/next and
+  to publish a reduced now-playing surface — title, artist, album, artwork only.
+  It does **not** publish the live-stream flag, playback rate, or queue
+  index/count via Media Session.
+- **Divergence: no cross-platform queue model.** Web has no
+  `(source, sourceID, stations[])` queue, no browse/favorites/recents/
+  stationList/single sources, and no circular stepping over an active queue.
+  Previous/next are wired unconditionally (not gated on a steppable queue) and
+  cycle the user's **favorites list only**; when the current station is not in
+  favorites, skip jumps to the first/last favorite, and skip is a no-op when
+  there are no favorites. The "no jump to unrelated stations" rule is therefore
+  not honored — skip can land on any favorite.
+- Geo-restricted streams: surfaces the friendly region-locked message and does
+  not retry (consistent — there is no automatic retry to suppress).
 
 ### iOS (reference)
 

--- a/docs/spec/contracts/privacy-data-boundaries.md
+++ b/docs/spec/contracts/privacy-data-boundaries.md
@@ -274,10 +274,10 @@ Diagnostics export line (always redacted form):
 | Region/GeoIP resolution, fail-open, 24h cache | Supported | Reference | Planned |
 | Diagnostics opt-in, capped, redacted on export, cleared on disable | Planned | Reference | Planned |
 | MetricKit crash/hang reports (own-app frames, opt-in) | Not planned | Reference | Not planned |
-| Broken-station report (anonymous POST + receipt polling) | Supported | Reference | Planned |
+| Broken-station report (anonymous POST + receipt polling) | Partial (fire-and-forget POST only; no `category`/`comment`, no receipt polling) | Reference | Planned |
 | Library data local-first; never sent to analytics | Supported | Reference | Planned |
 | CloudKit sync to user's own private DB | Not planned | Reference | Not planned (Apple-only) |
-| mailto destinations → first-party inbox only | Supported | Reference | Planned |
+| mailto destinations → first-party inbox only | Not planned (web has only a feedback `mailto:` → personal Gmail, not a first-party inbox; no catalog/broken-report mailto) | Reference | Planned |
 
 ## Open questions
 

--- a/docs/spec/contracts/search.md
+++ b/docs/spec/contracts/search.md
@@ -343,17 +343,17 @@ prefix, country/codec uppercasing, `schemaVersion` ride-along — owned by
 | Obligation | Web | iOS | Android |
 |---|---|---|---|
 | Normalizer (A) char set: lowercase + letters + digits + `ä ö ü ß`, drop the rest | Reference (`src/format.ts`) | Match | Match |
-| Tier order: local FTS/substring → FTS-miss net → custom+RB local → RB community | Must match result order | Reference | Must match |
-| Dedupe whole pipeline by station `id`, first-occurrence wins | Required | Required | Required |
+| Tier order: local FTS/substring → FTS-miss net → custom+RB local → RB community | Partial — no FTS; substring scan over built-ins + custom ("My stations"), then RB community appended | Reference | Must match |
+| Dedupe whole pipeline by station `id`, first-occurrence wins | Partial — dedupes RB pages by normalized stream URL + hides curated-collision rows; no whole-pipeline `id` dedupe | Required | Required |
 | Query-active suppresses alphabet/quality/favorite sort (relevance order kept) | Required | Reference | Required |
-| Country-filter + ≤2-char-query → skip RB network call | Required | Reference | Required |
+| Country-filter + ≤2-char-query → skip RB network call | Planned — gate not implemented; a ≤2-char query with a country filter still fires the RB call | Reference | Required |
 | RB request params (`order=votes`, `reverse=true`, `hidebroken=true`, loose-split `name`) | Required | Reference | Required |
 | RB HTTPS-only; coerce `http_resolved`/`url` scheme for the dedupe key | Required | Reference | Required |
 | RB dedupe by normalized stream URL; winner = `logo*1000+tags*100+clickcount` | Required | Reference | Required |
 | Map RB row → `Station` per the field table (`rb-` id, MP3 uppercased, `≤0 → nil`) | Required | Reference | Required |
-| Bundled/full-text index | Supported | Reference (`stations.fts5.db`) | Optional — may use in-memory substring if FTS too slow on device (browse.md) |
-| Graceful fallback when index missing/diverged | Required | Reference | Required |
-| FTS column weights name>tags>country>surface and name-tier→bm25→id ranking | If FTS used | Reference | If FTS used |
+| Bundled/full-text index | Not planned — web has no bundled index; local match is an in-memory substring scan over built-ins + custom | Reference (`stations.fts5.db`) | Optional — may use in-memory substring if FTS too slow on device (browse.md) |
+| Graceful fallback when index missing/diverged | Not applicable — no index to fall back from | Reference | Required |
+| FTS column weights name>tags>country>surface and name-tier→bm25→id ranking | Not applicable — FTS never used | Reference | If FTS used |
 
 ## Open questions
 

--- a/docs/spec/contracts/sync-merge.md
+++ b/docs/spec/contracts/sync-merge.md
@@ -360,11 +360,11 @@ and CKError codes only.
 | # | Web | iOS | Android |
 |---|---|---|---|
 | 1 | Local-only; no CloudKit, no account, no automatic cross-device sync. | Implements the full CloudKit sync above. | Local-only; no CloudKit, no account. |
-| 2 | When importing a backup file, merge with the **same algebra**: favorites/custom/list union by id with the imported copy winning on collision; preferences applied as a block. | Honor the cloud merge algebra exactly so two iOS devices converge. (Note: iOS **backup-file restore replaces** rather than unions — see Open questions.) | Same backup-import merge algebra as web. |
+| 2 | Backup covers **favorites + custom stations only** (no station lists, no preferences, no listening history). Import is a **union by id** — but the algebra **diverges from this contract**: the **existing local copy wins on id collision** (incoming is skipped, counted as "already had", never overwriting) and incoming entries are **appended after** existing ones (current order preserved). Decode-shape failures drop only the malformed *imported* entry, never a local one. | Honor the cloud merge algebra exactly so two iOS devices converge. (Note: iOS **backup-file restore replaces** rather than unions — see Open questions.) | Same backup-import merge algebra as web. |
 | 3 | Never require cloud to function. | Degrade to local-only when iCloud is unavailable; no feature blocks on it. | Never require cloud to function. |
 | 4 | Treat recents, diagnostics, and active wake intent as non-syncable; **backup/export files must exclude listening-history records** per [data-sync.md](../data-sync.md). | Recents / diagnostics / active wake intent absent from snapshot (structural). Listening-history **records** sync to iCloud (one shared blob) but are **excluded from the exported backup file**. | Same exclusions; no record-level history sync (local-only). |
 | 5 | Decode failure on import must not wipe surviving local entries — keep local on un-decodable id. | Keep local copy for unresolved ids; never let a single bad blob wipe or stall. | Decode failure on import must not wipe surviving local entries. |
-| 6 | Provide a user-initiated "remove all" only over local/backup data. | Provide "remove all iCloud data" via the `resetAt` tombstone; other devices honor it. | Provide "remove all" over local data. |
+| 6 | No user-initiated "remove all" data command exists today (favorites/custom are removed per-item only; clearing site data is the browser's own control) — Planned. Any future "remove all" would act over local/backup data only. | Provide "remove all iCloud data" via the `resetAt` tombstone; other devices honor it. | Provide "remove all" over local data. |
 
 ## Open questions
 

--- a/docs/spec/features/browse.md
+++ b/docs/spec/features/browse.md
@@ -369,31 +369,31 @@ map's "<n> stations" are pluralizable.
 |---|---|---|---|
 | Curated catalog | Supported. | Supported. | Supported. |
 | Large Radio Browser-backed catalog | Supported. | Supported with bundled index/cache behavior. | Supported with cache-backed loading. |
-| Discovery landing (genre/country chips + Featured rail + Browse all) | Supported. | Supported. | Planned. |
+| Discovery landing (genre/country chips + Featured rail + Browse all) | Not planned for current web. Web has no discovery landing — Browse shows the catalog directly under a filter row (genre/country dropdowns, played/news/curated toggles); the `featured` flag feeds a separate editorial rail, not a Browse discovery surface. | Supported. | Planned. |
 | Search normalization | Supported. | Reference native behavior. | Supported. |
 | Country filter | Supported. | Supported with native picker rows. | Supported. |
 | Genre/tag filter | Supported. | Supported. | Supported. |
 | News filter toggle | Supported. | Supported. | Supported. |
-| Stream-quality (Low/Medium/High) filter | Supported. | Supported (multi-select buckets). | Planned. |
-| Filter apply gated on live match count | Supported. | Supported. | Planned. |
-| Searchable country picker with selected-pinned-to-top | Supported. | Supported. | Supported. |
-| Back-to-discovery chevron + swipe | Supported. | Supported. | Planned. |
+| Stream-quality (Low/Medium/High) filter | Not planned for current web. No quality-bucket filter exists; web filters are genre, country, and the news/curated toggles. | Supported (multi-select buckets). | Planned. |
+| Filter apply gated on live match count | Not planned for current web. Web filters apply instantly via dropdowns/toggles — there is no filter popup or apply-with-count gate. | Supported. | Planned. |
+| Searchable country picker with selected-pinned-to-top | Partial. Country selection is a plain native `<select>` populated from the catalog's codes (alphabetical); no in-picker search and no selected-pinned-to-top. | Supported. | Supported. |
+| Back-to-discovery chevron + swipe | Not planned for current web. No discovery surface to return to; clearing the search/filter controls reverts to the catalog list. | Supported. | Planned. |
 | Map browse | Supported with web map asset. | Surface built (MapKit) but no Browse entry point wired at d241aa9. | Planned with native map, provider TBD. |
 | Add several stations to a station list | Not planned for current web. | Supported from Browse. | Supported. |
 | Add several stations to Favorites | Not planned for current web. | Supported (Favorites "+" target). | Planned. |
 | Multi-select selection bar (name + count + save) | Not planned for current web. | Supported (top, under the search field). | Supported. |
-| Sort controls | Supported. | Reference native behavior. | Supported for name, quality, and favorite-state sorting. |
-| Alphabet sort cycle (off/A–Z/Z–A) in the sort row | Supported. | Reference native behavior. | Supported. |
-| Quality / favorite-state sort | Supported. | In the sort model; not exposed by the Browse sort row's single control. | Supported. |
-| Stream-quality meter on Browse rows | Supported. | Hidden in Browse (reachable from the info preview). | Per platform. |
-| Featured-first catalog ordering | Supported. | Supported. | Partial. |
+| Sort controls | Not planned for current web. Browse has no sort row; the catalog renders most-played-first then catalog order, with no user-facing sort control. | Reference native behavior. | Supported for name, quality, and favorite-state sorting. |
+| Alphabet sort cycle (off/A–Z/Z–A) in the sort row | Not planned for current web. No sort row exists. | Reference native behavior. | Supported. |
+| Quality / favorite-state sort | Not planned for current web. | In the sort model; not exposed by the Browse sort row's single control. | Supported. |
+| Stream-quality meter on Browse rows | Not shown on web rows. Rows carry capability stars (stream/track/program) and a bitrate tooltip, not a Low/Medium/High meter. | Hidden in Browse (reachable from the info preview). | Per platform. |
+| Featured-first catalog ordering | Not applied on Browse for web. The home list orders most-played-first then catalog order; `featured` drives only the separate editorial highlights rail, not Browse row order. | Supported. | Partial. |
 | Result-count label | Supported. | Supported. | Supported. |
 | Visible-window paging (load more) | Supported. | Supported (25-row pages). | Supported. |
 | Community results appended to active search | Supported. | Supported (50-row pages). | Supported. |
-| Sort suppressed while a query is active | Required. | Reference. | Required. |
+| Sort suppressed while a query is active | Not applicable. Web exposes no sort control, so there is nothing to suppress. | Reference. | Required. |
 | Station info preview | Basic row details. | Supported from station rows (press-and-hold). | Supported with long-press row preview. |
 | Geo-restriction dim/badge on rows | Supported. | Supported. | Planned. |
-| Wide-layout multi-column grid | Responsive. | Supported (iPad + iPhone landscape). | Planned. |
+| Wide-layout multi-column grid | Not planned for current web. The layout caps to a single-column ~480px phone-width frame on wider screens; rows never lay out as a multi-column grid. | Supported (iPad + iPhone landscape). | Planned. |
 
 ## Open questions
 

--- a/docs/spec/features/custom-stations.md
+++ b/docs/spec/features/custom-stations.md
@@ -268,19 +268,35 @@ Owned strings on this surface (English reference values):
 |---|---|---|---|
 | Add custom stream | Supported. | Reference. | Supported. |
 | HTTPS-only enforcement | Supported. | Reference. | Supported. |
-| Probe before save | Partial. | Reference. | Supported. |
-| Private/local-network (DNS-rebind/SSRF) guard | Supported where implemented. | Reference. | Supported. |
-| Catalog-duplicate detection | Supported where implemented. | Reference. | Supported. |
-| Library-duplicate detection ("already added") | Supported where implemented. | Reference. | Supported. |
-| Test-stream playback before save | Browser-dependent. | Supported. | Supported. |
-| Auto-favorite on save | Product-preferred behavior. | Supported. | Supported. |
-| Edit existing custom station | Supported. | Supported. | Supported. |
-| Destructive delete confirmation | Supported. | Reference. | Supported. |
+| Probe before save | Not planned. | Reference. | Supported. |
+| Private/local-network (DNS-rebind/SSRF) guard | Not planned. | Reference. | Supported. |
+| Catalog-duplicate detection | Not planned. | Reference. | Supported. |
+| Library-duplicate detection ("already added") | Not planned. | Reference. | Supported. |
+| Test-stream playback before save | Not planned. | Supported. | Supported. |
+| Auto-favorite on save | Not planned. | Supported. | Supported. |
+| Edit existing custom station | Not planned. | Supported. | Supported. |
+| Destructive delete confirmation | Not planned. | Reference. | Supported. |
 | `custom-` id prefix reservation | Supported. | Supported. | Supported. |
-| Submit to catalog (email) | Supported. | Supported via Mail composer. | Supported via mail intent. |
+| Submit to catalog (email) | Not planned. | Supported via Mail composer. | Supported via mail intent. |
 | Local persistence | `localStorage`. | UserDefaults. | DataStore. |
 | Manual file export/import | Supported. | Planned/optional. | Supported through Android library backup. |
 | Cloud/account sync | Not planned. | Optional CloudKit sync. | Not planned for first port. |
+
+**Web platform note.** The web Add Station surface is a minimal name + URL +
+optional homepage/country/tags form (`src/main.ts` `handleAddSubmit`, the
+`#add-form` markup) with no async stream check. It validates synchronously
+(name required, URL must parse as http/https, `http://` rejected for
+mixed-content, homepage/country format) and saves immediately — there is **no**
+reachability/audio-like probe, no SSRF/DNS-rebind guard, no catalog- or
+library-duplicate detection, no test-before-save, no edit flow, no
+"Send to catalog" email, and **no confirmation on delete** (the trash button
+removes the row immediately). Saving does **not** auto-favorite; it stores the
+station in `localStorage` (`rrradio.custom.v1`, inserted at the **top** of the
+list), pushes a recent, and starts playback. The web station object is not
+minted with a `stream-only` status. Custom stations are covered by the web
+favorites/custom backup export/import (`src/backup.ts`). These behaviors are
+the reconciled product intent for native; the web app does not implement them
+today.
 
 ## Android First-Port Requirement
 

--- a/docs/spec/features/favorites.md
+++ b/docs/spec/features/favorites.md
@@ -215,25 +215,28 @@ stream-quality message. See [localization](../contracts/localization.md).
 
 | Behavior | Web | iOS | Android |
 |---|---|---|---|
-| Add/remove favorites | Supported. | Supported. | Supported. |
+| Add/remove favorites | Supported; adds at top (see web note). | Supported. | Supported. |
 | Reorder favorites | Supported. | Reference native behavior. | Partial; basic controls exist, native drag/reorder remains. |
 | Favorites list view | Supported. | Supported. | Supported. |
-| Favorites tile/app views | Partial/current web behavior may differ. | Reference. | Supported; visible/order settings still need parity. |
-| Display-mode order/visibility preferences | Partial. | Reference (Settings → Favorites display). | Partial; order/visibility parity remains. |
-| Drag-to-reorder + delete mode (jiggle/badges) | Supported. | Reference. | Partial. |
-| Custom station forced-favorite + delete-on-unfavorite | Supported. | Reference. | Supported. |
-| Favorites as playback queue (circular skip) | Supported. | Reference. | Partial. |
-| Per-row now-playing metadata (list/tiles) | Supported. | Reference. | Partial. |
-| Recents | Supported, capped. | Supported, capped (12). | Supported, capped. |
-| Recents auto-fill on play (catalog-only) | Supported. | Supported. | Supported. |
+| Favorites tile/app views | Not planned for current web (list mode only). | Reference. | Supported; visible/order settings still need parity. |
+| Display-mode order/visibility preferences | Not planned for current web (no display modes). | Reference (Settings → Favorites display). | Partial; order/visibility parity remains. |
+| Drag-to-reorder + delete mode (jiggle/badges) | Partial; drag-to-reorder only — no delete mode, jiggle, minus badges, or undo toast (removal is the row heart). | Reference. | Partial. |
+| Custom station forced-favorite + delete-on-unfavorite | Not planned for current web; custom stations are an independent list, not auto-favorited, and un-favoriting never deletes a custom station. | Reference. | Supported. |
+| Favorites as playback queue (circular skip) | Supported (media-session prev/next steps the favorites list circularly). | Reference. | Partial. |
+| Per-row now-playing metadata (list/tiles) | Not planned for current web; now-playing metadata shows only for the active station (mini-player / Now Playing), not per favorite row. | Reference. | Partial. |
+| Recents | Supported, capped (12). | Supported, capped (12). | Supported, capped. |
+| Recents auto-fill on play (catalog-only) | Partial; records a recent on every play but does **not** exclude custom stations. | Supported. | Supported. |
 | iCloud sync | Not planned. | Supported for favorites and order. | Not applicable. |
 | Manual file export/import | Supported. | Planned/optional. | Supported through Android library backup. |
 | Cross-platform sync | Not planned. | Not planned outside CloudKit. | Not planned for first port. |
 
 ## Persistence
 
-- Web persists favorites and recents in browser storage; favorites can be
-  exported/imported through the manual backup file.
+- Web persists favorites and recents in browser `localStorage`; favorites can be
+  exported/imported through the manual backup file. Web diverges from the iOS
+  add-at-tail intent: a newly favorited station is prepended (added at the **top**)
+  of the favorites list. Web recents cap at **12** and dedupe purely by station id
+  (no time window) — pushing an already-present station moves it back to the top.
 - iOS persists favorites, recents, custom stations, and station lists locally
   (per-store keys) and syncs favorites + favorites-order + custom + lists through
   CloudKit; recents stay local-only.
@@ -248,12 +251,15 @@ stream-quality message. See [localization](../contracts/localization.md).
 
 ## Open questions
 
-- Recents cap and dedupe diverge by platform: iOS caps at 12 and dedupes purely by id
-  (no time window). The shared product intent (a larger cap, e.g. 30, and/or a 60 s
-  same-station dedupe window) is not yet reconciled into a single number across web /
-  iOS / Android.
-- Web's tile/app display modes and order/visibility settings have no agreed parity
-  target with the iOS Reference behavior.
+- Recents cap and dedupe diverge by platform: both iOS and web cap at 12 and dedupe
+  purely by id (no time window). The shared product intent (a larger cap, e.g. 30,
+  and/or a 60 s same-station dedupe window) is not yet reconciled into a single number
+  across web / iOS / Android.
+- Web ships only the list display mode and has no agreed parity target for the iOS
+  Reference tile/app modes, the display-mode order/visibility settings, the
+  delete-mode (jiggle/badge/undo) editing affordance, or the custom-station
+  forced-favorite linkage. Web favorites also add at the top rather than the iOS tail;
+  whether that becomes the shared intent is unreconciled.
 
 ## Reference
 

--- a/docs/spec/features/first-run-offline.md
+++ b/docs/spec/features/first-run-offline.md
@@ -212,18 +212,18 @@ fr, it, ru):
 
 | Behavior | Web | iOS | Android |
 |---|---|---|---|
-| Cold launch shows real stations without waiting on network | Runtime/cache dependent | Reference (disk cache → bundled snapshot → network) | Cache-backed load; bundled snapshot is porting work |
-| Bundled catalog snapshot for first-run / cold cache | Not applicable (server-rendered/runtime cache) | Supported (`stations.json.lzfse`, 24,320 stations) | Planned (bundled snapshot porting work) |
-| Persisted disk cache of last network payload | Browser/runtime cache | Supported (Caches dir) | Partial (cache-backed load) |
-| Always-attempt network refresh after first paint, upgrade in place | Supported | Reference | Partial |
-| Branded launch splash with hand-off grace | Not applicable | Supported | Platform-specific |
-| Browse cached catalog offline | Supported where cached | Supported | Partial |
-| Local search offline (bundled full-text index) | Runtime index | Reference (`stations.fts5.db` + divergence guard) | Optional index deferred → substring fallback |
+| Cold launch shows real stations without waiting on network | Partial (fetches `stations.json` at boot; only a 3-station seed fallback when offline) | Reference (disk cache → bundled snapshot → network) | Cache-backed load; bundled snapshot is porting work |
+| Bundled catalog snapshot for first-run / cold cache | Not planned (catalog fetched as a static `stations.json`, not embedded) | Supported (`stations.json.lzfse`, 24,320 stations) | Planned (bundled snapshot porting work) |
+| Persisted disk cache of last network payload | Not planned (`stations.json` fetched `no-store`; no payload cache) | Supported (Caches dir) | Partial (cache-backed load) |
+| Always-attempt network refresh after first paint, upgrade in place | Not applicable (single boot fetch; no cache-then-refresh ladder) | Reference | Partial |
+| Branded launch splash with hand-off grace | Not planned (no launch splash; a "Tuning in…" line only covers a Browse fetch) | Supported | Platform-specific |
+| Browse cached catalog offline | Not planned (catalog and Browse feed come from the network) | Supported | Partial |
+| Local search offline (bundled full-text index) | Not planned (search queries Radio Browser online; no offline index) | Reference (`stations.fts5.db` + divergence guard) | Optional index deferred → substring fallback |
 | Community (Radio Browser) search requires network | Supported | Supported | Supported |
-| Play already-buffered/cached station offline | Browser-limited | Supported (no new stream without network) | Partial |
-| Auto-resume current stream on connectivity restore | Browser-limited | Supported | Planned |
-| Inline offline phrase in player chrome (no blocking modal) | Supported where browser allows | Reference | Partial |
-| Refresh-failure surfaced out-of-band (cached catalog stays) | Supported | Supported | Planned |
+| Play already-buffered/cached station offline | Not planned (no offline-playback handling) | Supported (no new stream without network) | Partial |
+| Auto-resume current stream on connectivity restore | Not planned (no connectivity listeners; no resume-on-restore) | Supported | Planned |
+| Inline offline phrase in player chrome (no blocking modal) | Not planned (no connectivity detection or offline phrase) | Reference | Partial |
+| Refresh-failure surfaced out-of-band (cached catalog stays) | Not planned (no catalog refresh-error channel) | Supported | Planned |
 
 ## Open questions
 

--- a/docs/spec/features/listening-history.md
+++ b/docs/spec/features/listening-history.md
@@ -325,7 +325,7 @@ Parameter/plural needs:
 | Station merge by name+country / stream URL | Planned | Supported | Planned |
 | Race chart (animated, 366-day cap) | Planned | Supported | Planned |
 | Minutes-by-day bars (weekly grouping, peak, tap-select) | Planned | Supported | Planned |
-| CSV export (mail / share) | Supported (export per [data-sync.md](../data-sync.md)) | Supported | Planned |
+| CSV export (mail / share) | Planned (web has no listening history; its JSON backup export of favorites + custom stations per [data-sync.md](../data-sync.md) is a different feature) | Supported | Planned |
 | Closed records synced to user's own iCloud (bounded, union-merge) | n/a | Supported | n/a |
 | Open sessions never synced; records excluded from backup-export | n/a | Supported | n/a |
 | History preferences synced (3 fields) | Not planned | Supported | Not planned |

--- a/docs/spec/features/metadata-artwork.md
+++ b/docs/spec/features/metadata-artwork.md
@@ -268,7 +268,7 @@ deviations* M12). These are localization gaps, not intended behavior.
 | Lyrics lookup | Supported. | Planned/partial native parity. | Planned. |
 | Music-service links (verified-gated) | Supported. | Supported (Apple Music deep link, Spotify/YT Music search). | Planned. |
 | Lock-screen / media-surface cover (downscaled) | Supported where browser allows. | Supported (≤512 px / ≤5 MB cap; sleep-timer moon badge). | Partial. |
-| Last-good retention on poll miss/fail | Supported. | Supported. | Partial. |
+| Last-good retention on poll miss/fail | Partial; a fetch error stops the poller without clobbering the displayed track, but a `null` "no-metadata" poll clears the track title. | Supported. | Partial. |
 
 ## Privacy Rules
 
@@ -285,8 +285,10 @@ before marking the station as fully parity-supported on native platforms.
 
 ## Open questions
 
-- **MusicBrainz / Cover Art Archive step** in the shared cover chain is web-only;
-  iOS does not implement it. Required obligation or web enhancement? (Tracked in
+- **MusicBrainz / Cover Art Archive step** in the shared cover chain is not
+  implemented on any platform today — the shipped web cover chain is iTunes-only
+  (`src/coverArt.ts`), and iOS does not implement it either. Required obligation or
+  a future enhancement? (Tracked in
   [metadata-fetchers](../contracts/metadata-fetchers.md#open-questions).)
 - **Schedule capability source of truth:** schedule is still ORF/FM4-hardcoded;
   the `hasScheduleData` catalog field is the forward path once populated.

--- a/docs/spec/features/now-playing.md
+++ b/docs/spec/features/now-playing.md
@@ -317,16 +317,16 @@ wake entry (sleep/wake also reachable while armed even with no current station).
 | Mini-player handoff | Supported. | Supported. | Supported. |
 | Mini-player swipe-to-close | Platform-specific (no equivalent gesture). | Supported. | Planned. |
 | Track metadata | Supported. | Reference. | Partial; basic ICY metadata exists. |
-| Cover art fallback | Supported. | Reference. | Partial; station artwork fallback exists, track cover art is deferred. |
-| Previous/next station controls | Supported. | Reference. | Supported for active playback queues. |
+| Cover art fallback | Partial; no-cover falls back to station favicon then initials, not the animated dot-matrix `rrr`. | Reference. | Partial; station artwork fallback exists, track cover art is deferred. |
+| Previous/next station controls | Partial; no in-view prev/next buttons. Mini-player skip + lock-screen/Bluetooth controls cycle the favorites list (no station-list queue). | Reference. | Supported for active playback queues. |
 | Program schedule | Supported for wired broadcasters. | Supported for wired broadcasters. | Planned. |
 | Lyrics | Supported where lookup matches. | Planned/partial native parity. | Planned. |
 | Music-service search links | Supported. | Planned/partial native parity. | Planned. |
 | Music-service verification gate | Supported. | Supported. | Planned. |
 | Sleep-timer / wake-alarm entry | Supported (browser-limited wake). | Reference. | Partial. |
-| Landscape / split layout | Supported via responsive layout. | Supported (iPad split + iPhone landscape). | Planned. |
+| Landscape / split layout | Planned; single-column responsive panel only, no multi-column split. | Supported (iPad split + iPhone landscape). | Planned. |
 | Car mode | Not a dedicated web feature. | Supported. | Android Auto/TBD; media notification first. |
-| Report broken station | Supported. | Supported. | Planned. |
+| Report broken station | Partial; one-tap report POST from the details panel, no category picker / comment / receipt lifecycle. | Supported. | Planned. |
 
 ## Native Port Notes
 

--- a/docs/spec/features/preferences-diagnostics.md
+++ b/docs/spec/features/preferences-diagnostics.md
@@ -296,35 +296,35 @@ English (deviation ST4–ST6). Full rules and the registry in
 
 | Preference | Web | iOS | Android |
 |---|---|---|---|
-| Theme | Supported. | Reference. | Supported for system/light/dark in a native Preferences sheet. |
-| Accent color | Supported/partial by web theme design. | Supported. | Partial; native preset accent palette exists, custom color entry remains deferred. |
-| Language | Browser/content dependent. | Supported. | Planned after localization scope. |
-| Landing page | Not a primary web contract. | Supported. | Supported for Lists, Browse, and Favorites startup targets. |
+| Theme | Partial; a light/dark toggle (persisted, OS preference as the unset default), no three-way System/Light/Dark control. | Reference. | Supported for system/light/dark in a native Preferences sheet. |
+| Accent color | Not planned; the web palette accent is a fixed design-system value, not a user preference. | Supported. | Partial; native preset accent palette exists, custom color entry remains deferred. |
+| Language | Not planned; the web UI ships English-only with no language switcher. | Supported. | Planned after localization scope. |
+| Landing page | Not planned; the web app has no landing-target preference. | Supported. | Supported for Lists, Browse, and Favorites startup targets. |
 | Favorites display modes | Partial. | Reference. | Partial; modes exist, preference persistence/order controls remain. |
-| Sleep default | Supported where exposed. | Supported. | Supported for the first sleep-timer tap. |
-| Wake default/notifications | Supported where exposed. | Supported. | Planned with wake feature. |
-| Music-service deep-link toggles | Partial; web shows service links per design. | Supported (per-service offered/hidden). | Partial; deep-link set TBD. |
+| Sleep default | Not planned; the web sleep timer cycles fixed durations with no default preference. | Supported. | Supported for the first sleep-timer tap. |
+| Wake default/notifications | Partial; web remembers the last-used wake time but exposes no default-time or notification preference. | Supported. | Planned with wake feature. |
+| Music-service deep-link toggles | Partial; web always shows Spotify/Apple Music/YouTube Music search links on verified tracks, with no per-service toggle. | Supported (per-service offered/hidden). | Partial; deep-link set TBD. |
 | AI station blurbs | Not planned. | Supported on iOS 26+. | Not planned for first port. |
-| Catalog manual refresh | Supported (reload). | Supported. | Supported. |
+| Catalog manual refresh | Not planned; the web catalog loads from `stations.json` on launch with no manual-refresh control. | Supported. | Supported. |
 
 ### Listening History
 
 | Behavior | Web | iOS | Android |
 |---|---|---|---|
-| Station history | Not part of current web contract beyond recents. | Supported as opt-in listening history. | Supported as local opt-in history. |
+| Station history | Not planned; web keeps only a recents list, not an opt-in listening-history surface. | Supported as opt-in listening history. | Supported as local opt-in history. |
 | Track-level history | Not planned for current web. | Supported only when user selects it. | Gated behind explicit opt-in; metadata-recording expansion remains future polish. |
-| Retention controls | Supported where exposed. | Supported (30d/90d/1y/Forever; default 90d). | Partial; bounded default, controls TBD. |
+| Retention controls | Not planned; web has no listening-history store to retain or prune. | Supported (30d/90d/1y/Forever; default 90d). | Partial; bounded default, controls TBD. |
 | Sync | Not planned. | Supported (closed sessions union across devices via iCloud). | Not planned. |
 
 ### Diagnostics
 
 | Behavior | Web | iOS | Android |
 |---|---|---|---|
-| Anonymous aggregate telemetry | Supported through GoatCounter. | Not the native support surface. | Not planned for first port. |
-| Local diagnostics | Not primary web contract. | Supported, opt-in, capped, exportable, with full-log viewer. | Supported, opt-in, capped, exportable. |
+| Anonymous aggregate telemetry | Supported through GoatCounter (events + privacy-preserving `error: <category>` reports). | Not the native support surface. | Not planned for first port. |
+| Local diagnostics | Not planned; web has no on-device opt-in diagnostics store or viewer. | Supported, opt-in, capped, exportable, with full-log viewer. | Supported, opt-in, capped, exportable. |
 | MetricKit crash/hang reports | Not applicable. | Supported (capped, call stack exported verbatim). | Not planned for first port. |
-| Redacted export / clear-on-disable | Supported where exposed. | Supported (preview also redacted). | Supported. |
-| Broken-station report | Supported. | Supported where implemented. | Supported through the shared anonymous report endpoint. |
+| Redacted export / clear-on-disable | Not applicable; web has no local diagnostics store to export or clear (telemetry is fire-and-forget). | Supported (preview also redacted). | Supported. |
+| Broken-station report | Supported (manual report POSTed to the shared anonymous endpoint). | Supported where implemented. | Supported through the shared anonymous report endpoint. |
 
 ### Cloud sync & car mode
 
@@ -332,8 +332,8 @@ English (deviation ST4–ST6). Full rules and the registry in
 |---|---|---|---|
 | iCloud/CloudKit library+preferences sync | Not planned. | Supported (own private DB). | Not applicable. |
 | Sync status / Sync now / Remove all | Not applicable. | Supported. | Not applicable. |
-| Local settings backup file (export/import) | Not planned. | Supported (JSON; works with sync off; excludes history). | Not planned. |
-| Car mode preferences | Browser/OS dependent. | Supported (tri-state: auto route detect / always / off). | Partial media controls; Android Auto TBD. |
+| Local settings backup file (export/import) | Partial; web exports/imports a JSON backup of favorites and custom stations only (no preferences, no history; import merges, never wipes). | Supported (JSON; works with sync off; excludes history). | Not planned. |
+| Car mode preferences | Not planned; web has no car-mode preference (CarPlay/Bluetooth control is media-session passthrough, not a setting). | Supported (tri-state: auto route detect / always / off). | Partial media controls; Android Auto TBD. |
 
 ## Open questions
 

--- a/docs/spec/features/search.md
+++ b/docs/spec/features/search.md
@@ -197,20 +197,20 @@ This surface owns four strings:
 | Behavior | Web | iOS | Android |
 |---|---|---|---|
 | Free-text search field in Browse | Supported | Reference | Supported |
-| Debounced incremental results | Supported | Reference (180 ms) | Supported |
-| Submit commits immediately (bypass debounce) | Supported | Reference | Supported |
+| Debounced incremental results | Supported (300 ms) | Reference (180 ms) | Supported |
+| Submit commits immediately (bypass debounce) | Not planned (debounce only) | Reference | Supported |
 | Whitespace/punctuation-tolerant matching (`WDR5`↔`WDR 5`) | Supported | Reference | Supported |
-| Searchable surface: name + tags + country + broadcaster + URLs | Supported | Reference | Supported (name/tags/country baseline) |
-| Bundled full-text index path | Supported | Reference (`stations.fts5.db`) | Optional — substring if FTS too slow on device |
-| Graceful substring fallback when index missing/diverged | Required | Reference | Required |
-| Query-active suppresses alphabet/quality/favorite sort | Required | Reference | Required |
+| Searchable surface: name + tags + country + broadcaster + URLs | Partial (name/tags/country only) | Reference | Supported (name/tags/country baseline) |
+| Bundled full-text index path | Not planned (substring filter only) | Reference (`stations.fts5.db`) | Optional — substring if FTS too slow on device |
+| Graceful substring fallback when index missing/diverged | Supported (substring is the only path) | Reference | Required |
+| Query-active suppresses alphabet/quality/favorite sort | Not applicable (no Browse sort control) | Reference | Required |
 | Radio Browser community results appended on load-more | Supported | Reference | Supported with cache-backed loading |
-| Country-filter + ≤2-char-query suppresses RB call | Required | Reference | Required |
-| Stream-quality (low/medium/high) filter gates every search tier | Supported | Reference | Supported |
-| Visible-window paging then RB pagination | Supported | Reference (25 then 50) | Supported |
+| Country-filter + ≤2-char-query suppresses RB call | Not planned (no short-circuit) | Reference | Required |
+| Stream-quality (low/medium/high) filter gates every search tier | Not applicable (no quality filter) | Reference | Supported |
+| Visible-window paging then RB pagination | Supported (100 then 60) | Reference (25 then 50) | Supported |
 | Clear button resets field + query + RB paginator | Supported | Reference | Supported |
-| No-results unavailable view with guidance text | Supported | Reference | Supported |
-| Radio Browser failure surfaces no error/retry | Matches | Reference | Matches |
+| No-results unavailable view with guidance text | Supported (different copy) | Reference | Supported |
+| Radio Browser failure surfaces no error/retry | Partial (initial fetch shows an "Off air" line; load-more silent) | Reference | Matches |
 
 ## Open questions
 

--- a/docs/spec/features/sleep-timer.md
+++ b/docs/spec/features/sleep-timer.md
@@ -211,11 +211,11 @@ Parameter/plural needs:
 | Behavior | Web | iOS | Android |
 |---|---|---|---|
 | Timer cycle | Supported. | Model only (no UI invokes `cycle()`). | Supported. |
-| Preset / free-form durations | 15/30/60/90 presets (web). | Free-form via wheel (sheet) and 24h picker (Settings default); cycle presets unwired. | 30/60/90. |
-| Visible remaining time | Supported where UI exposes it. | Supported (control chip + sheet countdown + lock screen). | Partial. |
+| Preset / free-form durations | 15/30/60 presets (web cycle is `[0, 15, 30, 60]`); no free-form entry. | Free-form via wheel (sheet) and 24h picker (Settings default); cycle presets unwired. | 30/60/90. |
+| Visible remaining time | Partial (moon-control chip shows the *armed* duration as `<n>m`, fixed at arming; no live countdown, no sheet, no lock-screen suffix). | Supported (control chip + sheet countdown + lock screen). | Partial. |
 | Background firing | Browser/OS dependent. | Supported while app/session remains eligible. | Planned through service/alarm design. |
 | Wake interaction | Silent-bed behavior. | Keep-alive aware. | To be designed with Android wake flow. |
-| Persisted default duration | Supported where settings exist. | Supported (synced via iCloud). | Partial. |
+| Persisted default duration | Not planned (no Settings row; the cycle resets to off on each load — there is no stored default). | Supported (synced via iCloud). | Partial. |
 | Pause-not-stop on fire | Supported. | Reference. | Supported. |
 
 ## Android First-Port Requirement

--- a/docs/spec/features/wake-to-radio.md
+++ b/docs/spec/features/wake-to-radio.md
@@ -235,12 +235,12 @@ formatting; "now"/"soon" are special-cased).
 |---|---|---|---|
 | In-app timer | Supported while tab/session remains alive. | Supported while app remains alive. | Planned while process/service remains alive. |
 | Keep audio alive | Silent-bed audio workaround. | Near-silent local audio keep-alive (default on). | TBD, likely foreground service if allowed. |
-| Local notification fallback | Browser support dependent. | Supported (one-shot, fixed identifier). | Planned. |
-| Notification-tap → playback | Browser support dependent. | Supported (queued, consumed on next active pass — see W1). | Planned. |
-| Pre-armed default time / prefs | Browser-local. | Supported (default time, notify, keep-alive). | Planned. |
-| Program-schedule preset arming | Where schedules exist. | Supported. | Planned. |
+| Local notification fallback | Partial (best-effort `Notification` fired at wake time only when the page is alive and permission granted; no scheduled/background fallback). | Supported (one-shot, fixed identifier). | Planned. |
+| Notification-tap → playback | Not planned (no notification-tap path; audio starts directly from the in-page timer). | Supported (queued, consumed on next active pass — see W1). | Planned. |
+| Pre-armed default time / prefs | Partial (last-used wake time persists in localStorage; no notify or keep-alive preference rows). | Supported (default time, notify, keep-alive). | Planned. |
+| Program-schedule preset arming | Not planned (no schedule → wake preset path on web). | Supported. | Planned. |
 | DST-safe next-fire resolution | Required. | Supported. | Required. |
-| Pause-while-armed warning | TBD. | Supported (once per alarm, keep-alive off). | TBD. |
+| Pause-while-armed warning | Not applicable (web swaps to the silent bed on pause, so the keep-alive footgun the warning guards against does not exist). | Supported (once per alarm, keep-alive off). | TBD. |
 | Lock-screen wake Live Activity | Not applicable. | Supported (glanceable; independent of playback). | TBD. |
 | Shortcuts/automation | Not applicable. | Supported (Set Wake Alarm arms; Play Station / Play Last Station play). | Not applicable. |
 | Exact alarm | Not available. | Not available to third-party app in this sense. | Open decision; may require permission. |
@@ -250,9 +250,17 @@ formatting; "now"/"soon" are special-cased).
 ## Web
 
 The web wake flow is browser-limited. It can work while the page and audio session
-remain eligible, but it must not promise alarm-clock reliability. A silent-bed
-audio workaround and the Media Session / Notifications APIs (where supported) are
-the closest analogs to the iOS keep-alive and notification fallback.
+remain eligible, but it must not promise alarm-clock reliability. The in-page
+scheduler (a clamped `setTimeout`, a 30s heartbeat, a `visibilitychange` re-check,
+and a best-effort screen Wake Lock) only runs while the tab is open; closing the
+page ends the alarm. A silent-bed audio workaround (always on while armed, not a
+user preference) stands in for the iOS keep-alive — it loops a near-silent AAC clip
+so the audio session stays active across the fire-time station swap. The Media
+Session API supplies the lock-screen "Wake to …" title. The notification is fired
+best-effort at wake time (only when the page is alive and `Notification` permission
+is granted), not scheduled to fire while the tab is suspended; there is no
+notification-tap-to-play path, no program-schedule preset arming, and no
+preference cloud sync on web. Only the last-used wake time persists in localStorage.
 
 ## iOS
 

--- a/docs/spec/playback.md
+++ b/docs/spec/playback.md
@@ -64,7 +64,10 @@ All platforms must handle transient stream failure:
 Platform notes:
 
 - Web must treat `HTMLAudioElement` as unreliable after some failures and
-  rebuild source state.
+  rebuild source state. Today the web recovery is partial: a stall watchdog
+  detects a frozen `currentTime` and rebuilds the source, but there is no
+  capped/backed-off retry on `error` events and no connectivity monitor, so
+  the network-restore auto-reconnect is not yet wired (see Platform Matrix).
 - iOS keeps AVPlayer item rebuilding, audio-session interruption handling,
   output-route-loss pause, and media-services-reset recovery as native reference
   behavior; a connectivity monitor drives the network-restore auto-reconnect.
@@ -100,6 +103,13 @@ station. Live streams disable seek / skip-by-time controls.
 - Previous/next media controls should not jump to unrelated catalog stations
   when the user is in a curated list or station list.
 
+Web platform note: the web app does not yet implement this queue model. Its
+Media Session previous/next handlers always step through the user's favorites
+(circularly, jumping to the first/last favorite when the current station is not
+a favorite), regardless of the list, browse result, or recents the user is
+viewing. The browse/list/recents queues above are product intent for web, not
+shipped behavior (see Platform Matrix).
+
 ## Testing Expectations
 
 - Unit tests cover state transitions, queue selection, retry classification,
@@ -116,13 +126,13 @@ Status words per the [README](README.md) status legend.
 |---|---|---|---|
 | Start / pause / resume / stop | Supported. | Reference. | Supported. |
 | Source rebuild on new station | Supported. | Reference. | Supported. |
-| Automatic retry (≤3, backoff) | Supported. | Reference. | Supported. |
+| Automatic retry (≤3, backoff) | Partial (stall watchdog only). | Reference. | Supported. |
 | Geo-restriction = permanent (no retry) | Supported. | Reference. | Supported. |
-| Network-restore auto-reconnect | Supported. | Reference. | Supported. |
+| Network-restore auto-reconnect | Planned. | Reference. | Supported. |
 | Lock-screen / system now-playing | Partial (browser-dependent). | Reference. | Supported. |
 | Headphone / Bluetooth transport | Partial (browser-dependent). | Reference. | Supported. |
 | Background playback | Partial. | Reference. | Supported. |
-| Active playback queue + circular stepping | Supported. | Reference. | Supported. |
+| Active playback queue + circular stepping | Partial (favorites-only skip). | Reference. | Supported. |
 | In-app car mode | Not applicable. | Supported. | Not planned. |
 | Native vehicle integration | Not applicable. | Partial; CarPlay app implemented, entitlement-gated (issue #51). | Planned (Android Auto is an open decision). |
 | Watch companion remote | Not applicable. | Supported. | Not applicable. |


### PR DESCRIPTION
Web finalization phase (follows #512, the iOS reconcile). One agent per web-relevant doc verified each doc's **Web** parity against the actual `src/` implementation at web `main` `dfc848467`. **Narrow mandate:** only Web matrix cells + web-scoped notes were touched — the product-intent body, iOS/Android cells, and stamps are untouched.

## What changed
- **20 docs edited · 113 Web matrix cells corrected** (3 docs — `data-sync`, `platforms`, `station-lists` — were already accurate).
- README master parity matrix Web column retargeted to `dfc848467`; **Localization** row added.
- COVERAGE gains a **Web reconciliation** section (web source map + the surfaces web doesn't implement).
- Generator builds all 28 pages; 327 intra-spec links resolve. No code touched.

## The honest headline
The web app implements a **focused subset** of the finalized product intent. Surfaces it does **not** have (now stated honestly in every matrix):

| Area | Web reality |
|---|---|
| Search | Substring scan over built-ins + custom only — **no FTS index**, no `≤2-char` RB gate, no submit-commit |
| Playback queue | **No queue model** — prev/next cycle the *favorites* list only and can jump to an unrelated station |
| Stream recovery | **No retry budget/backoff** — only an ~8s stall watchdog (one rebuild); no network-restore reconnect |
| Localization | **English-only** — no key registry, no language switcher, no plural engine |
| Listening history / station lists | **Not implemented** (the `dashboard.ts`/`tracker/` console is admin analytics, not user history) |
| Settings | **No Settings sheet** — only theme toggle + favorites/recents/custom/wake persistence |
| Custom stations | **No probe, dup-check, edit, or auto-favorite**; immediate delete, no confirmation |
| Offline | **No service worker / PWA** — boot fetch of `stations.json`, 3-station seed fallback |
| Broken reports | **Fire-and-forget POST** — no category/comment, no receipt lifecycle |
| Browse | **No discovery landing, sort, or quality filter** (map browse *is* supported) |

## Notable web divergences from intent (not just "less")
- **Favorites add-at-top** (iOS intent is add-at-tail) — `storage.ts` `favs.unshift`.
- **Backup merge is inverted**: web keeps the *local* copy on id collision (iOS restore replaces wholesale / contract says imported-wins). Web backup covers favorites + custom only.
- **Search debounce 300ms** (iOS reference 180ms); paging 100-then-60 (iOS 25-then-50).
- **Privacy**: web's only `mailto` points at a personal Gmail, not a first-party inbox; web broken-report sends no category/comment.

## Next
Android forward-spec phase (no Android repo yet — author the Android columns as deliberate build targets from the finalized intent, rather than reconcile against code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)