### PR TITLE
ci: auto-merge patch-level Dependabot dev-dependency bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,7 @@
 version: 2
+# Patch-level *dev*-dependency PRs from these updates are auto-merged once CI is
+# green — see .github/workflows/dependabot-auto-merge.yml. Everything else
+# (prod deps, any minor/major) still waits for a human; majors are ignored below.
 updates:
   # ────────────────────────────────────────────────────────────
   # Web app (root npm)

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,48 @@
+name: Dependabot auto-merge
+
+# Auto-merge the Dependabot PRs that are safe to land unattended: patch-level
+# bumps of *development* dependencies (test runners, linters, build tooling).
+# Production-dep bumps, any minor/major, and grouped PRs that contain a non-patch
+# change still wait for a human. Majors are already filtered in dependabot.yml.
+#
+# This uses GitHub's native auto-merge, so a PR only merges once the required
+# status checks on `main` (web / worker / catalog / e2e) pass — see the branch
+# protection on `main`. No third-party actions: dependabot/fetch-metadata is a
+# first-party GitHub action, in keeping with the repo's strict-CSP / minimal-
+# dependency posture.
+#
+# Prerequisites (configured once, outside this file):
+#   - repo setting `allow_auto_merge: true`
+#   - branch protection on `main` with the four CI checks marked required
+#     (otherwise `--auto` has nothing to wait on and won't enable).
+
+on: pull_request
+
+# Dependabot-triggered runs get a read-only token by default; grant just enough
+# to enable auto-merge on the PR. Scoped to this workflow only.
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # `update-type` is the highest semver bump in the PR (so a grouped PR with
+      # any minor/major won't match); `dependency-type` is direct:development
+      # only when every updated dep is a dev dependency.
+      - name: Enable auto-merge for patch-level dev-dependency bumps
+        if: >-
+          steps.meta.outputs.update-type == 'version-update:semver-patch' &&
+          steps.meta.outputs.dependency-type == 'direct:development'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Adds `.github/workflows/dependabot-auto-merge.yml` so **patch-level bumps of dev-only dependencies** land unattended once CI is green. Everything else still waits for a human.

The rule fires only when `dependabot/fetch-metadata` reports **both**:
- `update-type == version-update:semver-patch` (a grouped PR with any minor/major won't match — `update-type` is the highest bump in the group), **and**
- `dependency-type == direct:development` (every updated dep is a dev dependency; prod-dep PRs are excluded).

It uses **GitHub's native auto-merge** (`gh pr merge --auto --squash`), so a PR only merges after the required `main` checks pass. No third-party actions — `dependabot/fetch-metadata` is first-party, in keeping with the repo's minimal-dependency / strict-CSP posture.

## Repo config applied alongside this (already live)

- `allow_auto_merge: true` on the repository.
- Branch protection on `main`: `web` / `worker` / `catalog` / `e2e` marked **required**, `strict: false`, **`enforce_admins: false`** so direct pushes to main by an admin still work, no required PR reviews.

Together these are the prerequisites that let native auto-merge wait for green instead of merging immediately.

## Examples

- Worker `worker-deps` group, vitest `4.1.5 → 4.1.9` (cf. #566) → **auto-merges** after CI.
- Root `prod` group, or any PR containing a minor/major → **manual review** (unchanged).

Also adds a 3-line cross-reference comment to `dependabot.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)