### PR TITLE
feat(deploy): serve apple-app-site-association for iOS Universal Links

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -620,6 +620,19 @@ rrradio-ios/*.svg            — local logo assets
 
 The page is route-isolated from the web player and catalog. It does not import `src/main.ts`, `src/style.css`, station data, or any native app repository. The phone mockups currently use static placeholders; replace those with real app screenshots once the App Store page assets are ready.
 
+## Universal Links handoff (`apple-app-site-association`)
+
+`public/.well-known/apple-app-site-association` makes iOS hand off `https://rrradio.org/?play=<id>` / `?list=<id>` links to the installed app (issue #563; iOS entitlement in rrradio-ios #25). Vite copies the file verbatim into `dist/`, so GitHub Pages serves it at the apex. `src/aasa.test.ts` locks its shape (app ID, the `play`/`list` query constraints) so an edit that would break the handoff fails CI.
+
+The `?` query constraints are deliberate: only links carrying `play` or `list` hand off; a plain `https://rrradio.org/` stays in the browser, so the homepage / web player isn't hijacked.
+
+Serving gotchas (Apple is strict, and a future change could silently break this):
+
+- **Content-Type:** GitHub Pages serves the extensionless file as `application/octet-stream`, **not** `application/json`. That's fine — since iOS 14 the device fetches the file via Apple's CDN (`https://app-site-association.cdn-apple.com/a/v1/rrradio.org`), which ingests the octet-stream origin and re-serves it as `application/json`. GitHub Pages can't set custom headers (no `_headers` support), so don't chase the content-type — verify via Apple's CDN copy instead.
+- **No redirects, no rewrites** on `/.well-known/*`. The site is multi-page (real 404s, no SPA catch-all), so unknown paths aren't rewritten to `index.html` today. If you ever add a catch-all/SPA fallback or move hosting, exempt `/.well-known/` or the handoff dies silently.
+- **No `.json` extension, no signing** — modern AASA is raw JSON.
+- Universal Links only fire from a *tapped* link (Messages, Mail, Safari long-press → Open), never from typing the URL into Safari's address bar.
+
 ## Admin dashboard
 
 Private page that surfaces GoatCounter stats in our visual style. Lives at `https://<host>/rrradio/dashboard.html`. Source files:

--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -1,0 +1,13 @@
+{
+  "applinks": {
+    "details": [
+      {
+        "appIDs": ["AMWM3DHJSG.ios.rrradio.org"],
+        "components": [
+          { "/": "/", "?": { "play": "?*" }, "comment": "Play a station: /?play=<stationID>" },
+          { "/": "/", "?": { "list": "?*" }, "comment": "Play a list: /?list=<listID>" }
+        ]
+      }
+    ]
+  }
+}

--- a/src/aasa.test.ts
+++ b/src/aasa.test.ts
@@ -1,0 +1,74 @@
+/// <reference types="node" />
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Apple App Site Association (AASA) regression tests (issue #563).
+ *
+ * The web→app handoff (Universal Links) only fires when rrradio.org
+ * serves a valid AASA at `/.well-known/apple-app-site-association`.
+ * The file ships as a static asset under `public/`, so Vite copies it
+ * verbatim into `dist/` and GitHub Pages serves it at the apex.
+ *
+ * These tests assert the SOURCE file's shape so an accidental edit
+ * (wrong appID, dropped query constraint, a `.json` rename, a BOM that
+ * breaks JSON parsing) surfaces at PR time rather than as a silently
+ * broken handoff on a real device. The structure must stay in lockstep
+ * with the iOS entitlement (`applinks:rrradio.org`) in rrradio-ios #25.
+ */
+
+const AASA_PATH = resolve(process.cwd(), 'public/.well-known/apple-app-site-association');
+
+interface AasaComponent {
+  '/': string;
+  '?'?: Record<string, string>;
+  comment?: string;
+}
+interface AasaDetail {
+  appIDs: string[];
+  components: AasaComponent[];
+}
+interface Aasa {
+  applinks: { details: AasaDetail[] };
+}
+
+const raw = readFileSync(AASA_PATH, 'utf8');
+const aasa = JSON.parse(raw) as Aasa;
+
+describe('apple-app-site-association', () => {
+  it('is served extensionless — no `.json` sibling that would shadow it', () => {
+    // Apple requires the raw filename with no extension. A `.json`
+    // variant in the same dir would be a sign someone "fixed" the
+    // missing extension and broke the handoff.
+    expect(existsSync(`${AASA_PATH}.json`)).toBe(false);
+  });
+
+  it('parses as JSON with no UTF-8 BOM', () => {
+    // Apple's parser (and JSON.parse) choke on a leading BOM. readFileSync
+    // surfaces it as U+FEFF at index 0.
+    expect(raw.charCodeAt(0)).not.toBe(0xfeff);
+    expect(raw.trimStart().startsWith('{')).toBe(true);
+  });
+
+  it('declares exactly the rrradio iOS app ID', () => {
+    expect(aasa.applinks.details).toHaveLength(1);
+    // <TeamID>.<bundleID> = AMWM3DHJSG . ios.rrradio.org
+    expect(aasa.applinks.details[0].appIDs).toEqual(['AMWM3DHJSG.ios.rrradio.org']);
+  });
+
+  it('hands off only ?play= and ?list= links, scoped to the root path', () => {
+    const components = aasa.applinks.details[0].components;
+    // One component per recognised query key — and nothing else, so a
+    // plain https://rrradio.org/ (or any other query) stays in the
+    // browser and the web player isn't hijacked.
+    const queryKeys = components.map((c) => Object.keys(c['?'] ?? {}).join(','));
+    expect(queryKeys.sort()).toEqual(['list', 'play']);
+    for (const c of components) {
+      expect(c['/']).toBe('/');
+      const constraint = c['?'] ?? {};
+      // `?*` = "key present with any value".
+      expect(Object.values(constraint)).toEqual(['?*']);
+    }
+  });
+});


