### PR TITLE
fix(deploy): include hidden files so the AASA actually deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,6 +57,12 @@ jobs:
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         with:
           path: dist
+          # upload-pages-artifact@v5 excludes dot-directories by default
+          # (`--exclude=.[^/]*`), which silently dropped
+          # dist/.well-known/apple-app-site-association from the deployed
+          # tarball — the file passed CI but 404'd live (issue #563).
+          # The only dotfile we build is .well-known, so include them.
+          include-hidden-files: true
       # Persist dist for the e2e job so we don't rebuild.
       - uses: actions/upload-artifact@v7
         with:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -628,6 +628,7 @@ The `?` query constraints are deliberate: only links carrying `play` or `list` h
 
 Serving gotchas (Apple is strict, and a future change could silently break this):
 
+- **Hidden-file deploy (the one that bit us):** `actions/upload-pages-artifact@v5` excludes dot-directories by default (`--exclude=.[^/]*`), so `dist/.well-known/` was silently dropped from the deployed tarball — the file passed CI and lived on `main`, but the live URL 404'd. `deploy.yml` sets `include-hidden-files: true` on that step; `src/aasa.test.ts` asserts it stays. Don't trust "it's committed + CI green" — confirm the live URL serves `200` after the *deploy job* (not just CI) finishes and the Pages CDN propagates (a couple of minutes).
 - **Content-Type:** GitHub Pages serves the extensionless file as `application/octet-stream`, **not** `application/json`. That's fine — since iOS 14 the device fetches the file via Apple's CDN (`https://app-site-association.cdn-apple.com/a/v1/rrradio.org`), which ingests the octet-stream origin and re-serves it as `application/json`. GitHub Pages can't set custom headers (no `_headers` support), so don't chase the content-type — verify via Apple's CDN copy instead.
 - **No redirects, no rewrites** on `/.well-known/*`. The site is multi-page (real 404s, no SPA catch-all), so unknown paths aren't rewritten to `index.html` today. If you ever add a catch-all/SPA fallback or move hosting, exempt `/.well-known/` or the handoff dies silently.
 - **No `.json` extension, no signing** — modern AASA is raw JSON.

--- a/src/aasa.test.ts
+++ b/src/aasa.test.ts
@@ -37,6 +37,16 @@ const raw = readFileSync(AASA_PATH, 'utf8');
 const aasa = JSON.parse(raw) as Aasa;
 
 describe('apple-app-site-association', () => {
+  it('survives the Pages deploy — upload-pages-artifact keeps hidden files', () => {
+    // upload-pages-artifact@v5 excludes dot-directories by default
+    // (`--exclude=.[^/]*`), which dropped .well-known from the deployed
+    // tarball: the file passed CI but 404'd live. The deploy workflow
+    // must opt back in, or this whole file never reaches the site.
+    const deploy = readFileSync(resolve(process.cwd(), '.github/workflows/deploy.yml'), 'utf8');
+    expect(deploy).toMatch(/upload-pages-artifact/);
+    expect(deploy).toMatch(/include-hidden-files:\s*true/);
+  });
+
   it('is served extensionless — no `.json` sibling that would shadow it', () => {
     // Apple requires the raw filename with no extension. A `.json`
     // variant in the same dir would be a sign someone "fixed" the


### PR DESCRIPTION
## Problem
PR #626 added `public/.well-known/apple-app-site-association` and merged to `main`, but `https://rrradio.org/.well-known/apple-app-site-association` is **still 404**. The file passed CI, lives on `main`, and the deploy job succeeded — yet it never reached the served site. (Thanks to the rrradio-ios reviewer for pushing on this.)

## Root cause
`actions/upload-pages-artifact@v5` **excludes dot-directories by default** via `--exclude=.[^/]*` (unless `include-hidden-files: true`). So `dist/.well-known/` was silently stripped from the deployed tarball.

Proven, not guessed:
- Downloaded the deployed `github-pages` artifact from the latest `main` deploy — its `artifact.tar` contains `./privacy.html` but **not** `.well-known/apple-app-site-association`.
- The [v5 action source](https://github.com/actions/upload-pages-artifact/blob/v5/action.yml) confirms the default `--exclude=.[^/]*`.
- `.well-known/` is the **only** dotfile we build, so nothing else is affected.

This is the Actions-deploy analogue of the classic "Jekyll drops dot-folders" gotcha — same symptom (committed + CI-green but 404 live), different layer.

## Fix
Set `include-hidden-files: true` on the `upload-pages-artifact` step. `.git`/`.github` remain excluded unconditionally, and `.well-known` is the only dotfile in `dist`, so the blast radius is exactly the AASA file.

- `src/aasa.test.ts` now asserts `deploy.yml` keeps the flag → can't silently regress.
- `docs/operations.md` documents the gotcha.

## Verify after merge + deploy + CDN propagation (~couple min)
```
curl -i https://rrradio.org/.well-known/apple-app-site-association   # expect 200 + JSON
```
Then Apple's CDN copy: `https://app-site-association.cdn-apple.com/a/v1/rrradio.org`, then the on-device tap test.

## Gates
typecheck ✓ · 692 vitest (incl. new deploy guard) ✓

Refs #563

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbXN89jGYrHnuujc2yXKnQ