### PR TITLE
feat(web): auto-play from ?play=<id> (Universal Link fallback)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -5987,13 +5987,20 @@ player.setSkipHandlers(
 /** Pre-rendered /station/<id>/ landing pages set window.__STATION_ID__
  *  so the SPA can auto-play the station the visitor landed on. We also
  *  parse the URL path as a fallback (in case the injection was stripped
- *  or the user shared a link to a non-prerendered station id). The
- *  match is deferred until BUILTIN_STATIONS has hydrated. */
+ *  or the user shared a link to a non-prerendered station id), plus the
+ *  `?play=<id>` query — that's the Universal Link form the AASA hands to
+ *  the iOS app (public/.well-known/apple-app-site-association), so the
+ *  same link auto-plays in the browser when the app isn't installed.
+ *  onRowPlay → syncUrlForStation then rewrites the address bar to the
+ *  canonical /station/<id>/. The match is deferred until BUILTIN_STATIONS
+ *  has hydrated. */
 function autoLoadStationFromUrl(): void {
   const declared = (window as unknown as { __STATION_ID__?: unknown }).__STATION_ID__;
   const fromGlobal = typeof declared === 'string' ? declared : undefined;
   const fromPath = window.location.pathname.match(/\/station\/([^/]+)\/?$/)?.[1];
-  const id = fromGlobal ?? fromPath;
+  const fromQuery =
+    new URLSearchParams(window.location.search).get('play')?.trim() || undefined;
+  const id = fromGlobal ?? fromPath ?? fromQuery;
   if (!id) return;
   const station = BUILTIN_STATIONS.find((s) => s.id === id);
   if (!station) return;


### PR DESCRIPTION
The AASA (`public/.well-known/apple-app-site-association`) hands `https://rrradio.org/?play=<id>` to the iOS app. But the **web** player only auto-played from `__STATION_ID__` / the `/station/<id>/` path — so when the app isn't installed, a `?play=` link landed on the bare home page without playing.

This teaches `autoLoadStationFromUrl()` to also read `?play=<id>`, closing the Universal Link fallback loop: the same link deep-links the app when installed, and auto-plays in the browser when it isn't. `onRowPlay → syncUrlForStation` then rewrites the address bar to the canonical `/station/<id>/`.

Complements the iOS `DeepLinkTests` (`?play=fm4`) and the web `aasa.test.ts` (handoff scoped to `?play=`/`?list=`).

**Verified locally:** typecheck ✓, 790 unit tests ✓, `vite build` + station-page generation ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)