### PR TITLE
feat(web): make /ios landing indexable on Google

### DIFF
--- a/ios/index.html
+++ b/ios/index.html
@@ -3,11 +3,18 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>rrradio — tune in</title>
-<meta name="description" content="rrradio is a minimal, free, ad-free internet radio app for iPhone and Apple Watch. Tune the dial to read it." />
+<title>rrradio · free internet radio for iPhone &amp; Apple Watch</title>
+<meta name="description" content="Free, ad-free internet radio for iPhone and Apple Watch. Thousands of live stations worldwide — no account, no ads, no tracking. Free on the App Store." />
+<link rel="canonical" href="https://rrradio.org/ios/" />
+<meta name="robots" content="index, follow" />
+<!-- CSP. script-src keeps 'unsafe-inline' in source so `npm run dev`
+     serves the inline JSON-LD SEO block below cleanly; the build
+     (tools/build-station-pages.mjs) rewrites this on dist/ios/index.html
+     to drop 'unsafe-inline' and pin a 'sha256-…' hash per inline script,
+     matching the home + station pages. -->
 <meta http-equiv="Content-Security-Policy" content="
   default-src 'self';
-  script-src 'self';
+  script-src 'self' 'unsafe-inline';
   style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
   img-src 'self' data:;
   connect-src 'self';
@@ -22,6 +29,41 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500;600&family=IBM+Plex+Mono:wght@300;400;500;600&display=swap" rel="stylesheet" />
 <link rel="icon" type="image/svg+xml" href="rrradio-logo-app-dark.svg" />
+<!-- Search-engine + share metadata. og:image reuses the site-wide
+     1200x630 card at /og-image.png (absolute URL required by scrapers). -->
+<meta property="og:type" content="website" />
+<meta property="og:site_name" content="rrradio" />
+<meta property="og:title" content="rrradio · free internet radio for iPhone &amp; Apple Watch" />
+<meta property="og:description" content="Free, ad-free internet radio for iPhone and Apple Watch. Thousands of live stations worldwide — no account, no ads, no tracking." />
+<meta property="og:url" content="https://rrradio.org/ios/" />
+<meta property="og:image" content="https://rrradio.org/og-image.png" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta property="og:image:alt" content="rrradio — internet radio for iPhone and Apple Watch" />
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content="rrradio · free internet radio for iPhone &amp; Apple Watch" />
+<meta name="twitter:description" content="Free, ad-free internet radio for iPhone and Apple Watch — no account, no ads, no tracking." />
+<meta name="twitter:image" content="https://rrradio.org/og-image.png" />
+<meta name="twitter:image:alt" content="rrradio — internet radio for iPhone and Apple Watch" />
+<!-- Structured data — eligible for Google rich results. MobileApplication
+     points crawlers at the App Store listing and marks the app free. -->
+<script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "MobileApplication",
+    "name": "rrradio",
+    "operatingSystem": "iOS, watchOS",
+    "applicationCategory": "MultimediaApplication",
+    "url": "https://rrradio.org/ios/",
+    "downloadUrl": "https://apps.apple.com/app/rrradio-org/id6767256355",
+    "installUrl": "https://apps.apple.com/app/rrradio-org/id6767256355",
+    "description": "Free, ad-free internet radio for iPhone and Apple Watch. Thousands of live stations worldwide — no account, no ads, no tracking.",
+    "image": "https://rrradio.org/og-image.png",
+    "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+    "isAccessibleForFree": true,
+    "publisher": { "@type": "Organization", "name": "rrradio", "url": "https://rrradio.org/" }
+  }
+</script>
 <link rel="stylesheet" href="./landing.css" />
 <link rel="stylesheet" href="./tunein.css" />
 </head>

--- a/tools/build-station-pages.mjs
+++ b/tools/build-station-pages.mjs
@@ -477,6 +477,15 @@ const homepageHtml = replaceBlock(
 );
 writeFileSync(`${DIST}/index.html`, applyCspHashes(homepageHtml), 'utf8');
 
+// The /ios landing page is emitted by Vite (multi-page input), so it
+// skips the rewrite loop above. Run the same CSP hash sweep on it so its
+// inline JSON-LD SEO block ships without 'unsafe-inline', matching the
+// home + station pages.
+const iosPath = join(DIST, 'ios', 'index.html');
+if (existsSync(iosPath)) {
+  writeFileSync(iosPath, applyCspHashes(readFileSync(iosPath, 'utf8')), 'utf8');
+}
+
 // Dedicated recently-added landing page. Standalone HTML, no SPA shell
 // — Google can land users straight here from search and the page is
 // instantly useful + indexable on its own.
@@ -493,6 +502,7 @@ const today = new Date().toISOString().slice(0, 10);
 const sitemapEntries = [
   `  <url><loc>${SITE}/</loc><lastmod>${today}</lastmod><changefreq>weekly</changefreq><priority>1.0</priority></url>`,
   `  <url><loc>${SITE}/recently-added/</loc><lastmod>${today}</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>`,
+  `  <url><loc>${SITE}/ios/</loc><lastmod>${today}</lastmod><changefreq>monthly</changefreq><priority>0.9</priority></url>`,
   ...stations.map(
     (s) =>
       `  <url><loc>${SITE}/station/${s.id}/</loc><lastmod>${today}</lastmod><changefreq>weekly</changefreq><priority>0.8</priority></url>`,


### PR DESCRIPTION
## What

The `/ios` "vintage tuner" landing was crawlable but weakly discoverable — absent from the sitemap and lacking canonical / share / structured-data metadata, with a non-descriptive `<title>`.

## Changes

**`ios/index.html`** (head only — no body/UI changes):
- `<title>` → `rrradio · free internet radio for iPhone & Apple Watch` (was "rrradio — tune in")
- Keyword-rich meta description (151 chars, fits Google's snippet)
- `<link rel="canonical">` + explicit `robots: index, follow`
- Open Graph + Twitter card (reuses the site-wide `og-image.png`)
- `MobileApplication` JSON-LD pointing crawlers at the App Store listing

**`tools/build-station-pages.mjs`**:
- Adds `/ios/` to the generated sitemap (priority 0.9, monthly)
- Runs the existing CSP hash sweep on the Vite-built `/ios` page so the inline JSON-LD ships **without `'unsafe-inline'`** and with a pinned `sha256` — same strict-CSP treatment as the home + station pages

## Visitor impact

None to the page UI (tuner, dial, content, buttons all unchanged). The only visitor-visible change is the browser **tab / bookmark title** — which doubles as the clickable headline Google shows in search results. All other additions are metadata only crawlers and social-link scrapers read.

## Verification

- `tsc` + Vite + station-page generator all pass; sitemap grew 31199 → **31200** entries (the `/ios/` line)
- Built `/ios` CSP: `script-src 'self' 'sha256-…'` — no `'unsafe-inline'`, one hash for the one inline JSON-LD
- JSON-LD parses cleanly (`MobileApplication`, correct App Store URL)
- The 3 CSP/static-page tests assert only on `index.html` / `support.html` / `/` — none touch `/ios`, so nothing breaks

## Deploy note

⚠️ Merging to `main` auto-deploys to prod (GitHub Pages). After deploy, expedite indexing via Google Search Console → URL Inspection → Request Indexing for `https://rrradio.org/ios/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XaiFGu51kTpqC97KbtZFD3