### PR DESCRIPTION
Publishes the Apple App Site Association (AASA) file so iOS hands off `https://rrradio.org/?play=<id>` / `?list=<id>` links to the installed app. iOS side (entitlement `applinks:rrradio.org`, `DeepLink` parser, queue semantics) is already done in rrradio-ios #25; this is the missing web half.

## What ships
- `public/.well-known/apple-app-site-association` — Vite copies `public/` verbatim into `dist/`, which is what `deploy.yml` uploads via `upload-pages-artifact`, so GitHub Pages serves it at the apex. App ID `AMWM3DHJSG.ios.rrradio.org`.
- `src/aasa.test.ts` — guard test (4 cases): locks the app ID, the `play`/`list` query constraints, rejects a `.json` rename, catches a BOM.
- `docs/operations.md` — "Universal Links handoff" section documenting the serving gotchas.

## Why query-scoped (not a catch-all `{ "/": "*" }`)
The components only match `?play=` / `?list=` at the root path. This mirrors the real `DeepLink.parse` in rrradio-ios, which returns `nil` for any URL without `play`/`list`. A catch-all would hand off **every** rrradio.org link (homepage, `/rrradio-ios/`, `station-tracker.html`, dashboard) to the app — and the parser couldn't act on them, hijacking the web presence for installed users. The issue author rejected exactly this.

## Content-Type note (the GitHub Pages gotcha)
GitHub Pages serves the extensionless file as `application/octet-stream`, not `application/json`, and can't set custom headers. That's fine: since iOS 14 the device fetches AASA via **Apple's CDN**, which ingests the octet-stream origin and re-serves `application/json`. Verified empirically against a live GitHub Pages AASA (`wellping.github.io` → Apple's CDN copy parses cleanly).

## Verify after merge + Pages redeploy
- `curl -i https://rrradio.org/.well-known/apple-app-site-association` → 200 + JSON (no redirect)
- Apple's CDN copy: `https://app-site-association.cdn-apple.com/a/v1/rrradio.org`
- On a real iPhone with the app installed: tap (don't type) `https://rrradio.org/?play=<id>` → app opens and plays.

Closes #563

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbXN89jGYrHnuujc2yXKnQ