### PR TITLE
ci: make the broken-station crons fail loudly (#517)

### DIFF
--- a/.github/workflows/propose-fixes.yml
+++ b/.github/workflows/propose-fixes.yml
@@ -71,3 +71,47 @@ jobs:
           # provided automatically (issue repo + run link).
         run: |
           npm run propose-station-fix -- ${{ (github.event_name == 'workflow_dispatch' && inputs.dry_run) && '--dry-run' || '' }} --verbose
+
+      # A scheduled cron fails silently — nobody watches a 07:00 job. Surface
+      # any failure as a tracking issue so a broken run can't accumulate
+      # unnoticed (#517). Manual dispatch runs are visible to the operator.
+      - name: File a tracking issue if the scheduled run failed
+        if: failure() && github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WORKFLOW: ${{ github.workflow }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh label create workflow-failure \
+            --description "A scheduled workflow failed and needs attention" \
+            --color B60205 --force >/dev/null 2>&1 || true
+          title="Scheduled workflow failing: $WORKFLOW"
+          {
+            echo "\`$WORKFLOW\` failed on its scheduled run."
+            echo
+            echo "Run: $RUN_URL"
+            echo
+            echo "Check the failing step's log, fix the cause, then dispatch the workflow manually to confirm. This issue auto-closes on the next successful run."
+          } > failure-body.md
+          num=$(gh issue list --label workflow-failure --state open \
+            --json number,title \
+            --jq '[.[] | select(.title=="'"$title"'")][0].number // ""')
+          if [ -n "$num" ]; then
+            gh issue comment "$num" --body "Failed again $(date -u +'%Y-%m-%d %H:%M UTC') — $RUN_URL"
+          else
+            gh issue create --label workflow-failure --title "$title" --body-file failure-body.md
+          fi
+
+      - name: Close the tracking issue after a successful run
+        if: success()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WORKFLOW: ${{ github.workflow }}
+        run: |
+          title="Scheduled workflow failing: $WORKFLOW"
+          num=$(gh issue list --label workflow-failure --state open \
+            --json number,title \
+            --jq '[.[] | select(.title=="'"$title"'")][0].number // ""')
+          if [ -n "$num" ]; then
+            gh issue close "$num" --comment "Recovered: succeeded $(date -u +'%Y-%m-%d %H:%M UTC'). Closing."
+          fi

--- a/.github/workflows/triage-reports.yml
+++ b/.github/workflows/triage-reports.yml
@@ -61,7 +61,52 @@ jobs:
           # provided automatically and used for the issue repo + run link.
         run: |
           if [ -z "$STATS_ADMIN_TOKEN" ]; then
-            echo "STATS_ADMIN_TOKEN secret is not set — cannot read reports." >&2
+            echo "STATS_ADMIN_TOKEN secret is not set or empty — cannot read reports (see #517)." >&2
             exit 1
           fi
           npm run triage-reports -- ${{ (github.event_name == 'workflow_dispatch' && inputs.dry_run) && '--dry-run' || '' }} --verbose
+
+      # A scheduled cron fails silently — nobody watches a 06:00 job. Surface
+      # any failure (empty/wrong token, network, etc.) as a tracking issue so a
+      # broken-on-arrival run can't accumulate unnoticed (#517). Manual dispatch
+      # runs are visible to the operator, so they don't file noise.
+      - name: File a tracking issue if the scheduled run failed
+        if: failure() && github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WORKFLOW: ${{ github.workflow }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh label create workflow-failure \
+            --description "A scheduled workflow failed and needs attention" \
+            --color B60205 --force >/dev/null 2>&1 || true
+          title="Scheduled workflow failing: $WORKFLOW"
+          {
+            echo "\`$WORKFLOW\` failed on its scheduled run."
+            echo
+            echo "Run: $RUN_URL"
+            echo
+            echo "Check the failing step's log, fix the cause, then dispatch the workflow manually to confirm. This issue auto-closes on the next successful run."
+          } > failure-body.md
+          num=$(gh issue list --label workflow-failure --state open \
+            --json number,title \
+            --jq '[.[] | select(.title=="'"$title"'")][0].number // ""')
+          if [ -n "$num" ]; then
+            gh issue comment "$num" --body "Failed again $(date -u +'%Y-%m-%d %H:%M UTC') — $RUN_URL"
+          else
+            gh issue create --label workflow-failure --title "$title" --body-file failure-body.md
+          fi
+
+      - name: Close the tracking issue after a successful run
+        if: success()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WORKFLOW: ${{ github.workflow }}
+        run: |
+          title="Scheduled workflow failing: $WORKFLOW"
+          num=$(gh issue list --label workflow-failure --state open \
+            --json number,title \
+            --jq '[.[] | select(.title=="'"$title"'")][0].number // ""')
+          if [ -n "$num" ]; then
+            gh issue close "$num" --comment "Recovered: succeeded $(date -u +'%Y-%m-%d %H:%M UTC'). Closing."
+          fi


### PR DESCRIPTION
## What

The daily **triage-reports** (06:00 UTC) and **propose-fixes** (07:00 UTC) crons fail *silently* — nobody watches a scheduled job. That's why #517 went unnoticed for a day: the `STATS_ADMIN_TOKEN` secret was set but empty, so every triage run died at the auth guard with zero successful runs and no signal.

This PR makes those failures loud, using the repo's existing tracking-issue convention (same shape as `catalog-watch.yml`):

- On a **scheduled-run failure**, upsert one `workflow-failure` issue per workflow with the run link (dedup by exact title; comment on re-failure rather than duplicate).
- On the **next successful run**, auto-close that issue.
- Gated to `schedule` events so manual `workflow_dispatch` dry-runs (the verification step) don't file noise.
- Clarified the triage empty-secret guard message ("not set or empty … see #517").

Applies to both daily crons; covers *any* failure mode (empty/wrong token, network, probe errors), not just the missing secret.

## What this does NOT do

It does **not** fix the secret itself. The actual remedy for #517 is re-setting the Worker's real `ADMIN_TOKEN`, which must be done out of band:

```
gh secret set STATS_ADMIN_TOKEN --repo MarkusSteinbrecher/rrradio
# then verify:
gh workflow run triage-reports.yml -f dry_run=true
```

Once that's done and a scheduled run succeeds, any `workflow-failure` issue this PR would have filed auto-closes.

## Verification

- Both workflow YAMLs parse cleanly; new steps present and correctly ordered (label-create → triage → on-failure file → on-success close).
- `failure()`/`success()` step conditions + `github.event_name == 'schedule'` gate confirmed by inspection (Actions has no local-run path).

Part of #517 (the hardening half). The secret-reset half stays with the sponsor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)